### PR TITLE
wasm: use fixed SHA for attribute gen

### DIFF
--- a/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
@@ -254,10 +254,7 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 }
 
 func setupWasmExtension(ctx resource.Context) error {
-	proxySHA, err := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
-	if err != nil {
-		return err
-	}
+	proxySHA := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
 	attrGenURL := fmt.Sprintf("https://storage.googleapis.com/istio-build/proxy/attributegen-%v.wasm", proxySHA)
 	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:%v", registry.Address(), proxySHA)
 	useRemoteWasmModule := false

--- a/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/deployment"

--- a/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
+++ b/tests/integration/telemetry/envoyfilter/customizemetrics/customize_metrics_test.go
@@ -254,7 +254,7 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 }
 
 func setupWasmExtension(ctx resource.Context) error {
-	proxySHA, err := env.ReadProxySHA()
+	proxySHA, err := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use a fixed released artifact SHA instead of tracking master.