### PR TITLE
Add OpenShift-related warning to addons documentation

### DIFF
--- a/common/config/mdl.rb
+++ b/common/config/mdl.rb
@@ -1,6 +1,7 @@
 all
 rule 'MD002', :level => 1
 rule 'MD007', :indent => 4
+rule 'MD009', :br_spaces => 2
 rule 'MD013', :line_length => 160, :code_blocks => false, :tables => false
 rule 'MD026', :punctuation => ".,;:!"
 exclude_rule 'MD013'

--- a/samples/addons/README.md
+++ b/samples/addons/README.md
@@ -87,6 +87,13 @@ The [Prometheus Operator](https://github.com/coreos/prometheus-operator) manages
 As an alternative to the standard Prometheus deployment, we provide a `ServiceMonitor` to monitor the Istio control plane and `PodMonitor`
 Envoy proxies. To use these, make sure you have the Prometheus operator deployed, then run `kubectl apply -f samples/addons/extras/prometheus-operator.yaml`.
 
-Note: The example `PodMonitor` requires [metrics merging](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging) to be enabled. This is enabled by default.
+> **Note**  
+> The example `PodMonitor` requires [metrics merging](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging) to be enabled. This is enabled by default.
 
-Note: The configurations here are only for Istio deployments, and do not scrape metrics from the Kubernetes components. See the [Cluster Monitoring](https://coreos.com/operators/prometheus/docs/latest/user-guides/cluster-monitoring.html) documentation for configuring this.
+> **Note**  
+> The configurations here are only for Istio deployments, and do not scrape metrics from the Kubernetes components.  
+> See the [Cluster Monitoring](https://coreos.com/operators/prometheus/docs/latest/user-guides/cluster-monitoring.html) documentation for configuring this.
+
+> **Warning**   
+> When the example `PodMonitor` is used with OpenShift Monitoring, it must be created in all namespaces where istio-proxies exist.  
+> This is because `namespaceSelector` is ignored for tenancy isolation.

--- a/samples/addons/README.md
+++ b/samples/addons/README.md
@@ -89,11 +89,11 @@ Envoy proxies. To use these, make sure you have the Prometheus operator deployed
 
 > **Note**  
 > The example `PodMonitor` requires [metrics merging](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging) to be enabled. This is enabled by default.
-
+>
 > **Note**  
 > The configurations here are only for Istio deployments, and do not scrape metrics from the Kubernetes components.  
 > See the [Cluster Monitoring](https://coreos.com/operators/prometheus/docs/latest/user-guides/cluster-monitoring.html) documentation for configuring this.
-
-> **Warning**   
+>
+> **Warning**  
 > When the example `PodMonitor` is used with OpenShift Monitoring, it must be created in all namespaces where istio-proxies exist.  
 > This is because `namespaceSelector` is ignored for tenancy isolation.


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

Look [here](https://github.com/jewertow/upstream-istio/tree/add-warning-for-openshift-monitoring/samples/addons#prometheus-operator) to see the result.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
