### PR TITLE
use common var for ambient namespace label

### DIFF
--- a/pilot/pkg/ambient/ambientpod/podutil.go
+++ b/pilot/pkg/ambient/ambientpod/podutil.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/api/label"
 	"istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/ambient"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/pkg/log"
 )
 
@@ -106,7 +107,7 @@ func IsNamespaceActive(namespace *corev1.Namespace, meshMode string) bool {
 		(meshMode == AmbientMeshNamespace.String() &&
 			namespace != nil &&
 			!HasLegacyLabel(namespace.GetLabels()) &&
-			namespace.GetLabels()["istio.io/dataplane-mode"] == "ambient") {
+			namespace.GetLabels()[constants.DataplaneMode] == "ambient") {
 		return true
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -332,7 +332,7 @@ func TestAmbientIndex(t *testing.T) {
 		nil)
 
 	controller.client.Kube().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{"istio.io/dataplane-mode": "none"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{constants.DataplaneMode: "none"}},
 	}, metav1.CreateOptions{})
 	assertEvent("127.0.0.1", "127.0.0.2")
 	assert.Equal(t,
@@ -340,7 +340,7 @@ func TestAmbientIndex(t *testing.T) {
 		workloadapi.Protocol_DIRECT)
 
 	controller.client.Kube().CoreV1().Namespaces().Update(context.Background(), &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{"istio.io/dataplane-mode": "ambient"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{constants.DataplaneMode: "ambient"}},
 	}, metav1.UpdateOptions{})
 	assertEvent("127.0.0.1", "127.0.0.2")
 	assert.Equal(t,

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/util/workloadinstances"
 	"istio.io/istio/pilot/pkg/util/informermetric"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -378,8 +379,8 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.registerHandlers(filterdNs, "Namespaces", func(a any, event model.Event) error {
 		return nil
 	}, func(old, cur any) bool {
-		oldLabel := getNamespaceLabel(old, "istio.io/dataplane-mode")
-		newLabel := getNamespaceLabel(cur, "istio.io/dataplane-mode")
+		oldLabel := getNamespaceLabel(old, constants.DataplaneMode)
+		newLabel := getNamespaceLabel(cur, constants.DataplaneMode)
 		if oldLabel != newLabel {
 			c.handleSelectedNamespace(c.opts.EndpointMode, getNamespaceName(old, cur))
 		}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -154,4 +154,7 @@ const (
 	ManagedGatewayLabel          = "gateway.istio.io/managed"
 	ManagedGatewayController     = "istio.io-gateway-controller"
 	ManagedGatewayMeshController = "istio.io-mesh-controller"
+
+	// DataplaneMode namespace label for determining ambient mesh behavior
+	DataplaneMode = "istio.io/dataplane-mode"
 )

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -62,7 +63,7 @@ func TestBookinfo(t *testing.T) {
 				Prefix: "bookinfo",
 				Inject: false,
 				Labels: map[string]string{
-					"istio.io/dataplane-mode": "ambient",
+					constants.DataplaneMode: "ambient",
 				},
 			})
 			if err != nil {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -25,6 +25,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ambient"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -121,7 +122,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 		Prefix: "echo",
 		Inject: false,
 		Labels: map[string]string{
-			"istio.io/dataplane-mode": "ambient",
+			constants.DataplaneMode: "ambient",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

add constant for `istio.io/dataplane-mode` namespace label

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ X ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure