### PR TITLE
Auto-name the VS routes in HTTPRoute auto-generated  

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -282,7 +282,8 @@ func buildHTTPVirtualServices(
 		// TODO: implement rewrite, timeout, mirror, corspolicy, retries
 		vs := &istio.HTTPRoute{}
 		// Auto-name the route. If upstream defines an explicit name, will use it instead
-		vs.Name = fmt.Sprintf("%s.%d", obj.Name, pos)
+		// The position within the route is unique
+		vs.Name = fmt.Sprintf("%s.%s.%d", obj.Namespace, obj.Name, pos)
 
 		for _, match := range r.Matches {
 			uri, err := createURIMatch(match)

--- a/pilot/pkg/config/kube/gateway/testdata/alias.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/alias.yaml.golden
@@ -34,6 +34,7 @@ spec:
   - match:
     - uri:
         prefix: /
+    name: default.http.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -58,6 +59,7 @@ spec:
   - match:
     - uri:
         prefix: /
+    name: default.http.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix

--- a/pilot/pkg/config/kube/gateway/testdata/delegated.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/delegated.yaml.golden
@@ -49,7 +49,8 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: apple.http.0
+    route:
     - destination:
         host: httpbin-apple.apple.svc.domain.suffix
         port:
@@ -70,7 +71,8 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: banana.http.0
+    route:
     - destination:
         host: httpbin-banana.banana.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -48,6 +48,7 @@ spec:
           exact: some-value
       uri:
         prefix: /get
+    name: default.http.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -86,6 +87,7 @@ spec:
           exact: some-value
       uri:
         prefix: /get
+    name: default.http.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
@@ -110,6 +112,7 @@ spec:
   - match:
     - uri:
         prefix: /second
+    name: default.http2.0
     route:
     - destination:
         host: httpbin-second.default.svc.domain.suffix
@@ -118,6 +121,7 @@ spec:
   - match:
     - uri:
         prefix: /
+    name: default.http2.1
     route:
     - destination:
         host: httpbin-wildcard.default.svc.domain.suffix
@@ -142,6 +146,7 @@ spec:
   - match:
     - uri:
         prefix: /original
+    name: default.rewrite.0
     rewrite:
       authority: new.example.com
       uri: /replacement
@@ -154,16 +159,19 @@ spec:
       host: httpbin-mirror.default.svc.domain.suffix
       port:
         number: 80
+    name: default.mirror.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:
           number: 80
-  - redirect:
+  - name: default.redirect.0
+    redirect:
       port: 8080
       redirectCode: 302
       scheme: https
-  - route:
+  - name: default.rewrite.1
+    route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.yaml.golden
@@ -85,7 +85,8 @@ spec:
   hosts:
   - first.domain.example
   http:
-  - route:
+  - name: default.invalid-backendRef-kind.0
+    route:
     - destination: {}
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -103,7 +104,8 @@ spec:
   hosts:
   - third.domain.example
   http:
-  - route:
+  - name: default.invalid-backendRef-mixed.0
+    route:
     - destination:
         host: nonexistent.default.svc.domain.suffix
         port:
@@ -132,7 +134,8 @@ spec:
   hosts:
   - second.domain.example
   http:
-  - route:
+  - name: default.invalid-backendRef-notfound.0
+    route:
     - destination:
         host: nonexistent.default.svc.domain.suffix
         port:
@@ -159,4 +162,5 @@ spec:
       host: httpbin.default.svc.domain.suffix
       port:
         number: 80
+    name: default.no-backend.0
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/mesh.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mesh.yaml.golden
@@ -31,7 +31,8 @@ spec:
   hosts:
   - foo.example.com
   http:
-  - route:
+  - name: default.dual.0
+    route:
     - destination:
         host: example.default.svc.domain.suffix
         port:
@@ -52,7 +53,8 @@ spec:
   hosts:
   - example.default.svc.domain.suffix
   http:
-  - route:
+  - name: default.dual.0
+    route:
     - destination:
         host: example.default.svc.domain.suffix
         port:
@@ -80,12 +82,14 @@ spec:
     match:
     - uri:
         prefix: /path
+    name: default.header.0
     route:
     - destination:
         host: echo.default.svc.domain.suffix
         port:
           number: 80
-  - route:
+  - name: default.echo.0
+    route:
     - destination:
         host: echo.default.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.yaml.golden
@@ -31,7 +31,8 @@ spec:
   hosts:
   - simple2.domain.example
   http:
-  - route:
+  - name: istio-system.backend-not-allowed.0
+    route:
     - destination:
         host: my-svc.service.svc.domain.suffix
         port:
@@ -55,7 +56,8 @@ spec:
   hosts:
   - simple.domain.example
   http:
-  - route:
+  - name: istio-system.http.0
+    route:
     - destination:
         host: my-svc.service.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.yaml.golden
@@ -34,7 +34,8 @@ spec:
   hosts:
   - cert1.domain.example
   http:
-  - route:
+  - name: cert.http.0
+    route:
     - destination:
         host: httpbin.cert.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.yaml.golden
@@ -104,7 +104,8 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: default.bind-all.0
+    route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:
@@ -125,12 +126,14 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: default.bind-all.0
+    route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:
           number: 85
-  - route:
+  - name: istio-system.same-namespace-valid.0
+    route:
     - destination:
         host: httpbin.istio-system.svc.domain.suffix
         port:
@@ -151,7 +154,8 @@ spec:
   hosts:
   - alpha.foobar.example
   http:
-  - route:
+  - name: default.section-name-cross-namespace.0
+    route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:
@@ -172,12 +176,14 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: group-namespace1.bind-cross-namespace.0
+    route:
     - destination:
         host: httpbin.group-namespace1.svc.domain.suffix
         port:
           number: 86
-  - route:
+  - name: group-namespace2.bind-cross-namespace.0
+    route:
     - destination:
         host: httpbin.group-namespace2.svc.domain.suffix
         port:
@@ -198,7 +204,8 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: istio-system.same-namespace-valid.0
+    route:
     - destination:
         host: httpbin.istio-system.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/route-precedence.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-precedence.yaml.golden
@@ -35,6 +35,7 @@ spec:
   - match:
     - uri:
         regex: /foo((\/).*)?
+    name: allowed-1.http.1
     route:
     - destination:
         host: svc2.allowed-1.svc.domain.suffix
@@ -43,6 +44,7 @@ spec:
   - match:
     - uri:
         prefix: /foo/bar
+    name: allowed-2.http.0
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -57,6 +59,7 @@ spec:
           regex: some-value
       uri:
         exact: /baz
+    name: allowed-2.http.1
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -68,6 +71,7 @@ spec:
           exact: some-value
       uri:
         prefix: /foo
+    name: allowed-1.http.0
     route:
     - destination:
         host: svc1.allowed-1.svc.domain.suffix
@@ -76,6 +80,7 @@ spec:
   - match:
     - uri:
         prefix: /bar
+    name: allowed-2.http.0
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -84,6 +89,7 @@ spec:
   - match:
     - uri:
         prefix: /
+    name: allowed-2.http.2
     route:
     - destination:
         host: svc3.allowed-2.svc.domain.suffix
@@ -108,6 +114,7 @@ spec:
   - match:
     - uri:
         regex: /foo((\/).*)?
+    name: allowed-1.http.1
     route:
     - destination:
         host: svc2.allowed-1.svc.domain.suffix
@@ -119,6 +126,7 @@ spec:
           exact: some-value
       uri:
         prefix: /foo
+    name: allowed-1.http.0
     route:
     - destination:
         host: svc1.allowed-1.svc.domain.suffix
@@ -143,6 +151,7 @@ spec:
   - match:
     - uri:
         regex: /foo((\/).*)?
+    name: allowed-1.http.1
     route:
     - destination:
         host: svc2.allowed-1.svc.domain.suffix
@@ -154,6 +163,7 @@ spec:
           exact: some-value
       uri:
         prefix: /foo
+    name: allowed-1.http.0
     route:
     - destination:
         host: svc1.allowed-1.svc.domain.suffix
@@ -178,6 +188,7 @@ spec:
   - match:
     - uri:
         regex: /foo((\/).*)?
+    name: allowed-1.http.1
     route:
     - destination:
         host: svc2.allowed-1.svc.domain.suffix
@@ -189,6 +200,7 @@ spec:
           exact: some-value
       uri:
         prefix: /foo
+    name: allowed-1.http.0
     route:
     - destination:
         host: svc1.allowed-1.svc.domain.suffix
@@ -213,6 +225,7 @@ spec:
   - match:
     - uri:
         prefix: /foo/bar
+    name: allowed-2.http.0
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -227,6 +240,7 @@ spec:
           regex: some-value
       uri:
         exact: /baz
+    name: allowed-2.http.1
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -235,6 +249,7 @@ spec:
   - match:
     - uri:
         prefix: /bar
+    name: allowed-2.http.0
     route:
     - destination:
         host: svc2.allowed-2.svc.domain.suffix
@@ -243,6 +258,7 @@ spec:
   - match:
     - uri:
         prefix: /
+    name: allowed-2.http.2
     route:
     - destination:
         host: svc3.allowed-2.svc.domain.suffix

--- a/pilot/pkg/config/kube/gateway/testdata/serviceentry.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/serviceentry.yaml.golden
@@ -31,7 +31,8 @@ spec:
   hosts:
   - '*'
   http:
-  - route:
+  - name: default.http.0
+    route:
     - destination:
         host: google.com
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/tls.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tls.yaml.golden
@@ -74,7 +74,8 @@ spec:
   hosts:
   - domain.example
   http:
-  - route:
+  - name: default.http.0
+    route:
     - destination:
         host: httpbin.default.svc.domain.suffix
         port:

--- a/pilot/pkg/config/kube/gateway/testdata/weighted.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/weighted.yaml.golden
@@ -52,6 +52,7 @@ spec:
   - match:
     - uri:
         prefix: /weighted-100
+    name: default.http.1
     route:
     - destination:
         host: foo-svc.default.svc.domain.suffix
@@ -67,6 +68,7 @@ spec:
   - match:
     - uri:
         prefix: /get
+    name: default.http.0
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix

--- a/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.yaml.golden
@@ -34,6 +34,7 @@ spec:
   - match:
     - uri:
         prefix: /weighted-100
+    name: default.http.1
     route:
     - destination:
         host: foo-svc.default.svc.domain.suffix
@@ -48,4 +49,5 @@ spec:
     match:
     - uri:
         prefix: /get
+    name: default.http.0
 ---


### PR DESCRIPTION
**Please provide a description of this PR:**

Add a default name for the routes generated in Gateway/GAMMA - it allows better debugging and EnvoyFilters
targeting such routes.