### PR TITLE
wasm: Refactor Wasm related codes in Istio Agent

### DIFF
--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -160,9 +160,10 @@ func convertToWasmPluginWrapper(originPlugin config.Config) *WasmPluginWrapper {
 	// Normalize the image pull secret to the full resource name.
 	wasmPlugin.ImagePullSecret = toSecretResourceName(wasmPlugin.ImagePullSecret, plugin.Namespace)
 	datasource := buildDataSource(u, wasmPlugin)
+	resourceName := plugin.Namespace + "." + plugin.Name
 	wasmExtensionConfig := &envoyWasmFilterV3.Wasm{
 		Config: &envoyExtensionsWasmV3.PluginConfig{
-			Name:          plugin.Namespace + "." + plugin.Name,
+			Name:          resourceName,
 			RootId:        wasmPlugin.PluginName,
 			Configuration: cfg,
 			Vm:            buildVMConfig(datasource, plugin.ResourceVersion, wasmPlugin),
@@ -175,7 +176,7 @@ func convertToWasmPluginWrapper(originPlugin config.Config) *WasmPluginWrapper {
 	return &WasmPluginWrapper{
 		Name:                plugin.Name,
 		Namespace:           plugin.Namespace,
-		ResourceName:        plugin.Namespace + "." + plugin.Name,
+		ResourceName:        resourceName,
 		WasmPlugin:          wasmPlugin,
 		WasmExtensionConfig: wasmExtensionConfig,
 	}

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 
-	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
@@ -52,6 +51,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
+	wasmcache "istio.io/istio/pkg/wasm"
 )
 
 // TestXdsLeak is a regression test for https://github.com/istio/istio/issues/34097
@@ -444,14 +444,14 @@ func TestXdsProxyReconnects(t *testing.T) {
 
 type fakeAckCache struct{}
 
-func (f *fakeAckCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
+func (f *fakeAckCache) Get(string, *wasmcache.GetOptions) (string, error) {
 	return "test", nil
 }
 func (f *fakeAckCache) Cleanup() {}
 
 type fakeNackCache struct{}
 
-func (f *fakeNackCache) Get(string, string, string, string, time.Duration, []byte, extensions.PullPolicy) (string, error) {
+func (f *fakeNackCache) Get(string, *wasmcache.GetOptions) (string, error) {
 	return "", errors.New("errror")
 }
 func (f *fakeNackCache) Cleanup() {}

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -444,14 +444,14 @@ func TestXdsProxyReconnects(t *testing.T) {
 
 type fakeAckCache struct{}
 
-func (f *fakeAckCache) Get(string, *wasmcache.GetOptions) (string, error) {
+func (f *fakeAckCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "test", nil
 }
 func (f *fakeAckCache) Cleanup() {}
 
 type fakeNackCache struct{}
 
-func (f *fakeNackCache) Get(string, *wasmcache.GetOptions) (string, error) {
+func (f *fakeNackCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "", errors.New("errror")
 }
 func (f *fakeNackCache) Cleanup() {}

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -48,7 +48,7 @@ const (
 
 // Cache models a Wasm module cache.
 type Cache interface {
-	Get(url, checksum, resourceName, resourceVersion string, timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy) (string, error)
+	Get(url string, opts *GetOptions) (string, error)
 	Cleanup()
 }
 
@@ -58,7 +58,6 @@ type LocalFileCache struct {
 	modules map[moduleKey]*cacheEntry
 	// Map from tagged URL to checksum
 	checksums map[string]*checksumEntry
-
 	// http fetcher fetches Wasm module with HTTP get.
 	httpFetcher *HTTPFetcher
 
@@ -164,7 +163,7 @@ func NewLocalFileCache(dir string, options Options) *LocalFileCache {
 	return cache
 }
 
-func urlAsResourceName(fullURLStr string) string {
+func moduleNameFromURL(fullURLStr string) string {
 	if strings.HasPrefix(fullURLStr, ociURLPrefix) {
 		if tag, err := name.ParseReference(fullURLStr[len(ociURLPrefix):]); err == nil {
 			// remove tag or sha
@@ -202,32 +201,38 @@ func getModulePath(baseDir string, mkey moduleKey) (string, error) {
 }
 
 // Get returns path the local Wasm module file.
-func (c *LocalFileCache) Get(
-	downloadURL, checksum, resourceName, resourceVersion string,
-	timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy,
-) (string, error) {
+func (c *LocalFileCache) Get(downloadURL string, opts *GetOptions) (string, error) {
 	// Construct Wasm cache key with downloading URL and provided checksum of the module.
 	key := cacheKey{
 		downloadURL: downloadURL,
 		moduleKey: moduleKey{
-			name:     urlAsResourceName(downloadURL),
-			checksum: checksum,
+			name:     moduleNameFromURL(downloadURL),
+			checksum: opts.Checksum,
 		},
-		resourceName:    resourceName,
-		resourceVersion: resourceVersion,
+		resourceName:    opts.ResourceName,
+		resourceVersion: opts.ResourceVersion,
 	}
 
-	u, err := url.Parse(downloadURL)
+	entry, err := c.getOrFetch(key, opts)
 	if err != nil {
-		return "", fmt.Errorf("fail to parse Wasm module fetch url: %s, error: %v", downloadURL, err)
+		return "", err
+	}
+
+	return entry.modulePath, err
+}
+
+func (c *LocalFileCache) getOrFetch(key cacheKey, opts *GetOptions) (*cacheEntry, error) {
+
+	u, err := url.Parse(key.downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("fail to parse Wasm module fetch url: %s, error: %v", key.downloadURL, err)
 	}
 
 	// First check if the cache entry is already downloaded and policy does not require to pull always.
-	var modulePath string
-	modulePath, key.checksum = c.getEntry(key, shouldIgnoreResourceVersion(pullPolicy, u))
-	if modulePath != "" {
-		c.touchEntry(key)
-		return modulePath, nil
+	if ce, checksum := c.getEntry(key, shouldIgnoreResourceVersion(opts.PullPolicy, u)); ce != nil {
+		return ce, nil
+	} else {
+		key.checksum = checksum
 	}
 	// Fetch the image now as it is not available in cache.
 	var b []byte         // Byte array of Wasm binary.
@@ -235,15 +240,15 @@ func (c *LocalFileCache) Get(
 	var binaryFetcher func() ([]byte, error)
 	insecure := c.allowInsecure(u.Host)
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()
 	switch u.Scheme {
 	case "http", "https":
 		// Download the Wasm module with http fetcher.
-		b, err = c.httpFetcher.Fetch(ctx, downloadURL, insecure)
+		b, err = c.httpFetcher.Fetch(ctx, key.downloadURL, insecure)
 		if err != nil {
 			wasmRemoteFetchCount.With(resultTag.Value(downloadFailure)).Increment()
-			return "", err
+			return nil, err
 		}
 
 		// Get sha256 checksum and check if it is the same as provided one.
@@ -253,58 +258,48 @@ func (c *LocalFileCache) Get(
 		imgFetcherOps := ImageFetcherOption{
 			Insecure: insecure,
 		}
-		if pullSecret != nil {
-			imgFetcherOps.PullSecret = pullSecret
+		if opts.PullSecret != nil {
+			imgFetcherOps.PullSecret = opts.PullSecret
 		}
-		wasmLog.Debugf("fetching oci image from %s with options: %v", downloadURL, imgFetcherOps)
+		wasmLog.Debugf("fetching oci image from %s with options: %v", key.downloadURL, imgFetcherOps)
 		fetcher := NewImageFetcher(ctx, imgFetcherOps)
 		binaryFetcher, dChecksum, err = fetcher.PrepareFetch(u.Host + u.Path)
 		if err != nil {
 			wasmRemoteFetchCount.With(resultTag.Value(manifestFailure)).Increment()
-			return "", fmt.Errorf("could not fetch Wasm OCI image: %v", err)
+			return nil, fmt.Errorf("could not fetch Wasm OCI image: %v", err)
 		}
 	default:
-		return "", fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", u.Scheme)
+		return nil, fmt.Errorf("unsupported Wasm module downloading URL scheme: %v", u.Scheme)
 	}
 
 	if key.checksum == "" {
 		key.checksum = dChecksum
 		// check again if the cache is having the checksum.
-		if modulePath, _ := c.getEntry(key, true); modulePath != "" {
-			c.touchEntry(key)
-			return modulePath, nil
+		if ce, _ := c.getEntry(key, true); ce != nil {
+			return ce, nil
 		}
 	} else if dChecksum != key.checksum {
 		wasmRemoteFetchCount.With(resultTag.Value(checksumMismatch)).Increment()
-		return "", fmt.Errorf("module downloaded from %v has checksum %v, which does not match: %v", downloadURL, dChecksum, key.checksum)
+		return nil, fmt.Errorf("module downloaded from %v has checksum %v, which does not match: %v", key.downloadURL, dChecksum, key.checksum)
 	}
 
 	if binaryFetcher != nil {
 		b, err = binaryFetcher()
 		if err != nil {
 			wasmRemoteFetchCount.With(resultTag.Value(downloadFailure)).Increment()
-			return "", fmt.Errorf("could not fetch Wasm binary: %v", err)
+			return nil, fmt.Errorf("could not fetch Wasm binary: %v", err)
 		}
 	}
 
 	if !isValidWasmBinary(b) {
 		wasmRemoteFetchCount.With(resultTag.Value(fetchFailure)).Increment()
-		return "", fmt.Errorf("fetched Wasm binary from %s is invalid", downloadURL)
+		return nil, fmt.Errorf("fetched Wasm binary from %s is invalid", key.downloadURL)
 	}
 
 	wasmRemoteFetchCount.With(resultTag.Value(fetchSuccess)).Increment()
 
 	key.checksum = dChecksum
-
-	modulePath, err = getModulePath(c.dir, key.moduleKey)
-	if err != nil {
-		return "", err
-	}
-
-	if err := c.addEntry(key, b, modulePath); err != nil {
-		return "", err
-	}
-	return modulePath, nil
+	return c.addEntry(key, b)
 }
 
 // Cleanup closes background Wasm module purge routine.
@@ -328,13 +323,9 @@ func (c *LocalFileCache) updateChecksum(key cacheKey) bool {
 	return needChecksumUpdate
 }
 
-func (c *LocalFileCache) touchEntry(key cacheKey) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-	c.updateChecksum(key)
-}
-
-func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) error {
+// addEntry adds a wasmModule to cache with cacheKey, writes the module to the local file system,
+// and returns the created entry.
+func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte) (*cacheEntry, error) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	needChecksumUpdate := c.updateChecksum(key)
@@ -346,16 +337,20 @@ func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) err
 		if needChecksumUpdate {
 			ce.referencingURLs.Insert(key.downloadURL)
 		}
-		return nil
+		return ce, nil
 	}
 
+	modulePath, err := getModulePath(c.dir, key.moduleKey)
+	if err != nil {
+		return nil, err
+	}
 	// Materialize the Wasm module into a local file. Use checksum as name of the module.
-	if err := os.WriteFile(f, wasmModule, 0o644); err != nil {
-		return err
+	if err := os.WriteFile(modulePath, wasmModule, 0o644); err != nil {
+		return nil, err
 	}
 
 	ce := cacheEntry{
-		modulePath:      f,
+		modulePath:      modulePath,
 		last:            time.Now(),
 		referencingURLs: sets.New[string](),
 	}
@@ -364,16 +359,18 @@ func (c *LocalFileCache) addEntry(key cacheKey, wasmModule []byte, f string) err
 	}
 	c.modules[key.moduleKey] = &ce
 	wasmCacheEntries.Record(float64(len(c.modules)))
-	return nil
+	return &ce, nil
 }
 
-// getEntry finds a cached module, and returns the path of the module and its checksum.
-func (c *LocalFileCache) getEntry(key cacheKey, ignoreResourceVersion bool) (string, string) {
-	modulePath := ""
+// getEntry finds a cached module, and returns the found cache entry and its checksum.
+func (c *LocalFileCache) getEntry(key cacheKey, ignoreResourceVersion bool) (*cacheEntry, string) {
 	cacheHit := false
 
 	c.mux.Lock()
-	defer c.mux.Unlock()
+	defer func() {
+		c.mux.Unlock()
+		wasmCacheLookupCount.With(hitTag.Value(strconv.FormatBool(cacheHit))).Increment()
+	}()
 
 	if len(key.checksum) == 0 && strings.HasPrefix(key.downloadURL, ociURLPrefix) {
 		if d, err := name.NewDigest(key.downloadURL[len(ociURLPrefix):]); err == nil {
@@ -402,11 +399,11 @@ func (c *LocalFileCache) getEntry(key cacheKey, ignoreResourceVersion bool) (str
 	if ce, ok := c.modules[key.moduleKey]; ok {
 		// Update last touched time.
 		ce.last = time.Now()
-		modulePath = ce.modulePath
 		cacheHit = true
+		c.updateChecksum(key)
+		return ce, key.checksum
 	}
-	wasmCacheLookupCount.With(hitTag.Value(strconv.FormatBool(cacheHit))).Increment()
-	return modulePath, key.checksum
+	return nil, key.checksum
 }
 
 // Purge periodically clean up the stale Wasm modules local file and the cache map.

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -222,18 +222,17 @@ func (c *LocalFileCache) Get(downloadURL string, opts GetOptions) (string, error
 }
 
 func (c *LocalFileCache) getOrFetch(key cacheKey, opts GetOptions) (*cacheEntry, error) {
-
 	u, err := url.Parse(key.downloadURL)
 	if err != nil {
 		return nil, fmt.Errorf("fail to parse Wasm module fetch url: %s, error: %v", key.downloadURL, err)
 	}
 
 	// First check if the cache entry is already downloaded and policy does not require to pull always.
-	if ce, checksum := c.getEntry(key, shouldIgnoreResourceVersion(opts.PullPolicy, u)); ce != nil {
+	ce, checksum := c.getEntry(key, shouldIgnoreResourceVersion(opts.PullPolicy, u))
+	if ce != nil {
 		return ce, nil
-	} else {
-		key.checksum = checksum
 	}
+	key.checksum = checksum
 	// Fetch the image now as it is not available in cache.
 	var b []byte         // Byte array of Wasm binary.
 	var dChecksum string // Hex-Encoded sha256 checksum of binary.

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -48,7 +48,7 @@ const (
 
 // Cache models a Wasm module cache.
 type Cache interface {
-	Get(url string, opts *GetOptions) (string, error)
+	Get(url string, opts GetOptions) (string, error)
 	Cleanup()
 }
 
@@ -201,7 +201,7 @@ func getModulePath(baseDir string, mkey moduleKey) (string, error) {
 }
 
 // Get returns path the local Wasm module file.
-func (c *LocalFileCache) Get(downloadURL string, opts *GetOptions) (string, error) {
+func (c *LocalFileCache) Get(downloadURL string, opts GetOptions) (string, error) {
 	// Construct Wasm cache key with downloading URL and provided checksum of the module.
 	key := cacheKey{
 		downloadURL: downloadURL,
@@ -221,7 +221,7 @@ func (c *LocalFileCache) Get(downloadURL string, opts *GetOptions) (string, erro
 	return entry.modulePath, err
 }
 
-func (c *LocalFileCache) getOrFetch(key cacheKey, opts *GetOptions) (*cacheEntry, error) {
+func (c *LocalFileCache) getOrFetch(key cacheKey, opts GetOptions) (*cacheEntry, error) {
 
 	u, err := url.Parse(key.downloadURL)
 	if err != nil {
@@ -240,7 +240,7 @@ func (c *LocalFileCache) getOrFetch(key cacheKey, opts *GetOptions) (*cacheEntry
 	var binaryFetcher func() ([]byte, error)
 	insecure := c.allowInsecure(u.Host)
 
-	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), opts.RequestTimeout)
 	defer cancel()
 	switch u.Scheme {
 	case "http", "https":

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -936,7 +936,6 @@ func TestAllInsecureServer(t *testing.T) {
 		PullSecret:      []byte{},
 		PullPolicy:      defaultPullPolicy,
 	})
-
 	if err != nil {
 		t.Fatalf("failed to download Wasm module: %v", err)
 	}

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -132,7 +132,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "cache hit",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ts.URL), checksum: cacheHitSum}: {modulePath: "test.wasm"},
+				{name: moduleNameFromURL(ts.URL), checksum: cacheHitSum}: {modulePath: "test.wasm"},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			resourceName:           "namespace.resource",
@@ -190,7 +190,7 @@ func TestWasmCache(t *testing.T) {
 			// Test that downloading still proceeds and error returns.
 			name: "different url same checksum",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+				{name: moduleNameFromURL(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			fetchURL:               ts.URL + "/different-url",
@@ -206,7 +206,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "invalid wasm header",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
+				{name: moduleNameFromURL(ts.URL), checksum: httpDataCheckSum}: {modulePath: fmt.Sprintf("%s.wasm", httpDataCheckSum)},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			fetchURL:               ts.URL + "/invalid-wasm-header",
@@ -243,7 +243,7 @@ func TestWasmCache(t *testing.T) {
 			fetchURL:               ociURLWithTag,
 			requestTimeout:         time.Second * 10,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -261,7 +261,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:         time.Second * 10,
 			checksum:               dockerImageDigest,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -272,7 +272,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "cache hit for tagged oci url with digest",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			resourceName:           "namespace.resource",
@@ -281,7 +281,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:         time.Second * 10,
 			checksum:               dockerImageDigest,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -292,7 +292,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "cache hit for tagged oci url without digest",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {
@@ -307,7 +307,7 @@ func TestWasmCache(t *testing.T) {
 			fetchURL:        ociURLWithTag,
 			requestTimeout:  time.Second * 10,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -318,7 +318,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "cache miss for tagged oci url without digest",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			resourceName:           "namespace.resource",
@@ -326,7 +326,7 @@ func TestWasmCache(t *testing.T) {
 			fetchURL:               ociURLWithTag,
 			requestTimeout:         time.Second * 10,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -337,7 +337,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "cache hit for oci url suffixed by digest",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{},
 			resourceName:           "namespace.resource",
@@ -345,7 +345,7 @@ func TestWasmCache(t *testing.T) {
 			fetchURL:               ociURLWithDigest,
 			requestTimeout:         time.Second * 10,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{},
 			wantFileName:        ociWasmFile,
@@ -354,7 +354,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "pull due to pull-always policy when cache hit",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {
@@ -370,7 +370,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:  time.Second * 10,
 			pullPolicy:      extensions.PullPolicy_Always,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -381,7 +381,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "do not pull due to resourceVersion is the same",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {
@@ -397,7 +397,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:  time.Second * 10,
 			pullPolicy:      extensions.PullPolicy_Always,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "123456"}},
@@ -408,7 +408,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "pull due to if-not-present policy when cache hit",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {
@@ -424,7 +424,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:  time.Second * 10,
 			pullPolicy:      extensions.PullPolicy_IfNotPresent,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -435,7 +435,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "do not pull in spite of pull-always policy due to checksum",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			resourceName:    "namespace.resource",
 			resourceVersion: "0",
@@ -444,7 +444,7 @@ func TestWasmCache(t *testing.T) {
 			checksum:        dockerImageDigest,
 			pullPolicy:      extensions.PullPolicy_Always,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -455,7 +455,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "pull due to latest tag",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			resourceName:    "namespace.resource",
 			resourceVersion: "0",
@@ -471,7 +471,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout: time.Second * 10,
 			pullPolicy:     extensions.PullPolicy_UNSPECIFIED_POLICY, // Default policy
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithLatestTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -482,7 +482,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "do not pull in spite of latest tag due to checksum",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithLatestTag: {
@@ -499,7 +499,7 @@ func TestWasmCache(t *testing.T) {
 			checksum:        dockerImageDigest,
 			pullPolicy:      extensions.PullPolicy_UNSPECIFIED_POLICY, // Default policy
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithLatestTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -510,7 +510,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "do not pull in spite of latest tag due to IfNotPresent policy",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			initialCachedChecksums: map[string]*checksumEntry{
 				ociURLWithLatestTag: {
@@ -526,7 +526,7 @@ func TestWasmCache(t *testing.T) {
 			requestTimeout:  time.Second * 10,
 			pullPolicy:      extensions.PullPolicy_IfNotPresent,
 			wantCachedModules: map[moduleKey]*cacheEntry{
-				{name: urlAsResourceName(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
+				{name: moduleNameFromURL(ociURLWithLatestTag), checksum: dockerImageDigest}: {modulePath: ociWasmFile},
 			},
 			wantCachedChecksums: map[string]*checksumEntry{
 				ociURLWithLatestTag: {checksum: dockerImageDigest, resourceVersionByResource: map[string]string{"namespace.resource": "0"}},
@@ -537,7 +537,7 @@ func TestWasmCache(t *testing.T) {
 		{
 			name: "purge OCI image on expiry",
 			initialCachedModules: map[moduleKey]cacheEntry{
-				{name: urlAsResourceName(ociURLWithTag) + "-purged", checksum: dockerImageDigest}: {
+				{name: moduleNameFromURL(ociURLWithTag) + "-purged", checksum: dockerImageDigest}: {
 					modulePath:      ociWasmFile,
 					referencingURLs: sets.New(ociURLWithTag),
 				},
@@ -646,7 +646,7 @@ func TestWasmCache(t *testing.T) {
 					cache.modules[mkey].referencingURLs = sets.New[string]()
 				}
 
-				if urlAsResourceName(c.fetchURL) == k.name && c.checksum == k.checksum {
+				if moduleNameFromURL(c.fetchURL) == k.name && c.checksum == k.checksum {
 					cacheHitKey = &mkey
 				}
 			}
@@ -662,7 +662,14 @@ func TestWasmCache(t *testing.T) {
 			cache.mux.Unlock()
 
 			atomic.StoreInt32(&tsNumRequest, 0)
-			gotFilePath, gotErr := cache.Get(c.fetchURL, c.checksum, c.resourceName, c.resourceVersion, c.requestTimeout, []byte{}, c.pullPolicy)
+			gotFilePath, gotErr := cache.Get(c.fetchURL, &GetOptions{
+				Checksum:        c.checksum,
+				ResourceName:    c.resourceName,
+				ResourceVersion: c.resourceVersion,
+				Timeout:         c.requestTimeout,
+				PullSecret:      []byte{},
+				PullPolicy:      c.pullPolicy,
+			})
 			serverVisited := atomic.LoadInt32(&tsNumRequest) > 0
 
 			if c.checkPurgeTimeout > 0 {
@@ -713,7 +720,7 @@ func TestWasmCache(t *testing.T) {
 
 			cache.mux.Unlock()
 
-			wantFilePath := generateModulePath(t, tmpDir, urlAsResourceName(c.fetchURL), c.wantFileName)
+			wantFilePath := generateModulePath(t, tmpDir, moduleNameFromURL(c.fetchURL), c.wantFileName)
 			if c.wantErrorMsgPrefix != "" {
 				if gotErr == nil {
 					t.Errorf("Wasm module cache lookup got no error, want error prefix `%v`", c.wantErrorMsgPrefix)
@@ -828,7 +835,13 @@ func TestWasmCachePolicyChangesUsingHTTP(t *testing.T) {
 
 	testWasmGet := func(downloadURL string, policy extensions.PullPolicy, resourceVersion string, wantFilePath string, wantNumRequest int) {
 		t.Helper()
-		gotFilePath, err := cache.Get(downloadURL, "", "namespace.resource", resourceVersion, time.Second*10, []byte{}, policy)
+		gotFilePath, err := cache.Get(downloadURL, &GetOptions{
+			ResourceName:    "namespace.resource",
+			ResourceVersion: resourceVersion,
+			Timeout:         time.Second * 10,
+			PullSecret:      []byte{},
+			PullPolicy:      policy,
+		})
 		if err != nil {
 			t.Fatalf("failed to download Wasm module: %v", err)
 		}
@@ -874,12 +887,19 @@ func TestAllInsecureServer(t *testing.T) {
 	ociURLWithTag := fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host)
 	var defaultPullPolicy extensions.PullPolicy
 
-	gotFilePath, err := cache.Get(ociURLWithTag, "", "namespace.resource", "123456", time.Second*10, []byte{}, defaultPullPolicy)
+	gotFilePath, err := cache.Get(ociURLWithTag, &GetOptions{
+		ResourceName:    "namespace.resource",
+		ResourceVersion: "123456",
+		Timeout:         time.Second * 10,
+		PullSecret:      []byte{},
+		PullPolicy:      defaultPullPolicy,
+	})
+
 	if err != nil {
 		t.Fatalf("failed to download Wasm module: %v", err)
 	}
 
-	wantFilePath := generateModulePath(t, tmpDir, urlAsResourceName(ociURLWithTag), fmt.Sprintf("%s.wasm", dockerImageDigest))
+	wantFilePath := generateModulePath(t, tmpDir, moduleNameFromURL(ociURLWithTag), fmt.Sprintf("%s.wasm", dockerImageDigest))
 	if gotFilePath != wantFilePath {
 		t.Errorf("Wasm module local file path got %v, want %v", gotFilePath, wantFilePath)
 	}

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -198,7 +198,6 @@ func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, s
 		PullSecret:      pullSecret,
 		PullPolicy:      pullPolicy,
 	})
-
 	if err != nil {
 		status = fetchFailure
 		wasmLog.Errorf("cannot fetch Wasm module %v: %v", remote.GetHttpUri().GetUri(), err)

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -188,7 +188,17 @@ func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, s
 	if remote.GetHttpUri().Timeout != nil {
 		timeout = remote.GetHttpUri().Timeout.AsDuration()
 	}
-	f, err := cache.Get(httpURI.GetUri(), remote.Sha256, wasmHTTPFilterConfig.Config.Name, resourceVersion, timeout, pullSecret, pullPolicy)
+	// ec.Name is resourceName.
+	// https://github.com/istio/istio/blob/9ea7ad532a9cc58a3564143d41ac89a61aaa8058/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go#L103
+	f, err := cache.Get(httpURI.GetUri(), &GetOptions{
+		Checksum:        remote.Sha256,
+		ResourceName:    ec.Name,
+		ResourceVersion: resourceVersion,
+		Timeout:         timeout,
+		PullSecret:      pullSecret,
+		PullPolicy:      pullPolicy,
+	})
+
 	if err != nil {
 		status = fetchFailure
 		wasmLog.Errorf("cannot fetch Wasm module %v: %v", remote.GetHttpUri().GetUri(), err)

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -190,11 +190,11 @@ func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, s
 	}
 	// ec.Name is resourceName.
 	// https://github.com/istio/istio/blob/9ea7ad532a9cc58a3564143d41ac89a61aaa8058/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go#L103
-	f, err := cache.Get(httpURI.GetUri(), &GetOptions{
+	f, err := cache.Get(httpURI.GetUri(), GetOptions{
 		Checksum:        remote.Sha256,
 		ResourceName:    ec.Name,
 		ResourceVersion: resourceVersion,
-		Timeout:         timeout,
+		RequestTimeout:  timeout,
 		PullSecret:      pullSecret,
 		PullPolicy:      pullPolicy,
 	})

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -43,7 +43,7 @@ type mockCache struct {
 	wantPolicy extensions.PullPolicy
 }
 
-func (c *mockCache) Get(downloadURL string, opts *GetOptions) (string, error) {
+func (c *mockCache) Get(downloadURL string, opts GetOptions) (string, error) {
 	url, _ := url.Parse(downloadURL)
 	query := url.Query()
 

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
-	"time"
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -44,10 +43,7 @@ type mockCache struct {
 	wantPolicy extensions.PullPolicy
 }
 
-func (c *mockCache) Get(
-	downloadURL, checksum, resourceName, resourceVersion string,
-	timeout time.Duration, pullSecret []byte, pullPolicy extensions.PullPolicy,
-) (string, error) {
+func (c *mockCache) Get(downloadURL string, opts *GetOptions) (string, error) {
 	url, _ := url.Parse(downloadURL)
 	query := url.Query()
 
@@ -57,11 +53,11 @@ func (c *mockCache) Get(
 	if errMsg != "" {
 		err = errors.New(errMsg)
 	}
-	if c.wantSecret != nil && !reflect.DeepEqual(c.wantSecret, pullSecret) {
-		return "", fmt.Errorf("wrong secret for %v, got %q want %q", downloadURL, string(pullSecret), c.wantSecret)
+	if c.wantSecret != nil && !reflect.DeepEqual(c.wantSecret, opts.PullSecret) {
+		return "", fmt.Errorf("wrong secret for %v, got %q want %q", downloadURL, string(opts.PullSecret), c.wantSecret)
 	}
-	if c.wantPolicy != pullPolicy {
-		return "", fmt.Errorf("wrong pull policy for %v, got %v want %v", downloadURL, pullPolicy, c.wantPolicy)
+	if c.wantPolicy != opts.PullPolicy {
+		return "", fmt.Errorf("wrong pull policy for %v, got %v want %v", downloadURL, opts.PullPolicy, c.wantPolicy)
 	}
 
 	return module, err

--- a/pkg/wasm/options.go
+++ b/pkg/wasm/options.go
@@ -52,7 +52,7 @@ type GetOptions struct {
 	Checksum        string
 	ResourceName    string
 	ResourceVersion string
-	Timeout         time.Duration
+	RequestTimeout  time.Duration
 	PullSecret      []byte
 	PullPolicy      extensions.PullPolicy
 }

--- a/pkg/wasm/options.go
+++ b/pkg/wasm/options.go
@@ -17,6 +17,7 @@ package wasm
 import (
 	"time"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -27,6 +28,7 @@ const (
 	DefaultHTTPRequestMaxRetries = 5
 )
 
+// Options contains configurations to create a Cache instance.
 type Options struct {
 	PurgeInterval         time.Duration
 	ModuleExpiry          time.Duration
@@ -43,4 +45,14 @@ func defaultOptions() Options {
 		HTTPRequestTimeout:    DefaultHTTPRequestTimeout,
 		HTTPRequestMaxRetries: DefaultHTTPRequestMaxRetries,
 	}
+}
+
+// GetOptions is a struct for providing options to Get method of Cache.
+type GetOptions struct {
+	Checksum        string
+	ResourceName    string
+	ResourceVersion string
+	Timeout         time.Duration
+	PullSecret      []byte
+	PullPolicy      extensions.PullPolicy
 }


### PR DESCRIPTION
This PR proposes refactoring Wasm related codes for readability and extensibility.
Highlights are two folds.
1. Simplify `Cache.Get` method by adopting `GetOptions`.
2. `Cache.addEntry` and `Cache.getEntry` now return `cacheEntry` instead of `modulePath`.