### PR TITLE
ztunnel chart: remove quotes

### DIFF
--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -1,7 +1,7 @@
 # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
-hub: "gcr.io/istio-testing"
+hub: gcr.io/istio-testing
 # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
-tag: "latest"
+tag: latest
 # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.
 variant: ""
 


### PR DESCRIPTION
This could be fixed in release-builder but easier to just do it here. There are some regex replacers in the release that don't like these

**Please provide a description of this PR:**