### PR TITLE
Repair value override

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -250,9 +250,11 @@ func (c *instance) UpdateWorkloadLabel(add map[string]string, remove []string) e
 		wl.mutex.Unlock()
 		if pod.Name != "" {
 			return retry.UntilSuccess(func() (err error) {
-				pod, err := wl.Cluster().Kube().CoreV1().Pods(c.NamespaceName()).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+				podName := pod.Name
+				podNamespace := pod.Namespace
+				pod, err := wl.Cluster().Kube().CoreV1().Pods(c.NamespaceName()).Get(context.TODO(), podName, metav1.GetOptions{})
 				if err != nil {
-					return fmt.Errorf("get pod %s/%s failed: %v", pod.Namespace, pod.Name, err)
+					return fmt.Errorf("get pod %s/%s failed: %v", podNamespace, podName, err)
 				}
 				newLabels := make(map[string]string)
 				for k, v := range pod.GetLabels() {

--- a/releasenotes/notes/42590.yaml
+++ b/releasenotes/notes/42590.yaml
@@ -1,6 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: istioctl
-releaseNotes:
-  - |
-    **Fixed** Read overwrite pod.Name and pod.Namespace

--- a/releasenotes/notes/42590.yaml
+++ b/releasenotes/notes/42590.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** Read overwrite pod.Name and pod.Namespace


### PR DESCRIPTION

**Please provide a description of this PR:**

```go
				pod, err := wl.Cluster().Kube().CoreV1().Pods(c.NamespaceName()).Get(context.TODO(), pod.Name, metav1.GetOptions{})
				if err != nil {
					return fmt.Errorf("get pod %s/%s failed: %v", pod.Namespace, pod.Name, err)
				}
```
When err.`pod` will be override by default `fmt.Errorf("get pod %s/%s failed: %v", pod.Namespace, pod.Name, err)` . No more access to the most original names and spaces.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
