### PR TITLE
echo: allow connection pooling for HTTP1

### DIFF
--- a/pkg/test/echo/server/forwarder/config.go
+++ b/pkg/test/echo/server/forwarder/config.go
@@ -122,7 +122,7 @@ func (c *Config) fillDefaults() error {
 	case scheme.DNS:
 		c.newConnectionPerRequest = true
 		c.forceDNSLookup = true
-	case scheme.TCP, scheme.TLS, scheme.WebSocket, scheme.HTTPS:
+	case scheme.TCP, scheme.TLS, scheme.WebSocket:
 		c.newConnectionPerRequest = true
 		c.forceDNSLookup = c.Request.ForceDNSLookup
 	default:


### PR DESCRIPTION
This should reduce the number of connections we establish a bit. Note while HTTP1 cannot do concurrent requests on one connection, we can still pool them. If we sent 100 requests through echo, we usually are not actually sending 100 at once - we have a limit on the concurrency, so we will reuse connections as requests complete and we start new ones.

I was hoping this would help test times - it didn't, but still may be useful