### PR TITLE
gateway-api: use constants for deploymentcontroller's managed-by label

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   annotations:
     {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
-    {{ toYamlMap .Labels
-      (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")
+    {{ toYamlMap .Labels .DefaultLabels
       | nindent 4}}
   name: {{.Name}}
   namespace: {{.Namespace}}

--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -4,8 +4,7 @@ metadata:
   annotations:
     {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
-    {{ toYamlMap .Labels
-      (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")
+    {{ toYamlMap .Labels .DefaultLabels
       | nindent 4}}
   name: {{.Name}}
   namespace: {{.Namespace}}


### PR DESCRIPTION
**Please provide a description of this PR:**

Small clean-up. We currently define the managed-by label of the deploymentcontroller both in the template and the code, which is error-prone and leads to hard coupling between templates and controller code. Moving it only to the controller code will allow us to have user-defined templates for the deployment-controller without the danger that the user accidentally breaks the managed-by functionality. 