### PR TITLE
wasm: fix a race condition on making directories for wasm binaries.

### DIFF
--- a/pkg/wasm/cache.go
+++ b/pkg/wasm/cache.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -191,11 +190,8 @@ func getModulePath(baseDir string, mkey moduleKey) (string, error) {
 	sha := sha256.Sum256([]byte(mkey.name))
 	hashedName := hex.EncodeToString(sha[:])
 	moduleDir := filepath.Join(baseDir, hashedName)
-	if _, err := os.Stat(moduleDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(moduleDir, 0o755)
-		if err != nil {
-			return "", err
-		}
+	if err := os.Mkdir(moduleDir, 0o755); err != nil && !os.IsExist(err) {
+		return "", err
 	}
 	return filepath.Join(moduleDir, fmt.Sprintf("%s.wasm", mkey.checksum)), nil
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/42502.

There seems to be a race condition for making directories for Wam module, concurrently.

To prevent it, this PR proposes to just try to create the directory regardless of its existence, 
and then if there is an error, check if it is an "exist" error. 
