### PR TITLE
add cookie path support to config via label istio.io/persistent-session

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -271,6 +271,9 @@ func TestGRPC(t *testing.T) {
 		if sc.Cookie.Name != "test-cookie" {
 			t.Fatal("Missing expected cookie name", sc.Cookie)
 		}
+		if sc.Cookie.Path != "/Service/Method" {
+			t.Fatal("Missing expected cookie path", sc.Cookie)
+		}
 		clusterName := "outbound|9999||echo-persistent.test.svc.cluster.local"
 		adscConn.Send(&discovery.DiscoveryRequest{
 			TypeUrl:       v3.EndpointType,
@@ -353,7 +356,7 @@ func initPersistent(sd *memory.ServiceDiscovery) {
 		Attributes: model.ServiceAttributes{
 			Name:      svcname,
 			Namespace: ns,
-			Labels:    map[string]string{features.PersistentSessionLabel: "test-cookie"},
+			Labels:    map[string]string{features.PersistentSessionLabel: "test-cookie:/Service/Method"},
 		},
 		Hostname:       host.Name(hn),
 		DefaultAddress: "127.0.5.2",

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -298,6 +298,11 @@ func buildOutboundListeners(node *model.Proxy, push *model.PushContext, filter l
 				if features.PersistentSessionLabel != "" {
 					sessionCookie := sv.Attributes.Labels[features.PersistentSessionLabel]
 					if sessionCookie != "" {
+						cookieNamePath := strings.Split(sessionCookie, ":")
+						cookiePath := "/"
+						if len(cookieNamePath) > 1 {
+							cookiePath = cookieNamePath[1]
+						}
 						filters = append(filters, &hcm.HttpFilter{
 							Name: "envoy.filters.http.stateful_session", // TODO: wellknown.
 							ConfigType: &hcm.HttpFilter_TypedConfig{
@@ -306,9 +311,9 @@ func buildOutboundListeners(node *model.Proxy, push *model.PushContext, filter l
 										Name: "envoy.http.stateful_session.cookie",
 										TypedConfig: protoconv.MessageToAny(&cookiev3.CookieBasedSessionState{
 											Cookie: &httpv3.Cookie{
-												Path: "/",
+												Path: cookiePath,
 												Ttl:  &durationpb.Duration{Seconds: 120},
-												Name: sessionCookie,
+												Name: cookieNamePath[0],
 											},
 										}),
 									},


### PR DESCRIPTION
**Please provide a description of this PR:**
This is an enhancement over the previous PR #40660 to add cookie path support via the label configuration