### PR TITLE
Pods in unReady state must generate workload entries

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -695,7 +695,7 @@ func (c *Controller) setupIndex() *AmbientIndex {
 			wl := idx.byPod[p.Status.PodIP]
 			// Only add Pods to the service VIP if Pod in Ready state -
 			// Pods with valid WorkloadInfos are not necessarily ready to
-			// recieve traffic.
+			// receive traffic.
 			if wl != nil && IsPodReady(p) {
 				wl = c.extractWorkload(p)
 				// Update the pod, since it now has new VIP info
@@ -820,7 +820,7 @@ func (c *Controller) constructWorkload(pod *v1.Pod, waypoints []string, policies
 	// Create a workload entry for pods that may not be ready yet,
 	// so proxies handling their outbound traffic have a source workload,
 	// but explicitly do not add any VIPs to the entry until pods reach a state
-	// that indicates they are ready to recieve inbound traffic.
+	// that indicates they are ready to receive inbound traffic.
 	if IsPodReady(pod) {
 		if services, err := getPodServices(c.serviceLister, pod); err == nil && len(services) > 0 {
 			for _, svc := range services {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -693,8 +693,10 @@ func (c *Controller) setupIndex() *AmbientIndex {
 		var wls []*model.WorkloadInfo
 		for _, p := range pods {
 			wl := idx.byPod[p.Status.PodIP]
-			// Can be nil if it's not ready, hostNetwork, etc
-			if wl != nil {
+			// Only add Pods to the service VIP if Pod in Ready state -
+			// Pods with valid WorkloadInfos are not necessarily ready to
+			// recieve traffic.
+			if wl != nil && IsPodReady(p) {
 				wl = c.extractWorkload(p)
 				// Update the pod, since it now has new VIP info
 				idx.byPod[p.Status.PodIP] = wl
@@ -802,35 +804,49 @@ func (c *Controller) constructWorkload(pod *v1.Pod, waypoints []string, policies
 	if pod == nil {
 		return nil
 	}
-	if !IsPodReady(pod) {
+
+	// In some scenarios (e.g. outbound traffic that gates pod health checks) we must allow
+	// outbound traffic from pods that are in the Running phase but not yet at Ready status.
+	// If they are in neither state, no workload entry should be created.
+	if !IsPodReady(pod) && !IsPodRunning(pod) {
 		return nil
 	}
 	if pod.Spec.HostNetwork {
 		return nil
 	}
+
 	vips := map[string]*workloadapi.PortList{}
-	if services, err := getPodServices(c.serviceLister, pod); err == nil && len(services) > 0 {
-		for _, svc := range services {
-			for _, vip := range getVIPs(svc) {
-				if vips[vip] == nil {
-					vips[vip] = &workloadapi.PortList{}
-				}
-				for _, port := range svc.Spec.Ports {
-					if port.Protocol != v1.ProtocolTCP {
-						continue
+
+	// Create a workload entry for pods that may not be ready yet,
+	// so proxies handling their outbound traffic have a source workload,
+	// but explicitly do not add any VIPs to the entry until pods reach a state
+	// that indicates they are ready to recieve inbound traffic.
+	if IsPodReady(pod) {
+		if services, err := getPodServices(c.serviceLister, pod); err == nil && len(services) > 0 {
+			for _, svc := range services {
+				for _, vip := range getVIPs(svc) {
+					if vips[vip] == nil {
+						vips[vip] = &workloadapi.PortList{}
 					}
-					targetPort, err := FindPort(pod, &port)
-					if err != nil {
-						log.Debug(err)
-						continue
+					for _, port := range svc.Spec.Ports {
+						if port.Protocol != v1.ProtocolTCP {
+							continue
+						}
+						targetPort, err := FindPort(pod, &port)
+						if err != nil {
+							log.Debug(err)
+							continue
+						}
+						vips[vip].Ports = append(vips[vip].Ports, &workloadapi.Port{
+							ServicePort: uint32(port.Port),
+							TargetPort:  uint32(targetPort),
+						})
 					}
-					vips[vip].Ports = append(vips[vip].Ports, &workloadapi.Port{
-						ServicePort: uint32(port.Port),
-						TargetPort:  uint32(targetPort),
-					})
 				}
 			}
 		}
+	} else {
+		log.Debugf("Pod %s is Running but not yet in Ready state, creating workload entry without VIPs", pod.Name)
 	}
 
 	wl := &workloadapi.Workload{

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -354,6 +354,103 @@ func TestAmbientIndex(t *testing.T) {
 		workloadapi.Protocol_HTTP)
 }
 
+func TestPodLifecycleWorkloadGates(t *testing.T) {
+	cfg := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI))
+	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{
+		ConfigController: cfg,
+		MeshWatcher:      mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"}),
+	})
+	cfg.RegisterEventHandler(gvk.AuthorizationPolicy, controller.AuthorizationPolicyHandler)
+	go cfg.Run(test.NewStop(t))
+	assertWorkloads := func(lookup string, names ...string) {
+		t.Helper()
+		want := sets.New(names...)
+		assert.EventuallyEqual(t, func() sets.String {
+			var workloads []*model.WorkloadInfo
+			if lookup == "" {
+				workloads = controller.ambientIndex.All()
+			} else {
+				workloads = controller.ambientIndex.Lookup(lookup)
+			}
+			have := sets.New[string]()
+			for _, wl := range workloads {
+				have.Insert(wl.Name)
+			}
+			return have
+		}, want, retry.Timeout(time.Second*3))
+	}
+	assertEvent := func(ip ...string) {
+		t.Helper()
+		want := strings.Join(ip, ",")
+		attempts := 0
+		for attempts < 10 {
+			attempts++
+			ev := fx.WaitOrFail(t, "xds")
+			if ev.ID != want {
+				t.Logf("skip event %v, wanted %v", ev.ID, want)
+			} else {
+				return
+			}
+		}
+		t.Fatalf("didn't find event for %v", ip)
+	}
+	addPods := func(ip string, name, sa string, labels map[string]string, markReady bool, phase corev1.PodPhase) {
+		t.Helper()
+		pod := generatePod(ip, name, "ns1", sa, "node1", labels, nil)
+
+		p, _ := controller.client.Kube().CoreV1().Pods(pod.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if p == nil {
+			// Apiserver doesn't allow Create to modify the pod status; in real world its a 2 part process
+			pod.Status = corev1.PodStatus{}
+			newPod, err := controller.client.Kube().CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Cannot create %s: %v", pod.ObjectMeta.Name, err)
+			}
+			if markReady {
+				setPodReady(newPod)
+			}
+			newPod.Status.PodIP = ip
+			newPod.Status.Phase = phase
+			if _, err := controller.client.Kube().CoreV1().Pods(pod.Namespace).UpdateStatus(context.TODO(), newPod, metav1.UpdateOptions{}); err != nil {
+				t.Fatalf("Cannot update status %s: %v", pod.ObjectMeta.Name, err)
+			}
+		} else {
+			_, err := controller.client.Kube().CoreV1().Pods(pod.Namespace).Update(context.Background(), pod, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("Cannot update %s: %v", pod.ObjectMeta.Name, err)
+			}
+		}
+	}
+
+	addPods("127.0.0.1", "name1", "sa1", map[string]string{"app": "a"}, true, corev1.PodRunning)
+	assertWorkloads("", "name1")
+	assertEvent("127.0.0.1")
+
+	addPods("127.0.0.2", "name2", "sa1", map[string]string{"app": "a", "other": "label"}, false, corev1.PodRunning)
+	addPods("127.0.0.3", "name3", "sa1", map[string]string{"app": "other"}, false, corev1.PodPending)
+
+	assertEvent("127.0.0.2")
+
+	// Expect workload entries for pods that are either Ready, or unReady, but Running.
+	// All other statuses should not generate workload entries
+	assertWorkloads("", "name1", "name2")
+	assertWorkloads("127.0.0.1", "name1")
+	assertWorkloads("127.0.0.2", "name2")
+
+	// Non-existent IP should have no response
+	assertWorkloads("10.0.0.1")
+	fx.Clear()
+
+	createService(controller, "svc1", "ns1",
+		map[string]string{},
+		[]int32{80}, map[string]string{"app": "a"}, t)
+	// Service shouldn't change workload list
+	assertWorkloads("", "name1", "name2")
+	assertWorkloads("127.0.0.1", "name1")
+	//For pods that are in Ready state, VIPs should be populated.
+	assertWorkloads("10.0.0.1", "name1")
+}
+
 func TestRBACConvert(t *testing.T) {
 	files := file.ReadDirOrFail(t, "testdata")
 	if len(files) == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -447,7 +447,7 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 	// Service shouldn't change workload list
 	assertWorkloads("", "name1", "name2")
 	assertWorkloads("127.0.0.1", "name1")
-	//For pods that are in Ready state, VIPs should be populated.
+	// For pods that are in Ready state, VIPs should be populated.
 	assertWorkloads("10.0.0.1", "name1")
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -77,6 +77,10 @@ func shouldPodBeInEndpoints(pod *v1.Pod) bool {
 	}
 }
 
+func IsPodRunning(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodRunning
+}
+
 // IsPodReady is copied from kubernetes/pkg/api/v1/pod/utils.go
 func IsPodReady(pod *v1.Pod) bool {
 	return IsPodReadyConditionTrue(pod.Status)
@@ -146,6 +150,7 @@ func (pc *PodCache) onEvent(curr any, ev model.Event) error {
 	// PodIP will be empty when pod is just created, but before the IP is assigned
 	// via UpdateStatus.
 	if len(ip) == 0 {
+		log.Debugf("Pod name %s has no IP yet, skipping...", pod.Name, pod.Status.Phase)
 		return nil
 	}
 


### PR DESCRIPTION
Ran across a bug where a Pod that makes outbound calls to the k8s API as part of its readiness/liveness checks gets permanently stuck due to ztunnel dropping the connection, leading to the Pod never entering a Ready state (Pod has a phase of Running but never reaches a condition of Ready).

This is exposed by the fact that ztunnel explicitly drops the connection if it cannot find the _source_ workload in the xDS workload API - and indeed the source workload is _not_ present in the xDS workload API from ztunnel's perspective, because we currently only add a workload entry if the Pod has a condition of Ready.

This PR fixes that by adding more granularity to the lifecycle checks:

1. Allow creation of workload entries for pods in the Running phase, regardless of their Readiness (meaning they should be a valid source of traffic from ztunnel's perspective, even if they are not Ready).
2. Exclude those workload entries from VIP sets until they have a condition of Ready (meaning they should receive traffic only when they are Ready)

There is a separate discussion around how strict/consistent `ztunnel` should be when it comes to checking whether `source` or `dest` have workload entries before passing thru traffic over in the ztunnel repo: https://github.com/istio/ztunnel/issues/369