### PR TITLE
`PILOT_FILTER_GATEWAY_CLUSTER_CONFIG`: fix false negatives for AUTO_PASSTHROUGH

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -800,15 +800,27 @@ func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 	return gwSvcs
 }
 
-func (ps *PushContext) ServiceAttachedToGateway(hostname string, proxy *Proxy) bool {
+func (ps *PushContext) ServiceAttachedToGateway(hostname host.Name, proxy *Proxy) bool {
+	gw := proxy.MergedGateway
 	// MergedGateway will be nil when there are no configs in the
 	// system during initial installation.
-	if proxy.MergedGateway == nil {
+	if gw == nil {
 		return false
 	}
-	for _, gw := range proxy.MergedGateway.GatewayNameForServer {
-		if hosts := ps.virtualServiceIndex.destinationsByGateway[gw]; hosts != nil {
-			if hosts.Contains(hostname) {
+	if gw.ContainsAutoPassthroughGateways {
+		for server, tls := range gw.TLSServerInfo {
+			if server.Tls.Mode == networking.ServerTLSSettings_AUTO_PASSTHROUGH {
+				for _, h := range tls.SNIHosts {
+					if hostname.SubsetOf(host.Name(h)) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	for _, g := range gw.GatewayNameForServer {
+		if hosts := ps.virtualServiceIndex.destinationsByGateway[g]; hosts != nil {
+			if hosts.Contains(string(hostname)) {
 				return true
 			}
 		}

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -68,12 +68,12 @@ func checkProxyDependencies(proxy *model.Proxy, config model.ConfigKey, push *mo
 		}
 	case model.Router:
 		if config.Kind == kind.ServiceEntry {
-			if features.FilterGatewayClusterConfig && !push.ServiceAttachedToGateway(config.Name, proxy) {
+			// If config is ServiceEntry, name of the config is service's FQDN
+			hostname := host.Name(config.Name)
+			if features.FilterGatewayClusterConfig && !push.ServiceAttachedToGateway(hostname, proxy) {
 				return false
 			}
 
-			// If config is ServiceEntry, name of the config is service's FQDN
-			hostname := host.Name(config.Name)
 			// gateways have default sidecar scopes
 			if proxy.SidecarScope.GetService(hostname) == nil &&
 				proxy.PrevSidecarScope.GetService(hostname) == nil {

--- a/pkg/config/host/name.go
+++ b/pkg/config/host/name.go
@@ -24,7 +24,7 @@ type Name string
 // Matches returns true if this hostname overlaps with the other hostname. Names overlap if:
 // - they're fully resolved (i.e. not wildcarded) and match exactly (i.e. an exact string match)
 // - one or both are wildcarded (e.g. "*.foo.com"), in which case we use wildcard resolution rules
-// to determine if h is covered by o or o is covered by h.
+// to determine if n is covered by o or o is covered by n.
 // e.g.:
 //
 //	Name("foo.com").Matches("foo.com")   = true
@@ -60,7 +60,7 @@ func (n Name) Matches(o Name) bool {
 }
 
 // SubsetOf returns true if this hostname is a valid subset of the other hostname. The semantics are
-// the same as "Matches", but only in one direction (i.e., h is covered by o).
+// the same as "Matches", but only in one direction (i.e., n is covered by o).
 func (n Name) SubsetOf(o Name) bool {
 	hWildcard := n.IsWildCarded()
 	oWildcard := o.IsWildCarded()

--- a/releasenotes/notes/auto-passthrough-regression.yaml
+++ b/releasenotes/notes/auto-passthrough-regression.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** auto-passthrough gateways not getting XDS pushes on service updates 
+    if `PILOT_FILTER_GATEWAY_CLUSTER_CONFIG` is enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**
Auto-passthrough gateways do not require virtual services, we should push when related services are changed