### PR TITLE
Analyze: dedupe proxy image mismatched outputs

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -207,7 +207,7 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.ImageAnalyzer{},
 		expected: []message{
-			{msg.IstioProxyImageMismatch, "Pod enabled-namespace/details-v1-pod-old"},
+			{msg.PodsIstioProxyImageMismatchInNamespace, "Namespace enabled-namespace"},
 		},
 	},
 	{
@@ -218,7 +218,7 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.ImageAnalyzer{},
 		expected: []message{
-			{msg.IstioProxyImageMismatch, "Pod enabled-namespace/details-v1-pod-old"},
+			{msg.PodsIstioProxyImageMismatchInNamespace, "Namespace enabled-namespace"},
 		},
 	},
 	{
@@ -230,8 +230,8 @@ var testGrid = []testCase{
 		},
 		analyzer: &injection.ImageAnalyzer{},
 		expected: []message{
-			{msg.IstioProxyImageMismatch, "Pod enabled-namespace/details-v1-pod-old"},
-			{msg.IstioProxyImageMismatch, "Pod revision-namespace/revision-details-v1-pod-old"},
+			{msg.PodsIstioProxyImageMismatchInNamespace, "Namespace enabled-namespace"},
+			{msg.PodsIstioProxyImageMismatchInNamespace, "Namespace revision-namespace"},
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/injection/injection-image.go
+++ b/pkg/config/analysis/analyzers/injection/injection-image.go
@@ -129,7 +129,8 @@ func (a *ImageAnalyzer) Analyze(c analysis.Context) {
 				return true
 			}
 			if container.Image != proxyImage {
-				namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()] = append(namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()], r.Metadata.FullName.Name.String())
+				namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()] = append(
+					namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()], r.Metadata.FullName.Name.String())
 			}
 		}
 

--- a/pkg/config/analysis/analyzers/injection/injection-image.go
+++ b/pkg/config/analysis/analyzers/injection/injection-image.go
@@ -83,9 +83,11 @@ func (a *ImageAnalyzer) Analyze(c analysis.Context) {
 	}
 
 	injectedNamespaces := make(map[string]string)
-
+	namespaceMismatchedPods := make(map[string][]string)
+	namespaceResources := make(map[string]*resource.Instance)
 	// Collect the list of namespaces that have istio injection enabled.
 	c.ForEach(collections.K8SCoreV1Namespaces.Name(), func(r *resource.Instance) bool {
+		namespaceResources[r.Metadata.FullName.String()] = r
 		nsRevision, okNewInjectionLabel := r.Metadata.Labels[RevisionInjectionLabelName]
 		if r.Metadata.Labels[util.InjectionLabelName] == util.InjectionLabelEnableValue || okNewInjectionLabel {
 			if okNewInjectionLabel {
@@ -117,7 +119,7 @@ func (a *ImageAnalyzer) Analyze(c analysis.Context) {
 			return true
 		}
 
-		for i, container := range pod.Containers {
+		for _, container := range pod.Containers {
 			if container.Name != util.IstioProxyName {
 				continue
 			}
@@ -127,18 +129,16 @@ func (a *ImageAnalyzer) Analyze(c analysis.Context) {
 				return true
 			}
 			if container.Image != proxyImage {
-				m := msg.NewIstioProxyImageMismatch(r, container.Image, proxyImage)
-
-				if line, ok := util.ErrorLine(r, fmt.Sprintf(util.ImageInContainer, i)); ok {
-					m.Line = line
-				}
-
-				c.Report(collections.K8SCoreV1Pods.Name(), m)
+				namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()] = append(namespaceMismatchedPods[r.Metadata.FullName.Namespace.String()], r.Metadata.FullName.Name.String())
 			}
 		}
 
 		return true
 	})
+	for ns, pods := range namespaceMismatchedPods {
+		c.Report(collections.K8SCoreV1Namespaces.Name(),
+			msg.NewPodsIstioProxyImageMismatchInNamespace(namespaceResources[ns], pods))
+	}
 }
 
 // GetIstioProxyImage retrieves the proxy image name defined in the sidecar injector

--- a/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
+++ b/pkg/config/analysis/analyzers/testdata/injection-with-mismatched-sidecar.yaml
@@ -36,6 +36,51 @@ spec:
   - image: docker.io/istio/proxyv2:1.3.1
     name: istio-proxy
 ---
+# should not match the injector version.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v1-pod-old-pre
+  namespace: enabled-namespace
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0-prerelease
+    name: istio-proxy
+---
+# should not match the injector version.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v1-pod-old-pre-2
+  namespace: enabled-namespace
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0-prerelease
+    name: istio-proxy
+---
+# should not match the injector version.
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: details
+  name: details-v1-pod-old-pre-3
+  namespace: enabled-namespace
+spec:
+  containers:
+  - image: docker.io/istio/examples-bookinfo-details-v1:1.15.0
+    name: details
+  - image: docker.io/istio/proxyv2:1.3.0-prerelease
+    name: istio-proxy
+---
 # details-v1-pod-overwritten-sidecar has a custom sidecar version injected and
 # therefore should not match the injector version.
 apiVersion: v1

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -224,6 +224,10 @@ var (
 	// InvalidTelemetryProvider defines a diag.MessageType for message "InvalidTelemetryProvider".
 	// Description: The Telemetry with empty providers will be ignored
 	InvalidTelemetryProvider = diag.NewMessageType(diag.Warning, "IST0157", "The Telemetry %v in namespace %q with empty providers will be ignored.")
+
+	// PodsIstioProxyImageMismatchInNamespace defines a diag.MessageType for message "PodsIstioProxyImageMismatchInNamespace".
+	// Description: The Istio proxy image of the pods running in the namespace do not match the image defined in the injection configuration.
+	PodsIstioProxyImageMismatchInNamespace = diag.NewMessageType(diag.Warning, "IST0158", "The Istio proxy images of the pods running in the namespace do not match the image defined in the injection configuration (pod names: %v). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pods.")
 )
 
 // All returns a list of all known message types.
@@ -283,6 +287,7 @@ func All() []*diag.MessageType {
 		EnvoyFilterUsesRelativeOperationWithProxyVersion,
 		UnsupportedGatewayAPIVersion,
 		InvalidTelemetryProvider,
+		PodsIstioProxyImageMismatchInNamespace,
 	}
 }
 
@@ -813,5 +818,14 @@ func NewInvalidTelemetryProvider(r *resource.Instance, name string, namespace st
 		r,
 		name,
 		namespace,
+	)
+}
+
+// NewPodsIstioProxyImageMismatchInNamespace returns a new diag.Message based on PodsIstioProxyImageMismatchInNamespace.
+func NewPodsIstioProxyImageMismatchInNamespace(r *resource.Instance, podNames []string) diag.Message {
+	return diag.NewMessage(
+		PodsIstioProxyImageMismatchInNamespace,
+		r,
+		podNames,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -608,3 +608,13 @@ messages:
       type: string
     - name: namespace
       type: string
+
+  - name: "PodsIstioProxyImageMismatchInNamespace"
+    code: IST0158
+    level: Warning
+    description: "The Istio proxy image of the pods running in the namespace do not match the image defined in the injection configuration."
+    template: "The Istio proxy images of the pods running in the namespace do not match the image defined in the injection configuration (pod names: %v). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pods."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0105/"
+    args:
+      - name: podNames
+        type: "[]string"

--- a/releasenotes/notes/dedupe-mismatch-output.yaml
+++ b/releasenotes/notes/dedupe-mismatch-output.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Improved** the `istioctl analyze` to output mismatched proxy image messages as IST0158 on namespace level instead of IST0105 on pod level, which is more succinct.


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to https://github.com/istio/istio/issues/28511

Just upgraded Istio, and there's too many pod mismatch warning messages. Since the message needs to be based on resource, this PR optimizes the message to be displayed in namespace level instead of pod level.

The sample output contains three messages, otherwise it will display ~20 pod warning messages:

Warning [IST0158] (Namespace default) The Istio proxy images of the pods running in the namespace do not match the image defined in the injection configuration (pod names: [reviews-v3-c9c4fb987-rjknk details-v1-5ffd6b64f7-dkd24 reviews-v2-65c4dc6fdc-lcv5s sleep-78ff5975c6-p6frx helloworld-v2-54dddc5567-sgdm8 reviews-v1-85c9cf744f-htp9d helloworld-v1-78b9f5c87f-c6j68 ratings-v2-59b9459df8-5hhsm httpbin-9dbd644c7-tf5j4 ratings-v1-5f9699cfdf-rh6x8 reviews-v1-85c9cf744f-kcvkr details-v2-5f96c65ddb-k5g9p reviews-v1-85c9cf744f-5s29r productpage-v1-854f68c487-sdxx9 sleep-78ff5975c6-jl7cs]). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pods.
Warning [IST0158] (Namespace dt) The Istio proxy images of the pods running in the namespace do not match the image defined in the injection configuration (pod names: [httpbin-55dc8d5878-2hmxf sleep-7cc687fcdf-5m7fp]). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pods.
Warning [IST0158] (Namespace test) The Istio proxy images of the pods running in the namespace do not match the image defined in the injection configuration (pod names: [details-v1-5ffd6b64f7-csh7w reviews-v3-c9c4fb987-bqwbm reviews-v2-65c4dc6fdc-4sbfb ratings-v1-5f9699cfdf-dp7hs reviews-v1-569db879f5-sbc67 productpage-v1-979d4d9fc-kkvqf]). This often happens after upgrading the Istio control-plane and can be fixed by redeploying the pods.