### PR TITLE
Support appProtocol for iop components servicePorts

### DIFF
--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -408,6 +408,9 @@ func (t *Translator) fixMergedObjectWithCustomServicePortOverlay(oo *object.K8sO
 			Port:     p.GetPort(),
 			NodePort: p.GetNodePort(),
 		}
+		if p.GetAppProtocol() != "" {
+			port.AppProtocol = &p.AppProtocol
+		}
 		if p.TargetPort != nil {
 			port.TargetPort = p.TargetPort.ToKubernetes()
 		}

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -409,7 +409,8 @@ func (t *Translator) fixMergedObjectWithCustomServicePortOverlay(oo *object.K8sO
 			NodePort: p.GetNodePort(),
 		}
 		if p.GetAppProtocol() != "" {
-			port.AppProtocol = &p.AppProtocol
+			ap := p.AppProtocol
+			port.AppProtocol = &ap
 		}
 		if p.TargetPort != nil {
 			port.TargetPort = p.TargetPort.ToKubernetes()

--- a/releasenotes/notes/43173.yaml
+++ b/releasenotes/notes/43173.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** `appProtocol` field not taking effect in IstioOperator ServicePort.


### PR DESCRIPTION
**Please provide a description of this PR:**
Impl of https://github.com/istio/istio/issues/42759.
Needs to make sure only pass the pointer to the struct if `appProtocol` has a value, otherwise it will have regex errors.