### PR TITLE
Set valid target port when sidecar ingress port specified

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -469,7 +469,7 @@ func (lb *ListenerBuilder) buildInboundChainConfigs() []inboundChainConfig {
 			port := ServiceInstancePort{
 				Name:       i.Port.Name,
 				Port:       i.Port.Number,
-				TargetPort: i.Port.Number, // No targetPort support in the API
+				TargetPort: findTargetPort(i.Port.Number, lb.node.ServiceInstances),
 				Protocol:   protocol.Parse(i.Port.Protocol),
 			}
 			bindtoPort := getBindToPort(i.CaptureMode, lb.node)
@@ -524,6 +524,16 @@ func (lb *ListenerBuilder) buildInboundChainConfigs() []inboundChainConfig {
 	})
 
 	return chainConfigs
+}
+
+func findTargetPort(svcPort uint32, serviceInstances []*model.ServiceInstance) uint32 {
+	for _, instance := range serviceInstances {
+		if uint32(instance.ServicePort.Port) == svcPort {
+			return instance.Endpoint.EndpointPort
+		}
+	}
+
+	return svcPort
 }
 
 // getBindToPort determines whether we should bind to port based on the chain-specific config and the proxy


### PR DESCRIPTION
**Please provide a description of this PR:**

Though this was meant to support VM, but as istio evolves, it is not limited to that. Now we can set it for k8s service, and in this case I do not think it works when svc port != target port