### PR TITLE
k8s: Clean up networking.k8s.io/v1beta1 for ingress

### DIFF
--- a/pilot/pkg/config/kube/ingress/testdata/overlay.yaml
+++ b/pilot/pkg/config/kube/ingress/testdata/overlay.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo
@@ -12,7 +12,7 @@ spec:
               serviceName: service1
               servicePort: 4200
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo2

--- a/pilot/pkg/config/kube/ingress/testdata/simple.yaml
+++ b/pilot/pkg/config/kube/ingress/testdata/simple.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo

--- a/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml
+++ b/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tls

--- a/pilot/pkg/config/kube/ingress/testdata/tls.yaml
+++ b/pilot/pkg/config/kube/ingress/testdata/tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tls

--- a/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
@@ -864,7 +864,7 @@ spec:
 
 func TestIngress(t *testing.T) {
 	cfg := `
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{.Name}}

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -312,7 +312,7 @@ spec:
   controller: istio.io/ingress-controller`, apiVersion)
 
 			ingressConfigTemplate := `
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: %s


### PR DESCRIPTION
**Please provide a description of this PR:**
`networking.k8s.io/v1beta1 ` has been deprecated for k8s. 
Migrate manifests and API clients to use the networking.k8s.io/v1 API version, available since v1.19.