### PR TITLE
Add configurable priorityClassName to Gateway

### DIFF
--- a/manifests/charts/UPDATING-CHARTS.md
+++ b/manifests/charts/UPDATING-CHARTS.md
@@ -17,7 +17,7 @@ Exceptions to this rule are configuration items that affect K8s level settings (
 
 ## Step 2. Make corresponding values changes in [../profiles/default.yaml](../profiles/default.yaml)
 
-The values.yaml in `manifests` are only used for direct Helm based installations, which is being deprecated.
+The values.yaml in `manifests` are only used for direct Helm based installations.
 If any values.yaml changes are being made, the same changes must be made in the `manifests/profiles/default.yaml`
 file, which must be in sync with the Helm values in `manifests`.
 

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       securityContext:
       {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 8 }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -185,6 +185,9 @@
     "networkGateway": {
       "type": "string"
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "imagePullSecrets": {
       "type": "array",
       "items": {

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -91,3 +91,5 @@ affinity: {}
 networkGateway: ""
 
 imagePullSecrets: []
+
+priorityClassName: ""


### PR DESCRIPTION
Add the ability to configure the priorityClassName in the "gateway" helm chart.

Signed-off-by: Derrik Campau <dcampau@vmware.com>

**Please provide a description of this PR:**