### PR TITLE
Fix pilot status has too many logs

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -59,7 +59,7 @@ const (
 
 // initConfigController creates the config controller in the pilotConfig.
 func (s *Server) initConfigController(args *PilotArgs) error {
-	s.initStatusController(args, features.EnableStatus)
+	s.initStatusController(args, features.EnableStatus && features.EnableDistributionTracking)
 	meshConfig := s.environment.Mesh()
 	if len(meshConfig.ConfigSources) > 0 {
 		// Using MCP for config.

--- a/releasenotes/notes/pilot-status-too-many-logs.yaml
+++ b/releasenotes/notes/pilot-status-too-many-logs.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 42612
+releaseNotes:
+  - |
+    **Fixed** pilot status to not log too many errors when PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING is not enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/42612
After https://github.com/istio/istio/pull/40561 disabled the PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING env, pilot status controller keeps logging the error in a very small time interval:
```
2023-02-09T05:52:04.663205Z     error   status  Encountered error retrieving version 732d02fd-79e of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
2023-02-09T05:52:04.663207Z     error   status  Encountered error retrieving version 5d0e9369-e17 of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
2023-02-09T05:52:04.663209Z     error   status  Encountered error retrieving version 18491e2d-ef2 of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
2023-02-09T05:52:04.663211Z     error   status  Encountered error retrieving version d9e2b3b9-0f7 of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
2023-02-09T05:52:04.663213Z     error   status  Encountered error retrieving version 5f7ed4b8-66d of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
2023-02-09T05:52:04.663215Z     error   status  Encountered error retrieving version a090282d-2af of key gateway.networking.k8s.io/v1beta1/gatewayclasses//istio/1 from Store: distribution tracking is disabled
```
Since the feature works when the env is enabled, we should not start the controller if it is disabled.