### PR TITLE
agent: fail fast on first error

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/common/expfmt"
@@ -578,13 +577,12 @@ func scrapeAndWriteAgentMetrics(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	var errs error
 	for _, mf := range mfs {
 		if err := enc.Encode(mf); err != nil {
-			errs = multierror.Append(errs, err)
+			return err
 		}
 	}
-	return errs
+	return nil
 }
 
 func applyHeaders(into http.Header, from http.Header, keys ...string) {


### PR DESCRIPTION
Currently, we join all errors. Its better to fail on first because:

* Prometheus does this: https://github.com/prometheus/client_golang/blob/main/prometheus/promhttp/http.go#L205-L207
* Without it we get logs like
```
2022-12-16T21:54:52.211619Z     error   failed scraping and writing agent metrics: 28 errors occurred:
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
        * write tcp 10.244.0.46:15020->10.244.0.27:53666: write: broken pipe
```