### PR TITLE
waypoint: simplification jumbo

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -193,8 +193,6 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildWaypointInboundClusters(cb, proxy, req.Push, svcs)...)
-		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
-		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	default: // Gateways
 		patcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_GATEWAY}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -112,9 +112,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	builder.patchListeners()
 	l := builder.getListeners()
 	if builder.node.EnableHBONE() {
-		if builder.node.IsAmbient() {
-			l = append(l, outboundTunnelListener(builder.push, builder.node))
-		} else {
+		if !builder.node.IsAmbient() {
 			l = append(l, sidecarOutboundTunnelListener(builder.push, builder.node))
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -112,7 +112,9 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	builder.patchListeners()
 	l := builder.getListeners()
 	if builder.node.EnableHBONE() {
-		if !builder.node.IsAmbient() {
+		if builder.node.IsAmbient() {
+			l = append(l, outboundTunnelListener(builder.push, builder.node))
+		} else {
 			l = append(l, sidecarOutboundTunnelListener(builder.push, builder.node))
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -159,13 +159,12 @@ func (lb *ListenerBuilder) buildWaypointInboundTerminateConnect() *listener.List
 		xdsfilters.ConnectBaggageFilter,
 		xdsfilters.ConnectAuthorityFilter,
 	}, h.HttpFilters...)
-	name := "inbound_CONNECT_terminate"
 	l := &listener.Listener{
-		Name:    name,
+		Name:    "connect_terminate",
 		Address: util.BuildAddress(actualWildcard, model.HBoneInboundListenPort),
 		FilterChains: []*listener.FilterChain{
 			{
-				Name: name,
+				Name: "default",
 				TransportSocket: &core.TransportSocket{
 					Name: "tls",
 					ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&tls.DownstreamTlsContext{
@@ -323,7 +322,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 }
 
 func (lb *ListenerBuilder) buildWaypointInboundOriginateConnect() *listener.Listener {
-	name := "inbound_CONNECT_originate"
+	name := "connect_originate"
 	l := &listener.Listener{
 		Name:              name,
 		UseOriginalDst:    wrappers.Bool(false),

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -202,7 +202,8 @@ func ConstructSdsSecretConfig(name string) *tls.SdsSecretConfig {
 	return cfg
 }
 
-func appendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
+// AppendURIPrefixToTrustDomain append SPIFFE prefix to URI.
+func AppendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
 	var res []string
 	for _, td := range trustDomainAliases {
 		res = append(res, spiffe.URIPrefix+td+"/")
@@ -227,7 +228,7 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, proxy *model.Prox
 	// TODO: if user explicitly specifies SANs - should we alter his explicit config by adding all spifee aliases?
 	matchSAN := util.StringToExactMatch(subjectAltNames)
 	if len(trustDomainAliases) > 0 {
-		matchSAN = append(matchSAN, util.StringToPrefixMatch(appendURIPrefixToTrustDomain(trustDomainAliases))...)
+		matchSAN = append(matchSAN, util.StringToPrefixMatch(AppendURIPrefixToTrustDomain(trustDomainAliases))...)
 	}
 
 	// configure server listeners with SDS.

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -470,9 +470,9 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint) *endpoint.
 		if supportsTunnel {
 			address := e.Address
 			tunnelPort := 15008
-			// We will connect to inbound_CONNECT_originate internal listener, telling it to tunnel to ip:15008,
+			// We will connect to CONNECT origination internal listener, telling it to tunnel to ip:15008,
 			// and add some detunnel metadata that had the original port.
-			tunnelOrigLis := "inbound_CONNECT_originate"
+			tunnelOrigLis := "connect_originate"
 			ep.Metadata.FilterMetadata[model.TunnelLabelShortName] = util.BuildTunnelMetadataStruct(address, address, int(e.EndpointPort), tunnelPort)
 			ep = util.BuildInternalLbEndpoint(tunnelOrigLis, ep.Metadata)
 			ep.LoadBalancingWeight = &wrappers.UInt32Value{

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -29,7 +29,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -28,7 +28,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -29,7 +29,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -28,7 +28,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -23,7 +23,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -24,7 +24,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -39,7 +39,9 @@
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
         "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
-        "buffer_size_kb": 64
+        "value": {
+          "buffer_size_kb": 64
+        }
       }
     }
   ],

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -38,7 +38,8 @@
       "name": "envoy.bootstrap.internal_listener",
       "typed_config": {
         "@type":"type.googleapis.com/udpa.type.v1.TypedStruct",
-        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+        "type_url": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener",
+        "buffer_size_kb": 64
       }
     }
   ],


### PR DESCRIPTION
Minor improvements to waypoint xDS:
* set internal watermark buffer size to 64kb;
* remove passthrough clusters in waypoints - they would never do the right thing;
* rename to shorter symbols "connect_terminate" and "connect_originate";
* fully convert to typed SAN validation;
* remove unnecessary filters from CONNECT termination.