### PR TITLE
Revert "add e2e for MetricDefinition"

### DIFF
--- a/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
@@ -60,46 +60,6 @@ const (
 	registryPasswd = "passwd"
 )
 
-func TestMetricDefinitions(t *testing.T) {
-	framework.NewTest(t).
-		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
-		Features("observability.telemetry.stats.prometheus.customize-metric").
-		Run(func(t framework.TestContext) {
-			t.Cleanup(func() {
-				if t.Failed() {
-					util.PromDump(t.Clusters().Default(), promInst, prometheus.Query{Metric: "istio_custom_total"})
-				}
-			})
-			urlPath := "/custom_path"
-			httpSourceQuery := buildCustomQuery(urlPath)
-			cluster := t.Clusters().Default()
-			retry.UntilSuccessOrFail(t, func() error {
-				if err := sendHTTPTraffic(urlPath); err != nil {
-					t.Log("failed to send traffic")
-					return err
-				}
-				if _, err := util.QueryPrometheus(t, cluster, httpSourceQuery, promInst); err != nil {
-					util.PromDiff(t, promInst, cluster, httpSourceQuery)
-					return err
-				}
-				return nil
-			}, retry.Delay(1*time.Second), retry.Timeout(300*time.Second))
-			util.ValidateMetric(t, cluster, promInst, httpSourceQuery, 1)
-		})
-}
-
-func buildCustomQuery(urlPath string) (destinationQuery prometheus.Query) {
-	labels := map[string]string{
-		"url_path":        urlPath,
-		"response_status": "200",
-	}
-	sourceQuery := prometheus.Query{}
-	sourceQuery.Metric = "istio_custom_total"
-	sourceQuery.Labels = labels
-
-	return sourceQuery
-}
-
 func TestCustomizeMetrics(t *testing.T) {
 	framework.NewTest(t).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
@@ -257,14 +217,6 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 		return
 	}
 	cfValue := `
-meshConfig:
-  defaultConfig:
-    proxyStatsMatcher:
-      inclusionPrefixes:
-      - istio_custom_total
-    extraStatTags:
-    - url_path
-    - response_status
 values:
  telemetry:
    v2:
@@ -282,16 +234,6 @@ values:
                custom_dimension: "'test'"
              tags_to_remove:
              - %s
-         outboundSidecar:
-           definitions:
-           - name: custom_total
-             type: "COUNTER"
-             value: "1"
-           metrics:
-           - name: custom_total
-             dimensions:
-               url_path: request.url_path
-               response_status: string(response.code)
 `
 	cfg.ControlPlaneValues = fmt.Sprintf(cfValue, removedTag)
 	cfg.RemoteClusterValues = cfg.ControlPlaneValues
@@ -319,30 +261,6 @@ func setupWasmExtension(ctx resource.Context) error {
 	if err := ctx.ConfigIstio().EvalFile(appNsInst.Name(), args, "testdata/attributegen_envoy_filter.yaml").
 		Apply(); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func sendHTTPTraffic(urlPath string) error {
-	for _, cltInstance := range client {
-		httpOpts := echo.CallOptions{
-			To: server,
-			Port: echo.Port{
-				Name: "http",
-			},
-			HTTP: echo.HTTP{
-				Path:   urlPath,
-				Method: "GET",
-			},
-			Retry: echo.Retry{
-				NoRetry: true,
-			},
-		}
-
-		if _, err := cltInstance.Call(httpOpts); err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Reverts istio/istio#42563

This is causing flaky tests; @kyessenov is looking into it (I think?) but in the meantime we should revert to unblock other PRs as it fails >50% of the time