### PR TITLE
Fix syntax error for pod monitor resource

### DIFF
--- a/samples/addons/extras/prometheus-operator.yaml
+++ b/samples/addons/extras/prometheus-operator.yaml
@@ -25,17 +25,17 @@ spec:
     - action: replace
       regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
       replacement: '[$2]:$1'
-      source_labels:
+      sourceLabels:
       - __meta_kubernetes_pod_annotation_prometheus_io_port
       - __meta_kubernetes_pod_ip
-      target_label: __address__
+      targetLabel: __address__
     - action: replace
       regex: (\d+);((([0-9]+?)(\.|$)){4})
       replacement: $2:$1
-      source_labels:
+      sourceLabels:
       - __meta_kubernetes_pod_annotation_prometheus_io_port
       - __meta_kubernetes_pod_ip
-      target_label: __address__
+      targetLabel: __address__
     - action: labeldrop
       regex: "__meta_kubernetes_pod_label_(.+)"
     - sourceLabels: [__meta_kubernetes_namespace]


### PR DESCRIPTION
**Please provide a description of this PR:**
When applying the pod monitor custom resource definition, this is the error:

![33666](https://user-images.githubusercontent.com/15828926/220824974-d10b4739-1f6f-427c-8c4c-d423c93de71d.png)

The root cause is because the original author used https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config syntax, instead of 
https://prometheus-operator.dev/docs/operator/api/#:~:text=in%20the%20future.-,RelabelConfig,-(Appears%20on syntax 