### PR TITLE
Switching revision in IstioOperator istio-gateway cache fix

### DIFF
--- a/operator/pkg/cache/cache.go
+++ b/operator/pkg/cache/cache.go
@@ -71,3 +71,11 @@ func RemoveObject(name, objHash string) {
 		objectCache.Mu.Unlock()
 	}
 }
+
+// RemoveCache removes the object Cache with the give name.
+func RemoveCache(name string) {
+	objectCachesMu.Lock()
+	defer objectCachesMu.Unlock()
+
+	delete(objectCaches, name)
+}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -186,13 +186,14 @@ var (
 
 			// If revision is updated in the IstioOperator resource, we must remove entries
 			// from the cache. If the IstioOperator resource is reverted back to match this operator's
-			// revision, the operator should Reconcile the IstioOperator.
+			// revision, a clean cache would ensure that the operator Reconcile the IstioOperator,
+			// and not skip it.
 			if oldIOP.Spec.Revision != newIOP.Spec.Revision {
 				var host string
 				if restConfig != nil {
 					host = restConfig.Host
 				}
-				for _, component := range []name.ComponentName{name.IngressComponentName, name.EgressComponentName} {
+				for _, component := range name.AllComponentNames {
 					crHash := strings.Join([]string{newIOP.Name, newIOP.Namespace, string(component), host}, "-")
 					cache.RemoveCache(crHash)
 				}


### PR DESCRIPTION
Signed-off-by: Shubham Chauhan <shubham@tetrate.io>

**Please provide a description of this PR:**
Considering the following scenario

0. Setup multi-revisioned Istio control plane as mentioned in https://istio.io/latest/docs/setup/upgrade/canary/
Assuming there are two istio control plane revisions running - `rev1` and `rev2`
1. Create IstioOperator `iop1` with revision `rev1` with ingressGateway enabled. This is reconciled by `istio-operator-rev1` and skipped by `istio-operator-rev2`.
2. Update IstioOperator `iop1` to use revision `rev2`. The related objects like Deployment/ClusterRole/Service etc. must now be reconciled by `istio-operator-rev2`.
3. Update IstioOperator `iop1` to move back to revision `rev1`. `istio-operator-rev1` does not re-apply any related object manifests.

After Step 3), istio objects like the gateway Deployment etc. are not reconciled by `istio-operator-rev1`. This is because `istio-operator-rev1` never garbage collected objects from its local cache in Step 2) when the revision was updated. 