### PR TITLE
Replace deprecated jsonpb package

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -28,7 +28,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -464,19 +464,15 @@ func (s *StringBool) UnmarshalJSON(data []byte) error {
 type NodeMetaProxyConfig meshconfig.ProxyConfig
 
 func (s *NodeMetaProxyConfig) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
 	pc := (*meshconfig.ProxyConfig)(s)
-	if err := (&jsonpb.Marshaler{}).Marshal(&buf, pc); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return (&protojson.MarshalOptions{}).Marshal(pc)
 }
 
 func (s *NodeMetaProxyConfig) UnmarshalJSON(data []byte) error {
 	pc := (*meshconfig.ProxyConfig)(s)
-	return (&jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-	}).Unmarshal(bytes.NewReader(data), pc)
+	return (&protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}).Unmarshal(data, pc)
 }
 
 // Node is a typed version of Envoy node with metadata.

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -17,7 +17,7 @@ package model
 import (
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -249,8 +249,8 @@ func mergeVirtualServicesIfNeeded(
 		}
 		rootVs.Http = mergedRoutes
 		if log.DebugEnabled() {
-			jsonm := &jsonpb.Marshaler{Indent: "   "}
-			vsString, _ := jsonm.MarshalToString(rootVs)
+			jsonm := &protojson.MarshalOptions{Indent: "   "}
+			vsString := jsonm.Format(rootVs)
 			log.Debugf("merged virtualService: %s", vsString)
 		}
 		out = append(out, root)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,9 +30,9 @@ import (
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -88,7 +87,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
+	_ = protojson.Unmarshal([]byte(config), val)
 	return val
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -25,8 +24,8 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/jsonpb"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -528,7 +527,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
+	_ = protojson.Unmarshal([]byte(config), val)
 	return val
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Refactored to replace the use of the deprecated [jsonpb](https://pkg.go.dev/github.com/golang/protobuf/jsonpb) package with the `protojson` equivalent.