### PR TITLE
ambient upstream: new istioctl commands

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -713,7 +713,7 @@ func listenerConfigCmd() *cobra.Command {
 	listenerConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
 	listenerConfigCmd.PersistentFlags().BoolVar(&waypointProxyConfig, "waypoint", false, "Output waypoint information")
 	// Until stabilized
-	listenerConfigCmd.PersistentFlags().MarkHidden("waypoint")
+	_ = listenerConfigCmd.PersistentFlags().MarkHidden("waypoint")
 	listenerConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -239,6 +239,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(preCheck())
 	experimentalCmd.AddCommand(statsConfigCmd())
 	experimentalCmd.AddCommand(checkInjectCommand())
+	experimentalCmd.AddCommand(waypointCmd())
 
 	analyzeCmd := Analyze()
 	hideInheritedFlags(analyzeCmd, FlagIstioNamespace)

--- a/istioctl/cmd/waypoint.go
+++ b/istioctl/cmd/waypoint.go
@@ -1,0 +1,144 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/istioctl/pkg/util/handlers"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+func waypointCmd() *cobra.Command {
+	var waypointServiceAccount string
+	makeGateway := func(forApply bool) *gateway.Gateway {
+		ns := handlers.HandleNamespace(namespace, defaultNamespace)
+		if namespace == "" && !forApply {
+			ns = ""
+		}
+		name := waypointServiceAccount
+		if name == "" {
+			name = "namespace"
+		}
+		gw := gateway.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       gvk.KubernetesGateway.Kind,
+				APIVersion: gvk.KubernetesGateway.GroupVersion(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+			Spec: gateway.GatewaySpec{
+				GatewayClassName: constants.WaypointGatewayClassName,
+				Listeners: []gateway.Listener{{
+					Name:     "mesh",
+					Port:     15008,
+					Protocol: "ALL",
+				}},
+			},
+		}
+		if waypointServiceAccount != "" {
+			gw.Annotations = map[string]string{
+				constants.WaypointServiceAccount: waypointServiceAccount,
+			}
+		}
+		return &gw
+	}
+	waypointGenerateCmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate a waypoint configuration",
+		Long:  "Generate a waypoint configuration as YAML",
+		Example: ` # Generate a waypoint as yaml
+  istioctl x waypoint generate --service-account something --namespace default`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gw := makeGateway(false)
+			b, err := yaml.Marshal(gw)
+			if err != nil {
+				return err
+			}
+			// strip junk
+			res := strings.ReplaceAll(string(b), `  creationTimestamp: null
+`, "")
+			res = strings.ReplaceAll(res, `status: {}
+`, "")
+			fmt.Fprint(cmd.OutOrStdout(), res)
+			return nil
+		},
+	}
+	waypointApplyCmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply a waypoint configuration",
+		Long:  "Apply a waypoint configuration to the cluster",
+		Example: `  # Apply a waypoint to the current namespace
+  istioctl x waypoint apply`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gw := makeGateway(true)
+			client, err := kubeClient(kubeconfig, configContext)
+			if err != nil {
+				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+			}
+			gwc := client.GatewayAPI().GatewayV1beta1().Gateways(handlers.HandleNamespace(namespace, defaultNamespace))
+			b, err := yaml.Marshal(gw)
+			if err != nil {
+				return err
+			}
+			_, err = gwc.Patch(context.Background(), gw.Name, types.ApplyPatchType, b, metav1.PatchOptions{
+				Force:        nil,
+				FieldManager: "istioctl",
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v applied\n", gw.Namespace, gw.Name)
+			return nil
+		},
+	}
+	waypointCmd := &cobra.Command{
+		Use:   "waypoint",
+		Short: "Manage waypoint configuration",
+		Long:  "A group of commands used to manage waypoint configuration",
+		Example: `  # Apply a waypoint to the current namespace
+  istioctl x waypoint apply
+
+  # Generate a waypoint as yaml
+  istioctl x waypoint generate --service-account something --namespace default`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("unknown subcommand %q", args[0])
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.HelpFunc()(cmd, args)
+			return nil
+		},
+	}
+
+	waypointCmd.AddCommand(waypointApplyCmd)
+	waypointCmd.AddCommand(waypointGenerateCmd)
+	waypointCmd.PersistentFlags().StringVarP(&waypointServiceAccount, "service-account", "s", "", "service account to create a waypoint for")
+
+	return waypointCmd
+}

--- a/istioctl/pkg/util/configdump/workload.go
+++ b/istioctl/pkg/util/configdump/workload.go
@@ -1,0 +1,35 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configdump
+
+type ZtunnelWorkload struct {
+	WorkloadIP        string   `json:"workloadIp"`
+	WaypointAddresses []string `json:"waypointAddresses"`
+	GatewayIP         []byte   `json:"gatewayIp"`
+	Protocol          string   `json:"protocol"`
+	Name              string   `json:"name"`
+	Namespace         string   `json:"namespace"`
+	ServiceAccount    string   `json:"serviceAccount"`
+	WorkloadName      string   `json:"workloadName"`
+	WorkloadType      string   `json:"workloadType"`
+	CanonicalName     string   `json:"canonicalName"`
+	CanonicalRevision string   `json:"canonicalRevision"`
+	Node              string   `json:"node"`
+	NativeHbone       bool     `json:"nativeHbone"`
+}
+
+type ZtunnelDump struct {
+	Workloads map[string]*ZtunnelWorkload
+}

--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	matcher "github.com/cncf/xds/go/xds/type/matcher/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -31,6 +32,7 @@ import (
 
 	protio "istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 )
 
@@ -40,6 +42,8 @@ const (
 
 	// TCPListener identifies a listener as being of TCP type by the presence of TCP proxy filter
 	TCPListener = wellknown.TCPProxy
+
+	IPMatcher = "type.googleapis.com/xds.type.matcher.v3.IPMatcher"
 )
 
 // ListenerFilter is used to pass filter information into listener based config writer print functions
@@ -121,6 +125,141 @@ func retrieveListenerPort(l *listener.Listener) uint32 {
 	return l.Address.GetSocketAddress().GetPortValue()
 }
 
+func (c *ConfigWriter) PrintRemoteListenerSummary() error {
+	w, listeners, err := c.setupListenerConfigWriter()
+	if err != nil {
+		return err
+	}
+	// Sort by port, addr, type
+	sort.Slice(listeners, func(i, j int) bool {
+		if listeners[i].GetInternalListener() != nil && listeners[j].GetInternalListener() != nil {
+			return listeners[i].GetName() < listeners[j].GetName()
+		}
+		iPort := retrieveListenerPort(listeners[i])
+		jPort := retrieveListenerPort(listeners[j])
+		if iPort != jPort {
+			return iPort < jPort
+		}
+		iAddr := retrieveListenerAddress(listeners[i])
+		jAddr := retrieveListenerAddress(listeners[j])
+		if iAddr != jAddr {
+			return iAddr < jAddr
+		}
+		iType := retrieveListenerType(listeners[i])
+		jType := retrieveListenerType(listeners[j])
+		return iType < jType
+	})
+
+	fmt.Fprintln(w, "LISTENER\tCHAIN\tMATCH\tDESTINATION")
+	for _, l := range listeners {
+		chains := getFilterChains(l)
+		lname := "envoy://" + l.GetName()
+		// Avoid duplicating the listener and filter name
+		if l.GetInternalListener() != nil && len(chains) == 1 && chains[0].GetName() == lname {
+			lname = "internal"
+		}
+		for _, fc := range chains {
+
+			name := fc.GetName()
+			matches := newMatcher(fc, l)
+			destination := getFilterType(fc.GetFilters())
+			for _, match := range matches {
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", lname, name, match, destination)
+			}
+		}
+	}
+	return w.Flush()
+}
+
+func newMatcher(fc *listener.FilterChain, l *listener.Listener) []string {
+	if l.FilterChainMatcher == nil {
+		return []string{getMatches(fc.GetFilterChainMatch())}
+	}
+	switch v := l.GetFilterChainMatcher().GetOnNoMatch().GetOnMatch().(type) {
+	case *matcher.Matcher_OnMatch_Action:
+		if v.Action.GetName() == fc.GetName() {
+			return []string{"UNMATCHED"}
+		}
+	case *matcher.Matcher_OnMatch_Matcher:
+		ms, f := recurse(fc.GetName(), v.Matcher)
+		if !f {
+			return []string{"NONE"}
+		}
+		return ms
+	}
+	ms, f := recurse(fc.GetName(), l.GetFilterChainMatcher())
+	if !f {
+		return []string{"NONE"}
+	}
+	return ms
+}
+
+func recurse(name string, match *matcher.Matcher) ([]string, bool) {
+	switch v := match.GetOnNoMatch().GetOnMatch().(type) {
+	case *matcher.Matcher_OnMatch_Action:
+		if v.Action.GetName() == name {
+			// TODO this only makes sense in context of a chain... do we need a way to give it context
+			return []string{"ANY"}, true
+		}
+	case *matcher.Matcher_OnMatch_Matcher:
+		ms, f := recurse(name, v.Matcher)
+		if !f {
+			return []string{"NONE"}, true
+		}
+		return ms, true
+	}
+	// TODO support list
+	n := match.GetMatcherTree().GetInput().GetName()
+
+	var m map[string]*matcher.Matcher_OnMatch
+	equality := "="
+	switch v := match.GetMatcherTree().GetTreeType().(type) {
+	case *matcher.Matcher_MatcherTree_ExactMatchMap:
+		m = v.ExactMatchMap.Map
+	case *matcher.Matcher_MatcherTree_PrefixMatchMap:
+		m = v.PrefixMatchMap.Map
+		equality = "^"
+	case *matcher.Matcher_MatcherTree_CustomMatch:
+		tc := v.CustomMatch.GetTypedConfig()
+		switch tc.TypeUrl {
+		case IPMatcher:
+			ip := protoconv.SilentlyUnmarshalAny[matcher.IPMatcher](tc)
+			m = map[string]*matcher.Matcher_OnMatch{}
+			for _, rm := range ip.GetRangeMatchers() {
+				for _, r := range rm.Ranges {
+					cidr := r.AddressPrefix
+					pl := r.PrefixLen.GetValue()
+					if pl != 32 && pl != 128 {
+						cidr += fmt.Sprintf("/%d", pl)
+					}
+					m[cidr] = rm.OnMatch
+				}
+			}
+		default:
+			panic("unhandled")
+		}
+	}
+	outputs := []string{}
+	for k, v := range m {
+		switch v := v.GetOnMatch().(type) {
+		case *matcher.Matcher_OnMatch_Action:
+			if v.Action.GetName() == name {
+				outputs = append(outputs, fmt.Sprintf("%v%v%v", n, equality, k))
+			}
+			continue
+		case *matcher.Matcher_OnMatch_Matcher:
+			children, match := recurse(name, v.Matcher)
+			if !match {
+				continue
+			}
+			for _, child := range children {
+				outputs = append(outputs, fmt.Sprintf("%v%v%v -> %v", n, equality, k, child))
+			}
+		}
+	}
+	return outputs, len(outputs) > 0
+}
+
 // PrintListenerSummary prints a summary of the relevant listeners in the config dump to the ConfigWriter stdout
 func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 	w, listeners, err := c.setupListenerConfigWriter()
@@ -200,57 +339,61 @@ func retrieveListenerMatches(l *listener.Listener) []filterchain {
 	fChains := getFilterChains(l)
 	resp := make([]filterchain, 0, len(fChains))
 	for _, filterChain := range fChains {
-		match := filterChain.FilterChainMatch
-		if match == nil {
-			match = &listener.FilterChainMatch{}
-		}
-		// filterChaince also has SuffixLen, SourceType, SourcePrefixRanges which are not rendered.
-
-		descrs := []string{}
-		if len(match.ServerNames) > 0 {
-			descrs = append(descrs, fmt.Sprintf("SNI: %s", strings.Join(match.ServerNames, ",")))
-		}
-		if len(match.TransportProtocol) > 0 {
-			descrs = append(descrs, fmt.Sprintf("Trans: %s", match.TransportProtocol))
-		}
-
-		if len(match.ApplicationProtocols) > 0 {
-			found := false
-			for protDescr, protocols := range protDescrs {
-				if reflect.DeepEqual(match.ApplicationProtocols, protocols) {
-					found = true
-					descrs = append(descrs, protDescr)
-					break
-				}
-			}
-			if !found {
-				descrs = append(descrs, fmt.Sprintf("App: %s", strings.Join(match.ApplicationProtocols, ",")))
-			}
-		}
-
-		port := ""
-		if match.DestinationPort != nil {
-			port = fmt.Sprintf(":%d", match.DestinationPort.GetValue())
-		}
-		if len(match.PrefixRanges) > 0 {
-			pf := []string{}
-			for _, p := range match.PrefixRanges {
-				pf = append(pf, fmt.Sprintf("%s/%d", p.AddressPrefix, p.GetPrefixLen().GetValue()))
-			}
-			descrs = append(descrs, fmt.Sprintf("Addr: %s%s", strings.Join(pf, ","), port))
-		} else if port != "" {
-			descrs = append(descrs, fmt.Sprintf("Addr: *%s", port))
-		}
-		if len(descrs) == 0 {
-			descrs = []string{"ALL"}
-		}
 		fc := filterchain{
 			destination: getFilterType(filterChain.GetFilters()),
-			match:       strings.Join(descrs, "; "),
+			match:       getMatches(filterChain.FilterChainMatch),
 		}
 		resp = append(resp, fc)
 	}
 	return resp
+}
+
+func getMatches(f *listener.FilterChainMatch) string {
+	match := f
+	if match == nil {
+		match = &listener.FilterChainMatch{}
+	}
+	// filterChaince also has SuffixLen, SourceType, SourcePrefixRanges which are not rendered.
+
+	descrs := []string{}
+	if len(match.ServerNames) > 0 {
+		descrs = append(descrs, fmt.Sprintf("SNI: %s", strings.Join(match.ServerNames, ",")))
+	}
+	if len(match.TransportProtocol) > 0 {
+		descrs = append(descrs, fmt.Sprintf("Trans: %s", match.TransportProtocol))
+	}
+
+	if len(match.ApplicationProtocols) > 0 {
+		found := false
+		for protDescr, protocols := range protDescrs {
+			if reflect.DeepEqual(match.ApplicationProtocols, protocols) {
+				found = true
+				descrs = append(descrs, protDescr)
+				break
+			}
+		}
+		if !found {
+			descrs = append(descrs, fmt.Sprintf("App: %s", strings.Join(match.ApplicationProtocols, ",")))
+		}
+	}
+
+	port := ""
+	if match.DestinationPort != nil {
+		port = fmt.Sprintf(":%d", match.DestinationPort.GetValue())
+	}
+	if len(match.PrefixRanges) > 0 {
+		pf := []string{}
+		for _, p := range match.PrefixRanges {
+			pf = append(pf, fmt.Sprintf("%s/%d", p.AddressPrefix, p.GetPrefixLen().GetValue()))
+		}
+		descrs = append(descrs, fmt.Sprintf("Addr: %s%s", strings.Join(pf, ","), port))
+	} else if port != "" {
+		descrs = append(descrs, fmt.Sprintf("Addr: *%s", port))
+	}
+	if len(descrs) == 0 {
+		descrs = []string{"ALL"}
+	}
+	return strings.Join(descrs, "; ")
 }
 
 func getFilterType(filters []*listener.Filter) string {

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -1,0 +1,84 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configdump
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"istio.io/istio/istioctl/pkg/util/configdump"
+)
+
+// ConfigWriter is a writer for processing responses from the Ztunnel Admin config_dump endpoint
+type ConfigWriter struct {
+	Stdout      io.Writer
+	ztunnelDump *configdump.ZtunnelDump
+}
+
+// Prime loads the config dump into the writer ready for printing
+func (c *ConfigWriter) Prime(b []byte) error {
+	cd := configdump.ZtunnelDump{}
+	// TODO(fisherxu): migrate this to jsonpb when issue fixed in golang
+	// Issue to track -> https://github.com/golang/protobuf/issues/632
+	err := json.Unmarshal(b, &cd)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling config dump response from ztunnel: %v", err)
+	}
+	c.ztunnelDump = &cd
+	return nil
+}
+
+// PrintBootstrapDump prints just the bootstrap config dump to the ConfigWriter stdout
+func (c *ConfigWriter) PrintBootstrapDump(outputFormat string) error {
+	// TODO
+	return nil
+}
+
+// PrintSecretDump prints just the secret config dump to the ConfigWriter stdout
+func (c *ConfigWriter) PrintSecretDump(outputFormat string) error {
+	// TODO
+	return nil
+}
+
+// PrintSecretSummary prints a summary of dynamic active secrets from the config dump
+func (c *ConfigWriter) PrintSecretSummary() error {
+	// TODO
+	return nil
+}
+
+func (c *ConfigWriter) PrintFullSummary(wf WorkloadFilter) error {
+	_, _ = c.Stdout.Write([]byte("\n"))
+	if err := c.PrintWorkloadSummary(wf); err != nil {
+		return err
+	}
+	_, _ = c.Stdout.Write([]byte("\n"))
+	if err := c.PrintSecretSummary(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PrintVersionSummary prints version information for Istio and Ztunnel from the config dump
+func (c *ConfigWriter) PrintVersionSummary() error {
+	// TODO
+	return nil
+}
+
+// PrintPodRootCAFromDynamicSecretDump prints just pod's root ca from dynamic secret config dump to the ConfigWriter stdout
+func (c *ConfigWriter) PrintPodRootCAFromDynamicSecretDump() (string, error) {
+	// TODO
+	return "", nil
+}

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -1,0 +1,138 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configdump
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+
+	ztunnelDump "istio.io/istio/istioctl/pkg/util/configdump"
+)
+
+// WorkloadFilter is used to pass filter information into workload based config writer print functions
+type WorkloadFilter struct {
+	Address string
+	Node    string
+	Verbose bool
+}
+
+// Verify returns true if the passed workload matches the filter fields
+func (wf *WorkloadFilter) Verify(workload *ztunnelDump.ZtunnelWorkload) bool {
+	if wf.Address == "" && wf.Node == "" {
+		return true
+	}
+	if wf.Address != "" && !strings.EqualFold(workload.WorkloadIP, wf.Address) {
+		return false
+	}
+	if wf.Node != "" && !strings.EqualFold(workload.Node, wf.Node) {
+		return false
+	}
+	return true
+}
+
+// PrintListenerSummary prints a summary of the relevant listeners in the config dump to the ConfigWriter stdout
+func (c *ConfigWriter) PrintWorkloadSummary(filter WorkloadFilter) error {
+	w, zDump, err := c.setupWorkloadConfigWriter()
+	if err != nil {
+		return err
+	}
+
+	verifiedWorkloads := make([]*ztunnelDump.ZtunnelWorkload, 0, len(zDump.Workloads))
+	for _, wl := range zDump.Workloads {
+		if filter.Verify(wl) {
+			verifiedWorkloads = append(verifiedWorkloads, wl)
+		}
+	}
+
+	// Sort by name, node
+	sort.Slice(verifiedWorkloads, func(i, j int) bool {
+		iName := verifiedWorkloads[i].Name
+		jName := verifiedWorkloads[j].Name
+		if iName != jName {
+			return iName < jName
+		}
+		iNode := verifiedWorkloads[i].Node
+		jNode := verifiedWorkloads[j].Node
+		return iNode < jNode
+	})
+
+	if filter.Verbose {
+		fmt.Fprintln(w, "NAME\tNAMESPACE\tIP\tNODE\tL7 SUPPORT\tPROTOCOL")
+	} else {
+		fmt.Fprintln(w, "NAME\tNAMESPACE\tIP\tNODE")
+	}
+	for _, wl := range verifiedWorkloads {
+		if filter.Verbose {
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n", wl.Name, wl.Namespace, wl.WorkloadIP, wl.Node, len(wl.WaypointAddresses) != 0, wl.Protocol)
+		} else {
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", wl.Name, wl.Namespace, wl.WorkloadIP, wl.Node)
+		}
+	}
+	return w.Flush()
+}
+
+// PrintWorkloadDump prints the relevant workloads in the config dump to the ConfigWriter stdout
+func (c *ConfigWriter) PrintWorkloadDump(filter WorkloadFilter, outputFormat string) error {
+	_, zDump, err := c.setupWorkloadConfigWriter()
+	if err != nil {
+		return err
+	}
+	filteredWorkloads := []*ztunnelDump.ZtunnelWorkload{}
+	for _, workload := range zDump.Workloads {
+		if filter.Verify(workload) {
+			filteredWorkloads = append(filteredWorkloads, workload)
+		}
+	}
+	out, err := json.MarshalIndent(filteredWorkloads, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal workloads: %v", err)
+	}
+	if outputFormat == "yaml" {
+		if out, err = yaml.JSONToYAML(out); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(c.Stdout, string(out))
+	return nil
+}
+
+func (c *ConfigWriter) setupWorkloadConfigWriter() (*tabwriter.Writer, *ztunnelDump.ZtunnelDump, error) {
+	listeners, err := c.retrieveSortedWorkloadSlice()
+	if err != nil {
+		return nil, nil, err
+	}
+	w := new(tabwriter.Writer).Init(c.Stdout, 0, 8, 1, ' ', 0)
+	return w, listeners, nil
+}
+
+func (c *ConfigWriter) retrieveSortedWorkloadSlice() (*ztunnelDump.ZtunnelDump, error) {
+	if c.ztunnelDump == nil {
+		return nil, fmt.Errorf("config writer has not been primed")
+	}
+	workloadDump := c.ztunnelDump
+	if workloadDump == nil {
+		return nil, fmt.Errorf("workload dump empty")
+	}
+	if len(workloadDump.Workloads) == 0 {
+		return nil, fmt.Errorf("no workloads found")
+	}
+
+	return workloadDump, nil
+}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -151,8 +151,14 @@ const (
 	// load balancer, such as an Istio Gateway, is terminating the TLS.
 	CertProviderNone = "none"
 
-	ManagedGatewayLabel      = "gateway.istio.io/managed"
-	ManagedGatewayController = "istio.io-gateway-controller"
+	WaypointServiceAccount = "istio.io/for-service-account"
+
+	ManagedGatewayLabel          = "gateway.istio.io/managed"
+	ManagedGatewayController     = "istio.io-gateway-controller"
+	ManagedGatewayMeshController = "istio.io-mesh-controller"
+
+	WaypointGatewayClassName = "istio-waypoint"
+	GatewayNameLabel         = "istio.io/gateway-name"
 
 	WaypointGatewayClassName = "istio-waypoint"
 	GatewayNameLabel         = "istio.io/gateway-name"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -160,9 +160,6 @@ const (
 	WaypointGatewayClassName = "istio-waypoint"
 	GatewayNameLabel         = "istio.io/gateway-name"
 
-	WaypointGatewayClassName = "istio-waypoint"
-	GatewayNameLabel         = "istio.io/gateway-name"
-
 	// DataplaneMode namespace label for determining ambient mesh behavior
 	DataplaneMode        = "istio.io/dataplane-mode"
 	DataplaneModeAmbient = "ambient"


### PR DESCRIPTION
For https://github.com/istio/istio/issues/40879

This PR imports the istioctl/ changes from ambient. This consists of:
* A new `x waypoint` command. This is experimental, so should not be an issue
* `pc workloads` and a new `--waypoint` flag for `pc listener`. These are both *hidden* (since we don't have experimental within subcommands), so should be fine
* Minor tweaks to existing commands with no expected user changes

Overall, we expect no changes to non-ambient istioctl users.

Quoting from the issue:


> **Reviewer guide**
> 
> It is suggested that reviewers treat these PRs differently than normal, as the code has already been reviewed. PRs _should_ be thoroughly reviewed for risk to non-ambient users, ensuring any new/risky/expensive code is disabled by default. However, code quality comments, nit picks, or even bugs in ambient code should **not** block a merge; modifying these PRs will be high cost and lead to a 3-way drift from master, experimental-ambient, and the PR. Instead, these comments should be turned into issues to complete following the merge.
> 
> Release notes will not be added for any PR. Instead, they will be written holistically for the ambient feature in 1.18 at a later point.