### PR TITLE
allow wasm plugin secret to be read from any namespace

### DIFF
--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -49,6 +49,10 @@ const (
 	WasmResourceVersionEnv = "ISTIO_META_WASM_PLUGIN_RESOURCE_VERSION"
 )
 
+// This function determines if a resource is accessible to a given namespace.
+// For example, give a kubernetes secret "istio-system/wasm-secret" and a namespace of "foo",
+// this would return true only if there was a policy allowing "foo" to access wasm-secret in
+// the "istio-system" namespace.
 type ResourceReferenceAllowed func(string, string) bool
 
 func workloadModeForListenerClass(class istionetworking.ListenerClass) typeapi.WorkloadMode {

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -229,8 +229,14 @@ func TestToSecretName(t *testing.T) {
 	}
 
 	for _, tt := range cases {
+		secretAllowed := func(resourceName string, namespace string) bool {
+			if resourceName == "kubernetes://istio-system/sec" && namespace == "nm" {
+				return true
+			}
+			return false
+		}
 		t.Run(tt.name, func(t *testing.T) {
-			got := toSecretResourceName(tt.name, tt.namespace, "istio-system")
+			got := toSecretResourceName(tt.name, tt.namespace, secretAllowed)
 			if got != tt.want {
 				t.Errorf("got secret name %q, want %q", got, tt.want)
 			}

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -222,7 +222,7 @@ func TestToSecretName(t *testing.T) {
 		{
 			name:                  "kubernetes://istio-system/sec",
 			namespace:             "nm",
-			want:                  credentials.KubernetesSecretTypeURI + "nm/sec",
+			want:                  credentials.KubernetesSecretTypeURI + "istio-system/sec",
 			wantResourceName:      "sec",
 			wantResourceNamespace: "istio-system",
 		},

--- a/pilot/pkg/model/extensions_test.go
+++ b/pilot/pkg/model/extensions_test.go
@@ -219,11 +219,18 @@ func TestToSecretName(t *testing.T) {
 			wantResourceName:      "sec",
 			wantResourceNamespace: "nm",
 		},
+		{
+			name:                  "kubernetes://istio-system/sec",
+			namespace:             "nm",
+			want:                  credentials.KubernetesSecretTypeURI + "nm/sec",
+			wantResourceName:      "sec",
+			wantResourceNamespace: "istio-system",
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toSecretResourceName(tt.name, tt.namespace)
+			got := toSecretResourceName(tt.name, tt.namespace, "istio-system")
 			if got != tt.want {
 				t.Errorf("got secret name %q, want %q", got, tt.want)
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1881,7 +1881,7 @@ func (ps *PushContext) initWasmPlugins(env *Environment) error {
 	sortConfigByCreationTime(wasmplugins)
 	ps.wasmPluginsByNamespace = map[string][]*WasmPluginWrapper{}
 	for _, plugin := range wasmplugins {
-		if pluginWrapper := convertToWasmPluginWrapper(plugin); pluginWrapper != nil {
+		if pluginWrapper := convertToWasmPluginWrapper(plugin, env.Mesh().RootNamespace); pluginWrapper != nil {
 			ps.wasmPluginsByNamespace[plugin.Namespace] = append(ps.wasmPluginsByNamespace[plugin.Namespace], pluginWrapper)
 		}
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -599,7 +599,7 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"]),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], "istio-system"),
 				},
 			},
 		},
@@ -619,9 +619,9 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["authn-med-prio-all"]),
-					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all"]),
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"]),
+					convertToWasmPluginWrapper(wasmPlugins["authn-med-prio-all"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], "istio-system"),
 				},
 			},
 		},
@@ -641,11 +641,11 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"]),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], "istio-system"),
 				},
 				extensions.PluginPhase_AUTHZ: {
-					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"]),
-					convertToWasmPluginWrapper(wasmPlugins["global-authz-med-prio-app"]),
+					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["global-authz-med-prio-app"], "istio-system"),
 				},
 			},
 		},
@@ -674,10 +674,10 @@ func TestWasmPlugins(t *testing.T) {
 			},
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"]),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], "istio-system"),
 				},
 				extensions.PluginPhase_AUTHZ: {
-					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"]),
+					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], "istio-system"),
 				},
 			},
 		},

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -562,6 +562,10 @@ func TestWasmPlugins(t *testing.T) {
 		},
 	}
 
+	secretAllowed := func(resourceName string, namespace string) bool {
+		return false
+	}
+
 	testCases := []struct {
 		name               string
 		node               *Proxy
@@ -599,7 +603,7 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], secretAllowed),
 				},
 			},
 		},
@@ -619,9 +623,9 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["authn-med-prio-all"], "istio-system"),
-					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all"], "istio-system"),
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["authn-med-prio-all"], secretAllowed),
+					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all"], secretAllowed),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"], secretAllowed),
 				},
 			},
 		},
@@ -641,11 +645,11 @@ func TestWasmPlugins(t *testing.T) {
 			listenerInfo: anyListener,
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], secretAllowed),
 				},
 				extensions.PluginPhase_AUTHZ: {
-					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], "istio-system"),
-					convertToWasmPluginWrapper(wasmPlugins["global-authz-med-prio-app"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], secretAllowed),
+					convertToWasmPluginWrapper(wasmPlugins["global-authz-med-prio-app"], secretAllowed),
 				},
 			},
 		},
@@ -674,10 +678,10 @@ func TestWasmPlugins(t *testing.T) {
 			},
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
-					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["global-authn-high-prio-app"], secretAllowed),
 				},
 				extensions.PluginPhase_AUTHZ: {
-					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], "istio-system"),
+					convertToWasmPluginWrapper(wasmPlugins["authz-high-prio-ingress"], secretAllowed),
 				},
 			},
 		},


### PR DESCRIPTION
Currently we only allow wasm plugin secret to be read from the same namespace. However since the image secret is same, we can provision it in rootNamespace as well and allow Istio agent to read it from that namespace.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
