### PR TITLE
Increase EWGW HPA min replicas

### DIFF
--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -30,7 +30,7 @@ gateways:
     rollingMaxSurge: 100%
     rollingMaxUnavailable: 25%
     autoscaleEnabled: true
-    autoscaleMin: 1
+    autoscaleMin: 2
     autoscaleMax: 5
 
     cpu:

--- a/samples/multicluster/gen-eastwest-gateway.sh
+++ b/samples/multicluster/gen-eastwest-gateway.sh
@@ -73,6 +73,9 @@ spec:
         label:
           istio: eastwestgateway
           app: istio-eastwestgateway
+        k8s:
+          hpaSpec:
+            minReplicas: 2
 EOF
 )
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Increase the number of the minimum number of HPA auto scale to resolve the existing onprem cluster upgrade issue caused from PDB. See https://cloud.google.com/anthos/clusters/docs/on-prem/1.9/troubleshoot-cluster-creation-upgrade#upgrade_process_becomes_stuck
