### PR TITLE
Add readinessProbe and rollingUpdate to Gateway

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -11,6 +11,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    rollingUpdate:
+    {{- toYaml .Values.updateStrategy | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
@@ -71,6 +76,16 @@ spec:
             allowPrivilegeEscalation: true
             readOnlyRootFilesystem: true
           {{- end }}
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15021
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           env:
           {{- with .Values.networkGateway }}
           - name: ISTIO_META_REQUESTED_NETWORK_VIEW

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -195,6 +195,22 @@
           }
         }
       }
+    },
+    "updateStrategy": {
+      "properties": {
+        "maxSurge": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "maxUnavailable": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        }
+      }
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -7,6 +7,11 @@ replicaCount: 1
 
 kind: Deployment
 
+# for deployments
+updateStrategy: 
+  maxSurge: 25%
+  maxUnavailable: 25%
+
 rbac:
   # If enabled, roles will be created to enable accessing certificates from Gateways. This is not needed
   # when using http://gateway-api.org/.


### PR DESCRIPTION
* Adds the readinessProbe to the gateway chart. This is present in the deprecated/old "gateways" charts
* Adds a user-configurable rollingUpdate Strategy for Deployments.

Signed-off-by: Derrik Campau <dcampau@vmware.com>

**Please provide a description of this PR:**