### PR TITLE
Consolidate tombstone handling

### DIFF
--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/informer"
 	"istio.io/pkg/log"
 )
@@ -43,20 +44,8 @@ func (h *cacheHandler) onEvent(old any, curr any, event model.Event) error {
 		return err
 	}
 
-	currItem, ok := curr.(runtime.Object)
-	if !ok && event == model.EventDelete {
-		tombstone, ok := curr.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			scope.Warnf("Couldn't get object from tombstone %v, type %T", curr, curr)
-			return nil
-		}
-		currItem, ok = tombstone.Obj.(runtime.Object)
-		if !ok {
-			scope.Warnf("Tombstone's Object is not runtime Object %v, type %T", tombstone.Obj, tombstone.Obj)
-			return nil
-		}
-	} else if !ok {
-		scope.Warnf("Object can not be converted to runtime Object %v, is type %T", curr, curr)
+	currItem := controllers.ExtractObject(curr)
+	if currItem == nil {
 		return nil
 	}
 

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/util/sets"
 	istiolog "istio.io/pkg/log"
 )
@@ -119,14 +120,11 @@ func NewController(
 		waitForCRD:    waitForCRD,
 	}
 
-	_, _ = nsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			ns := obj.(*corev1.Namespace)
+	_, _ = nsInformer.AddEventHandler(controllers.EventHandler[*corev1.Namespace]{
+		AddFunc: func(ns *corev1.Namespace) {
 			gatewayController.namespaceEvent(nil, ns)
 		},
-		UpdateFunc: func(oldObj, newObj any) {
-			oldNs := oldObj.(*corev1.Namespace)
-			newNs := newObj.(*corev1.Namespace)
+		UpdateFunc: func(oldNs, newNs *corev1.Namespace) {
 			if !labels.Instance(oldNs.Labels).Equals(newNs.Labels) {
 				gatewayController.namespaceEvent(oldNs, newNs)
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
@@ -30,6 +30,7 @@ import (
 	serviceRegistryKube "istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/mcs"
 	"istio.io/istio/pkg/queue"
 )
@@ -89,10 +90,9 @@ func (c *autoServiceExportController) onServiceAdd(obj any) {
 			return nil
 		}
 
-		svc, err := extractService(obj)
-		if err != nil {
-			log.Warnf("%s failed converting service: %v", c.logPrefix(), err)
-			return err
+		svc := controllers.Extract[*v1.Service](obj)
+		if svc == nil {
+			return nil
 		}
 
 		if c.isClusterLocalService(svc) {

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -15,13 +15,11 @@
 package controller
 
 import (
-	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -29,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/informer"
 	"istio.io/istio/pkg/kube/mcs"
 )
@@ -115,16 +114,9 @@ type serviceExportCacheImpl struct {
 }
 
 func (ec *serviceExportCacheImpl) onServiceExportEvent(obj any, event model.Event) error {
-	se, ok := obj.(*unstructured.Unstructured)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return fmt.Errorf("couldn't get object from tombstone %#v", obj)
-		}
-		se, ok = tombstone.Obj.(*unstructured.Unstructured)
-		if !ok {
-			return fmt.Errorf("tombstone contained object that is not a ServiceExport %#v", obj)
-		}
+	se := controllers.Extract[*unstructured.Unstructured](obj)
+	if se == nil {
+		return nil
 	}
 
 	switch event {

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
@@ -212,21 +211,6 @@ func podKeyByProxy(proxy *model.Proxy) string {
 	}
 
 	return ""
-}
-
-func extractService(obj any) (*v1.Service, error) {
-	cm, ok := obj.(*v1.Service)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return nil, fmt.Errorf("couldn't get object from tombstone %#v", obj)
-		}
-		cm, ok = tombstone.Obj.(*v1.Service)
-		if !ok {
-			return nil, fmt.Errorf("tombstone contained object that is not a Service %#v", obj)
-		}
-	}
-	return cm, nil
 }
 
 func namespacedNameForService(svc *model.Service) types.NamespacedName {

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -195,12 +195,12 @@ func Extract[T Object](obj any) T {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			log.Errorf("couldn't get object from tombstone %+v", obj)
+			log.Errorf("couldn't get object from tombstone: %+v", obj)
 			return empty
 		}
 		o, ok = tombstone.Obj.(T)
 		if !ok {
-			log.Errorf("tombstone contained object that is not an object %+v", obj)
+			log.Errorf("tombstone contained object that is not an object (key:%v, obj:%T)", tombstone.Key, tombstone.Obj)
 			return empty
 		}
 	}

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -39,11 +39,6 @@ type Object interface {
 	runtime.Object
 }
 
-type comparableObject interface {
-	comparable
-	Object
-}
-
 // UnstructuredToGVR extracts the GVR of an unstructured resource. This is useful when using dynamic
 // clients.
 func UnstructuredToGVR(u unstructured.Unstructured) (schema.GroupVersionResource, error) {

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -221,20 +221,7 @@ func Extract[T Object](obj any) T {
 }
 
 func ExtractObject(obj any) Object {
-	o, ok := obj.(Object)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			log.Errorf("couldn't get object from tombstone %+v", obj)
-			return nil
-		}
-		o, ok = tombstone.Obj.(Object)
-		if !ok {
-			log.Errorf("tombstone contained object that is not an object %+v", obj)
-			return nil
-		}
-	}
-	return o
+	return Extract[Object](obj)
 }
 
 // IgnoreNotFound returns nil on NotFound errors.

--- a/pkg/kube/namespace/filter.go
+++ b/pkg/kube/namespace/filter.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
@@ -77,16 +77,9 @@ func (d *discoveryNamespacesFilter) Filter(obj any) bool {
 	}
 
 	// When an object is deleted, obj could be a DeletionFinalStateUnknown marker item.
-	object, ok := obj.(metav1.Object)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return false
-		}
-		object, ok = tombstone.Obj.(metav1.Object)
-		if !ok {
-			return false
-		}
+	object := controllers.ExtractObject(obj)
+	if object == nil {
+		return false
 	}
 
 	// permit if object resides in a namespace labeled for discovery

--- a/security/pkg/k8s/chiron/controller_test.go
+++ b/security/pkg/k8s/chiron/controller_test.go
@@ -375,13 +375,10 @@ func TestScrtUpdated(t *testing.T) {
 			scrt.Data[ca.RootCertFile] = []byte(exampleCACert2)
 		}
 
-		var newScrt any
-		if tc.invalidNewSecret {
-			// point to an invalid secret object
-			newScrt = &v1.ConfigMap{}
-		} else {
+		var newScrt *v1.Secret
+		if !tc.invalidNewSecret {
 			newScrt = &v1.Secret{}
-			scrt.DeepCopyInto(newScrt.(*v1.Secret))
+			scrt.DeepCopyInto(newScrt)
 		}
 		wc.scrtUpdated(scrt, newScrt)
 


### PR DESCRIPTION
Currently, we have this logic spread throughout the codebase, introducing boilerplate and risk of bugs. This unifies the implementation