### PR TITLE
Server Side Apply: Enabled without detection logic when k8s version > v1.22

### DIFF
--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -246,6 +246,9 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 
 // CheckSSAEnabled is a helper function to check whether ServerSideApply should be used when applying manifests.
 func (h *HelmReconciler) CheckSSAEnabled() bool {
+	if TestMode {
+		return false // our unit test setup doesn't work with SSA
+	}
 	if h.kubeClient != nil {
 		// SSA went GA in k8s 1.22
 		if kube.IsAtLeastVersion(h.kubeClient, 22) {

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -247,9 +247,9 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 // CheckSSAEnabled is a helper function to check whether ServerSideApply should be used when applying manifests.
 func (h *HelmReconciler) CheckSSAEnabled() bool {
 	if h.kubeClient != nil {
-		// There is a mutatingwebhook in gke that would corrupt the managedFields, which is fixed in k8s 1.18.
-		// See: https://github.com/kubernetes/kubernetes/issues/96351
-		if kube.IsAtLeastVersion(h.kubeClient, 18) {
+		// SSA went GA in k8s 1.22. Earlier versions (eg: 1.18) have an issue where managedFields is not present on upgraded clusters.
+		// See: https://github.com/istio/istio/issues/37946#issuecomment-1072875625
+		if kube.IsAtLeastVersion(h.kubeClient, 22) {
 			// todo(kebe7jun) a more general test method
 			// API Server does not support detecting whether ServerSideApply is enabled
 			// through the API for the time being.

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -247,9 +247,14 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 // CheckSSAEnabled is a helper function to check whether ServerSideApply should be used when applying manifests.
 func (h *HelmReconciler) CheckSSAEnabled() bool {
 	if h.kubeClient != nil {
-		// SSA went GA in k8s 1.22. Earlier versions (eg: 1.18) have an issue where managedFields is not present on upgraded clusters.
-		// See: https://github.com/istio/istio/issues/37946#issuecomment-1072875625
+		// SSA went GA in k8s 1.22
 		if kube.IsAtLeastVersion(h.kubeClient, 22) {
+			return true
+		}
+		// For versions greater than 1.18, detect if SSA is enabled.
+		// There is a known issue with this detection logic for k8s clusters that were upgraded.
+		// See: https://github.com/istio/istio/issues/37946#issuecomment-1072875625
+		if kube.IsAtLeastVersion(h.kubeClient, 18) {
 			// todo(kebe7jun) a more general test method
 			// API Server does not support detecting whether ServerSideApply is enabled
 			// through the API for the time being.

--- a/releasenotes/notes/37946.yaml
+++ b/releasenotes/notes/37946.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** server-side apply detection logic to not run for k8s cluster version < 1.22

--- a/releasenotes/notes/37946.yaml
+++ b/releasenotes/notes/37946.yaml
@@ -4,3 +4,4 @@ area: istioctl
 releaseNotes:
   - |
     **Fixed** Server Side Apply is enabled by default for Kubernetes cluster versions above 1.22
+    or be detected if it can be run in Kubernetes versions 1.18-1.21.

--- a/releasenotes/notes/37946.yaml
+++ b/releasenotes/notes/37946.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** server-side apply detection logic to not run for k8s cluster version < 1.22
+    **Fixed** Server Side Apply is enabled by default for Kubernetes cluster versions above 1.22


### PR DESCRIPTION
CheckSSAEnabled for version > 1.22 should always return true since it went GA in v1.22

Fixes: #37946 