### PR TITLE
feat: Added extra args to the istiod helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
 {{- if .Values.pilot.plugins }}
           - --plugins={{ .Values.pilot.plugins }}
 {{- end }}
+{{- if .Values.pilot.extraArgs }}
+{{ toYaml .Values.pilot.extraArgs | trim | indent 10 }}
+{{- end }}
           - --keepaliveMaxServerConnectionAge
           - "{{ .Values.pilot.keepaliveMaxServerConnectionAge }}"
           ports:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -53,6 +53,10 @@ pilot:
 
   plugins: []
 
+  ## This is used to add extra arguments
+  ## very usefull to add arguments like --tlsCertFile, --tlsKeyFile, --caCertFile
+  extraArgs: []
+
   # The following is used to limit how long a sidecar can be connected
   # to a pilot. It balances out load across pilot instances at the cost of
   # increasing system churn.


### PR DESCRIPTION
Hello Istio Comunity,

I was deploying the `istio` using helm by following the official documentation and I was not able to find the proper way of adding the extra arguments to `istiod` helm chart. Its very useful to add the arguments see the example below 
```
      - args:
        - discovery
        - --monitoringAddr=:15014
        - --log_output_level=default:info
        - --domain
        - cluster.local
        - --keepaliveMaxServerConnectionAge
        - 30m
        - --tlsCertFile=/var/run/secrets/istiod/tls/tls.crt
        - --tlsKeyFile=/var/run/secrets/istiod/tls/tls.key
        - --caCertFile=/var/run/secrets/istiod/tls/ca.crt
```

The values.yaml
```
  extraArgs:
  - --tlsCertFile=/var/run/secrets/istiod/tls/tls.crt
  - --tlsKeyFile=/var/run/secrets/istiod/tls/tls.key
  - --caCertFile=/var/run/secrets/istiod/tls/ca.crt
```
By using this feature during the helm deployment I am adding my root ca and CA for the istiod to use it 