### PR TITLE
unify cobra args validation.

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -149,10 +149,8 @@ See also 'istioctl experimental remove-from-mesh deployment' which does the reve
 
   # Restart pods from the ratings-v1 deployment with Istio sidecar
   istioctl x add dep ratings-v1`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting deployment name")
-			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err
@@ -204,10 +202,8 @@ See also 'istioctl experimental remove-from-mesh service' which does the reverse
 
   # Restart all ratings-v1 pods with an Istio sidecar
   istioctl x add svc ratings-v1`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting service name")
-			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err
@@ -267,10 +263,8 @@ See also 'istioctl experimental remove-from-mesh external-service' which does th
 		Example: ` # Control how meshed pods contact 172.12.23.125 and .126
   istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
    http:9080 tcp:8888 --labels app=test,version=v1 --annotations env=stage --serviceaccount stageAdmin`,
+		Args: cobra.MinimumNArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 3 {
-				return fmt.Errorf("provide service name, IP and Port List")
-			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -91,11 +91,8 @@ func podDescribeCmd() *cobra.Command {
 		Long: `Analyzes pod, its Services, DestinationRules, and VirtualServices and reports
 the configuration objects that affect that pod.`,
 		Example: `  istioctl experimental describe pod productpage-v1-c7765c886-7zzd4`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting pod name")
-			}
-
 			podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
 
 			client, err := interfaceFactory(kubeconfig)

--- a/istioctl/cmd/internal-debug.go
+++ b/istioctl/cmd/internal-debug.go
@@ -111,16 +111,13 @@ By default it will use the default serviceAccount from (istio-system) namespace 
   # (Select a specific control plane in an in-cluster canary Istio configuration.)
   istioctl x internal-debug syncz --xds-label istio.io/rev=default
 `,
+		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
 				return err
 			}
-			if len(args) == 0 {
-				return CommandParseError{
-					e: fmt.Errorf("debug type is required"),
-				}
-			}
+
 			var xdsRequest discovery.DiscoveryRequest
 			var namespace, serviceAccount string
 

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -1167,25 +1167,20 @@ func rootCACompareConfigCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			var configWriter1, configWriter2 *configdump.ConfigWriter
 			var err error
-			if len(args) == 2 {
-				if podName1, podNamespace1, err = getPodName(args[0]); err != nil {
-					return err
-				}
-				configWriter1, err = setupPodConfigdumpWriter(podName1, podNamespace1, false, c.OutOrStdout())
-				if err != nil {
-					return err
-				}
+			if podName1, podNamespace1, err = getPodName(args[0]); err != nil {
+				return err
+			}
+			configWriter1, err = setupPodConfigdumpWriter(podName1, podNamespace1, false, c.OutOrStdout())
+			if err != nil {
+				return err
+			}
 
-				if podName2, podNamespace2, err = getPodName(args[1]); err != nil {
-					return err
-				}
-				configWriter2, err = setupPodConfigdumpWriter(podName2, podNamespace2, false, c.OutOrStdout())
-				if err != nil {
-					return err
-				}
-			} else {
-				c.Println(c.UsageString())
-				return fmt.Errorf("rootca-compare requires 2 pods as an argument")
+			if podName2, podNamespace2, err = getPodName(args[1]); err != nil {
+				return err
+			}
+			configWriter2, err = setupPodConfigdumpWriter(podName2, podNamespace2, false, c.OutOrStdout())
+			if err != nil {
+				return err
 			}
 
 			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -89,10 +89,8 @@ func deploymentUnMeshifyCmd() *cobra.Command {
 
   # Restart all ratings-v1 pods without an Istio sidecar
   istioctl x rm dep ratings-v1`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting deployment name")
-			}
 			ns := handlers.HandleNamespace(namespace, defaultNamespace)
 			if util.IsSystemNamespace(resource.Namespace(ns)) || ns == istioNamespace {
 				return fmt.Errorf("namespace %s is a system namespace and has no Istio sidecar injected", ns)
@@ -133,10 +131,8 @@ func svcUnMeshifyCmd() *cobra.Command {
 
   # Restart all ratings-v1 pods without an Istio sidecar
   istioctl x rm svc ratings-v1`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting service name")
-			}
 			ns := handlers.HandleNamespace(namespace, defaultNamespace)
 			if util.IsSystemNamespace(resource.Namespace(ns)) || ns == istioNamespace {
 				return fmt.Errorf("namespace %s is a system namespace and has no Istio sidecar injected", ns)
@@ -184,10 +180,8 @@ The typical usage scenario is Mesh Expansion on VMs.`,
 
   # Remove "vmhttp" service entry rules
   istioctl x rm es vmhttp`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("expecting external service name")
-			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err

--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -130,13 +130,8 @@ func revisionDescribeCommand() *cobra.Command {
 `,
 		Short: "Show information about a revision, including customizations, " +
 			"istiod version and which pods/gateways are using it.",
+		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return fmt.Errorf("revision must be specified")
-			}
-			if len(args) != 1 {
-				return fmt.Errorf("exactly 1 revision should be specified")
-			}
 			revArgs.name = args[0]
 			if !validFormats[revArgs.output] {
 				return fmt.Errorf("unknown format %s. It should be %#v", revArgs.output, validFormats)


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

Let cobra args unify, for the validation logic.