### PR TITLE
make fsnotify event more readable.

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -357,8 +357,7 @@ func (s *Server) handleCACertsFileWatch() {
 				log.Debug("plugin cacerts watch stopped")
 				return
 			}
-
-			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
 				if timerC == nil {
 					timerC = time.After(100 * time.Millisecond)
 				}

--- a/pkg/kube/inject/watcher.go
+++ b/pkg/kube/inject/watcher.go
@@ -105,7 +105,7 @@ func (w *fileWatcher) Run(stop <-chan struct{}) {
 			}
 			log.Debugf("Injector watch update: %+v", event)
 			// use a timer to debounce configuration updates
-			if ((event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)) && timerC == nil {
+			if (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) && timerC == nil {
 				timerC = time.After(watchDebounceDelay)
 			}
 		case err, ok := <-w.watcher.Errors:

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -714,15 +714,15 @@ func (sc *SecretManagerClient) handleFileWatch() {
 }
 
 func isWrite(event fsnotify.Event) bool {
-	return event.Op&fsnotify.Write == fsnotify.Write
+	return event.Has(fsnotify.Write)
 }
 
 func isCreate(event fsnotify.Event) bool {
-	return event.Op&fsnotify.Create == fsnotify.Create
+	return event.Has(fsnotify.Create)
 }
 
 func isRemove(event fsnotify.Event) bool {
-	return event.Op&fsnotify.Remove == fsnotify.Remove
+	return event.Has(fsnotify.Remove)
 }
 
 // concatCerts concatenates PEM certificates, making sure each one starts on a new line


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**Please provide a description of this PR:**
As [fsnotify v1.6.0](https://github.com/fsnotify/fsnotify/releases/tag/v1.6.0) mentioned , 
```
if event.Op&Write == Write && !(event.Op&Remove == Remove) {
  }
```
can become 
```
if event.Has(Write) && !event.Has(Remove) {
  }
```

```release-note
None
```

/label release-notes-none