### PR TITLE
use interface to make code layering clearer

### DIFF
--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -17,6 +17,7 @@ package authz
 import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/util"

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/security/authz"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config"
@@ -252,7 +253,7 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 	baseDir := "http/"
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			option := Option{
+			option := authz.Option{
 				IsCustomBuilder: tc.meshConfig != nil,
 			}
 			push := push(t, baseDir+tc.input, tc.meshConfig)
@@ -318,7 +319,7 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 	baseDir := "tcp/"
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			option := Option{
+			option := authz.Option{
 				IsCustomBuilder: tc.meshConfig != nil,
 			}
 			push := push(t, baseDir+tc.input, tc.meshConfig)

--- a/pilot/pkg/security/authz/builder/fuzz_test.go
+++ b/pilot/pkg/security/authz/builder/fuzz_test.go
@@ -16,8 +16,8 @@ package builder
 
 import (
 	"testing"
-
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/security/authz"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/fuzz"
 )
@@ -28,7 +28,7 @@ func FuzzBuildHTTP(f *testing.F) {
 		push := fuzz.Struct[*model.PushContext](fg, validatePush)
 		node := fuzz.Struct[*model.Proxy](fg)
 		policies := push.AuthzPolicies.ListAuthorizationPolicies(node.ConfigNamespace, node.Labels)
-		option := fuzz.Struct[Option](fg)
+		option := fuzz.Struct[authz.Option](fg)
 		New(bundle, push, policies, option).BuildHTTP()
 	})
 }
@@ -39,7 +39,7 @@ func FuzzBuildTCP(f *testing.F) {
 		push := fuzz.Struct[*model.PushContext](fg, validatePush)
 		node := fuzz.Struct[*model.Proxy](fg)
 		policies := push.AuthzPolicies.ListAuthorizationPolicies(node.ConfigNamespace, node.Labels)
-		option := fuzz.Struct[Option](fg)
+		option := fuzz.Struct[authz.Option](fg)
 		New(bundle, push, policies, option).BuildTCP()
 	})
 }

--- a/pilot/pkg/security/authz/builder/fuzz_test.go
+++ b/pilot/pkg/security/authz/builder/fuzz_test.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"testing"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/authz"
 	"istio.io/istio/pilot/pkg/security/trustdomain"

--- a/pilot/pkg/security/authz/factory/factory.go
+++ b/pilot/pkg/security/authz/factory/factory.go
@@ -1,0 +1,28 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/security/authz"
+	"istio.io/istio/pilot/pkg/security/authz/builder"
+	"istio.io/istio/pilot/pkg/security/trustdomain"
+)
+
+func NewPolicyApplier(trustDomainBundle trustdomain.Bundle, push *model.PushContext,
+	policies model.AuthorizationPoliciesResult, option authz.Option,
+) authz.PolicyApplier {
+	return builder.New(trustDomainBundle, push, policies, option)
+}

--- a/pilot/pkg/security/authz/policy_applier.go
+++ b/pilot/pkg/security/authz/policy_applier.go
@@ -1,0 +1,36 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+)
+
+// PolicyApplier is the interface provides essential functionalities to help config Envoy (xDS) to enforce
+// authorization policy.
+type PolicyApplier interface {
+	// BuildHTTP returns the HTTP filters built from the authorization policy.
+	BuildHTTP() []*hcm.HttpFilter
+
+	// BuildTCP returns the TCP filters built from the authorization policy.
+	BuildTCP() []*listener.Filter
+}
+
+// Option general setting to control behavior
+type Option struct {
+	IsCustomBuilder  bool
+	UseAuthenticated bool
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
Add a `PolicyApplier` interface to make the code layering clearer. This is also to make the code of `authz` consistent with `authn` (`pilot/pkg/networking/plugin/authn` depends on the interface of `pilot/pkg/security/authn`).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**
- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**
- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
