### PR TITLE
charts: fix null rootNamespace

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -53,7 +53,7 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: null
+    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 # Source: istiod/templates/istiod-injector-configmap.yaml

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -186,31 +186,6 @@ ownerName: ""
 # See https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options
 meshConfig:
   enablePrometheusMerge: true
-  # Config for the default ProxyConfig.
-  # Initially using directly the proxy metadata - can also be activated using annotations
-  # on the pod. This is an unsupported low-level API, pending review and decisions on
-  # enabling the feature. Enabling the DNS listener is safe - and allows further testing
-  # and gradual adoption by setting capture only on specific workloads. It also allows
-  # VMs to use other DNS options, like dnsmasq or unbound.
-
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-
-  rootNamespace:
-
-  # The trust domain corresponds to the trust root of a system
-  # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-  trustDomain: "cluster.local"
-
-  # TODO: the intent is to eventually have this enabled by default when security is used.
-  # It is not clear if user should normally need to configure - the metadata is typically
-  # used as an escape and to control testing and rollout, but it is not intended as a long-term
-  # stable API.
-
-  # What we may configure in mesh config is the ".global" - and use of other suffixes.
-  # No hurry to do this in 1.6, we're trying to prove the code.
 
 global:
   # Used to locate istiod.

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -161,28 +161,6 @@ ownerName: ""
 # See https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options
 meshConfig:
   enablePrometheusMerge: true
-  # Config for the default ProxyConfig.
-  # Initially using directly the proxy metadata - can also be activated using annotations
-  # on the pod. This is an unsupported low-level API, pending review and decisions on
-  # enabling the feature. Enabling the DNS listener is safe - and allows further testing
-  # and gradual adoption by setting capture only on specific workloads. It also allows
-  # VMs to use other DNS options, like dnsmasq or unbound.
-
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-  rootNamespace:
-  # The trust domain corresponds to the trust root of a system
-  # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
-  trustDomain: "cluster.local"
-  # TODO: the intent is to eventually have this enabled by default when security is used.
-  # It is not clear if user should normally need to configure - the metadata is typically
-  # used as an escape and to control testing and rollout, but it is not intended as a long-term
-  # stable API.
-
-  # What we may configure in mesh config is the ".global" - and use of other suffixes.
-  # No hurry to do this in 1.6, we're trying to prove the code.
 global:
   # Used to locate istiod.
   istioNamespace: istio-system


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/42155

Output changes like so:

```diff
56c56
<     rootNamespace: null
---
>     rootNamespace: istio-system
```

**Please provide a description of this PR:**