### PR TITLE
NDS: merge name info by hostname

### DIFF
--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -114,21 +114,34 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 			}
 		}
 
-		nameInfo := &dnsProto.NameTable_NameInfo{
-			Ips:      addressList,
-			Registry: string(svc.Attributes.ServiceRegistry),
+		if ni, f := out.Table[hostName.String()]; !f {
+			nameInfo := &dnsProto.NameTable_NameInfo{
+				Ips:      addressList,
+				Registry: string(svc.Attributes.ServiceRegistry),
+			}
+			if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
+				!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+				// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
+				// No need to provide a DNS entry for each variant.
+				//
+				// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
+				// to avoid conflicting with the entries for the regular (cluster.local) service.
+				nameInfo.Namespace = svc.Attributes.Namespace
+				nameInfo.Shortname = svc.Attributes.Name
+			}
+			out.Table[hostName.String()] = nameInfo
+		} else {
+			ni.Ips = append(ni.Ips, addressList...)
+			// If the ServiceEntry is a decorator of the k8s service, retain k8s attributes
+			if provider.ID(ni.Registry) != provider.Kubernetes &&
+				svc.Attributes.ServiceRegistry == provider.Kubernetes {
+				ni.Registry = string(provider.Kubernetes)
+				if !strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+					ni.Namespace = svc.Attributes.Namespace
+					ni.Shortname = svc.Attributes.Name
+				}
+			}
 		}
-		if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
-			!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
-			// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
-			// No need to provide a DNS entry for each variant.
-			//
-			// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
-			// to avoid conflicting with the entries for the regular (cluster.local) service.
-			nameInfo.Namespace = svc.Attributes.Namespace
-			nameInfo.Shortname = svc.Attributes.Name
-		}
-		out.Table[hostName.String()] = nameInfo
 	}
 	return out
 }

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -168,6 +168,30 @@ func TestNameTable(t *testing.T) {
 		},
 	}
 
+	serviceWithVIP1 := &model.Service{
+		Hostname:       host.Name("mysql.foo.bar"),
+		DefaultAddress: "10.0.0.5",
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "tcp",
+				Port:     3306,
+				Protocol: protocol.TCP,
+			},
+		},
+		Resolution: model.Passthrough,
+		Attributes: model.ServiceAttributes{
+			Name:            "mysql-svc",
+			Namespace:       "testns",
+			ServiceRegistry: provider.External,
+		},
+	}
+	serviceWithVIP2 := serviceWithVIP1.DeepCopy()
+	serviceWithVIP2.DefaultAddress = "10.0.0.6"
+
+	decoratedService := serviceWithVIP1.DeepCopy()
+	decoratedService.DefaultAddress = "10.0.0.7"
+	decoratedService.Attributes.ServiceRegistry = provider.Kubernetes
+
 	push := model.NewPushContext()
 	push.Mesh = mesh
 	push.AddPublicServices([]*model.Service{headlessService})
@@ -187,6 +211,14 @@ func TestNameTable(t *testing.T) {
 	cpush := model.NewPushContext()
 	cpush.Mesh = mesh
 	wpush.AddPublicServices([]*model.Service{cidrService})
+
+	vpush := model.NewPushContext()
+	vpush.Mesh = mesh
+	vpush.AddPublicServices([]*model.Service{serviceWithVIP1, serviceWithVIP2})
+
+	dpush := model.NewPushContext()
+	dpush.Mesh = mesh
+	dpush.AddPublicServices([]*model.Service{serviceWithVIP1, decoratedService})
 
 	sepush := model.NewPushContext()
 	sepush.Mesh = mesh
@@ -416,6 +448,34 @@ func TestNameTable(t *testing.T) {
 					"foo.bar.com": {
 						Ips:      []string{"1.2.3.4", "19.6.7.8", "9.16.7.8"},
 						Registry: "External",
+					},
+				},
+			},
+		},
+		{
+			name:  "service entry with multiple VIPs",
+			proxy: proxy,
+			push:  vpush,
+			expectedNameTable: &dnsProto.NameTable{
+				Table: map[string]*dnsProto.NameTable_NameInfo{
+					serviceWithVIP1.Hostname.String(): {
+						Ips:      []string{serviceWithVIP1.DefaultAddress, serviceWithVIP2.DefaultAddress},
+						Registry: provider.External.String(),
+					},
+				},
+			},
+		},
+		{
+			name:  "service entry as a decorator",
+			proxy: proxy,
+			push:  dpush,
+			expectedNameTable: &dnsProto.NameTable{
+				Table: map[string]*dnsProto.NameTable_NameInfo{
+					serviceWithVIP1.Hostname.String(): {
+						Ips:       []string{serviceWithVIP1.DefaultAddress, decoratedService.DefaultAddress},
+						Registry:  provider.Kubernetes.String(),
+						Shortname: decoratedService.Attributes.Name,
+						Namespace: decoratedService.Attributes.Namespace,
 					},
 				},
 			},

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -472,7 +472,7 @@ func TestNameTable(t *testing.T) {
 			expectedNameTable: &dnsProto.NameTable{
 				Table: map[string]*dnsProto.NameTable_NameInfo{
 					serviceWithVIP1.Hostname.String(): {
-						Ips:       []string{serviceWithVIP1.DefaultAddress, decoratedService.DefaultAddress},
+						Ips:       []string{decoratedService.DefaultAddress},
 						Registry:  provider.Kubernetes.String(),
 						Shortname: decoratedService.Attributes.Name,
 						Namespace: decoratedService.Attributes.Namespace,

--- a/releasenotes/notes/nds-merging.yaml
+++ b/releasenotes/notes/nds-merging.yaml
@@ -1,7 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
-
+issue:
+- https://github.com/istio/istio/pull/43152
 releaseNotes:
   - |
     **Fixed** an issue where sidecars do not proxy DNS properly for a hostname backed by multiple services.

--- a/releasenotes/notes/nds-merging.yaml
+++ b/releasenotes/notes/nds-merging.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue where sidecars do not proxy DNS properly for a hostname backed by multiple services.


### PR DESCRIPTION
**Please provide a description of this PR:**
When a SE has multiple vips, we should merge those ips into the DNS name info instead of overriding
```yaml
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: svc
spec:
  hosts:
  - foo.bar
  addresses:
  - 10.0.0.5
  - 10.0.0.6
  ports:
  - name: tcp
    number: 33333
    protocol: tcp
  location: MESH_EXTERNAL
```