### PR TITLE
Remove deprecated engine type field in regex

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -853,8 +853,7 @@ func translateRouteMatch(node *model.Proxy, vs config.Config, in *networking.HTT
 					// use regex.
 					out.PathSpecifier = &route.RouteMatch_SafeRegex{
 						SafeRegex: &matcher.RegexMatcher{
-							EngineType: util.RegexEngine,
-							Regex:      regexp.QuoteMeta(path) + prefixMatchRegex,
+							Regex: regexp.QuoteMeta(path) + prefixMatchRegex,
 						},
 					}
 				}
@@ -864,8 +863,7 @@ func translateRouteMatch(node *model.Proxy, vs config.Config, in *networking.HTT
 		case *networking.StringMatch_Regex:
 			out.PathSpecifier = &route.RouteMatch_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
-					EngineType: util.RegexEngine,
-					Regex:      m.Regex,
+					Regex: m.Regex,
 				},
 			}
 		}
@@ -912,8 +910,7 @@ func translateQueryParamMatch(name string, in *networking.StringMatch) *route.Qu
 			StringMatch: &matcher.StringMatcher{
 				MatchPattern: &matcher.StringMatcher_SafeRegex{
 					SafeRegex: &matcher.RegexMatcher{
-						EngineType: util.RegexEngine,
-						Regex:      m.Regex,
+						Regex: m.Regex,
 					},
 				},
 			},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -28,7 +28,6 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/networking/util"
 	authzmatcher "istio.io/istio/pilot/pkg/security/authz/matcher"
 	authz "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pkg/config/labels"
@@ -163,8 +162,7 @@ func TestIsCatchAllRoute(t *testing.T) {
 				Match: &route.RouteMatch{
 					PathSpecifier: &route.RouteMatch_SafeRegex{
 						SafeRegex: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{}},
-							Regex:      "*",
+							Regex: "*",
 						},
 					},
 				},
@@ -199,8 +197,7 @@ func TestIsCatchAllRoute(t *testing.T) {
 					PathSpecifier: &route.RouteMatch_SafeRegex{
 						SafeRegex: &matcher.RegexMatcher{
 							// nolint: staticcheck
-							EngineType: &matcher.RegexMatcher_GoogleRe2{},
-							Regex:      "*",
+							Regex: "*",
 						},
 					},
 					Headers: []*route.HeaderMatcher{
@@ -210,8 +207,7 @@ func TestIsCatchAllRoute(t *testing.T) {
 								StringMatch: &matcher.StringMatcher{
 									MatchPattern: &matcher.StringMatcher_SafeRegex{
 										SafeRegex: &matcher.RegexMatcher{
-											EngineType: util.RegexEngine,
-											Regex:      "*",
+											Regex: "*",
 										},
 									},
 								},
@@ -230,8 +226,7 @@ func TestIsCatchAllRoute(t *testing.T) {
 					PathSpecifier: &route.RouteMatch_SafeRegex{
 						SafeRegex: &matcher.RegexMatcher{
 							// nolint: staticcheck
-							EngineType: &matcher.RegexMatcher_GoogleRe2{},
-							Regex:      "*",
+							Regex: "*",
 						},
 					},
 					QueryParameters: []*route.QueryParameterMatcher{
@@ -334,8 +329,7 @@ func TestTranslateCORSPolicy(t *testing.T) {
 			{
 				MatchPattern: &matcher.StringMatcher_SafeRegex{
 					SafeRegex: &matcher.RegexMatcher{
-						EngineType: util.RegexEngine,
-						Regex:      "regex",
+						Regex: "regex",
 					},
 				},
 			},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -196,8 +196,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(routes[0].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: util.RegexEngine,
-				Regex:      `/route/v1((\/).*)?`,
+				Regex: `/route/v1((\/).*)?`,
 			},
 		}))
 		g.Expect(routes[1].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_Prefix{
@@ -227,8 +226,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(routes[0].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: util.RegexEngine,
-				Regex:      `/route/v1((\/).*)?`,
+				Regex: `/route/v1((\/).*)?`,
 			},
 		}))
 		g.Expect(routes[0].Action.(*envoyroute.Route_Route).Route.ClusterNotFoundResponseCode).
@@ -2152,15 +2150,13 @@ var networkingSubsetWithPortLevelSettings = &networking.Subset{
 }
 
 func TestSortVHostRoutes(t *testing.T) {
-	regexEngine := &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{}}
 	first := []*envoyroute.Route{
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Path{Path: "/path1"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/prefix1"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: regexEngine,
-				Regex:      ".*?regex1",
+				Regex: ".*?regex1",
 			},
 		}}},
 	}
@@ -2169,8 +2165,7 @@ func TestSortVHostRoutes(t *testing.T) {
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/prefix1"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: regexEngine,
-				Regex:      ".*?regex1",
+				Regex: ".*?regex1",
 			},
 		}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/"}}},
@@ -2180,15 +2175,13 @@ func TestSortVHostRoutes(t *testing.T) {
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/prefix12"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: regexEngine,
-				Regex:      ".*?regex12",
+				Regex: ".*?regex12",
 			},
 		}}},
 		{Match: &envoyroute.RouteMatch{
 			PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
-					EngineType: regexEngine,
-					Regex:      "*",
+					Regex: "*",
 				},
 			},
 			Headers: []*envoyroute.HeaderMatcher{
@@ -2208,15 +2201,13 @@ func TestSortVHostRoutes(t *testing.T) {
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_Prefix{Prefix: "/prefix12"}}},
 		{Match: &envoyroute.RouteMatch{PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: regexEngine,
-				Regex:      ".*?regex12",
+				Regex: ".*?regex12",
 			},
 		}}},
 		{Match: &envoyroute.RouteMatch{
 			PathSpecifier: &envoyroute.RouteMatch_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
-					EngineType: regexEngine,
-					Regex:      "*",
+					Regex: "*",
 				},
 			},
 			Headers: []*envoyroute.HeaderMatcher{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -117,9 +117,6 @@ var ALPNHttp3OverQUIC = []string{"h3"}
 // ALPNDownstreamWithMxc advertises that Proxy is going to talk either tcp(for metadata exchange), http2 or http 1.1.
 var ALPNDownstreamWithMxc = []string{"istio-peer-exchange", "h2", "http/1.1"}
 
-// RegexEngine is the default google RE2 regex engine.
-var RegexEngine = &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{}}
-
 func ListContains(haystack []string, needle string) bool {
 	for _, n := range haystack {
 		if needle == n {
@@ -623,8 +620,7 @@ func ConvertToEnvoyMatch(in *networking.StringMatch) *matcher.StringMatcher {
 		return &matcher.StringMatcher{
 			MatchPattern: &matcher.StringMatcher_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
-					EngineType: RegexEngine,
-					Regex:      m.Regex,
+					Regex: m.Regex,
 				},
 			},
 		}

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -91,7 +91,6 @@ typedConfig:
                 - urlPath:
                     path:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notRule:
                 orRules:
@@ -108,7 +107,6 @@ typedConfig:
                   - urlPath:
                       path:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - orRules:
                 rules:
@@ -155,7 +153,6 @@ typedConfig:
                     prefix: prefix.
                 - requestedServerName:
                     safeRegex:
-                      googleRe2: {}
                       regex: .+
             - notRule:
                 orRules:
@@ -168,7 +165,6 @@ typedConfig:
                       prefix: not-prefix.
                   - requestedServerName:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - orRules:
                 rules:
@@ -200,7 +196,6 @@ typedConfig:
                     value:
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - notRule:
                 orRules:
@@ -233,7 +228,6 @@ typedConfig:
                       value:
                         stringMatch:
                           safeRegex:
-                            googleRe2: {}
                             regex: .+
         principals:
         - andIds:
@@ -252,13 +246,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*-suffix-principal
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notId:
                 orIds:
@@ -275,13 +267,11 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: spiffe://.*-not-suffix-principal
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - orIds:
                 ids:
@@ -313,7 +303,6 @@ typedConfig:
                     value:
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - notId:
                 orIds:
@@ -346,7 +335,6 @@ typedConfig:
                       value:
                         stringMatch:
                           safeRegex:
-                            googleRe2: {}
                             regex: .+
             - orIds:
                 ids:
@@ -354,25 +342,21 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-prefix-.*/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*-ns-suffix/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*/.*
             - notId:
                 orIds:
@@ -381,25 +365,21 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns-prefix-.*/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*-not-ns-suffix/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*/.*
             - orIds:
                 ids:
@@ -504,25 +484,21 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-prefix-.*/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*-ns-suffix/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*/.*
             - notId:
                 orIds:
@@ -531,25 +507,21 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns-prefix-.*/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*-not-ns-suffix/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*/.*
             - orIds:
                 ids:
@@ -565,13 +537,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*-suffix-principal
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notId:
                 orIds:
@@ -588,13 +558,11 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: spiffe://.*-not-suffix-principal
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - orIds:
                 ids:
@@ -626,7 +594,6 @@ typedConfig:
                     value:
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - notId:
                 orIds:
@@ -659,7 +626,6 @@ typedConfig:
                       value:
                         stringMatch:
                           safeRegex:
-                            googleRe2: {}
                             regex: .+
             - orIds:
                 ids:
@@ -691,7 +657,6 @@ typedConfig:
                     value:
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - notId:
                 orIds:
@@ -724,7 +689,6 @@ typedConfig:
                       value:
                         stringMatch:
                           safeRegex:
-                            googleRe2: {}
                             regex: .+
             - orIds:
                 ids:
@@ -756,7 +720,6 @@ typedConfig:
                     value:
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - notId:
                 orIds:
@@ -789,7 +752,6 @@ typedConfig:
                       value:
                         stringMatch:
                           safeRegex:
-                            googleRe2: {}
                             regex: .+
             - orIds:
                 ids:
@@ -833,7 +795,6 @@ typedConfig:
                         oneOf:
                           stringMatch:
                             safeRegex:
-                              googleRe2: {}
                               regex: .+
             - notId:
                 orIds:
@@ -878,7 +839,6 @@ typedConfig:
                           oneOf:
                             stringMatch:
                               safeRegex:
-                                googleRe2: {}
                                 regex: .+
             - orIds:
                 ids:
@@ -926,7 +886,6 @@ typedConfig:
                         oneOf:
                           stringMatch:
                             safeRegex:
-                              googleRe2: {}
                               regex: .+
             - notId:
                 orIds:
@@ -975,6 +934,5 @@ typedConfig:
                           oneOf:
                             stringMatch:
                               safeRegex:
-                                googleRe2: {}
                                 regex: .+
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-host-before-111-out.yaml
@@ -12,17 +12,14 @@ typedConfig:
                 - header:
                     name: :authority
                     safeRegexMatch:
-                      googleRe2: {}
                       regex: (?i)example\.com
                 - header:
                     name: :authority
                     safeRegexMatch:
-                      googleRe2: {}
                       regex: (?i)prefix\.example\..*
                 - header:
                     name: :authority
                     safeRegexMatch:
-                      googleRe2: {}
                       regex: (?i).*\.example\.com
                 - header:
                     name: :authority
@@ -33,17 +30,14 @@ typedConfig:
                   - header:
                       name: :authority
                       safeRegexMatch:
-                        googleRe2: {}
                         regex: (?i)not-example\.com
                   - header:
                       name: :authority
                       safeRegexMatch:
-                        googleRe2: {}
                         regex: (?i)prefix\.not-example\..*
                   - header:
                       name: :authority
                       safeRegexMatch:
-                        googleRe2: {}
                         regex: (?i).*\.not-example\.com
                   - header:
                       name: :authority

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -21,7 +21,6 @@ typedConfig:
                 - urlPath:
                     path:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notRule:
                 orRules:
@@ -38,7 +37,6 @@ typedConfig:
                   - urlPath:
                       path:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
         principals:
         - andIds:

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -123,13 +123,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/namespaces1/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/namespaces2/.*
       ns[foo]-policy[httpbin-8]-rule[0]:
         permissions:

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-multiple-td-aliases-out.yaml
@@ -59,6 +59,5 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[1]-ns[0]/.*
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-principal-with-wildcard-out.yaml
@@ -17,7 +17,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
         - andIds:
             ids:
@@ -27,7 +26,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*/ns/foo/sa/rule[0]-from[1]-principal[0]
                 - filterState:
                     key: io.istio.peer_principal
@@ -37,6 +35,5 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*bar/ns/foo/sa/rule[0]-from[1]-principal[1]
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -51,7 +51,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[1]-ns[0]/.*
       ns[foo]-policy[httpbin]-rule[1]:
         permissions:

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -124,13 +124,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[0]-ns[1]/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[0]-ns[2]/.*
             - orIds:
                 ids:
@@ -201,13 +199,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[1]-ns[1]/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[0]-from[1]-ns[2]/.*
             - orIds:
                 ids:
@@ -352,13 +348,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[1]-from[0]-ns[1]/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[1]-from[0]-ns[2]/.*
             - orIds:
                 ids:
@@ -410,13 +404,11 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[1]-from[1]-ns[1]/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/rule[1]-from[1]-ns[2]/.*
             - orIds:
                 ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/td-aliases-source-principal-out.yaml
@@ -17,7 +17,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/istio-system/.*
             - orIds:
                 ids:
@@ -25,19 +24,16 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*/ns/foo/sa/all-td
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*-td/ns/foo/sa/prefix-td
                 - filterState:
                     key: io.istio.peer_principal

--- a/pilot/pkg/security/authz/builder/testdata/tcp/allow-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/allow-both-http-tcp-out.yaml
@@ -19,7 +19,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-1/.*
   shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/builder/testdata/tcp/audit-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/audit-both-http-tcp-out.yaml
@@ -83,7 +83,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
             - notId:
                 orIds:
@@ -92,7 +91,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
             - orIds:
                 ids:
@@ -144,7 +142,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
             - notId:
                 orIds:
@@ -153,7 +150,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
             - orIds:
                 ids:

--- a/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/tcp/deny-both-http-tcp-out.yaml
@@ -45,7 +45,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-1/.*
       ns[foo]-policy[httpbin-deny]-rule[4]:
         permissions:
@@ -85,7 +84,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-2/.*
       ns[foo]-policy[httpbin-deny]-rule[7]:
         permissions:
@@ -103,7 +101,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-1/.*
       ns[foo]-policy[httpbin-deny]-rule[8]:
         permissions:
@@ -195,7 +192,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*principal-suffix
                 - filterState:
                     key: io.istio.peer_principal
@@ -205,7 +201,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notId:
                 orIds:
@@ -218,7 +213,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: spiffe://.*not-principal-suffix
                   - filterState:
                       key: io.istio.peer_principal
@@ -228,7 +222,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
             - orIds:
                 ids:
@@ -236,25 +229,21 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*ns-suffix/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-prefix.*/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*/.*
             - notId:
                 orIds:
@@ -263,25 +252,21 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*not-ns-suffix/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns-prefix.*/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*/.*
             - orIds:
                 ids:
@@ -333,25 +318,21 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*ns-suffix/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/ns-prefix.*/.*
                 - filterState:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .*/ns/.*/.*
             - notId:
                 orIds:
@@ -360,25 +341,21 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*not-ns-suffix/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/not-ns-prefix.*/.*
                   - filterState:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .*/ns/.*/.*
             - orIds:
                 ids:
@@ -390,7 +367,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: spiffe://.*principal-suffix
                 - filterState:
                     key: io.istio.peer_principal
@@ -400,7 +376,6 @@ typedConfig:
                     key: io.istio.peer_principal
                     stringMatch:
                       safeRegex:
-                        googleRe2: {}
                         regex: .+
             - notId:
                 orIds:
@@ -413,7 +388,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: spiffe://.*not-principal-suffix
                   - filterState:
                       key: io.istio.peer_principal
@@ -423,7 +397,6 @@ typedConfig:
                       key: io.istio.peer_principal
                       stringMatch:
                         safeRegex:
-                          googleRe2: {}
                           regex: .+
   shadowRulesStatPrefix: istio_dry_run_allow_
   statPrefix: tcp.

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -77,9 +77,6 @@ func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
 			SafeRegexMatch: &matcher.RegexMatcher{
-				EngineType: &matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-				},
 				Regex: `(?i)` + regex,
 			},
 		},

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -109,9 +109,6 @@ func TestHostMatcherWithRegex(t *testing.T) {
 				Name: ":authority",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
 					SafeRegexMatch: &matcher.RegexMatcher{
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 						Regex: `(?i).*\.example\.com`,
 					},
 				},
@@ -125,9 +122,6 @@ func TestHostMatcherWithRegex(t *testing.T) {
 				Name: ":authority",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
 					SafeRegexMatch: &matcher.RegexMatcher{
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 						Regex: `(?i)example\..*`,
 					},
 				},
@@ -141,9 +135,6 @@ func TestHostMatcherWithRegex(t *testing.T) {
 				Name: ":authority",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
 					SafeRegexMatch: &matcher.RegexMatcher{
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 						Regex: `(?i)example\.com`,
 					},
 				},
@@ -299,9 +290,6 @@ func TestPathMatcher(t *testing.T) {
 						MatchPattern: &matcher.StringMatcher_SafeRegex{
 							SafeRegex: &matcher.RegexMatcher{
 								Regex: ".+",
-								EngineType: &matcher.RegexMatcher_GoogleRe2{
-									GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-								},
 							},
 						},
 					},

--- a/pilot/pkg/security/authz/matcher/metadata_test.go
+++ b/pilot/pkg/security/authz/matcher/metadata_test.go
@@ -75,9 +75,6 @@ func TestMetadataListMatcher(t *testing.T) {
 									StringMatch: &matcher.StringMatcher{
 										MatchPattern: &matcher.StringMatcher_SafeRegex{
 											SafeRegex: &matcher.RegexMatcher{
-												EngineType: &matcher.RegexMatcher_GoogleRe2{
-													GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-												},
 												Regex: regex,
 											},
 										},

--- a/pilot/pkg/security/authz/matcher/string.go
+++ b/pilot/pkg/security/authz/matcher/string.go
@@ -30,9 +30,6 @@ func StringMatcherRegex(regex string) *matcher.StringMatcher {
 	return &matcher.StringMatcher{
 		MatchPattern: &matcher.StringMatcher_SafeRegex{
 			SafeRegex: &matcher.RegexMatcher{
-				EngineType: &matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-				},
 				Regex: regex,
 			},
 		},

--- a/pilot/pkg/security/authz/matcher/string_test.go
+++ b/pilot/pkg/security/authz/matcher/string_test.go
@@ -94,9 +94,6 @@ func TestStringMatcherRegex(t *testing.T) {
 				MatchPattern: &matcher.StringMatcher_SafeRegex{
 					SafeRegex: &matcher.RegexMatcher{
 						Regex: "*",
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 					},
 				},
 			},
@@ -108,9 +105,6 @@ func TestStringMatcherRegex(t *testing.T) {
 				MatchPattern: &matcher.StringMatcher_SafeRegex{
 					SafeRegex: &matcher.RegexMatcher{
 						Regex: "+?",
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 					},
 				},
 			},

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -121,7 +121,6 @@ func TestGenerator(t *testing.T) {
            key: io.istio.peer_principal
            string_match:
             safeRegex:
-              googleRe2: {}
               regex: .*/ns/foo/.*`),
 		},
 		{
@@ -134,7 +133,6 @@ func TestGenerator(t *testing.T) {
            key: io.istio.peer_principal
            string_match:
             safeRegex:
-              googleRe2: {}
               regex: .*/ns/foo/.*`),
 		},
 		{

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -250,7 +250,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -250,7 +250,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -335,10 +335,10 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}
+          "safe_regex": {"regex":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -245,7 +245,7 @@
           "suffix": "shadow_denied"
           },
           {
-          "safe_regex": {"google_re2":{}, "regex":"vhost\\.*\\.route\\.*"}
+          "safe_regex": {"regex":"vhost\\.*\\.route\\.*"}
           },
           {
           "prefix": "component"

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -134,7 +134,7 @@
           {{- end }}
           {{- range $a, $s := .inclusionRegexps }}
           {
-          "safe_regex": {"google_re2":{}, "regex":"{{js $s}}"}
+          "safe_regex": {"regex":"{{js $s}}"}
           },
           {{- end }}
           {


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/envoyproxy/envoy/pull/21633 has deprecated `engine_type` field in regex. The PR removes these fields no longer used by Envoy.
