### PR TITLE
wasm: Send nack when there is not well-formed resource messages

### DIFF
--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -74,7 +74,7 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) bool {
 func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, sendNack bool) {
 	ec := &core.TypedExtensionConfig{}
 	newExtensionConfig = resource
-	sendNack = false
+	sendNack = true
 	status := noRemoteLoad
 	defer func() {
 		wasmConfigConversionCount.
@@ -92,7 +92,7 @@ func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, s
 		}
 	}()
 	if err := resource.UnmarshalTo(ec); err != nil {
-		wasmLog.Debugf("failed to unmarshal extension config resource: %v", err)
+		wasmLog.Errorf("failed to unmarshal extension config resource: %v", err)
 		return
 	}
 
@@ -101,32 +101,42 @@ func convert(resource *anypb.Any, cache Cache) (newExtensionConfig *anypb.Any, s
 	if ec.GetTypedConfig() != nil && ec.GetTypedConfig().TypeUrl == xds.WasmHTTPFilterType {
 		err := ec.GetTypedConfig().UnmarshalTo(wasmHTTPFilterConfig)
 		if err != nil {
-			wasmLog.Debugf("failed to unmarshal extension config resource into Wasm HTTP filter: %v", err)
+			wasmLog.Errorf("failed to unmarshal extension config resource into Wasm HTTP filter: %v", err)
 			return
 		}
 	} else if ec.GetTypedConfig() == nil || ec.GetTypedConfig().TypeUrl != xds.TypedStructType {
+		// This is not for Wasm module.
+		sendNack = false
 		wasmLog.Debugf("cannot find typed struct in %+v", ec)
 		return
 	} else {
-		wasmStruct := &udpa.TypedStruct{}
+		typedStruct := &udpa.TypedStruct{}
 		wasmTypedConfig := ec.GetTypedConfig()
-		if err := wasmTypedConfig.UnmarshalTo(wasmStruct); err != nil {
-			wasmLog.Debugf("failed to unmarshal typed config for wasm filter: %v", err)
+		if err := wasmTypedConfig.UnmarshalTo(typedStruct); err != nil {
+			wasmLog.Errorf("failed to unmarshal typed config for wasm filter: %v", err)
 			return
 		}
 
-		if wasmStruct.TypeUrl != xds.WasmHTTPFilterType {
-			wasmLog.Debugf("typed extension config %+v does not contain wasm http filter", wasmStruct)
+		if typedStruct.TypeUrl != xds.WasmHTTPFilterType {
+			// This is not fro Wasm module.
+			sendNack = false
+			wasmLog.Debugf("typed extension config %+v does not contain wasm http filter", typedStruct)
 			return
 		}
 
-		if err := conversion.StructToMessage(wasmStruct.Value, wasmHTTPFilterConfig); err != nil {
-			wasmLog.Debugf("failed to convert extension config struct %+v to Wasm HTTP filter", wasmStruct)
+		if err := conversion.StructToMessage(typedStruct.Value, wasmHTTPFilterConfig); err != nil {
+			wasmLog.Errorf("failed to convert extension config struct %+v to Wasm HTTP filter", typedStruct)
 			return
 		}
 	}
 
 	if wasmHTTPFilterConfig.Config.GetVmConfig().GetCode().GetRemote() == nil {
+		if wasmHTTPFilterConfig.Config.GetVmConfig().GetCode().GetLocal() == nil {
+			wasmLog.Errorf("no remote and local load found in Wasm HTTP filter %+v", wasmHTTPFilterConfig)
+			return
+		}
+		// This has a local Wasm. Let's bypass it.
+		sendNack = false
 		wasmLog.Debugf("no remote load found in Wasm HTTP filter %+v", wasmHTTPFilterConfig)
 		return
 	}

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -30,6 +30,7 @@ import (
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"google.golang.org/protobuf/proto"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
@@ -64,6 +65,130 @@ func (c *mockCache) Get(downloadURL string, opts GetOptions) (string, error) {
 }
 func (c *mockCache) Cleanup() {}
 
+func messageToStruct(t *testing.T, m proto.Message) *structpb.Struct {
+	st, err := conversion.MessageToStruct(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+func newStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	st, err := structpb.NewStruct(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+func messageToAnyWithTypeURL(t *testing.T, msg proto.Message, typeURL string) *anypb.Any {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &anypb.Any{
+		// nolint: staticcheck
+		TypeUrl: typeURL,
+		Value:   b,
+	}
+}
+
+func TestWasmConvertWithWrongMessages(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []*anypb.Any
+		wantNack bool
+	}{
+		{
+			name:     "wrong typed config",
+			input:    []*anypb.Any{protoconv.MessageToAny(&emptypb.Empty{})},
+			wantNack: true,
+		},
+		{
+			name: "wrong value in typed struct",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name: "wrong-input",
+				TypedConfig: protoconv.MessageToAny(
+					&udpa.TypedStruct{
+						TypeUrl: xds.WasmHTTPFilterType,
+						Value:   newStruct(t, map[string]any{"wrong": "value"}),
+					},
+				),
+			})},
+			wantNack: true,
+		},
+		{
+			name: "empty wasm in typed struct",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name: "wrong-input",
+				TypedConfig: protoconv.MessageToAny(
+					&udpa.TypedStruct{
+						TypeUrl: xds.WasmHTTPFilterType,
+						Value:   messageToStruct(t, &wasm.Wasm{}),
+					},
+				),
+			})},
+			wantNack: true,
+		},
+		{
+			name: "no remote and local code in wasm",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name: "wrong-input",
+				TypedConfig: protoconv.MessageToAny(
+					&udpa.TypedStruct{
+						TypeUrl: xds.WasmHTTPFilterType,
+						Value: messageToStruct(t, &wasm.Wasm{
+							Config: &v3.PluginConfig{
+								Vm: &v3.PluginConfig_VmConfig{
+									VmConfig: &v3.VmConfig{
+										Code: &core.AsyncDataSource{},
+									},
+								},
+							},
+						}),
+					},
+				),
+			})},
+			wantNack: true,
+		},
+		{
+			name: "empty wasm in typed extension config",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name:        "wrong-input",
+				TypedConfig: protoconv.MessageToAny(&wasm.Wasm{}),
+			})},
+			wantNack: true,
+		},
+		{
+			name: "wrong wasm filter value",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name:        "wrong-input",
+				TypedConfig: messageToAnyWithTypeURL(t, &v3.VmConfig{Runtime: "test", VmId: "test"}, xds.WasmHTTPFilterType),
+			})},
+			wantNack: true,
+		},
+		{
+			name: "wrong typed struct value",
+			input: []*anypb.Any{protoconv.MessageToAny(&core.TypedExtensionConfig{
+				Name:        "wrong-input",
+				TypedConfig: messageToAnyWithTypeURL(t, &v3.VmConfig{Runtime: "test", VmId: "test"}, xds.TypedStructType),
+			})},
+			wantNack: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wantNack := true // Nack should be returned due to the wrong input.
+			mc := &mockCache{}
+			gotNack := MaybeConvertWasmExtensionConfig(tc.input, mc)
+			if gotNack != wantNack {
+				t.Errorf("wasm config conversion send nack got %v want %v", gotNack, tc.wantNack)
+			}
+		})
+	}
+}
+
 func TestWasmConvert(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -72,9 +197,29 @@ func TestWasmConvert(t *testing.T) {
 		wantNack   bool
 	}{
 		{
+			name: "nil typed config ",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["nil-typed-config"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["nil-typed-config"],
+			},
+			wantNack: true,
+		},
+		{
 			name: "remote load success",
 			input: []*core.TypedExtensionConfig{
 				extensionConfigMap["remote-load-success"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success-local-file"],
+			},
+			wantNack: false,
+		},
+		{
+			name: "remote load success without typed struct",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success-without-typed-struct"],
 			},
 			wantOutput: []*core.TypedExtensionConfig{
 				extensionConfigMap["remote-load-success-local-file"],
@@ -214,6 +359,10 @@ func buildAnyExtensionConfig(name string, msg proto.Message) *core.TypedExtensio
 }
 
 var extensionConfigMap = map[string]*core.TypedExtensionConfig{
+	"nil-typed-config": {
+		Name:        "nil-typed-config",
+		TypedConfig: nil,
+	},
 	"empty": {
 		Name: "empty",
 		TypedConfig: protoconv.MessageToAny(
@@ -276,6 +425,21 @@ var extensionConfigMap = map[string]*core.TypedExtensionConfig{
 						Local: &core.DataSource{
 							Specifier: &core.DataSource_Filename{
 								Filename: "test.wasm",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}),
+	"remote-load-success-without-typed-struct": buildAnyExtensionConfig("remote-load-success", &wasm.Wasm{
+		Config: &v3.PluginConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+						Remote: &core.RemoteDataSource{
+							HttpUri: &core.HttpUri{
+								Uri: "http://test?module=test.wasm",
 							},
 						},
 					}},


### PR DESCRIPTION
Change-Id: I8143ba8bc8c292ce2de5abda0a4f0c70c111bf80

In current impl, if ECDS resource message is not well-formed (e.g., fail to unmarshal or absence of required fields), the ECDS is just passed to Envoy.
This would just defer the error to Envoy and makes debugging harder.

This proposes to send Nack in that case.
In addition, to help debugging, Debugf is changed to Errorf for the cases that the message is not well-formed.