### PR TITLE
gateway-api: completely decouple template from code for managed-by label

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
-    {{ toYamlMap .Labels .DefaultLabels
+    {{ toYamlMap .Labels
       | nindent 4}}
   name: {{.Name}}
   namespace: {{.Namespace}}

--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
   labels:
-    {{ toYamlMap .Labels .DefaultLabels
+    {{ toYamlMap .Labels
       | nindent 4}}
   name: {{.Name}}
   namespace: {{.Namespace}}


### PR DESCRIPTION
**Please provide a description of this PR:**
Follow-up on #43067 - this is a simpler version, now entirely independent of the templates. We simply add the managed-by label after generating the resources, directly in `ApplyTemplate()`. Sorry for the noise- I came up with this one only after the previous PR was already merged.