### PR TITLE
implement config dump query by resource type for missing types

### DIFF
--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -631,7 +631,11 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 	}
 	if ts := s.getResourceTypes(req); len(ts) != 0 {
 		dump := s.getConfigDumpByResourceType(con, nil, ts)
-		writeJSON(w, dump, req)
+		configDump := &admin.ConfigDump{}
+		for _, configs := range dump {
+			configDump.Configs = append(configDump.Configs, configs...)
+		}
+		writeJSON(w, configDump, req)
 		return
 	}
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -715,6 +715,8 @@ func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, ts []str
 					default:
 						dumps[resourceType] = append(dumps[resourceType], protoconv.MessageToAny(tce))
 					}
+				default:
+					dumps[resourceType] = append(dumps[resourceType], rr.Resource)
 				}
 			}
 		} else {

--- a/releasenotes/notes/configdump-query-types.yaml
+++ b/releasenotes/notes/configdump-query-types.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
   - |
-    **Addded** support for missing resource types to `/config_dump` API
+    **Added** support for missing resource types to `/config_dump` API

--- a/releasenotes/notes/configdump-query-types.yaml
+++ b/releasenotes/notes/configdump-query-types.yaml
@@ -1,7 +1,9 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
-issue: https://github.com/istio/istio/pull/42658
+issue: 
+  - https://github.com/istio/istio/pull/42658
+
 releaseNotes:
   - |
     **Addded** support for missing resource types to `/config_dump` API

--- a/releasenotes/notes/configdump-query-types.yaml
+++ b/releasenotes/notes/configdump-query-types.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: https://github.com/istio/istio/pull/42658
+releaseNotes:
+  - |
+    **Addded** support for missing resource types to `/config_dump` API


### PR DESCRIPTION
**Please provide a description of this PR:**

`/debug/config_dump?types=ecds` was implemented but none of the other config_dump type

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure