### PR TITLE
tf: refactor ports to store full object

### DIFF
--- a/pkg/test/framework/components/echo/common/ports/ports.go
+++ b/pkg/test/framework/components/echo/common/ports/ports.go
@@ -20,44 +20,44 @@ import (
 )
 
 // Port names.
-const (
-	HTTP             = "http"
-	GRPC             = "grpc"
-	HTTP2            = "http2"
-	TCP              = "tcp"
-	HTTPS            = "https"
-	TCPServer        = "tcp-server"
-	AutoTCP          = "auto-tcp"
-	AutoTCPServer    = "auto-tcp-server"
-	AutoHTTP         = "auto-http"
-	AutoGRPC         = "auto-grpc"
-	AutoHTTPS        = "auto-https"
-	HTTPInstance     = "http-instance"
-	HTTPLocalHost    = "http-localhost"
-	TCPWorkloadOnly  = "tcp-wl-only"
-	HTTPWorkloadOnly = "http-wl-only"
-	TCPForHTTP       = "tcp-for-http"
+var (
+	HTTP             = echo.Port{Name: "http", Protocol: protocol.HTTP, ServicePort: 80, WorkloadPort: 18080}
+	GRPC             = echo.Port{Name: "grpc", Protocol: protocol.GRPC, ServicePort: 7070, WorkloadPort: 17070}
+	HTTP2            = echo.Port{Name: "http2", Protocol: protocol.HTTP, ServicePort: 85, WorkloadPort: 18085}
+	TCP              = echo.Port{Name: "tcp", Protocol: protocol.TCP, ServicePort: 9090, WorkloadPort: 19090}
+	HTTPS            = echo.Port{Name: "https", Protocol: protocol.HTTPS, ServicePort: 443, WorkloadPort: 18443, TLS: true}
+	TCPServer        = echo.Port{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 9091, WorkloadPort: 16060, ServerFirst: true}
+	AutoTCP          = echo.Port{Name: "auto-tcp", Protocol: protocol.TCP, ServicePort: 9092, WorkloadPort: 19091}
+	AutoTCPServer    = echo.Port{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 9093, WorkloadPort: 16061, ServerFirst: true}
+	AutoHTTP         = echo.Port{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 81, WorkloadPort: 18081}
+	AutoGRPC         = echo.Port{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, WorkloadPort: 17071}
+	AutoHTTPS        = echo.Port{Name: "auto-https", Protocol: protocol.HTTPS, ServicePort: 9443, WorkloadPort: 19443, TLS: true}
+	HTTPInstance     = echo.Port{Name: "http-instance", Protocol: protocol.HTTP, ServicePort: 82, WorkloadPort: 18082, InstanceIP: true}
+	HTTPLocalHost    = echo.Port{Name: "http-localhost", Protocol: protocol.HTTP, ServicePort: 84, WorkloadPort: 18084, LocalhostIP: true}
+	TCPWorkloadOnly  = echo.Port{Name: "tcp-wl-only", Protocol: protocol.TCP, ServicePort: echo.NoServicePort, WorkloadPort: 19092}
+	HTTPWorkloadOnly = echo.Port{Name: "http-wl-only", Protocol: protocol.HTTP, ServicePort: echo.NoServicePort, WorkloadPort: 18083}
+	TCPForHTTP       = echo.Port{Name: "tcp-for-http", Protocol: protocol.HTTP, ServicePort: 86, WorkloadPort: 18086}
 )
 
 // All the common ports.
 func All() echo.Ports {
 	return echo.Ports{
-		{Name: HTTP, Protocol: protocol.HTTP, ServicePort: 80, WorkloadPort: 18080},
-		{Name: GRPC, Protocol: protocol.GRPC, ServicePort: 7070, WorkloadPort: 17070},
-		{Name: HTTP2, Protocol: protocol.HTTP, ServicePort: 85, WorkloadPort: 18085},
-		{Name: TCP, Protocol: protocol.TCP, ServicePort: 9090, WorkloadPort: 19090},
-		{Name: HTTPS, Protocol: protocol.HTTPS, ServicePort: 443, WorkloadPort: 18443, TLS: true},
-		{Name: TCPServer, Protocol: protocol.TCP, ServicePort: 9091, WorkloadPort: 16060, ServerFirst: true},
-		{Name: AutoTCP, Protocol: protocol.TCP, ServicePort: 9092, WorkloadPort: 19091},
-		{Name: AutoTCPServer, Protocol: protocol.TCP, ServicePort: 9093, WorkloadPort: 16061, ServerFirst: true},
-		{Name: AutoHTTP, Protocol: protocol.HTTP, ServicePort: 81, WorkloadPort: 18081},
-		{Name: AutoGRPC, Protocol: protocol.GRPC, ServicePort: 7071, WorkloadPort: 17071},
-		{Name: AutoHTTPS, Protocol: protocol.HTTPS, ServicePort: 9443, WorkloadPort: 19443, TLS: true},
-		{Name: HTTPInstance, Protocol: protocol.HTTP, ServicePort: 82, WorkloadPort: 18082, InstanceIP: true},
-		{Name: HTTPLocalHost, Protocol: protocol.HTTP, ServicePort: 84, WorkloadPort: 18084, LocalhostIP: true},
-		{Name: TCPWorkloadOnly, Protocol: protocol.TCP, ServicePort: echo.NoServicePort, WorkloadPort: 19092},
-		{Name: HTTPWorkloadOnly, Protocol: protocol.HTTP, ServicePort: echo.NoServicePort, WorkloadPort: 18083},
-		{Name: TCPForHTTP, Protocol: protocol.HTTP, ServicePort: 86, WorkloadPort: 18086},
+		HTTP,
+		GRPC,
+		HTTP2,
+		TCP,
+		HTTPS,
+		TCPServer,
+		AutoTCP,
+		AutoTCPServer,
+		AutoHTTP,
+		AutoGRPC,
+		AutoHTTPS,
+		HTTPInstance,
+		HTTPLocalHost,
+		TCPWorkloadOnly,
+		HTTPWorkloadOnly,
+		TCPForHTTP,
 	}
 }
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -471,7 +471,7 @@ spec:
 							return err
 						}
 						return ExpectString(r.ResponseHeaders.Get("Location"),
-							fmt.Sprintf("https://%s:%d/foo", originalHostname.Hostname(), ports.All().MustForName("http").ServicePort),
+							fmt.Sprintf("https://%s:%d/foo", originalHostname.Hostname(), ports.HTTP.ServicePort),
 							"Location")
 					})),
 		},
@@ -975,8 +975,8 @@ func autoPassthroughCases(t TrafficContext) {
 
 	mtlsHost := host.Name(t.Apps.A.Config().ClusterLocalFQDN())
 	nakedHost := host.Name(t.Apps.Naked.Config().ClusterLocalFQDN())
-	httpsPort := ports.All().MustForName("https").ServicePort
-	httpsAutoPort := ports.All().MustForName("auto-https").ServicePort
+	httpsPort := ports.HTTP.ServicePort
+	httpsAutoPort := ports.AutoHTTPS.ServicePort
 	snis := []string{
 		model.BuildSubsetKey(model.TrafficDirectionOutbound, "", mtlsHost, httpsPort),
 		model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", mtlsHost, httpsPort),
@@ -1056,7 +1056,7 @@ func gatewayCases(t TrafficContext) {
 			"GatewayProtocol":    string(protocol),
 			"Gateway":            "gateway",
 			"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-			"Port":               dest.PortForName("http").ServicePort,
+			"Port":               ports.HTTP.ServicePort,
 			"Credential":         cred,
 			"Ciphers":            ciphers,
 		}
@@ -1197,7 +1197,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               dest.PortForName("http").ServicePort,
+				"Port":               ports.HTTP.ServicePort,
 			}
 		},
 	})
@@ -1369,7 +1369,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               ports.All().MustForName("auto-http").ServicePort,
+				"Port":               ports.AutoHTTP.ServicePort,
 			}
 		},
 	})
@@ -1416,7 +1416,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               ports.All().MustForName("auto-http").ServicePort,
+				"Port":               ports.AutoHTTP.ServicePort,
 			}
 		},
 	})
@@ -1492,12 +1492,12 @@ spec:
 				"Gateway":            "gateway",
 				"VirtualServiceHost": "*.example.com",
 				"DestinationHost":    dests[0].Config().ClusterLocalFQDN(),
-				"Port":               ports.All().MustForName(ports.HTTP).ServicePort,
+				"Port":               ports.HTTP.ServicePort,
 			}
 		},
 	})
 
-	for _, port := range []string{"auto-http", "http", "http2"} {
+	for _, port := range []echo.Port{ports.AutoHTTP, ports.HTTP, ports.HTTP2} {
 		for _, h2 := range []bool{true, false} {
 			port, h2 := port, h2
 			protoName := "http1"
@@ -1550,7 +1550,7 @@ spec:
 					return map[string]any{
 						"Gateway":            "gateway",
 						"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-						"Port":               ports.All().MustForName(port).ServicePort,
+						"Port":               port.ServicePort,
 					}
 				},
 			})
@@ -1628,7 +1628,7 @@ func ProxyProtocolFilterNotAppliedGatewayCase(apps *deployment.SingleNamespaceVi
 			// This creates a Gateway with a TCP listener that will accept TCP traffic from host
 			// `fqdn` and forward that traffic back to `fqdn`, from srcPort to targetPort
 			config: httpGateway("*", gatewayListenPort, gatewayListenPortName, "TCP") +
-				tcpVirtualService("gateway", fqdn, "", 80, d[0].PortForName("tcp").ServicePort),
+				tcpVirtualService("gateway", fqdn, "", 80, ports.TCP.ServicePort),
 			call: apps.Naked[0].CallOrFail,
 			opts: echo.CallOptions{
 				Count:                1,
@@ -1686,7 +1686,7 @@ func ProxyProtocolFilterAppliedGatewayCase(apps *deployment.SingleNamespaceView,
 			// This creates a Gateway with a TCP listener that will accept TCP traffic from host
 			// `fqdn` and forward that traffic back to `fqdn`, from srcPort to targetPort
 			config: httpGateway("*", gatewayListenPort, gatewayListenPortName, "TCP") +
-				tcpVirtualService("gateway", fqdn, "", 80, d[0].PortForName("tcp").ServicePort),
+				tcpVirtualService("gateway", fqdn, "", 80, ports.TCP.ServicePort),
 			call: apps.Naked[0].CallOrFail,
 			opts: echo.CallOptions{
 				Count:   1,
@@ -1716,7 +1716,6 @@ func ProxyProtocolFilterAppliedGatewayCase(apps *deployment.SingleNamespaceView,
 func XFFGatewayCase(apps *deployment.SingleNamespaceView, gateway string) []TrafficTestCase {
 	var cases []TrafficTestCase
 	gatewayListenPort := 80
-	gatewayListenPortName := "http"
 
 	destinationSets := []echo.Instances{
 		apps.A,
@@ -1730,8 +1729,8 @@ func XFFGatewayCase(apps *deployment.SingleNamespaceView, gateway string) []Traf
 		fqdn := d[0].Config().ClusterLocalFQDN()
 		cases = append(cases, TrafficTestCase{
 			name: d[0].Config().Service,
-			config: httpGateway("*", gatewayListenPort, gatewayListenPortName, "HTTP") +
-				httpVirtualService("gateway", fqdn, d[0].PortForName(gatewayListenPortName).ServicePort),
+			config: httpGateway("*", gatewayListenPort, ports.HTTP.Name, "HTTP") +
+				httpVirtualService("gateway", fqdn, ports.HTTP.ServicePort),
 			call: apps.Naked[0].CallOrFail,
 			opts: echo.CallOptions{
 				Count:   1,
@@ -1897,7 +1896,7 @@ spec:
 func hostCases(t TrafficContext) {
 	for _, c := range t.Apps.A {
 		cfg := t.Apps.Headless.Config()
-		port := ports.All().MustForName("auto-http").WorkloadPort
+		port := ports.AutoHTTP.WorkloadPort
 		wl := t.Apps.Headless[0].WorkloadsOrFail(t)
 		if len(wl) == 0 {
 			t.Fatalf("no workloads found")
@@ -1944,7 +1943,7 @@ func hostCases(t TrafficContext) {
 				},
 			})
 		}
-		port = ports.All().MustForName("http").WorkloadPort
+		port = ports.HTTP.WorkloadPort
 		hosts = []string{
 			cfg.ClusterLocalFQDN(),
 			fmt.Sprintf("%s:%d", cfg.ClusterLocalFQDN(), port),
@@ -2022,7 +2021,7 @@ spec:
     port: %d
     targetPort: %d
   selector:
-    app: b`, ports.All().MustForName("http").ServicePort, ports.All().MustForName("http").WorkloadPort)
+    app: b`, ports.HTTP.ServicePort, ports.HTTP.WorkloadPort)
 		t.RunTraffic(TrafficTestCase{
 			name:   fmt.Sprintf("case 1 both match in cluster %v", c.Config().Cluster.StableName()),
 			config: svc,
@@ -2030,7 +2029,7 @@ spec:
 			opts: echo.CallOptions{
 				Count:   1,
 				Address: "b-alt-1",
-				Port:    echo.Port{ServicePort: ports.All().MustForName("http").ServicePort, Protocol: protocol.HTTP},
+				Port:    echo.Port{ServicePort: ports.HTTP.ServicePort, Protocol: protocol.HTTP},
 				Timeout: time.Millisecond * 100,
 				Check:   check.OK(),
 			},
@@ -2051,7 +2050,7 @@ spec:
     port: %d
     targetPort: %d
   selector:
-    app: b`, ports.All().MustForName("http").ServicePort, ports.All().GetWorkloadOnlyPorts()[0].WorkloadPort)
+    app: b`, ports.HTTP.ServicePort, ports.All().GetWorkloadOnlyPorts()[0].WorkloadPort)
 		t.RunTraffic(TrafficTestCase{
 			name:   fmt.Sprintf("case 2 service port match in cluster %v", c.Config().Cluster.StableName()),
 			config: svc,
@@ -2059,7 +2058,7 @@ spec:
 			opts: echo.CallOptions{
 				Count:   1,
 				Address: "b-alt-2",
-				Port:    echo.Port{ServicePort: ports.All().MustForName("http").ServicePort, Protocol: protocol.TCP},
+				Port:    echo.Port{ServicePort: ports.HTTP.ServicePort, Protocol: protocol.TCP},
 				Scheme:  scheme.TCP,
 				Timeout: time.Millisecond * 100,
 				Check:   check.OK(),
@@ -2080,7 +2079,7 @@ spec:
     port: 12345
     targetPort: %d
   selector:
-    app: b`, ports.All().MustForName("http").WorkloadPort)
+    app: b`, ports.HTTP.WorkloadPort)
 		t.RunTraffic(TrafficTestCase{
 			name:   fmt.Sprintf("case 3 target port match in cluster %v", c.Config().Cluster.StableName()),
 			config: svc,
@@ -2161,12 +2160,12 @@ spec:
 `, map[string]any{
 				"Service":        svcName,
 				"Network":        c.Config().Cluster.NetworkName(),
-				"Port":           ports.All().MustForName("http").ServicePort,
-				"TargetPort":     ports.All().MustForName("http").WorkloadPort,
-				"TcpPort":        ports.All().MustForName("tcp").ServicePort,
-				"TcpTargetPort":  ports.All().MustForName("tcp").WorkloadPort,
-				"GrpcPort":       ports.All().MustForName("grpc").ServicePort,
-				"GrpcTargetPort": ports.All().MustForName("grpc").WorkloadPort,
+				"Port":           ports.HTTP.ServicePort,
+				"TargetPort":     ports.HTTP.WorkloadPort,
+				"TcpPort":        ports.TCP.ServicePort,
+				"TcpTargetPort":  ports.TCP.WorkloadPort,
+				"GrpcPort":       ports.GRPC.ServicePort,
+				"GrpcTargetPort": ports.GRPC.WorkloadPort,
 			})
 
 			destRule := fmt.Sprintf(`
@@ -2191,7 +2190,7 @@ spec:
 				opts: echo.CallOptions{
 					Count:   10,
 					Address: svcName,
-					Port:    echo.Port{ServicePort: ports.All().MustForName("http").ServicePort, Protocol: protocol.HTTP},
+					Port:    echo.Port{ServicePort: ports.HTTP.ServicePort, Protocol: protocol.HTTP},
 					Check: check.And(
 						check.OK(),
 						func(result echo.CallResult, rerr error) error {
@@ -2211,7 +2210,7 @@ spec:
 					Path:    "/?some-query-param=bar",
 					Headers: headers.New().With("x-some-header", "baz").Build(),
 				},
-				Port: echo.Port{ServicePort: ports.All().MustForName("http").ServicePort, Protocol: protocol.HTTP},
+				Port: echo.Port{ServicePort: ports.HTTP.ServicePort, Protocol: protocol.HTTP},
 				Check: check.And(
 					check.OK(),
 					ConsistentHostChecker,
@@ -2220,14 +2219,14 @@ spec:
 			tcpCallopts := echo.CallOptions{
 				Count:   10,
 				Address: svcName,
-				Port:    echo.Port{ServicePort: ports.All().MustForName("tcp").ServicePort, Protocol: protocol.TCP},
+				Port:    echo.Port{ServicePort: ports.TCP.ServicePort, Protocol: protocol.TCP},
 				Check: check.And(
 					check.OK(),
 					ConsistentHostChecker,
 				),
 			}
 			if c.Config().WorkloadClass() == echo.Proxyless {
-				callOpts.Port = echo.Port{ServicePort: ports.All().MustForName("grpc").ServicePort, Protocol: protocol.GRPC}
+				callOpts.Port = echo.Port{ServicePort: ports.GRPC.ServicePort, Protocol: protocol.GRPC}
 			}
 			// Setup tests for various forms of the API
 			// TODO: it may be necessary to vary the inputs of the hash and ensure we get a different backend
@@ -2406,8 +2405,8 @@ func protocolSniffingCases(t TrafficContext) {
 		})
 	}
 
-	autoPort := ports.All().MustForName("auto-http")
-	httpPort := ports.All().MustForName("http")
+	autoPort := ports.AutoHTTP
+	httpPort := ports.HTTP
 	// Tests for http1.0. Golang does not support 1.0 client requests at all
 	// To simulate these, we use TCP and hand-craft the requests.
 	t.RunTraffic(TrafficTestCase{
@@ -2501,7 +2500,7 @@ func instanceIPTests(t TrafficContext) {
 		name            string
 		endpoint        string
 		disableSidecar  bool
-		port            string
+		port            echo.Port
 		code            int
 		minIstioVersion string
 	}{
@@ -2509,25 +2508,25 @@ func instanceIPTests(t TrafficContext) {
 		{
 			name:           "instance IP without sidecar",
 			disableSidecar: true,
-			port:           "http-instance",
+			port:           ports.HTTPInstance,
 			code:           http.StatusOK,
 		},
 		{
 			name:     "instance IP with wildcard sidecar",
 			endpoint: "0.0.0.0",
-			port:     "http-instance",
+			port:     ports.HTTPInstance,
 			code:     http.StatusOK,
 		},
 		{
 			name:     "instance IP with localhost sidecar",
 			endpoint: "127.0.0.1",
-			port:     "http-instance",
+			port:     ports.HTTPInstance,
 			code:     http.StatusServiceUnavailable,
 		},
 		{
 			name:     "instance IP with empty sidecar",
 			endpoint: "",
-			port:     "http-instance",
+			port:     ports.HTTPInstance,
 			code:     http.StatusOK,
 		},
 
@@ -2535,7 +2534,7 @@ func instanceIPTests(t TrafficContext) {
 		{
 			name:           "localhost IP without sidecar",
 			disableSidecar: true,
-			port:           "http-localhost",
+			port:           ports.HTTPLocalHost,
 			code:           http.StatusServiceUnavailable,
 			// when testing with pre-1.10 versions this request succeeds
 			minIstioVersion: "1.10.0",
@@ -2543,19 +2542,19 @@ func instanceIPTests(t TrafficContext) {
 		{
 			name:     "localhost IP with wildcard sidecar",
 			endpoint: "0.0.0.0",
-			port:     "http-localhost",
+			port:     ports.HTTPLocalHost,
 			code:     http.StatusServiceUnavailable,
 		},
 		{
 			name:     "localhost IP with localhost sidecar",
 			endpoint: "127.0.0.1",
-			port:     "http-localhost",
+			port:     ports.HTTPLocalHost,
 			code:     http.StatusOK,
 		},
 		{
 			name:     "localhost IP with empty sidecar",
 			endpoint: "",
-			port:     "http-localhost",
+			port:     ports.HTTPLocalHost,
 			code:     http.StatusServiceUnavailable,
 			// when testing with pre-1.10 versions this request succeeds
 			minIstioVersion: "1.10.0",
@@ -2565,25 +2564,25 @@ func instanceIPTests(t TrafficContext) {
 		{
 			name:           "wildcard IP without sidecar",
 			disableSidecar: true,
-			port:           "http",
+			port:           ports.HTTP,
 			code:           http.StatusOK,
 		},
 		{
 			name:     "wildcard IP with wildcard sidecar",
 			endpoint: "0.0.0.0",
-			port:     "http",
+			port:     ports.HTTP,
 			code:     http.StatusOK,
 		},
 		{
 			name:     "wildcard IP with localhost sidecar",
 			endpoint: "127.0.0.1",
-			port:     "http",
+			port:     ports.HTTP,
 			code:     http.StatusOK,
 		},
 		{
 			name:     "wildcard IP with empty sidecar",
 			endpoint: "",
-			port:     "http",
+			port:     ports.HTTP,
 			code:     http.StatusOK,
 		},
 	}
@@ -2611,18 +2610,16 @@ spec:
       number: %d
       protocol: HTTP
     defaultEndpoint: %s:%d
-`, ports.All().MustForName(ipCase.port).WorkloadPort, ipCase.endpoint, ports.All().MustForName(ipCase.port).WorkloadPort)
+`, ipCase.port.WorkloadPort, ipCase.endpoint, ipCase.port.WorkloadPort)
 			}
 			t.RunTraffic(TrafficTestCase{
 				name:   ipCase.name,
 				call:   client.CallOrFail,
 				config: config,
 				opts: echo.CallOptions{
-					Count: 1,
-					To:    to,
-					Port: echo.Port{
-						Name: ipCase.port,
-					},
+					Count:   1,
+					To:      to,
+					Port:    ipCase.port,
 					Scheme:  scheme.HTTP,
 					Timeout: time.Second * 5,
 					Check:   check.Status(ipCase.code),

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1056,7 +1056,7 @@ func gatewayCases(t TrafficContext) {
 			"GatewayProtocol":    string(protocol),
 			"Gateway":            "gateway",
 			"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-			"Port":               ports.HTTP.ServicePort,
+			"Port":               dest.PortForName(ports.HTTP.Name).ServicePort,
 			"Credential":         cred,
 			"Ciphers":            ciphers,
 		}
@@ -1197,7 +1197,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               ports.HTTP.ServicePort,
+				"Port":               dest.PortForName(ports.HTTP.Name).ServicePort,
 			}
 		},
 	})
@@ -1369,7 +1369,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               ports.AutoHTTP.ServicePort,
+				"Port":               dest.PortForName(ports.AutoHTTP.Name).ServicePort,
 			}
 		},
 	})
@@ -1416,7 +1416,7 @@ spec:
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
-				"Port":               ports.AutoHTTP.ServicePort,
+				"Port":               dest.PortForName(ports.AutoHTTP.Name).ServicePort,
 			}
 		},
 	})

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1749,7 +1749,7 @@ func (b *authzTest) BuildForPorts(t framework.TestContext, ports ...echo.Port) a
 	out := make(authzTests, 0, len(ports))
 	for _, p := range ports {
 		opts := b.opts.DeepCopy()
-		opts.Port = p
+		opts.Port.Name = p.Name
 
 		tst := (&authzTest{
 			prefix: b.prefix,

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -71,31 +71,31 @@ func TestAuthz_Principal(t *testing.T) {
 					allow := allowValue(from.NamespacedName() == allowed.NamespacedName())
 
 					cases := []struct {
-						ports []string
+						ports []echo.Port
 						path  string
 						allow allowValue
 					}{
 						{
-							ports: []string{ports.GRPC, ports.TCP},
+							ports: []echo.Port{ports.GRPC, ports.TCP},
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow?param=value",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny?param=value",
 							allow: false,
 						},
@@ -148,61 +148,61 @@ func TestAuthz_DenyPrincipal(t *testing.T) {
 					allow := allowValue(from.NamespacedName() != denied.NamespacedName())
 
 					cases := []struct {
-						ports []string
+						ports []echo.Port
 						path  string
 						allow allowValue
 					}{
 						{
-							ports: []string{ports.GRPC, ports.TCP},
+							ports: []echo.Port{ports.GRPC, ports.TCP},
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny?param=value",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny/allow?param=value",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow?param=value",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny?param=value",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny/allow?param=value",
 							allow: true,
 						},
@@ -252,31 +252,31 @@ func TestAuthz_Namespace(t *testing.T) {
 					allow := allowValue(from.Config().Namespace.Name() == allowed.Config().Namespace.Name())
 
 					cases := []struct {
-						ports []string
+						ports []echo.Port
 						path  string
 						allow allowValue
 					}{
 						{
-							ports: []string{ports.GRPC, ports.TCP},
+							ports: []echo.Port{ports.GRPC, ports.TCP},
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow?param=value",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny?param=value",
 							allow: false,
 						},
@@ -329,61 +329,61 @@ func TestAuthz_DenyNamespace(t *testing.T) {
 					allow := allowValue(from.Config().Namespace.Name() == allowed.Config().Namespace.Name())
 
 					cases := []struct {
-						ports []string
+						ports []echo.Port
 						path  string
 						allow allowValue
 					}{
 						{
-							ports: []string{ports.GRPC, ports.TCP},
+							ports: []echo.Port{ports.GRPC, ports.TCP},
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny?param=value",
 							allow: allow,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/deny/allow?param=value",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/allow?param=value",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny?param=value",
 							allow: false,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny/allow",
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP, ports.HTTP2},
+							ports: []echo.Port{ports.HTTP, ports.HTTP2},
 							path:  "/global-deny/allow?param=value",
 							allow: true,
 						},
@@ -521,17 +521,17 @@ func TestAuthz_NotMethod(t *testing.T) {
 				ToMatch(toMatch).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 					cases := []struct {
-						ports  []string
+						ports  []echo.Port
 						method string
 						allow  allowValue
 					}{
 						{
-							ports:  []string{ports.HTTP, ports.HTTP2},
+							ports:  []echo.Port{ports.HTTP, ports.HTTP2},
 							method: "GET",
 							allow:  true,
 						},
 						{
-							ports:  []string{ports.HTTP, ports.HTTP2},
+							ports:  []echo.Port{ports.HTTP, ports.HTTP2},
 							method: "PUT",
 							allow:  false,
 						},
@@ -569,15 +569,15 @@ func TestAuthz_NotPort(t *testing.T) {
 				ToMatch(toMatch).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 					cases := []struct {
-						ports []string
+						ports []echo.Port
 						allow allowValue
 					}{
 						{
-							ports: []string{ports.HTTP},
+							ports: []echo.Port{ports.HTTP},
 							allow: true,
 						},
 						{
-							ports: []string{ports.HTTP2},
+							ports: []echo.Port{ports.HTTP2},
 							allow: false,
 						},
 					}
@@ -1236,7 +1236,7 @@ func TestAuthz_EgressGateway(t *testing.T) {
 								// header will be used for routing decisions.
 								Address: "10.4.4.4",
 								Port: echo.Port{
-									Name:        ports.HTTP,
+									Name:        ports.HTTP.Name,
 									Protocol:    protocol.HTTP,
 									ServicePort: 80,
 								},
@@ -1420,7 +1420,7 @@ func TestAuthz_Conditions(t *testing.T) {
 							newAuthzTest().
 								From(from).
 								To(to).
-								PortName(ports.HTTP).
+								PortName(ports.HTTP.Name).
 								Path(c.path).
 								Allow(c.allow).
 								Headers(c.headers).
@@ -1511,7 +1511,7 @@ func TestAuthz_PathNormalization(t *testing.T) {
 							newAuthzTest().
 								From(from).
 								To(to).
-								PortName(ports.HTTP).
+								PortName(ports.HTTP.Name).
 								Path(c.path).
 								Allow(c.allow).
 								BuildAndRun(t)
@@ -1572,40 +1572,40 @@ func TestAuthz_CustomServer(t *testing.T) {
 
 							authzPath := "/custom"
 							cases := []struct {
-								ports   []string
+								ports   []echo.Port
 								path    string
 								headers http.Header
 								allow   allowValue
 								skip    bool
 							}{
 								{
-									ports: []string{ports.TCP},
+									ports: []echo.Port{ports.TCP},
 									// For TCP, we rely on the hard-coded allowed service account.
 									allow: allowValue(fromAllowed),
 								},
 								{
-									ports:   []string{ports.HTTP, ports.HTTP2, ports.GRPC},
+									ports:   []echo.Port{ports.HTTP, ports.HTTP2, ports.GRPC},
 									path:    authzPath,
 									headers: allowHeaders(),
 									allow:   true,
 									skip:    !fromAllowed,
 								},
 								{
-									ports:   []string{ports.HTTP, ports.HTTP2, ports.GRPC},
+									ports:   []echo.Port{ports.HTTP, ports.HTTP2, ports.GRPC},
 									path:    authzPath,
 									headers: denyHeaders(),
 									allow:   false,
 									skip:    !fromAllowed,
 								},
 								{
-									ports:   []string{ports.HTTP, ports.HTTP2},
+									ports:   []echo.Port{ports.HTTP, ports.HTTP2},
 									path:    "/health",
 									headers: extAuthzHeaders(authz.XExtAuthzAllow),
 									allow:   true,
 									skip:    !fromAllowed,
 								},
 								{
-									ports:   []string{ports.HTTP, ports.HTTP2},
+									ports:   []echo.Port{ports.HTTP, ports.HTTP2},
 									path:    "/health",
 									headers: extAuthzHeaders("deny"),
 									allow:   true,
@@ -1745,11 +1745,11 @@ func (b *authzTest) Build(t framework.TestContext) *authzTest {
 	return b
 }
 
-func (b *authzTest) BuildForPorts(t framework.TestContext, ports ...string) authzTests {
+func (b *authzTest) BuildForPorts(t framework.TestContext, ports ...echo.Port) authzTests {
 	out := make(authzTests, 0, len(ports))
 	for _, p := range ports {
 		opts := b.opts.DeepCopy()
-		opts.Port.Name = p
+		opts.Port = p
 
 		tst := (&authzTest{
 			prefix: b.prefix,
@@ -1762,7 +1762,7 @@ func (b *authzTest) BuildForPorts(t framework.TestContext, ports ...string) auth
 	return out
 }
 
-func (b *authzTest) BuildAndRunForPorts(t framework.TestContext, ports ...string) {
+func (b *authzTest) BuildAndRunForPorts(t framework.TestContext, ports ...echo.Port) {
 	tsts := b.BuildForPorts(t, ports...)
 	tsts.RunAll(t)
 }

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -39,7 +39,7 @@ func TestPassThroughFilterChain(t *testing.T) {
 		Features("security.filterchain").
 		Run(func(t framework.TestContext) {
 			type expect struct {
-				port string
+				port echo.Port
 				// Plaintext will be sent from Naked pods.
 				plaintextSucceeds bool
 				// MTLS will be sent from all pods other than Naked.
@@ -396,7 +396,8 @@ spec:
 						ConditionallyTo(echotest.SameNetwork).
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							for _, expect := range tc.expected {
-								p := to.PortForName(expect.port)
+								expect := expect
+								p := expect.port
 								opts := echo.CallOptions{
 									// Do not set To, otherwise fillInCallOptions() will
 									// complain with port does not match.

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -119,7 +119,7 @@ func TestReachability(t *testing.T) {
 			migrationOpts := []echo.CallOptions{
 				{
 					Port: echo.Port{
-						Name: ports.HTTP,
+						Name: ports.HTTP.Name,
 					},
 					HTTP: echo.HTTP{
 						Path: migrationPathIstio,
@@ -127,7 +127,7 @@ func TestReachability(t *testing.T) {
 				},
 				{
 					Port: echo.Port{
-						Name: ports.HTTP,
+						Name: ports.HTTP.Name,
 					},
 					HTTP: echo.HTTP{
 						Path: migrationPathNonIstio,
@@ -433,35 +433,23 @@ func TestReachability(t *testing.T) {
 					if len(allOpts) == 0 {
 						allOpts = []echo.CallOptions{
 							{
-								Port: echo.Port{
-									Name: ports.HTTP,
-								},
+								Port: ports.HTTP,
 							},
 							{
-								Port: echo.Port{
-									Name: ports.HTTP,
-								},
+								Port: ports.HTTP,
 								Scheme: scheme.WebSocket,
 							},
 							{
-								Port: echo.Port{
-									Name: ports.HTTP2,
-								},
+								Port: ports.HTTP2,
 							},
 							{
-								Port: echo.Port{
-									Name: ports.HTTPS,
-								},
+								Port: ports.HTTPS,
 							},
 							{
-								Port: echo.Port{
-									Name: ports.TCP,
-								},
+								Port: ports.TCP,
 							},
 							{
-								Port: echo.Port{
-									Name: ports.GRPC,
-								},
+								Port: ports.GRPC,
 							},
 						}
 					}

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -436,7 +436,7 @@ func TestReachability(t *testing.T) {
 								Port: ports.HTTP,
 							},
 							{
-								Port: ports.HTTP,
+								Port:   ports.HTTP,
 								Scheme: scheme.WebSocket,
 							},
 							{

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -433,23 +433,35 @@ func TestReachability(t *testing.T) {
 					if len(allOpts) == 0 {
 						allOpts = []echo.CallOptions{
 							{
-								Port: ports.HTTP,
+								Port: echo.Port{
+									Name: ports.HTTP.Name,
+								},
 							},
 							{
-								Port:   ports.HTTP,
+								Port: echo.Port{
+									Name: ports.HTTP.Name,
+								},
 								Scheme: scheme.WebSocket,
 							},
 							{
-								Port: ports.HTTP2,
+								Port: echo.Port{
+									Name: ports.HTTP2.Name,
+								},
 							},
 							{
-								Port: ports.HTTPS,
+								Port: echo.Port{
+									Name: ports.HTTPS.Name,
+								},
 							},
 							{
-								Port: ports.TCP,
+								Port: echo.Port{
+									Name: ports.TCP.Name,
+								},
 							},
 							{
-								Port: ports.GRPC,
+								Port: echo.Port{
+									Name: ports.GRPC.Name,
+								},
 							},
 						}
 					}

--- a/tests/integration/telemetry/common/stats.go
+++ b/tests/integration/telemetry/common/stats.go
@@ -265,7 +265,7 @@ spec:
 						if _, err := cltInstance.Call(echo.CallOptions{
 							Address: "fake.external.com",
 							Scheme:  scheme.HTTPS,
-							Port:    echo.Port{ServicePort: ports.All().MustForName(ports.HTTPS).ServicePort},
+							Port:    ports.HTTPS,
 							Count:   1,
 							Retry:   echo.Retry{NoRetry: true}, // we do retry in outer loop
 							Check:   check.OK(),


### PR DESCRIPTION
Today, we have access to constants for the port name, but then need to jump through hoops to use the name to lookup the port. This avoids that.

**Please provide a description of this PR:**