### PR TITLE
feat(operator): override default k8s version from helm default capabilities

### DIFF
--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -10135,7 +10135,7 @@ spec:
           secretName: istio-kubeconfig
           optional: true
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-egressgateway
@@ -10154,7 +10154,7 @@ spec:
       app: istio-egressgateway
       istio: egressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
@@ -10173,7 +10173,7 @@ spec:
       app: istio-ingressgateway
       istio: ingressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -2933,7 +2933,7 @@ spec:
           secretName: istio-kubeconfig
           optional: true
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -29,6 +29,7 @@ import (
 
 	"istio.io/istio/manifests"
 	"istio.io/istio/operator/pkg/util"
+	operator_version "istio.io/istio/operator/version"
 	"istio.io/pkg/log"
 )
 
@@ -111,6 +112,11 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 	}
 
 	caps := *chartutil.DefaultCapabilities
+
+	// overwrite helm default capabilities
+	operatorVersion, _ := chartutil.ParseKubeVersion(operator_version.OperatorKubernetesMinSupportedVersion)
+	caps.KubeVersion = *operatorVersion
+
 	if version != nil {
 		caps.KubeVersion = chartutil.KubeVersion{
 			Version: version.GitVersion,

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -27,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/yaml"
 
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	"istio.io/istio/manifests"
 	"istio.io/istio/operator/pkg/util"
-	operator_version "istio.io/istio/operator/version"
 	"istio.io/pkg/log"
 )
 
@@ -114,7 +115,7 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 	caps := *chartutil.DefaultCapabilities
 
 	// overwrite helm default capabilities
-	operatorVersion, _ := chartutil.ParseKubeVersion(operator_version.OperatorKubernetesMinSupportedVersion)
+	operatorVersion, _ := chartutil.ParseKubeVersion("1." + strconv.Itoa(k8sversion.MinK8SVersion) + ".0")
 	caps.KubeVersion = *operatorVersion
 
 	if version != nil {

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -22,8 +22,6 @@ import (
 const (
 	// OperatorCodeBaseVersion is the version string from the code base.
 	OperatorCodeBaseVersion = "1.17.0"
-	// OperatorKubernetesMinSupportedVersion is the minimum supported Kubernetes version
-	OperatorKubernetesMinSupportedVersion = "1.22.0"
 )
 
 var (

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -22,6 +22,8 @@ import (
 const (
 	// OperatorCodeBaseVersion is the version string from the code base.
 	OperatorCodeBaseVersion = "1.17.0"
+	// OperatorKubernetesMinSupportedVersion is the minimum supported Kubernetes version
+	OperatorKubernetesMinSupportedVersion = "1.22.0"
 )
 
 var (

--- a/releasenotes/notes/42513.yaml
+++ b/releasenotes/notes/42513.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: environments
+area: istioctl
 
 releaseNotes:
   - |

--- a/releasenotes/notes/42513.yaml
+++ b/releasenotes/notes/42513.yaml
@@ -4,4 +4,4 @@ area: istioctl
 
 releaseNotes:
   - |
-    **Fix** helm chart library default behaviour to generate manifests with v1.20 Kubernetes object version if using istioctl without--cluster-specific and instead use minimum Kubernetes version defined by istioctl.
+    **Fixed** helm chart library default behaviour to generate manifests with v1.20 Kubernetes object version if using istioctl without--cluster-specific and instead use minimum Kubernetes version defined by istioctl.

--- a/releasenotes/notes/42513.yaml
+++ b/releasenotes/notes/42513.yaml
@@ -4,4 +4,4 @@ area: istioctl
 
 releaseNotes:
   - |
-    **Fixed** helm chart library default behaviour to generate manifests with v1.20 Kubernetes object version if using istioctl without--cluster-specific and instead use minimum Kubernetes version defined by istioctl.
+    **Fixed** helm chart library default behavior from generating manifests with a v1.20 Kubernetes object version when using istioctl without --cluster-specific instead using the minimum Kubernetes version defined by istioctl.

--- a/releasenotes/notes/42513.yaml
+++ b/releasenotes/notes/42513.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: environments
+
+releaseNotes:
+  - |
+    **Fix** helm chart library default behaviour to generate manifests with v1.20 Kubernetes object version if using istioctl without--cluster-specific and instead use minimum Kubernetes version defined by istioctl.


### PR DESCRIPTION


Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/42441, introduce OperatorKubernetesMinSupportedVersion that can overwrite helm chart DefaultCapabilities KubeVersion