### PR TITLE
Fix setting canonical-revision in ingress and egress gateways

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         chart: gateways
 {{- end }}
         service.istio.io/canonical-name: {{ $gateway.name }}
-        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default "latest" }}
+        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default .Values.revision | default "latest" }}
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "EgressGateways"

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -34,11 +34,7 @@ spec:
         chart: gateways
 {{- end }}
         service.istio.io/canonical-name: {{ $gateway.name }}
-        {{- if not (eq .Values.revision "") }}
-        service.istio.io/canonical-revision: {{ .Values.revision }}
-        {{- else}}
-        service.istio.io/canonical-revision: latest
-        {{- end }}
+        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default "latest" }}
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "EgressGateways"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         chart: gateways
 {{- end }}
         service.istio.io/canonical-name: {{ $gateway.name }}
-        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default "latest" }}
+        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default .Values.revision | default "latest" }}
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "IngressGateways"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -34,11 +34,7 @@ spec:
         chart: gateways
 {{- end }}
         service.istio.io/canonical-name: {{ $gateway.name }}
-        {{- if not (eq .Values.revision "") }}
-        service.istio.io/canonical-revision: {{ .Values.revision }}
-        {{- else}}
-        service.istio.io/canonical-revision: latest
-        {{- end }}
+        service.istio.io/canonical-revision: {{ index $gateway.labels "app.kubernetes.io/version" | default (index $gateway.labels "version") | default "latest" }}
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "IngressGateways"


### PR DESCRIPTION
**Please provide a description of this PR:**

I noticed that ingress and egress gateways set `service.istio.io/canonical-revision` based on control plane revision instead of workload revision as the [doc](https://istio.io/latest/docs/reference/config/labels/) says. This is inconsistent with sidecars and injected gateways which set that label based on `app.kubernets.io/version` or `version`. Additionally, control plane revision is set in `istio.io/rev`.