### PR TITLE
fix config compare logic

### DIFF
--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -35,13 +35,23 @@ func needsPush(prev config.Config, curr config.Config) bool {
 	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
 		return true
 	}
-	// If current metadata has "*istio.io" label/annotation, just push
+	// If current/previous metadata has "*istio.io" label/annotation, just push
 	for label := range curr.Meta.Labels {
 		if strings.Contains(label, "istio.io") {
 			return true
 		}
 	}
 	for annotation := range curr.Meta.Annotations {
+		if strings.Contains(annotation, "istio.io") {
+			return true
+		}
+	}
+	for label := range prev.Meta.Labels {
+		if strings.Contains(label, "istio.io") {
+			return true
+		}
+	}
+	for annotation := range prev.Meta.Annotations {
 		if strings.Contains(annotation, "istio.io") {
 			return true
 		}

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -95,13 +95,12 @@ func TestNeedsPush(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "config with istio.io label",
+			name: "current config with istio.io label",
 			prev: config.Config{
 				Meta: config.Meta{
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -115,7 +114,45 @@ func TestNeedsPush(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "config with istio.io annotation",
+			name: "previous config with istio.io label",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "current config with istio.io annotation",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "previous config with istio.io annotation",
 			prev: config.Config{
 				Meta: config.Meta{
 					GroupVersionKind: gvk.Ingress,
@@ -129,7 +166,6 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,


### PR DESCRIPTION
Currently we just check whether "curr" has istio.io labels/annotations. But if current does not have and previous has then also we need to push (e.g. exportTo annotation has been removed in current, so we need to apply defaults and push)
- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure