### PR TITLE
Fix analyzing envoy filter when 'filter' field is missing

### DIFF
--- a/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
+++ b/pkg/config/analysis/analyzers/envoyfilter/envoyfilter.go
@@ -105,7 +105,7 @@ func (*EnvoyPatchAnalyzer) analyzeEnvoyFilterPatch(r *resource.Instance, c analy
 				} else if patch.GetMatch() != nil {
 					if patch.Match.GetListener() != nil {
 						if patch.Match.GetListener().GetFilterChain() != nil {
-							instanceName = patch.Match.GetListener().FilterChain.Filter.Name
+							instanceName = patch.Match.GetListener().GetFilterChain().GetFilter().GetName()
 						}
 					}
 				}

--- a/releasenotes/notes/42832.yaml
+++ b/releasenotes/notes/42832.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - https://github.com/istio/istio/issues/42831
+  - 42831
+releaseNotes:
+- |
+  **Fixed** the issue where istioctl analyze was throwing SIGSEGV when optional field 'filter'
+  was missing under EnvoyFilter.ListenerMatch.FilterChainMatch section.


### PR DESCRIPTION
https://github.com/istio/istio/issues/42831
Before the change `istioctl analyze` was throwing SIGSEGV when optional field 'filter' was missing under EnvoyFilter.ListenerMatch.FilterChainMatch section.

**Please provide a description of this PR:**
Fixes SIGSEGV istioctl analyze issue described here  https://github.com/istio/istio/issues/42831

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure