### PR TITLE
Revert "Replace deprecated jsonpb package"

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -28,7 +28,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"google.golang.org/protobuf/encoding/protojson"
+	"github.com/golang/protobuf/jsonpb"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -464,15 +464,19 @@ func (s *StringBool) UnmarshalJSON(data []byte) error {
 type NodeMetaProxyConfig meshconfig.ProxyConfig
 
 func (s *NodeMetaProxyConfig) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
 	pc := (*meshconfig.ProxyConfig)(s)
-	return (&protojson.MarshalOptions{}).Marshal(pc)
+	if err := (&jsonpb.Marshaler{}).Marshal(&buf, pc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func (s *NodeMetaProxyConfig) UnmarshalJSON(data []byte) error {
 	pc := (*meshconfig.ProxyConfig)(s)
-	return (&protojson.UnmarshalOptions{
-		DiscardUnknown: true,
-	}).Unmarshal(data, pc)
+	return (&jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}).Unmarshal(bytes.NewReader(data), pc)
 }
 
 // Node is a typed version of Envoy node with metadata.

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -17,7 +17,7 @@ package model
 import (
 	"strings"
 
-	"google.golang.org/protobuf/encoding/protojson"
+	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -249,8 +249,8 @@ func mergeVirtualServicesIfNeeded(
 		}
 		rootVs.Http = mergedRoutes
 		if log.DebugEnabled() {
-			jsonm := &protojson.MarshalOptions{Indent: "   "}
-			vsString := jsonm.Format(rootVs)
+			jsonm := &jsonpb.Marshaler{Indent: "   "}
+			vsString, _ := jsonm.MarshalToString(rootVs)
 			log.Debugf("merged virtualService: %s", vsString)
 		}
 		out = append(out, root)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,9 +31,9 @@ import (
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -87,7 +88,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = protojson.Unmarshal([]byte(config), val)
+	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
 	return val
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -17,6 +17,7 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -24,8 +25,8 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/jsonpb"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -527,7 +528,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = protojson.Unmarshal([]byte(config), val)
+	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
 	return val
 }
 


### PR DESCRIPTION
Reverts istio/istio#42719

This is WAI, see https://github.com/istio/istio/blob/e0110ff89739f8dc15b69c4a9a3c53854bb57ca1/pkg/util/protomarshal/protomarshal.go#L20

A preferred patch would:
* Move all marshal to `protomarshal` package where this is encapsulated
* In lint config, ban import of `github.com/golang/protobuf/jsonpb` *and* `protojson` (protomarshal library will `nolint` this, of course)