### PR TITLE
Remove env var ENABLE_CA_SERVER

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -110,7 +110,6 @@ func TestNewServerCertInit(t *testing.T) {
 		name                      string
 		FSCertsPaths              TLSFSLoadPaths
 		tlsOptions                *TLSOptions
-		enableCA                  bool
 		certProvider              string
 		expNewCert                bool
 		expCert                   []byte
@@ -125,7 +124,6 @@ func TestNewServerCertInit(t *testing.T) {
 				KeyFile:    tlsArgkeyFile,
 				CaCertFile: tlsArgcaCertFile,
 			},
-			enableCA:                  false,
 			certProvider:              constants.CertProviderKubernetes,
 			expNewCert:                false,
 			expCert:                   testcerts.ServerCert,
@@ -133,29 +131,14 @@ func TestNewServerCertInit(t *testing.T) {
 			expSecureDiscoveryService: true,
 		},
 		{
-			name:         "Create new DNS cert using Istiod",
-			FSCertsPaths: TLSFSLoadPaths{},
-			tlsOptions: &TLSOptions{
-				CertFile:   "",
-				KeyFile:    "",
-				CaCertFile: "",
-			},
-			enableCA:                  true,
+			name:                      "Create new DNS cert using Istiod",
+			FSCertsPaths:              TLSFSLoadPaths{},
+			tlsOptions:                &TLSOptions{},
 			certProvider:              constants.CertProviderIstiod,
 			expNewCert:                true,
 			expCert:                   []byte{},
 			expKey:                    []byte{},
 			expSecureDiscoveryService: true,
-		},
-		{
-			name:         "No DNS cert created because CA is disabled",
-			FSCertsPaths: TLSFSLoadPaths{},
-			tlsOptions:   &TLSOptions{},
-			enableCA:     false,
-			certProvider: constants.CertProviderIstiod,
-			expNewCert:   false,
-			expCert:      []byte{},
-			expKey:       []byte{},
 		},
 		{
 			name: "DNS cert loaded because it is in known even if CA is Disabled",
@@ -165,7 +148,6 @@ func TestNewServerCertInit(t *testing.T) {
 				constants.DefaultPilotTLSCaCert,
 			},
 			tlsOptions:                &TLSOptions{},
-			enableCA:                  false,
 			certProvider:              constants.CertProviderNone,
 			expNewCert:                false,
 			expCert:                   testcerts.ServerCert,
@@ -180,7 +162,6 @@ func TestNewServerCertInit(t *testing.T) {
 				constants.DefaultPilotTLSCaCertAlternatePath,
 			},
 			tlsOptions:                &TLSOptions{},
-			enableCA:                  false,
 			certProvider:              constants.CertProviderNone,
 			expNewCert:                false,
 			expCert:                   testcerts.ServerCert,
@@ -191,7 +172,6 @@ func TestNewServerCertInit(t *testing.T) {
 			name:         "No cert provider",
 			FSCertsPaths: TLSFSLoadPaths{},
 			tlsOptions:   &TLSOptions{},
-			enableCA:     true,
 			certProvider: constants.CertProviderNone,
 			expNewCert:   false,
 			expCert:      []byte{},
@@ -202,7 +182,6 @@ func TestNewServerCertInit(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			test.SetForTest(t, &features.PilotCertProvider, c.certProvider)
-			test.SetForTest(t, &features.EnableCAServer, c.enableCA)
 
 			// check if we have some tls assets to write for test
 			if c.FSCertsPaths != (TLSFSLoadPaths{}) {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -418,9 +418,6 @@ var (
 	ExternalIstiod = env.Register("EXTERNAL_ISTIOD", false,
 		"If this is set to true, one Istiod will control remote clusters including CA.").Get()
 
-	EnableCAServer = env.Register("ENABLE_CA_SERVER", true,
-		"If this is set to false, will not create CA server in istiod.").Get()
-
 	EnableDebugOnHTTP = env.Register("ENABLE_DEBUG_ON_HTTP", true,
 		"If this is set to false, the debug interface will not be enabled, recommended for production").Get()
 

--- a/releasenotes/notes/remove-env-enable-ca-server.yaml
+++ b/releasenotes/notes/remove-env-enable-ca-server.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Removed** environment variable `ENABLE_CA_SERVER`.


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

**Please provide a description of this PR:**

When I was debugging some configuration issues, I noticed that `ENABLE_CA_SERVER` shouldn't be required, because Istio can decide whether it should create CA server without this flag. Currently, this flag is enabled by default and it's necessary to disable it when custom certs are provided for istiod and `values.global.caAddress` is set. I cannot find other use cases when that flag must be explicitly disabled.