### PR TITLE
wasm: Skip purging a Wasm module being referenced by the extensions

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -438,6 +438,10 @@ func (p *XdsProxy) handleUpstreamRequest(con *ProxyConnection) {
 				return
 			}
 
+			if req.GetTypeUrl() == v3.ExtensionConfigurationType {
+				p.wasmCache.UpdateExtensionReference(req.GetResourceNames())
+			}
+
 			// forward to istiod
 			con.sendRequest(req)
 			if !initialRequestsSent.Load() && req.TypeUrl == v3.ListenerType {

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -447,14 +447,20 @@ type fakeAckCache struct{}
 func (f *fakeAckCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "test", nil
 }
-func (f *fakeAckCache) Cleanup() {}
+func (c *fakeAckCache) UpdateExtensionReference([]string) {}
+func (c *fakeAckCache) DeleteExtensionReference(string)   {}
+func (c *fakeAckCache) ResetExtensionReference()          {}
+func (c *fakeAckCache) Cleanup()                          {}
 
 type fakeNackCache struct{}
 
 func (f *fakeNackCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "", errors.New("errror")
 }
-func (f *fakeNackCache) Cleanup() {}
+func (c *fakeNackCache) UpdateExtensionReference([]string) {}
+func (c *fakeNackCache) DeleteExtensionReference(string)   {}
+func (c *fakeNackCache) ResetExtensionReference()          {}
+func (c *fakeNackCache) Cleanup()                          {}
 
 func TestECDSWasmConversion(t *testing.T) {
 	node := model.NodeMetadata{

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -447,20 +447,20 @@ type fakeAckCache struct{}
 func (f *fakeAckCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "test", nil
 }
-func (c *fakeAckCache) UpdateExtensionReference([]string) {}
-func (c *fakeAckCache) DeleteExtensionReference(string)   {}
-func (c *fakeAckCache) ResetExtensionReference()          {}
-func (c *fakeAckCache) Cleanup()                          {}
+func (f *fakeAckCache) UpdateExtensionReference([]string) {}
+func (f *fakeAckCache) DeleteExtensionReference(string)   {}
+func (f *fakeAckCache) ResetExtensionReference()          {}
+func (f *fakeAckCache) Cleanup()                          {}
 
 type fakeNackCache struct{}
 
 func (f *fakeNackCache) Get(string, wasmcache.GetOptions) (string, error) {
 	return "", errors.New("errror")
 }
-func (c *fakeNackCache) UpdateExtensionReference([]string) {}
-func (c *fakeNackCache) DeleteExtensionReference(string)   {}
-func (c *fakeNackCache) ResetExtensionReference()          {}
-func (c *fakeNackCache) Cleanup()                          {}
+func (f *fakeNackCache) UpdateExtensionReference([]string) {}
+func (f *fakeNackCache) DeleteExtensionReference(string)   {}
+func (f *fakeNackCache) ResetExtensionReference()          {}
+func (f *fakeNackCache) Cleanup()                          {}
 
 func TestECDSWasmConversion(t *testing.T) {
 	node := model.NodeMetadata{

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -373,7 +373,9 @@ func (c *localFileCache) updateChecksum(key cacheKey) bool {
 
 func (c *localFileCache) touchEntry(key cacheKey, ce *cacheEntry) {
 	ce.last = time.Now()
-	// If the same entry is touched, the reference count will be increased and then decreased.
+	// Update the reference and count.
+	// If the touched entry is already referenced by the same resource,
+	// the reference count will be increased and then decreased.
 	ce.referenceCount++
 	if oldKey, ok := c.references[key.resourceName]; ok {
 		if old, ok := c.modules[oldKey]; ok {

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -369,6 +369,7 @@ func (c *localFileCache) updateChecksum(key cacheKey) bool {
 
 func (c *localFileCache) touchEntry(key cacheKey, ce *cacheEntry) {
 	ce.last = time.Now()
+	// If the same entry is touched, the reference count will be increased and then decreased.
 	ce.referenceCount++
 	if oldKey, ok := c.references[key.resourceName]; ok {
 		if old, ok := c.modules[oldKey]; ok {

--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -158,7 +158,11 @@ func (o cacheOptions) allowInsecure(host string) bool {
 }
 
 // NewLocalFileCache create a new Wasm module cache which downloads and stores Wasm module files locally.
-func NewLocalFileCache(dir string, options Options) *localFileCache {
+func NewLocalFileCache(dir string, options Options) Cache {
+	return newLocalFileCache(dir, options)
+}
+
+func newLocalFileCache(dir string, options Options) *localFileCache {
 	wasmLog.Debugf("LocalFileCache is created with the option\n%#v", options)
 
 	cacheOptions := cacheOptions{Options: options}

--- a/pkg/wasm/cache_test.go
+++ b/pkg/wasm/cache_test.go
@@ -80,7 +80,6 @@ func TestWasmCacheExpiry(t *testing.T) {
 	ociWasmFile := fmt.Sprintf("%s.wasm", dockerImageDigest)
 	ociURLWithTag := fmt.Sprintf("oci://%s/test/valid/docker:v0.1.0", ou.Host)
 	fakeWasmFile := fmt.Sprintf("%s.wasm", fakeImageDigest)
-	// ociURLWithDigest := fmt.Sprintf("oci://%s/test/valid/docker@sha256:%s", ou.Host, dockerImageDigest)
 
 	cases := []struct {
 		name                   string
@@ -259,7 +258,7 @@ func TestWasmCacheExpiry(t *testing.T) {
 			options := defaultOptions()
 			// Do not trigger, priodic purge loop for deteministic test.
 			options.PurgeInterval = 24 * time.Hour
-			cache := NewLocalFileCache(tmpDir, options)
+			cache := newLocalFileCache(tmpDir, options)
 			cache.ModuleExpiry = 0 // To avoid sanitize, set the expiry directly.
 			cache.httpFetcher.initialBackoff = time.Microsecond
 			defer close(cache.stopChan)
@@ -900,7 +899,7 @@ func TestWasmCache(t *testing.T) {
 			tmpDir := t.TempDir()
 			options := defaultOptions()
 			options.ModuleExpiry = 24 * time.Hour // This prevents expiration in the test.
-			cache := NewLocalFileCache(tmpDir, options)
+			cache := newLocalFileCache(tmpDir, options)
 			cache.httpFetcher.initialBackoff = time.Microsecond
 			defer close(cache.stopChan)
 
@@ -1045,7 +1044,7 @@ func setupOCIRegistry(t *testing.T, host string) (dockerImageDigest, invalidOCII
 
 func TestWasmCachePolicyChangesUsingHTTP(t *testing.T) {
 	tmpDir := t.TempDir()
-	cache := NewLocalFileCache(tmpDir, defaultOptions())
+	cache := newLocalFileCache(tmpDir, defaultOptions())
 	defer close(cache.stopChan)
 
 	gotNumRequest := 0
@@ -1106,7 +1105,7 @@ func TestAllInsecureServer(t *testing.T) {
 	tmpDir := t.TempDir()
 	options := defaultOptions()
 	options.InsecureRegistries = sets.New("*")
-	cache := NewLocalFileCache(tmpDir, options)
+	cache := newLocalFileCache(tmpDir, options)
 	defer close(cache.stopChan)
 
 	// Set up a fake registry for OCI images with TLS Server

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -63,7 +63,10 @@ func (c *mockCache) Get(downloadURL string, opts GetOptions) (string, error) {
 
 	return module, err
 }
-func (c *mockCache) Cleanup() {}
+func (c *mockCache) UpdateExtensionReference([]string) {}
+func (c *mockCache) DeleteExtensionReference(string)   {}
+func (c *mockCache) ResetExtensionReference()          {}
+func (c *mockCache) Cleanup()                          {}
 
 func messageToStruct(t *testing.T, m proto.Message) *structpb.Struct {
 	st, err := conversion.MessageToStruct(m)


### PR DESCRIPTION
Change-Id: I87827a763902c89182c745f6c94d67df57386e7f

Fixes: https://github.com/istio/istio/issues/42154

Skip purging a Wasm module when it is referenced by an ECDS resource.

The reference from ECDS resource is recorded when doing "Get", and dereferenced:
1. if the xDS connection is newly created
2. if ECDS resource is unsubscribed when using delta XDS
3. if ECDS resource is not seen in the discovery request when using SotW XDS

Note that SotW case, we don't need to reset the reference for each new connection.