### PR TITLE
Add locality info to debug interface

### DIFF
--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -172,7 +172,7 @@ func (sg *StatusGen) debugConfigDump(proxyID string) (model.Resources, error) {
 		return nil, fmt.Errorf("config dump could not find connection for proxyID %q", proxyID)
 	}
 
-	dump, err := sg.Server.configDump(conn, false)
+	dump, err := sg.Server.connectionConfigDump(conn, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Allows users to get proxy node locality via /debug/adsz. This can help debug the feature of [locality failover](https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/).