### PR TITLE
[release-1.16] Fix ignoring default CA cert by PeerCertVerifier (#43318)

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1012,7 +1012,7 @@ func getDNSNames(args *PilotArgs, host string) []string {
 
 // createPeerCertVerifier creates a SPIFFE certificate verifier with the current istiod configuration.
 func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCertVerifier, error) {
-	customTLSCertsExists, _, _, _ := hasCustomTLSCerts(tlsOptions)
+	customTLSCertsExists, _, _, caCertPath := hasCustomTLSCerts(tlsOptions)
 	if !customTLSCertsExists && s.CA == nil && features.SpiffeBundleEndpoints == "" && !s.isCADisabled() {
 		// Running locally without configured certs - no TLS mode
 		return nil, nil
@@ -1020,8 +1020,8 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCert
 	peerCertVerifier := spiffe.NewPeerCertVerifier()
 	var rootCertBytes []byte
 	var err error
-	if tlsOptions.CaCertFile != "" {
-		if rootCertBytes, err = os.ReadFile(tlsOptions.CaCertFile); err != nil {
+	if caCertPath != "" {
+		if rootCertBytes, err = os.ReadFile(caCertPath); err != nil {
 			return nil, err
 		}
 	} else {

--- a/releasenotes/notes/43318.yaml
+++ b/releasenotes/notes/43318.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** ignoring default CA certificate when `PeerCertificateVerifier` is created.


### PR DESCRIPTION
This is a manual cherry-pick of #43318. Related issue: #43336.