### PR TITLE
set AMBIENT_TYPE env var for ztunnel

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -250,6 +250,8 @@ spec:
         - proxy
         - sidecar
         env:
+        - name: AMBIENT_TYPE
+          value: "ztunnel"
         - name: CLUSTER_ID
           value: {{ .Values.global.multiCluster.clusterName | default "Kubernetes" }}
         - name: POD_NAME


### PR DESCRIPTION
**Please provide a description of this PR:**

related ztunnel PR:
https://github.com/istio/ztunnel/pull/296

sets env var for ztunnel that istiod checks for in internal `IsZTunnel()` logic


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ X ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure