### PR TITLE
istio/gateway: force redeployment of istio-gateway pods after version update

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         istio.io/rev: {{ . }}
         {{- end }}
         {{- include "gateway.selectorLabels" . | nindent 8 }}
+        {{- if .Chart.AppVersion }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
**Please provide a description of this PR:**

When updating the `istio/gateway` helm chart to the latest Istio version, the affected pods will not redeploy, but still run with the old Istio version. This happens, because the `podTemplate` does not change as the `image` tag does not change.

The fix adds the same `app.kubernetes.io/version` label to the `Pod` that is already present on the `Deployment`. This guarantees all pods are redeployed on a version change.

Note: This does not guarantee that the pods actually run with the version in the label, but I expect that it is common practice to update the control plane before everything else. This PR solves the problem for that case.