### PR TITLE
Move default mesh config value into Go code

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -88,10 +88,10 @@ func DefaultMeshConfig() *meshconfig.MeshConfig {
 		IngressClass:                "istio",
 		TrustDomain:                 constants.DefaultClusterLocalDomain,
 		TrustDomainAliases:          []string{},
-		EnableAutoMtls:              &wrappers.BoolValue{Value: true},
+		EnableAutoMtls:              wrappers.Bool(true),
 		OutboundTrafficPolicy:       &meshconfig.MeshConfig_OutboundTrafficPolicy{Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY},
 		LocalityLbSetting: &v1alpha3.LocalityLoadBalancerSetting{
-			Enabled: &wrappers.BoolValue{Value: true},
+			Enabled: wrappers.Bool(true),
 		},
 		Certificates:  []*meshconfig.Certificate{},
 		DefaultConfig: proxyConfig,
@@ -110,7 +110,8 @@ func DefaultMeshConfig() *meshconfig.MeshConfig {
 		DnsRefreshRate:  durationpb.New(60 * time.Second),
 		ServiceSettings: make([]*meshconfig.MeshConfig_ServiceSettings, 0),
 
-		DefaultProviders: &meshconfig.MeshConfig_DefaultProviders{},
+		EnablePrometheusMerge: wrappers.Bool(true),
+		DefaultProviders:      &meshconfig.MeshConfig_DefaultProviders{},
 		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
 				Name: "prometheus",


### PR DESCRIPTION
This is currently always set as default in install code but not in Go, unlike the rest

**Please provide a description of this PR:**