### PR TITLE
xds cache: skip expensive work when metrics disabled

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -165,6 +165,9 @@ func newLru(evictCallback simplelru.EvictCallback[string, cacheValue]) simplelru
 }
 
 func (l *lruCache) recordDependentConfigSize() {
+	if !enableStats() {
+		return
+	}
 	dsize := 0
 	for _, dependents := range l.configIndex {
 		dsize += len(dependents)


### PR DESCRIPTION
```
name                     old time/op    new time/op    delta
Cache/key-48               7.71µs ± 1%    7.77µs ± 0%   +0.85%  (p=0.001 n=9+8)
Cache/insert-48            3.88ms ± 7%    0.19ms ± 6%  -95.18%  (p=0.000 n=9+10)
Cache/get-48               7.70µs ± 1%    7.86µs ± 2%   +2.03%  (p=0.000 n=9+9)
Cache/insert_and_get-48    3.28ms ± 3%    0.20ms ± 3%  -93.87%  (p=0.000 n=8+10)

name                     old alloc/op   new alloc/op   delta
Cache/key-48                40.0B ± 0%     40.0B ± 0%     ~     (all equal)
Cache/insert-48            95.3kB ± 0%    94.8kB ± 0%   -0.53%  (p=0.000 n=9+9)
Cache/get-48                40.0B ± 0%     40.0B ± 0%     ~     (all equal)
Cache/insert_and_get-48    92.6kB ± 0%    93.1kB ± 0%   +0.50%  (p=0.000 n=9+9)

name                     old allocs/op  new allocs/op  delta
Cache/key-48                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
Cache/insert-48               825 ± 0%       825 ± 0%     ~     (all equal)
Cache/get-48                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
Cache/insert_and_get-48       823 ± 0%       827 ± 0%   +0.49%  (p=0.000 n=10+10)
```