### PR TITLE
Add label and annotations to gateway role

### DIFF
--- a/manifests/charts/gateway/templates/role.yaml
+++ b/manifests/charts/gateway/templates/role.yaml
@@ -5,6 +5,10 @@ kind: Role
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -15,6 +19,10 @@ kind: RoleBinding
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
**Please provide a description of this PR:**

Brings the chart more in line with the comment regarding labels and annotations. Currently, annotations and labels are not added to Role and RoleBinding for gateways, which is somewhat annoying seeing as our project would like to describe any role and rolebinding present in our cluster, unless we cant.

Simply adds the labels and annotations metadata in the same way other resources in the chart uses them.