### PR TITLE
Include ztunnel in release

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -163,7 +163,7 @@ $(TARGET_OUT)/istio_is_init: bin/init.sh istio.deps | $(TARGET_OUT)
 
 .PHONY: init-ztunnel-rs
 init-ztunnel-rs:
-	@TARGET_OUT=$(TARGET_OUT) bin/build_ztunnel.sh
+	TARGET_OUT=$(TARGET_OUT) bin/build_ztunnel.sh
 
 # Pull dependencies such as envoy
 depend: init | $(TARGET_OUT)

--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -113,15 +113,11 @@ function maybe_build_ztunnel() {
   popd
 }
 
-# TODO(https://github.com/istio/ztunnel/issues/394) use TARGET_ARCH
-# For now, we use amd64 even on arm64 just so we can actually do a release properly
-ZTUNNEL_ARCH="amd64"
-
 # ztunnel binary vars (TODO handle debug builds, centos, arm, darwin etc.)
 ISTIO_ZTUNNEL_BASE_URL="${ISTIO_ZTUNNEL_BASE_URL:-https://storage.googleapis.com/istio-build/ztunnel}"
 ZTUNNEL_REPO_SHA="${ZTUNNEL_REPO_SHA:-$(grep ZTUNNEL_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')}"
 ISTIO_ZTUNNEL_VERSION="${ISTIO_ZTUNNEL_VERSION:-${ZTUNNEL_REPO_SHA}}"
-ISTIO_ZTUNNEL_RELEASE_URL="${ISTIO_ZTUNNEL_RELEASE_URL:-${ISTIO_ZTUNNEL_BASE_URL}/ztunnel-${ISTIO_ZTUNNEL_VERSION}-${ZTUNNEL_ARCH}}"
+ISTIO_ZTUNNEL_RELEASE_URL="${ISTIO_ZTUNNEL_RELEASE_URL:-${ISTIO_ZTUNNEL_BASE_URL}/ztunnel-${ISTIO_ZTUNNEL_VERSION}-${TARGET_ARCH}}"
 ISTIO_ZTUNNEL_LINUX_RELEASE_NAME="${ISTIO_ZTUNNEL_LINUX_RELEASE_NAME:-ztunnel-${ISTIO_ZTUNNEL_VERSION}}"
 ISTIO_ZTUNNEL_LINUX_RELEASE_DIR="${ISTIO_ZTUNNEL_LINUX_RELEASE_DIR:-${TARGET_OUT_LINUX}/release}"
 ISTIO_ZTUNNEL_LINUX_DEBUG_DIR="${ISTIO_ZTUNNEL_LINUX_DEBUG_DIR:-${TARGET_OUT_LINUX}/debug}"

--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -113,22 +113,20 @@ function maybe_build_ztunnel() {
   popd
 }
 
-
+# TODO(https://github.com/istio/ztunnel/issues/394) use TARGET_ARCH
+# For now, we use amd64 even on arm64 just so we can actually do a release properly
+ZTUNNEL_ARCH="amd64"
 
 # ztunnel binary vars (TODO handle debug builds, centos, arm, darwin etc.)
 ISTIO_ZTUNNEL_BASE_URL="${ISTIO_ZTUNNEL_BASE_URL:-https://storage.googleapis.com/istio-build/ztunnel}"
 ZTUNNEL_REPO_SHA="${ZTUNNEL_REPO_SHA:-$(grep ZTUNNEL_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')}"
 ISTIO_ZTUNNEL_VERSION="${ISTIO_ZTUNNEL_VERSION:-${ZTUNNEL_REPO_SHA}}"
-ISTIO_ZTUNNEL_RELEASE_URL="${ISTIO_ZTUNNEL_RELEASE_URL:-${ISTIO_ZTUNNEL_BASE_URL}/ztunnel-${ISTIO_ZTUNNEL_VERSION}-${TARGET_ARCH}}"
+ISTIO_ZTUNNEL_RELEASE_URL="${ISTIO_ZTUNNEL_RELEASE_URL:-${ISTIO_ZTUNNEL_BASE_URL}/ztunnel-${ISTIO_ZTUNNEL_VERSION}-${ZTUNNEL_ARCH}}"
 ISTIO_ZTUNNEL_LINUX_RELEASE_NAME="${ISTIO_ZTUNNEL_LINUX_RELEASE_NAME:-ztunnel-${ISTIO_ZTUNNEL_VERSION}}"
 ISTIO_ZTUNNEL_LINUX_RELEASE_DIR="${ISTIO_ZTUNNEL_LINUX_RELEASE_DIR:-${TARGET_OUT_LINUX}/release}"
 ISTIO_ZTUNNEL_LINUX_DEBUG_DIR="${ISTIO_ZTUNNEL_LINUX_DEBUG_DIR:-${TARGET_OUT_LINUX}/debug}"
 ISTIO_ZTUNNEL_LINUX_RELEASE_PATH="${ISTIO_ZTUNNEL_LINUX_RELEASE_PATH:-${ISTIO_ZTUNNEL_LINUX_RELEASE_DIR}/${ISTIO_ZTUNNEL_LINUX_RELEASE_NAME}}"
 
-if [[ "${TARGET_ARCH}" == "amd64" ]]; then
-  set_download_command
-  maybe_build_ztunnel
-  download_ztunnel_if_necessary "${ISTIO_ZTUNNEL_RELEASE_URL}" "$ISTIO_ZTUNNEL_LINUX_RELEASE_PATH" "ztunnel"
-else
-  echo "Skipping ztunnel; only supports amd64"
-fi
+set_download_command
+maybe_build_ztunnel
+download_ztunnel_if_necessary "${ISTIO_ZTUNNEL_RELEASE_URL}" "$ISTIO_ZTUNNEL_LINUX_RELEASE_PATH" "ztunnel"

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "7af8f5de5c54e927398f6f8ee8923bdd50d772bc"
+    "lastStableSHA": "ef2372ca575d785c8cdab1f3b5af3da8a3d808b7"
   }
 ]

--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -67,7 +67,6 @@ images:
   - ${TARGET_OUT_LINUX}/istio-cni-taint
 
 - name: ztunnel
-  emulationRequired: true # TODO this is a hack to skip building in our release job; currently ztunnel is amd64 only
   dockerfile: pilot/docker/Dockerfile.ztunnel
   files:
   - ${TARGET_OUT_LINUX}/ztunnel # TODO "${RELEASE_MODE}" to allow separate debug builds


### PR DESCRIPTION
To do it properly, need https://github.com/istio/ztunnel/issues/394. For now this is a hack to unblock amd64 release.