### PR TITLE
EnvoyFilter: copy-on-write before applying EnvoyFilter

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -52,6 +52,8 @@ func ApplyListenerPatches(
 		return
 	}
 
+	lis = protoconv.Clone(lis) // copy-on-write
+
 	return patchListeners(patchContext, efw, lis, skipAdds)
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -45,6 +45,8 @@ func ApplyRouteConfigurationPatches(
 		return out
 	}
 
+	routeConfiguration = proto.Clone(routeConfiguration).(*route.RouteConfiguration) // copy-on-write
+
 	var portMap model.GatewayPortMap
 	if proxy.MergedGateway != nil {
 		portMap = proxy.MergedGateway.PortMap

--- a/pilot/pkg/util/protoconv/protoconv.go
+++ b/pilot/pkg/util/protoconv/protoconv.go
@@ -82,3 +82,11 @@ func UnmarshalAny[T any](a *anypb.Any) (*T, error) {
 	}
 	return any(dst).(*T), nil
 }
+
+func Clone[T proto.Message](in []T) []T {
+	out := make([]T, len(in))
+	for i := range in {
+		out[i] = proto.Clone(in[i]).(T)
+	}
+	return out
+}

--- a/pkg/util/sync/cow.go
+++ b/pkg/util/sync/cow.go
@@ -1,0 +1,41 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+)
+
+type CopyOnWrite[T proto.Message] struct {
+	value    T
+	copyOnce sync.Once
+}
+
+func NewCopyOnWrite[T proto.Message](value T) *CopyOnWrite[T] {
+	return &CopyOnWrite[T]{value: value}
+}
+
+func (cow *CopyOnWrite[T]) Value() T {
+	return cow.value
+}
+
+func (cow *CopyOnWrite[T]) Mutable() T {
+	cow.copyOnce.Do(func() {
+		cow.value = proto.Clone(cow.value).(T)
+	})
+	return cow.value
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

Alternative to #43436

Copies Envoy object prior to applying `EnvoyFilter` to it.

Fixes: https://github.com/istio/istio/issues/43435

**Implementation notes:**

This PR uses different strategies for different Envoy objects:
* In the case of `Cluster` object, it implements true "copy-on-write" (only copy if necessary)
* In the case of `Listener` and `RouteConfiguration`, it always creates a copy
* In the case of `Bootstrap` object, no copying is necessary