### PR TITLE
`String()` method instead of the `string` func

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -293,7 +293,7 @@ func httpRouteMatchSvc(vs *clientnetworking.VirtualService, route *v1alpha3.HTTP
 	mismatchNotes := []string{}
 	match := false
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}))
+		fqdn := model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}).String()
 		if extendFQDN(fqdn) == svcHost {
 			if dest.Destination.Subset != "" {
 				if contains(nonmatchingSubsets, dest.Destination.Subset) {
@@ -354,7 +354,7 @@ func tcpRouteMatchSvc(vs *clientnetworking.VirtualService, route *v1alpha3.TCPRo
 	facts := []string{}
 	svcHost := extendFQDN(fmt.Sprintf("%s.%s", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace))
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}))
+		fqdn := model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}).String()
 		if extendFQDN(fqdn) == svcHost {
 			match = true
 		}

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -207,20 +207,21 @@ func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 		// only happens when the gateway-api BackendRef is invalid
 		return ""
 	}
-	out := hostname
+
 	// Treat the wildcard hostname as fully qualified. Any other variant of a wildcard hostname will contain a `.` too,
 	// and skip the next if, so we only need to check for the literal wildcard itself.
 	if hostname == "*" {
-		return host.Name(out)
+		return host.Name(hostname)
 	}
 
 	// if the hostname is a valid ipv4 or ipv6 address, do not append domain or namespace
 	if netutil.IsValidIPAddress(hostname) {
-		return host.Name(out)
+		return host.Name(hostname)
 	}
 
 	// if FQDN is specified, do not append domain or namespace to hostname
 	if !strings.Contains(hostname, ".") {
+		out := hostname
 		if meta.Namespace != "" {
 			out = out + "." + meta.Namespace
 		}
@@ -233,7 +234,7 @@ func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 		}
 	}
 
-	return host.Name(out)
+	return host.Name(hostname)
 }
 
 // resolveGatewayName uses metadata information to resolve a reference

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -219,9 +219,10 @@ func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 		return host.Name(hostname)
 	}
 
+	out := hostname
+
 	// if FQDN is specified, do not append domain or namespace to hostname
 	if !strings.Contains(hostname, ".") {
-		out := hostname
 		if meta.Namespace != "" {
 			out = out + "." + meta.Namespace
 		}
@@ -234,7 +235,7 @@ func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 		}
 	}
 
-	return host.Name(hostname)
+	return host.Name(out)
 }
 
 // resolveGatewayName uses metadata information to resolve a reference

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1768,7 +1768,7 @@ func (ps *PushContext) setDestinationRules(configs []config.Config) {
 			inheritedConfigs[configs[i].Namespace] = ConvertConsolidatedDestRule(&configs[i])
 		}
 
-		rule.Host = string(ResolveShortnameToFQDN(rule.Host, configs[i].Meta))
+		rule.Host = ResolveShortnameToFQDN(rule.Host, configs[i].Meta).String()
 		exportToMap := make(map[visibility.Instance]bool)
 
 		// destination rules with workloadSelector should not be exported to other namespaces

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -99,7 +99,7 @@ func vsHostMatches(vsHost string, importedHost host.Name, vs config.Config) bool
 func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.Meta) {
 	// resolve top level hosts
 	for i, h := range rule.Hosts {
-		rule.Hosts[i] = string(ResolveShortnameToFQDN(h, meta))
+		rule.Hosts[i] = ResolveShortnameToFQDN(h, meta).String()
 	}
 	// resolve gateways to bind to
 	for i, g := range rule.Gateways {
@@ -118,11 +118,11 @@ func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta confi
 		}
 		for _, w := range d.Route {
 			if w.Destination != nil {
-				w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, meta))
+				w.Destination.Host = ResolveShortnameToFQDN(w.Destination.Host, meta).String()
 			}
 		}
 		if d.Mirror != nil {
-			d.Mirror.Host = string(ResolveShortnameToFQDN(d.Mirror.Host, meta))
+			d.Mirror.Host = ResolveShortnameToFQDN(d.Mirror.Host, meta).String()
 		}
 	}
 	// resolve host in tcp route.destination
@@ -136,7 +136,7 @@ func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta confi
 		}
 		for _, w := range d.Route {
 			if w.Destination != nil {
-				w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, meta))
+				w.Destination.Host = ResolveShortnameToFQDN(w.Destination.Host, meta).String()
 			}
 		}
 	}
@@ -151,7 +151,7 @@ func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta confi
 		}
 		for _, w := range tls.Route {
 			if w.Destination != nil {
-				w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, meta))
+				w.Destination.Host = ResolveShortnameToFQDN(w.Destination.Host, meta).String()
 			}
 		}
 	}


### PR DESCRIPTION
Two minor optimizations
1. two identical variables, one for `if` check and one for `return` are hard to read.
2. call the `String()` method instead of the `string` func