### PR TITLE
Create required directory on service start

### DIFF
--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -136,11 +136,11 @@ if [ "${EXEC_USER}" == "${USER:-}" ] ; then
   INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} "${ISTIO_BIN_BASE}/pilot-agent" proxy "${ISTIO_AGENT_FLAGS_ARRAY[@]}"
 else
 
-# su will mess with the limits set on the process we run. This may lead to quickly exhausting the file limits
-# We will get the host limit and set it in the child as well.
-# TODO(https://superuser.com/questions/1645513/why-does-executing-a-command-in-su-change-limits) can we do better?
-currentLimit=$(ulimit -n)
+  # su will mess with the limits set on the process we run. This may lead to quickly exhausting the file limits
+  # We will get the host limit and set it in the child as well.
+  # TODO(https://superuser.com/questions/1645513/why-does-executing-a-command-in-su-change-limits) can we do better?
+  currentLimit=$(ulimit -n)
 
-# Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-exec sudo -E -u "${EXEC_USER}" -s /bin/bash -c "ulimit -n ${currentLimit}; INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2>> ${ISTIO_LOG_DIR}/istio.err.log >> ${ISTIO_LOG_DIR}/istio.log"
+  # Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
+  exec sudo -E -u "${EXEC_USER}" -s /bin/bash -c "ulimit -n ${currentLimit}; INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2>> ${ISTIO_LOG_DIR}/istio.err.log >> ${ISTIO_LOG_DIR}/istio.log"
 fi

--- a/tools/packaging/common/istio.service
+++ b/tools/packaging/common/istio.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=istio-sidecar: The Istio sidecar
 Documentation=http://istio.io/
+StartLimitIntervalSec=0
 
 [Service]
 ExecStart=/usr/local/bin/istio-start.sh
+ExecStartPre=+/usr/bin/install -d -o istio-proxy -m 0755 /var/run/secrets
 ExecStopPost=/usr/local/bin/istio-start.sh clean
 Restart=always
-StartLimitInterval=0
 RestartSec=10
 KillMode=mixed
 TimeoutStopSec=30s


### PR DESCRIPTION
`/var/run/secrets` is deleted on reboot but required to restart the service, see #42603

Also `[Serivce].StartLimitInterval` is deprecated and has moved/renamed to `[Unit].StartLimitIntervalSec`