### PR TITLE
set the DNS lookup family policy based on the proxy's IP family for Dual Stack support

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -481,9 +481,9 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 		// to support the Dual Stack via Envoy bindconfig, and belows are related issue and PR in Envoy:
 		// https://github.com/envoyproxy/envoy/issues/9811
 		// https://github.com/envoyproxy/envoy/pull/22639
-		instExtraSvcAddr := instance.Service.GetExtraAddressesForProxy(proxy)
-		// the extra source address for UpstreamBindConfig shoulde be added when the service is a dual stack k8s service
-		if features.EnableDualStack && len(cb.passThroughBindIPs) > 1 && len(instExtraSvcAddr) > 0 {
+		// the extra source address for UpstreamBindConfig shoulde be added if dual stack is enabled and there are
+		// more than 1 IP for proxy
+		if features.EnableDualStack && len(cb.passThroughBindIPs) > 1 {
 			// add extra source addresses to cluster builder
 			var extraSrcAddrs []*core.ExtraSourceAddress
 			for _, extraBdIP := range cb.passThroughBindIPs[1:] {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -124,9 +124,17 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 			option.Localhost(option.LocalhostIPv4),
 			option.Wildcard(option.WildcardIPv4),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
-	} else {
-		// IPv6 only and Dual Stack
+	} else if network.AllIPv6(cfg.Metadata.InstanceIPs) {
+		// IPv6 only
 		opts = append(opts,
+			option.Localhost(option.LocalhostIPv6),
+			option.Wildcard(option.WildcardIPv6),
+			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+	} else {
+		// Dual Stack
+		opts = append(opts,
+			option.Localhost(option.LocalhostIPv4),
+			option.Wildcard(option.WildcardIPv4),
 			option.Localhost(option.LocalhostIPv6),
 			option.Wildcard(option.WildcardIPv6),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -124,17 +124,9 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 			option.Localhost(option.LocalhostIPv4),
 			option.Wildcard(option.WildcardIPv4),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
-	} else if network.AllIPv6(cfg.Metadata.InstanceIPs) {
-		// IPv6 only
-		opts = append(opts,
-			option.Localhost(option.LocalhostIPv6),
-			option.Wildcard(option.WildcardIPv6),
-			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
 	} else {
-		// Dual Stack
+		// IPv6 only and Dual Stack
 		opts = append(opts,
-			option.Localhost(option.LocalhostIPv4),
-			option.Wildcard(option.WildcardIPv4),
 			option.Localhost(option.LocalhostIPv6),
 			option.Wildcard(option.WildcardIPv6),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -118,16 +118,26 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 	opts = append(opts, getNodeMetadataOptions(cfg.Node)...)
 
 	// Check if nodeIP carries IPv4 or IPv6 and set up proxy accordingly
-	if network.AllIPv6(cfg.Metadata.InstanceIPs) {
+	if network.AllIPv4(cfg.Metadata.InstanceIPs) {
+		// IPv4 only
+		opts = append(opts,
+			option.Localhost(option.LocalhostIPv4),
+			option.Wildcard(option.WildcardIPv4),
+			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
+	} else if network.AllIPv6(cfg.Metadata.InstanceIPs) {
+		// IPv6 only
 		opts = append(opts,
 			option.Localhost(option.LocalhostIPv6),
 			option.Wildcard(option.WildcardIPv6),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
 	} else {
+		// Dual Stack
 		opts = append(opts,
 			option.Localhost(option.LocalhostIPv4),
 			option.Wildcard(option.WildcardIPv4),
-			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
+			option.Localhost(option.LocalhostIPv6),
+			option.Wildcard(option.WildcardIPv6),
+			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
 	}
 
 	proxyOpts, err := getProxyConfigOptions(cfg.Metadata)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"path"
 	"strconv"
@@ -124,12 +125,29 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 			option.Localhost(option.LocalhostIPv4),
 			option.Wildcard(option.WildcardIPv4),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
-	} else {
-		// IPv6 only and Dual Stack
+	} else if network.AllIPv6(cfg.Metadata.InstanceIPs) {
+		// IPv6 only
 		opts = append(opts,
 			option.Localhost(option.LocalhostIPv6),
 			option.Wildcard(option.WildcardIPv6),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+	} else {
+		// Dual Stack
+		// If dual-stack, it may be [IPv4, IPv6] or [IPv6, IPv4]
+		// So let the first ip family policy to decide its DNSLookupFamilyIP policy
+		netIP, _ := netip.ParseAddr(cfg.Metadata.InstanceIPs[0])
+		if netIP.Is6() && !netIP.IsLinkLocalUnicast() {
+			opts = append(opts,
+				option.Localhost(option.LocalhostIPv6),
+				option.Wildcard(option.WildcardIPv6),
+				option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+		} else {
+			opts = append(opts,
+				option.Localhost(option.LocalhostIPv4),
+				option.Wildcard(option.WildcardIPv4),
+				option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
+		}
+
 	}
 
 	proxyOpts, err := getProxyConfigOptions(cfg.Metadata)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -133,21 +133,28 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
 	} else {
 		// Dual Stack
-		// If dual-stack, it may be [IPv4, IPv6] or [IPv6, IPv4]
-		// So let the first ip family policy to decide its DNSLookupFamilyIP policy
-		netIP, _ := netip.ParseAddr(cfg.Metadata.InstanceIPs[0])
-		if netIP.Is6() && !netIP.IsLinkLocalUnicast() {
-			opts = append(opts,
-				option.Localhost(option.LocalhostIPv6),
-				option.Wildcard(option.WildcardIPv6),
-				option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+		if features.EnableDualStack {
+			// If dual-stack, it may be [IPv4, IPv6] or [IPv6, IPv4]
+			// So let the first ip family policy to decide its DNSLookupFamilyIP policy
+			netIP, _ := netip.ParseAddr(cfg.Metadata.InstanceIPs[0])
+			if netIP.Is6() && !netIP.IsLinkLocalUnicast() {
+				opts = append(opts,
+					option.Localhost(option.LocalhostIPv6),
+					option.Wildcard(option.WildcardIPv6),
+					option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+			} else {
+				opts = append(opts,
+					option.Localhost(option.LocalhostIPv4),
+					option.Wildcard(option.WildcardIPv4),
+					option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
+			}
 		} else {
+			// keep the original logic if Dual Stack is disable
 			opts = append(opts,
 				option.Localhost(option.LocalhostIPv4),
 				option.Wildcard(option.WildcardIPv4),
 				option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
 		}
-
 	}
 
 	proxyOpts, err := getProxyConfigOptions(cfg.Metadata)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -141,12 +141,12 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv6),
 					option.Wildcard(option.WildcardIPv6),
-					option.DNSLookupFamily(option.DNSLookupFamilyIPv6))
+					option.DNSLookupFamily(option.DNSLookupFamilyIPS))
 			} else {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv4),
 					option.Wildcard(option.WildcardIPv4),
-					option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
+					option.DNSLookupFamily(option.DNSLookupFamilyIPS))
 			}
 		} else {
 			// keep the original logic if Dual Stack is disable

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -36,7 +36,8 @@ const (
 	WildcardIPv4        WildcardValue        = "0.0.0.0"
 	WildcardIPv6        WildcardValue        = "::"
 	DNSLookupFamilyIPv4 DNSLookupFamilyValue = "V4_ONLY"
-	DNSLookupFamilyIPv6 DNSLookupFamilyValue = "AUTO"
+	DNSLookupFamilyIPv6 DNSLookupFamilyValue = "V6_ONLY"
+	DNSLookupFamilyIPS  DNSLookupFamilyValue = "ALL"
 )
 
 func ProxyConfig(value *model.NodeMetaProxyConfig) Instance {

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -154,8 +154,15 @@ func TestOptions(t *testing.T) {
 			testName: "dns lookup family v6",
 			key:      "dns_lookup_family",
 			option:   option.DNSLookupFamily(option.DNSLookupFamilyIPv6),
-			expected: option.DNSLookupFamilyValue("AUTO"),
+			expected: option.DNSLookupFamilyValue("V6_ONLY"),
 		},
+		{
+			testName: "dns lookup family dual stack",
+			key:      "dns_lookup_family",
+			option:   option.DNSLookupFamily(option.DNSLookupFamilyIPS),
+			expected: option.DNSLookupFamilyValue("ALL"),
+		},
+
 		{
 			testName: "lightstep address empty",
 			key:      "lightstep",

--- a/releasenotes/notes/43099.yaml
+++ b/releasenotes/notes/43099.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 40394
+  - 41462
+
+docs:
+  - '[Optimized Design] https://docs.google.com/document/d/15LP2XHpQ71ODkjCVItGacPgzcn19fsVhyE7ruMGXDyU/'
+  - '[Original Design] https://docs.google.com/document/d/1oT6pmRhOw7AtsldU0-HbfA0zA26j9LYiBD_eepeErsQ/'
+
+releaseNotes:
+- |
+  **Fixed** Fixed bug of Istio cannot be deployed on IPv6-first DS clusters for Dual Stack support in Istio.

--- a/releasenotes/notes/43099.yaml
+++ b/releasenotes/notes/43099.yaml
@@ -1,10 +1,10 @@
 apiVersion: release-notes/v2
-kind: feature
+kind: bug-fix 
 area: traffic-management
 
 issue:
   - 40394
-  - 41462
+  - 41462 
 
 docs:
   - '[Optimized Design] https://docs.google.com/document/d/15LP2XHpQ71ODkjCVItGacPgzcn19fsVhyE7ruMGXDyU/'
@@ -12,4 +12,4 @@ docs:
 
 releaseNotes:
 - |
-  **Fixed** Fixed bug of Istio cannot be deployed on IPv6-first DS clusters for Dual Stack support in Istio.
+  **Fixed** fixed bug of Istio cannot be deployed on IPv6-first DS clusters for Dual Stack support in Istio. 


### PR DESCRIPTION
Set the DNS lookup family policy based on the proxy's IP family for Dual Stack support.

1. IPv4 only should add IPv4 addresses and DNSLookupFamilyIPv4
2. IPv6 only should add IPv6 addresses and DNSLookupFamilyIPv6
3. Dual Stack should pick IPv4/DNSLookupFamilyIPv4 or IPv6/DNSLookupFamilyIPv6 according to the ip family order
4. Fixed a bug for cluster builder in `UpstreamBindConfig`, and this can make sure that a single stack service can be available for service with different ip family policy

This PR is submitted for [issue#41462](https://github.com/istio/istio/issues/41462) and it's also a part of [issue#40394](https://github.com/istio/istio/issues/40394)

**Please provide a description of this PR:**