### PR TITLE
removed sleep from mock of AuthorizationServer

### DIFF
--- a/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
+++ b/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
@@ -181,7 +181,7 @@ func (ms *AuthorizationServer) SetAccessToken(token string) {
 	ms.accessToken = token
 }
 
-// SetAccessToken sets the issued access token to token
+// EnableDynamicAccessToken sets the issued access token to token
 func (ms *AuthorizationServer) EnableDynamicAccessToken(enable bool) {
 	ms.mutex.Lock()
 	defer ms.mutex.Unlock()
@@ -227,9 +227,6 @@ func (ms *AuthorizationServer) Start(port int) error {
 			log.Errorf("Server failed to serve in %q: %v", ms.URL, err)
 		}
 	}()
-
-	// sleep a while for mock server to start.
-	time.Sleep(time.Second)
 
 	return nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR proposes to remove 1 second sleep from Start method of AuthorizationServer (mock).
This speeds up `TestTokenExchangePluginWithCache` described in #37555 .