### PR TITLE
ambient: add back orig_dst for inbound sidecars

### DIFF
--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -30,7 +30,6 @@ spec:
         VERIFY_CERTIFICATE_AT_CLIENT: "true"
         ENABLE_AUTO_SNI: "true"
 
-        PILOT_ENABLE_INBOUND_PASSTHROUGH: "false" # TODO(https://github.com/solo-io/istio-sidecarless/issues/155)
         PILOT_ENABLE_HBONE: "true"
     cni:
       logLevel: "debug"

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -436,6 +436,16 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	}
 	localCluster := cb.buildDefaultCluster(clusterName, clusterType, localityLbEndpoints,
 		model.TrafficDirectionInbound, instance.ServicePort, instance.Service, allInstance)
+	if cb.hbone && clusterType == cluster.Cluster_ORIGINAL_DST {
+		localCluster.cluster.LbConfig = &cluster.Cluster_OriginalDstLbConfig_{
+			OriginalDstLbConfig: &cluster.Cluster_OriginalDstLbConfig{
+				UseHttpHeader:        false,
+				HttpHeaderName:       "",
+				UpstreamPortOverride: wrappers.UInt32(uint32(clusterPort)),
+			},
+		}
+	}
+
 	// If stat name is configured, build the alt statname.
 	if len(cb.req.Push.Mesh.InboundClusterStatName) != 0 {
 		localCluster.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -436,15 +436,6 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	}
 	localCluster := cb.buildDefaultCluster(clusterName, clusterType, localityLbEndpoints,
 		model.TrafficDirectionInbound, instance.ServicePort, instance.Service, allInstance)
-	if cb.hbone && clusterType == cluster.Cluster_ORIGINAL_DST {
-		localCluster.cluster.LbConfig = &cluster.Cluster_OriginalDstLbConfig_{
-			OriginalDstLbConfig: &cluster.Cluster_OriginalDstLbConfig{
-				UseHttpHeader:        false,
-				HttpHeaderName:       "",
-				UpstreamPortOverride: wrappers.UInt32(uint32(clusterPort)),
-			},
-		}
-	}
 
 	// If stat name is configured, build the alt statname.
 	if len(cb.req.Push.Mesh.InboundClusterStatName) != 0 {

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -29,6 +29,7 @@ import (
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/duration"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -180,6 +181,9 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 
 				ClusterSpecifier: &route.RouteAction_Cluster{Cluster: destination},
 			}},
+			TypedPerFilterConfig: map[string]*anypb.Any{
+				xdsfilters.ConnectAuthorityFilter.Name: xdsfilters.ConnectAuthorityEnabledSidecar,
+			},
 		})
 	}
 	l := &listener.Listener{
@@ -243,7 +247,7 @@ func buildHBONEConnectionManager(vhost *route.VirtualHost) *listener.Filter {
 			ValidateClusters: proto.BoolFalse,
 		},
 	}
-	connMgr.HttpFilters = []*hcm.HttpFilter{xdsfilters.Router}
+	connMgr.HttpFilters = []*hcm.HttpFilter{xdsfilters.ConnectAuthorityFilter, xdsfilters.Router}
 	connMgr.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 		AllowConnect: true,
 	}

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -211,6 +211,11 @@ var (
 			"port":    15008,
 		})
 
+	ConnectAuthorityEnabledSidecar = protoconv.TypedStructWithFields("type.googleapis.com/io.istio.http.connect_authority.Config",
+		map[string]interface{}{
+			"enabled": true,
+		})
+
 	SetDstAddress = &listener.ListenerFilter{
 		Name: "set_dst_address",
 		ConfigType: &listener.ListenerFilter_TypedConfig{


### PR DESCRIPTION
This brings sidecars back to the correct behavior (following https://istio.io/latest/blog/2021/upcoming-networking-changes/). This was a workaround due to limitations in the HBONE implementation previously

**Please provide a description of this PR:**