### PR TITLE
Update regex to match multiple space characters

### DIFF
--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -173,7 +173,7 @@ func createBuildxBuilderIfNeeded(a Args) error {
 		if err != nil {
 			return fmt.Errorf("command failed: %v", err)
 		}
-		matches := regexp.MustCompile(`Driver: (.*)`).FindStringSubmatch(out.String())
+		matches := regexp.MustCompile(`Driver:\s+(.*)`).FindStringSubmatch(out.String())
 		if len(matches) == 0 || matches[1] != "docker-container" {
 			return fmt.Errorf("the docker buildx builder is not using the docker-container driver needed for .save.\n" +
 				"Create a new builder (ex: docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0" +


### PR DESCRIPTION
**Please provide a description of this PR:**
The existing regex only matches a literal space character whereas [docker buildx prints a \t character](https://github.com/docker/buildx/blob/master/commands/inspect.go#L52). This will result in a false negative when checking for a docker-container builder on a save operation. This PR fixes the regex to match on any number of space characters to account for variations in environments and terminal settings (at least until https://github.com/docker/buildx/issues/381 is addressed)