### PR TITLE
Change to support dual stack for gateway to generate configuration and use getWildcardsAndLocalHost for inbound cluster building

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -400,7 +400,7 @@ func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *Clus
 	enableSidecarServiceInboundListenerMerge bool,
 ) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
-	_, actualLocalHost := getActualWildcardAndLocalHost(proxy)
+	_, actualLocalHosts := getWildcardsAndLocalHost(proxy.GetIPMode())
 	clustersToBuild := make(map[int][]*model.ServiceInstance)
 
 	ingressPortListSet := sets.New[int]()
@@ -417,7 +417,7 @@ func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *Clus
 		clustersToBuild[ep] = append(clustersToBuild[ep], instance)
 	}
 
-	bind := actualLocalHost
+	bind := actualLocalHosts[0]
 	if features.EnableInboundPassthrough {
 		bind = ""
 	}
@@ -455,8 +455,6 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 	// clusters, because there would be no corresponding inbound listeners
 	sidecarScope := proxy.SidecarScope
 	noneMode := proxy.GetInterceptionMode() == model.InterceptionNone
-
-	_, actualLocalHost := getActualWildcardAndLocalHost(proxy)
 
 	// No user supplied sidecar scope or the user supplied one has no ingress listeners
 	if !sidecarScope.HasIngressListener() {
@@ -526,7 +524,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
 			} else if hostIP == model.LocalhostAddressPrefix || hostIP == model.LocalhostIPv6AddressPrefix {
-				endpointAddress = actualLocalHost
+				endpointAddress = hostIP
 			}
 		}
 		// Find the service instance that corresponds to this ingress listener by looking

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -456,6 +456,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 	sidecarScope := proxy.SidecarScope
 	noneMode := proxy.GetInterceptionMode() == model.InterceptionNone
 
+	_, actualLocalHosts := getWildcardsAndLocalHost(proxy.GetIPMode())
 	// No user supplied sidecar scope or the user supplied one has no ingress listeners
 	if !sidecarScope.HasIngressListener() {
 		// We should not create inbound listeners in NONE mode based on the service instances
@@ -524,7 +525,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
 			} else if hostIP == model.LocalhostAddressPrefix || hostIP == model.LocalhostIPv6AddressPrefix {
-				endpointAddress = hostIP
+				endpointAddress = actualLocalHosts[0]
 			}
 		}
 		// Find the service instance that corresponds to this ingress listener by looking

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -64,7 +64,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 	mergedGateway := builder.node.MergedGateway
 	log.Debugf("buildGatewayListeners: gateways after merging: %v", mergedGateway)
 
-	actualWildcard, _ := getActualWildcardAndLocalHost(builder.node)
+	actualWildcards, _ := getWildcardsAndLocalHost(builder.node.GetIPMode())
 	errs := istiomultierror.New()
 	// Mutable objects keyed by listener name so that we can build listeners at the end.
 	mutableopts := make(map[string]mutableListenerOpts)
@@ -78,9 +78,14 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 				port.Number, builder.node.ID)
 			continue
 		}
-		bind := actualWildcard
+		var extraBind []string
+		bind := actualWildcards[0]
+		if features.EnableDualStack && len(actualWildcards) > 1 {
+			extraBind = actualWildcards[1:]
+		}
 		if len(port.Bind) > 0 {
 			bind = port.Bind
+			extraBind = nil
 		}
 
 		// NOTE: There is no gating here to check for the value of the QUIC feature flag. However,
@@ -106,6 +111,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 				push:       builder.push,
 				proxy:      builder.node,
 				bind:       bind,
+				extraBind:  extraBind,
 				port:       &model.Port{Port: int(port.Number)},
 				bindToPort: true,
 				class:      istionetworking.ListenerClassGateway,

--- a/releasenotes/notes/42712.yaml
+++ b/releasenotes/notes/42712.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 40394
+  - 37622
+  - 35781
+  - 41271
+
+docs:
+  - '[Optimized Design] https://docs.google.com/document/d/15LP2XHpQ71ODkjCVItGacPgzcn19fsVhyE7ruMGXDyU/'
+  - '[Original Design] https://docs.google.com/document/d/1oT6pmRhOw7AtsldU0-HbfA0zA26j9LYiBD_eepeErsQ/'
+
+releaseNotes:
+- |
+  **Added** dual stack support for gateway to generate configuration and use `getWildcardsAndLocalHost` for inbound cluster building.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2402,7 +2402,7 @@ func instanceIPTests(t TrafficContext) {
 		},
 		{
 			name:     "localhost IP with localhost sidecar",
-			endpoint: "localhost",
+			endpoint: "[::1]",
 			port:     "http-localhost",
 			code:     http.StatusOK,
 		},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2353,9 +2353,9 @@ func instanceIPTests(t TrafficContext) {
 	t.SetDefaultSourceMatchers(match.NotProxylessGRPC)
 
 	isIPv6Only := false
-	ingresses, _ := t.Istio.Ingresses()
+	ingresses := t.Istio.Ingresses()
 	for _, ingress := range ingresses {
-		ipStr := ingress.HTTPAddress()
+		ipStr, _ := ingress.HTTPAddress()
 		ipAddr, _ := netip.ParseAddr(ipStr)
 		if ipAddr.Is6() {
 			isIPv6Only = true

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -20,6 +20,7 @@ package common
 import (
 	"fmt"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"reflect"
 	"sort"
@@ -2351,6 +2352,15 @@ func instanceIPTests(t TrafficContext) {
 	t.SetDefaultTargetMatchers(match.NotProxylessGRPC)
 	t.SetDefaultSourceMatchers(match.NotProxylessGRPC)
 
+	ipStr, _ := t.Istio.Ingresses().HTTPAddress()
+	ipAddr, _ := netip.ParseAddr(ipStr)
+	var locahostAddr string
+	if ipAddr.Is6() {
+		locahostAddr = "[::1]"
+	} else {
+		locahostAddr = "127.0.0.1"
+	}
+
 	ipCases := []struct {
 		name            string
 		endpoint        string
@@ -2402,7 +2412,7 @@ func instanceIPTests(t TrafficContext) {
 		},
 		{
 			name:     "localhost IP with localhost sidecar",
-			endpoint: "[::1]",
+			endpoint: locahostAddr,
 			port:     "http-localhost",
 			code:     http.StatusOK,
 		},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2352,25 +2352,6 @@ func instanceIPTests(t TrafficContext) {
 	t.SetDefaultTargetMatchers(match.NotProxylessGRPC)
 	t.SetDefaultSourceMatchers(match.NotProxylessGRPC)
 
-	isIPv6Only := false
-	ingresses := t.Istio.Ingresses()
-	for _, ingress := range ingresses {
-		ipStr, _ := ingress.HTTPAddress()
-		ipAddr, _ := netip.ParseAddr(ipStr)
-		if ipAddr.Is6() {
-			isIPv6Only = true
-		} else {
-			isIPv6Only = false
-		}
-	}
-
-	var locahostAddr string
-	if isIPv6Only {
-		locahostAddr = "[::1]"
-	} else {
-		locahostAddr = "127.0.0.1"
-	}
-
 	ipCases := []struct {
 		name            string
 		endpoint        string
@@ -2422,7 +2403,7 @@ func instanceIPTests(t TrafficContext) {
 		},
 		{
 			name:     "localhost IP with localhost sidecar",
-			endpoint: locahostAddr,
+			endpoint: "127.0.0.1",
 			port:     "http-localhost",
 			code:     http.StatusOK,
 		},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -20,7 +20,6 @@ package common
 import (
 	"fmt"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"reflect"
 	"sort"

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2352,10 +2352,20 @@ func instanceIPTests(t TrafficContext) {
 	t.SetDefaultTargetMatchers(match.NotProxylessGRPC)
 	t.SetDefaultSourceMatchers(match.NotProxylessGRPC)
 
-	ipStr, _ := t.Istio.Ingresses().HTTPAddress()
-	ipAddr, _ := netip.ParseAddr(ipStr)
+	isIPv6Only := false
+	ingresses, _ := t.Istio.Ingresses()
+	for _, ingress := range ingresses {
+		ipStr := ingress.HTTPAddress()
+		ipAddr, _ := netip.ParseAddr(ipStr)
+		if ipAddr.Is6() {
+			isIPv6Only = true
+		} else {
+			isIPv6Only = false
+		}
+	}
+
 	var locahostAddr string
-	if ipAddr.Is6() {
+	if isIPv6Only {
 		locahostAddr = "[::1]"
 	} else {
 		locahostAddr = "127.0.0.1"

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2402,7 +2402,7 @@ func instanceIPTests(t TrafficContext) {
 		},
 		{
 			name:     "localhost IP with localhost sidecar",
-			endpoint: "127.0.0.1",
+			endpoint: "localhost",
 			port:     "http-localhost",
 			code:     http.StatusOK,
 		},


### PR DESCRIPTION
**Please provide a description of this PR:**
Change to support dual stack for statefulsets/headless, service entry and gateway, this PR is for [issue#40394](https://github.com/istio/istio/issues/40394)

1. Support to generate configuration for Istio gateway with dual stack enabled
2. use `getWildcardsAndLocalHost` instead of `getActualWildcardAndLocalHost` for inbound cluster building