### PR TITLE
Updating the sample helloworld python base image

### DIFF
--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -19,7 +19,7 @@ COPY app.py ./
 COPY requirements.txt ./
 
 # install the dependencies and packages in the requirements file
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 5000
 

--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -12,10 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM python:3-onbuild
+FROM python:3.9-slim
 
 WORKDIR /opt/microservices
 COPY app.py ./
+COPY requirements.txt ./
+
+# install the dependencies and packages in the requirements file
+RUN pip install -r requirements.txt
 
 EXPOSE 5000
 


### PR DESCRIPTION
The current helloworld app images are 6 years old. The previous base image is old and was throwing a lot of errors so I am updating the python base image.
The reason for this update so that helloworld sample app can work with IPv6 and dual stack. Currently all our multi-cluster verification is based on helloworld sample app and it doesn't work in IPv6/dual stack environment.

I build the images and tested these images in both IPv4 and IPv6 environment. The images are available in my repo. I wasn't sure about what tags to use so I am using latest tag.

abasitt/examples-helloworld-v1:latest
abasitt/examples-helloworld-v2:latest

This will fix the issue [here ](https://github.com/istio/istio/issues/42855)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure