### PR TITLE
fix: * will match when value is not empty

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -61,7 +61,9 @@ typedConfig:
                     suffixMatch: -suffix-method
                 - header:
                     name: :method
-                    presentMatch: true
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: .+
             - notRule:
                 orRules:
                   rules:
@@ -76,7 +78,9 @@ typedConfig:
                       suffixMatch: -not-suffix-method
                   - header:
                       name: :method
-                      presentMatch: true
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: .+
             - orRules:
                 rules:
                 - urlPath:
@@ -448,7 +452,9 @@ typedConfig:
                     suffixMatch: -suffix-header
                 - header:
                     name: X-header
-                    presentMatch: true
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: .+
             - notId:
                 orIds:
                   ids:
@@ -463,7 +469,9 @@ typedConfig:
                       suffixMatch: -not-suffix-header
                   - header:
                       name: X-header
-                      presentMatch: true
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: .+
             - orIds:
                 ids:
                 - directRemoteIp:

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -158,7 +158,9 @@ typedConfig:
                     suffixMatch: -suffix-header
                 - header:
                     name: X-header
-                    presentMatch: true
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: .+
             - orIds:
                 ids:
                 - remoteIp:
@@ -238,7 +240,9 @@ typedConfig:
                     suffixMatch: -suffix-header
                 - header:
                     name: X-header
-                    presentMatch: true
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: .+
             - orIds:
                 ids:
                 - remoteIp:

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -23,14 +23,20 @@ import (
 )
 
 // HeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.
+// The wildcard "*" will be generated as ".+" instead of ".*".
 func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 	// We must check "*" first to make sure we'll generate a non empty value in the prefix/suffix case.
 	// Empty prefix/suffix value is invalid in HeaderMatcher.
 	if v == "*" {
 		return &routepb.HeaderMatcher{
 			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
-				PresentMatch: true,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+				SafeRegexMatch: &matcher.RegexMatcher{
+					EngineType: &matcher.RegexMatcher_GoogleRe2{
+						GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
+					},
+					Regex: ".+",
+				},
 			},
 		}
 	} else if strings.HasPrefix(v, "*") {

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -70,8 +70,13 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
-					PresentMatch: true,
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcher.RegexMatcher{
+						EngineType: &matcher.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
+						},
+						Regex: ".+",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**Please provide a description of this PR:**
According to [Istio document](https://istio.io/latest/docs/reference/config/security/authorization-policy/)  `“*”` will match when value is not empty. But right now it's not working correctly because it's using  `*` but it should use `.+` like the [StringMatcher](https://github.com/istio/istio/blob/d0705cf0ed5591cc26c08001f3faab0a880aec48/pilot/pkg/security/authz/matcher/string.go#L50)  

For example, we want to block an empty header but allow a nonempty header.
We can create an `AuthorizationPolicy`
```
kind: AuthorizationPolicy
metadata:
  name: test
  namespace: istio-system
spec:
  action: DENY
  rules:
  - from:
    when:
    - key: request.headers[test]
      notValues: ["*"]
```
and then try to access it.
`curl -v -H 'test;' DOMAIM
`
`curl -v -H 'test: "nonempty"' DOMAIM`

By using this PR it will block the empty header and allow nonempty header. `“*” `will match when value is not empty 