### PR TITLE
Ejjset secommprofile in sidecar

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -135,6 +135,8 @@ spec:
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
+      seccompProfile:
+        {{ toYaml .Values.global.proxy.seccompProfile | trim | indent 2 }}
       capabilities:
     {{- if not .Values.istio_cni.enabled }}
         add:
@@ -368,6 +370,8 @@ spec:
       runAsNonRoot: true
       runAsUser: 1337
       {{- end }}
+      seccompProfile:
+        {{ toYaml .Values.global.proxy.seccompProfile | trim | indent 2 }}
       {{- end }}
     resources:
   {{ template "resources" . }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -363,6 +363,9 @@ global:
       limits:
         cpu: 2000m
         memory: 1024Mi
+    
+    # Set to `type: RuntimeDefault` to use the default profile if available.
+    seccompProfile: {}
 
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.
     statusPort: 15020


### PR DESCRIPTION
**Please provide a description of this PR:**

Set seccompProfile in the security context for the containers in the Envoy sidecar istio-validation and istio-proxy so that when istiod is installed with istio cni enabled, the sidecar containers obey the restricted pod security standards https://kubernetes.io/docs/concepts/security/pod-security-standards/



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
