### PR TITLE
WIP - Improve multicluster update handling

### DIFF
--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -43,7 +43,7 @@ func NewMulticluster(configCluster cluster.ID) *Multicluster {
 	return m
 }
 
-func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, _ <-chan struct{}) error {
+func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, _ <-chan struct{}, update bool) error {
 	log.Infof("initializing Kubernetes credential reader for cluster %v", cluster.ID)
 	sc := NewCredentialsController(cluster.Client, cluster.ID)
 	m.m.Lock()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -315,6 +315,9 @@ type XDSUpdater interface {
 	// SvcUpdate is called when a service definition is updated/deleted.
 	SvcUpdate(shard ShardKey, hostname string, namespace string, event Event)
 
+	// SvcAudit is called when services may have been deleted during a controller update.
+	SvcAudit(shard ShardKey, services []*Service)
+
 	// ConfigUpdate is called to notify the XDS server of config updates and request a push.
 	// The requests may be collapsed and throttled.
 	ConfigUpdate(req *PushRequest)

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -370,6 +370,8 @@ func (f *FakeXdsUpdater) EDSCacheUpdate(_ model.ShardKey, _, _ string, _ []*mode
 
 func (f *FakeXdsUpdater) SvcUpdate(_ model.ShardKey, _, _ string, _ model.Event) {}
 
+func (f *FakeXdsUpdater) SvcAudit(_ model.ShardKey, _ []*model.Service) {}
+
 func (f *FakeXdsUpdater) ProxyUpdate(_ cluster2.ID, _ string) {}
 
 func (f *FakeXdsUpdater) RemoveShard(_ model.ShardKey) {}

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -96,6 +96,8 @@ func (fx *FakeXdsUpdater) EDSCacheUpdate(_ model.ShardKey, hostname, _ string, e
 	}
 }
 
+func (fx *FakeXdsUpdater) SvcAudit(_ model.ShardKey, _ []*model.Service) {}
+
 // SvcUpdate is called when a service port mapping definition is updated.
 // This interface is WIP - labels, annotations and other changes to service may be
 // updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -102,6 +102,8 @@ func (fx *FakeXdsUpdater) ProxyUpdate(_ cluster.ID, ip string) {
 	fx.Events <- Event{kind: "xds", proxyIP: ip}
 }
 
+func (fx *FakeXdsUpdater) SvcAudit(_ model.ShardKey, _ []*model.Service) {}
+
 func (fx *FakeXdsUpdater) SvcUpdate(_ model.ShardKey, hostname string, namespace string, _ model.Event) {
 	fx.Events <- Event{kind: "svcupdate", host: hostname, namespace: namespace}
 }

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -190,7 +190,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			client.RunAndWait(stop)
 		}
 		registries = append(registries, k8s)
-		if err := creds.ClusterAdded(&multicluster.Cluster{ID: k8sCluster, Client: client}, nil); err != nil {
+		if err := creds.ClusterAdded(&multicluster.Cluster{ID: k8sCluster, Client: client}, nil, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -556,6 +556,7 @@ func (fx *FakeXdsUpdater) ProxyUpdate(c cluster.ID, p string) {
 		fx.Delegate.ProxyUpdate(c, p)
 	}
 }
+func (fx *FakeXdsUpdater) SvcAudit(_ model.ShardKey, _ []*model.Service) {}
 
 func (fx *FakeXdsUpdater) SvcUpdate(s model.ShardKey, hostname string, namespace string, e model.Event) {
 	fx.Events <- FakeXdsEvent{Kind: "svcupdate", Host: hostname, Namespace: namespace}

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -71,7 +71,7 @@ var _ ClusterHandler = &handler{}
 
 type handler struct{}
 
-func (h handler) ClusterAdded(cluster *Cluster, stop <-chan struct{}) error {
+func (h handler) ClusterAdded(cluster *Cluster, stop <-chan struct{}, update bool) error {
 	mu.Lock()
 	defer mu.Unlock()
 	added = cluster.ID


### PR DESCRIPTION
When a remote cluster is updated stop the informers but don't cleanup.  During the subsequent add of the new kube clients perform audits after the sync where needed to clean things up.

**Please provide a description of this PR:**

Resolves the final check box of: https://github.com/istio/enhancements/pull/107