### PR TITLE
incremental EDS: take debounce into account

### DIFF
--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -456,11 +456,14 @@ func shouldUseDeltaEds(req *model.PushRequest) bool {
 // onlyEndpointsChanged checks if a request contains *only* endpoints updates. This allows us to perform more efficient pushes
 // where we only update the endpoints that did change.
 func onlyEndpointsChanged(req *model.PushRequest) bool {
+	// If we don't know what configs are updated, just send a full push
 	if len(req.ConfigsUpdated) == 0 {
 		return false
 	}
 	for cfg := range req.ConfigsUpdated {
 		if _, f := skippedEdsConfigs[cfg.Kind]; f {
+			// the updated config does not impact EDS, skip it
+			// this happens when push requests are merged due to debounce
 			continue
 		}
 		if cfg.Kind != kind.ServiceEntry {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -456,15 +456,18 @@ func shouldUseDeltaEds(req *model.PushRequest) bool {
 // onlyEndpointsChanged checks if a request contains *only* endpoints updates. This allows us to perform more efficient pushes
 // where we only update the endpoints that did change.
 func onlyEndpointsChanged(req *model.PushRequest) bool {
-	if len(req.ConfigsUpdated) > 0 {
-		for k := range req.ConfigsUpdated {
-			if k.Kind != kind.ServiceEntry {
-				return false
-			}
-		}
-		return true
+	if len(req.ConfigsUpdated) == 0 {
+		return false
 	}
-	return false
+	for cfg := range req.ConfigsUpdated {
+		if _, f := skippedEdsConfigs[cfg.Kind]; f {
+			continue
+		}
+		if cfg.Kind != kind.ServiceEntry {
+			return false
+		}
+	}
+	return true
 }
 
 func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -97,12 +97,44 @@ func TestIncrementalPush(t *testing.T) {
 			t.Fatalf("Expected a partial EDS update, but got: %v", xdstest.MapKeys(ads.GetEndpoints()))
 		}
 	})
+	t.Run("Full Push with updated services and virtual services", func(t *testing.T) {
+		ads.WaitClear()
+		s.Discovery.Push(&model.PushRequest{
+			Full: true,
+			ConfigsUpdated: sets.New(
+				model.ConfigKey{Kind: kind.ServiceEntry, Name: "weighted.static.svc.cluster.local", Namespace: "default"},
+				model.ConfigKey{Kind: kind.VirtualService, Name: "vs", Namespace: "testns"},
+			),
+		})
+		if _, err := ads.Wait(time.Second*5, watchAll...); err != nil {
+			t.Fatal(err)
+		}
+		if len(ads.GetEndpoints()) != 1 {
+			t.Fatalf("Expected a partial EDS update, but got: %v", xdstest.MapKeys(ads.GetEndpoints()))
+		}
+	})
+	t.Run("Full Push with updated services and destination rules", func(t *testing.T) {
+		ads.WaitClear()
+		s.Discovery.Push(&model.PushRequest{
+			Full: true,
+			ConfigsUpdated: sets.New(
+				model.ConfigKey{Kind: kind.ServiceEntry, Name: "destall.default.svc.cluster.local", Namespace: "default"},
+				model.ConfigKey{Kind: kind.DestinationRule, Name: "destall", Namespace: "testns"}),
+		})
+		if _, err := ads.Wait(time.Second*5, watchAll...); err != nil {
+			t.Fatal(err)
+		}
+		if len(ads.GetEndpoints()) != 4 {
+			t.Fatalf("Expected a full EDS update, but got: %v", xdstest.MapKeys(ads.GetEndpoints()))
+		}
+	})
 	t.Run("Full Push with multiple updates", func(t *testing.T) {
 		ads.WaitClear()
 		s.Discovery.Push(&model.PushRequest{
 			Full: true,
 			ConfigsUpdated: sets.New(
-				model.ConfigKey{Kind: kind.ServiceEntry, Name: "foo.bar", Namespace: "default"},
+				model.ConfigKey{Kind: kind.ServiceEntry, Name: "destall.default.svc.cluster.local", Namespace: "default"},
+				model.ConfigKey{Kind: kind.VirtualService, Name: "vs", Namespace: "testns"},
 				model.ConfigKey{Kind: kind.DestinationRule, Name: "destall", Namespace: "testns"}),
 		})
 		if _, err := ads.Wait(time.Second*5, watchAll...); err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
When checking incremental EDS, we can ignore irrelevant resource updates merged by debounce. This happens in cases like [creating a VS right after a service](https://istio.io/v1.15/docs/ops/best-practices/traffic-management/#set-default-routes-for-services), which is a common practice I think