### PR TITLE
authority header changes

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
@@ -112,9 +112,17 @@ typedConfig:
                           regex: .+
             - orRules:
                 rules:
-                - header:
-                    name: :authority
-                    suffixMatch: :80
+                - andRules:
+                    rules:
+                    - notRule:
+                        header:
+                          name: :authority
+                          safeRegexMatch:
+                            googleRe2: {}
+                            regex: (?i).*\[\^:0-9\]\+
+                    - header:
+                        exactMatch: http
+                        name: :scheme
                 - header:
                     name: :authority
                     suffixMatch: :90

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
@@ -111,18 +111,23 @@ typedConfig:
                           googleRe2: {}
                           regex: .+
             - orRules:
-                rules:
-                - andRules:
+               rules:
+                - orRules:
                     rules:
-                    - notRule:
-                        header:
-                          name: :authority
-                          safeRegexMatch:
-                            googleRe2: {}
-                            regex: (?i).*\[\^:0-9\]\+
+                    - andRules:
+                        rules:
+                        - notRule:
+                            header:
+                              name: :authority
+                              safeRegexMatch:
+                                googleRe2: {}
+                                regex: (?i).*\[\^:0-9\]\+
+                        - header:
+                            exactMatch: http
+                            name: :scheme
                     - header:
-                        exactMatch: http
-                        name: :scheme
+                        name: :authority
+                        suffixMatch: :80
                 - header:
                     name: :authority
                     suffixMatch: :90

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
@@ -111,7 +111,7 @@ typedConfig:
                           googleRe2: {}
                           regex: .+
             - orRules:
-               rules:
+                rules:
                 - orRules:
                     rules:
                     - andRules:

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
@@ -61,9 +61,17 @@ typedConfig:
             rules:
             - orRules:
                 rules:
-                - header:
-                    name: :authority
-                    suffixMatch: :80
+                - andRules:
+                    rules:
+                    - notRule:
+                        header:
+                          name: :authority
+                          safeRegexMatch:
+                            googleRe2: {}
+                            regex: (?i).*\[\^:0-9\]\+
+                    - header:
+                        exactMatch: http
+                        name: :scheme
                 - header:
                     name: :authority
                     suffixMatch: :90

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
@@ -61,17 +61,22 @@ typedConfig:
             rules:
             - orRules:
                 rules:
-                - andRules:
+                - orRules:
                     rules:
-                    - notRule:
-                        header:
-                          name: :authority
-                          safeRegexMatch:
-                            googleRe2: {}
-                            regex: (?i).*\[\^:0-9\]\+
+                    - andRules:
+                        rules:
+                        - notRule:
+                            header:
+                              name: :authority
+                              safeRegexMatch:
+                                googleRe2: {}
+                                regex: (?i).*\[\^:0-9\]\+
+                        - header:
+                            exactMatch: http
+                            name: :scheme
                     - header:
-                        exactMatch: http
-                        name: :scheme
+                        name: :authority
+                        suffixMatch: :80
                 - header:
                     name: :authority
                     suffixMatch: :90

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -56,6 +56,36 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	}
 }
 
+// HeaderMatcherWithRegex converts a key, value string pair to a corresponding HeaderMatcher with regex.
+func HeaderMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
+	var regex string
+	if v == "*" {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
+				PresentMatch: true,
+			},
+		}
+	} else if strings.HasPrefix(v, "*") {
+		regex = `.*` + regexp.QuoteMeta(v[1:])
+	} else if strings.HasSuffix(v, "*") {
+		regex = regexp.QuoteMeta(v[:len(v)-1]) + `.*`
+	} else {
+		regex = regexp.QuoteMeta(v)
+	}
+	return &routepb.HeaderMatcher{
+		Name: k,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+			SafeRegexMatch: &matcher.RegexMatcher{
+				EngineType: &matcher.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
+				},
+				Regex: `(?i)` + regex,
+			},
+		},
+	}
+}
+
 // HostMatcherWithRegex creates a host matcher for a host using regex for proxies before 1.11.
 func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
 	var regex string

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -195,24 +195,30 @@ func (requestHeaderGenerator) permission(key, value string, forTCP bool) (*rbacp
 	// When the port is 80 and the scheme is http, authority header does not contain a port. The situation is
 	// the same for port 443 and scheme https. So it seems safe to assume that if the header lacks a port, and the
 	// scheme matches, then we're on 80 or 443 as appropriate.
+	var perm *rbacpb.Permission
 	if header == ":authority" {
 		if value == "*:80" {
 			perms := []*rbacpb.Permission{
 				permissionNot(permissionHeader(matcher.HeaderMatcherWithRegex(":authority", "*[^:0-9]+"))),
 				permissionHeader(matcher.HeaderMatcher(":scheme", "http")),
 			}
-			return permissionAnd(perms), nil
+			perm = permissionAnd(perms)
 		}
 		if value == "*:443" {
 			perms := []*rbacpb.Permission{
 				permissionNot(permissionHeader(matcher.HeaderMatcherWithRegex(":authority", "*[^:0-9]+"))),
 				permissionHeader(matcher.HeaderMatcher(":scheme", "https")),
 			}
-			return permissionAnd(perms), nil
+			perm = permissionAnd(perms)
 		}
 	}
 
 	m := matcher.HeaderMatcher(header, value)
+
+	if perm != nil {
+		return permissionOr([]*rbacpb.Permission{perm, permissionHeader(m)}), nil
+	}
+
 	return permissionHeader(m), nil
 }
 

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -632,6 +632,18 @@ spec:
     - operation:
         paths: ["/allowed-identity"]
         methods: ["GET"]
+  - to:
+    - operation:
+        paths: ["/allowed-port"]
+        methods: ["GET"]
+        ports: ["80"]
+    - source:
+        principals: ["cluster.local/ns/istio-system/sa/{{.Source}}"]
+  - to:
+    - operation:
+        paths: ["/denied-port"]
+        methods: ["GET"]
+        ports: ["81"]
   - from:
     - source:
         principals: ["cluster.local/ns/{{.Namespace}}/sa/someone-else"]
@@ -689,6 +701,20 @@ spec:
 				opt = opt.DeepCopy()
 				opt.HTTP.Path = "/allowed"
 				opt.Check = check.OK()
+				overrideCheck(&opt)
+				src.CallOrFail(t, opt)
+			})
+			t.NewSubTest("port deny").Run(func(t framework.TestContext) {
+				opt = opt.DeepCopy()
+				opt.HTTP.Path = "/denied-port"
+				opt.Check = CheckDeny
+				overrideCheck(&opt)
+				src.CallOrFail(t, opt)
+			})
+			t.NewSubTest("port allow").Run(func(t framework.TestContext) {
+				opt = opt.DeepCopy()
+				opt.HTTP.Path = "/allowed-port"
+				opt.Check = CheckDeny
 				overrideCheck(&opt)
 				src.CallOrFail(t, opt)
 			})

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -635,15 +635,10 @@ spec:
   - to:
     - operation:
         paths: ["/allowed-port"]
-        methods: ["GET"]
         ports: ["80"]
+    from:
     - source:
         principals: ["cluster.local/ns/istio-system/sa/{{.Source}}"]
-  - to:
-    - operation:
-        paths: ["/denied-port"]
-        methods: ["GET"]
-        ports: ["81"]
   - from:
     - source:
         principals: ["cluster.local/ns/{{.Namespace}}/sa/someone-else"]
@@ -704,17 +699,10 @@ spec:
 				overrideCheck(&opt)
 				src.CallOrFail(t, opt)
 			})
-			t.NewSubTest("port deny").Run(func(t framework.TestContext) {
-				opt = opt.DeepCopy()
-				opt.HTTP.Path = "/denied-port"
-				opt.Check = CheckDeny
-				overrideCheck(&opt)
-				src.CallOrFail(t, opt)
-			})
 			t.NewSubTest("port allow").Run(func(t framework.TestContext) {
 				opt = opt.DeepCopy()
 				opt.HTTP.Path = "/allowed-port"
-				opt.Check = CheckDeny
+				opt.Check = check.OK()
 				overrideCheck(&opt)
 				src.CallOrFail(t, opt)
 			})


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes https://github.com/istio/istio/issues/42243 and https://github.com/istio/istio/issues/42208. Fixes authority header match rule for 80 or 443 for instances where those ports are allowed by left off the authority header by Envoy.