### PR TITLE
Fix analyze revision inconsistent behavior

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -181,6 +181,9 @@ func Analyze() *cobra.Command {
 			}
 			sa.SetSuppressions(suppressions)
 
+			if revision == "" {
+				revision = "default"
+			}
 			// If we're using kube, use that as a base source.
 			if useKube {
 				// Set up the kube client
@@ -320,7 +323,7 @@ func Analyze() *cobra.Command {
 		"Process directory arguments recursively. Useful when you want to analyze related manifests organized within the same directory.")
 	analysisCmd.PersistentFlags().BoolVar(&ignoreUnknown, "ignore-unknown", false,
 		"Don't complain about un-parseable input documents, for cases where analyze should run only on k8s compliant inputs.")
-	analysisCmd.PersistentFlags().StringVarP(&revision, "revision", "", "default",
+	analysisCmd.PersistentFlags().StringVarP(&revision, "revision", "", "",
 		"analyze a specific revision deployed.")
 	return analysisCmd
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
The default flag value `revision` doesn't work, which lead to inconsistent behavior of the analysis(some default revision resources are ignored). 
```
➜  istio git:(master) istioctl analyze
Error [IST0101] (Gateway default/aaaaa) Referenced selector not found: "istio=ingressgateway"  # should be found actually
Info [IST0118] (Service default/sleep2) Port name  (port: 6666, targetPort: 5000) doesn't follow the naming convention of Istio port.
Error: Analyzers found issues when analyzing namespace: default.
See https://istio.io/v1.17/docs/reference/config/analysis for more information about causes and resolutions.

➜  istio git:(master) istioctl analyze --revision default
Error [IST0101] (Gateway default/aaaaa) Referenced credentialName not found: "miketest"
Info [IST0118] (Service default/sleep2) Port name  (port: 6666, targetPort: 5000) doesn't follow the naming convention of Istio port.
Error: Analyzers found issues when analyzing namespace: default.
See https://istio.io/v1.17/docs/reference/config/analysis for more information about causes and resolutions.
```