### PR TITLE
TestSidecarRoutes: re-enable for Gateway API

### DIFF
--- a/pilot/pkg/config/kube/crd/config.go
+++ b/pilot/pkg/config/kube/crd/config.go
@@ -15,8 +15,6 @@
 package crd
 
 import (
-	"istio.io/istio/pkg/config"
-	kubelib "istio.io/istio/pkg/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -70,33 +68,6 @@ func (in *IstioKind) DeepCopyObject() runtime.Object {
 	}
 
 	return nil
-}
-
-func SlowConvertKindsToRuntimeObjects(in []IstioKind) ([]runtime.Object, error) {
-	res := make([]runtime.Object, 0, len(in))
-	for _, o := range in {
-		if r, err := SlowConvertToRuntimeObject(&o); err != nil {
-			return nil, err
-		} else {
-			res = append(res, r)
-		}
-	}
-	return res, nil
-}
-
-// SlowConvertToRuntimeObject converts an IstioKind to a runtime.Object.
-// As the name implies, it is not efficient.
-func SlowConvertToRuntimeObject(in *IstioKind) (runtime.Object, error) {
-	by, err := config.ToJSON(in)
-	if err != nil {
-		return nil, err
-	}
-	gvk := in.GetObjectKind().GroupVersionKind()
-	obj, _, err := kubelib.IstioCodec.UniversalDeserializer().Decode(by, &gvk, nil)
-	if err != nil {
-		return nil, err
-	}
-	return obj, nil
 }
 
 // IstioObject is a k8s wrapper interface for config objects

--- a/pilot/pkg/config/kube/crd/config.go
+++ b/pilot/pkg/config/kube/crd/config.go
@@ -15,6 +15,8 @@
 package crd
 
 import (
+	"istio.io/istio/pkg/config"
+	kubelib "istio.io/istio/pkg/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -68,6 +70,33 @@ func (in *IstioKind) DeepCopyObject() runtime.Object {
 	}
 
 	return nil
+}
+
+func SlowConvertKindsToRuntimeObjects(in []IstioKind) ([]runtime.Object, error) {
+	res := make([]runtime.Object, 0, len(in))
+	for _, o := range in {
+		if r, err := SlowConvertToRuntimeObject(&o); err != nil {
+			return nil, err
+		} else {
+			res = append(res, r)
+		}
+	}
+	return res, nil
+}
+
+// SlowConvertToRuntimeObject converts an IstioKind to a runtime.Object.
+// As the name implies, it is not efficient.
+func SlowConvertToRuntimeObject(in *IstioKind) (runtime.Object, error) {
+	by, err := config.ToJSON(in)
+	if err != nil {
+		return nil, err
+	}
+	gvk := in.GetObjectKind().GroupVersionKind()
+	obj, _, err := kubelib.IstioCodec.UniversalDeserializer().Decode(by, &gvk, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
 }
 
 // IstioObject is a k8s wrapper interface for config objects

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2404,27 +2404,27 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Matches:   []string{"a.example.org", "b.example.org"},
+					Matches:   []string{"known.default.svc.cluster.local", "alt-known.default.svc.cluster.local"},
 					Dest:      "example.com",
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/known.default.svc.cluster.local", "*/a.example.org"},
+					Egress:    []string{"*/known.default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
 				// imported
-				"a.example.org": {"outbound|80||example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||example.com"},
 				// Not imported but we include it anyway
-				"b.example.org": {"outbound|80||example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||example.com"},
 			},
 			expectedGateway: map[string][]string{
 				// imported
-				"a.example.org": {"outbound|80||example.com"},
-				// Not imported but we include it anyway
-				"b.example.org": nil,
+				"known.default.svc.cluster.local": {"outbound|80||example.com"},
+				// Not imported
+				"alt-known.default.svc.cluster.local": nil,
 			},
 		},
 	}
@@ -2467,10 +2467,6 @@ spec:
 						got := gotHosts[wk]
 						if !reflect.DeepEqual(wv, got) {
 							t.Errorf("%q: wanted %v, got %v (had %v)", wk, wv, got, xdstest.MapKeys(gotHosts))
-							t.Log(xdstest.Dump(t, vh))
-							for k, v := range gotHosts {
-								t.Logf("%q: %v", k, v)
-							}
 						}
 					}
 				})

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -26,11 +26,11 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -2272,11 +2273,11 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
-				"*.cluster.local":             nil,
+				"*.cluster.local":                 nil,
 			},
 			expectedGateway: map[string][]string{
 				"known.default.svc.cluster.local": {"outbound|80||known.default.svc.cluster.local"},
-				"*.cluster.local":             nil,
+				"*.cluster.local":                 nil,
 			},
 		},
 		{
@@ -2295,14 +2296,14 @@ spec:
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known.default.svc.cluster.local":     nil,                                            // Not imported
+				"known.default.svc.cluster.local":     nil,                                                  // Not imported
 				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"}, // No change
-				"*.example.org":                 {"outbound|80||arbitrary.example.com"},
+				"*.example.org":                       {"outbound|80||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
-				"known.default.svc.cluster.local":     nil,                                            // Not imported
+				"known.default.svc.cluster.local":     nil,                                                  // Not imported
 				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"}, // No change
-				"*.example.org":                 nil,                                            // Not imported
+				"*.example.org":                       nil,                                                  // Not imported
 			},
 		},
 		{
@@ -2437,11 +2438,11 @@ spec:
 					for _, tc := range tt.cfg {
 						cfg = cfg + "\n---\n" + tc.Config(t, variant)
 					}
-					istio, kube, err := crd.ParseInputs(cfg)
+					istio, k, err := crd.ParseInputs(cfg)
 					if err != nil {
 						t.Fatal(err)
 					}
-					kubeo, err := crd.SlowConvertKindsToRuntimeObjects(kube)
+					kubeo, err := kube.SlowConvertKindsToRuntimeObjects(k)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -26,6 +26,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -1626,10 +1627,13 @@ metadata:
   creationTimestamp: "{{.Time}}"
 spec:
   parentRefs:
-  - kind: TODO
-    name: TODO
-{{ with .PortMatch }}
+{{- range $val := .Matches }}
+  - kind: ServiceEntry
+    group: networking.istio.io
+    name: "{{$val}}"
+{{ with $.PortMatch }}
     port: {{.}}
+{{ end }}
 {{ end }}
   hostnames:
 {{- range $val := .Matches }}
@@ -1694,69 +1698,44 @@ spec:
 
 func TestSidecarRoutes(t *testing.T) {
 	knownServices := `
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
+apiVersion: v1
+kind: Service
 metadata:
-  name: known-default.example.com
+  name: known
   namespace: default
 spec:
-  hosts:
-  - known-default.example.com
-  addresses:
-  - 2.0.0.0
-  endpoints:
-  - address: 1.0.0.0
-  resolution: STATIC
+  clusterIP: 2.0.0.0
   ports:
-  - name: http
-    number: 80
-    protocol: HTTP
-  - name: http-other
-    number: 8080
-    protocol: HTTP
+  - port: 80
+    name: http
+  - port: 8080
+    name: http
 ---
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
+apiVersion: v1
+kind: Service
 metadata:
-  name: alt-known-default.example.com
+  name: alt-known
   namespace: default
 spec:
-  hosts:
-  - alt-known-default.example.com
-  addresses:
-  - 2.0.0.1
-  endpoints:
-  - address: 1.0.0.1
-  resolution: STATIC
+  clusterIP: 2.0.0.1
   ports:
-  - name: http
-    number: 80
-    protocol: HTTP
-  - name: http-other
-    number: 8080
-    protocol: HTTP
+  - port: 80
+    name: http
+  - port: 8080
+    name: http
 ---
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
+apiVersion: v1
+kind: Service
 metadata:
-  name: not-default.example.org
+  name: not-default
   namespace: not-default
 spec:
-  hosts:
-  - not-default.example.org
-  addresses:
-  - 2.0.0.2
-  endpoints:
-  - address: 1.0.0.2
-  resolution: STATIC
+  clusterIP: 2.0.0.2
   ports:
-  - name: http
-    number: 80
-    protocol: HTTP
-  - name: http-other
-    number: 8080
-    protocol: HTTP
----
+  - port: 80
+    name: http
+  - port: 8080
+    name: http
 `
 	proxy := func(ns string) *model.Proxy {
 		return &model.Proxy{ConfigNamespace: ns}
@@ -1774,29 +1753,29 @@ spec:
 			name: "simple port 80",
 			cfg: []Configer{vsArgs{
 				Namespace: "default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "simple port 8080",
 			cfg: []Configer{vsArgs{
 				Namespace: "default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("default"),
 			routeName: "8080",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|8080||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|8080||alt-known.default.svc.cluster.local"},
 			},
 			expectedGateway: map[string][]string{
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
@@ -1860,87 +1839,87 @@ spec:
 			name: "producer rule port 80",
 			cfg: []Configer{vsArgs{
 				Namespace: "default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "producer rule port 8080",
 			cfg: []Configer{vsArgs{
 				Namespace: "default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "8080",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|8080||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|8080||alt-known.default.svc.cluster.local"},
 			},
 			expectedGateway: map[string][]string{ // No implicit port matching for gateway
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "consumer rule port 80",
 			cfg: []Configer{vsArgs{
 				Namespace: "not-default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "consumer rule port 8080",
 			cfg: []Configer{vsArgs{
 				Namespace: "not-default",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "8080",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|8080||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|8080||alt-known.default.svc.cluster.local"},
 			},
 			expectedGateway: map[string][]string{ // No implicit port matching for gateway
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "arbitrary rule port 80",
 			cfg: []Configer{vsArgs{
 				Namespace: "arbitrary",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
 			name: "arbitrary rule port 8080",
 			cfg: []Configer{vsArgs{
 				Namespace: "arbitrary",
-				Match:     "known-default.example.com",
-				Dest:      "alt-known-default.example.com",
+				Match:     "known.default.svc.cluster.local",
+				Dest:      "alt-known.default.svc.cluster.local",
 			}},
 			proxy:     proxy("not-default"),
 			routeName: "8080",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|8080||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|8080||alt-known.default.svc.cluster.local"},
 			},
 			expectedGateway: map[string][]string{ // No implicit port matching for gateway
-				"known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
 		},
 		{
@@ -1948,19 +1927,19 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "arbitrary",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "arbitrary.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "default.example.com",
 					Time:      TimeBase,
 				},
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "not-default.example.com",
 					Time:      TimeNewer,
 				},
@@ -1969,11 +1948,11 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// Oldest wins
-				"known-default.example.com": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
 				// TODO: consumer namespace wins
-				"known-default.example.com": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 			},
 		},
 		{
@@ -1981,19 +1960,19 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "arbitrary",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "arbitrary.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "default.example.com",
 					Time:      TimeBase,
 				},
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "not-default.example.com",
 					Time:      TimeNewer,
 				},
@@ -2002,11 +1981,11 @@ spec:
 			routeName: "8080",
 			expected: map[string][]string{
 				// Oldest wins
-				"known-default.example.com": {"outbound|8080||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|8080||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
 				// TODO: Consumer gateway wins. No implicit destination port for Gateway
-				"known-default.example.com": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 			},
 		},
 		{
@@ -2020,8 +1999,8 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// match no VS, get default config
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
-				"known-default.example.com":     {"outbound|80||known-default.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				"known.default.svc.cluster.local":     {"outbound|80||known.default.svc.cluster.local"},
 				// Wildcard doesn't match any known services, insert it as-is
 				"*.unknown.example.com": {"outbound|80||arbitrary.example.com"},
 			},
@@ -2031,28 +2010,28 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "arbitrary.example.com",
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/*.example.com"},
+					Egress:    []string{"*/*.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"alt-known-default.example.com": {"outbound|80||arbitrary.example.com"},
-				"known-default.example.com":     {"outbound|80||arbitrary.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||arbitrary.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 			expectedGateway: map[string][]string{
 				// Exact service matches do not get the wildcard applied
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
-				"known-default.example.com":     {"outbound|80||known-default.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				"known.default.svc.cluster.local":     {"outbound|80||known.default.svc.cluster.local"},
 				// The wildcard
-				"*.example.com": {"outbound|80||arbitrary.example.com"},
+				"*.cluster.local": {"outbound|80||arbitrary.example.com"},
 			},
 		},
 		{
@@ -2060,13 +2039,13 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "wild.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "explicit.example.com",
 					Time:      TimeNewer,
 				},
@@ -2074,18 +2053,18 @@ spec:
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"alt-known-default.example.com": {"outbound|80||wild.example.com"},
-				"known-default.example.com":     {"outbound|80||wild.example.com"}, // oldest wins
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"}, // oldest wins
 				// Matched an exact service, so we have no route for the wildcard
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 			expectedGateway: map[string][]string{
 				// No overrides, use default
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 				// Explicit has precedence
-				"known-default.example.com": {"outbound|80||explicit.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
 				// Last is our wildcard
-				"*.example.com": {"outbound|80||wild.example.com"},
+				"*.cluster.local": {"outbound|80||wild.example.com"},
 			},
 		},
 		{
@@ -2093,13 +2072,13 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "wild.example.com",
 					Time:      TimeNewer,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "explicit.example.com",
 					Time:      TimeOlder,
 				},
@@ -2107,18 +2086,18 @@ spec:
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"alt-known-default.example.com": {"outbound|80||wild.example.com"},
-				"known-default.example.com":     {"outbound|80||explicit.example.com"}, // oldest wins
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"}, // oldest wins
 				// Matched an exact service, so we have no route for the wildcard
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 			expectedGateway: map[string][]string{
 				// No overrides, use default
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 				// Explicit has precedence
-				"known-default.example.com": {"outbound|80||explicit.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
 				// Last is our wildcard
-				"*.example.com": {"outbound|80||wild.example.com"},
+				"*.cluster.local": {"outbound|80||wild.example.com"},
 			},
 		},
 		{
@@ -2126,37 +2105,37 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "wild.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "explicit.example.com",
 					Time:      TimeNewer,
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"default/known-default.example.com", "default/alt-known-default.example.com"},
+					Egress:    []string{"default/known.default.svc.cluster.local", "default/alt-known.default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				// Even though we did not import `*.example.com`, the VS attaches
-				"alt-known-default.example.com": {"outbound|80||wild.example.com"},
-				"known-default.example.com":     {"outbound|80||wild.example.com"},
+				// Even though we did not import `*.cluster.local`, the VS attaches
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 			expectedGateway: map[string][]string{
 				// No rule imported
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 				// Imported rule
-				"known-default.example.com": {"outbound|80||explicit.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
 				// Not imported
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 		},
 		{
@@ -2164,29 +2143,29 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "wild.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "explicit.example.com",
 					Time:      TimeNewer,
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"default/known-default.example.com", "default/alt-known-default.example.com"},
+					Egress:    []string{"default/known.default.svc.cluster.local", "default/alt-known.default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
 				// Similar to above, but now the older wildcard VS is in a complete different namespace which we don't import
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
-				"known-default.example.com":     {"outbound|80||explicit.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
-				"*.example.com": nil,
+				"*.cluster.local": nil,
 			},
 		},
 		{
@@ -2194,13 +2173,13 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "*.com",
+					Match:     "*.cluster.local",
 					Dest:      "wild.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "explicit.example.com",
 					Time:      TimeNewer,
 				},
@@ -2209,17 +2188,17 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// Wildcard is older, so it wins, even though it is cross namespace
-				"alt-known-default.example.com": {"outbound|80||wild.example.com"},
-				"known-default.example.com":     {"outbound|80||wild.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
-				"*.com": nil,
+				"*.cluster.local": nil,
 			},
 			expectedGateway: map[string][]string{
 				// Exact match wins
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"},
-				"known-default.example.com":     {"outbound|80||explicit.example.com"},
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
 				// Wildcard last
-				"*.com": {"outbound|80||wild.example.com"},
+				"*.cluster.local": {"outbound|80||wild.example.com"},
 			},
 		},
 		{
@@ -2242,7 +2221,7 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// wildcard does not match
-				"known-default.example.com": {"outbound|80||known-default.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||known.default.svc.cluster.local"},
 				// Even though its less exact, this wildcard wins
 				"*.tld":         {"outbound|80||wild.example.com"},
 				"*.example.tld": nil,
@@ -2253,18 +2232,18 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "arbitrary.example.com",
-					Dest:      "arbitrary.example.com",
+					Match:     "arbitrary.svc.cluster.local",
+					Dest:      "arbitrary.svc.cluster.local",
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/*.example.com"},
+					Egress:    []string{"*/*.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"arbitrary.example.com": {"outbound|80||arbitrary.example.com"},
+				"arbitrary.svc.cluster.local": {"outbound|80||arbitrary.svc.cluster.local"},
 			},
 		},
 		{
@@ -2272,23 +2251,23 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "arbitrary.example.com",
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/known-default.example.com"},
+					Egress:    []string{"*/known.default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||arbitrary.example.com"},
-				"*.example.com":             nil,
+				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
+				"*.cluster.local":             nil,
 			},
 			expectedGateway: map[string][]string{
-				"known-default.example.com": {"outbound|80||known-default.example.com"},
-				"*.example.com":             nil,
+				"known.default.svc.cluster.local": {"outbound|80||known.default.svc.cluster.local"},
+				"*.cluster.local":             nil,
 			},
 		},
 		{
@@ -2301,19 +2280,19 @@ spec:
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/explicit.example.org", "*/alt-known-default.example.com"},
+					Egress:    []string{"*/explicit.example.org", "*/alt-known.default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com":     nil,                                            // Not imported
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"}, // No change
+				"known.default.svc.cluster.local":     nil,                                            // Not imported
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"}, // No change
 				"*.example.org":                 {"outbound|80||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
-				"known-default.example.com":     nil,                                            // Not imported
-				"alt-known-default.example.com": {"outbound|80||alt-known-default.example.com"}, // No change
+				"known.default.svc.cluster.local":     nil,                                            // Not imported
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"}, // No change
 				"*.example.org":                 nil,                                            // Not imported
 			},
 		},
@@ -2322,26 +2301,26 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "*.example.com",
+					Match:     "*.cluster.local",
 					Dest:      "arbitrary.example.com",
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "explicit.example.com",
-					Dest:      "explicit.example.com",
+					Match:     "explicit.default.svc.cluster.local",
+					Dest:      "explicit.default.svc.cluster.local",
 				},
 				scArgs{
 					Namespace: "not-default",
-					Egress:    []string{"not-default/*.example.com", "not-default/not-default.example.org"},
+					Egress:    []string{"not-default/*.cluster.local", "not-default/not-default.example.org"},
 				},
 			},
 			proxy:     proxy("not-default"),
 			routeName: "80",
 			expected: map[string][]string{
-				// even though there is an *.example.com, since we do not import it we should create a wildcard matcher
-				"*.example.com": {"outbound|80||arbitrary.example.com"},
+				// even though there is an *.cluster.local, since we do not import it we should create a wildcard matcher
+				"*.cluster.local": {"outbound|80||arbitrary.example.com"},
 				// We did not import this, shouldn't show up
-				"explicit.example.com": nil,
+				"explicit.default.svc.cluster.local": nil,
 			},
 		},
 		{
@@ -2349,13 +2328,13 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "old.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "new.example.com",
 					Time:      TimeNewer,
 				},
@@ -2363,7 +2342,7 @@ spec:
 			proxy:     proxy("default"),
 			routeName: "80",
 			expected: map[string][]string{
-				"known-default.example.com": {"outbound|80||old.example.com"}, // oldest wins
+				"known.default.svc.cluster.local": {"outbound|80||old.example.com"}, // oldest wins
 			},
 		},
 		{
@@ -2371,13 +2350,13 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "producer.example.com",
 					Time:      TimeOlder,
 				},
 				vsArgs{
 					Namespace: "default",
-					Match:     "known-default.example.com",
+					Match:     "known.default.svc.cluster.local",
 					Dest:      "consumer.example.com",
 					Time:      TimeNewer,
 				},
@@ -2386,11 +2365,11 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				// oldest wins
-				"known-default.example.com": {"outbound|80||producer.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||producer.example.com"},
 			},
 			expectedGateway: map[string][]string{
 				// TODO: consumer namespace wins
-				"known-default.example.com": {"outbound|80||producer.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||producer.example.com"},
 			},
 		},
 		{
@@ -2421,7 +2400,7 @@ spec:
 				},
 				scArgs{
 					Namespace: "default",
-					Egress:    []string{"*/known-default.example.com", "*/a.example.org"},
+					Egress:    []string{"*/known.default.svc.cluster.local", "*/a.example.org"},
 				},
 			},
 			proxy:     proxy("default"),
@@ -2441,8 +2420,7 @@ spec:
 		},
 	}
 	// TODO test httproute when support for arbitrary hostnames is added in the GEP
-	// TODO for _, variant := range []string{"httproute", "virtualservice"} {
-	for _, variant := range []string{"virtualservice"} {
+	for _, variant := range []string{"httproute", "virtualservice"} {
 		t.Run(variant, func(t *testing.T) {
 			for _, tt := range cases {
 				t.Run(tt.name, func(t *testing.T) {
@@ -2450,7 +2428,18 @@ spec:
 					for _, tc := range tt.cfg {
 						cfg = cfg + "\n---\n" + tc.Config(variant)
 					}
-					s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: cfg})
+					istio, kube, err := crd.ParseInputs(cfg)
+					if err != nil {
+						t.Fatal(err)
+					}
+					kubeo, err := crd.SlowConvertKindsToRuntimeObjects(kube)
+					if err != nil {
+						t.Fatal(err)
+					}
+					s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+						Configs:           istio,
+						KubernetesObjects: kubeo,
+					})
 					sim := simulation.NewSimulation(t, s, s.SetupProxy(tt.proxy))
 					xdstest.ValidateListeners(t, sim.Listeners)
 					xdstest.ValidateRouteConfigurations(t, sim.Routes)
@@ -2468,7 +2457,11 @@ spec:
 					for wk, wv := range exp {
 						got := gotHosts[wk]
 						if !reflect.DeepEqual(wv, got) {
-							t.Errorf("%v: wanted %v, got %v (had %v)", wk, wv, got, xdstest.MapKeys(gotHosts))
+							t.Errorf("%q: wanted %v, got %v (had %v)", wk, wv, got, xdstest.MapKeys(gotHosts))
+							t.Log(xdstest.Dump(t, vh))
+							for k, v := range gotHosts {
+								t.Logf("%q: %v", k, v)
+							}
 						}
 					}
 				})

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2301,7 +2301,7 @@ spec:
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
-					Match:     "*.cluster.local",
+					Match:     "*.default.svc.cluster.local",
 					Dest:      "arbitrary.example.com",
 				},
 				vsArgs{
@@ -2311,14 +2311,14 @@ spec:
 				},
 				scArgs{
 					Namespace: "not-default",
-					Egress:    []string{"not-default/*.cluster.local", "not-default/not-default.example.org"},
+					Egress:    []string{"not-default/*.default.svc.cluster.local", "not-default/not-default.not-default.svc.cluster.local"},
 				},
 			},
 			proxy:     proxy("not-default"),
 			routeName: "80",
 			expected: map[string][]string{
-				// even though there is an *.cluster.local, since we do not import it we should create a wildcard matcher
-				"*.cluster.local": {"outbound|80||arbitrary.example.com"},
+				// even though there is an *.svc.cluster.local, since we do not import it we should create a wildcard matcher
+				"*.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 				// We did not import this, shouldn't show up
 				"explicit.default.svc.cluster.local": nil,
 			},

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -32,7 +32,6 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -486,7 +485,7 @@ func getKubernetesObjects(t test.Failer, opts FakeOptions) map[cluster.ID][]runt
 
 func kubernetesObjectsFromString(s string) ([]runtime.Object, error) {
 	var objects []runtime.Object
-	decode := scheme.Codecs.UniversalDeserializer().Decode
+	decode := kubelib.IstioCodec.UniversalDeserializer().Decode
 	objectStrs := strings.Split(s, "---")
 	for _, s := range objectStrs {
 		if len(strings.TrimSpace(s)) == 0 {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -41,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
@@ -1251,6 +1252,7 @@ func isEmptyFile(f string) bool {
 
 // IstioScheme returns a scheme will all known Istio-related types added
 var IstioScheme = istioScheme()
+var IstioCodec = serializer.NewCodecFactory(IstioScheme)
 
 // FakeIstioScheme is an IstioScheme that has List type registered.
 var FakeIstioScheme = func() *runtime.Scheme {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1251,8 +1251,10 @@ func isEmptyFile(f string) bool {
 }
 
 // IstioScheme returns a scheme will all known Istio-related types added
-var IstioScheme = istioScheme()
-var IstioCodec = serializer.NewCodecFactory(IstioScheme)
+var (
+	IstioScheme = istioScheme()
+	IstioCodec  = serializer.NewCodecFactory(IstioScheme)
+)
 
 // FakeIstioScheme is an IstioScheme that has List type registered.
 var FakeIstioScheme = func() *runtime.Scheme {

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -308,11 +308,11 @@ func StripUnusedFields(obj any) (any, error) {
 func SlowConvertKindsToRuntimeObjects(in []crd.IstioKind) ([]runtime.Object, error) {
 	res := make([]runtime.Object, 0, len(in))
 	for _, o := range in {
-		if r, err := SlowConvertToRuntimeObject(&o); err != nil {
+		r, err := SlowConvertToRuntimeObject(&o)
+		if err != nil {
 			return nil, err
-		} else {
-			res = append(res, r)
 		}
+		res = append(res, r)
 	}
 	return res, nil
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pkg/config"
 	istioversion "istio.io/pkg/version"
 )
 
@@ -300,5 +302,32 @@ func StripUnusedFields(obj any) (any, error) {
 	}
 	// ManagedFields is large and we never use it
 	t.GetObjectMeta().SetManagedFields(nil)
+	return obj, nil
+}
+
+func SlowConvertKindsToRuntimeObjects(in []crd.IstioKind) ([]runtime.Object, error) {
+	res := make([]runtime.Object, 0, len(in))
+	for _, o := range in {
+		if r, err := SlowConvertToRuntimeObject(&o); err != nil {
+			return nil, err
+		} else {
+			res = append(res, r)
+		}
+	}
+	return res, nil
+}
+
+// SlowConvertToRuntimeObject converts an IstioKind to a runtime.Object.
+// As the name implies, it is not efficient.
+func SlowConvertToRuntimeObject(in *crd.IstioKind) (runtime.Object, error) {
+	by, err := config.ToJSON(in)
+	if err != nil {
+		return nil, err
+	}
+	gvk := in.GetObjectKind().GroupVersionKind()
+	obj, _, err := IstioCodec.UniversalDeserializer().Decode(by, &gvk, nil)
+	if err != nil {
+		return nil, err
+	}
 	return obj, nil
 }


### PR DESCRIPTION
As part of the GAMMA impl, this was removed because we can't attach to arbitrary hostnames. However, nothing in the test actually applies to arbitrary hostnames -- we can do the same test using Service, but in a way to support both modes.

There are a few tests with wildcards we genuinely can't do with gateway (yet), so those are skipped.

This also introduces some helper functions to make it easier to use K8s and Istio types in a single YAML, for tests.

cc @frankbu 