### PR TITLE
added small delay before updating status

### DIFF
--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -192,6 +192,8 @@ func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
 					continue
 				}
 				csr.Status.Certificate = certificate
+				// fake clientset doesn't handle resource version, so we need to delay the update
+				// to make sure watchers can catch the event
 				time.Sleep(time.Millisecond)
 				client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 			}

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -192,6 +192,7 @@ func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
 					continue
 				}
 				csr.Status.Certificate = certificate
+				time.Sleep(time.Millisecond)
 				client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
 			}
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR proposes to add a small delay before the fake client "signs" the cert request.

I don't like it, but is a cheap option to make sure we don't have a race condition in the test, where the update happens [between the list and the watch](https://github.com/istio/istio/blob/master/security/pkg/k8s/chiron/utils.go#L437), and goes undetected; in this case, we need to wait for a full 60 sec before the `certWatchTimeout` expires, to perform a read. This happens randomly, but often enough to be caught on test.

I reckon that the best option would be making `certWatchTimeout` configurable from external packages, so I'm asking @howardjohn to help with the tradeoff.

the fake clientset doesn't actually set `ResourceVersion`, which doesn't help either.

This brings execution of `TestK8sSignWithMeshConfig` from a random ~60s to a few millis.

Contributes to #37555 