### PR TITLE
waypoint: re-enable authz

### DIFF
--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -15,8 +15,6 @@
 package model
 
 import (
-	"fmt"
-
 	authpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -75,7 +73,6 @@ type AuthorizationPoliciesResult struct {
 
 // ListAuthorizationPolicies returns authorization policies applied to the workload in the given namespace.
 func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string, workload labels.Instance) AuthorizationPoliciesResult {
-	fmt.Printf("Listing policies for %s, %v\n", namespace, workload)
 	ret := AuthorizationPoliciesResult{}
 	if policy == nil {
 		return ret
@@ -112,6 +109,5 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string,
 		}
 	}
 
-	fmt.Printf("%d, %d, %d\n", len(ret.Allow), len(ret.Deny), len(ret.Audit))
 	return ret
 }

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"fmt"
+
 	authpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -73,6 +75,7 @@ type AuthorizationPoliciesResult struct {
 
 // ListAuthorizationPolicies returns authorization policies applied to the workload in the given namespace.
 func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string, workload labels.Instance) AuthorizationPoliciesResult {
+	fmt.Printf("Listing policies for %s, %v\n", namespace, workload)
 	ret := AuthorizationPoliciesResult{}
 	if policy == nil {
 		return ret
@@ -109,5 +112,6 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string,
 		}
 	}
 
+	fmt.Printf("%d, %d, %d\n", len(ret.Allow), len(ret.Deny), len(ret.Audit))
 	return ret
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -231,7 +231,6 @@ type TrafficDirection string
 const (
 	// TrafficDirectionInbound indicates inbound traffic
 	TrafficDirectionInbound    TrafficDirection = "inbound"
-	TrafficDirectionInboundPod TrafficDirection = "inbound-pod"
 	TrafficDirectionInboundVIP TrafficDirection = "inbound-vip"
 	// TrafficDirectionOutbound indicates outbound traffic
 	TrafficDirectionOutbound TrafficDirection = "outbound"

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -64,10 +64,10 @@ var hboneTransportSocketMatch = &structpb.Struct{
 	},
 }
 
-// passthroughHttpProtocolOptions are http protocol options used for pass through clusters.
+// PassthroughHttpProtocolOptions are http protocol options used for pass through clusters.
 // nolint
 // revive:disable-next-line
-var passthroughHttpProtocolOptions = protoconv.MessageToAny(&http.HttpProtocolOptions{
+var PassthroughHttpProtocolOptions = protoconv.MessageToAny(&http.HttpProtocolOptions{
 	CommonHttpProtocolOptions: &core.HttpProtocolOptions{
 		IdleTimeout: durationpb.New(5 * time.Minute),
 	},
@@ -672,7 +672,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		ConnectTimeout:       cb.req.Push.Mesh.ConnectTimeout,
 		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
-			v3.HttpProtocolOptionsType: passthroughHttpProtocolOptions,
+			v3.HttpProtocolOptionsType: PassthroughHttpProtocolOptions,
 		},
 	}
 	cb.applyConnectionPool(cb.req.Push.Mesh, NewMutableCluster(cluster), &networking.ConnectionPoolSettings{})

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -121,7 +121,7 @@ var BaggagePassthroughTransportSocket = util.InternalUpstreamTransportSocket(uti
 func (cb *ClusterBuilder) buildWaypointInboundInternal() []*cluster.Cluster {
 	clusters := []*cluster.Cluster{}
 	{
-		// This cluster routes to "internal" listener.
+		// This TCP cluster routes to "internal" listener.
 		clusterType := cluster.Cluster_STATIC
 		llb := util.BuildInternalEndpoint("internal", nil)
 		localCluster := cb.buildDefaultCluster("internal", clusterType, llb,
@@ -131,13 +131,16 @@ func (cb *ClusterBuilder) buildWaypointInboundInternal() []*cluster.Cluster {
 		clusters = append(clusters, localCluster.build())
 	}
 	{
-		// This cluster routes from "internal" listener.
+		// This TCP/HTTP cluster routes from "internal" listener.
 		clusterType := cluster.Cluster_STATIC
 		llb := util.BuildInternalEndpoint("inbound_CONNECT_originate", nil)
 		localCluster := cb.buildDefaultCluster("encap", clusterType, llb,
 			model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 		localCluster.cluster.TransportSocketMatches = nil
 		localCluster.cluster.TransportSocket = util.InternalUpstreamTransportSocket()
+		localCluster.cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+			v3.HttpProtocolOptionsType: PassthroughHttpProtocolOptions,
+		}
 		clusters = append(clusters, localCluster.build())
 	}
 	return clusters

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1085,9 +1085,8 @@ type httpListenerOpts struct {
 	port  int
 	hbone bool
 
-	// controls whether or not the filter chain should have telemetry filters.
-	skipTelemetryFilters bool
-	skipRBACFilters      bool
+	// Waypoint-specific modifications in HCM
+	isWaypoint bool
 }
 
 // filterChainOpts describes a filter chain: a set of filters with the same TLS context

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -370,18 +370,17 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	routerFilterCtx, reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
 
 	filters := []*hcm.HttpFilter{}
-	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{
-		Port:  httpOpts.port,
-		Class: httpOpts.class,
-	})
+	if !httpOpts.isWaypoint {
+		wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{
+			Port:  httpOpts.port,
+			Class: httpOpts.class,
+		})
 
-	// Metadata exchange filter needs to be added before any other HTTP filters are added. This is done to
-	// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/istio/istio/issues/41066
-	if features.MetadataExchange && !httpOpts.hbone && !lb.node.IsAmbient() {
-		filters = append(filters, xdsfilters.HTTPMx)
-	}
-
-	if !httpOpts.skipRBACFilters { // TODO poorly named, probably should skip more. Meant for outer HBONE listener
+		// Metadata exchange filter needs to be added before any other HTTP filters are added. This is done to
+		// ensure that mx filter comes before HTTP RBAC filter. This is related to https://github.com/istio/istio/issues/41066
+		if features.MetadataExchange && !httpOpts.hbone && !lb.node.IsAmbient() {
+			filters = append(filters, xdsfilters.HTTPMx)
+		}
 		// TODO: how to deal with ext-authz? It will be in the ordering twice
 		filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHN)
@@ -389,11 +388,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHZ)
 
 		var httpauthz []*hcm.HttpFilter
-		if lb.node.Type == model.Waypoint {
-			httpauthz = lb.authzBuilder.BuildHTTPWithListener(httpOpts.class, httpOpts.routeConfig.Name)
-		} else {
-			httpauthz = lb.authzBuilder.BuildHTTP(httpOpts.class)
-		}
+		httpauthz = lb.authzBuilder.BuildHTTP(httpOpts.class)
 		filters = append(filters, httpauthz...)
 
 		// TODO: these feel like the wrong place to insert, but this retains backwards compatibility with the original implementation
@@ -418,7 +413,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 
 	// TypedPerFilterConfig in route needs these filters.
 	filters = append(filters, xdsfilters.Fault, xdsfilters.Cors)
-	if !httpOpts.skipTelemetryFilters {
+	if !httpOpts.isWaypoint {
 		filters = append(filters, lb.push.Telemetry.HTTPFilters(lb.node, httpOpts.class)...)
 	}
 	// Add EmptySessionFilter so that it can be overridden at route level per service.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -386,11 +386,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHN)
 		filters = append(filters, lb.authnBuilder.BuildHTTP(httpOpts.class)...)
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHZ)
-
-		var httpauthz []*hcm.HttpFilter
-		httpauthz = lb.authzBuilder.BuildHTTP(httpOpts.class)
-		filters = append(filters, httpauthz...)
-
+		filters = append(filters, lb.authzBuilder.BuildHTTP(httpOpts.class)...)
 		// TODO: these feel like the wrong place to insert, but this retains backwards compatibility with the original implementation
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_STATS)
 		filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -845,12 +844,6 @@ func buildSidecarInboundHTTPOpts(lb *ListenerBuilder, cc inboundChainConfig) *ht
 		httpOpts.connectionManager.HttpProtocolOptions = &core.Http1ProtocolOptions{
 			AcceptHttp_10: true,
 		}
-	}
-
-	// Never set telemetry filters on the pod listener for ambient. They should
-	// only apply in the internal inbound-vip listener.
-	if strings.HasPrefix(cc.clusterName, string(model.TrafficDirectionInboundPod)) && lb.node.IsAmbient() {
-		httpOpts.skipTelemetryFilters = true
 	}
 
 	return httpOpts

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -270,14 +270,16 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 		}
 		tcpChain := &listener.FilterChain{
 			Filters: append([]*listener.Filter{
-				xdsfilters.ConnectAuthorityNetworkFilter},
+				xdsfilters.ConnectAuthorityNetworkFilter,
+			},
 				lb.buildInboundNetworkFilters(cc)...),
 			Name: "direct-tcp",
 		}
 		// TODO: maintains undesirable persistent HTTP connections to "encap"
 		httpChain := &listener.FilterChain{
 			Filters: append([]*listener.Filter{
-				xdsfilters.ConnectAuthorityNetworkFilter},
+				xdsfilters.ConnectAuthorityNetworkFilter,
+			},
 				lb.buildWaypointInboundHTTPFilters(nil, cc, pre, post)...),
 			Name: "direct-http",
 		}
@@ -297,7 +299,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 				Ranges: ipRange,
 				OnMatch: match.ToMatcher(match.NewAppProtocol(match.ProtocolMatch{
 					TCP:  match.ToChain(tcpChain.Name),
-					HTTP: match.ToChain(httpChain.Name),
+					HTTP: match.ToChain(tcpChain.Name),
 				})),
 			})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -346,7 +346,6 @@ func (lb *ListenerBuilder) buildWaypointInboundOriginateConnect() *listener.List
 // buildWaypointHTTPFilters augments the common chain of Waypoint-bound HTTP filters.
 // Authn/authz filters are pre-pended. Telemetry filters are appended.
 func (lb *ListenerBuilder) buildWaypointHTTPFilters() (pre []*hcm.HttpFilter, post []*hcm.HttpFilter) {
-	fmt.Printf("building authz: %s, %v\n", lb.node.GetNodeName(), lb.node.Labels)
 	// TODO(): consider dedicated listener class for waypoint filters
 	cls := istionetworking.ListenerClassSidecarInbound
 	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -410,8 +410,8 @@ func (lb *ListenerBuilder) buildWaypointInboundVIPHTTPFilters(svc *model.Service
 
 	// Last filter must be router.
 	router := h.HttpFilters[len(h.HttpFilters)-1]
-	h.HttpFilters = append(pre, h.HttpFilters...)
-	h.HttpFilters = append(h.HttpFilters[:len(h.HttpFilters)-1], post...)
+	h.HttpFilters = append(pre, h.HttpFilters[:len(h.HttpFilters)-1]...)
+	h.HttpFilters = append(h.HttpFilters, post...)
 	h.HttpFilters = append(h.HttpFilters, router)
 
 	filters = append(filters, &listener.Filter{

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -299,7 +299,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 				Ranges: ipRange,
 				OnMatch: match.ToMatcher(match.NewAppProtocol(match.ProtocolMatch{
 					TCP:  match.ToChain(tcpChain.Name),
-					HTTP: match.ToChain(tcpChain.Name),
+					HTTP: match.ToChain(httpChain.Name),
 				})),
 			})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -346,6 +346,7 @@ func (lb *ListenerBuilder) buildWaypointInboundOriginateConnect() *listener.List
 // buildWaypointHTTPFilters augments the common chain of Waypoint-bound HTTP filters.
 // Authn/authz filters are pre-pended. Telemetry filters are appended.
 func (lb *ListenerBuilder) buildWaypointHTTPFilters() (pre []*hcm.HttpFilter, post []*hcm.HttpFilter) {
+	fmt.Printf("building authz: %s, %v\n", lb.GetNodeName(), lb.Labels)
 	// TODO(): consider dedicated listener class for waypoint filters
 	cls := istionetworking.ListenerClassSidecarInbound
 	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -346,7 +346,7 @@ func (lb *ListenerBuilder) buildWaypointInboundOriginateConnect() *listener.List
 // buildWaypointHTTPFilters augments the common chain of Waypoint-bound HTTP filters.
 // Authn/authz filters are pre-pended. Telemetry filters are appended.
 func (lb *ListenerBuilder) buildWaypointHTTPFilters() (pre []*hcm.HttpFilter, post []*hcm.HttpFilter) {
-	fmt.Printf("building authz: %s, %v\n", lb.GetNodeName(), lb.Labels)
+	fmt.Printf("building authz: %s, %v\n", lb.node.GetNodeName(), lb.node.Labels)
 	// TODO(): consider dedicated listener class for waypoint filters
 	cls := istionetworking.ListenerClassSidecarInbound
 	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -295,6 +295,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
 		ListenerFilters: []*listener.ListenerFilter{
 			util.InternalListenerSetAddressFilter(),
+			// TODO: This may affect the data path due to the server-first protocols triggering a time-out. Need exception filter.
 			xdsfilters.HTTPInspector,
 		},
 		TrafficDirection: core.TrafficDirection_INBOUND,

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -269,12 +269,17 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 			hbone: true,
 		}
 		tcpChain := &listener.FilterChain{
-			Filters: lb.buildInboundNetworkFilters(cc),
-			Name:    "direct-tcp",
+			Filters: append([]*listener.Filter{
+				xdsfilters.ConnectAuthorityNetworkFilter},
+				lb.buildInboundNetworkFilters(cc)...),
+			Name: "direct-tcp",
 		}
+		// TODO: maintains undesirable persistent HTTP connections to "encap"
 		httpChain := &listener.FilterChain{
-			Filters: lb.buildWaypointInboundHTTPFilters(nil, cc, pre, post),
-			Name:    "direct-http",
+			Filters: append([]*listener.Filter{
+				xdsfilters.ConnectAuthorityNetworkFilter},
+				lb.buildWaypointInboundHTTPFilters(nil, cc, pre, post)...),
+			Name: "direct-http",
 		}
 		// Workload IP filtering happens here.
 		ipRange := []*xds.CidrRange{}

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -351,22 +351,17 @@ func (lb *ListenerBuilder) buildWaypointInboundOriginateConnect() *listener.List
 // buildWaypointHTTPFilters augments the common chain of Waypoint-bound HTTP filters.
 // Authn/authz filters are pre-pended. Telemetry filters are appended.
 func (lb *ListenerBuilder) buildWaypointHTTPFilters() (pre []*hcm.HttpFilter, post []*hcm.HttpFilter) {
-	// TODO(): consider dedicated listener class for waypoint filters
+	// TODO: consider dedicated listener class for waypoint filters
 	cls := istionetworking.ListenerClassSidecarInbound
 	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{
 		Class: cls,
 	})
-
 	// TODO: how to deal with ext-authz? It will be in the ordering twice
 	pre = append(pre, lb.authzCustomBuilder.BuildHTTP(cls)...)
 	pre = extension.PopAppend(pre, wasm, extensions.PluginPhase_AUTHN)
 	pre = append(pre, lb.authnBuilder.BuildHTTP(cls)...)
 	pre = extension.PopAppend(pre, wasm, extensions.PluginPhase_AUTHZ)
-
-	var httpauthz []*hcm.HttpFilter
-	httpauthz = lb.authzBuilder.BuildHTTP(cls)
-	pre = append(pre, httpauthz...)
-
+	pre = append(pre, lb.authzBuilder.BuildHTTP(cls)...)
 	// TODO: these feel like the wrong place to insert, but this retains backwards compatibility with the original implementation
 	post = extension.PopAppend(post, wasm, extensions.PluginPhase_STATS)
 	post = extension.PopAppend(post, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -408,8 +408,11 @@ func (lb *ListenerBuilder) buildWaypointInboundVIPHTTPFilters(svc *model.Service
 	}
 	h := lb.buildHTTPConnectionManager(httpOpts)
 
+	// Last filter must be router.
+	router := h.HttpFilters[len(h.HttpFilters)-1]
 	h.HttpFilters = append(pre, h.HttpFilters...)
-	h.HttpFilters = append(h.HttpFilters, post...)
+	h.HttpFilters = append(h.HttpFilters[:len(h.HttpFilters)-1], post...)
+	h.HttpFilters = append(h.HttpFilters, router)
 
 	filters = append(filters, &listener.Filter{
 		Name:       wellknown.HTTPConnectionManager,

--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -86,7 +86,7 @@ func (b *Builder) BuildTCP() []*listener.Filter {
 	return b.tcpFilters
 }
 
-func (b *Builder) BuildHTTPWithListener(class networking.ListenerClass, listener string) []*hcm.HttpFilter {
+func (b *Builder) BuildHTTP(class networking.ListenerClass) []*hcm.HttpFilter {
 	if b == nil || b.builder == nil {
 		return nil
 	}
@@ -98,15 +98,7 @@ func (b *Builder) BuildHTTPWithListener(class networking.ListenerClass, listener
 		return b.httpFilters
 	}
 	b.httpBuilt = true
-	if listener != "" {
-		b.httpFilters = b.builder.BuildHTTPAmbient(listener)
-	} else {
-		b.httpFilters = b.builder.BuildHTTP()
-	}
+	b.httpFilters = b.builder.BuildHTTP()
 
 	return b.httpFilters
-}
-
-func (b *Builder) BuildHTTP(class networking.ListenerClass) []*hcm.HttpFilter {
-	return b.BuildHTTPWithListener(class, "")
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -65,9 +65,6 @@ type Builder struct {
 	allowPolicies []model.AuthorizationPolicy
 	auditPolicies []model.AuthorizationPolicy
 
-	// For AmbientAdapations
-	AmbientListenerName string
-
 	// logger emits logs about policies
 	logger *AuthzLogger
 }
@@ -97,16 +94,6 @@ func New(trustDomainBundle trustdomain.Bundle, push *model.PushContext, policies
 		trustDomainBundle: trustDomainBundle,
 		option:            option,
 	}
-}
-
-func (b Builder) BuildHTTPAmbient(listener string) []*hcm.HttpFilter {
-	b.AmbientListenerName = listener
-	return b.BuildHTTP()
-}
-
-func (b Builder) BuildTCPAmbient(listener string) []*listener.Filter {
-	b.AmbientListenerName = listener
-	return b.BuildTCP()
 }
 
 // BuildHTTP returns the HTTP filters built from the authorization policy.
@@ -241,10 +228,6 @@ func (b Builder) build(policies []model.AuthorizationPolicy, action rbacpb.RBAC_
 			m.MigrateTrustDomain(b.trustDomainBundle)
 			if len(b.trustDomainBundle.TrustDomains) > 1 {
 				b.logger.AppendDebugf("patched source principal with trust domain aliases %v", b.trustDomainBundle.TrustDomains)
-			}
-
-			if b.option.IsAmbient {
-				m.AmbientDestinationPortAdaptations(b.AmbientListenerName)
 			}
 
 			generated, err := m.Generate(forTCP, b.option.UseAuthenticated, action)

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -279,12 +279,7 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			if g == nil {
 				t.Fatalf("failed to create generator")
 			}
-			var got []*hcm.HttpFilter
-			if tc.ambient {
-				got = g.BuildHTTPAmbient(tc.listener)
-			} else {
-				got = g.BuildHTTP()
-			}
+			got := g.BuildHTTP()
 			verify(t, convertHTTP(got), baseDir, tc.want, false /* forTCP */)
 		})
 	}

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-ambient-out.yaml
@@ -7,10 +7,15 @@ typedConfig:
         permissions:
         - andRules:
             rules:
+            - orRules:
+                rules:
+                - destinationPort: 80
+                - destinationPort: 90
             - notRule:
                 orRules:
                   rules:
-                  - any: true
+                  - destinationPort: 80
+                  - destinationPort: 90
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-ambient-out.yaml
@@ -59,7 +59,10 @@ typedConfig:
         permissions:
         - andRules:
             rules:
-            - any: true
+            - orRules:
+                rules:
+                - destinationPort: 80
+                - destinationPort: 90
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -334,12 +334,3 @@ func (p *ruleList) appendLast(g generator, key string, values, notValues []strin
 
 	p.rules = append(p.rules, r)
 }
-
-func (p *ruleList) replaceRule(index int, g generator, key string, values, notValues []string) {
-	p.rules[index] = &rule{
-		key:       key,
-		values:    values,
-		notValues: notValues,
-		g:         g,
-	}
-}

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -21,9 +21,7 @@ import (
 	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 
 	authzpb "istio.io/api/security/v1beta1"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -163,52 +161,6 @@ func (m *Model) MigrateTrustDomain(tdBundle trustdomain.Bundle) {
 			}
 		}
 	}
-}
-
-// Update rules for ambient based on listener name. Because the Waypoint Proxy receives
-// the destination as envoy://listener_name/, Envoy will not have a port to evaluate. This
-// will precalculate the RBAC rules with regard to destination port for any matches and replace
-// as necessary. For not matches, we add an `any: true` as it will always match. For value match,
-// we replace with a nil, which the generator replaces with an `any: true` if there are no other
-// rules to evaluate. We leave non-matching ports so they do not match any requests.
-func (m *Model) AmbientDestinationPortAdaptations(listenerName string) {
-	// Extract port from listener name (e.g. inbound-pod|80||10.244.2.4)
-	_, _, _, portInt := model.ParseSubsetKey(listenerName)
-	port := fmt.Sprint(portInt) // the value and notValues from permissions is a string
-
-	count := 0
-	for i, p := range m.permissions {
-		for j, r := range p.rules {
-			if r.key == attrDestPort {
-				if len(r.values) == 0 && len(r.notValues) == 0 {
-					continue
-				}
-				for _, v := range r.values {
-					// Check if v matches the extracted port
-					if v == port {
-						// We do not use anyGenerator here, as this will always insert a `any: true` rule, which will
-						// always match. If we leave nil, nil, the permission generator inserts an `any: true`
-						m.permissions[i].replaceRule(j, destPortGenerator{}, attrDestPort, nil, nil)
-						count++
-						break
-					}
-				}
-
-				for _, v := range r.notValues {
-					// Check if v matches the extracted port
-					if v == port {
-						// We insert an any rule here, which will always match, because a matching notPorts will always have
-						// a match in this case
-						m.permissions[i].replaceRule(j, anyGenerator{}, attrAny, nil, []string{""})
-						count++
-						break
-					}
-				}
-			}
-		}
-	}
-
-	log.Infof("Updated %d ambient rules for listener %s", count, listenerName)
 }
 
 // Generate generates the Envoy RBAC config from the model.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -124,14 +124,6 @@ func supportsL7(opt echo.CallOptions, src, dst echo.Instance) bool {
 	return (s || d) && isL7Scheme
 }
 
-// Waypoint does not currently do L7 for pod IP traffic
-func supportsL7PodIP(opt echo.CallOptions, src, dst echo.Instance) bool {
-	s := src.Config().HasSidecar()
-	d := dst.Config().HasSidecar()
-	isL7Scheme := opt.Scheme == scheme.HTTP || opt.Scheme == scheme.GRPC || opt.Scheme == scheme.WebSocket
-	return (s || d) && isL7Scheme
-}
-
 func TestServices(t *testing.T) {
 	runTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
 		if supportsL7(opt, src, dst) {
@@ -178,7 +170,7 @@ func TestPodIP(t *testing.T) {
 								for _, opt := range callOptions {
 									opt := opt.DeepCopy()
 									selfSend := dstWl.Address() == srcWl.Address()
-									if supportsL7PodIP(opt, src, dst) {
+									if supportsL7(opt, src, dst) {
 										opt.Check = httpValidator
 									} else {
 										opt.Check = tcpValidator

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -617,7 +617,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      istio.io/gateway-name: waypoint-istio-waypoint
   rules:
   - from:
     - source:

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -750,7 +750,8 @@ spec:
 				"Destination": dst.Config().Service,
 				"Source":      "istio-ingressgateway-service-account",
 				"Namespace":   apps.Namespace.Name(),
-			}, `apiVersion: security.istio.io/v1beta1
+			}, `
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy
@@ -760,6 +761,7 @@ spec:
       app: "{{ .Destination }}"
 `+policySpec+`
 ---
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-waypoint

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -762,7 +762,7 @@ spec:
 ---
 kind: AuthorizationPolicy
 metadata:
-  name: policy
+  name: policy-waypoint
 spec:
   selector:
     matchLabels:

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -646,7 +646,21 @@ spec:
 					"Destination": dst.Config().Service,
 					"Source":      src.Config().Service,
 					"Namespace":   apps.Namespace.Name(),
-				}, `apiVersion: security.istio.io/v1beta1
+				}, `
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: policy
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: waypoint-istio-waypoint
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/something/sa/else"]
+---
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy
@@ -658,6 +672,7 @@ spec:
   - from:
     - source:
         principals: ["cluster.local/ns/something/sa/else"]
+---
 `).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				opt.Check = CheckDeny


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Ref https://github.com/istio/istio/issues/43009.

Enables sniffed HTTP processing on direct pod IP chain.
Enables general filters on waypoints using waypoint labels. Filters are applied uniformly across all HTTP chains.