### PR TITLE
Fix delegate VirtualService merging for visibility.Private

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -174,11 +174,17 @@ func mergeVirtualServicesIfNeeded(
 		// it is delegate, add it to the indexer cache along with the exportTo for the delegate
 		if len(rule.Hosts) == 0 {
 			delegatesMap[key(vs.Name, vs.Namespace)] = vs
+			exportToMap := make(map[visibility.Instance]bool)
 			if len(rule.ExportTo) == 0 {
 				// No exportTo in virtualService. Use the global default
-				delegatesExportToMap[key(vs.Name, vs.Namespace)] = defaultExportTo
+				for v := range defaultExportTo {
+					if v == visibility.Private {
+						exportToMap[visibility.Instance(vs.Namespace)] = true
+					} else {
+						exportToMap[v] = true
+					}
+				}
 			} else {
-				exportToMap := make(map[visibility.Instance]bool)
 				for _, e := range rule.ExportTo {
 					if e == string(visibility.Private) {
 						exportToMap[visibility.Instance(vs.Namespace)] = true
@@ -186,8 +192,8 @@ func mergeVirtualServicesIfNeeded(
 						exportToMap[visibility.Instance(e)] = true
 					}
 				}
-				delegatesExportToMap[key(vs.Name, vs.Namespace)] = exportToMap
 			}
+			delegatesExportToMap[key(vs.Name, vs.Namespace)] = exportToMap
 			continue
 		}
 

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -635,52 +635,73 @@ func TestMergeVirtualServices(t *testing.T) {
 		name                    string
 		virtualServices         []config.Config
 		expectedVirtualServices []config.Config
+		defaultExportTo         map[visibility.Instance]bool
 	}{
 		{
 			name:                    "one independent vs",
 			virtualServices:         []config.Config{independentVs},
 			expectedVirtualServices: []config.Config{independentVs},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
 			name:                    "one root vs",
 			virtualServices:         []config.Config{rootVs},
 			expectedVirtualServices: []config.Config{oneRoot},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
 			name:                    "one delegate vs",
 			virtualServices:         []config.Config{delegateVs},
 			expectedVirtualServices: []config.Config{},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
 			name:                    "root and delegate vs",
 			virtualServices:         []config.Config{rootVs.DeepCopy(), delegateVs},
 			expectedVirtualServices: []config.Config{mergedVs},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
 			name:                    "root and conflicted delegate vs",
 			virtualServices:         []config.Config{rootVs.DeepCopy(), delegateVs2},
 			expectedVirtualServices: []config.Config{mergedVs2},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
 			name:                    "multiple routes delegate to one",
 			virtualServices:         []config.Config{multiRoutes.DeepCopy(), singleDelegate},
 			expectedVirtualServices: []config.Config{mergedVs3},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
-			name:                    "root not specify delegate namespace",
+			name:                    "root not specify delegate namespace default public",
 			virtualServices:         []config.Config{defaultVs.DeepCopy(), delegateVsExportedToAll},
 			expectedVirtualServices: []config.Config{mergedVsInDefault},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
 		},
 		{
-			name:                    "delegate not exported to root vs namespace",
+			name:                    "delegate not exported to root vs namespace default public",
 			virtualServices:         []config.Config{rootVs, delegateVsNotExported},
 			expectedVirtualServices: []config.Config{oneRoot},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Public: true},
+		},
+		{
+			name:                    "root not specify delegate namespace default private",
+			virtualServices:         []config.Config{defaultVs.DeepCopy(), delegateVsExportedToAll},
+			expectedVirtualServices: []config.Config{mergedVsInDefault},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Private: true},
+		},
+		{
+			name:                    "delegate not exported to root vs namespace default private",
+			virtualServices:         []config.Config{rootVs, delegateVsNotExported},
+			expectedVirtualServices: []config.Config{oneRoot},
+			defaultExportTo:         map[visibility.Instance]bool{visibility.Private: true},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _ := mergeVirtualServicesIfNeeded(tc.virtualServices, map[visibility.Instance]bool{visibility.Public: true})
+			got, _ := mergeVirtualServicesIfNeeded(tc.virtualServices, tc.defaultExportTo)
 			assert.Equal(t, got, tc.expectedVirtualServices)
 		})
 	}

--- a/releasenotes/notes/bug-fix-virtualservice-visibilty-private.yaml
+++ b/releasenotes/notes/bug-fix-virtualservice-visibilty-private.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [42602]
+releaseNotes:
+- |
+    **Fixed** VirtualService delegate behaviour with `defaultVirtualServiceExportTo: ["."]` 


### PR DESCRIPTION
For `defaultVirtualServiceExportTo: ["."]`, defaultExportTo is a map containing a key `visibility.Instance(".")` which doesn't match the key `visibility.Instance(root.Namespace)`. 

This PR fixes that check by adding a key `visibility.Instance(vs.Namespace)`, similar to what is done while processing exportTo within VirtualServices.

Fixes #42602

**Please provide a description of this PR:**