### PR TITLE
Optimise validate filter chain match

### DIFF
--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -113,6 +113,8 @@ func validateFilterChainMatch(t testing.TB, l *listener.Listener) {
 				fcms = append(fcms, Dump(t, fc.GetFilterChainMatch()))
 			}
 			t.Errorf("overlapping filter chains %d and %d:\n%v\n Full listener: %v", i1, i2, strings.Join(fcms, ",\n"), Dump(t, l))
+		} else {
+			check[s] = i1
 		}
 		//for i2, l2 := range l.FilterChains {
 		//	if i1 == i2 {

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -15,17 +15,14 @@
 package xdstest
 
 import (
-	"fmt"
-	"strings"
-	"testing"
-	"time"
-
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/util/sets"
+	"strings"
+	"testing"
 )
 
 func ValidateListeners(t testing.TB, ls []*listener.Listener) {
@@ -44,26 +41,11 @@ func ValidateListener(t testing.TB, l *listener.Listener) {
 	if err := l.Validate(); err != nil {
 		t.Errorf("listener %v is invalid: %v", l.Name, err)
 	}
-	bins := time.Now()
 	validateInspector(t, l)
-	ains := time.Now()
-	fmt.Println("inspector diff", ains.Sub(bins))
-	blist := time.Now()
 	validateListenerTLS(t, l)
-	alist := time.Now()
-	fmt.Println("listn diff", alist.Sub(blist))
-	bmatch := time.Now()
 	validateFilterChainMatch(t, l)
-	amatch := time.Now()
-	fmt.Println("match diff", amatch.Sub(bmatch))
-	binb := time.Now()
 	validateInboundListener(t, l)
-	ainb := time.Now()
-	fmt.Println("inb diff", ainb.Sub(binb))
-	blistf := time.Now()
 	validateListenerFilters(t, l)
-	alistf := time.Now()
-	fmt.Println("listf diff", alistf.Sub(blistf))
 }
 
 func validateListenerFilters(t testing.TB, l *listener.Listener) {
@@ -116,18 +98,6 @@ func validateFilterChainMatch(t testing.TB, l *listener.Listener) {
 		} else {
 			check[s] = i1
 		}
-		//for i2, l2 := range l.FilterChains {
-		//	if i1 == i2 {
-		//		continue
-		//	}
-		//	if cmp.Equal(l1.FilterChainMatch, l2.FilterChainMatch, protocmp.Transform()) {
-		//		var fcms []string
-		//		for _, fc := range l.FilterChains {
-		//			fcms = append(fcms, Dump(t, fc.GetFilterChainMatch()))
-		//		}
-		//		t.Errorf("overlapping filter chains %d and %d:\n%v\n Full listener: %v", i1, i2, strings.Join(fcms, ",\n"), Dump(t, l))
-		//	}
-		//}
 	}
 
 	// Due to the trie based logic of FCM, an unset field is only a wildcard if no

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -15,14 +15,16 @@
 package xdstest
 
 import (
+	"strings"
+	"testing"
+
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/util/sets"
-	"strings"
-	"testing"
 )
 
 func ValidateListeners(t testing.TB, ls []*listener.Listener) {


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR proposes to refactor `validateFilterChainMatch` to make it linear.

This brings `istio.io/istio/pilot/pkg/networking/core/v1alpha3` package test execution from ~30s to ~7s

Contributes to #37555 