### PR TITLE
Change Istio-CNI installation namespace to istio-system

### DIFF
--- a/manifests/profiles/openshift.yaml
+++ b/manifests/profiles/openshift.yaml
@@ -4,7 +4,7 @@ spec:
   components:
     cni:
       enabled: true
-      namespace: kube-system
+      namespace: istio-system
   values:
     cni:
       cniBinDir: /var/lib/cni/bin

--- a/releasenotes/notes/42055.yaml
+++ b/releasenotes/notes/42055.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: istio-cni 
+area: installation
 issue:
   - 42055
 releaseNotes:

--- a/releasenotes/notes/42055.yaml
+++ b/releasenotes/notes/42055.yaml
@@ -7,4 +7,3 @@ releaseNotes:
   - |
     **Fixed** changed istio-cni openshift installation namespace from kube-system to istio-system to allow
     istio-cni to work with increased Openshift 4.12 security restrictions.
-    

--- a/releasenotes/notes/42055.yaml
+++ b/releasenotes/notes/42055.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istio-cni 
+issue:
+  - 42055
+releaseNotes:
+  - |
+    **Fixed** changed istio-cni openshift installation namespace from kube-system to istio-system to allow
+    istio-cni to work with increased Openshift 4.12 security restrictions.

--- a/releasenotes/notes/42055.yaml
+++ b/releasenotes/notes/42055.yaml
@@ -7,3 +7,4 @@ releaseNotes:
   - |
     **Fixed** changed istio-cni openshift installation namespace from kube-system to istio-system to allow
     istio-cni to work with increased Openshift 4.12 security restrictions.
+    


### PR DESCRIPTION
**Please provide a description of this PR:**
Per issue https://github.com/istio/istio/issues/42055, in Openshift 4.12, Istio CNI is unable to work correctly anymore if deployed in the `kube-system` namespace due to increased security restrictions.  Per the discussion in that ticket, I'm opening a PR to change the installation namespace to `istio-system` for Istio CNI.