### PR TITLE
[release-1.16] Update master to 1.16

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -69,13 +69,13 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: modules
   client-go:
     git: https://github.com/istio/client-go
-    branch: master
+    branch: release-1.16
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master
   tools:
     git: https://github.com/istio/tools
-    branch: master
+    branch: release-1.16
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}


### PR DESCRIPTION
**Please provide a description of this PR:**

Update master to release-1.16. This appears to have been missed during branch cut.