### PR TITLE
Add OCSP stapling support.

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1750,7 +1750,7 @@ func buildSecretReference(ctx ConfigContext, ref k8s.SecretObjectReference, gw c
 	})
 
 	if ctx.Credentials != nil {
-		if key, cert, err := ctx.Credentials.GetKeyAndCert(secret.Name, secret.Namespace); err != nil {
+		if key, cert, _, err := ctx.Credentials.GetKeyCertAndStaple(secret.Name, secret.Namespace); err != nil {
 			return "", &ConfigError{
 				Reason:  InvalidTLS,
 				Message: fmt.Sprintf("invalid certificate reference %v, %v", objectReferenceString(ref), err),

--- a/pilot/pkg/credentials/kube/multicluster.go
+++ b/pilot/pkg/credentials/kube/multicluster.go
@@ -116,20 +116,20 @@ type AggregateController struct {
 
 var _ credentials.Controller = &AggregateController{}
 
-func (a *AggregateController) GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error) {
+func (a *AggregateController) GetKeyCertAndStaple(name, namespace string) (key []byte, cert []byte, staple []byte, err error) {
 	// Search through all clusters, find first non-empty result
 	var firstError error
 	for _, c := range a.controllers {
-		k, c, err := c.GetKeyAndCert(name, namespace)
+		k, c, s, err := c.GetKeyCertAndStaple(name, namespace)
 		if err != nil {
 			if firstError == nil {
 				firstError = err
 			}
 		} else {
-			return k, c, nil
+			return k, c, s, nil
 		}
 	}
-	return nil, nil, firstError
+	return nil, nil, nil, firstError
 }
 
 func (a *AggregateController) GetCaCert(name, namespace string) (cert []byte, err error) {

--- a/pilot/pkg/credentials/model.go
+++ b/pilot/pkg/credentials/model.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Controller interface {
-	GetKeyAndCert(name, namespace string) (key []byte, cert []byte, err error)
+	GetKeyCertAndStaple(name, namespace string) (key []byte, cert []byte, staple []byte, err error)
 	GetCaCert(name, namespace string) (cert []byte, err error)
 	GetDockerCredential(name, namespace string) (cred []byte, err error)
 	Authorize(serviceAccount, namespace string) error

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -199,7 +199,7 @@ func (s *SecretGen) generate(sr SecretResource, configClusterSecrets, proxyClust
 		return res
 	}
 
-	key, cert, err := secretController.GetKeyAndCert(sr.Name, sr.Namespace)
+	key, cert, staple, err := secretController.GetKeyCertAndStaple(sr.Name, sr.Namespace)
 	if err != nil {
 		pilotSDSCertificateErrors.Increment()
 		log.Warnf("failed to fetch key and certificate for %s: %v", sr.ResourceName, err)
@@ -211,7 +211,7 @@ func (s *SecretGen) generate(sr SecretResource, configClusterSecrets, proxyClust
 			return nil
 		}
 	}
-	res := toEnvoyKeyCertSecret(sr.ResourceName, key, cert, proxy, s.meshConfig)
+	res := toEnvoyKeyCertStapleSecret(sr.ResourceName, key, cert, staple, proxy, s.meshConfig)
 	return res
 }
 
@@ -330,7 +330,7 @@ func toEnvoyCaSecret(name string, cert []byte) *discovery.Resource {
 	}
 }
 
-func toEnvoyKeyCertSecret(name string, key, cert []byte, proxy *model.Proxy, meshConfig *mesh.MeshConfig) *discovery.Resource {
+func toEnvoyKeyCertStapleSecret(name string, key, cert, staple []byte, proxy *model.Proxy, meshConfig *mesh.MeshConfig) *discovery.Resource {
 	var res *anypb.Any
 	pkpConf := proxy.Metadata.ProxyConfigOrDefault(meshConfig.GetDefaultConfig()).GetPrivateKeyProvider()
 	switch pkpConf.GetProvider().(type) {
@@ -403,6 +403,11 @@ func toEnvoyKeyCertSecret(name string, key, cert []byte, proxy *model.Proxy, mes
 					PrivateKey: &core.DataSource{
 						Specifier: &core.DataSource_InlineBytes{
 							InlineBytes: key,
+						},
+					},
+					OcspStaple: &core.DataSource{
+						Specifier: &core.DataSource_InlineBytes{
+							InlineBytes: staple,
 						},
 					},
 				},


### PR DESCRIPTION
This PR adds capability to forward OCSP staple from kubernetes secret to Envoy.

PR covers Stage 1 of following design: https://docs.google.com/document/d/15wwYyVyOluubL2KIM89b2X8NFwyhMVxq2_I1MESrZdI/edit?pli=1

Where:
* Stage 1 - implement OCSP staple forwarding to Envoy proxy
* Stage 2 - implement control mechanism allowing to choose Envoy stapling mode via secret annotations

**Brief**
OSCP staple is DER encoded response provided by OSCP server as a reply to OSCP request.
Such response is stapled to TLS Certificate and provided to client on https handshake.

This PR implements forwarding of the OCSP staple to Envoy proxy.
OSCP staple is expected to be found inside kubernetes secret under field named `tls.ocsp-staple`.
Pre-fetching OSCP response and storing it in kubernetes secret is left out intentionally, allowing usage of any third-party components: stand-alone operator or cert-manager. 
Existence of `tls.ocsp-staple` key is optional in a sense that it's absence is not changing current Istio behavior.
However when `tls.ocsp-staple` entry is present in the secret it is forwarded to Envoy proxy as inline bytes.

Choosing Envoy OSCP stapling policy is outside of this PR scope as well.
One of possible implementations for setting Envoy stapling policy is secret annotation mentioned in desigend document above.

Another option is to configure Enovy stapling policy via EnvoyFilter object.





Related to issue [#17763](https://github.com/istio/istio/issues/17763)