### PR TITLE
grpcgen: make sure router filter is always last: insert statefulSessionAffinity filter at the beginning (backport of #43420)

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -228,15 +228,17 @@ func TestGRPC(t *testing.T) {
 		hcm := &hcm.HttpConnectionManager{}
 		ss := &statefulsession.StatefulSession{}
 		sc := &cookiev3.CookieBasedSessionState{}
+		filterIndex := -1
 		for _, rsc := range msg.Resources {
 			valBytes := rsc.Value
 			ll := &listener.Listener{}
 			_ = proto.Unmarshal(valBytes, ll)
 			if strings.HasPrefix(ll.Name, "echo-persistent.test.svc.cluster.local:") {
 				proto.Unmarshal(ll.ApiListener.ApiListener.Value, hcm)
-				for _, f := range hcm.HttpFilters {
+				for index, f := range hcm.HttpFilters {
 					if f.Name == util.StatefulSessionFilter {
 						proto.Unmarshal(f.GetTypedConfig().Value, ss)
+						filterIndex = index
 						if ss.GetSessionState().Name == "envoy.http.stateful_session.cookie" {
 							proto.Unmarshal(ss.GetSessionState().TypedConfig.Value, sc)
 						}
@@ -246,6 +248,9 @@ func TestGRPC(t *testing.T) {
 		}
 		if sc.Cookie == nil {
 			t.Fatal("Failed to find session cookie")
+		}
+		if filterIndex == (len(hcm.HttpFilters) - 1) {
+			t.Fatal("session-cookie-filter cannot be the last filter!")
 		}
 		if sc.Cookie.Name != "test-cookie" {
 			t.Fatal("Missing expected cookie name", sc.Cookie)

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -292,7 +292,7 @@ func buildOutboundListeners(node *model.Proxy, push *model.PushContext, filter l
 				}
 				filters := supportedFilters
 				if sessionFilter := util.BuildStatefulSessionFilter(sv); sessionFilter != nil {
-					filters = append(filters, sessionFilter)
+					filters = append([]*hcm.HttpFilter{sessionFilter}, filters...)
 				}
 				ll := &listener.Listener{
 					Name: net.JoinHostPort(matchedHost, sPort),


### PR DESCRIPTION
**Please provide a description of this PR:**
For statefulSesion affinithy support a new http-filter was added at the end which violates the condition that the router filter has to be the last filter (see https://github.com/grpc/proposal/blob/master/A39-xds-http-filters.md#http-filter-registry and https://www.envoyproxy.io/docs/envoy/v1.25.1/intro/arch_overview/http/http_filters.html#filter-ordering)

So this PR fixes it by inserting stateful session filter at the beginning (backport of https://github.com/istio/istio/pull/43420)