### PR TITLE
Rewrite the Run function of configStoreMonitor

### DIFF
--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) Get(kind config.GroupVersionKind, key, namespace string) *c
 
 func (c *Controller) Create(config config.Config) (revision string, err error) {
 	if revision, err = c.configStore.Create(config); err == nil {
-		c.monitor.ScheduleProcessEvent(&ConfigEvent{
+		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			config: config,
 			event:  model.EventAdd,
 		})
@@ -114,7 +114,7 @@ func (c *Controller) Create(config config.Config) (revision string, err error) {
 func (c *Controller) Update(config config.Config) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(config.GroupVersionKind, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.Update(config); err == nil {
-		c.monitor.ScheduleProcessEvent(&ConfigEvent{
+		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			old:    *oldconfig,
 			config: config,
 			event:  model.EventUpdate,
@@ -126,7 +126,7 @@ func (c *Controller) Update(config config.Config) (newRevision string, err error
 func (c *Controller) UpdateStatus(config config.Config) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(config.GroupVersionKind, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.UpdateStatus(config); err == nil {
-		c.monitor.ScheduleProcessEvent(&ConfigEvent{
+		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			old:    *oldconfig,
 			config: config,
 			event:  model.EventUpdate,
@@ -144,7 +144,7 @@ func (c *Controller) Patch(orig config.Config, patchFn config.PatchFunc) (newRev
 		return "", fmt.Errorf("unsupported merge type: %s", typ)
 	}
 	if newRevision, err = c.configStore.Patch(cfg, patchFn); err == nil {
-		c.monitor.ScheduleProcessEvent(&ConfigEvent{
+		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			old:    orig,
 			config: cfg,
 			event:  model.EventUpdate,
@@ -156,7 +156,7 @@ func (c *Controller) Patch(orig config.Config, patchFn config.PatchFunc) (newRev
 func (c *Controller) Delete(kind config.GroupVersionKind, key, namespace string, resourceVersion *string) (err error) {
 	if config := c.Get(kind, key, namespace); config != nil {
 		if err = c.configStore.Delete(kind, key, namespace, resourceVersion); err == nil {
-			c.monitor.ScheduleProcessEvent(&ConfigEvent{
+			c.monitor.ScheduleProcessEvent(ConfigEvent{
 				config: *config,
 				event:  model.EventDelete,
 			})

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) Get(kind config.GroupVersionKind, key, namespace string) *c
 
 func (c *Controller) Create(config config.Config) (revision string, err error) {
 	if revision, err = c.configStore.Create(config); err == nil {
-		c.monitor.ScheduleProcessEvent(ConfigEvent{
+		c.monitor.ScheduleProcessEvent(&ConfigEvent{
 			config: config,
 			event:  model.EventAdd,
 		})
@@ -114,7 +114,7 @@ func (c *Controller) Create(config config.Config) (revision string, err error) {
 func (c *Controller) Update(config config.Config) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(config.GroupVersionKind, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.Update(config); err == nil {
-		c.monitor.ScheduleProcessEvent(ConfigEvent{
+		c.monitor.ScheduleProcessEvent(&ConfigEvent{
 			old:    *oldconfig,
 			config: config,
 			event:  model.EventUpdate,
@@ -126,7 +126,7 @@ func (c *Controller) Update(config config.Config) (newRevision string, err error
 func (c *Controller) UpdateStatus(config config.Config) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(config.GroupVersionKind, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.UpdateStatus(config); err == nil {
-		c.monitor.ScheduleProcessEvent(ConfigEvent{
+		c.monitor.ScheduleProcessEvent(&ConfigEvent{
 			old:    *oldconfig,
 			config: config,
 			event:  model.EventUpdate,
@@ -144,7 +144,7 @@ func (c *Controller) Patch(orig config.Config, patchFn config.PatchFunc) (newRev
 		return "", fmt.Errorf("unsupported merge type: %s", typ)
 	}
 	if newRevision, err = c.configStore.Patch(cfg, patchFn); err == nil {
-		c.monitor.ScheduleProcessEvent(ConfigEvent{
+		c.monitor.ScheduleProcessEvent(&ConfigEvent{
 			old:    orig,
 			config: cfg,
 			event:  model.EventUpdate,
@@ -156,7 +156,7 @@ func (c *Controller) Patch(orig config.Config, patchFn config.PatchFunc) (newRev
 func (c *Controller) Delete(kind config.GroupVersionKind, key, namespace string, resourceVersion *string) (err error) {
 	if config := c.Get(kind, key, namespace); config != nil {
 		if err = c.configStore.Delete(kind, key, namespace, resourceVersion); err == nil {
-			c.monitor.ScheduleProcessEvent(ConfigEvent{
+			c.monitor.ScheduleProcessEvent(&ConfigEvent{
 				config: *config,
 				event:  model.EventDelete,
 			})

--- a/pilot/pkg/config/memory/controller_test.go
+++ b/pilot/pkg/config/memory/controller_test.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory_test
+package memory
 
 import (
 	"sync/atomic"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/test/mock"
 	"istio.io/istio/pkg/config/schema/collections"
 )
@@ -29,28 +28,28 @@ const (
 )
 
 func TestControllerEvents(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
+	store := Make(collections.Mocks)
+	ctl := NewController(store)
 	// Note that the operations must go through the controller since the store does not trigger back events
 	mock.CheckCacheEvents(ctl, ctl, TestNamespace, 5, t)
 }
 
 func TestControllerCacheFreshness(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
+	store := Make(collections.Mocks)
+	ctl := NewController(store)
 	mock.CheckCacheFreshness(ctl, TestNamespace, t)
 }
 
 func TestControllerClientSync(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	ctl := memory.NewController(store)
+	store := Make(collections.Mocks)
+	ctl := NewController(store)
 	mock.CheckCacheSync(store, ctl, TestNamespace, 5, t)
 }
 
 func TestControllerHashSynced(t *testing.T) {
-	store := memory.Make(collections.Mocks)
+	store := Make(collections.Mocks)
 	var v int32
-	ctl := memory.NewController(store)
+	ctl := NewController(store)
 
 	ctl.RegisterHasSyncedHandler(func() bool {
 		return atomic.LoadInt32(&v) > 0

--- a/pilot/pkg/config/memory/monitor.go
+++ b/pilot/pkg/config/memory/monitor.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"go.uber.org/atomic"
+
 	"istio.io/istio/pilot/pkg/model"
 	config2 "istio.io/istio/pkg/config"
 	"istio.io/pkg/log"

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -32,10 +32,8 @@ func TestMonitorLifecycle(t *testing.T) {
 		m := NewMonitor(store)
 
 		stop := make(chan struct{})
-		exit := make(chan struct{})
 		go func() {
 			m.Run(stop)
-			close(exit)
 		}()
 		go func() {
 			for i := 0; i < 100; i++ {
@@ -49,7 +47,7 @@ func TestMonitorLifecycle(t *testing.T) {
 			}
 		}()
 		go close(stop)
-		<-exit
+		m.WaitCompleted()
 	}
 }
 
@@ -65,10 +63,8 @@ func TestMonitorGracefulExit(t *testing.T) {
 	})
 
 	stop := make(chan struct{})
-	exit := make(chan struct{})
 	go func() {
 		m.Run(stop)
-		close(exit)
 	}()
 	eventsNumber := 100
 	for i := 0; i < eventsNumber; i++ {
@@ -81,7 +77,7 @@ func TestMonitorGracefulExit(t *testing.T) {
 		})
 	}
 	close(stop)
-	<-exit
+	m.WaitCompleted()
 	if number != eventsNumber {
 		t.Fatalf("should process the handler %d times, get got %d", eventsNumber, number)
 	}

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory_test
+package memory
 
 import (
 	"sync"
 	"testing"
+	"time"
 
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"
 	"istio.io/istio/pkg/config"
@@ -27,18 +27,69 @@ import (
 
 func TestMonitorLifecycle(t *testing.T) {
 	// Regression test to ensure no race conditions during monitor shutdown
-	store := memory.Make(collections.Mocks)
-	m := memory.NewMonitor(store)
+	for i := 0; i < 100; i++ {
+		store := Make(collections.Mocks)
+		m := NewMonitor(store)
+
+		stop := make(chan struct{})
+		exit := make(chan struct{})
+		go func() {
+			m.Run(stop)
+			close(exit)
+		}()
+		go func() {
+			for i := 0; i < 100; i++ {
+				m.ScheduleProcessEvent(ConfigEvent{
+					config: config.Config{
+						Meta: config.Meta{
+							GroupVersionKind: collections.Mock.Resource().GroupVersionKind(),
+						},
+					},
+				})
+			}
+		}()
+		go close(stop)
+		<-exit
+	}
+}
+
+func TestMonitorGracefulExit(t *testing.T) {
+	// Regression test to ensure no race conditions during monitor shutdown
+	store := Make(collections.Mocks)
+	m := NewMonitor(store)
+
+	var number int
+	m.AppendEventHandler(collections.Mock.Resource().GroupVersionKind(), func(c config.Config, c2 config.Config, event model.Event) {
+		number++
+		time.Sleep(time.Millisecond * 10)
+	})
+
 	stop := make(chan struct{})
-	go m.Run(stop)
-	m.ScheduleProcessEvent(memory.ConfigEvent{})
+	exit := make(chan struct{})
+	go func() {
+		m.Run(stop)
+		close(exit)
+	}()
+	eventsNumber := 100
+	for i := 0; i < eventsNumber; i++ {
+		m.ScheduleProcessEvent(ConfigEvent{
+			config: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: collections.Mock.Resource().GroupVersionKind(),
+				},
+			},
+		})
+	}
 	close(stop)
-	m.ScheduleProcessEvent(memory.ConfigEvent{})
+	<-exit
+	if number != eventsNumber {
+		t.Fatalf("should process the handler %d times, get got %d", eventsNumber, number)
+	}
 }
 
 func TestEventConsistency(t *testing.T) {
-	store := memory.Make(collections.Mocks)
-	controller := memory.NewController(store)
+	store := Make(collections.Mocks)
+	controller := NewController(store)
 
 	testConfig := mock.Make(TestNamespace, 0)
 	var testEvent model.Event

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -31,9 +31,9 @@ func TestMonitorLifecycle(t *testing.T) {
 	m := memory.NewMonitor(store)
 	stop := make(chan struct{})
 	go m.Run(stop)
-	m.ScheduleProcessEvent(&memory.ConfigEvent{})
+	m.ScheduleProcessEvent(memory.ConfigEvent{})
 	close(stop)
-	m.ScheduleProcessEvent(&memory.ConfigEvent{})
+	m.ScheduleProcessEvent(memory.ConfigEvent{})
 }
 
 func TestEventConsistency(t *testing.T) {

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -31,9 +31,9 @@ func TestMonitorLifecycle(t *testing.T) {
 	m := memory.NewMonitor(store)
 	stop := make(chan struct{})
 	go m.Run(stop)
-	m.ScheduleProcessEvent(memory.ConfigEvent{})
+	m.ScheduleProcessEvent(&memory.ConfigEvent{})
 	close(stop)
-	m.ScheduleProcessEvent(memory.ConfigEvent{})
+	m.ScheduleProcessEvent(&memory.ConfigEvent{})
 }
 
 func TestEventConsistency(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

There are several problems with the old logic when stop has been closed: 
-  Can't make sure all the events in the `eventCh` been processed.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
