### PR TITLE
Fix tcp-echo sample run panic.

### DIFF
--- a/samples/tcp-echo/src/main.go
+++ b/samples/tcp-echo/src/main.go
@@ -25,6 +25,10 @@ import (
 
 // main serves as the program entry point
 func main() {
+	if len(os.Args) != 3 {
+		fmt.Println("you should run it like: 'main [PORTS...] prefix' , please notice PORTS are comma-delineated , like  port 1[,port 2]  ")
+		os.Exit(1)
+	}
 	// obtain the port and prefix via program arguments
 	ports := strings.Split(os.Args[1], ",")
 	prefix := os.Args[2]


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**Please provide a description of this PR:**
Build the sample ```samples/tcp-echo/src/main.go```, run it without parms, it panic without hint.
Fix it with parms valid and give hint for user..

/label release-notes-none

```release-note
None
```