### PR TITLE
Drop `http.DefaultClient`

### DIFF
--- a/istioctl/cmd/clusters.go
+++ b/istioctl/cmd/clusters.go
@@ -38,7 +38,7 @@ func clustersCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, err := kubeClient.AllDiscoveryDo(context.Background(), istioNamespace, "/debug/clusterz")
+			res, err := kubeClient.AllDiscoveryDo(context.Background(), istioNamespace, "debug/clusterz")
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -89,7 +89,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 					return err
 				}
 
-				path := fmt.Sprintf("/debug/config_dump?proxyID=%s.%s", podName, ns)
+				path := fmt.Sprintf("debug/config_dump?proxyID=%s.%s", podName, ns)
 				istiodDumps, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, path)
 				if err != nil {
 					return err
@@ -100,7 +100,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				}
 				return c.Diff()
 			}
-			statuses, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, "/debug/syncz")
+			statuses, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, "debug/syncz")
 			if err != nil {
 				return err
 			}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -143,6 +143,7 @@ type Server struct {
 	fetchDNS              func() *dnsProto.NameTable
 	upstreamLocalAddress  *net.TCPAddr
 	config                Options
+	http                  *http.Client
 }
 
 func init() {
@@ -194,6 +195,7 @@ func NewServer(config Options) (*Server, error) {
 	s := &Server{
 		statusPort:            config.StatusPort,
 		ready:                 probes,
+		http:                  &http.Client{},
 		appProbersDestination: config.PodIP,
 		envoyStatsPort:        config.EnvoyPrometheusPort,
 		fetchDNS:              config.FetchDNS,
@@ -628,7 +630,7 @@ func (s *Server) scrape(url string, header http.Header) (io.ReadCloser, context.
 		"X-Prometheus-Scrape-Timeout-Seconds",
 	)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.http.Do(req)
 	if err != nil {
 		return nil, cancel, "", fmt.Errorf("error scraping %s: %v", url, err)
 	}

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -351,6 +351,7 @@ my_metric{app="bar"} 0
 					Port: strings.Split(app.URL, ":")[2],
 				},
 				envoyStatsPort: envoyPort,
+				http: &http.Client{},,
 			}
 			req := &http.Request{}
 			server.handleStats(rec, req)

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -351,7 +351,7 @@ my_metric{app="bar"} 0
 					Port: strings.Split(app.URL, ":")[2],
 				},
 				envoyStatsPort: envoyPort,
-				http: &http.Client{},,
+				http:           &http.Client{},
 			}
 			req := &http.Request{}
 			server.handleStats(rec, req)
@@ -446,6 +446,7 @@ my_other_metric{} 0
 					Port: strings.Split(app.URL, ":")[2],
 				},
 				envoyStatsPort: envoyPort,
+				http:           &http.Client{},
 			}
 			req := &http.Request{}
 			req.Header = make(http.Header)
@@ -519,6 +520,7 @@ func TestStatsError(t *testing.T) {
 					Port: strconv.Itoa(tt.app),
 				},
 				envoyStatsPort: tt.envoy,
+				http:           &http.Client{},
 			}
 			req := &http.Request{}
 			rec := httptest.NewRecorder()

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -819,10 +819,6 @@ func (c *client) EnvoyDoWithPort(ctx context.Context, podName, podNamespace, met
 }
 
 func (c *client) portForwardRequest(ctx context.Context, podName, podNamespace, method, path string, port int) ([]byte, error) {
-	if path[0] == '/' {
-		// DO NOT MERGE!!!
-		panic("bad path " + path)
-	}
 	formatError := func(err error) error {
 		return fmt.Errorf("failure running port forward process: %v", err)
 	}

--- a/pkg/proxy/proxyinfo.go
+++ b/pkg/proxy/proxyinfo.go
@@ -37,7 +37,7 @@ func GetProxyInfo(kubeconfig, configContext, revision, istioNamespace string) (*
 		return nil, err
 	}
 	// Ask Pilot for the Envoy sidecar sync status, which includes the sidecar version info
-	allSyncz, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, "/debug/syncz")
+	allSyncz, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, "debug/syncz")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -463,12 +463,14 @@ func newPortForward(c cluster.Cluster, pod corev1.Pod, port int) (kube.PortForwa
 	return fw, err
 }
 
+var dumpClient = &http.Client{}
+
 func portForwardRequest(fw kube.PortForwarder, method, path string) ([]byte, error) {
 	req, err := http.NewRequest(method, fmt.Sprintf("http://%s/%s", fw.Address(), path), nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := dumpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using a single shared client risks other parts of the code (or dependencies) modifying the client and breaking things. See https://github.com/kubernetes-sigs/gateway-api/pull/1617 for an exmaple where this happened.

Also fix up paths to avoid `//debug` requests which always get a 301.

**Please provide a description of this PR:**