### PR TITLE
added timeout option for hbone dialer

### DIFF
--- a/pkg/hbone/dialer.go
+++ b/pkg/hbone/dialer.go
@@ -40,6 +40,7 @@ type Config struct {
 	ProxyAddress string
 	Headers      http.Header
 	TLS          *tls.Config
+	Timeout      *time.Duration
 }
 
 type Dialer interface {
@@ -50,6 +51,7 @@ type Dialer interface {
 // NewDialer creates a Dialer that proxies connections over HBONE to the configured proxy.
 func NewDialer(cfg Config) Dialer {
 	var transport *http2.Transport
+
 	if cfg.TLS != nil {
 		transport = &http2.Transport{
 			TLSClientConfig: cfg.TLS,
@@ -58,8 +60,12 @@ func NewDialer(cfg Config) Dialer {
 		transport = &http2.Transport{
 			// For h2c
 			AllowHTTP: true,
-			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-				return net.Dial(network, addr)
+			DialTLSContext: func(ctx context.Context, network, addr string, tlsCfg *tls.Config) (net.Conn, error) {
+				d := net.Dialer{}
+				if cfg.Timeout != nil {
+					d.Timeout = *cfg.Timeout
+				}
+				return d.Dial(network, addr)
 			},
 		}
 	}

--- a/pkg/hbone/dialer_test.go
+++ b/pkg/hbone/dialer_test.go
@@ -17,6 +17,7 @@ package hbone
 import (
 	"net"
 	"testing"
+	"time"
 )
 
 func newTCPServer(t testing.TB, data string) string {
@@ -44,13 +45,16 @@ func newTCPServer(t testing.TB, data string) string {
 }
 
 func TestDialerError(t *testing.T) {
+	timeout := 500 * time.Millisecond
 	d := NewDialer(Config{
 		ProxyAddress: "127.0.0.10:1", // Random address that should fail to dial
 		Headers: map[string][]string{
 			"some-addition-metadata": {"test-value"},
 		},
-		TLS: nil, // No TLS for simplification
+		TLS:     nil, // No TLS for simplification
+		Timeout: &timeout,
 	})
+
 	_, err := d.Dial("tcp", "fake")
 	if err == nil {
 		t.Fatal("expected error, got none.")
@@ -58,6 +62,7 @@ func TestDialerError(t *testing.T) {
 }
 
 func TestDialer(t *testing.T) {
+	timeout := 500 * time.Millisecond
 	testAddr := newTCPServer(t, "hello")
 	proxy := newHBONEServer(t)
 	d := NewDialer(Config{
@@ -65,7 +70,8 @@ func TestDialer(t *testing.T) {
 		Headers: map[string][]string{
 			"some-addition-metadata": {"test-value"},
 		},
-		TLS: nil, // No TLS for simplification
+		TLS:     nil, // No TLS for simplification
+		Timeout: &timeout,
 	})
 	send := func() {
 		client, err := d.Dial("tcp", testAddr)


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds the option of configuring a timeout for `hbone` dialer, and makes use of it in the tests:
- `TestDialerError` (previously 75s, with this modification is 0.5s)
- `TestDialer` (previously 0.01s, with this modification is still 0.01s)
The change is backward compatible.

related to #37555 