### PR TITLE
Fix operator remove not working properly

### DIFF
--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -91,6 +91,9 @@ func operatorInit(args *RootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	if err != nil {
 		l.LogAndFatal(err)
 	}
+	if oiArgs.common.revision == "default" {
+		oiArgs.common.revision = ""
+	}
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.
 	already, _ := isControllerInstalled(kubeClient.Kube(), oiArgs.common.operatorNamespace, oiArgs.common.revision)
 	if already {

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -83,8 +83,8 @@ func operatorRemove(cmd *cobra.Command, args *RootArgs, orArgs *operatorRemoveAr
 	if orArgs.purge && orArgs.revision != "" {
 		orArgs.revision = ""
 		l.LogAndFatal("At most one of the --revision (or --set revision=<revision>) or --purge flags could be set\n")
-	} else if !orArgs.purge && orArgs.revision == "" {
-		orArgs.revision = "default"
+	} else if orArgs.revision == "default" {
+		orArgs.revision = ""
 	}
 
 	installed, err := isControllerInstalled(kubeClient.Kube(), orArgs.operatorNamespace, orArgs.revision)

--- a/releasenotes/notes/fix-remove-iop-not-work.yaml
+++ b/releasenotes/notes/fix-remove-iop-not-work.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `istioctl operator remove` not working properly.

--- a/releasenotes/notes/fix-remove-iop-not-work.yaml
+++ b/releasenotes/notes/fix-remove-iop-not-work.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** `istioctl operator remove` not working properly.
+    **Fixed** `istioctl operator remove` cannot remove the operator controller due to the `no Deployment detected` error.

--- a/releasenotes/notes/fix-remove-iop-not-work.yaml
+++ b/releasenotes/notes/fix-remove-iop-not-work.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** `istioctl operator remove` cannot remove the operator controller due to the `no Deployment detected` error.
+    **Fixed** `istioctl operator remove` cannot remove the operator controller due to a `no Deployment detected` error.


### PR DESCRIPTION
**Please provide a description of this PR:**
Once I used `operator init` to init the operator, I try to use `operator remove` or `operator remove --revision default` to remove the opeartor, however, neither of them work.
The error is like:
```bash
istioctl operator remove --dry-run
Operator controller is not installed in istio-operator namespace (no Deployment detected).
Aborting, use --force to override.
```
The installed deployments cannot be found because it always adds `-default` before check the deployment, and actually the   name doesn't contain `-default` suffix.

Also, this PR makes `operator init` consistent with `--revision=default` like other commands.