### PR TITLE
ambient upstream: CNI for ambient redirection

### DIFF
--- a/cni/pkg/ambient/ambientpod/podutil.go
+++ b/cni/pkg/ambient/ambientpod/podutil.go
@@ -1,0 +1,127 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambientpod
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/api/label"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/pkg/log"
+)
+
+func hasPodIP(pod *corev1.Pod) bool {
+	return pod.Status.PodIP != ""
+}
+
+func isRunning(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning
+}
+
+func ShouldPodBeInIpset(namespace *corev1.Namespace, pod *corev1.Pod, ignoreNotRunning bool) bool {
+	// Pod must:
+	// - Be running
+	// - Have an IP address
+	// - Cannot have a legacy label (istio.io/rev or istio-injection=enabled)
+	// - If mesh is in namespace mode, must be in active namespace
+	if (ignoreNotRunning || (isRunning(pod) && hasPodIP(pod))) &&
+		!HasLegacyLabel(pod.GetLabels()) &&
+		!PodHasOptOut(pod) &&
+		IsNamespaceActive(namespace) {
+		return true
+	}
+
+	return false
+}
+
+func PodHasOptOut(pod *corev1.Pod) bool {
+	if val, ok := pod.Annotations[constants.AmbientRedirection]; ok {
+		return val == constants.AmbientRedirectionDisabled
+	}
+	return false
+}
+
+func IsNamespaceActive(namespace *corev1.Namespace) bool {
+	//   - Namespace cannot have "legacy" labels (ie. istio.io/rev or istio-injection=enabled)
+	//   - Namespace must have label istio.io/dataplane-mode=ambient
+	if namespace != nil &&
+		!HasLegacyLabel(namespace.GetLabels()) &&
+		namespace.GetLabels()[constants.DataplaneMode] == constants.DataplaneModeAmbient {
+		return true
+	}
+
+	return false
+}
+
+func HasSelectors(lbls map[string]string, selectors []labels.Selector) bool {
+	for _, sel := range selectors {
+		if sel.Matches(labels.Set(lbls)) {
+			return true
+		}
+	}
+	return false
+}
+
+var LegacyLabelSelector = []*metav1.LabelSelector{
+	{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "istio-injection",
+				Operator: metav1.LabelSelectorOpIn,
+				Values: []string{
+					"enabled",
+				},
+			},
+		},
+	},
+	{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      label.IoIstioRev.Name,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+	},
+}
+
+var LegacySelectors = ConvertDisabledSelectors(LegacyLabelSelector)
+
+func ConvertDisabledSelectors(selectors []*metav1.LabelSelector) []labels.Selector {
+	res := make([]labels.Selector, 0, len(selectors))
+	for _, k := range selectors {
+		s, err := metav1.LabelSelectorAsSelector(k)
+		if err != nil {
+			log.Errorf("failed to convert label selector: %v", err)
+			continue
+		}
+		res = append(res, s)
+	}
+	return res
+}
+
+// We do not support the istio.io/rev or istio-injection sidecar labels
+// If a pod or namespace has these labels, ambient mesh will not be applied
+// to that namespace
+func HasLegacyLabel(lbl map[string]string) bool {
+	for _, sel := range LegacySelectors {
+		if sel.Matches(labels.Set(lbl)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cni/pkg/ambient/constants/constants.go
+++ b/cni/pkg/ambient/constants/constants.go
@@ -1,0 +1,65 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	// In the below, we add the fwmask to ensure only that mark can match
+	OutboundMask = "0x100"
+	OutboundMark = OutboundMask + "/" + OutboundMask
+	SkipMask     = "0x200"
+	SkipMark     = SkipMask + "/" + SkipMask
+	ConnSkipMask = "0x220"
+	ConnSkipMark = ConnSkipMask + "/" + ConnSkipMask
+	ProxyMask    = "0x210"
+	ProxyMark    = ProxyMask + "/" + ProxyMask
+	ProxyRetMask = "0x040"
+	ProxyRetMark = ProxyRetMask + "/" + ProxyRetMask
+
+	InboundTun  = "istioin"
+	OutboundTun = "istioout"
+
+	InboundTunIP         = "192.168.126.1"
+	ZTunnelInboundTunIP  = "192.168.126.2"
+	OutboundTunIP        = "192.168.127.1"
+	ZTunnelOutboundTunIP = "192.168.127.2"
+	TunPrefix            = 30
+
+	ChainZTunnelPrerouting  = "ztunnel-PREROUTING"
+	ChainZTunnelPostrouting = "ztunnel-POSTROUTING"
+	ChainZTunnelInput       = "ztunnel-INPUT"
+	ChainZTunnelOutput      = "ztunnel-OUTPUT"
+	ChainZTunnelForward     = "ztunnel-FORWARD"
+
+	ChainPrerouting  = "PREROUTING"
+	ChainPostrouting = "POSTROUTING"
+	ChainInput       = "INPUT"
+	ChainOutput      = "OUTPUT"
+	ChainForward     = "FORWARD"
+
+	TableMangle = "mangle"
+	TableNat    = "nat"
+
+	DNSCapturePort = 15053
+)
+
+const (
+	RouteTableInbound  = 100
+	RouteTableOutbound = 101
+	RouteTableProxy    = 102
+)
+
+const (
+	AmbientConfigFilepath = "/etc/ambient-config/config.json"
+)

--- a/cni/pkg/ambient/informers.go
+++ b/cni/pkg/ambient/informers.go
@@ -1,0 +1,149 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/cni/pkg/ambient/ambientpod"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+)
+
+var ErrLegacyLabel = "Namespace %s has sidecar label istio-injection or istio.io/rev " +
+	"enabled while also setting ambient mode. This is not supported and the namespace will " +
+	"be ignored from the ambient mesh."
+
+func (s *Server) setupHandlers() {
+	s.queue = controllers.NewQueue("ambient",
+		controllers.WithGenericReconciler(s.Reconcile),
+		controllers.WithMaxAttempts(5),
+	)
+
+	// We only need to handle pods on our node
+	podInformer := s.kubeClient.KubeInformer().InformerFor(&corev1.Pod{}, func(k kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
+		return informersv1.NewFilteredPodInformer(
+			k, metav1.NamespaceAll, resync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			func(options *metav1.ListOptions) {
+				options.FieldSelector = "spec.nodeName=" + NodeName
+			},
+		)
+	})
+	_ = podInformer.SetTransform(kube.StripUnusedFields)
+	_, _ = podInformer.AddEventHandler(controllers.FromEventHandler(func(o controllers.Event) {
+		s.queue.Add(o)
+	}))
+	s.podLister = listerv1.NewPodLister(podInformer.GetIndexer())
+
+	// Namespaces could be anything though, so we watch all of those
+	ns := s.kubeClient.KubeInformer().Core().V1().Namespaces()
+	s.nsLister = ns.Lister()
+	_, _ = ns.Informer().AddEventHandler(controllers.ObjectHandler(s.EnqueueNamespace))
+}
+
+func (s *Server) Run(stop <-chan struct{}) {
+	go s.queue.Run(stop)
+	<-stop
+}
+
+func (s *Server) ReconcileNamespaces() {
+	namespaces, _ := s.nsLister.List(klabels.Everything())
+	for _, ns := range namespaces {
+		s.EnqueueNamespace(ns)
+	}
+}
+
+// EnqueueNamespace takes a Namespace and enqueues all Pod objects that make need an update
+func (s *Server) EnqueueNamespace(o controllers.Object) {
+	nsLabels := o.GetLabels()
+	namespace := o.GetName()
+	matchAmbient := s.matchesAmbientSelectors(nsLabels)
+	pods, _ := s.podLister.Pods(namespace).List(klabels.Everything())
+	if matchAmbient {
+		if ambientpod.HasLegacyLabel(nsLabels) {
+			log.Errorf(ErrLegacyLabel, namespace)
+			return
+		}
+		log.Infof("Namespace %s is enabled in ambient mesh", namespace)
+		for _, pod := range pods {
+			s.queue.Add(controllers.Event{
+				New:   pod,
+				Old:   pod,
+				Event: controllers.EventUpdate,
+			})
+		}
+	} else {
+		log.Infof("Namespace %s is disabled from ambient mesh", namespace)
+		for _, pod := range pods {
+			s.queue.Add(controllers.Event{
+				New:   pod,
+				Event: controllers.EventDelete,
+			})
+		}
+	}
+}
+
+func (s *Server) Reconcile(input any) error {
+	event := input.(controllers.Event)
+	log := log.WithLabels("type", event.Event)
+	pod := event.Latest().(*corev1.Pod)
+	if ztunnelPod(pod) {
+		return s.ReconcileZtunnel()
+	}
+	switch event.Event {
+	case controllers.EventAdd:
+	case controllers.EventUpdate:
+		// For update, we just need to handle opt outs
+		newPod := event.New.(*corev1.Pod)
+		oldPod := event.Old.(*corev1.Pod)
+		if ambientpod.PodHasOptOut(newPod) && !ambientpod.PodHasOptOut(oldPod) {
+			log.Debugf("Pod %s matches opt out, but was not before, removing from mesh", newPod.Name)
+			DelPodFromMesh(s.kubeClient.Kube(), newPod)
+			return nil
+		}
+
+		if event.New == event.Old {
+			// This is a bit of a hack, but in this case we are queued from namespace handler
+			if ambientpod.PodHasOptOut(pod) {
+				log.Debugf("Pod %s matches opt out, skipping", pod.Name)
+				return nil
+			}
+			AddPodToMesh(s.kubeClient.Kube(), pod, "")
+		}
+	case controllers.EventDelete:
+		if IsPodInIpset(pod) {
+			log.Infof("Pod %s/%s is now stopped... cleaning up.", pod.Namespace, pod.Name)
+			DelPodFromMesh(s.kubeClient.Kube(), pod)
+		}
+		return nil
+	}
+	if ambientpod.PodHasOptOut(pod) {
+		log.Debugf("Pod %s matches opt out, skipping", pod.Name)
+		return nil
+	}
+	return nil
+}
+
+func ztunnelPod(pod *corev1.Pod) bool {
+	return pod.GetLabels()["app"] == "ztunnel"
+}

--- a/cni/pkg/ambient/iptables.go
+++ b/cni/pkg/ambient/iptables.go
@@ -1,0 +1,300 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"strconv"
+	"strings"
+
+	"istio.io/istio/cni/pkg/ambient/constants"
+)
+
+type iptablesRule struct {
+	Table    string
+	Chain    string
+	RuleSpec []string
+}
+
+// detectIptablesCommand will attempt to detect whether to use iptables-legacy, iptables or iptables-nft
+// based on output of iptables-nft or if the command exists.
+//
+// Logic is based on Kubernetes https://github.com/danwinship/kubernetes/blob/ca32fd23cca0797aa787fc5d883807d4eee6899f/build/debian-iptables/iptables-wrapper
+func (s *Server) detectIptablesCommand() string {
+	var err error
+	var numLegacyLines int
+	var numNftLines int
+	var output string
+
+	log.Infof("Detecting iptables command")
+
+	output, err = executeOutput("bash", "-c",
+		"(iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l",
+	)
+	if err != nil {
+		log.Errorf("Error getting iptables-legacy-save output: %v, assuming 0", err)
+	} else {
+		numLegacyLines, err = strconv.Atoi(strings.TrimSpace(output))
+		if err != nil {
+			log.Errorf("Error converting iptables-legacy-save output to int: %v, assuming 0", err)
+		}
+	}
+
+	if numLegacyLines > 10 {
+		log.Infof("Detected iptables-legacy")
+		return "iptables-legacy"
+	}
+
+	output, err = executeOutput("bash", "-c",
+		`(timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l`,
+	)
+	if err != nil {
+		log.Errorf("Error getting iptables-nft-save output: %v, assuming 0", err)
+	} else {
+		numNftLines, err = strconv.Atoi(strings.TrimSpace(output))
+		if err != nil {
+			log.Errorf("Error converting iptables-nft-save output to int: %v, assuming 0", err)
+		}
+	}
+
+	if numLegacyLines > numNftLines {
+		log.Infof("Using iptables command: iptables-legacy")
+		return "iptables-legacy"
+	}
+	log.Infof("Using iptables command: iptables-nft")
+	return "iptables-nft"
+}
+
+func (s *Server) IptablesCmd() string {
+	c, _ := s.iptablesCommand.Get()
+	return c
+}
+
+// Initialize the chains and lists for ztunnel
+func (s *Server) initializeLists() error {
+	var err error
+
+	list := []*ExecList{
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-N", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-I", "PREROUTING", "-j", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-N", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-I", "POSTROUTING", "-j", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-N", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-I", "PREROUTING", "-j", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-N", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-I", "POSTROUTING", "-j", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-N", constants.ChainZTunnelOutput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-I", "OUTPUT", "-j", constants.ChainZTunnelOutput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-N", constants.ChainZTunnelInput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-I", "INPUT", "-j", constants.ChainZTunnelInput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-N", constants.ChainZTunnelForward}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-I", "FORWARD", "-j", constants.ChainZTunnelForward}),
+	}
+
+	for _, l := range list {
+		err = execute(l.Cmd, l.Args...)
+		if err != nil {
+			if strings.Contains(err.Error(), "Chain already exists") {
+				log.Debugf("Chain already exists caught during running command %v: %v", l.Cmd, err)
+			} else {
+				log.Errorf("Error running command %v (can safely ignore chain exist errors): %v", l.Cmd, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Flush the chains and lists for ztunnel
+func (s *Server) flushLists() {
+	var err error
+
+	list := []*ExecList{
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-F", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableNat, "-F", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-F", constants.ChainZTunnelPrerouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-F", constants.ChainZTunnelPostrouting}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-F", constants.ChainZTunnelOutput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-F", constants.ChainZTunnelInput}),
+		newExec(s.IptablesCmd(),
+			[]string{"-t", constants.TableMangle, "-F", constants.ChainZTunnelForward}),
+	}
+
+	for _, l := range list {
+		err = execute(l.Cmd, l.Args...)
+		if err != nil {
+			log.Warnf("Error running command %v: %v", l.Cmd, err)
+		}
+	}
+}
+
+func (s *Server) cleanRules() {
+	var err error
+
+	s.flushLists()
+
+	list := []*ExecList{
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableNat,
+				"-D", constants.ChainPrerouting,
+				"-j", constants.ChainZTunnelPrerouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableNat,
+				"-X", constants.ChainZTunnelPrerouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableNat,
+				"-D", constants.ChainPostrouting,
+				"-j", constants.ChainZTunnelPostrouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableNat,
+				"-X", constants.ChainZTunnelPostrouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-D", constants.ChainPrerouting,
+				"-j", constants.ChainZTunnelPrerouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-X", constants.ChainZTunnelPrerouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-D", constants.ChainPostrouting,
+				"-j", constants.ChainZTunnelPostrouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-X", constants.ChainZTunnelPostrouting,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-D", constants.ChainForward,
+				"-j", constants.ChainZTunnelForward,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-X", constants.ChainZTunnelForward,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-D", constants.ChainInput,
+				"-j", constants.ChainZTunnelInput,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-X", constants.ChainZTunnelInput,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-D", constants.ChainOutput,
+				"-j", constants.ChainZTunnelOutput,
+			},
+		),
+		newExec(
+			s.IptablesCmd(),
+			[]string{
+				"-t", constants.TableMangle,
+				"-X", constants.ChainZTunnelOutput,
+			},
+		),
+	}
+
+	for _, l := range list {
+		err = execute(l.Cmd, l.Args...)
+		if err != nil {
+			log.Errorf("Error running command %v: %v", l.Cmd, err)
+		}
+	}
+}
+
+func newIptableRule(table, chain string, rule ...string) *iptablesRule {
+	return &iptablesRule{
+		Table:    table,
+		Chain:    chain,
+		RuleSpec: rule,
+	}
+}
+
+func (s *Server) iptablesAppend(rules []*iptablesRule) error {
+	for _, rule := range rules {
+		log.Debugf("Appending rule: %+v", rule)
+		err := execute(s.IptablesCmd(), append([]string{"-t", rule.Table, "-A", rule.Chain}, rule.RuleSpec...)...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -1,0 +1,799 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/cni/pkg/ambient/constants"
+	pconstants "istio.io/istio/pkg/config/constants"
+	istiolog "istio.io/pkg/log"
+)
+
+var log = istiolog.RegisterScope("ambient", "ambient controller", 0)
+
+func IsPodInIpset(pod *corev1.Pod) bool {
+	ipset, err := Ipset.List()
+	if err != nil {
+		log.Errorf("Failed to list ipset entries: %v", err)
+		return false
+	}
+
+	// Since not all kernels support comments in ipset, we should also try and
+	// match against the IP
+	for _, ip := range ipset {
+		if ip.Comment == string(pod.UID) {
+			return true
+		}
+		if ip.IP.String() == pod.Status.PodIP {
+			return true
+		}
+	}
+
+	return false
+}
+
+func RouteExists(rte []string) bool {
+	output, err := executeOutput(
+		"bash", "-c",
+		fmt.Sprintf("ip route show %s | wc -l", strings.Join(rte, " ")),
+	)
+	if err != nil {
+		return false
+	}
+
+	log.Debugf("RouteExists(%s): %s", strings.Join(rte, " "), output)
+
+	return output == "1"
+}
+
+func AddPodToMesh(client kubernetes.Interface, pod *corev1.Pod, ip string) {
+	if ip == "" {
+		ip = pod.Status.PodIP
+	}
+	if ip == "" {
+		log.Debugf("skip adding pod %s/%s, IP not yet allocated", pod.Name, pod.Namespace)
+		return
+	}
+
+	if !IsPodInIpset(pod) {
+		log.Infof("Adding pod '%s/%s' (%s) to ipset", pod.Name, pod.Namespace, string(pod.UID))
+		err := Ipset.AddIP(net.ParseIP(ip).To4(), string(pod.UID))
+		if err != nil {
+			log.Errorf("Failed to add pod %s to ipset list: %v", pod.Name, err)
+		}
+	} else {
+		log.Infof("Pod '%s/%s' (%s) is in ipset", pod.Name, pod.Namespace, string(pod.UID))
+	}
+
+	rte, err := buildRouteFromPod(pod, ip)
+	if err != nil {
+		log.Errorf("Failed to build route for pod %s: %v", pod.Name, err)
+	}
+
+	if !RouteExists(rte) {
+		log.Infof("Adding route for %s/%s: %+v", pod.Name, pod.Namespace, rte)
+		// @TODO Try and figure out why buildRouteFromPod doesn't return a good route that we can
+		// use err = netlink.RouteAdd(rte):
+		// Error: {"level":"error","time":"2022-06-24T16:30:59.083809Z","msg":"Failed to add route ({Ifindex: 4 Dst: 10.244.2.7/32
+		// Via: Family: 2, Address: 192.168.126.2 Src: 10.244.2.1 Gw: <nil> Flags: [] Table: 100 Realm: 0}) for pod
+		// helloworld-v2-same-node-67b6b764bf-zhmp4: invalid argument"}
+		err = execute("ip", append([]string{"route", "add"}, rte...)...)
+		if err != nil {
+			log.Warnf("Failed to add route (%s) for pod %s: %v", rte, pod.Name, err)
+		}
+	} else {
+		log.Infof("Route already exists for %s/%s: %+v", pod.Name, pod.Namespace, rte)
+	}
+
+	dev, err := getDeviceWithDestinationOf(ip)
+	if err != nil {
+		log.Warnf("Failed to get device for destination %s", ip)
+		return
+	}
+	err = SetProc("/proc/sys/net/ipv4/conf/"+dev+"/rp_filter", "0")
+	if err != nil {
+		log.Warnf("Failed to set rp_filter to 0 for device %s", dev)
+	}
+
+	if err := annotateEnrolledPod(client, pod); err != nil {
+		log.Errorf("failed to annotate pod enrollment: %v", err)
+	}
+}
+
+var annotationPatch = []byte(fmt.Sprintf(
+	`{"metadata":{"annotations":{"%s":"%s"}}}`,
+	pconstants.AmbientRedirection,
+	pconstants.AmbientRedirectionEnabled,
+))
+
+var annotationRemovePatch = []byte(fmt.Sprintf(
+	`{"metadata":{"annotations":{"%s":null}}}`,
+	pconstants.AmbientRedirection,
+))
+
+func annotateEnrolledPod(client kubernetes.Interface, pod *corev1.Pod) error {
+	_, err := client.CoreV1().
+		Pods(pod.Namespace).
+		Patch(
+			context.Background(),
+			pod.Name,
+			types.MergePatchType,
+			annotationPatch,
+			metav1.PatchOptions{},
+		)
+	return err
+}
+
+func annotateUnenrollPod(client kubernetes.Interface, pod *corev1.Pod) error {
+	if pod.Annotations[pconstants.AmbientRedirection] != pconstants.AmbientRedirectionEnabled {
+		return nil
+	}
+	// TODO: do not overwrite if already none
+	_, err := client.CoreV1().
+		Pods(pod.Namespace).
+		Patch(
+			context.Background(),
+			pod.Name,
+			types.MergePatchType,
+			annotationRemovePatch,
+			metav1.PatchOptions{},
+		)
+	return err
+}
+
+func DelPodFromMesh(client kubernetes.Interface, pod *corev1.Pod) {
+	log.Debugf("Removing pod '%s/%s' (%s) from mesh", pod.Name, pod.Namespace, string(pod.UID))
+	if IsPodInIpset(pod) {
+		log.Infof("Removing pod '%s' (%s) from ipset", pod.Name, string(pod.UID))
+		err := Ipset.DeleteIP(net.ParseIP(pod.Status.PodIP).To4())
+		if err != nil {
+			log.Errorf("Failed to delete pod %s from ipset list: %v", pod.Name, err)
+		}
+	} else {
+		log.Infof("Pod '%s/%s' (%s) is not in ipset", pod.Name, pod.Namespace, string(pod.UID))
+	}
+	rte, err := buildRouteFromPod(pod, "")
+	if err != nil {
+		log.Errorf("Failed to build route for pod %s: %v", pod.Name, err)
+	}
+	if RouteExists(rte) {
+		log.Infof("Removing route: %+v", rte)
+		// @TODO Try and figure out why buildRouteFromPod doesn't return a good route that we can
+		// use this:
+		// err = netlink.RouteDel(rte)
+		err = execute("ip", append([]string{"route", "del"}, rte...)...)
+		if err != nil {
+			log.Warnf("Failed to delete route (%s) for pod %s: %v", rte, pod.Name, err)
+		}
+	}
+
+	if err := annotateUnenrollPod(client, pod); err != nil {
+		log.Errorf("failed to annotate pod unenrollment: %v", err)
+	}
+}
+
+func buildRouteFromPod(pod *corev1.Pod, ip string) ([]string, error) {
+	if ip == "" {
+		ip = pod.Status.PodIP
+	}
+
+	if ip == "" {
+		return nil, errors.New("no ip found")
+	}
+
+	return []string{
+		"table",
+		fmt.Sprintf("%d", constants.RouteTableInbound),
+		fmt.Sprintf("%s/32", ip),
+		"via",
+		constants.ZTunnelInboundTunIP,
+		"dev",
+		constants.InboundTun,
+		"src",
+		HostIP,
+	}, nil
+}
+
+func getDeviceWithDestinationOf(ip string) (string, error) {
+	routes, err := netlink.RouteListFiltered(
+		netlink.FAMILY_V4,
+		&netlink.Route{Dst: &net.IPNet{IP: net.ParseIP(ip), Mask: net.CIDRMask(32, 32)}},
+		netlink.RT_FILTER_DST)
+	if err != nil {
+		return "", err
+	}
+
+	if len(routes) == 0 {
+		return "", errors.New("no routes found")
+	}
+
+	linkIndex := routes[0].LinkIndex
+	link, err := netlink.LinkByIndex(linkIndex)
+	if err != nil {
+		return "", err
+	}
+	return link.Attrs().Name, nil
+}
+
+func GetHostIP(kubeClient kubernetes.Interface) (string, error) {
+	var ip string
+	// Get the node from the Kubernetes API
+	node, err := kubeClient.CoreV1().Nodes().Get(context.TODO(), NodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting node: %v", err)
+	}
+
+	ip = node.Spec.PodCIDR
+
+	// This needs to be done as in Kind, the node internal IP is not the one we want.
+	if ip == "" {
+		// PodCIDR is not set, try to get the IP from the node internal IP
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				return address.Address, nil
+			}
+		}
+	} else {
+		network, err := netip.ParsePrefix(ip)
+		if err != nil {
+			return "", fmt.Errorf("error parsing node IP: %v", err)
+		}
+
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			return "", fmt.Errorf("error getting interfaces: %v", err)
+		}
+
+		for _, iface := range ifaces {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return "", fmt.Errorf("error getting addresses: %v", err)
+			}
+
+			for _, addr := range addrs {
+				a, err := netip.ParseAddr(strings.Split(addr.String(), "/")[0])
+				if err != nil {
+					return "", fmt.Errorf("error parsing address: %v", err)
+				}
+				if network.Contains(a) {
+					return a.String(), nil
+				}
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// CreateRulesOnNode initializes the routing, firewall and ipset rules on the node.
+func (s *Server) CreateRulesOnNode(ztunnelVeth, ztunnelIP string, captureDNS bool) error {
+	var err error
+
+	log.Debugf("CreateRulesOnNode: ztunnelVeth=%s, ztunnelIP=%s", ztunnelVeth, ztunnelIP)
+
+	// Check if chain exists, if it exists flush.. otherwise initialize
+	err = execute(s.IptablesCmd(), "-t", "mangle", "-C", "output", "-j", constants.ChainZTunnelOutput)
+	if err == nil {
+		log.Debugf("Chain %s already exists, flushing", constants.ChainOutput)
+		s.flushLists()
+	} else {
+		log.Debugf("Initializing lists")
+		err = s.initializeLists()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create ipset of pod members.
+	log.Debug("Creating ipset")
+	err = Ipset.CreateSet()
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("error creating ipset: %v", err)
+	}
+
+	appendRules := []*iptablesRule{
+		// Skip things that come from the tunnels, but don't apply the conn skip mark
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", constants.InboundTun,
+			"-j", "MARK",
+			"--set-mark", constants.SkipMark,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", constants.InboundTun,
+			"-j", "RETURN",
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", constants.OutboundTun,
+			"-j", "MARK",
+			"--set-mark", constants.SkipMark,
+		),
+		newIptableRule(constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", constants.OutboundTun,
+			"-j", "RETURN",
+		),
+
+		// Make sure that whatever is skipped is also skipped for returning packets.
+		// If we have a skip mark, save it to conn mark.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelForward,
+			"-m", "mark",
+			"--mark", constants.ConnSkipMark,
+			"-j", "CONNMARK",
+			"--save-mark",
+			"--nfmask", constants.ConnSkipMask,
+			"--ctmask", constants.ConnSkipMask,
+		),
+		// Input chain might be needed for things in host namespace that are skipped.
+		// Place the mark here after routing was done, not sure if conn-tracking will figure
+		// it out if I do it before, as NAT might change the connection tuple.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelInput,
+			"-m", "mark",
+			"--mark", constants.ConnSkipMark,
+			"-j", "CONNMARK",
+			"--save-mark",
+			"--nfmask", constants.ConnSkipMask,
+			"--ctmask", constants.ConnSkipMask,
+		),
+
+		// For things with the proxy mark, we need different routing just on returning packets
+		// so we give a different mark to them.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelForward,
+			"-m", "mark",
+			"--mark", constants.ProxyMark,
+			"-j", "CONNMARK",
+			"--save-mark",
+			"--nfmask", constants.ProxyMask,
+			"--ctmask", constants.ProxyMask,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelInput,
+			"-m", "mark",
+			"--mark", constants.ProxyMark,
+			"-j", "CONNMARK",
+			"--save-mark",
+			"--nfmask", constants.ProxyMask,
+			"--ctmask", constants.ProxyMask,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelOutput,
+			"--source", HostIP,
+			"-j", "MARK",
+			"--set-mark", constants.ConnSkipMask,
+		),
+
+		// If we have an outbound mark, we don't need kube-proxy to do anything,
+		// so accept it before kube-proxy translates service vips to pod ips
+		newIptableRule(
+			constants.TableNat,
+			constants.ChainZTunnelPrerouting,
+			"-m", "mark",
+			"--mark", constants.OutboundMark,
+			"-j", "ACCEPT",
+		),
+		newIptableRule(
+			constants.TableNat,
+			constants.ChainZTunnelPostrouting,
+			"-m", "mark",
+			"--mark", constants.OutboundMark,
+			"-j", "ACCEPT",
+		),
+	}
+
+	if captureDNS {
+		appendRules = append(appendRules,
+			newIptableRule(
+				constants.TableNat,
+				constants.ChainZTunnelPrerouting,
+				"-p", "udp",
+				"-m", "set",
+				"--match-set", Ipset.Name, "src",
+				"--dport", "53",
+				"-j", "DNAT",
+				"--to", fmt.Sprintf("%s:%d", ztunnelIP, constants.DNSCapturePort),
+			),
+		)
+	}
+
+	appendRules2 := []*iptablesRule{
+		// Don't set anything on the tunnel (geneve port is 6081), as the tunnel copies
+		// the mark to the un-tunneled packet.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-p", "udp",
+			"-m", "udp",
+			"--dport", "6081",
+			"-j", "RETURN",
+		),
+
+		// If we have the conn mark, restore it to mark, to make sure that the other side of the connection
+		// is skipped as well.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-m", "connmark",
+			"--mark", constants.ConnSkipMark,
+			"-j", "MARK",
+			"--set-mark", constants.SkipMark,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-m", "mark",
+			"--mark", constants.SkipMark,
+			"-j", "RETURN",
+		),
+
+		// If we have the proxy mark in, set the return mark to make sure that original src packets go to ztunnel
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"!", "-i", ztunnelVeth,
+			"-m", "connmark",
+			"--mark", constants.ProxyMark,
+			"-j", "MARK",
+			"--set-mark", constants.ProxyRetMark,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-m", "mark",
+			"--mark", constants.ProxyRetMark,
+			"-j", "RETURN",
+		),
+
+		// Send fake source outbound connections to the outbound route table (for original src)
+		// if it's original src, the source ip of packets coming from the proxy might be that of a pod, so
+		// make sure we don't tproxy it
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", ztunnelVeth,
+			"!", "--source", ztunnelIP,
+			"-j", "MARK",
+			"--set-mark", constants.ProxyMark,
+		),
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-m", "mark",
+			"--mark", constants.SkipMark,
+			"-j", "RETURN",
+		),
+
+		// Make sure anything that leaves ztunnel is routed normally (xds, connections to other ztunnels,
+		// connections to upstream pods...)
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-i", ztunnelVeth,
+			"-j", "MARK",
+			"--set-mark", constants.ConnSkipMark,
+		),
+
+		// skip udp so DNS works. We can make this more granular.
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-p", "udp",
+			"-j", "MARK",
+			"--set-mark", constants.ConnSkipMark,
+		),
+
+		// Skip things from host ip - these are usually kubectl probes
+		// skip anything with skip mark. This can be used to add features like port exclusions
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-m", "mark",
+			"--mark", constants.SkipMark,
+			"-j", "RETURN",
+		),
+
+		// Mark outbound connections to route them to the proxy using ip rules/route tables
+		// Per Yuval, interface_prefix can be left off this rule... but we should check this (hard to automate
+		// detection).
+		newIptableRule(
+			constants.TableMangle,
+			constants.ChainZTunnelPrerouting,
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", Ipset.Name, "src",
+			"-j", "MARK",
+			"--set-mark", constants.OutboundMark,
+		),
+	}
+
+	err = s.iptablesAppend(appendRules)
+	if err != nil {
+		log.Errorf("failed to append iptables rule: %v", err)
+	}
+
+	err = s.iptablesAppend(appendRules2)
+	if err != nil {
+		log.Errorf("failed to append iptables rule: %v", err)
+	}
+
+	// Need to do some work in procfs
+	// @TODO: This likely needs to be cleaned up, there are a lot of martians in AWS
+	// that seem to necessitate this work.
+	procs := map[string]int{
+		"/proc/sys/net/ipv4/conf/default/rp_filter":                0,
+		"/proc/sys/net/ipv4/conf/all/rp_filter":                    0,
+		"/proc/sys/net/ipv4/conf/" + ztunnelVeth + "/rp_filter":    0,
+		"/proc/sys/net/ipv4/conf/" + ztunnelVeth + "/accept_local": 1,
+	}
+	for proc, val := range procs {
+		err = SetProc(proc, fmt.Sprint(val))
+		if err != nil {
+			log.Errorf("failed to write to proc file %s: %v", proc, err)
+		}
+	}
+
+	// Create tunnels
+	inbnd := &netlink.Geneve{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: constants.InboundTun,
+		},
+		ID:     1000,
+		Remote: net.ParseIP(ztunnelIP),
+	}
+	log.Debugf("Building inbound tunnel: %+v", inbnd)
+	err = netlink.LinkAdd(inbnd)
+	if err != nil {
+		log.Errorf("failed to add inbound tunnel: %v", err)
+	}
+	err = netlink.AddrAdd(inbnd, &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   net.ParseIP(constants.InboundTunIP),
+			Mask: net.CIDRMask(constants.TunPrefix, 32),
+		},
+	})
+	if err != nil {
+		log.Errorf("failed to add inbound tunnel address: %v", err)
+	}
+
+	outbnd := &netlink.Geneve{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: constants.OutboundTun,
+		},
+		ID:     1001,
+		Remote: net.ParseIP(ztunnelIP),
+	}
+	log.Debugf("Building outbound tunnel: %+v", outbnd)
+	err = netlink.LinkAdd(outbnd)
+	if err != nil {
+		log.Errorf("failed to add outbound tunnel: %v", err)
+	}
+	err = netlink.AddrAdd(outbnd, &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   net.ParseIP(constants.OutboundTunIP),
+			Mask: net.CIDRMask(constants.TunPrefix, 32),
+		},
+	})
+	if err != nil {
+		log.Errorf("failed to add outbound tunnel address: %v", err)
+	}
+
+	err = netlink.LinkSetUp(inbnd)
+	if err != nil {
+		log.Errorf("failed to set inbound tunnel up: %v", err)
+	}
+	err = netlink.LinkSetUp(outbnd)
+	if err != nil {
+		log.Errorf("failed to set outbound tunnel up: %v", err)
+	}
+
+	procs = map[string]int{
+		"/proc/sys/net/ipv4/conf/" + constants.InboundTun + "/rp_filter":     0,
+		"/proc/sys/net/ipv4/conf/" + constants.InboundTun + "/accept_local":  1,
+		"/proc/sys/net/ipv4/conf/" + constants.OutboundTun + "/rp_filter":    0,
+		"/proc/sys/net/ipv4/conf/" + constants.OutboundTun + "/accept_local": 1,
+	}
+	for proc, val := range procs {
+		err = SetProc(proc, fmt.Sprint(val))
+		if err != nil {
+			log.Errorf("failed to write to proc file %s: %v", proc, err)
+		}
+	}
+
+	dirEntries, err := os.ReadDir("/proc/sys/net/ipv4/conf")
+	if err != nil {
+		log.Errorf("failed to read /proc/sys/net/ipv4/conf: %v", err)
+	}
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			if _, err := os.Stat("/proc/sys/net/ipv4/conf/" + dirEntry.Name() + "/rp_filter"); err != nil {
+				err := SetProc("/proc/sys/net/ipv4/conf/"+dirEntry.Name()+"/rp_filter", "0")
+				if err != nil {
+					log.Errorf("failed to set /proc/sys/net/ipv4/conf/%s/rp_filter: %v", dirEntry.Name(), err)
+				}
+			}
+		}
+	}
+
+	routes := []*ExecList{
+		newExec("ip",
+			[]string{
+				"route", "add", "table", fmt.Sprint(constants.RouteTableOutbound), ztunnelIP,
+				"dev", ztunnelVeth, "scope", "link",
+			},
+		),
+		newExec("ip",
+			[]string{
+				"route", "add", "table", fmt.Sprint(constants.RouteTableOutbound), "0.0.0.0/0",
+				"via", constants.ZTunnelOutboundTunIP, "dev", constants.OutboundTun,
+			},
+		),
+		newExec("ip",
+			[]string{
+				"route", "add", "table", fmt.Sprint(constants.RouteTableProxy), ztunnelIP,
+				"dev", ztunnelVeth, "scope", "link",
+			},
+		),
+		newExec("ip",
+			[]string{
+				"route", "add", "table", fmt.Sprint(constants.RouteTableProxy), "0.0.0.0/0",
+				"via", ztunnelIP, "dev", ztunnelVeth, "onlink",
+			},
+		),
+		newExec("ip",
+			[]string{
+				"route", "add", "table", fmt.Sprint(constants.RouteTableInbound), ztunnelIP,
+				"dev", ztunnelVeth, "scope", "link",
+			},
+		),
+		// Everything with the skip mark goes directly to the main table
+		newExec("ip",
+			[]string{
+				"rule", "add", "priority", "100",
+				"fwmark", fmt.Sprint(constants.SkipMark),
+				"goto", "32766",
+			},
+		),
+		// Everything with the outbound mark goes to the tunnel out device
+		// using the outbound route table
+		newExec("ip",
+			[]string{
+				"rule", "add", "priority", "101",
+				"fwmark", fmt.Sprint(constants.OutboundMark),
+				"lookup", fmt.Sprint(constants.RouteTableOutbound),
+			},
+		),
+		// Things with the proxy return mark go directly to the proxy veth using the proxy
+		// route table (useful for original src)
+		newExec("ip",
+			[]string{
+				"rule", "add", "priority", "102",
+				"fwmark", fmt.Sprint(constants.ProxyRetMark),
+				"lookup", fmt.Sprint(constants.RouteTableProxy),
+			},
+		),
+		// Send all traffic to the inbound table. This table has routes only to pods in the mesh.
+		// It does not have a catch-all route, so if a route is missing, the search will continue
+		// allowing us to override routing just for member pods.
+		newExec("ip",
+			[]string{
+				"rule", "add", "priority", "103",
+				"table", fmt.Sprint(constants.RouteTableInbound),
+			},
+		),
+	}
+
+	for _, route := range routes {
+		err = execute(route.Cmd, route.Args...)
+		if err != nil {
+			log.Errorf(fmt.Errorf("failed to add route (%+v): %v", route, err))
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) cleanup() {
+	log.Infof("server terminated, cleaning up")
+	s.cleanRules()
+
+	// Clean up ip route tables
+	_ = routeFlushTable(constants.RouteTableInbound)
+	_ = routeFlushTable(constants.RouteTableOutbound)
+	_ = routeFlushTable(constants.RouteTableProxy)
+
+	exec := []*ExecList{
+		newExec("ip", []string{"rule", "del", "priority", "100"}),
+		newExec("ip", []string{"rule", "del", "priority", "101"}),
+		newExec("ip", []string{"rule", "del", "priority", "102"}),
+		newExec("ip", []string{"rule", "del", "priority", "103"}),
+	}
+	for _, e := range exec {
+		err := execute(e.Cmd, e.Args...)
+		if err != nil {
+			log.Warnf("Error running command %v %v: %v", e.Cmd, strings.Join(e.Args, " "), err)
+		}
+	}
+
+	// Delete tunnel links
+	err := netlink.LinkDel(&netlink.Geneve{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: constants.InboundTun,
+		},
+	})
+	if err != nil {
+		log.Warnf("error deleting inbound tunnel: %v", err)
+	}
+	err = netlink.LinkDel(&netlink.Geneve{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: constants.OutboundTun,
+		},
+	})
+	if err != nil {
+		log.Warnf("error deleting outbound tunnel: %v", err)
+	}
+
+	_ = Ipset.DestroySet()
+}
+
+func routeFlushTable(table int) error {
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return err
+	}
+	err = routesDelete(routes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func routesDelete(routes []netlink.Route) error {
+	for _, r := range routes {
+		err := netlink.RouteDel(&r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func SetProc(path string, value string) error {
+	return os.WriteFile(path, []byte(value), 0o644)
+}

--- a/cni/pkg/ambient/options.go
+++ b/cni/pkg/ambient/options.go
@@ -1,0 +1,45 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	klabels "k8s.io/apimachinery/pkg/labels"
+
+	ipsetlib "istio.io/istio/cni/pkg/ipset"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/pkg/env"
+)
+
+var (
+	PodNamespace = env.RegisterStringVar("SYSTEM_NAMESPACE", constants.IstioSystemNamespace, "pod's namespace").Get()
+	PodName      = env.RegisterStringVar("POD_NAME", "", "").Get()
+	NodeName     = env.RegisterStringVar("NODE_NAME", "", "").Get()
+	Revision     = env.RegisterStringVar("REVISION", "", "").Get()
+	HostIP       = env.RegisterStringVar("HOST_IP", "", "").Get()
+)
+
+var Ipset = &ipsetlib.IPSet{
+	Name: "ztunnel-pods-ips",
+}
+
+var ambientSelectors = klabels.SelectorFromValidatedSet(map[string]string{
+	constants.DataplaneMode: constants.DataplaneModeAmbient,
+})
+
+type AmbientArgs struct {
+	SystemNamespace string
+	Revision        string
+	KubeConfig      string
+}

--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -1,0 +1,240 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
+
+	"istio.io/istio/cni/pkg/ambient/constants"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/lazy"
+)
+
+type Server struct {
+	kubeClient kube.Client
+	ctx        context.Context
+	queue      controllers.Queue
+
+	nsLister  listerv1.NamespaceLister
+	podLister listerv1.PodLister
+
+	mu         sync.Mutex
+	ztunnelPod *corev1.Pod
+
+	iptablesCommand lazy.Lazy[string]
+}
+
+type AmbientConfigFile struct {
+	ZTunnelReady bool `json:"ztunnelReady"`
+}
+
+func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
+	client, err := buildKubeClient(args.KubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing kube client: %v", err)
+	}
+	// Set some defaults
+	s := &Server{
+		ctx:        ctx,
+		kubeClient: client,
+	}
+	s.iptablesCommand = lazy.New(func() (string, error) {
+		return s.detectIptablesCommand(), nil
+	})
+
+	// We need to find our Host IP -- is there a better way to do this?
+	h, err := GetHostIP(s.kubeClient.Kube())
+	if err != nil || h == "" {
+		return nil, fmt.Errorf("error getting host IP: %v", err)
+	}
+	HostIP = h
+	log.Infof("HostIP=%v", HostIP)
+
+	s.setupHandlers()
+
+	s.UpdateConfig()
+
+	return s, nil
+}
+
+func (s *Server) isZTunnelRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ztunnelPod != nil
+}
+
+// buildKubeClient creates the kube client
+func buildKubeClient(kubeConfig string) (kube.Client, error) {
+	// Used by validation
+	kubeRestConfig, err := kube.DefaultRestConfig(kubeConfig, "", func(config *rest.Config) {
+		config.QPS = 80
+		config.Burst = 160
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed creating kube config: %v", err)
+	}
+
+	client, err := kube.NewClient(kube.NewClientConfigForRestConfig(kubeRestConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed creating kube client: %v", err)
+	}
+
+	return client, nil
+}
+
+func (s *Server) Start() {
+	s.kubeClient.RunAndWait(s.ctx.Done())
+	go func() {
+		s.queue.Run(s.ctx.Done())
+		s.cleanup()
+	}()
+}
+
+func (s *Server) UpdateConfig() {
+	log.Debug("Generating new ambient config file")
+
+	cfg := &AmbientConfigFile{
+		ZTunnelReady: s.isZTunnelRunning(),
+	}
+
+	if err := cfg.write(); err != nil {
+		log.Errorf("Failed to write config file: %v", err)
+	}
+	log.Debug("Done")
+}
+
+var ztunnelLabels = labels.SelectorFromValidatedSet(labels.Set{"app": "ztunnel"})
+
+func (s *Server) ReconcileZtunnel() error {
+	pods, err := s.podLister.Pods(metav1.NamespaceAll).List(ztunnelLabels)
+	if err != nil {
+		return err
+	}
+	var activePod *corev1.Pod
+	for _, p := range pods {
+		ready := kube.CheckPodReady(p) == nil
+		if !ready {
+			continue
+		}
+		if activePod == nil {
+			// Only pod ready, mark this as active
+			activePod = p
+		} else if p.CreationTimestamp.After(activePod.CreationTimestamp.Time) {
+			// If we have multiple pods that are ready, use the newest one.
+			// This ensures on a rolling update we start sending traffic to the new pod and drain the old one.
+			activePod = p
+		}
+	}
+
+	needsUpdate := false
+	s.mu.Lock()
+	if getUID(s.ztunnelPod) != getUID(activePod) {
+		// Active pod change
+		s.ztunnelPod = activePod
+		needsUpdate = true
+	}
+	s.mu.Unlock()
+
+	if !needsUpdate {
+		log.Debugf("active ztunnel unchanged")
+		return nil
+	}
+	s.UpdateConfig()
+	if activePod == nil {
+		log.Infof("active ztunnel updated, no ztunnel running on the node")
+		s.cleanup()
+		return nil
+	}
+	log.Infof("active ztunnel updated to %v", activePod.Name)
+	// TODO: we should not cleanup and recreate; this has downtime. We should mutate the existing rules in place
+	s.cleanup()
+	veth, err := getDeviceWithDestinationOf(activePod.Status.PodIP)
+	if err != nil {
+		return fmt.Errorf("failed to get device: %v", err)
+	}
+
+	captureDNS := getEnvFromPod(activePod, "ISTIO_META_DNS_CAPTURE") == "true"
+	err = s.CreateRulesOnNode(veth, activePod.Status.PodIP, captureDNS)
+	if err != nil {
+		return fmt.Errorf("failed to configure node for ztunnel: %v", err)
+	}
+	// Reconcile namespaces, as it is possible for the original reconciliation to have failed, and a
+	// small pod to have started up before ztunnel is running... so we need to go back and make sure we
+	// catch the existing pods
+	s.ReconcileNamespaces()
+	return nil
+}
+
+// getUID is a nil safe UID accessor
+func getUID(o *corev1.Pod) types.UID {
+	if o == nil {
+		return ""
+	}
+	return o.GetUID()
+}
+
+func (c *AmbientConfigFile) write() error {
+	configFile := constants.AmbientConfigFilepath
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Writing ambient config: %s", data)
+
+	return atomicWrite(configFile, data)
+}
+
+func atomicWrite(filename string, data []byte) error {
+	tmpFile := filename + ".tmp"
+	if err := os.WriteFile(tmpFile, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpFile, filename)
+}
+
+func ReadAmbientConfig() (*AmbientConfigFile, error) {
+	configFile := constants.AmbientConfigFilepath
+
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return &AmbientConfigFile{
+			ZTunnelReady: false,
+		}, nil
+	}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &AmbientConfigFile{}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/cni/pkg/ambient/util.go
+++ b/cni/pkg/ambient/util.go
@@ -1,0 +1,90 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type ExecList struct {
+	Cmd  string
+	Args []string
+}
+
+func newExec(cmd string, args []string) *ExecList {
+	return &ExecList{
+		Cmd:  cmd,
+		Args: args,
+	}
+}
+
+func executeOutput(cmd string, args ...string) (string, error) {
+	externalCommand := exec.Command(cmd, args...)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	externalCommand.Stdout = stdout
+	externalCommand.Stderr = stderr
+
+	err := externalCommand.Run()
+
+	if err != nil || len(stderr.Bytes()) != 0 {
+		return stderr.String(), err
+	}
+
+	return strings.TrimSuffix(stdout.String(), "\n"), err
+}
+
+func execute(cmd string, args ...string) error {
+	log.Debugf("Running command: %s %s", cmd, strings.Join(args, " "))
+	externalCommand := exec.Command(cmd, args...)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	externalCommand.Stdout = stdout
+	externalCommand.Stderr = stderr
+
+	err := externalCommand.Run()
+
+	if len(stdout.String()) != 0 {
+		log.Debugf("Command output: \n%v", stdout.String())
+	}
+
+	if err != nil || len(stderr.Bytes()) != 0 {
+		log.Debugf("Command error output: \n%v", stderr.String())
+		return errors.New(stderr.String())
+	}
+
+	return nil
+}
+
+func (s *Server) matchesAmbientSelectors(lbl map[string]string) bool {
+	return ambientSelectors.Matches(labels.Set(lbl))
+}
+
+func getEnvFromPod(pod *corev1.Pod, envName string) string {
+	for _, container := range pod.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == envName {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 
+	"istio.io/istio/cni/pkg/ambient"
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/constants"
 	"istio.io/istio/cni/pkg/install"
@@ -77,6 +78,18 @@ var rootCmd = &cobra.Command{
 		if err = udsLogger.StartUDSLogServer(cfg.InstallConfig.LogUDSAddress, ctx.Done()); err != nil {
 			log.Errorf("Failed to start up UDS Log Server: %v", err)
 			return
+		}
+
+		if cfg.InstallConfig.AmbientEnabled {
+			// Start ambient controller
+			server, err := ambient.NewServer(ctx, ambient.AmbientArgs{
+				SystemNamespace: ambient.PodNamespace,
+				Revision:        ambient.Revision,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create ambient informer service: %v", err)
+			}
+			server.Start()
 		}
 
 		isReady := install.StartServer()
@@ -147,6 +160,7 @@ func init() {
 		"Binaries that should not be installed. Currently Istio only installs one binary `istio-cni`")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
 	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
+	registerBooleanParameter(constants.AmbientEnabled, false, "Whether ambient controller is enabled")
 
 	// Repair
 	registerBooleanParameter(constants.RepairEnabled, true, "Whether to enable race condition repair or not")
@@ -236,6 +250,8 @@ func constructConfig() (*config.Config, error) {
 		SkipCNIBinaries:   viper.GetStringSlice(constants.SkipCNIBinaries),
 		MonitoringPort:    viper.GetInt(constants.MonitoringPort),
 		LogUDSAddress:     viper.GetString(constants.LogUDSAddress),
+
+		AmbientEnabled: viper.GetBool(constants.AmbientEnabled),
 	}
 
 	if len(installCfg.K8sNodeName) == 0 {

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -80,6 +80,9 @@ type InstallConfig struct {
 	// The UDS server address that CNI plugin will send log to.
 	LogUDSAddress string
 
+	// Whether ambient is enabled
+	AmbientEnabled bool
+
 	// Use the external nsenter command for network namespace switching
 	HostNSEnterExec bool
 }
@@ -144,6 +147,8 @@ func (c InstallConfig) String() string {
 	b.WriteString("MonitoringPort: " + fmt.Sprint(c.MonitoringPort) + "\n")
 	b.WriteString("LogUDSAddress: " + fmt.Sprint(c.LogUDSAddress) + "\n")
 	b.WriteString("HostNSEnterExec: " + fmt.Sprint(c.HostNSEnterExec) + "\n")
+
+	b.WriteString("AmbientEnabled: " + fmt.Sprint(c.AmbientEnabled) + "\n")
 
 	return b.String()
 }

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -34,6 +34,7 @@ const (
 	UpdateCNIBinaries    = "update-cni-binaries"
 	MonitoringPort       = "monitoring-port"
 	LogUDSAddress        = "log-uds-address"
+	AmbientEnabled       = "ambient-enabled"
 
 	// Repair
 	RepairEnabled            = "repair-enabled"

--- a/cni/pkg/ipset/ipset_linux.go
+++ b/cni/pkg/ipset/ipset_linux.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
-	"go.uber.org/multierr"
 )
 
 type IPSet struct {
@@ -88,7 +87,7 @@ func (m *IPSet) ClearEntriesWithComment(comment string) error {
 		if entry.Comment == comment {
 			err := netlink.IpsetDel(m.Name, &entry)
 			if err != nil {
-				return multierr.Append(err, fmt.Errorf("failed to delete IP %s from ipset %s: %w", entry.IP, m.Name, err))
+				return fmt.Errorf("failed to delete IP %s from ipset %s: %w", entry.IP, m.Name, err)
 			}
 		}
 	}

--- a/cni/pkg/ipset/ipset_linux.go
+++ b/cni/pkg/ipset/ipset_linux.go
@@ -1,0 +1,96 @@
+package ipset
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"go.uber.org/multierr"
+)
+
+type IPSet struct {
+	// the name of the ipset to use
+	Name string
+}
+
+func (m *IPSet) CreateSet() error {
+	err := netlink.IpsetCreate(m.Name, "hash:ip", netlink.IpsetCreateOptions{Comments: true})
+	if ipsetErr, ok := err.(nl.IPSetError); ok && ipsetErr == nl.IPSET_ERR_EXIST {
+		return nil
+	}
+	return err
+}
+
+func (m *IPSet) DestroySet() error {
+	err := netlink.IpsetDestroy(m.Name)
+	return err
+}
+
+func (m *IPSet) AddIP(ip net.IP, comment string) error {
+	err := netlink.IpsetAdd(m.Name, &netlink.IPSetEntry{
+		Comment: comment,
+		IP:      ip,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add IP %s to ipset %s: %w", ip, m.Name, err)
+	}
+	return nil
+}
+
+func (m *IPSet) Flush() error {
+	err := netlink.IpsetFlush(m.Name)
+	if err != nil {
+		return fmt.Errorf("failed to flush ipset %s: %w", m.Name, err)
+	}
+	return nil
+}
+
+func (m *IPSet) List() ([]netlink.IPSetEntry, error) {
+	res, err := netlink.IpsetList(m.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list ipset %s: %w", m.Name, err)
+	}
+	return res.Entries, nil
+}
+
+func (m *IPSet) DeleteIP(ip net.IP) error {
+	err := netlink.IpsetDel(m.Name, &netlink.IPSetEntry{
+		IP: ip,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete IP %s from ipset %s: %w", ip, m.Name, err)
+	}
+	return nil
+}
+
+// This is only supported in kernel module from revision 2 or 4, so may not be present
+func (m *IPSet) ClearEntriesWithComment(comment string) error {
+	res, err := netlink.IpsetList(m.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ipset %s: %w", m.Name, err)
+	}
+	for _, entry := range res.Entries {
+		if entry.Comment == comment {
+			err := netlink.IpsetDel(m.Name, &entry)
+			if err != nil {
+				return multierr.Append(err, fmt.Errorf("failed to delete IP %s from ipset %s: %w", entry.IP, m.Name, err))
+			}
+		}
+	}
+	return nil
+}

--- a/cni/pkg/plugin/ambient.go
+++ b/cni/pkg/plugin/ambient.go
@@ -1,0 +1,73 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/cni/pkg/ambient"
+	"istio.io/istio/cni/pkg/ambient/ambientpod"
+)
+
+func checkAmbient(conf Config, ambientConfig ambient.AmbientConfigFile, podName, podNamespace, podIfname string, podIPs []net.IPNet) (bool, error) {
+	if !ambientConfig.ZTunnelReady {
+		return false, fmt.Errorf("ztunnel not ready")
+	}
+
+	client, err := newKubeClient(conf)
+	if err != nil {
+		return false, err
+	}
+
+	if client == nil {
+		return false, nil
+	}
+
+	pod, err := client.CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), podNamespace, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if ambientpod.HasLegacyLabel(pod.Labels) || ambientpod.HasLegacyLabel(ns.Labels) {
+		return false, fmt.Errorf("ambient: pod %s/%s or namespace has legacy labels", podNamespace, podName)
+	}
+
+	if ambientpod.ShouldPodBeInIpset(ns, pod, true) {
+		ambient.NodeName = pod.Spec.NodeName
+
+		ambient.HostIP, err = ambient.GetHostIP(client)
+		if err != nil || ambient.HostIP == "" {
+			return false, fmt.Errorf("error getting host IP: %v", err)
+		}
+
+		// Can't set this on GKE, but needed in AWS.. so silently ignore failures
+		_ = ambient.SetProc("/proc/sys/net/ipv4/conf/"+podIfname+"/rp_filter", "0")
+
+		for _, ip := range podIPs {
+			ambient.AddPodToMesh(client, pod, ip.IP.String())
+		}
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -31,6 +31,7 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
+	"istio.io/istio/cni/pkg/ambient"
 	"istio.io/istio/cni/pkg/constants"
 	"istio.io/pkg/log"
 )
@@ -77,6 +78,7 @@ type Config struct {
 	// Add plugin-specific flags here
 	LogLevel        string     `json:"log_level"`
 	LogUDSAddress   string     `json:"log_uds_address"`
+	AmbientEnabled  bool       `json:"ambient_enabled"`
 	Kubernetes      Kubernetes `json:"kubernetes"`
 	HostNSEnterExec bool       `json:"hostNSEnterExec"`
 }
@@ -183,17 +185,15 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 	} else {
 		loggedPrevResult = conf.PrevResult
 	}
-	log.Debugf("istio-cni CmdAdd config: %+v", conf)
-	log.Debugf("istio-cni CmdAdd previous result: %s", loggedPrevResult)
+	log.WithLabels("if", args.IfName).Debugf("istio-cni CmdAdd config: %+v", conf)
+	log.Debugf("istio-cni CmdAdd previous result: %+v", loggedPrevResult)
 
 	// Determine if running under k8s by checking the CNI args
-	log.Debugf("istio-cni cmdAdd args: %s", args.Args)
 	k8sArgs := K8sArgs{}
 	if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
 		return err
 	}
 
-	log.Infof("istio-cni cmdAdd with k8s args: %+v", k8sArgs)
 	if conf.Kubernetes.InterceptRuleMgrType != "" {
 		interceptRuleMgrType = conf.Kubernetes.InterceptRuleMgrType
 	}
@@ -210,6 +210,34 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 				break
 			}
 		}
+		if conf.AmbientEnabled {
+
+			ambientConf, err := ambient.ReadAmbientConfig()
+			if err != nil {
+				log.Errorf("istio-cni cmdAdd failed to read ambient config %v", err)
+				return err
+			}
+
+			log.Debugf("ambientConf.ZTunnelReady: %v", ambientConf.ZTunnelReady)
+			added := false
+			if !excludePod && ambientConf.ZTunnelReady {
+				podIPs, err := getPodIPs(args.IfName, conf.PrevResult)
+				if err != nil {
+					log.Errorf("istio-cni cmdAdd failed to get pod IPs: %s", err)
+					return err
+				}
+				log.Infof("istio-cni cmdAdd podName: %s podIPs: %+v", podName, podIPs)
+				added, err = checkAmbient(*conf, *ambientConf, podName, podNamespace, args.IfName, podIPs)
+				if err != nil {
+					log.Errorf("istio-cni cmdAdd failed to check ambient: %s", err)
+				}
+			}
+
+			if added {
+				return pluginResponse(conf)
+			}
+		}
+
 		if !excludePod {
 			client, err := newKubeClient(*conf)
 			if err != nil {
@@ -292,6 +320,10 @@ func CmdAdd(args *skel.CmdArgs) (err error) {
 		log.Debugf("Not a kubernetes pod")
 	}
 
+	return pluginResponse(conf)
+}
+
+func pluginResponse(conf *Config) error {
 	var result *cniv1.Result
 	if conf.PrevResult == nil {
 		result = &cniv1.Result{
@@ -310,4 +342,26 @@ func CmdCheck(args *skel.CmdArgs) (err error) {
 
 func CmdDelete(args *skel.CmdArgs) (err error) {
 	return nil
+}
+
+func getPodIPs(iface string, prevResult *cniv1.Result) ([]net.IPNet, error) {
+	if prevResult == nil || len(prevResult.IPs) == 0 {
+		return nil, fmt.Errorf("no ip addresses supplied")
+	}
+
+	ips := make([]net.IPNet, 0, len(prevResult.IPs))
+
+	for _, ipConfig := range prevResult.IPs {
+		if ipConfig.Interface == nil {
+			ips = append(ips, ipConfig.Address)
+			continue
+		}
+		idx := *ipConfig.Interface
+		if idx >= 0 && idx < len(prevResult.Interfaces) && prevResult.Interfaces[idx].Name != iface {
+			continue
+		}
+		ips = append(ips, ipConfig.Address)
+	}
+
+	return ips, nil
 }

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -10,11 +10,8 @@ metadata:
     operator.istio.io/component: "Cni"
 rules:
 - apiGroups: [""]
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
+  resources: ["pods","nodes","namespaces"]
+  verbs: ["get", "list", "watch"]
 ---
 {{- if .Values.cni.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -23,7 +23,8 @@ data:
           "name": "istio-cni",
           "type": "istio-cni",
           "log_level": {{ quote .Values.cni.logLevel }},
-          "log_uds_address": "__LOG_UDS_ADDRESS__", 
+          "log_uds_address": "__LOG_UDS_ADDRESS__",
+          {{if .Values.cni.ambient.enabled}}"ambient_enabled": true,{{end}}
           "kubernetes": {
               "kubeconfig": "__KUBECONFIG_FILEPATH__",
               "cni_bin_dir": {{ .Values.cni.cniBinDir | default $defaultBinDir | quote }},

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
 {{ toYaml .Values.cni.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      {{if .Values.cni.ambient.enabled }}hostNetwork: true{{ end }}
       nodeSelector:
         kubernetes.io/os: linux
       # Can be configured to allow for excluding instio-cni from being scheduled on specified nodes
@@ -133,6 +134,15 @@ spec:
               value: "{{.Values.cni.repair.brokenPodLabelKey}}"
             - name: REPAIR_BROKEN_POD_LABEL_VALUE
               value: "{{.Values.cni.repair.brokenPodLabelValue}}"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            {{- if .Values.cni.ambient.enabled }}
+            - name: AMBIENT_ENABLED
+              value: "true"
+            {{- end }}
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -140,12 +150,54 @@ spec:
               name: cni-net-dir
             - mountPath: /var/run/istio-cni
               name: cni-log-dir
+            {{- if .Values.cni.ambient.enabled }}
+            - mountPath: /etc/ambient-config
+              name: cni-ambientconfig
+            {{ end }}
           resources:
 {{- if .Values.cni.resources }}
 {{ toYaml .Values.cni.resources | trim | indent 12 }}
 {{- else }}
 {{ toYaml .Values.global.defaultResources | trim | indent 12 }}
 {{- end }}
+          {{- if .Values.cni.ambient.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - sh
+                - -c
+                - |-
+                  iptables -t nat -F ztunnel-PREROUTING
+                  iptables -t nat -F ztunnel-POSTROUTING
+                  iptables -t mangle -F ztunnel-PREROUTING
+                  iptables -t mangle -F ztunnel-FOWARD
+                  iptables -t mangle -F ztunnel-INPUT
+                  iptables -t nat -D PREROUTING -j ztunnel-PREROUTING
+                  iptables -t nat -X ztunnel-PREROUTING
+                  iptables -t nat -D POSTROUTING -j ztunnel-POSTROUTING
+                  iptables -t nat -X ztunnel-POSTROUTING
+                  iptables -t mangle -D PREROUTING -j ztunnel-PREROUTING
+                  iptables -t mangle -X ztunnel-PREROUTING
+                  iptables -t mangle -D FORWARD -j ztunnel-FORWARD
+                  iptables -t mangle -X ztunnel-FORWARD
+                  iptables -t mangle -D INPUT -j ztunnel-INPUT
+                  iptables -t mangle -X ztunnel-INPUT
+
+                  ip route flush table 100
+                  ip route flush table 101
+                  ip route flush table 102
+
+                  ip rule del priority 100
+                  ip rule del priority 101
+                  ip rule del priority 102
+                  ip rule del priority 103
+
+                  ip link del name istioin
+                  ip link del name istioout
+
+                  ipset destroy ztunnel-pods-ips
+        {{ end }}
 {{- if .Values.cni.taint.enabled }}
         - name: taint-controller
 {{- if contains "/" .Values.cni.image }}
@@ -178,6 +230,11 @@ spec:
         - name: cni-bin-dir
           hostPath:
             path: {{ .Values.cni.cniBinDir | default $defaultBinDir }}
+        {{- if .Values.cni.ambient.enabled }}
+        - name: cni-ambientconfig
+          hostPath:
+            path: /etc/ambient-config
+        {{- end }}
         - name: cni-net-dir
           hostPath:
             path: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -44,6 +44,12 @@ cni:
   # Allow the istio-cni container to run in privileged mode, needed for some platforms (e.g. OpenShift)
   privileged: false
 
+  # Configure ambient settings
+  ambient:
+    # If enabled, ambient redirection will be enabled
+    enabled: false
+    # Eventually this will have switch for iptables vs eBPF
+
   repair:
     enabled: true
     hub: ""

--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -13,3 +13,6 @@ spec:
         PILOT_ENABLE_INBOUND_PASSTHROUGH: "false"
         PILOT_ENABLE_HBONE: "true"
         CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    cni:
+      ambient:
+        enabled: true

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -200,7 +200,7 @@ func (x OutboundTrafficPolicyConfig_Mode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use OutboundTrafficPolicyConfig_Mode.Descriptor instead.
 func (OutboundTrafficPolicyConfig_Mode) EnumDescriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{19, 0}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{20, 0}
 }
 
 // Types of Access logs to export.
@@ -255,7 +255,7 @@ func (x TelemetryV2StackDriverConfig_AccessLogging) Number() protoreflect.EnumNu
 
 // Deprecated: Use TelemetryV2StackDriverConfig_AccessLogging.Descriptor instead.
 func (TelemetryV2StackDriverConfig_AccessLogging) EnumDescriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{27, 0}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{28, 0}
 }
 
 // ArchConfig specifies the pod scheduling target architecture(amd64, ppc64le, s390x, arm64)
@@ -366,7 +366,8 @@ type CNIConfig struct {
 	// The Container seccompProfile
 	//
 	// See: https://kubernetes.io/docs/tutorials/security/seccomp/
-	SeccompProfile *structpb.Struct `protobuf:"bytes,19,opt,name=seccompProfile,proto3" json:"seccompProfile,omitempty"`
+	SeccompProfile *structpb.Struct  `protobuf:"bytes,19,opt,name=seccompProfile,proto3" json:"seccompProfile,omitempty"`
+	Ambient        *CNIAmbientConfig `protobuf:"bytes,21,opt,name=ambient,proto3" json:"ambient,omitempty"`
 }
 
 func (x *CNIConfig) Reset() {
@@ -549,6 +550,61 @@ func (x *CNIConfig) GetSeccompProfile() *structpb.Struct {
 	return nil
 }
 
+func (x *CNIConfig) GetAmbient() *CNIAmbientConfig {
+	if x != nil {
+		return x.Ambient
+	}
+	return nil
+}
+
+type CNIAmbientConfig struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Controls whether ambient redirection is enabled
+	Enabled *wrapperspb.BoolValue `protobuf:"bytes,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+}
+
+func (x *CNIAmbientConfig) Reset() {
+	*x = CNIAmbientConfig{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *CNIAmbientConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CNIAmbientConfig) ProtoMessage() {}
+
+func (x *CNIAmbientConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CNIAmbientConfig.ProtoReflect.Descriptor instead.
+func (*CNIAmbientConfig) Descriptor() ([]byte, []int) {
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CNIAmbientConfig) GetEnabled() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.Enabled
+	}
+	return nil
+}
+
 type CNITaintConfig struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -561,7 +617,7 @@ type CNITaintConfig struct {
 func (x *CNITaintConfig) Reset() {
 	*x = CNITaintConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -574,7 +630,7 @@ func (x *CNITaintConfig) String() string {
 func (*CNITaintConfig) ProtoMessage() {}
 
 func (x *CNITaintConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -587,7 +643,7 @@ func (x *CNITaintConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CNITaintConfig.ProtoReflect.Descriptor instead.
 func (*CNITaintConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{2}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CNITaintConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -620,7 +676,7 @@ type CNIRepairConfig struct {
 func (x *CNIRepairConfig) Reset() {
 	*x = CNIRepairConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -633,7 +689,7 @@ func (x *CNIRepairConfig) String() string {
 func (*CNIRepairConfig) ProtoMessage() {}
 
 func (x *CNIRepairConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +702,7 @@ func (x *CNIRepairConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CNIRepairConfig.ProtoReflect.Descriptor instead.
 func (*CNIRepairConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{3}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CNIRepairConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -733,7 +789,7 @@ type ResourceQuotas struct {
 func (x *ResourceQuotas) Reset() {
 	*x = ResourceQuotas{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -746,7 +802,7 @@ func (x *ResourceQuotas) String() string {
 func (*ResourceQuotas) ProtoMessage() {}
 
 func (x *ResourceQuotas) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -759,7 +815,7 @@ func (x *ResourceQuotas) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceQuotas.ProtoReflect.Descriptor instead.
 func (*ResourceQuotas) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{4}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ResourceQuotas) GetEnabled() *wrapperspb.BoolValue {
@@ -791,7 +847,7 @@ type CPUTargetUtilizationConfig struct {
 func (x *CPUTargetUtilizationConfig) Reset() {
 	*x = CPUTargetUtilizationConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -804,7 +860,7 @@ func (x *CPUTargetUtilizationConfig) String() string {
 func (*CPUTargetUtilizationConfig) ProtoMessage() {}
 
 func (x *CPUTargetUtilizationConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +873,7 @@ func (x *CPUTargetUtilizationConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CPUTargetUtilizationConfig.ProtoReflect.Descriptor instead.
 func (*CPUTargetUtilizationConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{5}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CPUTargetUtilizationConfig) GetTargetAverageUtilization() int32 {
@@ -840,7 +896,7 @@ type Resources struct {
 func (x *Resources) Reset() {
 	*x = Resources{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -853,7 +909,7 @@ func (x *Resources) String() string {
 func (*Resources) ProtoMessage() {}
 
 func (x *Resources) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -866,7 +922,7 @@ func (x *Resources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Resources.ProtoReflect.Descriptor instead.
 func (*Resources) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{6}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Resources) GetLimits() map[string]string {
@@ -895,7 +951,7 @@ type ServiceAccount struct {
 func (x *ServiceAccount) Reset() {
 	*x = ServiceAccount{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -908,7 +964,7 @@ func (x *ServiceAccount) String() string {
 func (*ServiceAccount) ProtoMessage() {}
 
 func (x *ServiceAccount) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -921,7 +977,7 @@ func (x *ServiceAccount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAccount.ProtoReflect.Descriptor instead.
 func (*ServiceAccount) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{7}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ServiceAccount) GetAnnotations() *structpb.Struct {
@@ -946,7 +1002,7 @@ type DefaultPodDisruptionBudgetConfig struct {
 func (x *DefaultPodDisruptionBudgetConfig) Reset() {
 	*x = DefaultPodDisruptionBudgetConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -959,7 +1015,7 @@ func (x *DefaultPodDisruptionBudgetConfig) String() string {
 func (*DefaultPodDisruptionBudgetConfig) ProtoMessage() {}
 
 func (x *DefaultPodDisruptionBudgetConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -972,7 +1028,7 @@ func (x *DefaultPodDisruptionBudgetConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DefaultPodDisruptionBudgetConfig.ProtoReflect.Descriptor instead.
 func (*DefaultPodDisruptionBudgetConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{8}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DefaultPodDisruptionBudgetConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -997,7 +1053,7 @@ type DefaultResourcesConfig struct {
 func (x *DefaultResourcesConfig) Reset() {
 	*x = DefaultResourcesConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1010,7 +1066,7 @@ func (x *DefaultResourcesConfig) String() string {
 func (*DefaultResourcesConfig) ProtoMessage() {}
 
 func (x *DefaultResourcesConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1079,7 @@ func (x *DefaultResourcesConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DefaultResourcesConfig.ProtoReflect.Descriptor instead.
 func (*DefaultResourcesConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{9}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *DefaultResourcesConfig) GetRequests() *ResourcesRequestsConfig {
@@ -1140,7 +1196,7 @@ type EgressGatewayConfig struct {
 func (x *EgressGatewayConfig) Reset() {
 	*x = EgressGatewayConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1153,7 +1209,7 @@ func (x *EgressGatewayConfig) String() string {
 func (*EgressGatewayConfig) ProtoMessage() {}
 
 func (x *EgressGatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1166,7 +1222,7 @@ func (x *EgressGatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EgressGatewayConfig.ProtoReflect.Descriptor instead.
 func (*EgressGatewayConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{10}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *EgressGatewayConfig) GetAutoscaleEnabled() *wrapperspb.BoolValue {
@@ -1384,7 +1440,7 @@ type GatewaysConfig struct {
 func (x *GatewaysConfig) Reset() {
 	*x = GatewaysConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1397,7 +1453,7 @@ func (x *GatewaysConfig) String() string {
 func (*GatewaysConfig) ProtoMessage() {}
 
 func (x *GatewaysConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1410,7 +1466,7 @@ func (x *GatewaysConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewaysConfig.ProtoReflect.Descriptor instead.
 func (*GatewaysConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{11}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GatewaysConfig) GetIstioEgressgateway() *EgressGatewayConfig {
@@ -1584,7 +1640,7 @@ type GlobalConfig struct {
 func (x *GlobalConfig) Reset() {
 	*x = GlobalConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1597,7 +1653,7 @@ func (x *GlobalConfig) String() string {
 func (*GlobalConfig) ProtoMessage() {}
 
 func (x *GlobalConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1610,7 +1666,7 @@ func (x *GlobalConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalConfig.ProtoReflect.Descriptor instead.
 func (*GlobalConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{12}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{13}
 }
 
 // Deprecated: Do not use.
@@ -1934,7 +1990,7 @@ type STSConfig struct {
 func (x *STSConfig) Reset() {
 	*x = STSConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1947,7 +2003,7 @@ func (x *STSConfig) String() string {
 func (*STSConfig) ProtoMessage() {}
 
 func (x *STSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1960,7 +2016,7 @@ func (x *STSConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use STSConfig.ProtoReflect.Descriptor instead.
 func (*STSConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{13}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *STSConfig) GetServicePort() uint32 {
@@ -1982,7 +2038,7 @@ type IstiodConfig struct {
 func (x *IstiodConfig) Reset() {
 	*x = IstiodConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1995,7 +2051,7 @@ func (x *IstiodConfig) String() string {
 func (*IstiodConfig) ProtoMessage() {}
 
 func (x *IstiodConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2008,7 +2064,7 @@ func (x *IstiodConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IstiodConfig.ProtoReflect.Descriptor instead.
 func (*IstiodConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{14}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *IstiodConfig) GetEnableAnalysis() *wrapperspb.BoolValue {
@@ -2033,7 +2089,7 @@ type GlobalLoggingConfig struct {
 func (x *GlobalLoggingConfig) Reset() {
 	*x = GlobalLoggingConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2046,7 +2102,7 @@ func (x *GlobalLoggingConfig) String() string {
 func (*GlobalLoggingConfig) ProtoMessage() {}
 
 func (x *GlobalLoggingConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2059,7 +2115,7 @@ func (x *GlobalLoggingConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalLoggingConfig.ProtoReflect.Descriptor instead.
 func (*GlobalLoggingConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{15}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GlobalLoggingConfig) GetLevel() string {
@@ -2161,7 +2217,7 @@ type IngressGatewayConfig struct {
 func (x *IngressGatewayConfig) Reset() {
 	*x = IngressGatewayConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2174,7 +2230,7 @@ func (x *IngressGatewayConfig) String() string {
 func (*IngressGatewayConfig) ProtoMessage() {}
 
 func (x *IngressGatewayConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2187,7 +2243,7 @@ func (x *IngressGatewayConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngressGatewayConfig.ProtoReflect.Descriptor instead.
 func (*IngressGatewayConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{16}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *IngressGatewayConfig) GetAutoscaleEnabled() *wrapperspb.BoolValue {
@@ -2438,7 +2494,7 @@ type IngressGatewayZvpnConfig struct {
 func (x *IngressGatewayZvpnConfig) Reset() {
 	*x = IngressGatewayZvpnConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2451,7 +2507,7 @@ func (x *IngressGatewayZvpnConfig) String() string {
 func (*IngressGatewayZvpnConfig) ProtoMessage() {}
 
 func (x *IngressGatewayZvpnConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2464,7 +2520,7 @@ func (x *IngressGatewayZvpnConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IngressGatewayZvpnConfig.ProtoReflect.Descriptor instead.
 func (*IngressGatewayZvpnConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{17}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *IngressGatewayZvpnConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -2498,7 +2554,7 @@ type MultiClusterConfig struct {
 func (x *MultiClusterConfig) Reset() {
 	*x = MultiClusterConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2511,7 +2567,7 @@ func (x *MultiClusterConfig) String() string {
 func (*MultiClusterConfig) ProtoMessage() {}
 
 func (x *MultiClusterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2524,7 +2580,7 @@ func (x *MultiClusterConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiClusterConfig.ProtoReflect.Descriptor instead.
 func (*MultiClusterConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{18}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *MultiClusterConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -2567,7 +2623,7 @@ type OutboundTrafficPolicyConfig struct {
 func (x *OutboundTrafficPolicyConfig) Reset() {
 	*x = OutboundTrafficPolicyConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2580,7 +2636,7 @@ func (x *OutboundTrafficPolicyConfig) String() string {
 func (*OutboundTrafficPolicyConfig) ProtoMessage() {}
 
 func (x *OutboundTrafficPolicyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2593,7 +2649,7 @@ func (x *OutboundTrafficPolicyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutboundTrafficPolicyConfig.ProtoReflect.Descriptor instead.
 func (*OutboundTrafficPolicyConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{19}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *OutboundTrafficPolicyConfig) GetMode() OutboundTrafficPolicyConfig_Mode {
@@ -2720,7 +2776,7 @@ type PilotConfig struct {
 func (x *PilotConfig) Reset() {
 	*x = PilotConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2733,7 +2789,7 @@ func (x *PilotConfig) String() string {
 func (*PilotConfig) ProtoMessage() {}
 
 func (x *PilotConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2746,7 +2802,7 @@ func (x *PilotConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PilotConfig.ProtoReflect.Descriptor instead.
 func (*PilotConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{20}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PilotConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -2994,7 +3050,7 @@ type PilotIngressConfig struct {
 func (x *PilotIngressConfig) Reset() {
 	*x = PilotIngressConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3007,7 +3063,7 @@ func (x *PilotIngressConfig) String() string {
 func (*PilotIngressConfig) ProtoMessage() {}
 
 func (x *PilotIngressConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3020,7 +3076,7 @@ func (x *PilotIngressConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PilotIngressConfig.ProtoReflect.Descriptor instead.
 func (*PilotIngressConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{21}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *PilotIngressConfig) GetIngressService() string {
@@ -3057,7 +3113,7 @@ type PilotPolicyConfig struct {
 func (x *PilotPolicyConfig) Reset() {
 	*x = PilotPolicyConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3070,7 +3126,7 @@ func (x *PilotPolicyConfig) String() string {
 func (*PilotPolicyConfig) ProtoMessage() {}
 
 func (x *PilotPolicyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3083,7 +3139,7 @@ func (x *PilotPolicyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PilotPolicyConfig.ProtoReflect.Descriptor instead.
 func (*PilotPolicyConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{22}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *PilotPolicyConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -3108,7 +3164,7 @@ type TelemetryConfig struct {
 func (x *TelemetryConfig) Reset() {
 	*x = TelemetryConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3121,7 +3177,7 @@ func (x *TelemetryConfig) String() string {
 func (*TelemetryConfig) ProtoMessage() {}
 
 func (x *TelemetryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3134,7 +3190,7 @@ func (x *TelemetryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelemetryConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{23}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TelemetryConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -3168,7 +3224,7 @@ type TelemetryV2Config struct {
 func (x *TelemetryV2Config) Reset() {
 	*x = TelemetryV2Config{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3181,7 +3237,7 @@ func (x *TelemetryV2Config) String() string {
 func (*TelemetryV2Config) ProtoMessage() {}
 
 func (x *TelemetryV2Config) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3250,7 @@ func (x *TelemetryV2Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelemetryV2Config.ProtoReflect.Descriptor instead.
 func (*TelemetryV2Config) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{24}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TelemetryV2Config) GetEnabled() *wrapperspb.BoolValue {
@@ -3244,7 +3300,7 @@ type TelemetryV2MetadataExchangeConfig struct {
 func (x *TelemetryV2MetadataExchangeConfig) Reset() {
 	*x = TelemetryV2MetadataExchangeConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3257,7 +3313,7 @@ func (x *TelemetryV2MetadataExchangeConfig) String() string {
 func (*TelemetryV2MetadataExchangeConfig) ProtoMessage() {}
 
 func (x *TelemetryV2MetadataExchangeConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3270,7 +3326,7 @@ func (x *TelemetryV2MetadataExchangeConfig) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use TelemetryV2MetadataExchangeConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryV2MetadataExchangeConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{25}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TelemetryV2MetadataExchangeConfig) GetWasmEnabled() *wrapperspb.BoolValue {
@@ -3297,7 +3353,7 @@ type TelemetryV2PrometheusConfig struct {
 func (x *TelemetryV2PrometheusConfig) Reset() {
 	*x = TelemetryV2PrometheusConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3310,7 +3366,7 @@ func (x *TelemetryV2PrometheusConfig) String() string {
 func (*TelemetryV2PrometheusConfig) ProtoMessage() {}
 
 func (x *TelemetryV2PrometheusConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3323,7 +3379,7 @@ func (x *TelemetryV2PrometheusConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelemetryV2PrometheusConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryV2PrometheusConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{26}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TelemetryV2PrometheusConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -3368,7 +3424,7 @@ type TelemetryV2StackDriverConfig struct {
 func (x *TelemetryV2StackDriverConfig) Reset() {
 	*x = TelemetryV2StackDriverConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3381,7 +3437,7 @@ func (x *TelemetryV2StackDriverConfig) String() string {
 func (*TelemetryV2StackDriverConfig) ProtoMessage() {}
 
 func (x *TelemetryV2StackDriverConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3394,7 +3450,7 @@ func (x *TelemetryV2StackDriverConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelemetryV2StackDriverConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryV2StackDriverConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{27}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TelemetryV2StackDriverConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -3468,7 +3524,7 @@ type TelemetryV2AccessLogPolicyFilterConfig struct {
 func (x *TelemetryV2AccessLogPolicyFilterConfig) Reset() {
 	*x = TelemetryV2AccessLogPolicyFilterConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3481,7 +3537,7 @@ func (x *TelemetryV2AccessLogPolicyFilterConfig) String() string {
 func (*TelemetryV2AccessLogPolicyFilterConfig) ProtoMessage() {}
 
 func (x *TelemetryV2AccessLogPolicyFilterConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3494,7 +3550,7 @@ func (x *TelemetryV2AccessLogPolicyFilterConfig) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use TelemetryV2AccessLogPolicyFilterConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryV2AccessLogPolicyFilterConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{28}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TelemetryV2AccessLogPolicyFilterConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -3526,7 +3582,7 @@ type PilotConfigSource struct {
 func (x *PilotConfigSource) Reset() {
 	*x = PilotConfigSource{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3539,7 +3595,7 @@ func (x *PilotConfigSource) String() string {
 func (*PilotConfigSource) ProtoMessage() {}
 
 func (x *PilotConfigSource) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3552,7 +3608,7 @@ func (x *PilotConfigSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PilotConfigSource.ProtoReflect.Descriptor instead.
 func (*PilotConfigSource) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{29}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PilotConfigSource) GetSubscribedResources() []string {
@@ -3583,7 +3639,7 @@ type PortsConfig struct {
 func (x *PortsConfig) Reset() {
 	*x = PortsConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3596,7 +3652,7 @@ func (x *PortsConfig) String() string {
 func (*PortsConfig) ProtoMessage() {}
 
 func (x *PortsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3609,7 +3665,7 @@ func (x *PortsConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortsConfig.ProtoReflect.Descriptor instead.
 func (*PortsConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{30}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *PortsConfig) GetName() string {
@@ -3717,7 +3773,7 @@ type ProxyConfig struct {
 func (x *ProxyConfig) Reset() {
 	*x = ProxyConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3730,7 +3786,7 @@ func (x *ProxyConfig) String() string {
 func (*ProxyConfig) ProtoMessage() {}
 
 func (x *ProxyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3743,7 +3799,7 @@ func (x *ProxyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProxyConfig.ProtoReflect.Descriptor instead.
 func (*ProxyConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{31}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ProxyConfig) GetAutoInject() string {
@@ -3914,7 +3970,7 @@ type ProxyInitConfig struct {
 func (x *ProxyInitConfig) Reset() {
 	*x = ProxyInitConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3927,7 +3983,7 @@ func (x *ProxyInitConfig) String() string {
 func (*ProxyInitConfig) ProtoMessage() {}
 
 func (x *ProxyInitConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3940,7 +3996,7 @@ func (x *ProxyInitConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProxyInitConfig.ProtoReflect.Descriptor instead.
 func (*ProxyInitConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{32}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ProxyInitConfig) GetImage() string {
@@ -3971,7 +4027,7 @@ type ResourcesRequestsConfig struct {
 func (x *ResourcesRequestsConfig) Reset() {
 	*x = ResourcesRequestsConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3984,7 +4040,7 @@ func (x *ResourcesRequestsConfig) String() string {
 func (*ResourcesRequestsConfig) ProtoMessage() {}
 
 func (x *ResourcesRequestsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3997,7 +4053,7 @@ func (x *ResourcesRequestsConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourcesRequestsConfig.ProtoReflect.Descriptor instead.
 func (*ResourcesRequestsConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{33}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ResourcesRequestsConfig) GetCpu() string {
@@ -4027,7 +4083,7 @@ type SDSConfig struct {
 func (x *SDSConfig) Reset() {
 	*x = SDSConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4040,7 +4096,7 @@ func (x *SDSConfig) String() string {
 func (*SDSConfig) ProtoMessage() {}
 
 func (x *SDSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4053,7 +4109,7 @@ func (x *SDSConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SDSConfig.ProtoReflect.Descriptor instead.
 func (*SDSConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{34}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{35}
 }
 
 // Deprecated: Do not use.
@@ -4080,7 +4136,7 @@ type SecretVolume struct {
 func (x *SecretVolume) Reset() {
 	*x = SecretVolume{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4093,7 +4149,7 @@ func (x *SecretVolume) String() string {
 func (*SecretVolume) ProtoMessage() {}
 
 func (x *SecretVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4106,7 +4162,7 @@ func (x *SecretVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretVolume.ProtoReflect.Descriptor instead.
 func (*SecretVolume) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{35}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SecretVolume) GetMountPath() string {
@@ -4145,7 +4201,7 @@ type ServiceConfig struct {
 func (x *ServiceConfig) Reset() {
 	*x = ServiceConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4158,7 +4214,7 @@ func (x *ServiceConfig) String() string {
 func (*ServiceConfig) ProtoMessage() {}
 
 func (x *ServiceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4171,7 +4227,7 @@ func (x *ServiceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceConfig.ProtoReflect.Descriptor instead.
 func (*ServiceConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{36}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ServiceConfig) GetAnnotations() *structpb.Struct {
@@ -4253,7 +4309,7 @@ type SidecarInjectorConfig struct {
 func (x *SidecarInjectorConfig) Reset() {
 	*x = SidecarInjectorConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4266,7 +4322,7 @@ func (x *SidecarInjectorConfig) String() string {
 func (*SidecarInjectorConfig) ProtoMessage() {}
 
 func (x *SidecarInjectorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4279,7 +4335,7 @@ func (x *SidecarInjectorConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SidecarInjectorConfig.ProtoReflect.Descriptor instead.
 func (*SidecarInjectorConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{37}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SidecarInjectorConfig) GetEnableNamespacesByDefault() *wrapperspb.BoolValue {
@@ -4372,7 +4428,7 @@ type TracerConfig struct {
 func (x *TracerConfig) Reset() {
 	*x = TracerConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4385,7 +4441,7 @@ func (x *TracerConfig) String() string {
 func (*TracerConfig) ProtoMessage() {}
 
 func (x *TracerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4398,7 +4454,7 @@ func (x *TracerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerConfig.ProtoReflect.Descriptor instead.
 func (*TracerConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{38}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *TracerConfig) GetDatadog() *TracerDatadogConfig {
@@ -4442,7 +4498,7 @@ type TracerDatadogConfig struct {
 func (x *TracerDatadogConfig) Reset() {
 	*x = TracerDatadogConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4455,7 +4511,7 @@ func (x *TracerDatadogConfig) String() string {
 func (*TracerDatadogConfig) ProtoMessage() {}
 
 func (x *TracerDatadogConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4468,7 +4524,7 @@ func (x *TracerDatadogConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerDatadogConfig.ProtoReflect.Descriptor instead.
 func (*TracerDatadogConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{39}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *TracerDatadogConfig) GetAddress() string {
@@ -4493,7 +4549,7 @@ type TracerLightStepConfig struct {
 func (x *TracerLightStepConfig) Reset() {
 	*x = TracerLightStepConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4506,7 +4562,7 @@ func (x *TracerLightStepConfig) String() string {
 func (*TracerLightStepConfig) ProtoMessage() {}
 
 func (x *TracerLightStepConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4519,7 +4575,7 @@ func (x *TracerLightStepConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerLightStepConfig.ProtoReflect.Descriptor instead.
 func (*TracerLightStepConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{40}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *TracerLightStepConfig) GetAddress() string {
@@ -4551,7 +4607,7 @@ type TracerZipkinConfig struct {
 func (x *TracerZipkinConfig) Reset() {
 	*x = TracerZipkinConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4564,7 +4620,7 @@ func (x *TracerZipkinConfig) String() string {
 func (*TracerZipkinConfig) ProtoMessage() {}
 
 func (x *TracerZipkinConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4577,7 +4633,7 @@ func (x *TracerZipkinConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerZipkinConfig.ProtoReflect.Descriptor instead.
 func (*TracerZipkinConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{41}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *TracerZipkinConfig) GetAddress() string {
@@ -4606,7 +4662,7 @@ type TracerStackdriverConfig struct {
 func (x *TracerStackdriverConfig) Reset() {
 	*x = TracerStackdriverConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4619,7 +4675,7 @@ func (x *TracerStackdriverConfig) String() string {
 func (*TracerStackdriverConfig) ProtoMessage() {}
 
 func (x *TracerStackdriverConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4632,7 +4688,7 @@ func (x *TracerStackdriverConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerStackdriverConfig.ProtoReflect.Descriptor instead.
 func (*TracerStackdriverConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{42}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *TracerStackdriverConfig) GetDebug() *wrapperspb.BoolValue {
@@ -4680,7 +4736,7 @@ type BaseConfig struct {
 func (x *BaseConfig) Reset() {
 	*x = BaseConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4693,7 +4749,7 @@ func (x *BaseConfig) String() string {
 func (*BaseConfig) ProtoMessage() {}
 
 func (x *BaseConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4706,7 +4762,7 @@ func (x *BaseConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BaseConfig.ProtoReflect.Descriptor instead.
 func (*BaseConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{43}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *BaseConfig) GetEnableCRDTemplates() *wrapperspb.BoolValue {
@@ -4751,7 +4807,7 @@ type IstiodRemoteConfig struct {
 func (x *IstiodRemoteConfig) Reset() {
 	*x = IstiodRemoteConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4764,7 +4820,7 @@ func (x *IstiodRemoteConfig) String() string {
 func (*IstiodRemoteConfig) ProtoMessage() {}
 
 func (x *IstiodRemoteConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4777,7 +4833,7 @@ func (x *IstiodRemoteConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IstiodRemoteConfig.ProtoReflect.Descriptor instead.
 func (*IstiodRemoteConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{44}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *IstiodRemoteConfig) GetInjectionURL() string {
@@ -4821,7 +4877,7 @@ type Values struct {
 func (x *Values) Reset() {
 	*x = Values{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4834,7 +4890,7 @@ func (x *Values) String() string {
 func (*Values) ProtoMessage() {}
 
 func (x *Values) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4847,7 +4903,7 @@ func (x *Values) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Values.ProtoReflect.Descriptor instead.
 func (*Values) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{45}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *Values) GetCni() *CNIConfig {
@@ -4969,7 +5025,7 @@ type ZeroVPNConfig struct {
 func (x *ZeroVPNConfig) Reset() {
 	*x = ZeroVPNConfig{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4982,7 +5038,7 @@ func (x *ZeroVPNConfig) String() string {
 func (*ZeroVPNConfig) ProtoMessage() {}
 
 func (x *ZeroVPNConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4995,7 +5051,7 @@ func (x *ZeroVPNConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ZeroVPNConfig.ProtoReflect.Descriptor instead.
 func (*ZeroVPNConfig) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{46}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ZeroVPNConfig) GetEnabled() *wrapperspb.BoolValue {
@@ -5034,7 +5090,7 @@ type IntOrString struct {
 func (x *IntOrString) Reset() {
 	*x = IntOrString{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5047,7 +5103,7 @@ func (x *IntOrString) String() string {
 func (*IntOrString) ProtoMessage() {}
 
 func (x *IntOrString) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5060,7 +5116,7 @@ func (x *IntOrString) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntOrString.ProtoReflect.Descriptor instead.
 func (*IntOrString) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{47}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *IntOrString) GetType() int64 {
@@ -5100,7 +5156,7 @@ type TelemetryV2PrometheusConfig_ConfigOverride struct {
 func (x *TelemetryV2PrometheusConfig_ConfigOverride) Reset() {
 	*x = TelemetryV2PrometheusConfig_ConfigOverride{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[53]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5113,7 +5169,7 @@ func (x *TelemetryV2PrometheusConfig_ConfigOverride) String() string {
 func (*TelemetryV2PrometheusConfig_ConfigOverride) ProtoMessage() {}
 
 func (x *TelemetryV2PrometheusConfig_ConfigOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[53]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5126,7 +5182,7 @@ func (x *TelemetryV2PrometheusConfig_ConfigOverride) ProtoReflect() protoreflect
 
 // Deprecated: Use TelemetryV2PrometheusConfig_ConfigOverride.ProtoReflect.Descriptor instead.
 func (*TelemetryV2PrometheusConfig_ConfigOverride) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{26, 0}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{27, 0}
 }
 
 func (x *TelemetryV2PrometheusConfig_ConfigOverride) GetGateway() *structpb.Struct {
@@ -5170,7 +5226,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x20, 0x01, 0x28, 0x0d, 0x52, 0x07, 0x70, 0x70, 0x63, 0x36, 0x34, 0x6c, 0x65, 0x12, 0x14, 0x0a,
 	0x05, 0x73, 0x33, 0x39, 0x30, 0x78, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x73, 0x33,
 	0x39, 0x30, 0x78, 0x12, 0x14, 0x0a, 0x05, 0x61, 0x72, 0x6d, 0x36, 0x34, 0x18, 0x04, 0x20, 0x01,
-	0x28, 0x0d, 0x52, 0x05, 0x61, 0x72, 0x6d, 0x36, 0x34, 0x22, 0xaf, 0x07, 0x0a, 0x09, 0x43, 0x4e,
+	0x28, 0x0d, 0x52, 0x05, 0x61, 0x72, 0x6d, 0x36, 0x34, 0x22, 0xe5, 0x07, 0x0a, 0x09, 0x43, 0x4e,
 	0x49, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c,
 	0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
 	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56,
@@ -5229,7 +5285,15 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x63, 0x63, 0x6f, 0x6d, 0x70, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x13, 0x20, 0x01,
 	0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
 	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x0e, 0x73, 0x65, 0x63,
-	0x63, 0x6f, 0x6d, 0x70, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x22, 0x46, 0x0a, 0x0e, 0x43,
+	0x63, 0x6f, 0x6d, 0x70, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x12, 0x34, 0x0a, 0x07, 0x61,
+	0x6d, 0x62, 0x69, 0x65, 0x6e, 0x74, 0x18, 0x15, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x76,
+	0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2e, 0x43, 0x4e, 0x49, 0x41, 0x6d, 0x62, 0x69, 0x65,
+	0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x07, 0x61, 0x6d, 0x62, 0x69, 0x65, 0x6e,
+	0x74, 0x22, 0x48, 0x0a, 0x10, 0x43, 0x4e, 0x49, 0x41, 0x6d, 0x62, 0x69, 0x65, 0x6e, 0x74, 0x43,
+	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c,
+	0x75, 0x65, 0x52, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64, 0x22, 0x46, 0x0a, 0x0e, 0x43,
 	0x4e, 0x49, 0x54, 0x61, 0x69, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34, 0x0a,
 	0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a,
 	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
@@ -6290,7 +6354,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP() []byte {
 }
 
 var file_pkg_apis_istio_v1alpha1_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
 	(IngressControllerMode)(0),                         // 0: v1alpha1.ingressControllerMode
 	(Tracer)(0),                                        // 1: v1alpha1.tracer
@@ -6298,254 +6362,257 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
 	(TelemetryV2StackDriverConfig_AccessLogging)(0),    // 3: v1alpha1.TelemetryV2StackDriverConfig.AccessLogging
 	(*ArchConfig)(nil),                                 // 4: v1alpha1.ArchConfig
 	(*CNIConfig)(nil),                                  // 5: v1alpha1.CNIConfig
-	(*CNITaintConfig)(nil),                             // 6: v1alpha1.CNITaintConfig
-	(*CNIRepairConfig)(nil),                            // 7: v1alpha1.CNIRepairConfig
-	(*ResourceQuotas)(nil),                             // 8: v1alpha1.ResourceQuotas
-	(*CPUTargetUtilizationConfig)(nil),                 // 9: v1alpha1.CPUTargetUtilizationConfig
-	(*Resources)(nil),                                  // 10: v1alpha1.Resources
-	(*ServiceAccount)(nil),                             // 11: v1alpha1.ServiceAccount
-	(*DefaultPodDisruptionBudgetConfig)(nil),           // 12: v1alpha1.DefaultPodDisruptionBudgetConfig
-	(*DefaultResourcesConfig)(nil),                     // 13: v1alpha1.DefaultResourcesConfig
-	(*EgressGatewayConfig)(nil),                        // 14: v1alpha1.EgressGatewayConfig
-	(*GatewaysConfig)(nil),                             // 15: v1alpha1.GatewaysConfig
-	(*GlobalConfig)(nil),                               // 16: v1alpha1.GlobalConfig
-	(*STSConfig)(nil),                                  // 17: v1alpha1.STSConfig
-	(*IstiodConfig)(nil),                               // 18: v1alpha1.IstiodConfig
-	(*GlobalLoggingConfig)(nil),                        // 19: v1alpha1.GlobalLoggingConfig
-	(*IngressGatewayConfig)(nil),                       // 20: v1alpha1.IngressGatewayConfig
-	(*IngressGatewayZvpnConfig)(nil),                   // 21: v1alpha1.IngressGatewayZvpnConfig
-	(*MultiClusterConfig)(nil),                         // 22: v1alpha1.MultiClusterConfig
-	(*OutboundTrafficPolicyConfig)(nil),                // 23: v1alpha1.OutboundTrafficPolicyConfig
-	(*PilotConfig)(nil),                                // 24: v1alpha1.PilotConfig
-	(*PilotIngressConfig)(nil),                         // 25: v1alpha1.PilotIngressConfig
-	(*PilotPolicyConfig)(nil),                          // 26: v1alpha1.PilotPolicyConfig
-	(*TelemetryConfig)(nil),                            // 27: v1alpha1.TelemetryConfig
-	(*TelemetryV2Config)(nil),                          // 28: v1alpha1.TelemetryV2Config
-	(*TelemetryV2MetadataExchangeConfig)(nil),          // 29: v1alpha1.TelemetryV2MetadataExchangeConfig
-	(*TelemetryV2PrometheusConfig)(nil),                // 30: v1alpha1.TelemetryV2PrometheusConfig
-	(*TelemetryV2StackDriverConfig)(nil),               // 31: v1alpha1.TelemetryV2StackDriverConfig
-	(*TelemetryV2AccessLogPolicyFilterConfig)(nil),     // 32: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig
-	(*PilotConfigSource)(nil),                          // 33: v1alpha1.PilotConfigSource
-	(*PortsConfig)(nil),                                // 34: v1alpha1.PortsConfig
-	(*ProxyConfig)(nil),                                // 35: v1alpha1.ProxyConfig
-	(*ProxyInitConfig)(nil),                            // 36: v1alpha1.ProxyInitConfig
-	(*ResourcesRequestsConfig)(nil),                    // 37: v1alpha1.ResourcesRequestsConfig
-	(*SDSConfig)(nil),                                  // 38: v1alpha1.SDSConfig
-	(*SecretVolume)(nil),                               // 39: v1alpha1.SecretVolume
-	(*ServiceConfig)(nil),                              // 40: v1alpha1.ServiceConfig
-	(*SidecarInjectorConfig)(nil),                      // 41: v1alpha1.SidecarInjectorConfig
-	(*TracerConfig)(nil),                               // 42: v1alpha1.TracerConfig
-	(*TracerDatadogConfig)(nil),                        // 43: v1alpha1.TracerDatadogConfig
-	(*TracerLightStepConfig)(nil),                      // 44: v1alpha1.TracerLightStepConfig
-	(*TracerZipkinConfig)(nil),                         // 45: v1alpha1.TracerZipkinConfig
-	(*TracerStackdriverConfig)(nil),                    // 46: v1alpha1.TracerStackdriverConfig
-	(*BaseConfig)(nil),                                 // 47: v1alpha1.BaseConfig
-	(*IstiodRemoteConfig)(nil),                         // 48: v1alpha1.IstiodRemoteConfig
-	(*Values)(nil),                                     // 49: v1alpha1.Values
-	(*ZeroVPNConfig)(nil),                              // 50: v1alpha1.ZeroVPNConfig
-	(*IntOrString)(nil),                                // 51: v1alpha1.IntOrString
-	nil,                                                // 52: v1alpha1.Resources.LimitsEntry
-	nil,                                                // 53: v1alpha1.Resources.RequestsEntry
-	nil,                                                // 54: v1alpha1.EgressGatewayConfig.LabelsEntry
-	nil,                                                // 55: v1alpha1.IngressGatewayConfig.LabelsEntry
-	(*TelemetryV2PrometheusConfig_ConfigOverride)(nil), // 56: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride
-	(*wrapperspb.BoolValue)(nil),                       // 57: google.protobuf.BoolValue
-	(*structpb.Value)(nil),                             // 58: google.protobuf.Value
-	(*structpb.Struct)(nil),                            // 59: google.protobuf.Struct
-	(*durationpb.Duration)(nil),                        // 60: google.protobuf.Duration
-	(*wrapperspb.Int32Value)(nil),                      // 61: google.protobuf.Int32Value
-	(*wrapperspb.StringValue)(nil),                     // 62: google.protobuf.StringValue
+	(*CNIAmbientConfig)(nil),                           // 6: v1alpha1.CNIAmbientConfig
+	(*CNITaintConfig)(nil),                             // 7: v1alpha1.CNITaintConfig
+	(*CNIRepairConfig)(nil),                            // 8: v1alpha1.CNIRepairConfig
+	(*ResourceQuotas)(nil),                             // 9: v1alpha1.ResourceQuotas
+	(*CPUTargetUtilizationConfig)(nil),                 // 10: v1alpha1.CPUTargetUtilizationConfig
+	(*Resources)(nil),                                  // 11: v1alpha1.Resources
+	(*ServiceAccount)(nil),                             // 12: v1alpha1.ServiceAccount
+	(*DefaultPodDisruptionBudgetConfig)(nil),           // 13: v1alpha1.DefaultPodDisruptionBudgetConfig
+	(*DefaultResourcesConfig)(nil),                     // 14: v1alpha1.DefaultResourcesConfig
+	(*EgressGatewayConfig)(nil),                        // 15: v1alpha1.EgressGatewayConfig
+	(*GatewaysConfig)(nil),                             // 16: v1alpha1.GatewaysConfig
+	(*GlobalConfig)(nil),                               // 17: v1alpha1.GlobalConfig
+	(*STSConfig)(nil),                                  // 18: v1alpha1.STSConfig
+	(*IstiodConfig)(nil),                               // 19: v1alpha1.IstiodConfig
+	(*GlobalLoggingConfig)(nil),                        // 20: v1alpha1.GlobalLoggingConfig
+	(*IngressGatewayConfig)(nil),                       // 21: v1alpha1.IngressGatewayConfig
+	(*IngressGatewayZvpnConfig)(nil),                   // 22: v1alpha1.IngressGatewayZvpnConfig
+	(*MultiClusterConfig)(nil),                         // 23: v1alpha1.MultiClusterConfig
+	(*OutboundTrafficPolicyConfig)(nil),                // 24: v1alpha1.OutboundTrafficPolicyConfig
+	(*PilotConfig)(nil),                                // 25: v1alpha1.PilotConfig
+	(*PilotIngressConfig)(nil),                         // 26: v1alpha1.PilotIngressConfig
+	(*PilotPolicyConfig)(nil),                          // 27: v1alpha1.PilotPolicyConfig
+	(*TelemetryConfig)(nil),                            // 28: v1alpha1.TelemetryConfig
+	(*TelemetryV2Config)(nil),                          // 29: v1alpha1.TelemetryV2Config
+	(*TelemetryV2MetadataExchangeConfig)(nil),          // 30: v1alpha1.TelemetryV2MetadataExchangeConfig
+	(*TelemetryV2PrometheusConfig)(nil),                // 31: v1alpha1.TelemetryV2PrometheusConfig
+	(*TelemetryV2StackDriverConfig)(nil),               // 32: v1alpha1.TelemetryV2StackDriverConfig
+	(*TelemetryV2AccessLogPolicyFilterConfig)(nil),     // 33: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig
+	(*PilotConfigSource)(nil),                          // 34: v1alpha1.PilotConfigSource
+	(*PortsConfig)(nil),                                // 35: v1alpha1.PortsConfig
+	(*ProxyConfig)(nil),                                // 36: v1alpha1.ProxyConfig
+	(*ProxyInitConfig)(nil),                            // 37: v1alpha1.ProxyInitConfig
+	(*ResourcesRequestsConfig)(nil),                    // 38: v1alpha1.ResourcesRequestsConfig
+	(*SDSConfig)(nil),                                  // 39: v1alpha1.SDSConfig
+	(*SecretVolume)(nil),                               // 40: v1alpha1.SecretVolume
+	(*ServiceConfig)(nil),                              // 41: v1alpha1.ServiceConfig
+	(*SidecarInjectorConfig)(nil),                      // 42: v1alpha1.SidecarInjectorConfig
+	(*TracerConfig)(nil),                               // 43: v1alpha1.TracerConfig
+	(*TracerDatadogConfig)(nil),                        // 44: v1alpha1.TracerDatadogConfig
+	(*TracerLightStepConfig)(nil),                      // 45: v1alpha1.TracerLightStepConfig
+	(*TracerZipkinConfig)(nil),                         // 46: v1alpha1.TracerZipkinConfig
+	(*TracerStackdriverConfig)(nil),                    // 47: v1alpha1.TracerStackdriverConfig
+	(*BaseConfig)(nil),                                 // 48: v1alpha1.BaseConfig
+	(*IstiodRemoteConfig)(nil),                         // 49: v1alpha1.IstiodRemoteConfig
+	(*Values)(nil),                                     // 50: v1alpha1.Values
+	(*ZeroVPNConfig)(nil),                              // 51: v1alpha1.ZeroVPNConfig
+	(*IntOrString)(nil),                                // 52: v1alpha1.IntOrString
+	nil,                                                // 53: v1alpha1.Resources.LimitsEntry
+	nil,                                                // 54: v1alpha1.Resources.RequestsEntry
+	nil,                                                // 55: v1alpha1.EgressGatewayConfig.LabelsEntry
+	nil,                                                // 56: v1alpha1.IngressGatewayConfig.LabelsEntry
+	(*TelemetryV2PrometheusConfig_ConfigOverride)(nil), // 57: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride
+	(*wrapperspb.BoolValue)(nil),                       // 58: google.protobuf.BoolValue
+	(*structpb.Value)(nil),                             // 59: google.protobuf.Value
+	(*structpb.Struct)(nil),                            // 60: google.protobuf.Struct
+	(*durationpb.Duration)(nil),                        // 61: google.protobuf.Duration
+	(*wrapperspb.Int32Value)(nil),                      // 62: google.protobuf.Int32Value
+	(*wrapperspb.StringValue)(nil),                     // 63: google.protobuf.StringValue
 }
 var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
-	57,  // 0: v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 1: v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
-	59,  // 2: v1alpha1.CNIConfig.affinity:type_name -> google.protobuf.Struct
-	59,  // 3: v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
-	7,   // 4: v1alpha1.CNIConfig.repair:type_name -> v1alpha1.CNIRepairConfig
-	57,  // 5: v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
-	6,   // 6: v1alpha1.CNIConfig.taint:type_name -> v1alpha1.CNITaintConfig
-	8,   // 7: v1alpha1.CNIConfig.resource_quotas:type_name -> v1alpha1.ResourceQuotas
-	10,  // 8: v1alpha1.CNIConfig.resources:type_name -> v1alpha1.Resources
-	57,  // 9: v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
-	59,  // 10: v1alpha1.CNIConfig.seccompProfile:type_name -> google.protobuf.Struct
-	57,  // 11: v1alpha1.CNITaintConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 12: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 13: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
-	57,  // 14: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
-	52,  // 15: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
-	53,  // 16: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
-	59,  // 17: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
-	57,  // 18: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
-	37,  // 19: v1alpha1.DefaultResourcesConfig.requests:type_name -> v1alpha1.ResourcesRequestsConfig
-	57,  // 20: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 21: v1alpha1.EgressGatewayConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
-	57,  // 22: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	57,  // 23: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	59,  // 24: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
-	54,  // 25: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
-	59,  // 26: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	59,  // 27: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	59,  // 28: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
-	59,  // 29: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
-	34,  // 30: v1alpha1.EgressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	10,  // 31: v1alpha1.EgressGatewayConfig.resources:type_name -> v1alpha1.Resources
-	39,  // 32: v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	59,  // 33: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	50,  // 34: v1alpha1.EgressGatewayConfig.zvpn:type_name -> v1alpha1.ZeroVPNConfig
-	59,  // 35: v1alpha1.EgressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
-	51,  // 36: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 37: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	59,  // 38: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	59,  // 39: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	57,  // 40: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 41: v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	14,  // 42: v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> v1alpha1.EgressGatewayConfig
-	57,  // 43: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
-	20,  // 44: v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> v1alpha1.IngressGatewayConfig
-	4,   // 45: v1alpha1.GlobalConfig.arch:type_name -> v1alpha1.ArchConfig
-	57,  // 46: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
-	59,  // 47: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
-	12,  // 48: v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> v1alpha1.DefaultPodDisruptionBudgetConfig
-	13,  // 49: v1alpha1.GlobalConfig.defaultResources:type_name -> v1alpha1.DefaultResourcesConfig
-	59,  // 50: v1alpha1.GlobalConfig.defaultTolerations:type_name -> google.protobuf.Struct
-	57,  // 51: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
-	19,  // 52: v1alpha1.GlobalConfig.logging:type_name -> v1alpha1.GlobalLoggingConfig
-	59,  // 53: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
-	22,  // 54: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
-	57,  // 55: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
-	57,  // 56: v1alpha1.GlobalConfig.oneNamespace:type_name -> google.protobuf.BoolValue
-	57,  // 57: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
-	35,  // 58: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
-	36,  // 59: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
-	38,  // 60: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
-	58,  // 61: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
-	42,  // 62: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
-	57,  // 63: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
-	18,  // 64: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
-	17,  // 65: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
-	57,  // 66: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
-	57,  // 67: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
-	57,  // 68: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
-	57,  // 69: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
-	57,  // 70: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	57,  // 71: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 72: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
-	57,  // 73: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	57,  // 74: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	59,  // 75: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	55,  // 76: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
-	59,  // 77: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	59,  // 78: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	59,  // 79: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
-	59,  // 80: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
-	34,  // 81: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	59,  // 82: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
-	39,  // 83: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	59,  // 84: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	21,  // 85: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
-	51,  // 86: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 87: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	59,  // 88: v1alpha1.IngressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
-	59,  // 89: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	59,  // 90: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	59,  // 91: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	57,  // 92: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 93: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	57,  // 94: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 95: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 96: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
-	2,   // 97: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
-	57,  // 98: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 99: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	10,  // 100: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
-	9,   // 101: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
-	59,  // 102: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	60,  // 103: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	59,  // 104: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	59,  // 105: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	57,  // 106: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	57,  // 107: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
-	59,  // 108: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	51,  // 109: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 110: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	59,  // 111: v1alpha1.PilotConfig.tolerations:type_name -> google.protobuf.Struct
-	57,  // 112: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
-	57,  // 113: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
-	59,  // 114: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	59,  // 115: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	33,  // 116: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
-	58,  // 117: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	59,  // 118: v1alpha1.PilotConfig.seccompProfile:type_name -> google.protobuf.Struct
-	0,   // 119: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
-	57,  // 120: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 121: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
-	28,  // 122: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
-	57,  // 123: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
-	29,  // 124: v1alpha1.TelemetryV2Config.metadata_exchange:type_name -> v1alpha1.TelemetryV2MetadataExchangeConfig
-	30,  // 125: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
-	31,  // 126: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
-	32,  // 127: v1alpha1.TelemetryV2Config.access_log_policy:type_name -> v1alpha1.TelemetryV2AccessLogPolicyFilterConfig
-	57,  // 128: v1alpha1.TelemetryV2MetadataExchangeConfig.wasmEnabled:type_name -> google.protobuf.BoolValue
-	57,  // 129: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 130: v1alpha1.TelemetryV2PrometheusConfig.wasmEnabled:type_name -> google.protobuf.BoolValue
-	56,  // 131: v1alpha1.TelemetryV2PrometheusConfig.config_override:type_name -> v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride
-	57,  // 132: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 133: v1alpha1.TelemetryV2StackDriverConfig.logging:type_name -> google.protobuf.BoolValue
-	57,  // 134: v1alpha1.TelemetryV2StackDriverConfig.monitoring:type_name -> google.protobuf.BoolValue
-	57,  // 135: v1alpha1.TelemetryV2StackDriverConfig.topology:type_name -> google.protobuf.BoolValue
-	57,  // 136: v1alpha1.TelemetryV2StackDriverConfig.disableOutbound:type_name -> google.protobuf.BoolValue
-	59,  // 137: v1alpha1.TelemetryV2StackDriverConfig.configOverride:type_name -> google.protobuf.Struct
-	3,   // 138: v1alpha1.TelemetryV2StackDriverConfig.outboundAccessLogging:type_name -> v1alpha1.TelemetryV2StackDriverConfig.AccessLogging
-	3,   // 139: v1alpha1.TelemetryV2StackDriverConfig.inboundAccessLogging:type_name -> v1alpha1.TelemetryV2StackDriverConfig.AccessLogging
-	57,  // 140: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig.enabled:type_name -> google.protobuf.BoolValue
-	60,  // 141: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig.logWindowDuration:type_name -> google.protobuf.Duration
-	57,  // 142: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	57,  // 143: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
-	10,  // 144: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
-	1,   // 145: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
-	59,  // 146: v1alpha1.ProxyConfig.lifecycle:type_name -> google.protobuf.Struct
-	57,  // 147: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	10,  // 148: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
-	59,  // 149: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	59,  // 150: v1alpha1.ServiceConfig.annotations:type_name -> google.protobuf.Struct
-	57,  // 151: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	59,  // 152: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
-	59,  // 153: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
-	57,  // 154: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	59,  // 155: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	59,  // 156: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
-	59,  // 157: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	57,  // 158: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
-	43,  // 159: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
-	44,  // 160: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
-	45,  // 161: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
-	46,  // 162: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	57,  // 163: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	57,  // 164: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	57,  // 165: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	57,  // 166: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	5,   // 167: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
-	15,  // 168: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
-	16,  // 169: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
-	24,  // 170: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	58,  // 171: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	27,  // 172: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
-	41,  // 173: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
-	5,   // 174: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIConfig
-	58,  // 175: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	47,  // 176: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
-	48,  // 177: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	57,  // 178: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	61,  // 179: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	62,  // 180: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	59,  // 181: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.gateway:type_name -> google.protobuf.Struct
-	59,  // 182: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.inboundSidecar:type_name -> google.protobuf.Struct
-	59,  // 183: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.outboundSidecar:type_name -> google.protobuf.Struct
-	184, // [184:184] is the sub-list for method output_type
-	184, // [184:184] is the sub-list for method input_type
-	184, // [184:184] is the sub-list for extension type_name
-	184, // [184:184] is the sub-list for extension extendee
-	0,   // [0:184] is the sub-list for field type_name
+	58,  // 0: v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 1: v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
+	60,  // 2: v1alpha1.CNIConfig.affinity:type_name -> google.protobuf.Struct
+	60,  // 3: v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
+	8,   // 4: v1alpha1.CNIConfig.repair:type_name -> v1alpha1.CNIRepairConfig
+	58,  // 5: v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
+	7,   // 6: v1alpha1.CNIConfig.taint:type_name -> v1alpha1.CNITaintConfig
+	9,   // 7: v1alpha1.CNIConfig.resource_quotas:type_name -> v1alpha1.ResourceQuotas
+	11,  // 8: v1alpha1.CNIConfig.resources:type_name -> v1alpha1.Resources
+	58,  // 9: v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
+	60,  // 10: v1alpha1.CNIConfig.seccompProfile:type_name -> google.protobuf.Struct
+	6,   // 11: v1alpha1.CNIConfig.ambient:type_name -> v1alpha1.CNIAmbientConfig
+	58,  // 12: v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 13: v1alpha1.CNITaintConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 14: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 15: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
+	58,  // 16: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
+	53,  // 17: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
+	54,  // 18: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
+	60,  // 19: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
+	58,  // 20: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
+	38,  // 21: v1alpha1.DefaultResourcesConfig.requests:type_name -> v1alpha1.ResourcesRequestsConfig
+	58,  // 22: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	10,  // 23: v1alpha1.EgressGatewayConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
+	58,  // 24: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	58,  // 25: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	60,  // 26: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
+	55,  // 27: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
+	60,  // 28: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	60,  // 29: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	60,  // 30: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
+	60,  // 31: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
+	35,  // 32: v1alpha1.EgressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
+	11,  // 33: v1alpha1.EgressGatewayConfig.resources:type_name -> v1alpha1.Resources
+	40,  // 34: v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
+	60,  // 35: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	51,  // 36: v1alpha1.EgressGatewayConfig.zvpn:type_name -> v1alpha1.ZeroVPNConfig
+	60,  // 37: v1alpha1.EgressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
+	52,  // 38: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	52,  // 39: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	60,  // 40: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	60,  // 41: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	58,  // 42: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	12,  // 43: v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
+	15,  // 44: v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> v1alpha1.EgressGatewayConfig
+	58,  // 45: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
+	21,  // 46: v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> v1alpha1.IngressGatewayConfig
+	4,   // 47: v1alpha1.GlobalConfig.arch:type_name -> v1alpha1.ArchConfig
+	58,  // 48: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
+	60,  // 49: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
+	13,  // 50: v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> v1alpha1.DefaultPodDisruptionBudgetConfig
+	14,  // 51: v1alpha1.GlobalConfig.defaultResources:type_name -> v1alpha1.DefaultResourcesConfig
+	60,  // 52: v1alpha1.GlobalConfig.defaultTolerations:type_name -> google.protobuf.Struct
+	58,  // 53: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
+	20,  // 54: v1alpha1.GlobalConfig.logging:type_name -> v1alpha1.GlobalLoggingConfig
+	60,  // 55: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
+	23,  // 56: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
+	58,  // 57: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
+	58,  // 58: v1alpha1.GlobalConfig.oneNamespace:type_name -> google.protobuf.BoolValue
+	58,  // 59: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
+	36,  // 60: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
+	37,  // 61: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
+	39,  // 62: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
+	59,  // 63: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
+	43,  // 64: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
+	58,  // 65: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
+	19,  // 66: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
+	18,  // 67: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
+	58,  // 68: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
+	58,  // 69: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
+	58,  // 70: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
+	58,  // 71: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
+	58,  // 72: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	58,  // 73: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	10,  // 74: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
+	58,  // 75: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	58,  // 76: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	60,  // 77: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	56,  // 78: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
+	60,  // 79: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	60,  // 80: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	60,  // 81: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
+	60,  // 82: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
+	35,  // 83: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
+	60,  // 84: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	40,  // 85: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
+	60,  // 86: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	22,  // 87: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
+	52,  // 88: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	52,  // 89: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	60,  // 90: v1alpha1.IngressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
+	60,  // 91: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	60,  // 92: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	60,  // 93: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	58,  // 94: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	12,  // 95: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
+	58,  // 96: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 97: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 98: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	2,   // 99: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
+	58,  // 100: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 101: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	11,  // 102: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
+	10,  // 103: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.CPUTargetUtilizationConfig
+	60,  // 104: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	61,  // 105: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	60,  // 106: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	60,  // 107: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	58,  // 108: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	58,  // 109: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
+	60,  // 110: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	52,  // 111: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	52,  // 112: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	60,  // 113: v1alpha1.PilotConfig.tolerations:type_name -> google.protobuf.Struct
+	58,  // 114: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
+	58,  // 115: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
+	60,  // 116: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	60,  // 117: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	34,  // 118: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
+	59,  // 119: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	60,  // 120: v1alpha1.PilotConfig.seccompProfile:type_name -> google.protobuf.Struct
+	0,   // 121: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
+	58,  // 122: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 123: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	29,  // 124: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
+	58,  // 125: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	30,  // 126: v1alpha1.TelemetryV2Config.metadata_exchange:type_name -> v1alpha1.TelemetryV2MetadataExchangeConfig
+	31,  // 127: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
+	32,  // 128: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
+	33,  // 129: v1alpha1.TelemetryV2Config.access_log_policy:type_name -> v1alpha1.TelemetryV2AccessLogPolicyFilterConfig
+	58,  // 130: v1alpha1.TelemetryV2MetadataExchangeConfig.wasmEnabled:type_name -> google.protobuf.BoolValue
+	58,  // 131: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 132: v1alpha1.TelemetryV2PrometheusConfig.wasmEnabled:type_name -> google.protobuf.BoolValue
+	57,  // 133: v1alpha1.TelemetryV2PrometheusConfig.config_override:type_name -> v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride
+	58,  // 134: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 135: v1alpha1.TelemetryV2StackDriverConfig.logging:type_name -> google.protobuf.BoolValue
+	58,  // 136: v1alpha1.TelemetryV2StackDriverConfig.monitoring:type_name -> google.protobuf.BoolValue
+	58,  // 137: v1alpha1.TelemetryV2StackDriverConfig.topology:type_name -> google.protobuf.BoolValue
+	58,  // 138: v1alpha1.TelemetryV2StackDriverConfig.disableOutbound:type_name -> google.protobuf.BoolValue
+	60,  // 139: v1alpha1.TelemetryV2StackDriverConfig.configOverride:type_name -> google.protobuf.Struct
+	3,   // 140: v1alpha1.TelemetryV2StackDriverConfig.outboundAccessLogging:type_name -> v1alpha1.TelemetryV2StackDriverConfig.AccessLogging
+	3,   // 141: v1alpha1.TelemetryV2StackDriverConfig.inboundAccessLogging:type_name -> v1alpha1.TelemetryV2StackDriverConfig.AccessLogging
+	58,  // 142: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig.enabled:type_name -> google.protobuf.BoolValue
+	61,  // 143: v1alpha1.TelemetryV2AccessLogPolicyFilterConfig.logWindowDuration:type_name -> google.protobuf.Duration
+	58,  // 144: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	58,  // 145: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	11,  // 146: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
+	1,   // 147: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
+	60,  // 148: v1alpha1.ProxyConfig.lifecycle:type_name -> google.protobuf.Struct
+	58,  // 149: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	11,  // 150: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
+	60,  // 151: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	60,  // 152: v1alpha1.ServiceConfig.annotations:type_name -> google.protobuf.Struct
+	58,  // 153: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	60,  // 154: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
+	60,  // 155: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
+	58,  // 156: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	60,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	60,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
+	60,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	58,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	44,  // 161: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
+	45,  // 162: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
+	46,  // 163: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
+	47,  // 164: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
+	58,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	58,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	58,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	58,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	5,   // 169: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
+	16,  // 170: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
+	17,  // 171: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
+	25,  // 172: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
+	59,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	28,  // 174: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
+	42,  // 175: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
+	5,   // 176: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIConfig
+	59,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	48,  // 178: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
+	49,  // 179: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
+	58,  // 180: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	62,  // 181: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	63,  // 182: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	60,  // 183: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.gateway:type_name -> google.protobuf.Struct
+	60,  // 184: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.inboundSidecar:type_name -> google.protobuf.Struct
+	60,  // 185: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.outboundSidecar:type_name -> google.protobuf.Struct
+	186, // [186:186] is the sub-list for method output_type
+	186, // [186:186] is the sub-list for method input_type
+	186, // [186:186] is the sub-list for extension type_name
+	186, // [186:186] is the sub-list for extension extendee
+	0,   // [0:186] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }
@@ -6579,7 +6646,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CNITaintConfig); i {
+			switch v := v.(*CNIAmbientConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6591,7 +6658,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CNIRepairConfig); i {
+			switch v := v.(*CNITaintConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6603,7 +6670,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResourceQuotas); i {
+			switch v := v.(*CNIRepairConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6615,7 +6682,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CPUTargetUtilizationConfig); i {
+			switch v := v.(*ResourceQuotas); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6627,7 +6694,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Resources); i {
+			switch v := v.(*CPUTargetUtilizationConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6639,7 +6706,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ServiceAccount); i {
+			switch v := v.(*Resources); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6651,7 +6718,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DefaultPodDisruptionBudgetConfig); i {
+			switch v := v.(*ServiceAccount); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6663,7 +6730,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*DefaultResourcesConfig); i {
+			switch v := v.(*DefaultPodDisruptionBudgetConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6675,7 +6742,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*EgressGatewayConfig); i {
+			switch v := v.(*DefaultResourcesConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6687,7 +6754,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GatewaysConfig); i {
+			switch v := v.(*EgressGatewayConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6699,7 +6766,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GlobalConfig); i {
+			switch v := v.(*GatewaysConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6711,7 +6778,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*STSConfig); i {
+			switch v := v.(*GlobalConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6723,7 +6790,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*IstiodConfig); i {
+			switch v := v.(*STSConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6735,7 +6802,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GlobalLoggingConfig); i {
+			switch v := v.(*IstiodConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6747,7 +6814,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*IngressGatewayConfig); i {
+			switch v := v.(*GlobalLoggingConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6759,7 +6826,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*IngressGatewayZvpnConfig); i {
+			switch v := v.(*IngressGatewayConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6771,7 +6838,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MultiClusterConfig); i {
+			switch v := v.(*IngressGatewayZvpnConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6783,7 +6850,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*OutboundTrafficPolicyConfig); i {
+			switch v := v.(*MultiClusterConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6795,7 +6862,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PilotConfig); i {
+			switch v := v.(*OutboundTrafficPolicyConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6807,7 +6874,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PilotIngressConfig); i {
+			switch v := v.(*PilotConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6819,7 +6886,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PilotPolicyConfig); i {
+			switch v := v.(*PilotIngressConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6831,7 +6898,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryConfig); i {
+			switch v := v.(*PilotPolicyConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6843,7 +6910,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryV2Config); i {
+			switch v := v.(*TelemetryConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6855,7 +6922,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryV2MetadataExchangeConfig); i {
+			switch v := v.(*TelemetryV2Config); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6867,7 +6934,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryV2PrometheusConfig); i {
+			switch v := v.(*TelemetryV2MetadataExchangeConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6879,7 +6946,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryV2StackDriverConfig); i {
+			switch v := v.(*TelemetryV2PrometheusConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6891,7 +6958,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TelemetryV2AccessLogPolicyFilterConfig); i {
+			switch v := v.(*TelemetryV2StackDriverConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6903,7 +6970,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PilotConfigSource); i {
+			switch v := v.(*TelemetryV2AccessLogPolicyFilterConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6915,7 +6982,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PortsConfig); i {
+			switch v := v.(*PilotConfigSource); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6927,7 +6994,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProxyConfig); i {
+			switch v := v.(*PortsConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6939,7 +7006,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProxyInitConfig); i {
+			switch v := v.(*ProxyConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6951,7 +7018,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResourcesRequestsConfig); i {
+			switch v := v.(*ProxyInitConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6963,7 +7030,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SDSConfig); i {
+			switch v := v.(*ResourcesRequestsConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6975,7 +7042,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SecretVolume); i {
+			switch v := v.(*SDSConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6987,7 +7054,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ServiceConfig); i {
+			switch v := v.(*SecretVolume); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6999,7 +7066,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SidecarInjectorConfig); i {
+			switch v := v.(*ServiceConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7011,7 +7078,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TracerConfig); i {
+			switch v := v.(*SidecarInjectorConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7023,7 +7090,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TracerDatadogConfig); i {
+			switch v := v.(*TracerConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7035,7 +7102,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TracerLightStepConfig); i {
+			switch v := v.(*TracerDatadogConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7047,7 +7114,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[41].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TracerZipkinConfig); i {
+			switch v := v.(*TracerLightStepConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7059,7 +7126,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TracerStackdriverConfig); i {
+			switch v := v.(*TracerZipkinConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7071,7 +7138,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BaseConfig); i {
+			switch v := v.(*TracerStackdriverConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7083,7 +7150,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[44].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*IstiodRemoteConfig); i {
+			switch v := v.(*BaseConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7095,7 +7162,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Values); i {
+			switch v := v.(*IstiodRemoteConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7107,7 +7174,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ZeroVPNConfig); i {
+			switch v := v.(*Values); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -7119,6 +7186,18 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ZeroVPNConfig); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IntOrString); i {
 			case 0:
 				return &v.state
@@ -7130,7 +7209,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 				return nil
 			}
 		}
-		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[53].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TelemetryV2PrometheusConfig_ConfigOverride); i {
 			case 0:
 				return &v.state
@@ -7149,7 +7228,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc,
 			NumEnums:      4,
-			NumMessages:   53,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -78,6 +78,7 @@ message CNIConfig {
 
   CNITaintConfig taint  = 15;
 
+
   ResourceQuotas resource_quotas = 16;
 
   Resources resources = 17;
@@ -89,8 +90,13 @@ message CNIConfig {
   // See: https://kubernetes.io/docs/tutorials/security/seccomp/
   google.protobuf.Struct seccompProfile = 19;
 
+  CNIAmbientConfig ambient = 21;
 }
 
+message CNIAmbientConfig {
+  // Controls whether ambient redirection is enabled
+  google.protobuf.BoolValue enabled = 1;
+}
 
 message CNITaintConfig {
   // Controls whether taint behavior is enabled.

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -150,4 +150,16 @@ const (
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external
 	// load balancer, such as an Istio Gateway, is terminating the TLS.
 	CertProviderNone = "none"
+
+	// DataplaneMode namespace label for determining ambient mesh behavior
+	DataplaneMode        = "istio.io/dataplane-mode"
+	DataplaneModeAmbient = "ambient"
+
+	// AmbientRedirection specifies whether a pod has ambient redirection (to ztunnel) configured.
+	AmbientRedirection = "ambient.istio.io/redirection"
+	// AmbientRedirectionEnabled indicates redirection is configured. This is set by the CNI when it
+	// actually sets up redirection, rather than by the user.
+	AmbientRedirectionEnabled = "enabled"
+	// AmbientRedirectionDisabled is an opt-out, configured by user.
+	AmbientRedirectionDisabled = "disabled"
 )


### PR DESCRIPTION
For https://github.com/istio/istio/issues/40879

This PR upstreams the CNI logic for ambient redirection to ztunnel. This is intended to be *off by default* and have no impact for existing users. Both the CNI daemon and CNI plugin have an explicit flag for "ambient enabled" and should perform no new actions when that is unset. The default is *not enabled*.


Quoting from the issue:
> **Reviewer guide**
> 
> It is suggested that reviewers treat these PRs differently than normal, as the code has already been reviewed. PRs should be thoroughly reviewed for risk to non-ambient users, ensuring any new/risky/expensive code is disabled by default. However, code quality comments, nit picks, or even bugs in ambient code should not block a merge; modifying these PRs will be high cost and lead to a 3-way drift from master, experimental-ambient, and the PR. Instead, these comments should be turned into issues to complete following the merge.
> 
> Release notes will not be added for any PR. Instead, they will be written holistically for the ambient feature in 1.18 at a later point.