### PR TITLE
OCSP stapling

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1750,7 +1750,7 @@ func buildSecretReference(ctx ConfigContext, ref k8s.SecretObjectReference, gw c
 	})
 
 	if ctx.Credentials != nil {
-		if key, cert, err := ctx.Credentials.GetKeyAndCert(secret.Name, secret.Namespace); err != nil {
+		if key, cert, _, err := ctx.Credentials.GetKeyCertAndStaple(secret.Name, secret.Namespace); err != nil {
 			return "", &ConfigError{
 				Reason:  InvalidTLS,
 				Message: fmt.Sprintf("invalid certificate reference %v, %v", objectReferenceString(ref), err),

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -116,20 +116,20 @@ type AggregateController struct {
 
 var _ credentials.Controller = &AggregateController{}
 
-func (a *AggregateController) GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error) {
+func (a *AggregateController) GetKeyCertAndStaple(name, namespace string) (key []byte, cert []byte, staple []byte, err error) {
 	// Search through all clusters, find first non-empty result
 	var firstError error
 	for _, c := range a.controllers {
-		k, c, err := c.GetKeyAndCert(name, namespace)
+		k, c, s, err := c.GetKeyCertAndStaple(name, namespace)
 		if err != nil {
 			if firstError == nil {
 				firstError = err
 			}
 		} else {
-			return k, c, nil
+			return k, c, s, nil
 		}
 	}
-	return nil, nil, firstError
+	return nil, nil, nil, firstError
 }
 
 func (a *AggregateController) GetCaCert(name, namespace string) (cert []byte, err error) {

--- a/pilot/pkg/credentials/model.go
+++ b/pilot/pkg/credentials/model.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Controller interface {
-	GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error)
+	GetKeyCertAndStaple(name, namespace string) (key []byte, cert []byte, staple []byte, err error)
 	GetCaCert(name, namespace string) (cert []byte, err error)
 	GetDockerCredential(name, namespace string) (cred []byte, err error)
 	Authorize(serviceAccount, namespace string) error

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -199,7 +199,7 @@ func (s *SecretGen) generate(sr SecretResource, configClusterSecrets, proxyClust
 		return res
 	}
 
-	key, cert, err := secretController.GetKeyAndCert(sr.Name, sr.Namespace)
+	key, cert, staple, err := secretController.GetKeyCertAndStaple(sr.Name, sr.Namespace)
 	if err != nil {
 		pilotSDSCertificateErrors.Increment()
 		log.Warnf("failed to fetch key and certificate for %s: %v", sr.ResourceName, err)
@@ -211,7 +211,7 @@ func (s *SecretGen) generate(sr SecretResource, configClusterSecrets, proxyClust
 			return nil
 		}
 	}
-	res := toEnvoyKeyCertSecret(sr.ResourceName, key, cert, proxy, s.meshConfig)
+	res := toEnvoyKeyCertStapleSecret(sr.ResourceName, key, cert, staple, proxy, s.meshConfig)
 	return res
 }
 
@@ -330,7 +330,7 @@ func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {
 	}
 }
 
-func toEnvoyKeyCertSecret(name string, key, cert []byte, proxy *model.Proxy, meshConfig *mesh.MeshConfig) *discovery.Resource {
+func toEnvoyKeyCertStapleSecret(name string, key, cert, staple []byte, proxy *model.Proxy, meshConfig *mesh.MeshConfig) *discovery.Resource {
 	var res *anypb.Any
 	pkpConf := proxy.Metadata.ProxyConfigOrDefault(meshConfig.GetDefaultConfig()).GetPrivateKeyProvider()
 	switch pkpConf.GetProvider().(type) {
@@ -403,6 +403,11 @@ func toEnvoyKeyCertSecret(name string, key, cert []byte, proxy *model.Proxy, mes
 					PrivateKey: &core.DataSource{
 						Specifier: &core.DataSource_InlineBytes{
 							InlineBytes: key,
+						},
+					},
+					OcspStaple: &core.DataSource{
+						Specifier: &core.DataSource_InlineBytes{
+							InlineBytes: staple,
 						},
 					},
 				},


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds support for OCSP stapling with SDS is enabled.
When optional OSCP staple is present in kubernetes secret, pilot forwards staple inline bytes to Envoy.
This effectively enables OSCP stapling feature implemented in Envoy.






Related to:
- Issue  #17763
- PR (Closed) raised against release-1.16 branch #42837

Raised against master as requested by @kfaseela  @dhawton 