### PR TITLE
Dependency guard jsonpb and protojson packages

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -239,6 +239,8 @@ linters-settings:
     packages-with-error-message:
     - github.com/gogo/protobuf: "gogo/protobuf is deprecated, use golang/protobuf"
     - golang.org/x/net/http2/h2c: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"
+    - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use the util/protomarshal instead"
+    - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use the util/protomarshal instead"
   gosec:
     includes:
     - G401

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -239,8 +239,8 @@ linters-settings:
     packages-with-error-message:
     - github.com/gogo/protobuf: "gogo/protobuf is deprecated, use golang/protobuf"
     - golang.org/x/net/http2/h2c: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"
-    - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use the util/protomarshal instead"
-    - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use the util/protomarshal instead"
+    - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
+    - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
   gosec:
     includes:
     - G401

--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -37,7 +37,7 @@ type ConfigWriter struct {
 // Prime loads the config dump into the writer ready for printing
 func (c *ConfigWriter) Prime(b []byte) error {
 	cd := &adminv3.ConfigDump{}
-	err := protomarshal.Unmarshal(b, cd)
+	err := protomarshal.UnmarshalWithGlobalTypesResolver(b, cd)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config dump response from Envoy: %v", err)
 	}

--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -21,7 +21,6 @@ import (
 	"text/tabwriter"
 
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	"google.golang.org/protobuf/encoding/protojson"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/istioctl/pkg/util/configdump"
@@ -38,7 +37,7 @@ type ConfigWriter struct {
 // Prime loads the config dump into the writer ready for printing
 func (c *ConfigWriter) Prime(b []byte) error {
 	cd := &adminv3.ConfigDump{}
-	err := protojson.Unmarshal(b, cd)
+	err := protomarshal.Unmarshal(b, cd)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config dump response from Envoy: %v", err)
 	}

--- a/istioctl/pkg/writer/envoy/configdump/ecds.go
+++ b/istioctl/pkg/writer/envoy/configdump/ecds.go
@@ -38,7 +38,7 @@ func (c *ConfigWriter) PrintEcds(outputFormat string) error {
 		return err
 	}
 
-	out, err := protomarshal.MarshalIndent(dump, "    ")
+	out, err := protomarshal.MarshalIndentWithGlobalTypesResolver(dump, "    ")
 	if err != nil {
 		return err
 	}

--- a/istioctl/pkg/writer/envoy/configdump/ecds.go
+++ b/istioctl/pkg/writer/envoy/configdump/ecds.go
@@ -21,8 +21,9 @@ import (
 	"text/tabwriter"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"google.golang.org/protobuf/encoding/protojson"
 	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 const typeURLPrefix = "type.googleapis.com/"
@@ -37,11 +38,7 @@ func (c *ConfigWriter) PrintEcds(outputFormat string) error {
 		return err
 	}
 
-	opts := protojson.MarshalOptions{
-		Multiline: true,
-		Indent:    "    ",
-	}
-	out, err := opts.Marshal(dump)
+	out, err := protomarshal.MarshalIndent(dump, "    ")
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -17,12 +17,12 @@ package translate
 import (
 	"testing"
 
-	"github.com/golang/protobuf/jsonpb"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/operator/pkg/apis/istio"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 func TestValueToProto(t *testing.T) {
@@ -189,14 +189,13 @@ values:
 				t.Errorf("ValuesToProto(%s)(%v): gotErr:%s, wantErr:%s", tt.desc, tt.valueYAML, gotErr, wantErr)
 			}
 			if tt.wantErr == "" {
-				ms := jsonpb.Marshaler{}
-				gotString, err := ms.MarshalToString(gotSpec)
+				byteArray, err := protomarshal.Marshal(gotSpec)
 				if err != nil {
 					t.Errorf("failed to marshal translated IstioOperatorSpec: %s", err)
 				}
-				cpYaml, _ := yaml.JSONToYAML([]byte(gotString))
-				if want := tt.want; !util.IsYAMLEqual(gotString, want) {
-					t.Errorf("ValuesToProto(%s): got:\n%s\n\nwant:\n%s\nDiff:\n%s\n", tt.desc, string(cpYaml), want, util.YAMLDiff(gotString, want))
+				cpYaml, _ := yaml.JSONToYAML(byteArray)
+				if want := tt.want; !util.IsYAMLEqual(string(byteArray), want) {
+					t.Errorf("ValuesToProto(%s): got:\n%s\n\nwant:\n%s\nDiff:\n%s\n", tt.desc, string(cpYaml), want, util.YAMLDiff(string(byteArray), want))
 				}
 
 			}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -28,7 +28,6 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/jsonpb"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -464,19 +463,13 @@ func (s *StringBool) UnmarshalJSON(data []byte) error {
 type NodeMetaProxyConfig meshconfig.ProxyConfig
 
 func (s *NodeMetaProxyConfig) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
 	pc := (*meshconfig.ProxyConfig)(s)
-	if err := (&jsonpb.Marshaler{}).Marshal(&buf, pc); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return protomarshal.Marshal(pc)
 }
 
 func (s *NodeMetaProxyConfig) UnmarshalJSON(data []byte) error {
 	pc := (*meshconfig.ProxyConfig)(s)
-	return (&jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-	}).Unmarshal(bytes.NewReader(data), pc)
+	return protomarshal.UnmarshalAllowUnknown(data, pc)
 }
 
 // Node is a typed version of Envoy node with metadata.

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -17,7 +17,6 @@ package model
 import (
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -27,6 +26,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -249,8 +249,7 @@ func mergeVirtualServicesIfNeeded(
 		}
 		rootVs.Http = mergedRoutes
 		if log.DebugEnabled() {
-			jsonm := &jsonpb.Marshaler{Indent: "   "}
-			vsString, _ := jsonm.MarshalToString(rootVs)
+			vsString, _ := protomarshal.ToJSONWithIndent(rootVs, "   ")
 			log.Debugf("merged virtualService: %s", vsString)
 		}
 		out = append(out, root)

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
@@ -88,7 +86,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
+	_ = protomarshal.UnmarshalString(config, val)
 	return val
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -25,7 +24,6 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/jsonpb"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -41,6 +39,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 func TestVirtualListenerBuilder(t *testing.T) {
@@ -528,7 +527,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 func buildPatchStruct(config string) *structpb.Struct {
 	val := &structpb.Struct{}
-	_ = jsonpb.Unmarshal(strings.NewReader(config), val)
+	_ = protomarshal.UnmarshalString(config, val)
 	return val
 }
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -24,7 +24,6 @@ import (
 	gogojsonpb "github.com/gogo/protobuf/jsonpb" // nolint: depguard
 	gogoproto "github.com/gogo/protobuf/proto"   // nolint: depguard
 	gogotypes "github.com/gogo/protobuf/types"   // nolint: depguard
-	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -149,7 +148,7 @@ func ToProto(s Spec) (*anypb.Any, error) {
 		return nil, err
 	}
 	pbs := &structpb.Struct{}
-	if err := jsonpb.Unmarshal(bytes.NewReader(js), pbs); err != nil {
+	if err := protomarshal.Unmarshal(js, pbs); err != nil {
 		return nil, err
 	}
 	return protoconv.MessageToAnyWithError(pbs)

--- a/pkg/config/xds/xds.go
+++ b/pkg/config/xds/xds.go
@@ -15,7 +15,6 @@
 package xds
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -25,7 +24,6 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -78,15 +76,15 @@ func StructToMessage(pbst *structpb.Struct, out proto.Message, strict bool) erro
 		return errors.New("nil struct")
 	}
 
-	buf := &bytes.Buffer{}
-	if err := (&jsonpb.Marshaler{OrigName: true}).Marshal(buf, pbst); err != nil {
+	buf, err := protomarshal.MarshalProtoNames(pbst)
+	if err != nil {
 		return err
 	}
 
 	// If strict is not set, ignore unknown fields as they may be sending versions of
 	// the proto we are not internally using
 	if strict {
-		return protomarshal.Unmarshal(buf.Bytes(), out)
+		return protomarshal.Unmarshal(buf, out)
 	}
-	return protomarshal.UnmarshalAllowUnknown(buf.Bytes(), out)
+	return protomarshal.UnmarshalAllowUnknown(buf, out)
 }

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -25,8 +25,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"            // nolint: depguard
-	legacyproto "github.com/golang/protobuf/proto" // nolint: staticcheck
+	"github.com/golang/protobuf/jsonpb"             // nolint: depguard
+	legacyproto "github.com/golang/protobuf/proto"  // nolint: staticcheck
+	"google.golang.org/protobuf/encoding/protojson" // nolint: depguard
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"sigs.k8s.io/yaml"
@@ -58,6 +59,10 @@ func UnmarshalAllowUnknownWithAnyResolver(anyResolver jsonpb.AnyResolver, b []by
 	}).Unmarshal(bytes.NewReader(b), legacyproto.MessageV1(m))
 }
 
+func UnmarshalWithGlobalTypesResolver(b []byte, m proto.Message) error {
+	return protojson.Unmarshal(b, m)
+}
+
 // ToJSON marshals a proto to canonical JSON
 func ToJSON(msg proto.Message) (string, error) {
 	return ToJSONWithIndent(msg, "")
@@ -79,6 +84,15 @@ func MarshalIndent(msg proto.Message, indent string) ([]byte, error) {
 		return nil, err
 	}
 	return []byte(res), err
+}
+
+// MarshalIndentWithGlobalTypesResolver marshals a proto to canonical JSON with indentation
+// and multiline while using generic types resolver
+func MarshalIndentWithGlobalTypesResolver(msg proto.Message, indent string) ([]byte, error) {
+	return protojson.MarshalOptions{
+		Multiline: true,
+		Indent: indent,
+	}.Marshal(msg)
 }
 
 // MarshalProtoNames marshals a proto to canonical JSON original protobuf names

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -91,7 +91,7 @@ func MarshalIndent(msg proto.Message, indent string) ([]byte, error) {
 func MarshalIndentWithGlobalTypesResolver(msg proto.Message, indent string) ([]byte, error) {
 	return protojson.MarshalOptions{
 		Multiline: true,
-		Indent: indent,
+		Indent:    indent,
 	}.Marshal(msg)
 }
 

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -18,7 +18,6 @@
 package operator
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -27,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +43,7 @@ import (
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/tests/util/sanitycheck"
 	"istio.io/pkg/log"
 )
@@ -209,8 +208,7 @@ func checkInstallStatus(cs istioKube.CLIClient, revision string) error {
 			return fmt.Errorf("failed to marshal istioOperator status: %v", err)
 		}
 		status := &api.InstallStatus{}
-		jspb := jsonpb.Unmarshaler{AllowUnknownFields: true}
-		if err := jspb.Unmarshal(bytes.NewReader(iopStatusString), status); err != nil {
+		if err := protomarshal.UnmarshalAllowUnknown(iopStatusString, status); err != nil {
 			return fmt.Errorf("failed to unmarshal istioOperator status: %v", err)
 		}
 		errs := util.Errors{}

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -26,7 +26,6 @@ import (
 	loggingpb "cloud.google.com/go/logging/apiv2/loggingpb"
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	cloudtrace "cloud.google.com/go/trace/apiv1/tracepb"
-	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"istio.io/api/annotation"
@@ -41,6 +40,7 @@ import (
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/tests/integration/telemetry"
 	sdtest "istio.io/istio/tests/integration/telemetry/stackdriver"
 )
@@ -267,7 +267,7 @@ func goldenRequestCounts(trustDomain string) (cltRequestCount, srvRequestCount *
 	}
 	cltRequestCount = &monitoring.TimeSeries{}
 	srvRequestCount = &monitoring.TimeSeries{}
-	if err = jsonpb.UnmarshalString(sr, srvRequestCount); err != nil {
+	if err = protomarshal.UnmarshalString(sr, srvRequestCount); err != nil {
 		return
 	}
 	cltRequestCountTmpl, err := os.ReadFile(clientRequestCount)
@@ -281,7 +281,7 @@ func goldenRequestCounts(trustDomain string) (cltRequestCount, srvRequestCount *
 	if err != nil {
 		return
 	}
-	err = jsonpb.UnmarshalString(cr, cltRequestCount)
+	protomarshal.UnmarshalString(cr, cltRequestCount)
 	return
 }
 
@@ -298,7 +298,7 @@ func goldenLogEntry(trustDomain string) (srvLogEntry *loggingpb.LogEntry, err er
 		return
 	}
 	srvLogEntry = &loggingpb.LogEntry{}
-	if err = jsonpb.UnmarshalString(sr, srvLogEntry); err != nil {
+	if err = protomarshal.UnmarshalString(sr, srvLogEntry); err != nil {
 		return
 	}
 	return


### PR DESCRIPTION
**Please provide a description of this PR:**

Added a dependency guard to CI to make sure we have the use of jsonpb (deprecated but we still need to use this one) and protojson in a single wrapper.
Asking developers to use the protomarshal instead.

As suggested in: https://github.com/istio/istio/pull/42722#issue-1525901856