### PR TITLE
Add ExternalName to `model.Service`

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -595,10 +595,19 @@ type ServiceAttributes struct {
 	// We translate that to the appropriate node port here.
 	ClusterExternalPorts map[cluster.ID]map[uint32]uint32
 
+	K8sAttributes
+}
+
+type K8sAttributes struct {
 	// Type holds the value of the corev1.Type of the Kubernetes service
+	// spec.Type
 	Type string
 
+	// spec.ExternalName
+	ExternalName string
+
 	// NodeLocal means the proxy will only forward traffic to node local endpoints
+	// spec.InternalTrafficPolicy == Local
 	NodeLocal bool
 }
 
@@ -691,8 +700,8 @@ func (s *ServiceAttributes) Equals(other *ServiceAttributes) bool {
 			return false
 		}
 	}
-	return s.Name == other.Name && s.Namespace == other.Namespace && s.NodeLocal == other.NodeLocal &&
-		s.ServiceRegistry == other.ServiceRegistry && s.Type == other.Type
+	return s.Name == other.Name && s.Namespace == other.Namespace &&
+		s.ServiceRegistry == other.ServiceRegistry && s.K8sAttributes == other.K8sAttributes
 }
 
 // ServiceDiscovery enumerates Istio service instances.

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -469,6 +469,60 @@ func TestServicesEqual(t *testing.T) {
 			shouldEq: false,
 			name:     "service with just label change",
 		},
+		{
+			first: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						Type: "ClusterIP",
+					},
+				},
+			},
+			other: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						Type: "NodePort",
+					},
+				},
+			},
+			shouldEq: false,
+			name:     "different types",
+		},
+		{
+			first: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						ExternalName: "foo.com",
+					},
+				},
+			},
+			other: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						ExternalName: "bar.com",
+					},
+				},
+			},
+			shouldEq: false,
+			name:     "different external names",
+		},
+		{
+			first: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						NodeLocal: false,
+					},
+				},
+			},
+			other: &Service{
+				Attributes: ServiceAttributes{
+					K8sAttributes: K8sAttributes{
+						NodeLocal: true,
+					},
+				},
+			},
+			shouldEq: false,
+			name:     "different internal traffic policies",
+		},
 	}
 
 	for _, testCase := range cases {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -448,7 +448,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						Name:            "svc1",
 						Namespace:       "nsa",
 						LabelSelectors:  map[string]string{"app": "prod-app"},
-						Type:            string(corev1.ServiceTypeClusterIP),
+						K8sAttributes: model.K8sAttributes{
+							Type: string(corev1.ServiceTypeClusterIP),
+						},
 					},
 				},
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
@@ -525,7 +527,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						Name:            "svc1",
 						Namespace:       "nsa",
 						LabelSelectors:  map[string]string{"app": "prod-app"},
-						Type:            string(corev1.ServiceTypeClusterIP),
+						K8sAttributes: model.K8sAttributes{
+							Type: string(corev1.ServiceTypeClusterIP),
+						},
 					},
 				},
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
@@ -599,7 +603,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 						Name:            "svc1",
 						Namespace:       "nsa",
 						LabelSelectors:  map[string]string{"app": "prod-app"},
-						Type:            string(corev1.ServiceTypeClusterIP),
+						K8sAttributes: model.K8sAttributes{
+							Type: string(corev1.ServiceTypeClusterIP),
+						},
 					},
 				},
 				ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -308,6 +308,12 @@ func TestExternalServiceConversion(t *testing.T) {
 		t.Fatalf("service hostname incorrect => %q, want %q",
 			service.Hostname, ServiceHostname(serviceName, namespace, domainSuffix))
 	}
+
+	if service.Attributes.Type != string(extSvc.Spec.Type) ||
+		service.Attributes.ExternalName != extSvc.Spec.ExternalName {
+		t.Fatalf("service attributes incorrect => %v/%v, want %v/%v",
+			service.Attributes.Type, service.Attributes.ExternalName, extSvc.Spec.Type, extSvc.Spec.ExternalName)
+	}
 }
 
 func TestExternalClusterLocalServiceConversion(t *testing.T) {

--- a/releasenotes/notes/svc-external-name.yaml
+++ b/releasenotes/notes/svc-external-name.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/43440
+
+releaseNotes:
+  - |
+    **Fixed** an issue where updating Service ExternalName does not take effect.


### PR DESCRIPTION
**Please provide a description of this PR:**
In 1.17 we filter service events by comparing services(https://github.com/istio/istio/pull/42617). However the comparison does not take ExternalName into account since `model.Service` does not include it. It does matter because ExternalName is used to generate endpoints for DNS clusters.

This bug is breaking Knative
Fixes https://github.com/istio/istio/issues/43440


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
