### PR TITLE
Provision to provide overridden/explicit value for failoverPriority label

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -18,6 +18,7 @@ package loadbalancer
 import (
 	"math"
 	"sort"
+	"strings"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -26,6 +27,10 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+const (
+	FailoverPriorityLabelDefaultSeparator = '='
 )
 
 func GetLocalityLbSetting(
@@ -245,6 +250,22 @@ func applyPriorityFailover(
 	loadAssignment.Endpoints = localityLbEndpoints
 }
 
+// Returning the label names in a separate array as the iteration of map is not ordered.
+func priorityLabelOverrides(labels []string) ([]string, map[string]string) {
+	priorityLabels := make([]string, 0, len(labels))
+	overriddenValueByLabel := make(map[string]string, len(labels))
+	var tempStrings []string
+	for _, labelWithValue := range labels {
+		tempStrings = strings.Split(labelWithValue, string(FailoverPriorityLabelDefaultSeparator))
+		priorityLabels = append(priorityLabels, tempStrings[0])
+		if len(tempStrings) == 2 {
+			overriddenValueByLabel[tempStrings[0]] = tempStrings[1]
+			continue
+		}
+	}
+	return priorityLabels, overriddenValueByLabel
+}
+
 // set loadbalancing priority by failover priority label.
 // split one LocalityLbEndpoints to multiple LocalityLbEndpoints based on failover priorities.
 func applyPriorityFailoverPerLocality(
@@ -255,11 +276,16 @@ func applyPriorityFailoverPerLocality(
 	lowestPriority := len(failoverPriorities)
 	// key is priority, value is the index of LocalityLbEndpoints.LbEndpoints
 	priorityMap := map[int][]int{}
+	priorityLabels, priorityLabelOverrides := priorityLabelOverrides(failoverPriorities)
 	for i, istioEndpoint := range ep.IstioEndpoints {
 		var priority int
 		// failoverPriority labels match
-		for j, label := range failoverPriorities {
-			if proxyLabels[label] != istioEndpoint.Labels[label] {
+		for j, label := range priorityLabels {
+			valueForProxy, ok := priorityLabelOverrides[label]
+			if !ok {
+				valueForProxy = proxyLabels[label]
+			}
+			if valueForProxy != istioEndpoint.Labels[label] {
 				priority = lowestPriority - j
 				break
 			}

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -471,6 +471,152 @@ func TestApplyLocalitySetting(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:             "priority assignment as per the overridden value",
+				failoverPriority: []string{"topology.istio.io/network=n1"},
+				proxyLabels: map[string]string{
+					"topology.istio.io/network": "n2",
+					"topology.istio.io/cluster": "test",
+				},
+				expected: []*endpoint.LocalityLbEndpoints{
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone1",
+							SubZone: "subzone1",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("1.1.1.1"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 0,
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone1",
+							SubZone: "subzone1",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("2.2.2.2"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 1,
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region2",
+							Zone:    "zone2",
+							SubZone: "subzone2",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("3.3.3.3"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 0,
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region2",
+							Zone:    "zone2",
+							SubZone: "subzone2",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("4.4.4.4"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 1,
+					},
+				},
+			},
+			{
+				name:             "no endpoints with overridden value",
+				failoverPriority: []string{"topology.istio.io/network=n3"},
+				proxyLabels: map[string]string{
+					"topology.istio.io/network": "n1",
+					"topology.istio.io/cluster": "test",
+				},
+				expected: []*endpoint.LocalityLbEndpoints{
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone1",
+							SubZone: "subzone1",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("1.1.1.1"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+							{
+								HostIdentifier: buildEndpoint("2.2.2.2"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 2,
+						},
+						Priority: 0,
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region2",
+							Zone:    "zone2",
+							SubZone: "subzone2",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("3.3.3.3"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+							{
+								HostIdentifier: buildEndpoint("4.4.4.4"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 2,
+						},
+						Priority: 0,
+					},
+				},
+			},
 		}
 
 		wrappedEndpoints := buildWrappedLocalityLbEndpoints()
@@ -485,6 +631,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 					t.Fatalf("expected endpoints %d but got %d", len(cluster.LoadAssignment.Endpoints), len(tt.expected))
 				}
 				for i := range cluster.LoadAssignment.Endpoints {
+					// TODO Below assertions are not robust to ordering changes in cluster.LoadAssignment.Endpoints[i]
 					if cluster.LoadAssignment.Endpoints[i].LoadBalancingWeight.GetValue() != tt.expected[i].LoadBalancingWeight.GetValue() {
 						t.Errorf("Got unexpected lb weight %v expected %v", cluster.LoadAssignment.Endpoints[i].LoadBalancingWeight, tt.expected[i].LoadBalancingWeight)
 					}

--- a/releasenotes/notes/43535.yaml
+++ b/releasenotes/notes/43535.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 39111
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** Provision to provide overridden/explicit value for failoverPriority label. This provided value is used while assigning priority for endpoints instead of the client's value.

--- a/releasenotes/notes/43535.yaml
+++ b/releasenotes/notes/43535.yaml
@@ -8,4 +8,4 @@ issue:
 # release notes.
 releaseNotes:
 - |
-  **Added** Provision to provide overridden/explicit value for failoverPriority label. This provided value is used while assigning priority for endpoints instead of the client's value.
+  **Added** provision to provide overridden/explicit value for `failoverPriority` label. This provided value is used while assigning priority for endpoints instead of the client's value.


### PR DESCRIPTION
Provision to provide overridden/explicit value for failoverPriority label. 
This provided value is used while assigning priority for endpoints instead of the client's value.

A usecase for this enhancement is discussed in https://github.com/istio/istio/issues/39111

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure