### PR TITLE
Set deprecation warnings in helm

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -119,7 +119,6 @@ data:
           "excludeIPRanges": "",
           "excludeInboundPorts": "",
           "excludeOutboundPorts": "",
-          "holdApplicationUntilProxyStarts": false,
           "image": "proxyv2",
           "includeIPRanges": "*",
           "includeInboundPorts": "*",
@@ -155,25 +154,6 @@ data:
           "servicePort": 0
         },
         "tag": "latest",
-        "tracer": {
-          "datadog": {
-            "address": "$(HOST_IP):8126"
-          },
-          "lightstep": {
-            "accessToken": "",
-            "address": ""
-          },
-          "stackdriver": {
-            "debug": false,
-            "maxNumberOfAnnotations": 200,
-            "maxNumberOfAttributes": 200,
-            "maxNumberOfMessageEvents": 200
-          },
-          "zipkin": {
-            "address": ""
-          }
-        },
-        "useMCP": false,
         "variant": ""
       },
       "revision": "",

--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -17,3 +17,40 @@ Next steps:
     * https://istio.io/latest/docs/ops/best-practices/security/
 
 For further documentation see https://istio.io website
+
+{{-
+  $deps := dict
+    "global.outboundTrafficPolicy" "meshConfig.outboundTrafficPolicy"
+    "global.certificates" "meshConfig.certificates"
+    "global.localityLbSetting" "meshConfig.localityLbSetting"
+    "global.policyCheckFailOpen" "meshConfig.policyCheckFailOpen"
+    "global.enableTracing" "meshConfig.enableTracing"
+    "global.proxy.accessLogFormat" "meshConfig.accessLogFormat"
+    "global.proxy.accessLogFile" "meshConfig.accessLogFile"
+    "global.proxy.concurrency" "meshConfig.defaultConfig.concurrency"
+    "global.proxy.envoyAccessLogService" "meshConfig.defaultConfig.envoyAccessLogService"
+    "global.proxy.envoyAccessLogService.enabled" "meshConfig.enableEnvoyAccessLogService"
+    "global.proxy.envoyMetricsService" "meshConfig.defaultConfig.envoyMetricsService"
+    "global.proxy.protocolDetectionTimeout" "meshConfig.protocolDetectionTimeout"
+    "global.proxy.holdApplicationUntilProxyStarts" "meshConfig.defaultConfig.holdApplicationUntilProxyStarts"
+    "pilot.ingress" "meshConfig.ingressService, meshConfig.ingressControllerMode, and meshConfig.ingressClass"
+    "global.mtls.enabled" "the PeerAuthentication resource"
+    "global.mtls.auto" "meshConfig.enableAutoMtls"
+    "global.tracer.lightstep.address" "meshConfig.defaultConfig.tracing.lightstep.address"
+    "global.tracer.lightstep.accessToken" "meshConfig.defaultConfig.tracing.lightstep.accessToken"
+    "global.tracer.zipkin.address" "meshConfig.defaultConfig.tracing.zipkin.address"
+    "global.tracer.stackdriver.debug" "meshConfig.defaultConfig.tracing.stackdriver.debug"
+    "global.tracer.stackdriver.maxNumberOfAttributes" "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAttributes"
+    "global.tracer.stackdriver.maxNumberOfAnnotations" "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAnnotations"
+    "global.tracer.stackdriver.maxNumberOfMessageEvents" "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfMessageEvents"
+    "global.tracer.datadog.address" "meshConfig.defaultConfig.tracing.datadog.address"
+    "global.meshExpansion.enabled" "Gateway and other Istio networking resources, such as in samples/multicluster/"
+    "istiocoredns.enabled" "the in-proxy DNS capturing (ISTIO_META_DNS_CAPTURE)"
+}}
+{{- range $dep, $replace := $deps }}
+{{- /* Complex logic to turn the string above into a null-safe traversal like ((.Values.global).certificates */}}
+{{- $res := tpl (print "{{" (repeat (split "." $dep | len) "(")  ".Values." (replace "." ")." $dep) ")}}") $}}
+{{- if not (eq $res "")}}
+WARNING: {{$dep|quote}} is deprecated; use {{$replace|quote}} instead.
+{{- end }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -27,7 +27,7 @@
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -371,9 +371,6 @@ global:
     # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
     tracer: "zipkin"
 
-    # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
-    holdApplicationUntilProxyStarts: false
-
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxyv2
@@ -489,36 +486,6 @@ global:
     # The service port used by Security Token Service (STS) server to handle token exchange requests.
     # Setting this port to a non-zero value enables STS server.
     servicePort: 0
-
-  # Configuration for each of the supported tracers
-  tracer:
-    # Configuration for envoy to send trace data to LightStep.
-    # Disabled by default.
-    # address: the <host>:<port> of the satellite pool
-    # accessToken: required for sending data to the pool
-    #
-    datadog:
-      # Host:Port for submitting traces to the Datadog agent.
-      address: "$(HOST_IP):8126"
-    lightstep:
-      address: "" # example: lightstep-satellite:443
-      accessToken: "" # example: abcdefg1234567
-    stackdriver:
-      # enables trace output to stdout.
-      debug: false
-      # The global default max number of message events per span.
-      maxNumberOfMessageEvents: 200
-      # The global default max number of annotation events per span.
-      maxNumberOfAnnotations: 200
-      # The global default max number of attributes per span.
-      maxNumberOfAttributes: 200
-    zipkin:
-      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-      # zipkin service (port 9411) in the same namespace as the other istio components.
-      address: ""
-
-  # Use the Mesh Control Protocol (MCP) for configuring Istiod. Requires an MCP source.
-  useMCP: false
 
   # The name of the CA for workload certificates.
   # For example, when caName=GkeWorkloadCertificate, GKE workload certificates

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -27,7 +27,7 @@
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -180,9 +180,9 @@ meshConfig:
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term
   # stable API.
-# What we may configure in mesh config is the ".global" - and use of other suffixes.
-# No hurry to do this in 1.6, we're trying to prove the code.
 
+  # What we may configure in mesh config is the ".global" - and use of other suffixes.
+  # No hurry to do this in 1.6, we're trying to prove the code.
 global:
   # Used to locate istiod.
   istioNamespace: istio-system
@@ -204,10 +204,10 @@ global:
   defaultResources:
     requests:
       cpu: 10m
-      #   memory: 128Mi
-      # limits:
-      #   cpu: 100m
-      #   memory: 128Mi
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -180,9 +180,9 @@ meshConfig:
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term
   # stable API.
+# What we may configure in mesh config is the ".global" - and use of other suffixes.
+# No hurry to do this in 1.6, we're trying to prove the code.
 
-  # What we may configure in mesh config is the ".global" - and use of other suffixes.
-  # No hurry to do this in 1.6, we're trying to prove the code.
 global:
   # Used to locate istiod.
   istioNamespace: istio-system
@@ -204,10 +204,10 @@ global:
   defaultResources:
     requests:
       cpu: 10m
-    #   memory: 128Mi
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
+      #   memory: 128Mi
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io
@@ -316,8 +316,6 @@ global:
     # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
     # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
     tracer: "zipkin"
-    # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
-    holdApplicationUntilProxyStarts: false
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxyv2
@@ -420,34 +418,6 @@ global:
     # The service port used by Security Token Service (STS) server to handle token exchange requests.
     # Setting this port to a non-zero value enables STS server.
     servicePort: 0
-  # Configuration for each of the supported tracers
-  tracer:
-    # Configuration for envoy to send trace data to LightStep.
-    # Disabled by default.
-    # address: the <host>:<port> of the satellite pool
-    # accessToken: required for sending data to the pool
-    #
-    datadog:
-      # Host:Port for submitting traces to the Datadog agent.
-      address: "$(HOST_IP):8126"
-    lightstep:
-      address: "" # example: lightstep-satellite:443
-      accessToken: "" # example: abcdefg1234567
-    stackdriver:
-      # enables trace output to stdout.
-      debug: false
-      # The global default max number of message events per span.
-      maxNumberOfMessageEvents: 200
-      # The global default max number of annotation events per span.
-      maxNumberOfAnnotations: 200
-      # The global default max number of attributes per span.
-      maxNumberOfAttributes: 200
-    zipkin:
-      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-      # zipkin service (port 9411) in the same namespace as the other istio components.
-      address: ""
-  # Use the Mesh Control Protocol (MCP) for configuring Istiod. Requires an MCP source.
-  useMCP: false
   # The name of the CA for workload certificates.
   # For example, when caName=GkeWorkloadCertificate, GKE workload certificates
   # will be used as the certificates for workloads.

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -53,7 +53,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -100,22 +99,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -98,22 +98,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -98,22 +98,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyTest",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -53,7 +53,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -100,22 +99,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -55,7 +55,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -102,22 +101,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -98,22 +98,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
@@ -98,22 +98,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "",
       "excludeInboundPorts": "",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "*",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -51,7 +51,6 @@
       "excludeIPRanges": "10.96.0.2/24,10.96.0.3/24",
       "excludeInboundPorts": "4,5,6",
       "excludeOutboundPorts": "",
-      "holdApplicationUntilProxyStarts": false,
       "image": "proxyv2",
       "includeIPRanges": "127.0.0.1/24,10.96.0.1/24",
       "includeInboundPorts": "*",
@@ -98,22 +97,10 @@
     },
     "tag": "latest",
     "tracer": {
-      "datadog": {
-        "address": "$(HOST_IP):8126"
-      },
-      "lightstep": {
-        "accessToken": "",
-        "address": ""
-      },
-      "stackdriver": {
-        "debug": false,
-        "maxNumberOfAnnotations": 200,
-        "maxNumberOfAttributes": 200,
-        "maxNumberOfMessageEvents": 200
-      },
-      "zipkin": {
-        "address": ""
-      }
+      "datadog": {},
+      "lightstep": {},
+      "stackdriver": {},
+      "zipkin": {}
     },
     "useMCP": false,
     "variant": ""


### PR DESCRIPTION
This mirrors the istioctl logic

Example:

```
$ helm install --dry-run istiod manifests/charts/istio-control/istio-discovery --set global.outboundTrafficPolicy.mode=fake
...

WARNING: "global.outboundTrafficPolicy" is deprecated; use "meshConfig.outboundTrafficPolicy" instead.
```
