### PR TITLE
fix: `istioctl install --set` and `istioctl manifest generate --set` boolean var failed

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -124,9 +124,6 @@ func InstallCmdWithArgs(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Opt
 
   # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
   istioctl install --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
-
-  # For setting boolean-string option, it should be enclosed quotes and escaped with a backslash (\).
-  istioctl install --set meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT=\"false\"
 `,
 		Args: cobra.ExactArgs(0),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -108,9 +108,6 @@ func ManifestGenerateCmd(rootArgs *RootArgs, mgArgs *ManifestGenerateArgs, logOp
 
   # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
   istioctl manifest generate --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
-
-  # For setting boolean-string option, it should be enclosed quotes and escaped with a backslash (\).
-  istioctl manifest generate --set meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT=\"false\"
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/version"
@@ -189,6 +191,12 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 
 	// If enablement came from user values overlay (file or --set), translate into addonComponents paths and overlay that.
 	outYAML, err = translate.OverlayValuesEnablement(outYAML, overlayYAML, overlayYAML)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// convertDefaultIOPMapValues converts default paths values into string, prevent errors when unmarshalling.
+	outYAML, err = convertDefaultIOPMapValues(outYAML, setFlags)
 	if err != nil {
 		return "", nil, err
 	}
@@ -515,6 +523,84 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 	}
 
 	return string(out), nil
+}
+
+var defaultSetFlagConvertPaths = []string{
+	"meshConfig.defaultConfig.proxyMetadata",
+}
+
+// convertDefaultIOPMapValues converts default map[string]string values into string.
+func convertDefaultIOPMapValues(outYAML string, setFlags []string) (string, error) {
+	return convertIOPMapValues(outYAML, setFlags, defaultSetFlagConvertPaths)
+}
+
+// convertIOPMapValues converts certain paths of map[string]string values into string.
+func convertIOPMapValues(outYAML string, setFlags []string, convertPaths []string) (string, error) {
+	for _, setFlagConvertPath := range convertPaths {
+		if containParentPath(setFlags, setFlagConvertPath) {
+			var (
+				converter              = map[string]interface{}{}
+				convertedProxyMetadata = map[string]string{}
+				subPaths               = strings.Split(setFlagConvertPath, ".")
+			)
+
+			if err := yaml.Unmarshal([]byte(outYAML), &converter); err != nil {
+				return outYAML, err
+			}
+			originMap, ok := converter["spec"].(map[string]any)
+			if !ok {
+				return outYAML, nil
+			}
+
+			for index, subPath := range subPaths {
+				if _, ok := originMap[subPath].(map[string]any); !ok {
+					return outYAML, fmt.Errorf("can not convert subPath %s in setFlag path %s",
+						subPath, setFlagConvertPath)
+				}
+
+				if index == len(subPaths)-1 {
+					for key, value := range originMap[subPath].(map[string]any) {
+						if reflect.TypeOf(value).Kind() == reflect.Int {
+							convertedProxyMetadata[key] = strconv.FormatInt(value.(int64), 10)
+						}
+						if reflect.TypeOf(value).Kind() == reflect.Bool {
+							convertedProxyMetadata[key] = strconv.FormatBool(value.(bool))
+						}
+						if reflect.TypeOf(value).Kind() == reflect.Float64 {
+							convertedProxyMetadata[key] = fmt.Sprint(value)
+						}
+						if reflect.TypeOf(value).Kind() == reflect.String {
+							convertedProxyMetadata[key] = value.(string)
+						}
+					}
+					originMap[subPath] = convertedProxyMetadata
+				} else {
+					originMap = originMap[subPath].(map[string]any)
+				}
+			}
+
+			convertedYaml, err := yaml.Marshal(converter)
+			if err != nil {
+				return outYAML, err
+			}
+			return string(convertedYaml), nil
+		}
+	}
+
+	return outYAML, nil
+}
+
+// containParentPath checks if setFlags contain parent path.
+func containParentPath(setFlags []string, parentPath string) bool {
+	ret := false
+	for _, sf := range setFlags {
+		p, _ := getPV(sf)
+		if strings.Contains(p, parentPath) {
+			ret = true
+			break
+		}
+	}
+	return ret
 }
 
 // GetValueForSetFlag parses the passed set flags which have format key=value and if any set the given path,

--- a/operator/pkg/util/testdata/yaml/input/convention_boolean.yaml
+++ b/operator/pkg/util/testdata/yaml/input/convention_boolean.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_AGENT_DUAL_STACK: false
+        PROXY_XDS_VIA_AGENT: false
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/operator/pkg/util/testdata/yaml/input/convention_float.yaml
+++ b/operator/pkg/util/testdata/yaml/input/convention_float.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        PROXY_UPSTREAM_WEIGHT: 0.85
+        PROXY_DOWNSTREAM_WEIGHT: 0.15
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/operator/pkg/util/testdata/yaml/input/convention_integer.yaml
+++ b/operator/pkg/util/testdata/yaml/input/convention_integer.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_MULTI_CLUSTERS: 10
+        PROXY_XDS_LISTENERS: 20
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/operator/pkg/util/testdata/yaml/output/convention_boolean.yaml
+++ b/operator/pkg/util/testdata/yaml/output/convention_boolean.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_AGENT_DUAL_STACK: "false"
+        PROXY_XDS_VIA_AGENT: "false"
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/operator/pkg/util/testdata/yaml/output/convention_float.yaml
+++ b/operator/pkg/util/testdata/yaml/output/convention_float.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        PROXY_UPSTREAM_WEIGHT: "0.85"
+        PROXY_DOWNSTREAM_WEIGHT: "0.15"
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/operator/pkg/util/testdata/yaml/output/convention_integer.yaml
+++ b/operator/pkg/util/testdata/yaml/output/convention_integer.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio
+spec:
+  profile: default
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_MULTI_CLUSTERS: "10"
+        PROXY_XDS_LISTENERS: "20"
+  values:
+    pilot:
+      env:
+        ISTIO_DUAL_STACK: false

--- a/releasenotes/notes/43355.yaml
+++ b/releasenotes/notes/43355.yaml
@@ -31,4 +31,4 @@ issue:
 # release notes.
 releaseNotes:
   - |-
-    **Fixed** `istioctl install --set <boolvar>=<bool>` or `istioctl manifests generate --set <boolvar>=<bool>` returns `Error: generate config: failed to unmarshall mesh config: json: cannot unmarshal bool into Go value of type string`.
+    **Fixed** `istioctl install --set <boolvar>=<bool>` and `istioctl manifests generate --set <boolvar>=<bool>` improperly converting a boolean into a string.

--- a/releasenotes/notes/43355.yaml
+++ b/releasenotes/notes/43355.yaml
@@ -1,0 +1,34 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: bug-fix
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: istioctl
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 43355
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |-
+    **Fixed** `istioctl install --set <boolvar>=<bool>` or `istioctl manifests generate --set <boolvar>=<bool>` returns `Error: generate config: failed to unmarshall mesh config: json: cannot unmarshal bool into Go value of type string`.


### PR DESCRIPTION
**Please provide a description of this PR:**

No matter we pass bool value to be enclosed quotes and escaped with a backslash or not, it will fail in both two situations.

We can now just pass true or false, no need to be enclosed quotes and escaped with a backslash.

```shell
istioctl manifest generate --set meshConfig.defaultConfig.proxyMetadata.ISTIO_AGENT_DUAL_STACK=true

istioctl install --set meshConfig.defaultConfig.proxyMetadata.ISTIO_AGENT_DUAL_STACK=true --set meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT=false
```

Fixes: https://github.com/istio/istio/issues/43355