### PR TITLE
[Release 1.17] Manual cherry-pick of #43218

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	k8s.io/kubectl v0.26.0
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.1
-	sigs.k8s.io/gateway-api v0.6.0
+	sigs.k8s.io/gateway-api v0.6.1
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1464,8 +1464,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.14.1 h1:vThDes9pzg0Y+UbCPY3Wj34CGIYPgdmspPm2GIpxpzM=
 sigs.k8s.io/controller-runtime v0.14.1/go.mod h1:GaRkrY8a7UZF0kqFFbUKG7n9ICiTY5T55P1RiE3UZlU=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v0.6.0 h1:v2FqrN2ROWZLrSnI2o91taHR8Sj3s+Eh3QU7gLNWIqA=
-sigs.k8s.io/gateway-api v0.6.0/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
+sigs.k8s.io/gateway-api v0.6.1 h1:d/nIkhtbU0zVoFsriKi8lXwBYKNopz3EGeSwDqxeTRs=
+sigs.k8s.io/gateway-api v0.6.1/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -25,6 +25,8 @@ import (
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/util/sets"
 )
 
 func createRouteStatus(gateways []routeParentReference, obj config.Config, current []k8s.RouteParentStatus, routeErr *ConfigError) []k8s.RouteParentStatus {
@@ -41,44 +43,72 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 	// Collect all of our unique parent references. There may be multiple when we have a route without section name,
 	// but reference a parent with multiple sections.
 	// While we process these internally for-each sectionName, in the status we are just supposed to report one merged entry
-	seen := map[k8s.ParentReference]routeParentReference{}
-	failedCount := map[k8s.ParentReference]int{}
+	seen := map[k8s.ParentReference][]routeParentReference{}
+	seenReasons := sets.New[ParentErrorReason]()
 	successCount := map[k8s.ParentReference]int{}
 	for _, incoming := range gateways {
 		// We will append it if it is our first occurrence, or the existing one has an error. This means
 		// if *any* section has no errors, we will declare Admitted
-		if incoming.DeniedReason != nil {
-			failedCount[incoming.OriginalReference]++
-		} else {
+		if incoming.DeniedReason == nil {
 			successCount[incoming.OriginalReference]++
 		}
-		exist, f := seen[incoming.OriginalReference]
-		if !f {
-			exist = incoming
+		seen[incoming.OriginalReference] = append(seen[incoming.OriginalReference], incoming)
+		if incoming.DeniedReason != nil {
+			seenReasons.Insert(incoming.DeniedReason.Reason)
 		} else {
-			if incoming.DeniedReason == nil {
-				// The incoming gateway has no error; wipe out any errors
-				// When we have multiple, this means we attached without sectionName - we only need one success to be valid.
-				exist.DeniedReason = nil
-			} else if exist.DeniedReason != nil {
-				// TODO this only handles message, not reason
-				exist.DeniedReason.Message += "; " + incoming.DeniedReason.Message
-			}
+			seenReasons.Insert(ParentNoError)
 		}
-		seen[exist.OriginalReference] = exist
 	}
-	// Enhance error message when we have multiple
-	for k, gw := range seen {
-		if gw.DeniedReason == nil {
+	reasonRanking := []ParentErrorReason{
+		// No errors is preferred
+		ParentNoError,
+		// All route level errors
+		ParentErrorNotAllowed,
+		ParentErrorNoHostname,
+		ParentErrorParentRefConflict,
+		// Failures to match the Port or SectionName. These are last so that if we bind to 1 listener we
+		// just report errors for that 1 listener instead of for all sections we didn't bind to
+		ParentErrorNotAccepted,
+	}
+	// Next we want to collapse these. We need to report 1 type of error, or none.
+	report := map[k8s.ParentReference]routeParentReference{}
+	for _, wantReason := range reasonRanking {
+		if !seenReasons.Contains(wantReason) {
 			continue
 		}
-		if failedCount[k] > 1 {
-			gw.DeniedReason.Message = fmt.Sprintf("failed to bind to %d parents, errors: %v", failedCount[k], gw.DeniedReason.Message)
+		// We found our highest priority ranking, now we need to collapse this into a single message
+		for k, refs := range seen {
+			for _, ref := range refs {
+				reason := ParentNoError
+				if ref.DeniedReason != nil {
+					reason = ref.DeniedReason.Reason
+				}
+				if wantReason != reason {
+					// Skip this one, it is for a less relevant reason
+					continue
+				}
+				exist, f := report[k]
+				if f {
+					if ref.DeniedReason != nil {
+						if exist.DeniedReason != nil {
+							// join the error
+							exist.DeniedReason.Message += "; " + ref.DeniedReason.Message
+						} else {
+							exist.DeniedReason = ref.DeniedReason
+						}
+					}
+				} else {
+					exist = ref
+				}
+				report[k] = exist
+			}
 		}
+		// Once we find the best reason, do not consider any others
+		break
 	}
 
 	// Now we fill in all the parents we do own
-	for k, gw := range seen {
+	for k, gw := range report {
 		msg := "Route was valid"
 		if successCount[k] > 1 {
 			msg = fmt.Sprintf("Route was valid, bound to %d parents", successCount[k])
@@ -124,9 +154,11 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 type ParentErrorReason string
 
 const (
+	ParentErrorNotAccepted       = ParentErrorReason(k8sbeta.RouteReasonNoMatchingParent)
 	ParentErrorNotAllowed        = ParentErrorReason(k8s.RouteReasonNotAllowedByListeners)
 	ParentErrorNoHostname        = ParentErrorReason(k8s.RouteReasonNoMatchingListenerHostname)
 	ParentErrorParentRefConflict = ParentErrorReason("ParentRefConflict")
+	ParentNoError                = ParentErrorReason("")
 )
 
 type ConfigErrorReason = string
@@ -282,14 +314,14 @@ func generateSupportedKinds(l k8s.Listener) ([]k8s.RouteGroupKind, bool) {
 	switch l.Protocol {
 	case k8sbeta.HTTPProtocolType, k8sbeta.HTTPSProtocolType:
 		// Only terminate allowed, so its always HTTP
-		supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(StrPointer(gvk.HTTPRoute.Group)), Kind: k8s.Kind(gvk.HTTPRoute.Kind)}}
+		supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(ptr.Of(gvk.HTTPRoute.Group)), Kind: k8s.Kind(gvk.HTTPRoute.Kind)}}
 	case k8sbeta.TCPProtocolType:
-		supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(StrPointer(gvk.TCPRoute.Group)), Kind: k8s.Kind(gvk.TCPRoute.Kind)}}
+		supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(ptr.Of(gvk.TCPRoute.Group)), Kind: k8s.Kind(gvk.TCPRoute.Kind)}}
 	case k8sbeta.TLSProtocolType:
 		if l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == k8sbeta.TLSModePassthrough {
-			supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(StrPointer(gvk.TLSRoute.Group)), Kind: k8s.Kind(gvk.TLSRoute.Kind)}}
+			supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(ptr.Of(gvk.TLSRoute.Group)), Kind: k8s.Kind(gvk.TLSRoute.Kind)}}
 		} else {
-			supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(StrPointer(gvk.TCPRoute.Group)), Kind: k8s.Kind(gvk.TCPRoute.Kind)}}
+			supported = []k8s.RouteGroupKind{{Group: (*k8s.Group)(ptr.Of(gvk.TCPRoute.Group)), Kind: k8s.Kind(gvk.TCPRoute.Kind)}}
 		}
 		// UDP route note support
 	}
@@ -315,5 +347,5 @@ func routeGroupKindEqual(rgk1, rgk2 k8s.RouteGroupKind) bool {
 }
 
 func getGroup(rgk k8s.RouteGroupKind) k8s.Group {
-	return k8s.Group(defaultIfNil((*string)(rgk.Group), gvk.KubernetesGateway.Group))
+	return ptr.OrDefault(rgk.Group, k8s.Group(gvk.KubernetesGateway.Group))
 }

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
@@ -565,6 +565,58 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   creationTimestamp: null
+  name: invalid-parentRef-port
+  namespace: default
+spec: null
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: fake
+      message: port 1234 not found
+      reason: NoMatchingParent
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      port: 1234
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: invalid-sectionname-port
+  namespace: default
+spec: null
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: fake
+      message: sectionName "fake" not found
+      reason: NoMatchingParent
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: All references resolved
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: istio.io/gateway-controller
+    parentRef:
+      name: gateway
+      namespace: istio-system
+      sectionName: fake
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
   name: no-backend
   namespace: default
 spec: null

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.yaml
@@ -225,3 +225,37 @@ spec:
         backendRef:
           name: httpbin
           port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-parentRef-port
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+    port: 1234
+  hostnames: ["first.domain.example"]
+  rules:
+  - backendRefs:
+    - name: httpbin
+      port: 80
+      weight: 1
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-sectionname-port
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: istio-system
+    sectionName: fake
+  hostnames: ["first.domain.example"]
+  rules:
+  - backendRefs:
+    - name: httpbin
+      port: 80
+      weight: 1

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -103,13 +103,7 @@ func TestGatewayConformance(t *testing.T) {
 				GatewayClassName: "istio",
 				Debug:            scopes.Framework.DebugEnabled(),
 				// CleanupBaseResources: gatewayConformanceInputs.Cleanup,
-				SupportedFeatures: map[suite.SupportedFeature]bool{
-					suite.SupportReferenceGrant:                 true,
-					suite.SupportTLSRoute:                       true,
-					suite.SupportHTTPRouteQueryParamMatching:    true,
-					suite.SupportHTTPRouteMethodMatching:        true,
-					suite.SupportHTTPResponseHeaderModification: true,
-				},
+				SupportedFeatures: suite.AllFeatures,
 			}
 			if rev := ctx.Settings().Revisions.Default(); rev != "" {
 				opts.NamespaceLabels = map[string]string{

--- a/tests/integration/pilot/testdata/gateway-api-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-crd.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -440,7 +440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -1874,7 +1874,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
@@ -3362,7 +3362,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
@@ -7116,7 +7116,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
@@ -7395,7 +7395,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
@@ -7914,7 +7914,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
@@ -8482,7 +8482,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a manual cherry pick required to move the gateway-api implementation in 1.17 to the latest 0.6.1 Gateway API.

Depends on #43281 (cherry-pick of an earlier PR).

Fixes #43280 