### PR TITLE
Include trustDomains from CaCertificates in SAN Validation

### DIFF
--- a/pilot/pkg/networking/plugin/authn/util.go
+++ b/pilot/pkg/networking/plugin/authn/util.go
@@ -26,6 +26,9 @@ func TrustDomainsForValidation(meshConfig *meshconfig.MeshConfig) []string {
 	}
 
 	tds := append([]string{meshConfig.TrustDomain}, meshConfig.TrustDomainAliases...)
+	for _, cacert := range meshConfig.GetCaCertificates() {
+		tds = append(tds, cacert.GetTrustDomains()...)
+	}
 	return dedupTrustDomains(tds)
 }
 

--- a/pilot/pkg/networking/plugin/authn/util_test.go
+++ b/pilot/pkg/networking/plugin/authn/util_test.go
@@ -60,6 +60,26 @@ func TestTrustDomainsForValidation(t *testing.T) {
 			},
 			want: []string{"cluster.local", "alias-1.domain", "alias-2.domain", "some-other-alias-1.domain"},
 		},
+		{
+			name: "Extra trust domains in mesh config caCertificates",
+			meshConfig: &meshconfig.MeshConfig{
+				TrustDomain: "cluster.local",
+				CaCertificates: []*meshconfig.MeshConfig_CertificateData{
+					{
+						TrustDomains: []string{
+							"external-1.domain",
+						},
+					},
+					{
+						TrustDomains: []string{
+							"external-2.domain",
+							"external-3.domain",
+						},
+					},
+				},
+			},
+			want: []string{"cluster.local", "external-1.domain", "external-2.domain", "external-3.domain"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/add_trust_domans_san_validator.yaml
+++ b/releasenotes/notes/add_trust_domans_san_validator.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+issue:
+ - https://github.com/istio/istio/issues/41666
+
+releaseNotes:
+  - |
+    **Added** support for pushing additional federated trust domains from caCertificates to the peer SAN validator.


### PR DESCRIPTION
**Please provide a description of this PR:**
As discussed in https://github.com/istio/istio/issues/41666, if additional federated trust domains are configured via meshConfig's caCertificates, those trustDomains are not passed to the SAN validation, which means that to effectively istio in a multi trustDomain world, one has to either a) use trustDomainAliases or b) completely disable this validation with the PILOT_SKIP_VALIDATE_TRUST_DOMAIN env var. This PR adds those additional trust domains to the SAN verification. 