### PR TITLE
Add envFrom values to Gateway helm chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
           - name: {{ $key }}
             value: {{ $val | quote }}
           {{- end }}
+          envFrom:
+          {{- with .Values.envFrom }}
+            {{- toYaml .| nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: 15090
             protocol: TCP

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
           {{- end }}
           envFrom:
           {{- with .Values.envFrom }}
-            {{- toYaml .| nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
           - containerPort: 15090

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -48,6 +48,9 @@
     "env": {
       "type": "object"
     },
+    "envFrom": {
+      "type": "array"
+    },
     "labels": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -73,6 +73,8 @@ autoscaling:
 # Pod environment variables
 env: {}
 
+envFrom: []
+
 # Labels to apply to all resources
 labels: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds an optional field to support loading all required envs directly from Kubernetes secrets or configmaps
See also: 
- https://github.com/istio/istio/issues/42860