### PR TITLE
Make istio_authn filter optional for gateway < 1.17

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -692,6 +692,9 @@ var (
 
 	EnableDualStack = env.RegisterBoolVar("ISTIO_DUAL_STACK", false,
 		"If enabled, pilot will configure clusters/listeners/routes for dual stack capability.").Get()
+
+	EnableGatewayAuthnFilter = env.RegisterBoolVar("PILOT_ENABLE_GATEWAY_AUTHN_FILTER", true,
+	"If enabled, pilot will configure istio_authn filter at gateway. To be disabled if gateway version < 1.17").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -145,7 +145,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 			}
 
 			for cnum := range mutable.FilterChains {
-				if util.IsIstioVersionGE117(builder.node.IstioVersion) {
+				if util.IsIstioVersionGE117(builder.node.IstioVersion) && features.EnableGatewayAuthnFilter {
 					mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, xdsfilters.IstioNetworkAuthenticationFilter)
 				}
 				if mutable.FilterChains[cnum].ListenerProtocol == istionetworking.ListenerProtocolTCP {


### PR DESCRIPTION
- With recent Istio upgrade to 1.17 from master we noticed in our environment that gateway proxy running on 1.15 fails with this error:

```
Didn't find a registered implementation for name: 'istio_authn'

```
- Upgrading gateway proxy to 1.17 latest master fixes the issue.

- This PR introduces a controplane knob `PILOT_ENABLE_GATEWAY_AUTHN_FILTER` defaulting to `true` so that we can set it to false in our env and not configure this filter for old gateway proxies.