### PR TITLE
reducing leaseduration, renewdeadline and retryperiod

### DIFF
--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection_test.go
@@ -1268,9 +1268,9 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 
 	lec := LeaderElectionConfig{
 		Lock:          lock,
-		LeaseDuration: 15 * time.Second,
-		RenewDeadline: 2 * time.Second,
-		RetryPeriod:   1 * time.Second,
+		LeaseDuration: 40 * time.Millisecond,
+		RenewDeadline: 20 * time.Millisecond,
+		RetryPeriod:   10 * time.Millisecond,
 
 		// This is what we're testing
 		ReleaseOnCancel: true,
@@ -1296,14 +1296,14 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 	// Wait for us to become the leader
 	select {
 	case <-onNewLeader:
-	case <-time.After(10 * time.Second):
+	case <-time.After(1 * time.Second):
 		t.Fatal("failed to become the leader")
 	}
 
 	// Wait for renew (update) to be invoked
 	select {
 	case <-onRenewCalled:
-	case <-time.After(10 * time.Second):
+	case <-time.After(1 * time.Second):
 		t.Fatal("the elector failed to renew the lock")
 	}
 
@@ -1317,7 +1317,7 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 
 	select {
 	case <-onRelease:
-	case <-time.After(10 * time.Second):
+	case <-time.After(1 * time.Second):
 		t.Fatal("the lock was not released")
 	}
 }


### PR DESCRIPTION


**Please provide a description of this PR:**

Opening a draft PR for #37555, to check if the direction is good.
I reduced the times configured for the LeaderElector, so to shorten the waiting times for the tests.

- `TestReleaseOnCancellation_ConfigMaps`
- `TestReleaseOnCancellation_Lease`
- `TestReleaseOnCancellation_Endpoints`
now execute in 0.01s.

[stress test](https://github.com/istio/istio/wiki/Test-Flakes#reproducing-test-flakes) applied to the 3 methods are reporting 0 failures (ran for 12 minutes)

Eager to have feedback / suggestions.