### PR TITLE
Add new `config.Name` helper to convert to NamespacedName

### DIFF
--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -302,7 +302,7 @@ func (h *HelmReconciler) Delete() error {
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.
 func (h *HelmReconciler) SetStatusBegin() error {
 	isop := &istioV1Alpha1.IstioOperator{}
-	if err := h.getClient().Get(context.TODO(), config.Name(h.iop), isop); err != nil {
+	if err := h.getClient().Get(context.TODO(), config.NamespacedName(h.iop), isop); err != nil {
 		if runtime.IsNotRegisteredError(err) {
 			// CRD not yet installed in cluster, nothing to update.
 			return nil
@@ -326,7 +326,7 @@ func (h *HelmReconciler) SetStatusBegin() error {
 // SetStatusComplete updates the status field on the IstioOperator instance based on the resulting err parameter.
 func (h *HelmReconciler) SetStatusComplete(status *v1alpha1.InstallStatus) error {
 	iop := &istioV1Alpha1.IstioOperator{}
-	if err := h.getClient().Get(context.TODO(), config.Name(h.iop), iop); err != nil {
+	if err := h.getClient().Get(context.TODO(), config.NamespacedName(h.iop), iop); err != nil {
 		return fmt.Errorf("failed to get IstioOperator before updating status due to %v", err)
 	}
 	iop.Status = status

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,6 +39,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
 	"istio.io/istio/pkg/config/analysis/analyzers/webhook"
 	"istio.io/istio/pkg/config/analysis/local"
@@ -302,11 +302,7 @@ func (h *HelmReconciler) Delete() error {
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.
 func (h *HelmReconciler) SetStatusBegin() error {
 	isop := &istioV1Alpha1.IstioOperator{}
-	namespacedName := types.NamespacedName{
-		Name:      h.iop.Name,
-		Namespace: h.iop.Namespace,
-	}
-	if err := h.getClient().Get(context.TODO(), namespacedName, isop); err != nil {
+	if err := h.getClient().Get(context.TODO(), config.Name(h.iop), isop); err != nil {
 		if runtime.IsNotRegisteredError(err) {
 			// CRD not yet installed in cluster, nothing to update.
 			return nil
@@ -330,11 +326,7 @@ func (h *HelmReconciler) SetStatusBegin() error {
 // SetStatusComplete updates the status field on the IstioOperator instance based on the resulting err parameter.
 func (h *HelmReconciler) SetStatusComplete(status *v1alpha1.InstallStatus) error {
 	iop := &istioV1Alpha1.IstioOperator{}
-	namespacedName := types.NamespacedName{
-		Name:      h.iop.Name,
-		Namespace: h.iop.Namespace,
-	}
-	if err := h.getClient().Get(context.TODO(), namespacedName, iop); err != nil {
+	if err := h.getClient().Get(context.TODO(), config.Name(h.iop), iop); err != nil {
 		return fmt.Errorf("failed to get IstioOperator before updating status due to %v", err)
 	}
 	iop.Status = status

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -216,7 +216,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *ingress.Ingress) (bool, err
 	if err != nil {
 		return false, err
 	}
-	item := config.Name(ing)
+	item := config.NamespacedName(ing)
 	if shouldProcess {
 		// record processed ingress
 		c.mutex.Lock()

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -216,7 +216,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *ingress.Ingress) (bool, err
 	if err != nil {
 		return false, err
 	}
-	item := types.NamespacedName{Name: ing.Name, Namespace: ing.Namespace}
+	item := config.Name(ing)
 	if shouldProcess {
 		// record processed ingress
 		c.mutex.Lock()

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -164,7 +164,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *knetworking.Ingress) (bool,
 	if err != nil {
 		return false, err
 	}
-	item := config.Name(ing)
+	item := config.NamespacedName(ing)
 	if shouldProcess {
 		// record processed ingress
 		c.mutex.Lock()

--- a/pilot/pkg/config/kube/ingressv1/controller.go
+++ b/pilot/pkg/config/kube/ingressv1/controller.go
@@ -164,7 +164,7 @@ func (c *controller) shouldProcessIngressUpdate(ing *knetworking.Ingress) (bool,
 	if err != nil {
 		return false, err
 	}
-	item := types.NamespacedName{Name: ing.Name, Namespace: ing.Namespace}
+	item := config.Name(ing)
 	if shouldProcess {
 		// record processed ingress
 		c.mutex.Lock()

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -74,7 +74,7 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 			// This can happen when there are more than one destination rule of same host in one namespace.
 			copied := mdr.rule.DeepCopy()
 			mdr.rule = &copied
-			mdr.from = append(mdr.from, types.NamespacedName{Namespace: destRuleConfig.Namespace, Name: destRuleConfig.Name})
+			mdr.from = append(mdr.from, config.Name(destRuleConfig))
 			mergedRule := copied.Spec.(*networking.DestinationRule)
 
 			existingSubset := map[string]struct{}{}
@@ -160,12 +160,7 @@ func (ps *PushContext) inheritDestinationRule(parent, child *ConsolidatedDestRul
 func ConvertConsolidatedDestRule(cfg *config.Config) *ConsolidatedDestRule {
 	return &ConsolidatedDestRule{
 		rule: cfg,
-		from: []types.NamespacedName{
-			{
-				Namespace: cfg.Namespace,
-				Name:      cfg.Name,
-			},
-		},
+		from: []types.NamespacedName{config.Name(cfg)},
 	}
 }
 

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -74,7 +74,7 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 			// This can happen when there are more than one destination rule of same host in one namespace.
 			copied := mdr.rule.DeepCopy()
 			mdr.rule = &copied
-			mdr.from = append(mdr.from, config.Name(destRuleConfig))
+			mdr.from = append(mdr.from, config.NamespacedName(destRuleConfig))
 			mergedRule := copied.Spec.(*networking.DestinationRule)
 
 			existingSubset := map[string]struct{}{}
@@ -160,7 +160,7 @@ func (ps *PushContext) inheritDestinationRule(parent, child *ConsolidatedDestRul
 func ConvertConsolidatedDestRule(cfg *config.Config) *ConsolidatedDestRule {
 	return &ConsolidatedDestRule{
 		rule: cfg,
-		from: []types.NamespacedName{config.Name(cfg)},
+		from: []types.NamespacedName{config.NamespacedName(cfg)},
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1260,7 +1260,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 			return nil, fmt.Errorf("failed to find model service for %v", hostname)
 		}
 
-		for _, modelService := range c.servicesForNamespacedName(config.Name(svc)) {
+		for _, modelService := range c.servicesForNamespacedName(config.NamespacedName(svc)) {
 			discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(modelService)
 
 			tps := make(map[model.Port]*model.Port)
@@ -1320,7 +1320,7 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 ) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 
-	for _, svc := range c.servicesForNamespacedName(config.Name(service)) {
+	for _, svc := range c.servicesForNamespacedName(config.NamespacedName(service)) {
 		discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(svc)
 
 		tps := make(map[model.Port]*model.Port)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/util/workloadinstances"
 	"istio.io/istio/pilot/pkg/util/informermetric"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -1259,7 +1260,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 			return nil, fmt.Errorf("failed to find model service for %v", hostname)
 		}
 
-		for _, modelService := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(svc)) {
+		for _, modelService := range c.servicesForNamespacedName(config.Name(svc)) {
 			discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(modelService)
 
 			tps := make(map[model.Port]*model.Port)
@@ -1319,7 +1320,7 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 ) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 
-	for _, svc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(service)) {
+	for _, svc := range c.servicesForNamespacedName(config.Name(service)) {
 		discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(svc)
 
 		tps := make(map[model.Port]*model.Port)

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -70,7 +70,7 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 		// if the service is headless service, trigger a full push if EnableHeadlessService is true,
 		// otherwise push endpoint updates - needed for NDS output.
 		if svc.Spec.ClusterIP == v1.ClusterIPNone {
-			for _, modelSvc := range c.servicesForNamespacedName(config.Name(svc)) {
+			for _, modelSvc := range c.servicesForNamespacedName(config.NamespacedName(svc)) {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					Full: features.EnableHeadlessService,
 					// TODO: extend and set service instance type, so no need to re-init push context

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -69,7 +70,7 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 		// if the service is headless service, trigger a full push if EnableHeadlessService is true,
 		// otherwise push endpoint updates - needed for NDS output.
 		if svc.Spec.ClusterIP == v1.ClusterIPNone {
-			for _, modelSvc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(svc)) {
+			for _, modelSvc := range c.servicesForNamespacedName(config.Name(svc)) {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					Full: features.EnableHeadlessService,
 					// TODO: extend and set service instance type, so no need to re-init push context

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -70,7 +70,7 @@ func (e *endpointsController) GetProxyServiceInstances(c *Controller, proxy *mod
 func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *model.Proxy) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 
-	for _, svc := range c.servicesForNamespacedName(config.Name(endpoints)) {
+	for _, svc := range c.servicesForNamespacedName(config.NamespacedName(endpoints)) {
 		pod := c.pods.getPodByProxy(proxy)
 		builder := NewEndpointBuilder(c, pod)
 
@@ -253,7 +253,7 @@ func (e *endpointsController) buildIstioEndpointsWithService(name, namespace str
 
 func (e *endpointsController) getServiceNamespacedName(ep any) types.NamespacedName {
 	endpoint := ep.(*v1.Endpoints)
-	return config.Name(endpoint)
+	return config.NamespacedName(endpoint)
 }
 
 // endpointsEqual returns true if the two endpoints are the same in aspects Pilot cares about

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube/informer"
@@ -69,7 +70,7 @@ func (e *endpointsController) GetProxyServiceInstances(c *Controller, proxy *mod
 func endpointServiceInstances(c *Controller, endpoints *v1.Endpoints, proxy *model.Proxy) []*model.ServiceInstance {
 	var out []*model.ServiceInstance
 
-	for _, svc := range c.servicesForNamespacedName(kube.NamespacedNameForK8sObject(endpoints)) {
+	for _, svc := range c.servicesForNamespacedName(config.Name(endpoints)) {
 		pod := c.pods.getPodByProxy(proxy)
 		builder := NewEndpointBuilder(c, pod)
 
@@ -252,7 +253,7 @@ func (e *endpointsController) buildIstioEndpointsWithService(name, namespace str
 
 func (e *endpointsController) getServiceNamespacedName(ep any) types.NamespacedName {
 	endpoint := ep.(*v1.Endpoints)
-	return kube.NamespacedNameForK8sObject(endpoint)
+	return config.Name(endpoint)
 }
 
 // endpointsEqual returns true if the two endpoints are the same in aspects Pilot cares about

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	kubesr "istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/kube"
@@ -137,7 +138,7 @@ func (ec *serviceExportCacheImpl) onServiceExportEvent(obj any, event model.Even
 }
 
 func (ec *serviceExportCacheImpl) updateXDS(se metav1.Object) {
-	for _, svc := range ec.servicesForNamespacedName(kubesr.NamespacedNameForK8sObject(se)) {
+	for _, svc := range ec.servicesForNamespacedName(config.Name(se)) {
 		// Re-build the endpoints for this service with a new discoverability policy.
 		// Also update any internal caching.
 		endpoints := ec.buildEndpointsForService(svc, true)
@@ -177,7 +178,7 @@ func (ec *serviceExportCacheImpl) ExportedServices() []exportedService {
 	for _, export := range exports {
 		uExport := export.(*unstructured.Unstructured)
 		es := exportedService{
-			namespacedName:  kubesr.NamespacedNameForK8sObject(uExport),
+			namespacedName:  config.Name(uExport),
 			discoverability: make(map[host.Name]string),
 		}
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -138,7 +138,7 @@ func (ec *serviceExportCacheImpl) onServiceExportEvent(obj any, event model.Even
 }
 
 func (ec *serviceExportCacheImpl) updateXDS(se metav1.Object) {
-	for _, svc := range ec.servicesForNamespacedName(config.Name(se)) {
+	for _, svc := range ec.servicesForNamespacedName(config.NamespacedName(se)) {
 		// Re-build the endpoints for this service with a new discoverability policy.
 		// Also update any internal caching.
 		endpoints := ec.buildEndpointsForService(svc, true)
@@ -178,7 +178,7 @@ func (ec *serviceExportCacheImpl) ExportedServices() []exportedService {
 	for _, export := range exports {
 		uExport := export.(*unstructured.Unstructured)
 		es := exportedService{
-			namespacedName:  config.Name(uExport),
+			namespacedName:  config.NamespacedName(uExport),
 			discoverability: make(map[host.Name]string),
 		}
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -279,7 +280,7 @@ func (ic *serviceImportCacheImpl) ImportedServices() []importedService {
 	for _, si := range sis {
 		usi := si.(*unstructured.Unstructured)
 		info := importedService{
-			namespacedName: kube.NamespacedNameForK8sObject(usi),
+			namespacedName: config.Name(usi),
 		}
 
 		// Lookup the synthetic MCS service.

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -280,7 +280,7 @@ func (ic *serviceImportCacheImpl) ImportedServices() []importedService {
 	for _, si := range sis {
 		usi := si.(*unstructured.Unstructured)
 		info := importedService{
-			namespacedName: config.Name(usi),
+			namespacedName: config.NamespacedName(usi),
 		}
 
 		// Lookup the synthetic MCS service.

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -31,6 +31,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -243,7 +244,7 @@ func serviceClusterSetLocalHostname(nn types.NamespacedName) host.Name {
 
 // serviceClusterSetLocalHostnameForKR calls serviceClusterSetLocalHostname with the name and namespace of the given kubernetes resource.
 func serviceClusterSetLocalHostnameForKR(obj metav1.Object) host.Name {
-	return serviceClusterSetLocalHostname(types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()})
+	return serviceClusterSetLocalHostname(config.Name(obj))
 }
 
 func labelRequirement(key string, op selection.Operator, vals []string, opts ...field.PathOption) *klabels.Requirement {

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -244,7 +244,7 @@ func serviceClusterSetLocalHostname(nn types.NamespacedName) host.Name {
 
 // serviceClusterSetLocalHostnameForKR calls serviceClusterSetLocalHostname with the name and namespace of the given kubernetes resource.
 func serviceClusterSetLocalHostnameForKR(obj metav1.Object) host.Name {
-	return serviceClusterSetLocalHostname(config.Name(obj))
+	return serviceClusterSetLocalHostname(config.NamespacedName(obj))
 }
 
 func labelRequirement(key string, op selection.Operator, vals []string, opts ...field.PathOption) *klabels.Requirement {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/features"
@@ -191,14 +190,6 @@ func ExternalNameServiceInstances(k8sSvc *corev1.Service, svc *model.Service) []
 		})
 	}
 	return out
-}
-
-// NamespacedNameForK8sObject is a helper that creates a NamespacedName for the given K8s Object.
-func NamespacedNameForK8sObject(obj metav1.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	}
 }
 
 // ServiceHostname produces FQDN for a k8s service

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -348,7 +348,7 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
 	cs := convertServices(curr)
 	configsUpdated := sets.New[model.ConfigKey]()
-	key := types.NamespacedName{Namespace: curr.Namespace, Name: curr.Name}
+	key := config.Name(curr)
 
 	s.mutex.Lock()
 	// If it is add/delete event we should always do a full push. If it is update event, we should do full push,
@@ -510,7 +510,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			// Not a match, skip this one
 			continue
 		}
-		seNamespacedName := types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.Name}
+		seNamespacedName := config.Name(cfg)
 		services := s.services.getServices(seNamespacedName)
 		instance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 		instances = append(instances, instance...)

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -348,7 +348,7 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
 	cs := convertServices(curr)
 	configsUpdated := sets.New[model.ConfigKey]()
-	key := config.Name(curr)
+	key := config.NamespacedName(curr)
 
 	s.mutex.Lock()
 	// If it is add/delete event we should always do a full push. If it is update event, we should do full push,
@@ -510,7 +510,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			// Not a match, skip this one
 			continue
 		}
-		seNamespacedName := config.Name(cfg)
+		seNamespacedName := config.NamespacedName(cfg)
 		services := s.services.getServices(seNamespacedName)
 		instance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 		instances = append(instances, instance...)

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -1177,7 +1175,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 2})
 
 		key := instancesKey{namespace: selector.Namespace, hostname: "selector.com"}
-		namespacedName := types.NamespacedName{Namespace: selector.Namespace, Name: selector.Name}
+		namespacedName := config.Name(selector)
 		if len(sd.serviceInstances.ip2instance) != 1 {
 			t.Fatalf("service instances store `ip2instance` memory leak, expect 1, got %d", len(sd.serviceInstances.ip2instance))
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1175,7 +1175,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 2})
 
 		key := instancesKey{namespace: selector.Namespace, hostname: "selector.com"}
-		namespacedName := config.Name(selector)
+		namespacedName := config.NamespacedName(selector)
 		if len(sd.serviceInstances.ip2instance) != 1 {
 			t.Fatalf("service instances store `ip2instance` memory leak, expect 1, got %d", len(sd.serviceInstances.ip2instance))
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -75,7 +75,7 @@ func TestServiceInstancesStore(t *testing.T) {
 		makeInstance(selector, "1.1.1.1", 444, selector.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 		makeInstance(selector, "1.1.1.1", 445, selector.Spec.(*networking.ServiceEntry).Ports[1], nil, PlainText),
 	}}
-	key := config.Name(selector)
+	key := config.NamespacedName(selector)
 	store.updateServiceEntryInstances(key, expectedSeInstances)
 
 	gotSeInstances := store.getServiceEntryInstances(key)
@@ -115,8 +115,8 @@ func TestServiceStore(t *testing.T) {
 		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 	}
 
-	store.updateServices(config.Name(httpDNSRR), expectedServices)
-	got := store.getServices(config.Name(httpDNSRR))
+	store.updateServices(config.NamespacedName(httpDNSRR), expectedServices)
+	got := store.getServices(config.NamespacedName(httpDNSRR))
 	if !reflect.DeepEqual(got, expectedServices) {
 		t.Errorf("got unexpected services %v", got)
 	}
@@ -129,7 +129,7 @@ func TestServiceStore(t *testing.T) {
 		t.Errorf("expected allocate needed")
 	}
 	store.allocateNeeded = false
-	store.deleteServices(config.Name(httpDNSRR))
+	store.deleteServices(config.NamespacedName(httpDNSRR))
 	got = store.getAllServices()
 	if got != nil {
 		t.Errorf("got unexpected services %v", got)

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -22,6 +22,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -74,7 +75,7 @@ func TestServiceInstancesStore(t *testing.T) {
 		makeInstance(selector, "1.1.1.1", 444, selector.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 		makeInstance(selector, "1.1.1.1", 445, selector.Spec.(*networking.ServiceEntry).Ports[1], nil, PlainText),
 	}}
-	key := types.NamespacedName{Namespace: selector.Namespace, Name: selector.Name}
+	key := config.Name(selector)
 	store.updateServiceEntryInstances(key, expectedSeInstances)
 
 	gotSeInstances := store.getServiceEntryInstances(key)
@@ -114,8 +115,8 @@ func TestServiceStore(t *testing.T) {
 		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 	}
 
-	store.updateServices(types.NamespacedName{Namespace: httpDNSRR.Namespace, Name: httpDNSRR.Name}, expectedServices)
-	got := store.getServices(types.NamespacedName{Namespace: httpDNSRR.Namespace, Name: httpDNSRR.Name})
+	store.updateServices(config.Name(httpDNSRR), expectedServices)
+	got := store.getServices(config.Name(httpDNSRR))
 	if !reflect.DeepEqual(got, expectedServices) {
 		t.Errorf("got unexpected services %v", got)
 	}
@@ -128,7 +129,7 @@ func TestServiceStore(t *testing.T) {
 		t.Errorf("expected allocate needed")
 	}
 	store.allocateNeeded = false
-	store.deleteServices(types.NamespacedName{Namespace: httpDNSRR.Namespace, Name: httpDNSRR.Name})
+	store.deleteServices(config.Name(httpDNSRR))
 	got = store.getAllServices()
 	if got != nil {
 		t.Errorf("got unexpected services %v", got)

--- a/pilot/pkg/serviceregistry/serviceentry/util.go
+++ b/pilot/pkg/serviceregistry/serviceentry/util.go
@@ -27,7 +27,7 @@ func getWorkloadServiceEntries(ses []config.Config, wle *networking.WorkloadEntr
 	for i, cfg := range ses {
 		se := cfg.Spec.(*networking.ServiceEntry)
 		if se.WorkloadSelector != nil && labels.Instance(se.WorkloadSelector.Labels).SubsetOf(wle.Labels) {
-			out[types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}] = &ses[i]
+			out[config.Name(cfg)] = &ses[i]
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/util.go
+++ b/pilot/pkg/serviceregistry/serviceentry/util.go
@@ -27,7 +27,7 @@ func getWorkloadServiceEntries(ses []config.Config, wle *networking.WorkloadEntr
 	for i, cfg := range ses {
 		se := cfg.Spec.(*networking.ServiceEntry)
 		if se.WorkloadSelector != nil && labels.Instance(se.WorkloadSelector.Labels).SubsetOf(wle.Labels) {
-			out[config.Name(cfg)] = &ses[i]
+			out[config.NamespacedName(cfg)] = &ses[i]
 		}
 	}
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -349,6 +349,14 @@ func (c Config) DeepCopy() Config {
 	return clone
 }
 
+func (c Config) GetName() string {
+	return c.Name
+}
+
+func (c Config) GetNamespace() string {
+	return c.Namespace
+}
+
 var _ fmt.Stringer = GroupVersionKind{}
 
 type GroupVersionKind struct {
@@ -390,3 +398,15 @@ func (g GroupVersionKind) CanonicalGroup() string {
 // PatchFunc provides the cached config as a base for modification. Only diff the between the cfg
 // parameter and the returned Config will be applied.
 type PatchFunc func(cfg Config) (Config, kubetypes.PatchType)
+
+type Namer interface {
+	GetName() string
+	GetNamespace() string
+}
+
+func Name(n Namer) kubetypes.NamespacedName {
+	return kubetypes.NamespacedName{
+		Namespace: n.GetNamespace(),
+		Name:      n.GetName(),
+	}
+}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -404,7 +404,7 @@ type Namer interface {
 	GetNamespace() string
 }
 
-func Name(n Namer) kubetypes.NamespacedName {
+func NamespacedName(n Namer) kubetypes.NamespacedName {
 	return kubetypes.NamespacedName{
 		Namespace: n.GetNamespace(),
 		Name:      n.GetName(),

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -98,7 +98,7 @@ func (q Queue) Add(item any) {
 
 // AddObject takes an Object and adds the types.NamespacedName associated.
 func (q Queue) AddObject(obj Object) {
-	q.queue.Add(config.Name(obj))
+	q.queue.Add(config.NamespacedName(obj))
 }
 
 // Run the queue. This is synchronous, so should typically be called in a goroutine.

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
+	"istio.io/istio/pkg/config"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -97,10 +98,7 @@ func (q Queue) Add(item any) {
 
 // AddObject takes an Object and adds the types.NamespacedName associated.
 func (q Queue) AddObject(obj Object) {
-	q.queue.Add(types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	})
+	q.queue.Add(config.Name(obj))
 }
 
 // Run the queue. This is synchronous, so should typically be called in a goroutine.


### PR DESCRIPTION
This is a common operation (more common on ambient branch) which is fairly verbose and easy to mix up the 2 string fields. Add a small helper

**Please provide a description of this PR:**