### PR TITLE
ztunnel: move chart over to standard helm mechanism

### DIFF
--- a/manifests/charts/ztunnel/README.md
+++ b/manifests/charts/ztunnel/README.md
@@ -1,0 +1,36 @@
+# Istio Ztunnel Helm Chart
+
+This chart installs an Istio ztunnel.
+
+## Setup Repo Info
+
+```console
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Installing the Chart
+
+To install the chart:
+
+```console
+helm install ztunnel istio/ztunnel
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the chart:
+
+```console
+helm delete ztunnel
+```
+
+## Configuration
+
+To view support configuration options and documentation, run:
+
+```console
+helm show values istio/ztunnel
+```

--- a/manifests/charts/ztunnel/templates/NOTES.txt
+++ b/manifests/charts/ztunnel/templates/NOTES.txt
@@ -1,0 +1,5 @@
+ztunnel successfully installed!
+
+To learn more about the release, try:
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
         image: "{{ .Values.image }}"
 {{- else }}
         {{/*  TODO(https://github.com/istio/istio/issues/43243): use distroless, but we are depending on a variant of things not in the distroless image */}}
-        image: "{{ .Values.hub }}/{{ .Values.image | default "proxyv2" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
+        image: "{{ .Values.hub }}/{{ .Values.image | default "ztunnel" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
 {{- end }}
 {{- with .Values.imagePullPolicy }}
         imagePullPolicy: {{ . }}
@@ -204,7 +204,7 @@ spec:
 {{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
 {{- else }}
-        image: "{{ .Values.hub }}/{{ .Values.image | default "proxyv2" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
+        image: "{{ .Values.hub }}/{{ .Values.image | default "ztunnel" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
 {{- end }}
 {{- with .Values.imagePullPolicy }}
         imagePullPolicy: {{ . }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -4,9 +4,9 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-{{- range $key, $val := .Values.ztunnel.deploymentLabels }}
-    {{ $key }}: "{{ $val }}"
-{{- end }}
+    {{- .Values.labels | toYaml | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -20,15 +20,11 @@ spec:
       labels:
         sidecar.istio.io/inject: "false"
         app: ztunnel
-        {{- range $key, $val := .Values.ztunnel.podLabels }}
-        {{ $key }}: "{{ $val }}"
-        {{- end }}
+{{ with .Values.podLabels -}}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
         ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
-        {{- if .Values.ztunnel.podAnnotations }}
-{{ toYaml .Values.ztunnel.podAnnotations | indent 8 }}
-        {{- end }}
+{{ with .Values.podAnnotations -}}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       serviceAccountName: ztunnel
       tolerations:
@@ -40,14 +36,14 @@ spec:
           operator: Exists
       initContainers:
       - name: istio-init
-{{- if contains "/" .Values.ztunnel.image }}
-        image: "{{ .Values.ztunnel.image }}"
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
 {{- else }}
         {{/*  TODO(https://github.com/istio/istio/issues/43243): use distroless, but we are depending on a variant of things not in the distroless image */}}
-        image: "{{ .Values.ztunnel.hub | default .Values.global.hub }}/{{ .Values.ztunnel.image | default "ztunnel" }}:{{ .Values.ztunnel.tag | default .Values.global.tag }}"
+        image: "{{ .Values.hub }}/{{ .Values.image | default "proxyv2" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
 {{- end }}
-{{- if .Values.global.imagePullPolicy }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- with .Values.imagePullPolicy }}
+        imagePullPolicy: {{ . }}
 {{- end }}
         securityContext:
           privileged: true
@@ -197,21 +193,21 @@ spec:
           value: "{{ $value }}"
         {{- end }}
         {{- end }}
-        {{- if .Values.ztunnel.env }}
-        {{- range $key, $val := .Values.ztunnel.env }}
+        {{- with .Values.env }}
+        {{- range $key, $val := . }}
         - name: {{ $key }}
           value: "{{ $val }}"
         {{- end }}
         {{- end }}
       containers:
       - name: istio-proxy
-{{- if contains "/" .Values.ztunnel.image }}
-        image: "{{ .Values.ztunnel.image }}"
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
 {{- else }}
-        image: "{{ .Values.ztunnel.hub | default .Values.global.hub }}/{{ .Values.ztunnel.image | default "proxyv2" }}:{{ .Values.ztunnel.tag | default .Values.global.tag }}{{with (.Values.ztunnel.variant | default .Values.global.variant)}}-{{.}}{{end}}"
+        image: "{{ .Values.hub }}/{{ .Values.image | default "proxyv2" }}:{{ .Values.tag }}{{with (.Values.variant )}}-{{.}}{{end}}"
 {{- end }}
-{{- if .Values.global.imagePullPolicy }}
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+{{- with .Values.imagePullPolicy }}
+        imagePullPolicy: {{ . }}
 {{- end }}
         securityContext:
           capabilities:
@@ -226,7 +222,7 @@ spec:
         - ztunnel
         env:
         - name: CLUSTER_ID
-          value: {{ .Values.global.multiCluster.clusterName | default "Kubernetes" }}
+          value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -253,8 +249,8 @@ spec:
           value: "{{ $value }}"
         {{- end }}
         {{- end }}
-        {{- if .Values.ztunnel.env }}
-        {{- range $key, $val := .Values.ztunnel.env }}
+        {{- with .Values.env }}
+        {{- range $key, $val := . }}
         - name: {{ $key }}
           value: "{{ $val }}"
         {{- end }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
-  {{- if .Values.global.imagePullSecrets }}
+  {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
-  {{- range .Values.global.imagePullSecrets }}
+  {{- range . }}
   - name: {{ . }}
   {{- end }}
   {{- end }}
@@ -10,6 +10,7 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    app: ztunnel
-    release: {{ .Release.Name }}
+    {{- .Values.labels | toYaml | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
 ---

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -1,58 +1,51 @@
-ztunnel:
-  hub: ""
-  tag: ""
-  variant: ""
+# Hub to pull from. Image will be `Hub/Image:Tag-Variant`
+hub: "gcr.io/istio-testing"
+# Tag to pull from. Image will be `Hub/Image:Tag-Variant`
+tag: "latest"
+# Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.
+variant: ""
 
-  # Can be a full hub/image:tag
-  image: ztunnel
+# Image name to pull from. Image will be `Hub/Image:Tag-Variant`
+# If Image contains a "/", it will replace the entire `image` in the pod.
+image: ztunnel
 
-  resources:
-    requests:
-      cpu: 500m
-      memory: 2048Mi
+# Labels to apply to all top level resources
+labels: {}
+# Annotations to apply to all top level resources
+annotations: {}
 
-  env: {}
-  podAnnotations:
-    prometheus.io/port: "15020"
-    prometheus.io/scrape: "true"
+# Annotations added to each pod. The default annotations are required for scraping prometheus (in most environments).
+podAnnotations:
+  prometheus.io/port: "15020"
+  prometheus.io/scrape: "true"
 
-  # Additional labels to apply to the deployment.
-  deploymentLabels: {}
+# Additional labels to apply on the pod level
+podLabels: {}
 
-  # Additional labels to apply on the pod level for monitoring and logging configuration.
-  podLabels: {}
+# Pod resource configuration
+resources:
+  requests:
+    cpu: 500m
+    memory: 2048Mi
 
-global:
-  istioNamespace: istio-system
-  # Default hub for Istio images.
-  # Releases are published to docker hub under 'istio' project.
-  # Dev builds from prow are on gcr.io
-  hub: gcr.io/istio-testing
-  # Default tag for Istio images.
-  tag: latest
-  # Variant of the image to use.
-  # Currently supported are: [debug, distroless]
-  variant: ""
+# List of secret names to add to the service account as image pull secrets
+imagePullSecrets: []
 
-  multiCluster:
-    # Set to true to connect two kubernetes clusters via their respective
-    # ingressgateway services when pods in each cluster cannot directly
-    # talk to one another. All clusters should be using Istio mTLS and must
-    # have a shared root CA for this model to work.
-    enabled: false
-    # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
-    # to properly label proxies
-    clusterName: ""
+# A `key: value` mapping of environment variables to add to the pod
+env: {}
 
-  # Specify image pull policy if default behavior isn't desired.
-  # Default behavior: latest images will be Always else IfNotPresent.
-  imagePullPolicy: ""
+# Override for the pod imagePullPolicy
+imagePullPolicy: ""
 
-# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
-revision: ""
+# Settings for multicluster
+multiCluster:
+  # The name of the cluster we are installing in. Note this is a user-defined name, which must be consistent
+  # with Istiod configuration.
+  clusterName: ""
 
-# meshConfig defines runtime configuration of components, including Istiod and istio-agent behavior
-# For ztunnel, only defaultConfig is used.
+# meshConfig defines runtime configuration of components.
+# For ztunnel, only defaultConfig is used, but this is nested under `meshConfig` for consistency with other
+# components.
 # TODO: https://github.com/istio/istio/issues/43248
 meshConfig:
   defaultConfig:

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -92,6 +92,9 @@ type ComponentMaps struct {
 	ToHelmValuesTreeRoot string
 	// SkipReverseTranslate defines whether reverse translate of this component need to be skipped.
 	SkipReverseTranslate bool
+	// FlattenValues, if true, means the component expects values not prefixed with ToHelmValuesTreeRoot
+	// For example `.name=foo` instead of `.component.name=foo`.
+	FlattenValues bool
 }
 
 // TranslationFunc maps a yamlStr API path into a YAML values tree.
@@ -161,6 +164,7 @@ func NewTranslator() *Translator {
 				ResourceName:         "ztunnel",
 				HelmSubdir:           "ztunnel",
 				ToHelmValuesTreeRoot: "ztunnel",
+				FlattenValues:        true,
 			},
 		},
 		// nolint: lll
@@ -582,6 +586,25 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 	mergedVals, err = util.OverlayTrees(mergedVals, globalUnvalidatedVals)
 	if err != nil {
 		return "", err
+	}
+	c, f := t.ComponentMaps[componentName]
+	if f && c.FlattenValues {
+		globals, ok := mergedVals["global"].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("global value isn't a map")
+		}
+		components, ok := mergedVals[c.ToHelmValuesTreeRoot].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("component value isn't a map")
+		}
+		finalVals := map[string]any{}
+		for k, v := range globals {
+			finalVals[k] = v
+		}
+		for k, v := range components {
+			finalVals[k] = v
+		}
+		mergedVals = finalVals
 	}
 
 	mergedYAML, err := yaml.Marshal(mergedVals)


### PR DESCRIPTION
The ztunnel chart - like most other Istio charts - is currently implemented in a non-standard way. Due to how the operator works, charts are currently nested. A user configures `.values.global.foo=bar` or `.values.ztunnel.foo=bar` to set values.

Neither of those really make sense in Helm -- we don't need a "global" when we are dealing with a single chart, and we don't need to specify "ztunnel" before everything when we already know we are installing ztunnel.

This PR moves to a more standard approach, flattening out the values. It also moves some trivial differences to align with the `gateway` chart (which takes the same approach!!). A README and NOTES.txt is added for documentation during install, and prepares it for eventual inclusion in artifacthub.

To make the operator work, we need a small tweak. The operator will still build values in the nested format, but for specific charts (ztunnel only, currently), will construct a different 'shape' of the values before passing it off to helm. First, globals are applied to the top level, followed by the component config. This allows, for example, `global.hub=a,global.tag=b,ztunnel.tag=c` to render to `hub=a,tag=c`. This allows the operator model and helm model to co-exist, using the idioms of each API.

**Please provide a description of this PR:**