### PR TITLE
Add port flags to different dashboard cmds

### DIFF
--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -33,8 +33,14 @@ import (
 )
 
 var (
-	listenPort   = 0
-	controlZport = 0
+	listenPort     = 0
+	controlZport   = 0
+	promPort       = 0
+	grafanaPort    = 0
+	kialiPort      = 0
+	jaegerPort     = 0
+	zipkinPort     = 0
+	skywalkingPort = 0
 
 	bindAddress = ""
 
@@ -47,6 +53,15 @@ var (
 	addonNamespace = ""
 
 	envoyDashNs = ""
+)
+
+const (
+	defaultPrometheusPort = 9090
+	defaultGrafanaPort    = 3000
+	defaultKialiPort      = 20001
+	defaultJaegerPort     = 16686
+	defaultZipkinPort     = 9411
+	defaultSkywalkingPort = 12800
 )
 
 // port-forward to Istio System Prometheus; open browser
@@ -78,7 +93,7 @@ func promDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "Prometheus",
-				"http://%s", bindAddress, 9090, client, cmd.OutOrStdout(), browser)
+				"http://%s", bindAddress, promPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -114,7 +129,7 @@ func grafanaDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "Grafana",
-				"http://%s", bindAddress, 3000, client, cmd.OutOrStdout(), browser)
+				"http://%s", bindAddress, grafanaPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -150,7 +165,7 @@ func kialiDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "Kiali",
-				"http://%s/kiali", bindAddress, 20001, client, cmd.OutOrStdout(), browser)
+				"http://%s/kiali", bindAddress, kialiPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -186,7 +201,7 @@ func jaegerDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "Jaeger",
-				"http://%s", bindAddress, 16686, client, cmd.OutOrStdout(), browser)
+				"http://%s", bindAddress, jaegerPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -222,7 +237,7 @@ func zipkinDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "Zipkin",
-				"http://%s", bindAddress, 9411, client, cmd.OutOrStdout(), browser)
+				"http://%s", bindAddress, zipkinPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -289,7 +304,7 @@ func envoyDashCmd() *cobra.Command {
 			}
 
 			return portForward(podName, ns, fmt.Sprintf("Envoy sidecar %s", podName),
-				"http://%s", bindAddress, 15000, client, c.OutOrStdout(), browser)
+				"http://%s", bindAddress, proxyAdminPort, client, c.OutOrStdout(), browser)
 		},
 	}
 
@@ -396,7 +411,7 @@ func skywalkingDashCmd() *cobra.Command {
 
 			// only use the first pod in the list
 			return portForward(pl.Items[0].Name, addonNamespace, "SkyWalking",
-				"http://%s", bindAddress, 8080, client, cmd.OutOrStdout(), browser)
+				"http://%s", bindAddress, skywalkingPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
 
@@ -510,17 +525,35 @@ func dashboard() *cobra.Command {
 	dashboardCmd.PersistentFlags().StringVarP(&addonNamespace, "namespace", "n", istioNamespace,
 		"Namespace where the addon is running, if not specified, istio-system would be used")
 
-	dashboardCmd.AddCommand(kialiDashCmd())
-	dashboardCmd.AddCommand(promDashCmd())
-	dashboardCmd.AddCommand(grafanaDashCmd())
-	dashboardCmd.AddCommand(jaegerDashCmd())
-	dashboardCmd.AddCommand(zipkinDashCmd())
-	dashboardCmd.AddCommand(skywalkingDashCmd())
+	kiali := kialiDashCmd()
+	kiali.PersistentFlags().IntVar(&kialiPort, "kiali_port", defaultKialiPort, "Kiali port")
+	dashboardCmd.AddCommand(kiali)
+
+	prom := promDashCmd()
+	prom.PersistentFlags().IntVar(&promPort, "prom_port", defaultPrometheusPort, "Prometheus port")
+	dashboardCmd.AddCommand(prom)
+
+	graf := grafanaDashCmd()
+	graf.PersistentFlags().IntVar(&grafanaPort, "grafana_port", defaultGrafanaPort, "Grafana port")
+	dashboardCmd.AddCommand(graf)
+
+	jaeger := jaegerDashCmd()
+	jaeger.PersistentFlags().IntVar(&jaegerPort, "jaeger_port", defaultJaegerPort, "Jaeger port")
+	dashboardCmd.AddCommand(jaeger)
+
+	zipkin := zipkinDashCmd()
+	zipkin.PersistentFlags().IntVar(&zipkinPort, "zipkin_port", defaultZipkinPort, "Zipkin port")
+	dashboardCmd.AddCommand(zipkin)
+
+	skywalking := skywalkingDashCmd()
+	skywalking.PersistentFlags().IntVar(&skywalkingPort, "skywalking_port", defaultSkywalkingPort, "Skywalking port")
+	dashboardCmd.AddCommand(skywalking)
 
 	envoy := envoyDashCmd()
 	envoy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	envoy.PersistentFlags().StringVarP(&envoyDashNs, "namespace", "n", defaultNamespace,
 		"Namespace where the addon is running, if not specified, istio-system would be used")
+	envoy.PersistentFlags().IntVar(&proxyAdminPort, "envoy_port", defaultProxyAdminPort, "Envoy listen port")
 	dashboardCmd.AddCommand(envoy)
 
 	controlz := controlZDashCmd()

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -526,34 +526,34 @@ func dashboard() *cobra.Command {
 		"Namespace where the addon is running, if not specified, istio-system would be used")
 
 	kiali := kialiDashCmd()
-	kiali.PersistentFlags().IntVar(&kialiPort, "kiali_port", defaultKialiPort, "Kiali port")
+	kiali.PersistentFlags().IntVar(&kialiPort, "ui-port", defaultKialiPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(kiali)
 
 	prom := promDashCmd()
-	prom.PersistentFlags().IntVar(&promPort, "prom_port", defaultPrometheusPort, "Prometheus port")
+	prom.PersistentFlags().IntVar(&promPort, "ui-port", defaultPrometheusPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(prom)
 
 	graf := grafanaDashCmd()
-	graf.PersistentFlags().IntVar(&grafanaPort, "grafana_port", defaultGrafanaPort, "Grafana port")
+	graf.PersistentFlags().IntVar(&grafanaPort, "ui-port", defaultGrafanaPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(graf)
 
 	jaeger := jaegerDashCmd()
-	jaeger.PersistentFlags().IntVar(&jaegerPort, "jaeger_port", defaultJaegerPort, "Jaeger port")
+	jaeger.PersistentFlags().IntVar(&jaegerPort, "ui-port", defaultJaegerPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(jaeger)
 
 	zipkin := zipkinDashCmd()
-	zipkin.PersistentFlags().IntVar(&zipkinPort, "zipkin_port", defaultZipkinPort, "Zipkin port")
+	zipkin.PersistentFlags().IntVar(&zipkinPort, "ui-port", defaultZipkinPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(zipkin)
 
 	skywalking := skywalkingDashCmd()
-	skywalking.PersistentFlags().IntVar(&skywalkingPort, "skywalking_port", defaultSkywalkingPort, "Skywalking port")
+	skywalking.PersistentFlags().IntVar(&skywalkingPort, "ui-port", defaultSkywalkingPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(skywalking)
 
 	envoy := envoyDashCmd()
 	envoy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	envoy.PersistentFlags().StringVarP(&envoyDashNs, "namespace", "n", defaultNamespace,
 		"Namespace where the addon is running, if not specified, istio-system would be used")
-	envoy.PersistentFlags().IntVar(&proxyAdminPort, "envoy_port", defaultProxyAdminPort, "Envoy listen port")
+	envoy.PersistentFlags().IntVar(&proxyAdminPort, "ui-port", defaultProxyAdminPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(envoy)
 
 	controlz := controlZDashCmd()

--- a/releasenotes/notes/dashboard-custom-port.yaml
+++ b/releasenotes/notes/dashboard-custom-port.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** local flags for different `istioctl dashboard` commands to allow users to specify the component port to use for the dashboard.

--- a/releasenotes/notes/dashboard-custom-port.yaml
+++ b/releasenotes/notes/dashboard-custom-port.yaml
@@ -3,4 +3,4 @@ kind: feature
 area: istioctl
 releaseNotes:
   - |
-    **Added** local flags for different `istioctl dashboard` commands to allow users to specify the component port to use for the dashboard.
+    **Added** local flags `--ui-port` for different `istioctl dashboard` commands to allow users to specify the component UI port to use for the dashboard.


### PR DESCRIPTION
**Please provide a description of this PR:**
Allow users to specify component ports.
And also fix default skywalking port.