### PR TITLE
auto allocate ips based on hashing

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
@@ -166,7 +166,7 @@ func TestServiceEntryDuplicatedHostname(t *testing.T) {
 				{
 					Name: "HTTP call",
 					Call: simulation.Call{
-						Address:    "240.240.99.222",
+						Address:    "240.240.21.222",
 						Port:       80,
 						HostHeader: "istio.io",
 						Protocol:   simulation.HTTP,
@@ -179,14 +179,14 @@ func TestServiceEntryDuplicatedHostname(t *testing.T) {
 				{
 					Name: "HTTPS call",
 					Call: simulation.Call{
-						Address:    "240.240.99.222",
+						Address:    "240.240.21.222",
 						Port:       443,
 						HostHeader: "istio.io",
 						Protocol:   simulation.HTTP,
 						TLS:        simulation.TLS,
 					},
 					Result: simulation.Result{
-						ListenerMatched: "240.240.99.222_443",
+						ListenerMatched: "240.240.21.222_443",
 						ClusterMatched:  "outbound|443||istio.io",
 					},
 				},

--- a/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
@@ -166,7 +166,7 @@ func TestServiceEntryDuplicatedHostname(t *testing.T) {
 				{
 					Name: "HTTP call",
 					Call: simulation.Call{
-						Address:    "240.240.0.1",
+						Address:    "240.240.99.222",
 						Port:       80,
 						HostHeader: "istio.io",
 						Protocol:   simulation.HTTP,
@@ -179,14 +179,14 @@ func TestServiceEntryDuplicatedHostname(t *testing.T) {
 				{
 					Name: "HTTPS call",
 					Call: simulation.Call{
-						Address:    "240.240.0.1",
+						Address:    "240.240.99.222",
 						Port:       443,
 						HostHeader: "istio.io",
 						Protocol:   simulation.HTTP,
 						TLS:        simulation.TLS,
 					},
 					Result: simulation.Result{
-						ListenerMatched: "240.240.0.1_443",
+						ListenerMatched: "240.240.99.222_443",
 						ClusterMatched:  "outbound|443||istio.io",
 					},
 				},

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -52,8 +52,8 @@ var (
 )
 
 var (
-	maxPrime = 65011
-	maxIPs   = 255 * 255
+	prime  = 65011     // Used for secondary hash function.
+	maxIPs = 255 * 255 // Maximum possible IPs for address allocation.
 )
 
 // instancesKey acts as a key to identify all instances for a given hostname/namespace pair
@@ -903,7 +903,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 				// This means we have a collision. Resolve collision by "DoubleHashing".
 				i := uint32(1)
 				for {
-					sh := uint32(maxPrime) - (s % uint32(maxPrime))
+					sh := uint32(prime) - (s % uint32(prime))
 					nh := (s + i*sh) % uint32(maxIPs)
 					if hashedServices[nh] == nil {
 						hashedServices[nh] = svc

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -894,17 +894,17 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 			hash.Write([]byte(svc.Attributes.Namespace + "/" + svc.Hostname.String()))
 			// First hash is calculated by
 			s := hash.Sum32()
-			fh := s % uint32(maxIPs)
-			// Check if there is no service with this hash first. If there is not service
+			firstHash := s % uint32(maxIPs)
+			// Check if there is no service with this hash first. If there is no service
 			// at this location - then we can safely assign this position for this service.
-			if hashedServices[fh] == nil {
-				hashedServices[fh] = svc
+			if hashedServices[firstHash] == nil {
+				hashedServices[firstHash] = svc
 			} else {
 				// This means we have a collision. Resolve collision by "DoubleHashing".
 				i := uint32(1)
 				for {
-					sh := uint32(prime) - (s % uint32(prime))
-					nh := (s + i*sh) % uint32(maxIPs)
+					secondHash := uint32(prime) - (s % uint32(prime))
+					nh := (s + i*secondHash) % uint32(maxIPs)
 					if hashedServices[nh] == nil {
 						hashedServices[nh] = svc
 						break

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -891,7 +891,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 		// 3. the hostname is not a wildcard
 		if svc.DefaultAddress == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
 			svc.Resolution != model.Passthrough {
-			hash.Write([]byte(svc.Hostname.String()))
+			hash.Write([]byte(svc.Attributes.Namespace + "/" + svc.Hostname.String()))
 			// First hash is calculated by
 			s := hash.Sum32()
 			fh := s % uint32(maxIPs)

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1664,7 +1664,7 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 					Hostname:                 "foo.com",
 					Resolution:               model.ClientSideLB,
 					DefaultAddress:           "0.0.0.0",
-					AutoAllocatedIPv4Address: "240.240.37.178",
+					AutoAllocatedIPv4Address: "240.240.62.90",
 					AutoAllocatedIPv6Address: "2001:2::f0f0:3e5a",
 				},
 			},

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1665,7 +1665,7 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 					Resolution:               model.ClientSideLB,
 					DefaultAddress:           "0.0.0.0",
 					AutoAllocatedIPv4Address: "240.240.37.178",
-					AutoAllocatedIPv6Address: "2001:2::f0f0:25b2",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:3e5a",
 				},
 			},
 		},
@@ -1683,8 +1683,8 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 					Hostname:                 "foo.com",
 					Resolution:               model.DNSLB,
 					DefaultAddress:           "0.0.0.0",
-					AutoAllocatedIPv4Address: "240.240.37.178",
-					AutoAllocatedIPv6Address: "2001:2::f0f0:25b2",
+					AutoAllocatedIPv4Address: "240.240.62.90",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:3e5a",
 				},
 			},
 		},
@@ -1725,7 +1725,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 	// 240.240.2.255
 	// 240.240.3.0
 	// 240.240.3.255
-	// The last IP should be 240.240.50.246
+	// The last IP should be 240.240.202.167
 	doNotWant := map[string]bool{
 		"240.240.0.0":   true,
 		"240.240.0.255": true,
@@ -1734,7 +1734,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 		"240.240.2.0":   true,
 		"240.240.2.255": true,
 	}
-	expectedLastIP := "240.240.50.246"
+	expectedLastIP := "240.240.202.167"
 	if gotServices[len(gotServices)-1].AutoAllocatedIPv4Address != expectedLastIP {
 		t.Errorf("expected last IP address to be %s, got %s", expectedLastIP, gotServices[len(gotServices)-1].AutoAllocatedIPv4Address)
 	}
@@ -1755,15 +1755,15 @@ func Test_autoAllocateIP_values(t *testing.T) {
 func Test_autoAllocateIP_deterministic(t *testing.T) {
 	inServices := make([]*model.Service, 0)
 	originalServices := map[string]string{
-		"a.com": "240.240.156.7",
-		"c.com": "240.240.72.226",
-		"e.com": "240.240.85.4",
-		"g.com": "240.240.179.215",
-		"i.com": "240.240.13.244",
-		"k.com": "240.240.197.245",
-		"l.com": "240.240.56.10",
-		"n.com": "240.240.82.93",
-		"o.com": "240.240.234.248",
+		"a.com": "240.240.81.186",
+		"c.com": "240.240.79.99",
+		"e.com": "240.240.175.33",
+		"g.com": "240.240.106.30",
+		"i.com": "240.240.124.21",
+		"k.com": "240.240.234.190",
+		"l.com": "240.240.142.221",
+		"n.com": "240.240.41.17",
+		"o.com": "240.240.31.228",
 	}
 
 	allocateAndValidate := func() {
@@ -1777,7 +1777,7 @@ func Test_autoAllocateIP_deterministic(t *testing.T) {
 		}
 		for k, v := range originalServices {
 			if gotIPMap[v] != k {
-				t.Errorf("ipaddress changed for service %s. expected: %s, got: %s", k, v, gotIPMap[k])
+				t.Errorf("ipaddress changed for service %s. expected: %s, got: %s", k, v, gotIPMap[v])
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1705,8 +1705,8 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 }
 
 func Test_autoAllocateIP_values(t *testing.T) {
-	inServices := make([]*model.Service, 512)
-	for i := 0; i < 512; i++ {
+	inServices := make([]*model.Service, 255*255)
+	for i := 0; i < 255*255; i++ {
 		temp := model.Service{
 			Hostname:       host.Name(fmt.Sprintf("foo%d.com", i)),
 			Resolution:     model.ClientSideLB,
@@ -1723,7 +1723,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 	// 240.240.1.255
 	// 240.240.2.0
 	// 240.240.2.255
-	// The last IP should be 240.240.2.4
+	// The last IP should be 240.240.50.246
 	doNotWant := map[string]bool{
 		"240.240.0.0":   true,
 		"240.240.0.255": true,
@@ -1732,7 +1732,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 		"240.240.2.0":   true,
 		"240.240.2.255": true,
 	}
-	expectedLastIP := "240.240.2.4"
+	expectedLastIP := "240.240.50.246"
 	if gotServices[len(gotServices)-1].AutoAllocatedIPv4Address != expectedLastIP {
 		t.Errorf("expected last IP address to be %s, got %s", expectedLastIP, gotServices[len(gotServices)-1].AutoAllocatedIPv4Address)
 	}

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -45,7 +45,7 @@ func TestNDS(t *testing.T) {
 			expected: &dnsProto.NameTable{
 				Table: map[string]*dnsProto.NameTable_NameInfo{
 					"random-1.host.example": {
-						Ips:      []string{"240.240.0.1"},
+						Ips:      []string{"240.240.103.94"},
 						Registry: "External",
 					},
 					"random-2.host.example": {
@@ -53,7 +53,7 @@ func TestNDS(t *testing.T) {
 						Registry: "External",
 					},
 					"random-3.host.example": {
-						Ips:      []string{"240.240.0.2"},
+						Ips:      []string{"240.240.218.23"},
 						Registry: "External",
 					},
 				},

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -45,7 +45,7 @@ func TestNDS(t *testing.T) {
 			expected: &dnsProto.NameTable{
 				Table: map[string]*dnsProto.NameTable_NameInfo{
 					"random-1.host.example": {
-						Ips:      []string{"240.240.103.94"},
+						Ips:      []string{"240.240.114.167"},
 						Registry: "External",
 					},
 					"random-2.host.example": {
@@ -53,7 +53,7 @@ func TestNDS(t *testing.T) {
 						Registry: "External",
 					},
 					"random-3.host.example": {
-						Ips:      []string{"240.240.218.23"},
+						Ips:      []string{"240.240.48.215"},
 						Registry: "External",
 					},
 				},


### PR DESCRIPTION
To prevent unnecessary listener draining and to have a stable IP allocated for service entries.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure