### PR TITLE
use errors.Is to check for a specific error

### DIFF
--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -69,7 +69,7 @@ func extractResourceFile(in io.Reader, out io.Writer) error {
 	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
 	for {
 		raw, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -242,7 +242,7 @@ func (v *validator) validateFile(istioNamespace *string, defaultNamespace string
 		// YAML allows non-string keys and the produces generic keys for nested fields
 		raw := make(map[any]any)
 		err := decoder.Decode(&raw)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return warnings, errs
 		}
 		if err != nil {

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -112,7 +113,7 @@ func extract(gzipStream io.Reader, destination string) error {
 
 	for {
 		header, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -17,6 +17,7 @@ package util
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -224,7 +225,7 @@ func yamlStringsToList(str string) []string {
 	res := make([]string, 0)
 	for {
 		doc, err := decoder.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -468,7 +468,7 @@ my_other_metric{} 0
 				omParser := textparse.NewOpenMetricsParser(rec.Body.Bytes())
 				for {
 					_, err := omParser.Next()
-					if err == io.EOF {
+					if errors.Is(err, io.EOF) {
 						break
 					}
 					if err != nil {

--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -290,7 +290,7 @@ func (s *KubeSource) parseContent(r *collection.Schemas, name, yamlText string) 
 	for {
 		chunkCount++
 		doc, lineNum, err := decoder.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pilot/pkg/config/file/util/kubeyaml/kubeyaml.go
+++ b/pilot/pkg/config/file/util/kubeyaml/kubeyaml.go
@@ -17,6 +17,7 @@ package kubeyaml
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"unicode"
@@ -98,7 +99,7 @@ func (r *YAMLReader) Read() ([]byte, int, error) {
 	for {
 		r.currLine++
 		line, err := r.reader.Read()
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, startLine, err
 		}
 
@@ -117,12 +118,12 @@ func (r *YAMLReader) Read() ([]byte, int, error) {
 				if buffer.Len() != 0 {
 					return buffer.Bytes(), startLine, nil
 				}
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					return nil, startLine, err
 				}
 			}
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if buffer.Len() != 0 {
 				// If we're at EOF, we have a final, non-terminated line. Return it.
 				return buffer.Bytes(), startLine, nil

--- a/pilot/pkg/config/file/util/kubeyaml/kubeyaml_test.go
+++ b/pilot/pkg/config/file/util/kubeyaml/kubeyaml_test.go
@@ -16,6 +16,7 @@ package kubeyaml
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -135,7 +136,7 @@ func TestLineNumber(t *testing.T) {
 			var expectedLineNumbers []int
 			for {
 				_, line, err := decoder.Read()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				expectedLineNumbers = append(expectedLineNumbers, line)

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -17,6 +17,7 @@ package crd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -171,7 +172,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]config.Config, []Istio
 	for {
 		obj := IstioKind{}
 		err := yamlDecoder.Decode(&obj)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -16,6 +16,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math"
 	"strings"
@@ -130,7 +131,7 @@ func containsExpectedMessage(msg string) bool {
 // IsExpectedGRPCError checks a gRPC error code and determines whether it is an expected error when
 // things are operating normally. This is basically capturing when the client disconnects.
 func IsExpectedGRPCError(err error) bool {
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return true
 	}
 

--- a/pkg/config/crd/validator.go
+++ b/pkg/config/crd/validator.go
@@ -15,6 +15,7 @@
 package crd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -101,7 +102,7 @@ func NewValidatorFromFiles(files ...string) (*Validator, error) {
 		for {
 			un := &unstructured.Unstructured{}
 			err = yamlDecoder.Decode(&un)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -544,7 +545,7 @@ func IntoResourceFile(injector Injector, sidecarTemplate Templates,
 	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
 	for {
 		raw, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -123,7 +124,7 @@ func (s *tcpInstance) echo(id uuid.UUID, conn net.Conn) {
 
 	var err error
 	defer func() {
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			_ = forceClose(conn)
 		} else {
 			_ = conn.Close()
@@ -155,7 +156,7 @@ func (s *tcpInstance) echo(id uuid.UUID, conn net.Conn) {
 			firstReply = false
 		}
 
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			epLog.WithLabels("id", id).Warnf("TCP read failed: %v", err)
 			break
 		}
@@ -170,7 +171,7 @@ func (s *tcpInstance) echo(id uuid.UUID, conn net.Conn) {
 		}
 
 		// Read can return n > 0 with EOF, do this last.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 	}

--- a/pkg/test/echo/server/forwarder/tcp.go
+++ b/pkg/test/echo/server/forwarder/tcp.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -115,13 +116,13 @@ func (c *tcpProtocol) makeRequest(ctx context.Context, cfg *Config, requestID in
 	buf := make([]byte, 1024+len(message))
 	for {
 		n, err := conn.Read(buf)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			fwLog.Warnf("TCP read failed (already read %d bytes): %v", len(resBuffer.String()), err)
 			return msgBuilder.String(), err
 		}
 		resBuffer.Write(buf[:n])
 		// the message is sent last - when we get the whole message we can stop reading
-		if err == io.EOF || strings.Contains(resBuffer.String(), message) {
+		if errors.Is(err, io.EOF) || strings.Contains(resBuffer.String(), message) {
 			break
 		}
 	}

--- a/pkg/test/echo/server/forwarder/udp.go
+++ b/pkg/test/echo/server/forwarder/udp.go
@@ -17,6 +17,7 @@ package forwarder
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -82,7 +83,7 @@ func (c *udpProtocol) makeRequest(ctx context.Context, cfg *Config, requestID in
 	var resBuffer bytes.Buffer
 	buf := make([]byte, 1024+len(message))
 	n, err := conn.Read(buf)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		fwLog.Warnf("UDP read failed (already read %d bytes): %v", len(resBuffer.String()), err)
 		return msgBuilder.String(), err
 	}

--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -17,6 +17,7 @@ package file
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -125,7 +126,7 @@ func ReadTarFile(filePath string) (string, error) {
 	tr := tar.NewReader(bytes.NewBuffer(b))
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break // End of archive
 		}
 		if err != nil {

--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -260,7 +260,7 @@ func extractWasmPluginBinary(r io.Reader) ([]byte, error) {
 	tr := tar.NewReader(io.LimitReader(gr, 1024*1024*256))
 	for {
 		h, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, err

--- a/samples/tcp-echo/src/main.go
+++ b/samples/tcp-echo/src/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -71,7 +72,7 @@ func handleConnection(conn net.Conn, prefix string) {
 		// read client request data
 		bytes, err := reader.ReadBytes(byte('\n'))
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				fmt.Println("failed to read data, err:", err)
 			}
 			return


### PR DESCRIPTION
**Please provide a description of this PR:**
Comparing with` == `will fail on wrapped errors. Use errors.Is to check for a specific error is better.