### PR TITLE
Added mtlsPolicy to be singleton 

### DIFF
--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -73,7 +73,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 		return nil
 	}
 	var out model.Resources
-	policyApplier := factory.NewPolicyApplier(push, node.Metadata.Namespace, node.Labels)
+	mtlsChecker := factory.NewMtlsChecker(push, node.Metadata.Namespace, node.Labels)
 	serviceInstancesByPort := map[uint32]*model.ServiceInstance{}
 	for _, si := range node.ServiceInstances {
 		serviceInstancesByPort[si.Endpoint.EndpointPort] = si
@@ -107,7 +107,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 					},
 				},
 			}},
-			FilterChains: buildInboundFilterChains(node, push, si, policyApplier),
+			FilterChains: buildInboundFilterChains(node, push, si, mtlsChecker),
 			// the following must not be set or the client will NACK
 			ListenerFilters: nil,
 			UseOriginalDst:  nil,
@@ -127,8 +127,8 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 }
 
 // nolint: unparam
-func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *model.ServiceInstance, applier authn.PolicyApplier) []*listener.FilterChain {
-	mode := applier.GetMutualTLSModeForPort(si.Endpoint.EndpointPort)
+func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *model.ServiceInstance, checker authn.MtlsChecker) []*listener.FilterChain {
+	mode := checker.GetMutualTLSModeForPort(si.Endpoint.EndpointPort)
 
 	// auto-mtls label is set - clients will attempt to connect using mtls, and
 	// gRPC doesn't support permissive.

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -73,7 +73,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 		return nil
 	}
 	var out model.Resources
-	mtlsChecker := factory.NewMtlsChecker(push, node.Metadata.Namespace, node.Labels)
+	mtlsPolicy := factory.NewMtlsPolicy(push, node.Metadata.Namespace, node.Labels)
 	serviceInstancesByPort := map[uint32]*model.ServiceInstance{}
 	for _, si := range node.ServiceInstances {
 		serviceInstancesByPort[si.Endpoint.EndpointPort] = si
@@ -107,7 +107,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 					},
 				},
 			}},
-			FilterChains: buildInboundFilterChains(node, push, si, mtlsChecker),
+			FilterChains: buildInboundFilterChains(node, push, si, mtlsPolicy),
 			// the following must not be set or the client will NACK
 			ListenerFilters: nil,
 			UseOriginalDst:  nil,
@@ -127,7 +127,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 }
 
 // nolint: unparam
-func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *model.ServiceInstance, checker authn.MtlsChecker) []*listener.FilterChain {
+func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *model.ServiceInstance, checker authn.MtlsPolicy) []*listener.FilterChain {
 	mode := checker.GetMutualTLSModeForPort(si.Endpoint.EndpointPort)
 
 	// auto-mtls label is set - clients will attempt to connect using mtls, and

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -29,3 +29,11 @@ func NewPolicyApplier(push *model.PushContext, namespace string, labels labels.I
 		push.AuthnPolicies.GetJwtPoliciesForWorkload(namespace, labels),
 		push.AuthnPolicies.GetPeerAuthenticationsForWorkload(namespace, labels), push)
 }
+
+// NewMtlsChecker returns a checker used to detect proxy's inbound mtls mode.
+func NewMtlsChecker(push *model.PushContext, namespace string, labels labels.Instance) authn.PolicyApplier {
+	return v1beta1.NewPolicyApplier(
+		push.AuthnPolicies.GetRootNamespace(),
+		nil,
+		push.AuthnPolicies.GetPeerAuthenticationsForWorkload(namespace, labels), push)
+}

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -30,8 +30,8 @@ func NewPolicyApplier(push *model.PushContext, namespace string, labels labels.I
 		push.AuthnPolicies.GetPeerAuthenticationsForWorkload(namespace, labels), push)
 }
 
-// NewMtlsChecker returns a checker used to detect proxy mtls mode.
-func NewMtlsChecker(push *model.PushContext, namespace string, labels labels.Instance) authn.MtlsChecker {
+// NewMtlsPolicy returns a checker used to detect proxy mtls mode.
+func NewMtlsPolicy(push *model.PushContext, namespace string, labels labels.Instance) authn.MtlsPolicy {
 	return v1beta1.NewPolicyApplier(
 		push.AuthnPolicies.GetRootNamespace(),
 		nil,

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -30,8 +30,8 @@ func NewPolicyApplier(push *model.PushContext, namespace string, labels labels.I
 		push.AuthnPolicies.GetPeerAuthenticationsForWorkload(namespace, labels), push)
 }
 
-// NewMtlsChecker returns a checker used to detect proxy's inbound mtls mode.
-func NewMtlsChecker(push *model.PushContext, namespace string, labels labels.Instance) authn.PolicyApplier {
+// NewMtlsChecker returns a checker used to detect proxy mtls mode.
+func NewMtlsChecker(push *model.PushContext, namespace string, labels labels.Instance) authn.MtlsChecker {
 	return v1beta1.NewPolicyApplier(
 		push.AuthnPolicies.GetRootNamespace(),
 		nil,

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -47,6 +47,12 @@ type PolicyApplier interface {
 	GetMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode
 }
 
+type MtlsChecker interface {
+	// GetMutualTLSModeForPort gets the mTLS mode for the given port. If there is no port level setting, it
+	// returns the inherited namespace/mesh level setting.
+	GetMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode
+}
+
 // MTLSSettings describes the mTLS options for a filter chain
 type MTLSSettings struct {
 	// Port is the port this option applies for

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -42,10 +42,10 @@ type PolicyApplier interface {
 	// PortLevelSetting returns port level mTLS settings.
 	PortLevelSetting() map[uint32]*v1beta1.PeerAuthentication_MutualTLS
 
-	MtlsChecker
+	MtlsPolicy
 }
 
-type MtlsChecker interface {
+type MtlsPolicy interface {
 	// GetMutualTLSModeForPort gets the mTLS mode for the given port. If there is no port level setting, it
 	// returns the inherited namespace/mesh level setting.
 	GetMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -42,9 +42,7 @@ type PolicyApplier interface {
 	// PortLevelSetting returns port level mTLS settings.
 	PortLevelSetting() map[uint32]*v1beta1.PeerAuthentication_MutualTLS
 
-	// GetMutualTLSModeForPort gets the mTLS mode for the given port. If there is no port level setting, it
-	// returns the inherited namespace/mesh level setting.
-	GetMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode
+	MtlsChecker
 }
 
 type MtlsChecker interface {

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -49,16 +49,41 @@ var authnLog = log.RegisterScope("authn", "authn debugging", 0)
 
 // Implementation of authn.PolicyApplier with v1beta1 API.
 type v1beta1PolicyApplier struct {
-	jwtPolicies []*config.Config
-
-	peerPolices []*config.Config
-
 	// processedJwtRules is the consolidate JWT rules from all jwtPolicies.
 	processedJwtRules []*v1beta1.JWTRule
 
 	consolidatedPeerPolicy *v1beta1.PeerAuthentication
 
 	push *model.PushContext
+}
+
+// NewPolicyApplier returns new applier for v1beta1 authentication policies.
+func NewPolicyApplier(rootNamespace string,
+	jwtPolicies []*config.Config,
+	peerPolicies []*config.Config,
+	push *model.PushContext,
+) authn.PolicyApplier {
+	processedJwtRules := []*v1beta1.JWTRule{}
+
+	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.
+	// https://github.com/istio/istio/issues/19245
+	for idx := range jwtPolicies {
+		spec := jwtPolicies[idx].Spec.(*v1beta1.RequestAuthentication)
+		processedJwtRules = append(processedJwtRules, spec.JwtRules...)
+	}
+
+	// Sort the jwt rules by the issuer alphabetically to make the later-on generated filter
+	// config deterministic.
+	sort.Slice(processedJwtRules, func(i, j int) bool {
+		return strings.Compare(
+			processedJwtRules[i].GetIssuer(), processedJwtRules[j].GetIssuer()) < 0
+	})
+
+	return &v1beta1PolicyApplier{
+		processedJwtRules:      processedJwtRules,
+		consolidatedPeerPolicy: ComposePeerAuthentication(rootNamespace, peerPolicies),
+		push:                   push,
+	}
 }
 
 func (a *v1beta1PolicyApplier) JwtFilter() *hcm.HttpFilter {
@@ -171,37 +196,6 @@ func (a *v1beta1PolicyApplier) InboundMTLSSettings(
 			trustDomainAliases, minTLSVersion),
 		HTTP: authn_utils.BuildInboundTLS(effectiveMTLSMode, node, networking.ListenerProtocolHTTP,
 			trustDomainAliases, minTLSVersion),
-	}
-}
-
-// NewPolicyApplier returns new applier for v1beta1 authentication policies.
-func NewPolicyApplier(rootNamespace string,
-	jwtPolicies []*config.Config,
-	peerPolicies []*config.Config,
-	push *model.PushContext,
-) authn.PolicyApplier {
-	processedJwtRules := []*v1beta1.JWTRule{}
-
-	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.
-	// https://github.com/istio/istio/issues/19245
-	for idx := range jwtPolicies {
-		spec := jwtPolicies[idx].Spec.(*v1beta1.RequestAuthentication)
-		processedJwtRules = append(processedJwtRules, spec.JwtRules...)
-	}
-
-	// Sort the jwt rules by the issuer alphabetically to make the later-on generated filter
-	// config deterministic.
-	sort.Slice(processedJwtRules, func(i, j int) bool {
-		return strings.Compare(
-			processedJwtRules[i].GetIssuer(), processedJwtRules[j].GetIssuer()) < 0
-	})
-
-	return &v1beta1PolicyApplier{
-		jwtPolicies:            jwtPolicies,
-		peerPolices:            peerPolicies,
-		processedJwtRules:      processedJwtRules,
-		consolidatedPeerPolicy: ComposePeerAuthentication(rootNamespace, peerPolicies),
-		push:                   push,
 	}
 }
 

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -506,13 +506,3 @@ func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr
 	}).UnsortedList()
 	return ips
 }
-
-func lbEpKey(b *endpoint.LbEndpoint) string {
-	if addr := b.GetEndpoint().GetAddress().GetSocketAddress(); addr != nil {
-		return addr.Address + ":" + strconv.Itoa(int(addr.GetPortValue()))
-	}
-	if addr := b.GetEndpoint().GetAddress().GetPipe(); addr != nil {
-		return addr.GetPath() + ":" + strconv.Itoa(int(addr.GetMode()))
-	}
-	return ""
-}

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -31,12 +31,9 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/istio/pilot/pkg/security/authn/factory"
 	"istio.io/istio/pkg/cluster"
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/spiffe"
@@ -508,144 +505,6 @@ func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr
 		ServiceAccount: ident.ServiceAccount,
 	}).UnsortedList()
 	return ips
-}
-
-// TODO this logic is probably done elsewhere in XDS, possible code-reuse + perf improvements
-type mtlsChecker struct {
-	push            *model.PushContext
-	svcPort         int
-	destinationRule *networkingapi.DestinationRule
-
-	// cache of host identifiers that have mTLS disabled
-	mtlsDisabledHosts map[string]struct{}
-
-	// cache of labels/port that have mTLS disabled by peerAuthn
-	peerAuthDisabledMTLS map[string]bool
-	// cache of labels that have mTLS modes set for subset policies
-	subsetPolicyMode map[string]*networkingapi.ClientTLSSettings_TLSmode
-	// the tlsMode of the root traffic policy if it's set
-	rootPolicyMode *networkingapi.ClientTLSSettings_TLSmode
-}
-
-func newMtlsChecker(push *model.PushContext, svcPort int, dr *config.Config) *mtlsChecker {
-	var drSpec *networkingapi.DestinationRule
-	if dr != nil {
-		drSpec = dr.Spec.(*networkingapi.DestinationRule)
-	}
-	return &mtlsChecker{
-		push:                 push,
-		svcPort:              svcPort,
-		destinationRule:      drSpec,
-		mtlsDisabledHosts:    map[string]struct{}{},
-		peerAuthDisabledMTLS: map[string]bool{},
-		subsetPolicyMode:     map[string]*networkingapi.ClientTLSSettings_TLSmode{},
-		rootPolicyMode:       mtlsModeForDefaultTrafficPolicy(dr, svcPort),
-	}
-}
-
-// mTLSDisabled returns true if the given lbEp has mTLS disabled due to any of:
-// - disabled tlsMode
-// - DestinationRule disabling mTLS on the entire host or the port
-// - PeerAuthentication disabling mTLS at any applicable level (mesh, ns, workload, port)
-func (c *mtlsChecker) isMtlsDisabled(lbEp *endpoint.LbEndpoint) bool {
-	if c == nil {
-		return false
-	}
-	_, ok := c.mtlsDisabledHosts[lbEpKey(lbEp)]
-	return ok
-}
-
-// computeForEndpoint checks destination rule, peer authentication and tls mode labels to determine if mTLS was turned off.
-func (c *mtlsChecker) computeForEndpoint(ep *model.IstioEndpoint) {
-	if drMode := c.mtlsModeForDestinationRule(ep); drMode != nil {
-		switch *drMode {
-		case networkingapi.ClientTLSSettings_DISABLE:
-			c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
-			return
-		case networkingapi.ClientTLSSettings_ISTIO_MUTUAL:
-			// don't mark this EP disabled, even if PA or tlsMode meta mark disabled
-			return
-		}
-	}
-
-	// if endpoint has no sidecar or explicitly tls disabled by "security.istio.io/tlsMode" label.
-	if ep.TLSMode != model.IstioMutualTLSModeLabel {
-		c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
-		return
-	}
-
-	mtlsDisabledByPeerAuthentication := func(ep *model.IstioEndpoint) bool {
-		// apply any matching peer authentications
-		peerAuthnKey := ep.Labels.String() + ":" + strconv.Itoa(int(ep.EndpointPort))
-		if value, ok := c.peerAuthDisabledMTLS[peerAuthnKey]; ok {
-			// avoid recomputing since most EPs will have the same labels/port
-			return value
-		}
-		c.peerAuthDisabledMTLS[peerAuthnKey] = factory.
-			NewPolicyApplier(c.push, ep.Namespace, ep.Labels).
-			GetMutualTLSModeForPort(ep.EndpointPort) == model.MTLSDisable
-		return c.peerAuthDisabledMTLS[peerAuthnKey]
-	}
-
-	//  mtls disabled by PeerAuthentication
-	if mtlsDisabledByPeerAuthentication(ep) {
-		c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
-	}
-}
-
-func (c *mtlsChecker) mtlsModeForDestinationRule(ep *model.IstioEndpoint) *networkingapi.ClientTLSSettings_TLSmode {
-	if c.destinationRule == nil || len(c.destinationRule.Subsets) == 0 {
-		return c.rootPolicyMode
-	}
-
-	drSubsetKey := ep.Labels.String()
-	if value, ok := c.subsetPolicyMode[drSubsetKey]; ok {
-		// avoid recomputing since most EPs will have the same labels/port
-		return value
-	}
-
-	subsetValue := c.rootPolicyMode
-	for _, subset := range c.destinationRule.Subsets {
-		if labels.Instance(subset.Labels).SubsetOf(ep.Labels) {
-			mode := trafficPolicyTLSModeForPort(subset.TrafficPolicy, c.svcPort)
-			if mode != nil {
-				subsetValue = mode
-			}
-			break
-		}
-	}
-	c.subsetPolicyMode[drSubsetKey] = subsetValue
-	return subsetValue
-}
-
-// mtlsModeForDefaultTrafficPolicy returns true if the default traffic policy on a given dr disables mTLS
-func mtlsModeForDefaultTrafficPolicy(destinationRule *config.Config, port int) *networkingapi.ClientTLSSettings_TLSmode {
-	if destinationRule == nil {
-		return nil
-	}
-	dr, ok := destinationRule.Spec.(*networkingapi.DestinationRule)
-	if !ok || dr == nil {
-		return nil
-	}
-	return trafficPolicyTLSModeForPort(dr.GetTrafficPolicy(), port)
-}
-
-func trafficPolicyTLSModeForPort(tp *networkingapi.TrafficPolicy, port int) *networkingapi.ClientTLSSettings_TLSmode {
-	if tp == nil {
-		return nil
-	}
-	var mode *networkingapi.ClientTLSSettings_TLSmode
-	if tp.Tls != nil {
-		mode = &tp.Tls.Mode
-	}
-	// if there is a port-level setting matching this cluster
-	for _, portSettings := range tp.GetPortLevelSettings() {
-		if int(portSettings.GetPort().GetNumber()) == port && portSettings.Tls != nil {
-			mode = &portSettings.Tls.Mode
-			break
-		}
-	}
-	return mode
 }
 
 func lbEpKey(b *endpoint.LbEndpoint) string {

--- a/pilot/pkg/xds/mtls_checker.go
+++ b/pilot/pkg/xds/mtls_checker.go
@@ -98,7 +98,7 @@ func (c *mtlsChecker) computeForEndpoint(ep *model.IstioEndpoint) {
 			return value
 		}
 		c.peerAuthDisabledMTLS[peerAuthnKey] = factory.
-			NewPolicyApplier(c.push, ep.Namespace, ep.Labels).
+			NewMtlsChecker(c.push, ep.Namespace, ep.Labels).
 			GetMutualTLSModeForPort(ep.EndpointPort) == model.MTLSDisable
 		return c.peerAuthDisabledMTLS[peerAuthnKey]
 	}

--- a/pilot/pkg/xds/mtls_checker.go
+++ b/pilot/pkg/xds/mtls_checker.go
@@ -1,0 +1,165 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"strconv"
+
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+
+	networkingapi "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/security/authn/factory"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/labels"
+)
+
+// TODO this logic is probably done elsewhere in XDS, possible code-reuse + perf improvements
+type mtlsChecker struct {
+	push            *model.PushContext
+	svcPort         int
+	destinationRule *networkingapi.DestinationRule
+
+	// cache of host identifiers that have mTLS disabled
+	mtlsDisabledHosts map[string]struct{}
+
+	// cache of labels/port that have mTLS disabled by peerAuthn
+	peerAuthDisabledMTLS map[string]bool
+	// cache of labels that have mTLS modes set for subset policies
+	subsetPolicyMode map[string]*networkingapi.ClientTLSSettings_TLSmode
+	// the tlsMode of the root traffic policy if it's set
+	rootPolicyMode *networkingapi.ClientTLSSettings_TLSmode
+}
+
+func newMtlsChecker(push *model.PushContext, svcPort int, dr *config.Config) *mtlsChecker {
+	var drSpec *networkingapi.DestinationRule
+	if dr != nil {
+		drSpec = dr.Spec.(*networkingapi.DestinationRule)
+	}
+	return &mtlsChecker{
+		push:                 push,
+		svcPort:              svcPort,
+		destinationRule:      drSpec,
+		mtlsDisabledHosts:    map[string]struct{}{},
+		peerAuthDisabledMTLS: map[string]bool{},
+		subsetPolicyMode:     map[string]*networkingapi.ClientTLSSettings_TLSmode{},
+		rootPolicyMode:       mtlsModeForDefaultTrafficPolicy(dr, svcPort),
+	}
+}
+
+// mTLSDisabled returns true if the given lbEp has mTLS disabled due to any of:
+// - disabled tlsMode
+// - DestinationRule disabling mTLS on the entire host or the port
+// - PeerAuthentication disabling mTLS at any applicable level (mesh, ns, workload, port)
+func (c *mtlsChecker) isMtlsDisabled(lbEp *endpoint.LbEndpoint) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.mtlsDisabledHosts[lbEpKey(lbEp)]
+	return ok
+}
+
+// computeForEndpoint checks destination rule, peer authentication and tls mode labels to determine if mTLS was turned off.
+func (c *mtlsChecker) computeForEndpoint(ep *model.IstioEndpoint) {
+	if drMode := c.mtlsModeForDestinationRule(ep); drMode != nil {
+		switch *drMode {
+		case networkingapi.ClientTLSSettings_DISABLE:
+			c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
+			return
+		case networkingapi.ClientTLSSettings_ISTIO_MUTUAL:
+			// don't mark this EP disabled, even if PA or tlsMode meta mark disabled
+			return
+		}
+	}
+
+	// if endpoint has no sidecar or explicitly tls disabled by "security.istio.io/tlsMode" label.
+	if ep.TLSMode != model.IstioMutualTLSModeLabel {
+		c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
+		return
+	}
+
+	mtlsDisabledByPeerAuthentication := func(ep *model.IstioEndpoint) bool {
+		// apply any matching peer authentications
+		peerAuthnKey := ep.Labels.String() + ":" + strconv.Itoa(int(ep.EndpointPort))
+		if value, ok := c.peerAuthDisabledMTLS[peerAuthnKey]; ok {
+			// avoid recomputing since most EPs will have the same labels/port
+			return value
+		}
+		c.peerAuthDisabledMTLS[peerAuthnKey] = factory.
+			NewPolicyApplier(c.push, ep.Namespace, ep.Labels).
+			GetMutualTLSModeForPort(ep.EndpointPort) == model.MTLSDisable
+		return c.peerAuthDisabledMTLS[peerAuthnKey]
+	}
+
+	//  mtls disabled by PeerAuthentication
+	if mtlsDisabledByPeerAuthentication(ep) {
+		c.mtlsDisabledHosts[lbEpKey(ep.EnvoyEndpoint)] = struct{}{}
+	}
+}
+
+func (c *mtlsChecker) mtlsModeForDestinationRule(ep *model.IstioEndpoint) *networkingapi.ClientTLSSettings_TLSmode {
+	if c.destinationRule == nil || len(c.destinationRule.Subsets) == 0 {
+		return c.rootPolicyMode
+	}
+
+	drSubsetKey := ep.Labels.String()
+	if value, ok := c.subsetPolicyMode[drSubsetKey]; ok {
+		// avoid recomputing since most EPs will have the same labels/port
+		return value
+	}
+
+	subsetValue := c.rootPolicyMode
+	for _, subset := range c.destinationRule.Subsets {
+		if labels.Instance(subset.Labels).SubsetOf(ep.Labels) {
+			mode := trafficPolicyTLSModeForPort(subset.TrafficPolicy, c.svcPort)
+			if mode != nil {
+				subsetValue = mode
+			}
+			break
+		}
+	}
+	c.subsetPolicyMode[drSubsetKey] = subsetValue
+	return subsetValue
+}
+
+// mtlsModeForDefaultTrafficPolicy returns true if the default traffic policy on a given dr disables mTLS
+func mtlsModeForDefaultTrafficPolicy(destinationRule *config.Config, port int) *networkingapi.ClientTLSSettings_TLSmode {
+	if destinationRule == nil {
+		return nil
+	}
+	dr, ok := destinationRule.Spec.(*networkingapi.DestinationRule)
+	if !ok || dr == nil {
+		return nil
+	}
+	return trafficPolicyTLSModeForPort(dr.GetTrafficPolicy(), port)
+}
+
+func trafficPolicyTLSModeForPort(tp *networkingapi.TrafficPolicy, port int) *networkingapi.ClientTLSSettings_TLSmode {
+	if tp == nil {
+		return nil
+	}
+	var mode *networkingapi.ClientTLSSettings_TLSmode
+	if tp.Tls != nil {
+		mode = &tp.Tls.Mode
+	}
+	// if there is a port-level setting matching this cluster
+	for _, portSettings := range tp.GetPortLevelSettings() {
+		if int(portSettings.GetPort().GetNumber()) == port && portSettings.Tls != nil {
+			mode = &portSettings.Tls.Mode
+			break
+		}
+	}
+	return mode
+}

--- a/pilot/pkg/xds/mtls_checker.go
+++ b/pilot/pkg/xds/mtls_checker.go
@@ -163,3 +163,13 @@ func trafficPolicyTLSModeForPort(tp *networkingapi.TrafficPolicy, port int) *net
 	}
 	return mode
 }
+
+func lbEpKey(b *endpoint.LbEndpoint) string {
+	if addr := b.GetEndpoint().GetAddress().GetSocketAddress(); addr != nil {
+		return addr.Address + ":" + strconv.Itoa(int(addr.GetPortValue()))
+	}
+	if addr := b.GetEndpoint().GetAddress().GetPipe(); addr != nil {
+		return addr.GetPath() + ":" + strconv.Itoa(int(addr.GetMode()))
+	}
+	return ""
+}


### PR DESCRIPTION
Previously mtls checker currently couples with PolicyApplier to use only one of its method `GetMutualTLSModeForPort`, but actually policyapplier will do other work like processing `requestAuthentication`

In this PR, introduce a new mtlsChecker, which only checks inbound mtls mode of a proxy, and does not process any jwt rules. more efficient from performance view
