### PR TITLE
gateway-api: fix `EnqueueForParentHandler`

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -145,7 +145,7 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 
 	// Use the full informer; we are already watching all Gateways for the core Istiod logic
 	dc.gwInformer = gw.Informer()
-	dc.gwClassHandle, _ = dc.gwInformer.AddEventHandler(controllers.ObjectHandler(dc.queue.AddObject))
+	dc.gwHandle, _ = dc.gwInformer.AddEventHandler(controllers.ObjectHandler(dc.queue.AddObject))
 	dc.gwClassInformer = gwc.Informer()
 	dc.gwClassHandle, _ = dc.gwClassInformer.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
 		gws, _ := dc.gatewayLister.List(klabels.Everything())

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -94,7 +94,7 @@ func EnqueueForParentHandler(q Queue, kind config.GroupVersionKind) func(obj Obj
 				log.Errorf("could not parse OwnerReference api version %q: %v", ref.APIVersion, err)
 				continue
 			}
-			if refGV == kind.Kubernetes().GroupVersion() {
+			if refGV.Group == kind.Group && ref.Kind == kind.Kind {
 				// We found a parent we care about, add it to the queue
 				q.Add(types.NamespacedName{
 					// Reference doesn't have namespace, but its always same-namespace, so use objects

--- a/releasenotes/notes/gateway-handler.yaml
+++ b/releasenotes/notes/gateway-handler.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/43332
+
+releaseNotes:
+  - |
+    **Fixed** istiod not reconciling k8s gateway deployments and services when they are changed.


### PR DESCRIPTION
**Please provide a description of this PR:**
When parsing the owner references of gateway deployments/services, compare GroupKind rather than GroupVersion
Fixes #43332
which is a regression after bumping the gateway-api version


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
