### PR TITLE
grpcgen persistence: add another label for cookie path since chars ':' and '/' are disallowed

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -126,6 +126,12 @@ var (
 		"If not empty, services with this label will use cookie based persistent sessions",
 	).Get()
 
+	PersistentCookiePathLabel = env.Register(
+		"PILOT_PERSISTENT_COOKIE_PATH_LABEL",
+		"istio.io/persistent-cookie-path",
+		"Specifies optional cookie path for cookie based persistent sessions. '/' is default. Use '.' instead of '/' in the path.",
+	).Get()
+
 	PersistentSessionHeaderLabel = env.Register(
 		"PILOT_PERSISTENT_SESSION_HEADER_LABEL",
 		"istio.io/persistent-session-header",


### PR DESCRIPTION


**Please provide a description of this PR:**
It was discovered that the characters `':'` and `'/'` are not allowed in Kubernetes label so we are unable to use the feature added in https://github.com/istio/istio/pull/42496 . This PR creates another label to specify the cookie path (`"istio.io/persistent-cookie-path"`) and also allows char `'.'`  to be used in place of '/' in the path string.

Also refactored to test persistence using `testPersistence` func. Also refactored `initPersistence`