### PR TITLE
[release-1.16] Fix `manifest generate` generates deprecated versions of templates

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 19
+	MinK8SVersion               = 22
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.\n"

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -54,6 +54,11 @@ var (
 		Minor:      "20",
 		GitVersion: "v1.20.2",
 	}
+	version1_22 = &version.Info{
+		Major:      "1",
+		Minor:      "22",
+		GitVersion: "v1.22",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -115,6 +120,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		{
 			version:  version1_20,
 			expected: 20,
+			errMsg:   nil,
+			isValid:  true,
+		},
+		{
+			version:  version1_22,
+			expected: 22,
 			errMsg:   nil,
 			isValid:  true,
 		},
@@ -188,6 +199,11 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_20,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_20.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_22,
 			isValid: true,
 		},
 	}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -10135,7 +10135,7 @@ spec:
           secretName: istio-kubeconfig
           optional: true
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-egressgateway
@@ -10154,7 +10154,7 @@ spec:
       app: istio-egressgateway
       istio: egressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
@@ -10173,7 +10173,7 @@ spec:
       app: istio-ingressgateway
       istio: ingressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -2933,7 +2933,7 @@ spec:
           secretName: istio-kubeconfig
           optional: true
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/yaml"
 
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	"istio.io/istio/manifests"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/pkg/log"
@@ -101,6 +103,11 @@ func renderChart(namespace, values string, chrt *chart.Chart, filterFunc Templat
 	}
 
 	caps := *chartutil.DefaultCapabilities
+
+	// overwrite helm default capabilities
+	operatorVersion, _ := chartutil.ParseKubeVersion("1." + strconv.Itoa(k8sversion.MinK8SVersion) + ".0")
+	caps.KubeVersion = *operatorVersion
+
 	if version != nil {
 		caps.KubeVersion = chartutil.KubeVersion{
 			Version: version.GitVersion,

--- a/releasenotes/notes/42513.yaml
+++ b/releasenotes/notes/42513.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+
+releaseNotes:
+  - |
+    **Fixed** helm chart library default behavior from generating manifests with a v1.20 Kubernetes object version when using istioctl without --cluster-specific instead using the minimum Kubernetes version defined by istioctl.


### PR DESCRIPTION
**Please provide a description of this PR:**
Manual cherry-pick https://github.com/istio/istio/pull/42513.
Also, combine this one https://github.com/istio/istio/pull/41838, which unblocks the former PR.
From https://istio.io/latest/docs/releases/supported-releases/, the min supported version is 1.22.

Fix https://github.com/istio/istio/issues/42945.