### PR TITLE
Update key type to uint64

### DIFF
--- a/pilot/pkg/model/xds_cache.go
+++ b/pilot/pkg/model/xds_cache.go
@@ -71,7 +71,7 @@ func size(cs int) {
 	xdsCacheSize.Record(float64(cs))
 }
 
-type KeyHash uint64
+type KeyHash any
 
 // XdsCacheEntry interface defines functions that should be implemented by
 // resources that can be cached.

--- a/pilot/pkg/model/xds_cache_test.go
+++ b/pilot/pkg/model/xds_cache_test.go
@@ -77,9 +77,9 @@ func TestAddTwoEntries(t *testing.T) {
 
 	assert.Equal(t, cache.store.Len(), 1)
 	assert.Equal(t, cache.indexLength(), 2)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
 	})
 
 	// second entry has different key and dependencies
@@ -97,10 +97,10 @@ func TestAddTwoEntries(t *testing.T) {
 
 	assert.Equal(t, cache.store.Len(), 2)
 	assert.Equal(t, cache.indexLength(), 3)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
 	})
 }
 
@@ -129,8 +129,8 @@ func TestCleanIndexesOnAddExistant(t *testing.T) {
 
 	assert.Equal(t, cache.store.Len(), 1)
 	assert.Equal(t, cache.indexLength(), 1)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
 	})
 
 	// second entry has the same key but different dependencies
@@ -150,8 +150,8 @@ func TestCleanIndexesOnAddExistant(t *testing.T) {
 		return len(cache.configIndex) == 1, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](secondEntry.Key()),
 	})
 }
 
@@ -184,9 +184,9 @@ func TestCleanIndexesOnEvict(t *testing.T) {
 
 	assert.Equal(t, cache.store.Len(), 1)
 	assert.Equal(t, cache.indexLength(), 2)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
 	})
 
 	// second entry has different key and dependencies
@@ -209,9 +209,9 @@ func TestCleanIndexesOnEvict(t *testing.T) {
 		return len(cache.configIndex) == 2, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](secondEntry.Key()),
 	})
 }
 
@@ -255,12 +255,12 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 	// indexes populated
 	assert.Equal(t, cache.store.Len(), 2)
 	assert.Equal(t, cache.indexLength(), 5)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	cache.Clear(sets.Set[ConfigKey]{})
@@ -268,12 +268,12 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 	// no change on empty clear
 	assert.Equal(t, cache.store.Len(), 2)
 	assert.Equal(t, cache.indexLength(), 5)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	// clear only DestinationRule dependencies, should clear all firstEntry references
@@ -286,10 +286,10 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 		return len(cache.configIndex) == 3, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():  sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():  sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	// add firstEntry again
@@ -302,12 +302,12 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 		return len(cache.configIndex) == 5, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	// clear only EnvoyFilter dependencies, should clear all secondEntry references
@@ -320,10 +320,10 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 		return len(cache.configIndex) == 3, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
 	})
 
 	// add secondEntry again
@@ -337,12 +337,12 @@ func TestCleanIndexesOnCacheClear(t *testing.T) {
 		return len(cache.configIndex) == 5, nil
 	})
 	assert.Equal(t, err, nil)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	// clear only Service dependencies, should clear both firstEntry and secondEntry references
@@ -395,12 +395,12 @@ func TestCacheClearAll(t *testing.T) {
 
 	// indexes populated
 	assert.Equal(t, cache.indexLength(), 5)
-	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.String{
-		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key, secondEntry.key),
-		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New(firstEntry.key),
-		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New(secondEntry.key),
-		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New(secondEntry.key),
+	assert.Equal(t, cache.configIndexSnapshot(), map[ConfigHash]sets.Set[KeyHash]{
+		ConfigKey{Kind: kind.Service, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key(), secondEntry.Key()),
+		ConfigKey{Kind: kind.DestinationRule, Name: "name", Namespace: "namespace"}.HashCode(): sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.Gateway, Name: "name", Namespace: "namespace"}.HashCode():         sets.New[KeyHash](firstEntry.Key()),
+		ConfigKey{Kind: kind.EnvoyFilter, Name: "name", Namespace: "namespace"}.HashCode():     sets.New[KeyHash](secondEntry.Key()),
+		ConfigKey{Kind: kind.WasmPlugin, Name: "name", Namespace: "namespace"}.HashCode():      sets.New[KeyHash](secondEntry.Key()),
 	})
 
 	cache.ClearAll()

--- a/pilot/pkg/model/xds_cache_test.go
+++ b/pilot/pkg/model/xds_cache_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/hash"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -34,8 +35,10 @@ type entry struct {
 	dependentConfigs []ConfigHash
 }
 
-func (e *entry) Key() string {
-	return e.key
+func (e *entry) Key() KeyHash {
+	h := hash.New()
+	h.Write([]byte(e.key))
+	return KeyHash(h.Sum64())
 }
 
 func (e *entry) DependentConfigs() []ConfigHash {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -57,7 +57,7 @@ type clusterCache struct {
 	serviceAccounts []string // contains all the service accounts associated with the service
 }
 
-func (t *clusterCache) Key() string {
+func (t *clusterCache) Key() model.KeyHash {
 	// nolint: gosec
 	// Not security sensitive code
 	h := hash.New()
@@ -117,7 +117,7 @@ func (t *clusterCache) Key() string {
 	}
 	h.Write(Separator)
 
-	return h.Sum()
+	return model.KeyHash(h.Sum64())
 }
 
 func (t clusterCache) DependentConfigs() []model.ConfigHash {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -15,7 +15,6 @@
 package route
 
 import (
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -115,7 +114,7 @@ func (r *Cache) DependentConfigs() []model.ConfigHash {
 	return configs
 }
 
-func (r *Cache) Key() string {
+func (r *Cache) Key() model.KeyHash {
 	// nolint: gosec
 	// Not security sensitive code
 	h := hash.New()
@@ -177,11 +176,19 @@ func (r *Cache) Key() string {
 	}
 	h.Write(Separator)
 
-	return h.Sum()
+	return model.KeyHash(h.Sum64())
 }
 
 func hashToBytes(number model.ConfigHash) []byte {
-	big := new(big.Int)
-	big.SetUint64(uint64(number))
-	return big.Bytes()
+	v := uint64(number)
+	return []byte{
+		byte(0xff & v),
+		byte(0xff & (v >> 8)),
+		byte(0xff & (v >> 16)),
+		byte(0xff & (v >> 24)),
+		byte(0xff & (v >> 32)),
+		byte(0xff & (v >> 40)),
+		byte(0xff & (v >> 48)),
+		byte(0xff & (v >> 56)),
+	}
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -630,6 +630,20 @@ func BenchmarkCache(b *testing.B) {
 			c.Add(key, req, res)
 		}
 	})
+	b.Run("insert staled value", func(b *testing.B) {
+		c := model.NewXdsCache()
+		stop := make(chan struct{})
+		defer close(stop)
+		c.Run(stop)
+		key := makeCacheKey(100)
+		req := &model.PushRequest{Start: zeroTime.Add(time.Duration(100))}
+		c.Add(key, req, res)
+		for n := 0; n < b.N; n++ {
+			key := makeCacheKey(n)
+			req := &model.PushRequest{Start: zeroTime.Add(time.Duration(99))}
+			c.Add(key, req, res)
+		}
+	})
 	// to trigger clear index on old dependents
 	b.Run("insert same key", func(b *testing.B) {
 		c := model.NewXdsCache()

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -630,20 +630,6 @@ func BenchmarkCache(b *testing.B) {
 			c.Add(key, req, res)
 		}
 	})
-	b.Run("insert staled value", func(b *testing.B) {
-		c := model.NewXdsCache()
-		stop := make(chan struct{})
-		defer close(stop)
-		c.Run(stop)
-		key := makeCacheKey(100)
-		req := &model.PushRequest{Start: zeroTime.Add(time.Duration(100))}
-		c.Add(key, req, res)
-		for n := 0; n < b.N; n++ {
-			key := makeCacheKey(n)
-			req := &model.PushRequest{Start: zeroTime.Add(time.Duration(99))}
-			c.Add(key, req, res)
-		}
-	})
 	// to trigger clear index on old dependents
 	b.Run("insert same key", func(b *testing.B) {
 		c := model.NewXdsCache()

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -333,12 +333,12 @@ func (s *DiscoveryServer) cachez(w http.ResponseWriter, req *http.Request) {
 	}
 	snapshot := s.Cache.Snapshot()
 	resources := make(map[string][]string, len(snapshot)) // Key is typeUrl and value is resource names.
-	for key, resource := range snapshot {
+	for _, resource := range snapshot {
 		if resource == nil {
 			continue
 		}
 		resourceType := resource.Resource.TypeUrl
-		resources[resourceType] = append(resources[resourceType], resource.Name+"/"+key)
+		resources[resourceType] = append(resources[resourceType], resource.Name)
 	}
 	writeJSON(w, resources, req)
 }

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -118,7 +118,7 @@ func (b *EndpointBuilder) DestinationRule() *networkingapi.DestinationRule {
 }
 
 // Key provides the eds cache key and should include any information that could change the way endpoints are generated.
-func (b *EndpointBuilder) Key() string {
+func (b *EndpointBuilder) Key() model.KeyHash {
 	// nolint: gosec
 	// Not security sensitive code
 	h := hash.New()
@@ -171,7 +171,7 @@ func (b *EndpointBuilder) Key() string {
 	}
 	h.Write(Separator)
 
-	return h.Sum()
+	return model.KeyHash(h.Sum64())
 }
 
 func (b *EndpointBuilder) Cacheable() bool {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/util/hash"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -51,8 +52,10 @@ type SecretResource struct {
 
 var _ model.XdsCacheEntry = SecretResource{}
 
-func (sr SecretResource) Key() string {
-	return sr.SecretResource.Key() + "/" + sr.pkpConfHash
+func (sr SecretResource) Key() model.KeyHash {
+	h := hash.New()
+	h.Write([]byte(sr.SecretResource.Key() + "/" + sr.pkpConfHash))
+	return model.KeyHash(h.Sum64())
 }
 
 func (sr SecretResource) DependentConfigs() []model.ConfigHash {

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -55,7 +55,7 @@ var _ model.XdsCacheEntry = SecretResource{}
 func (sr SecretResource) Key() model.KeyHash {
 	h := hash.New()
 	h.Write([]byte(sr.SecretResource.Key() + "/" + sr.pkpConfHash))
-	return model.KeyHash(h.Sum64())
+	return h.Sum()
 }
 
 func (sr SecretResource) DependentConfigs() []model.ConfigHash {


### PR DESCRIPTION
**Please provide a description of this PR:**

Previously we use string type, which is actually encoded from hash.Sum64(). So this will not increase collision risk


Performance improve

```
Cache/key-4                   8.803µ ± 1%   8.684µ ± ∞ ¹   -1.35% (p=0.000 n=21+5)
Cache/insert-4                190.9µ ± 3%   167.8µ ± ∞ ¹  -12.10% (p=0.000 n=21+5)
Cache/insert_same_key-4       99.83µ ± 3%   90.71µ ± ∞ ¹   -9.13% (p=0.001 n=21+5)
Cache/get-4                   8.928µ ± 0%   8.762µ ± ∞ ¹   -1.86% (p=0.000 n=21+5)
Cache/insert_and_get-4        199.4µ ± 1%   174.4µ ± ∞ ¹  -12.53% (p=0.000 n=21+5)

```