### PR TITLE
Update default k8s for test and buildkit

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -37,7 +37,7 @@ setup_and_export_git_sha
 source "${ROOT}/common/scripts/kind_provisioner.sh"
 
 TOPOLOGY=SINGLE_CLUSTER
-NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.25.4"
+NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.26.1"
 KIND_CONFIG=""
 CLUSTER_TOPOLOGY_CONFIG_FILE="${ROOT}/prow/config/topology/multicluster.json"
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -100,7 +100,7 @@ function download_untar_istio_release() {
 function buildx-create() {
   export DOCKER_CLI_EXPERIMENTAL=enabled
   if ! docker buildx ls | grep -q container-builder; then
-    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.10.3 --name container-builder --buildkitd-flags="--debug"
+    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0 --name container-builder --buildkitd-flags="--debug"
     # Pre-warm the builder. If it fails, fetch logs, but continue
     docker buildx inspect --bootstrap container-builder || docker logs buildx_buildkit_container-builder0 || true
   fi

--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -175,7 +175,7 @@ func createBuildxBuilderIfNeeded(a Args) error {
 		matches := regexp.MustCompile(`Driver: (.*)`).FindStringSubmatch(out.String())
 		if len(matches) == 0 || matches[1] != "docker-container" {
 			return fmt.Errorf("the docker buildx builder is not using the docker-container driver needed for .save.\n" +
-				"Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.10.3" +
+				"Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0" +
 				" --name istio-builder --driver docker-container --buildkitd-flags=\"--debug\" --use)")
 		}
 		return nil
@@ -183,7 +183,7 @@ func createBuildxBuilderIfNeeded(a Args) error {
 	return exec.Command("sh", "-c", `
 export DOCKER_CLI_EXPERIMENTAL=enabled
 if ! docker buildx ls | grep -q container-builder; then
-  docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.10.3 --name container-builder --buildkitd-flags="--debug"
+  docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0 --name container-builder --buildkitd-flags="--debug"
   # Pre-warm the builder. If it fails, fetch logs, but continue
   docker buildx inspect --bootstrap container-builder || docker logs buildx_buildkit_container-builder0 || true
 fi


### PR DESCRIPTION
**Please provide a description of this PR:**

Update the default k8s for pre-submit to 1.26.1. This requires an equal change in istio/test-infra to move the post-submit test from 1.26 to 1.25.4. A PR in istio/test-infra for that is forthcoming.

Also update buildkit to v0.11.0