### PR TITLE
Fix re-add remote cluster case.

### DIFF
--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -347,7 +347,7 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
 	existingClusters := c.cs.GetExistingClustersFor(secretKey)
 	for _, existingCluster := range existingClusters {
 		if _, ok := s.Data[string(existingCluster.ID)]; !ok {
-			c.deleteCluster(secretKey, existingCluster.ID)
+			c.deleteCluster(secretKey, existingCluster)
 		}
 	}
 
@@ -406,33 +406,24 @@ func (c *Controller) deleteSecret(secretKey string) {
 			log.Infof("ignoring delete cluster %v from secret %v as it would overwrite the config cluster", c.configClusterID, secretKey)
 			continue
 		}
-		log.Infof("Deleting cluster_id=%v configured by secret=%v", cluster.ID, secretKey)
-		cluster.Stop()
-		err := c.handleDelete(cluster.ID)
-		if err != nil {
-			log.Errorf("Error removing cluster_id=%v configured by secret=%v: %v",
-				cluster.ID, secretKey, err)
-		}
-		c.cs.Delete(secretKey, cluster.ID)
+
+		c.deleteCluster(secretKey, cluster)
 	}
 
 	log.Infof("Number of remote clusters: %d", c.cs.Len())
 }
 
-func (c *Controller) deleteCluster(secretKey string, clusterID cluster.ID) {
-	c.cs.Lock()
-	defer func() {
-		c.cs.Unlock()
-		log.Infof("Number of remote clusters: %d", c.cs.Len())
-	}()
-	log.Infof("Deleting cluster_id=%v configured by secret=%v", clusterID, secretKey)
-	c.cs.remoteClusters[secretKey][clusterID].Stop()
-	err := c.handleDelete(clusterID)
+func (c *Controller) deleteCluster(secretKey string, cluster *Cluster) {
+	log.Infof("Deleting cluster_id=%v configured by secret=%v", cluster.ID, secretKey)
+	cluster.Stop()
+	err := c.handleDelete(cluster.ID)
 	if err != nil {
 		log.Errorf("Error removing cluster_id=%v configured by secret=%v: %v",
-			clusterID, secretKey, err)
+			cluster.ID, secretKey, err)
 	}
-	delete(c.cs.remoteClusters[secretKey], clusterID)
+	c.cs.Delete(secretKey, cluster.ID)
+
+	log.Infof("Number of remote clusters: %d", c.cs.Len())
 }
 
 func (c *Controller) handleAdd(cluster *Cluster, stop <-chan struct{}) error {

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -112,6 +112,8 @@ func Test_SecretController(t *testing.T) {
 		secret0UpdateKubeconfigSame    = makeSecret("s0", clusterCredential{"c0", []byte("kubeconfig0-1")})
 		secret0AddCluster              = makeSecret("s0", clusterCredential{"c0", []byte("kubeconfig0-1")}, clusterCredential{"c0-1", []byte("kubeconfig0-2")})
 		secret0DeleteCluster           = secret0UpdateKubeconfigChanged // "c0-1" cluster deleted
+		secret0ReAddCluster            = makeSecret("s0", clusterCredential{"c0", []byte("kubeconfig0-1")}, clusterCredential{"c0-1", []byte("kubeconfig0-2")})
+		secret0ReDeleteCluster         = secret0UpdateKubeconfigChanged // "c0-1" cluster re-deleted
 		secret1                        = makeSecret("s1", clusterCredential{"c1", []byte("kubeconfig1-0")})
 	)
 	secret0UpdateKubeconfigSame.Annotations = map[string]string{"foo": "bar"}
@@ -132,9 +134,11 @@ func Test_SecretController(t *testing.T) {
 		{update: secret0UpdateKubeconfigSame},                       // 2
 		{update: secret0AddCluster, wantAdded: "c0-1"},              // 3
 		{update: secret0DeleteCluster, wantDeleted: "c0-1"},         // 4
-		{add: secret1, wantAdded: "c1"},                             // 5
-		{delete: secret0, wantDeleted: "c0"},                        // 6
-		{delete: secret1, wantDeleted: "c1"},                        // 7
+		{update: secret0ReAddCluster, wantAdded: "c0-1"},            // 5
+		{update: secret0ReDeleteCluster, wantDeleted: "c0-1"},       // 6
+		{add: secret1, wantAdded: "c1"},                             // 7
+		{delete: secret0, wantDeleted: "c0"},                        // 8
+		{delete: secret1, wantDeleted: "c1"},                        // 9
 	}
 
 	// Start the secret controller and sleep to allow secret process to start.


### PR DESCRIPTION
If we delete remote cluster A and re-add remote cluster A, we will get the following warn message and the re-add action is failed.
```
warn  cluster has already been registered  cluster=c0-1 secret=istio-system/s0
```

The added unit test can show this case. The reason is that when we remove cluster A, we forget to delete cluster A from cluster set.

This pr also refactors codes by reusing the method `deleteCluster`.

CC @howardjohn @hzxuzhonghu 