### PR TITLE
Fix revision variable in istioctl analyze

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -75,6 +75,7 @@ var (
 	analysisTimeout   time.Duration
 	recursive         bool
 	ignoreUnknown     bool
+	revisionSpecified string
 
 	fileExtensions = []string{".json", ".yaml", ".yml"}
 )
@@ -192,7 +193,7 @@ func Analyze() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				sa.AddRunningKubeSourceWithRevision(k, revision)
+				sa.AddRunningKubeSourceWithRevision(k, revisionSpecified)
 			}
 
 			// If we explicitly specify mesh config, use it.
@@ -320,7 +321,7 @@ func Analyze() *cobra.Command {
 		"Process directory arguments recursively. Useful when you want to analyze related manifests organized within the same directory.")
 	analysisCmd.PersistentFlags().BoolVar(&ignoreUnknown, "ignore-unknown", false,
 		"Don't complain about un-parseable input documents, for cases where analyze should run only on k8s compliant inputs.")
-	analysisCmd.PersistentFlags().StringVarP(&revision, "revision", "", "default",
+	analysisCmd.PersistentFlags().StringVarP(&revisionSpecified, "revision", "", "default",
 		"analyze a specific revision deployed.")
 	return analysisCmd
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/pull/42435 caused an error when using `istioctl analyze` in the istio.io tests as the revision was not being set to `default`. 

See https://github.com/istio/istio.io/pull/12417.

No new release note since this is just correcting the default revision to being `default`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
