### PR TITLE
Fix `pc log -h` listed active loggers out of date

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -44,6 +44,7 @@ const (
 	prometheusMergedOutput = "prom-merged"
 
 	defaultProxyAdminPort = 15000
+	loggerIDs             = "https://github.com/envoyproxy/envoy/blob/a62fa454ffa4c28bec01d37788a38e71a0e230d3//source/common/common/logger.h#L29"
 )
 
 var (
@@ -88,51 +89,6 @@ const (
 	// TraceLevel enables trace level logging
 	TraceLevel
 )
-
-// existing sorted active loggers
-var activeLoggers = []string{
-	"admin",
-	"aws",
-	"assert",
-	"backtrace",
-	"client",
-	"config",
-	"connection",
-	"conn_handler", // Added through https://github.com/envoyproxy/envoy/pull/8263
-	"dubbo",
-	"file",
-	"filter",
-	"forward_proxy",
-	"grpc",
-	"hc",
-	"health_checker",
-	"http",
-	"http2",
-	"hystrix",
-	"init",
-	"io",
-	"jwt",
-	"kafka",
-	"lua",
-	"main",
-	"misc",
-	"mongo",
-	"quic",
-	"pool",
-	"rbac",
-	"redis",
-	"router",
-	"runtime",
-	"stats",
-	"secret",
-	"tap",
-	"testing",
-	"thrift",
-	"tracing",
-	"upstream",
-	"udp",
-	"wasm",
-}
 
 var levelToString = map[Level]string{
 	TraceLevel:    "trace",
@@ -941,14 +897,13 @@ func logCmd() *cobra.Command {
 		levelToString[ErrorLevel],
 		levelToString[CriticalLevel],
 		levelToString[OffLevel])
-	s := strings.Join(activeLoggers, ", ")
 
 	logCmd.PersistentFlags().BoolVarP(&reset, "reset", "r", reset, "Reset levels to default value (warning).")
 	logCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	logCmd.PersistentFlags().StringVar(&loggerLevelString, "level", loggerLevelString,
 		fmt.Sprintf("Comma-separated minimum per-logger level of messages to output, in the form of"+
-			" [<logger>:]<level>,[<logger>:]<level>,... where logger can be one of %s and level can be one of %s",
-			s, levelListString))
+			" [<logger>:]<level>,[<logger>:]<level>,... where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
+			"or referred from https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h, and level can be one of %s", levelListString))
 
 	return logCmd
 }

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -44,7 +44,6 @@ const (
 	prometheusMergedOutput = "prom-merged"
 
 	defaultProxyAdminPort = 15000
-	loggerIDs             = "https://github.com/envoyproxy/envoy/blob/a62fa454ffa4c28bec01d37788a38e71a0e230d3//source/common/common/logger.h#L29"
 )
 
 var (


### PR DESCRIPTION
**Please provide a description of this PR:**
The activeLoggers slice has not been maintained for a while, and it's hard to maintain manually. Many logger components are missing. Revised to use command or see the logger page like Envoy doc does in the tip (https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy). Are there any other suggestions?