### PR TITLE
Lightstep deprecated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,8 +86,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.11.0
-	istio.io/api v0.0.0-20230127221132-b214fbae4c46
-	istio.io/client-go v1.12.0-alpha.5.0.20230127221532-27fae32187e9
+	istio.io/api v0.0.0-20230130180802-522813ce750f
+	istio.io/client-go v1.12.0-alpha.5.0.20230130181203-df89c46280f4
 	istio.io/pkg v0.0.0-20230117175411-c5010484eff7
 	k8s.io/api v0.26.0
 	k8s.io/apiextensions-apiserver v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1401,8 +1401,12 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20230127221132-b214fbae4c46 h1:NcGalxEC1eVOo588iEgi0VTcTKyL978gSn0l+EC9KB4=
 istio.io/api v0.0.0-20230127221132-b214fbae4c46/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
+istio.io/api v0.0.0-20230130180802-522813ce750f h1:me81q+0CvaHFMDssK2SnJ9c8dBqywhln/L9oAm187hk=
+istio.io/api v0.0.0-20230130180802-522813ce750f/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
 istio.io/client-go v1.12.0-alpha.5.0.20230127221532-27fae32187e9 h1:BetNyFN0qdTMCxdQ5MIzeOOtJz+2hbG67I1d9jrd8WA=
 istio.io/client-go v1.12.0-alpha.5.0.20230127221532-27fae32187e9/go.mod h1:QcFP3ttlNzMxEDuYB8ZYpne48bDnLOZSkloaJLwL994=
+istio.io/client-go v1.12.0-alpha.5.0.20230130181203-df89c46280f4 h1:rFSguusN3XL3r7PFTgz76vu2KF1JAmZlisMZyt3nxcM=
+istio.io/client-go v1.12.0-alpha.5.0.20230130181203-df89c46280f4/go.mod h1:qEsKVFGUsIshpIAdaciIQv8ACLEPDuvllyeNzn3+GLw=
 istio.io/pkg v0.0.0-20230117175411-c5010484eff7 h1:f8kwTQNUBaxh2tE+Klb1xoPRe68GRQT8bhtpd7W3sc8=
 istio.io/pkg v0.0.0-20230117175411-c5010484eff7/go.mod h1:BrWkMDfL8n60pWeRnHoNBckpgBOzMFasZsGUGCP9grE=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/go.sum
+++ b/go.sum
@@ -1399,12 +1399,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20230127221132-b214fbae4c46 h1:NcGalxEC1eVOo588iEgi0VTcTKyL978gSn0l+EC9KB4=
-istio.io/api v0.0.0-20230127221132-b214fbae4c46/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
 istio.io/api v0.0.0-20230130180802-522813ce750f h1:me81q+0CvaHFMDssK2SnJ9c8dBqywhln/L9oAm187hk=
 istio.io/api v0.0.0-20230130180802-522813ce750f/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
-istio.io/client-go v1.12.0-alpha.5.0.20230127221532-27fae32187e9 h1:BetNyFN0qdTMCxdQ5MIzeOOtJz+2hbG67I1d9jrd8WA=
-istio.io/client-go v1.12.0-alpha.5.0.20230127221532-27fae32187e9/go.mod h1:QcFP3ttlNzMxEDuYB8ZYpne48bDnLOZSkloaJLwL994=
 istio.io/client-go v1.12.0-alpha.5.0.20230130181203-df89c46280f4 h1:rFSguusN3XL3r7PFTgz76vu2KF1JAmZlisMZyt3nxcM=
 istio.io/client-go v1.12.0-alpha.5.0.20230130181203-df89c46280f4/go.mod h1:qEsKVFGUsIshpIAdaciIQv8ACLEPDuvllyeNzn3+GLw=
 istio.io/pkg v0.0.0-20230117175411-c5010484eff7 h1:f8kwTQNUBaxh2tE+Klb1xoPRe68GRQT8bhtpd7W3sc8=

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -831,6 +831,7 @@ func addHostsFromMeshConfig(ps *PushContext, hosts sets.String) {
 			hosts.Insert(p.EnvoyExtAuthzGrpc.Service)
 		case *meshconfig.MeshConfig_ExtensionProvider_Zipkin:
 			hosts.Insert(p.Zipkin.Service)
+		//nolint: staticcheck  // Lightstep deprecated
 		case *meshconfig.MeshConfig_ExtensionProvider_Lightstep:
 			hosts.Insert(p.Lightstep.Service)
 		case *meshconfig.MeshConfig_ExtensionProvider_Datadog:

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -166,6 +166,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 		// for lightstep for everything before 1.16, but OTel-based configuration for all other cases
 		useOTel := util.IsIstioVersionGE116(model.ParseIstioVersion(proxy.Metadata.IstioVersion))
 		if useOTel {
+			//nolint: staticcheck  // Lightstep deprecated
 			tracing, err = buildHCMTracing(pushCtx, envoyOpenTelemetry, provider.Lightstep.GetService(),
 				provider.Lightstep.GetPort(), provider.Lightstep.GetMaxTagLength(),
 				func(_, hostname, clusterName string) (*anypb.Any, error) {
@@ -188,6 +189,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 					return anypb.New(dc)
 				}, serviceCluster)
 		} else {
+			//nolint: staticcheck  // Lightstep deprecated
 			tracing, err = buildHCMTracing(pushCtx, envoyLightstep, provider.Lightstep.GetService(), provider.Lightstep.GetPort(), provider.Lightstep.GetMaxTagLength(),
 				func(_, hostname, clusterName string) (*anypb.Any, error) {
 					lc := &tracingcfg.LightstepConfig{

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -377,6 +377,7 @@ func getProxyConfigOptions(metadata *model.BootstrapNodeMetadata) ([]option.Inst
 			isH2 = true
 			// Write the token file.
 			lightstepAccessTokenPath := lightstepAccessTokenFile(config.ConfigPath)
+			//nolint: staticcheck  // Lightstep deprecated
 			err := os.WriteFile(lightstepAccessTokenPath, []byte(tracer.Lightstep.AccessToken), 0o666)
 			if err != nil {
 				return nil, err

--- a/pkg/config/validation/extensionprovider.go
+++ b/pkg/config/validation/extensionprovider.go
@@ -252,6 +252,7 @@ func validateExtensionProvider(config *meshconfig.MeshConfig) (errs error) {
 			currentErrs = appendErrors(currentErrs, ValidateExtensionProviderEnvoyExtAuthzGRPC(provider.EnvoyExtAuthzGrpc))
 		case *meshconfig.MeshConfig_ExtensionProvider_Zipkin:
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingZipkin(provider.Zipkin))
+		//nolint: staticcheck  // Lightstep deprecated
 		case *meshconfig.MeshConfig_ExtensionProvider_Lightstep:
 			currentErrs = appendErrors(currentErrs, validateExtensionProviderTracingLightStep(provider.Lightstep))
 		case *meshconfig.MeshConfig_ExtensionProvider_Datadog:


### PR DESCRIPTION
**Please provide a description of this PR:**

Supersedes https://github.com/istio/istio/pull/43051

Lightship was deprecated in https://github.com/istio/api/pull/2635 and pulling the client-go changes into istio/istio requires some lint changes. The release-notes are in the istio/api PR.