### PR TITLE
bugfix: merging the results of `istioctl x ps` when Istiod ID is not specified

### DIFF
--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -391,6 +391,8 @@ func mapShards(responses []*discovery.DiscoveryResponse) (map[string]*discovery.
 	for _, response := range responses {
 		id := CpInfo(response).ID
 		if prevResp, ok := retval[id]; ok && id == "" {
+			// Managed Control Plane may not reveal its instance ID.
+			// In that case, let's aggregate the resulted resources into one response as a workaround.
 			prevResp.Resources = append(prevResp.Resources, response.Resources...)
 		} else {
 			retval[CpInfo(response).ID] = response

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -391,8 +391,9 @@ func mapShards(responses []*discovery.DiscoveryResponse) (map[string]*discovery.
 	for _, response := range responses {
 		id := CpInfo(response).ID
 		if prevResp, ok := retval[id]; ok && id == "" {
-			// Managed Control Plane may not reveal its instance ID.
-			// In that case, let's aggregate the resulted resources into one response as a workaround.
+			// In some special environment (e.g., managed control plane),
+			// Istiod does not have "POD_NAME" env var, and so `ID` field is an emptry string.
+			// In that case, let's aggregate the resulted resources into one response to prevent loss of results.
 			prevResp.Resources = append(prevResp.Resources, response.Resources...)
 		} else {
 			retval[CpInfo(response).ID] = response

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -389,7 +389,12 @@ func mapShards(responses []*discovery.DiscoveryResponse) (map[string]*discovery.
 	retval := map[string]*discovery.DiscoveryResponse{}
 
 	for _, response := range responses {
-		retval[CpInfo(response).ID] = response
+		id := CpInfo(response).ID
+		if prevResp, ok := retval[id]; ok && id == "" {
+			prevResp.Resources = append(prevResp.Resources, response.Resources...)
+		} else {
+			retval[CpInfo(response).ID] = response
+		}
 	}
 
 	return retval, nil


### PR DESCRIPTION
In some environment, Istiod may not have "POD_NAME" env var.  (e.g, managed control plane)
In such cases, `istioctl x ps` may not display all the results.

This PR fixes it by aggregating the resulted discovery responses into one.