### PR TITLE
Add Programmed condition to Gateways

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1403,12 +1403,10 @@ func convertGateways(r ConfigContext) ([]config.Config, map[parentKey][]*parentI
 				reason:  string(k8sbeta.GatewayReasonAccepted),
 				message: "Resources available",
 			}
+			// We don't return before generating the config, so we can set this to a positive condition
 			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)] = &condition{
-				error: &ConfigError{
-					Reason:  string(k8sbeta.GatewayReasonPending),
-					Message: "Config has not yet been generated for the Gateway",
-				},
-				setOnce: string(k8sbeta.GatewayReasonPending),
+				reason:  string(k8sbeta.GatewayReasonProgrammed),
+				message: "Gateway has been programmed into Istio configuration",
 			}
 			// nolint: staticcheck // Deprecated condition, set both until 1.17
 			gatewayConditions[string(k8sbeta.GatewayConditionScheduled)] = &condition{

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1371,17 +1371,24 @@ func convertGateways(r ConfigContext) ([]config.Config, map[parentKey][]*parentI
 		// Setup initial conditions to the success state. If we encounter errors, we will update this.
 		gatewayConditions := map[string]*condition{
 			string(k8sbeta.GatewayConditionReady): {
-				reason:  "ListenersValid",
+				reason:  string(k8sbeta.GatewayReasonReady),
 				message: "Listeners valid",
 			},
 		}
 		if IsManaged(kgw) {
 			gatewayConditions[string(k8sbeta.GatewayConditionAccepted)] = &condition{
 				error: &ConfigError{
-					Reason:  string(k8sbeta.GatewayReasonAccepted),
+					Reason:  string(k8sbeta.GatewayReasonNoResources),
 					Message: "Resources not yet deployed to the cluster",
 				},
 				setOnce: string(k8sbeta.GatewayReasonPending), // Default reason
+			}
+			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)] = &condition{
+				error: &ConfigError{
+					Reason:  string(k8sbeta.GatewayReasonPending),
+					Message: "Resources not yet deployed to the cluster",
+				},
+				setOnce: string(k8sbeta.GatewayReasonPending),
 			}
 			// nolint: staticcheck // Deprecated condition, set both until 1.17
 			gatewayConditions[string(k8sbeta.GatewayConditionScheduled)] = &condition{
@@ -1395,6 +1402,13 @@ func convertGateways(r ConfigContext) ([]config.Config, map[parentKey][]*parentI
 			gatewayConditions[string(k8sbeta.GatewayConditionAccepted)] = &condition{
 				reason:  string(k8sbeta.GatewayReasonAccepted),
 				message: "Resources available",
+			}
+			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)] = &condition{
+				error: &ConfigError{
+					Reason:  string(k8sbeta.GatewayReasonPending),
+					Message: "Config has not yet been generated for the Gateway",
+				},
+				setOnce: string(k8sbeta.GatewayReasonPending),
 			}
 			// nolint: staticcheck // Deprecated condition, set both until 1.17
 			gatewayConditions[string(k8sbeta.GatewayConditionScheduled)] = &condition{
@@ -1478,6 +1492,7 @@ func convertGateways(r ConfigContext) ([]config.Config, map[parentKey][]*parentI
 
 		// TODO: we lose address if servers is empty due to an error
 		internal, external, pending, warnings := r.Context.ResolveGatewayInstances(obj.Namespace, gatewayServices, servers)
+
 		if len(skippedAddresses) > 0 {
 			warnings = append(warnings, fmt.Sprintf("Only Hostname is supported, ignoring %v", skippedAddresses))
 		}
@@ -1493,13 +1508,25 @@ func convertGateways(r ConfigContext) ([]config.Config, map[parentKey][]*parentI
 				Reason:  string(k8sbeta.GatewayReasonAddressNotAssigned),
 				Message: msg,
 			}
+			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)].error = &ConfigError{
+				Reason:  string(k8sbeta.GatewayReasonInvalid),
+				Message: msg,
+			}
 		} else if len(invalidListeners) > 0 {
+			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)].error = &ConfigError{
+				Reason:  string(k8sbeta.GatewayReasonInvalid),
+				Message: fmt.Sprintf("Invalid listeners: %v", invalidListeners),
+			}
 			gatewayConditions[string(k8sbeta.GatewayConditionReady)].error = &ConfigError{
 				Reason:  string(k8sbeta.GatewayReasonListenersNotValid),
 				Message: fmt.Sprintf("Invalid listeners: %v", invalidListeners),
 			}
 		} else {
 			gatewayConditions[string(k8sbeta.GatewayConditionReady)].message = fmt.Sprintf("Gateway valid, assigned to service(s) %s", humanReadableJoin(internal))
+			gatewayConditions[string(k8sbeta.GatewayConditionProgrammed)] = &condition{
+				reason:  string(k8sbeta.GatewayReasonProgrammed),
+				message: "Gateway has been programmed into Istio configuration",
+			}
 		}
 		obj.Status.(*kstatus.WrappedStatus).Mutate(func(s config.Status) config.Status {
 			gs := s.(*k8s.GatewayStatus)

--- a/pilot/pkg/config/kube/gateway/testdata/alias.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/alias.status.yaml.golden
@@ -39,8 +39,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/delegated.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest.status.yaml.golden
@@ -9,9 +9,15 @@ status:
   conditions:
   - lastTransitionTime: fake
     message: Resources not yet deployed to the cluster
-    reason: Accepted
+    reason: NoResources
     status: "False"
     type: Accepted
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: hostname "eastwestgateway-istio.istio-system.svc.domain.suffix"
+      not found'
+    reason: Invalid
+    status: "False"
+    type: Programmed
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "eastwestgateway-istio.istio-system.svc.domain.suffix"
       not found'

--- a/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/invalid.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake
@@ -92,6 +97,12 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: hostname "fake-service.com"
+      not found'
+    reason: Invalid
+    status: "False"
+    type: Programmed
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "fake-service.com"
       not found'
@@ -160,6 +171,14 @@ status:
       hostname "istio-ingressgateway.istio-system.svc.domain.suffix" (hint: the service
       port should be specified, not the workload port. Did you mean one of these ports:
       [80]?)'
+    reason: Invalid
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: port 8080 not found for
+      hostname "istio-ingressgateway.istio-system.svc.domain.suffix" (hint: the service
+      port should be specified, not the workload port. Did you mean one of these ports:
+      [80]?)'
     reason: AddressNotAssigned
     status: "False"
     type: Ready
@@ -223,6 +242,12 @@ status:
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: Only Hostname is supported,
       ignoring [1.2.3.4]'
+    reason: Invalid
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: Only Hostname is supported,
+      ignoring [1.2.3.4]'
     reason: AddressNotAssigned
     status: "False"
     type: Ready
@@ -283,6 +308,11 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
+  - lastTransitionTime: fake
+    message: 'Invalid listeners: [default]'
+    reason: Invalid
+    status: "False"
+    type: Programmed
   - lastTransitionTime: fake
     message: 'Invalid listeners: [default]'
     reason: ListenersNotValid
@@ -349,6 +379,11 @@ status:
     type: Accepted
   - lastTransitionTime: fake
     message: 'Invalid listeners: [default]'
+    reason: Invalid
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: 'Invalid listeners: [default]'
     reason: ListenersNotValid
     status: "False"
     type: Ready
@@ -411,6 +446,11 @@ status:
     reason: Accepted
     status: "True"
     type: Accepted
+  - lastTransitionTime: fake
+    message: 'Invalid listeners: [default]'
+    reason: Invalid
+    status: "False"
+    type: Programmed
   - lastTransitionTime: fake
     message: 'Invalid listeners: [default]'
     reason: ListenersNotValid

--- a/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mcs.status.yaml.golden
@@ -16,8 +16,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/mesh.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/multi-gateway.status.yaml.golden
@@ -35,6 +35,14 @@ status:
       and istio-ingressgateway.istio-system.svc.domain.suffix:80, but failed to assign
       to all requested addresses: hostname "istio-ingressgateway.not-default.svc.domain.suffix"
       not found'
+    reason: Invalid
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: 'Assigned to service(s) example.com:34000, example.com:80, istio-ingressgateway.istio-system.svc.domain.suffix:34000,
+      and istio-ingressgateway.istio-system.svc.domain.suffix:80, but failed to assign
+      to all requested addresses: hostname "istio-ingressgateway.not-default.svc.domain.suffix"
+      not found'
     reason: AddressNotAssigned
     status: "False"
     type: Ready

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-service.status.yaml.golden
@@ -16,8 +16,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/reference-policy-tls.status.yaml.golden
@@ -30,6 +30,12 @@ status:
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: port 443 not found for
       hostname "istio-ingressgateway.istio-system.svc.domain.suffix"'
+    reason: Invalid
+    status: "False"
+    type: Programmed
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: port 443 not found for
+      hostname "istio-ingressgateway.istio-system.svc.domain.suffix"'
     reason: AddressNotAssigned
     status: "False"
     type: Ready

--- a/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-binding.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/route-precedence.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/serviceentry.status.yaml.golden
@@ -9,9 +9,15 @@ status:
   conditions:
   - lastTransitionTime: fake
     message: Resources not yet deployed to the cluster
-    reason: Accepted
+    reason: NoResources
     status: "False"
     type: Accepted
+  - lastTransitionTime: fake
+    message: 'Failed to assign to any requested addresses: hostname "gateway-istio.istio-system.svc.domain.suffix"
+      not found'
+    reason: Invalid
+    status: "False"
+    type: Programmed
   - lastTransitionTime: fake
     message: 'Failed to assign to any requested addresses: hostname "gateway-istio.istio-system.svc.domain.suffix"
       not found'

--- a/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tcp.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/tls.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/weighted.status.yaml.golden
@@ -31,9 +31,14 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:34000
       and istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/zero.status.yaml.golden
@@ -31,8 +31,13 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
+    message: Gateway has been programmed into Istio configuration
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  - lastTransitionTime: fake
     message: Gateway valid, assigned to service(s) istio-ingressgateway.istio-system.svc.domain.suffix:80
-    reason: ListenersValid
+    reason: Ready
     status: "True"
     type: Ready
   - lastTransitionTime: fake

--- a/releasenotes/notes/43498.yaml
+++ b/releasenotes/notes/43498.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 43498
+releaseNotes:
+  - |
+    **Fixed** reporting Programmed condition on Gateway API Gateway resources.

--- a/releasenotes/notes/43498.yaml
+++ b/releasenotes/notes/43498.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
   - 43498
 releaseNotes:


### PR DESCRIPTION
**Please provide a description of this PR:**

Gateway API is now testing for the Programmed status on Gateways in conformance tests (since kubernetes-sigs/gateway-api#1732). This PR adds the Programmed Status to Gateways (not just listeners within Gateways) and fixes a couple of other Gateway API [conventions](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.GatewayConditionReason). 