### PR TITLE
Fix gatewayclass not being created correctly in ambient

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -807,7 +807,7 @@ func (a *AmbientSnapshot) matchesScope(scope WaypointScope, w *WorkloadInfo) boo
 		return false
 	}
 	// Filter out waypoints.
-	if w.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshController {
+	if w.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 		return false
 	}
 	return true

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -109,7 +109,7 @@ func (a *AmbientIndex) updateWaypoint(sa model.WaypointScope, ipStr string, isDe
 			if !(wl.Namespace == sa.Namespace && (sa.ServiceAccount == "" || wl.ServiceAccount == sa.ServiceAccount)) {
 				continue
 			}
-			if wl.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshController {
+			if wl.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 				continue
 			}
 			wl := wl.Clone()
@@ -138,7 +138,7 @@ func (a *AmbientIndex) updateWaypoint(sa model.WaypointScope, ipStr string, isDe
 			if !(wl.Namespace == sa.Namespace && (sa.ServiceAccount == "" || wl.ServiceAccount == sa.ServiceAccount)) {
 				continue
 			}
-			if wl.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshController {
+			if wl.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 				continue
 			}
 			found := false
@@ -540,7 +540,7 @@ func (c *Controller) extractWorkload(p *v1.Pod) *model.WorkloadInfo {
 		// if there are none, check namespace wide waypoints
 		waypoints = c.ambientIndex.waypoints[model.WaypointScope{Namespace: p.Namespace}]
 	}
-	if p.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshController {
+	if p.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 		// Waypoints do not have waypoints
 		waypoints = nil
 	}
@@ -595,7 +595,7 @@ func (c *Controller) setupIndex() *AmbientIndex {
 		p := controllers.Extract[*v1.Pod](newObj)
 		updates := sets.New[model.ConfigKey]()
 		// This is a waypoint update
-		if p.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshController {
+		if p.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 			n := model.WaypointScope{Namespace: p.Namespace, ServiceAccount: p.Annotations[constants.WaypointServiceAccount]}
 			ip := p.Status.PodIP
 			if isDelete || !IsPodReady(p) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -229,7 +229,7 @@ func TestAmbientIndex(t *testing.T) {
 	assert.Equal(t, len(controller.ambientIndex.byService), 0)
 
 	// Add a waypoint proxy for namespace
-	addPods("127.0.0.200", "waypoint-ns", "namespace-wide", map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshController}, nil)
+	addPods("127.0.0.200", "waypoint-ns", "namespace-wide", map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel}, nil)
 	assertWorkloads("", "name1", "name2", "name3", "waypoint-ns")
 	// All these workloads updated, so push them
 	assertEvent("127.0.0.1", "127.0.0.2", "127.0.0.200", "127.0.0.3")
@@ -237,7 +237,7 @@ func TestAmbientIndex(t *testing.T) {
 	assert.Equal(t, controller.ambientIndex.Lookup("127.0.0.3")[0].WaypointAddresses, [][]byte{netip.MustParseAddr("127.0.0.200").AsSlice()})
 
 	// Add another one, expect the same result
-	addPods("127.0.0.201", "waypoint2-ns", "namespace-wide", map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshController}, nil)
+	addPods("127.0.0.201", "waypoint2-ns", "namespace-wide", map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel}, nil)
 	assertEvent("127.0.0.1", "127.0.0.2", "127.0.0.201", "127.0.0.3")
 	assert.Equal(t,
 		controller.ambientIndex.Lookup("127.0.0.3")[0].WaypointAddresses,
@@ -271,7 +271,7 @@ func TestAmbientIndex(t *testing.T) {
 		[][]byte{netip.MustParseAddr("127.0.0.200").AsSlice()})
 
 	addPods("127.0.0.201", "waypoint2-sa", "waypoint-sa",
-		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshController},
+		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{constants.WaypointServiceAccount: "sa2"})
 	assertEvent("127.0.0.201")
 	// Unrelated SA should not change anything

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -153,9 +153,10 @@ const (
 
 	WaypointServiceAccount = "istio.io/for-service-account"
 
-	ManagedGatewayLabel          = "gateway.istio.io/managed"
-	ManagedGatewayController     = "istio.io-gateway-controller"
-	ManagedGatewayMeshController = "istio.io-mesh-controller"
+	ManagedGatewayLabel               = "gateway.istio.io/managed"
+	ManagedGatewayController          = "istio.io-gateway-controller"
+	ManagedGatewayMeshControllerLabel = "istio.io-mesh-controller"
+	ManagedGatewayMeshController      = "istio.io/mesh-controller"
 
 	WaypointGatewayClassName = "istio-waypoint"
 	GatewayNameLabel         = "istio.io/gateway-name"


### PR DESCRIPTION
**Please provide a description of this PR:**
From the latest build, when creating the waypoint, gateway class is not being created with the error:
```
2023-02-17T06:47:04.595700Z     error   controllers     error handling /istio-waypoint, retrying (retry count: 9): GatewayClass.gateway.networking.k8s.io "istio-waypoint" is invalid: spec.controllerName: Invalid value: "istio.io-mesh-controller": spec.controllerName in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$'     controller=gateway class
2023-02-17T06:47:05.877416Z     error   controllers     error handling /istio-waypoint, retrying (retry count: 10): GatewayClass.gateway.networking.k8s.io "istio-waypoint" is invalid: spec.controllerName: Invalid value: "istio.io-mesh-controller": spec.controllerName in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$'    controller=gateway class
2023-02-17T06:47:08.439353Z     error   controllers     error handling /istio-waypoint, retrying (retry count: 11): GatewayClass.gateway.networking.k8s.io "istio-waypoint" is invalid: spec.controllerName: Invalid value: "istio.io-mesh-controller": spec.controllerName in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$'    controller=gateway class
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
