### PR TITLE
fix bug for Istio 1.17 release when generating UpstreamBindConfig configuration 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -482,9 +482,9 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 		// to support the Dual Stack via Envoy bindconfig, and belows are related issue and PR in Envoy:
 		// https://github.com/envoyproxy/envoy/issues/9811
 		// https://github.com/envoyproxy/envoy/pull/22639
-		instExtraSvcAddr := instance.Service.GetExtraAddressesForProxy(proxy)
-		// the extra source address for UpstreamBindConfig shoulde be added when the service is a dual stack k8s service
-		if features.EnableDualStack && len(cb.passThroughBindIPs) > 1 && len(instExtraSvcAddr) > 0 {
+		// the extra source address for UpstreamBindConfig shoulde be added if dual stack is enabled and there are
+		// more than 1 IP for proxy
+		if features.EnableDualStack && len(cb.passThroughBindIPs) > 1 {
 			// add extra source addresses to cluster builder
 			var extraSrcAddrs []*core.ExtraSourceAddress
 			for _, extraBdIP := range cb.passThroughBindIPs[1:] {


### PR DESCRIPTION
This is the partly cherrypick for Istio 1.17 release based on [PR#43099](https://github.com/istio/istio/pull/43099).
And just merge code changes on bug fixing of `UpstreamBindConfig` configuration, exclude the `DNSlookupFamily` setting.

In fact, these code changes was added in Istio 1.16 via [PR#41618](https://github.com/istio/istio/pull/41618), and I added the assertion of `len(instExtraSvcAddr) > 0` when adding feature flag. It's unnecessary and caused bug described as below:
_The UpstreamBindConfig configuration will be incorrect if the service is deployed with a sing stack ip family in a dual stack cluster. And correct if the service is deployed with dual stack ip family in a dual stack cluster._  