### PR TITLE
Fix endpoint filtering for ambient

### DIFF
--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -294,16 +294,6 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 				}
 			}
 
-			locLbEps, found := localityEpMap[ep.Locality.Label]
-			if !found {
-				locLbEps = &LocalityEndpoints{
-					llbEndpoints: endpoint.LocalityLbEndpoints{
-						Locality:    util.ConvertLocality(ep.Locality.Label),
-						LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(endpoints)),
-					},
-				}
-				localityEpMap[ep.Locality.Label] = locLbEps
-			}
 			// Currently the HBONE implementation leads to different endpoint generation depending on if the
 			// client proxy supports HBONE or not. This breaks the cache.
 			// For now, just disable caching if the global HBONE flag is enabled.
@@ -313,6 +303,17 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 					continue
 				}
 				ep.EnvoyEndpoint = eep
+			}
+
+			locLbEps, found := localityEpMap[ep.Locality.Label]
+			if !found {
+				locLbEps = &LocalityEndpoints{
+					llbEndpoints: endpoint.LocalityLbEndpoints{
+						Locality:    util.ConvertLocality(ep.Locality.Label),
+						LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(endpoints)),
+					},
+				}
+				localityEpMap[ep.Locality.Label] = locLbEps
 			}
 			// detect if mTLS is possible for this endpoint, used later during ep filtering
 			// this must be done while converting IstioEndpoints because we still have workload labels


### PR DESCRIPTION
We need to filter before we construct the LB map, otherwise we get a weight of 0 if we filter all endpoints which gets a NACK

fixes https://github.com/istio/istio/issues/43544

**Please provide a description of this PR:**