### PR TITLE
optimize SupersetOf func performance

### DIFF
--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -136,7 +136,18 @@ func (s Set[T]) Intersection(s2 Set[T]) Set[T] {
 // s.SupersetOf(s2) = false
 // s2.SupersetOf(s) = true
 func (s Set[T]) SupersetOf(s2 Set[T]) bool {
-	return s2.Difference(s).IsEmpty()
+	if s2 == nil {
+		return true
+	}
+	if len(s2) > len(s) {
+		return false
+	}
+	for key := range s2 {
+		if !s.Contains(key) {
+			return false
+		}
+	}
+	return true
 }
 
 // UnsortedList returns the slice with contents in random order.

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -186,6 +186,12 @@ func (s Set[T]) Contains(item T) bool {
 	return ok
 }
 
+// ContainsAll is alias of SupersetOf
+// returns true if s contains all elements of s2
+func (s Set[T]) ContainsAll(s2 Set[T]) bool {
+	return s.SupersetOf(s2)
+}
+
 // Equals checks whether the given set is equal to the current set.
 func (s Set[T]) Equals(other Set[T]) bool {
 	if s.Len() != other.Len() {

--- a/pkg/util/sets/set_test.go
+++ b/pkg/util/sets/set_test.go
@@ -97,21 +97,92 @@ func TestIntersection(t *testing.T) {
 }
 
 func TestSupersetOf(t *testing.T) {
-	elements := []string{"a", "b", "c", "d"}
-	s1 := New(elements...)
-
-	elements2 := []string{"a", "b"}
-	s2 := New(elements2...)
-
-	if !s1.SupersetOf(s2) {
-		t.Errorf("%v should be superset of %v", SortedList(s1), SortedList(s2))
+	testCases := []struct {
+		name   string
+		first  Set[string]
+		second Set[string]
+		want   bool
+	}{
+		{
+			name:   "both nil",
+			first:  nil,
+			second: nil,
+			want:   true,
+		},
+		{
+			name:   "first nil",
+			first:  nil,
+			second: New("a"),
+			want:   false,
+		},
+		{
+			name:   "second nil",
+			first:  New("a"),
+			second: nil,
+			want:   true,
+		},
+		{
+			name:   "both empty",
+			first:  New[string](),
+			second: New[string](),
+			want:   true,
+		},
+		{
+			name:   "first empty",
+			first:  New[string](),
+			second: New("a"),
+			want:   false,
+		},
+		{
+			name:   "second empty",
+			first:  New("a"),
+			second: New[string](),
+			want:   true,
+		},
+		{
+			name:   "equal",
+			first:  New("a", "b"),
+			second: New("a", "b"),
+			want:   true,
+		},
+		{
+			name:   "first contains all second",
+			first:  New("a", "b", "c"),
+			second: New("a", "b"),
+			want:   true,
+		},
+		{
+			name:   "second contains all first",
+			first:  New("a", "b"),
+			second: New("a", "b", "c"),
+			want:   false,
+		},
 	}
-
-	s3 := New[string]()
-	if !New[string]().SupersetOf(s3) {
-		fmt.Printf("%q\n", SortedList(s3)[0])
-		t.Errorf("%v should be superset of empty set", SortedList(s1))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.first.SupersetOf(tt.second); got != tt.want {
+				t.Errorf("want %v, but got %v", tt.want, got)
+			}
+		})
 	}
+}
+
+func BenchmarkSupersetOf(b *testing.B) {
+	set1 := New[string]()
+	for i := 0; i < 1000; i++ {
+		set1.Insert(fmt.Sprint(i))
+	}
+	set2 := New[string]()
+	for i := 0; i < 50; i++ {
+		set2.Insert(fmt.Sprint(i))
+	}
+	b.ResetTimer()
+
+	b.Run("SupersetOf", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			set1.SupersetOf(set2)
+		}
+	})
 }
 
 func TestEquals(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

1. Optimize `SupersetOf` func performance
2. Add an alias func `ContainsAll` of `SupersetOf`
3. Add more test cases

benchmark:
```shell
$ go test -bench="BenchmarkSupersetOf" -test.benchmem -count=10 . >> old.txt # old code
$ go test -bench="BenchmarkSupersetOf" -test.benchmem -count=10 . >> new.txt # new code
$ benchstat old.txt new.txt
name                      old time/op    new time/op    delta
SupersetOf/SupersetOf-12    1.28µs ± 4%    1.17µs ± 6%    -8.44%  (p=0.000 n=9+10)

name                      old alloc/op   new alloc/op   delta
SupersetOf/SupersetOf-12     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
SupersetOf/SupersetOf-12      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```