### PR TITLE
Update bookinfo gateway selector for Helm

### DIFF
--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: bookinfo-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
     istio: ingressgateway # use istio default controller
   servers:


### PR DESCRIPTION
Signed-off-by: nshankar <nshankar@microsoft.ghe.com>

**Please provide a description of this PR:**

Updates the bookinfo-gateway selector with a comment on what the default ingress k8s pod selector is for Helm. 