### PR TITLE
optimize convertIstioListenerToWrapper performance

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -164,8 +164,6 @@ type IstioEgressListenerWrapper struct {
 	// a private virtual service for serviceA from the local namespace,
 	// with a different path rewrite or no path rewrites.
 	virtualServices []config.Config
-
-	listenerHosts map[string][]host.Name
 }
 
 const defaultSidecar = "default-sidecar"
@@ -444,7 +442,7 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		IstioListener: istioListener,
 	}
 
-	out.listenerHosts = make(map[string][]host.Name)
+	listenerHosts := make(map[string][]host.Name)
 	for _, h := range istioListener.Hosts {
 		parts := strings.SplitN(h, "/", 2)
 		if len(parts) < 2 {
@@ -454,15 +452,15 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		if parts[0] == currentNamespace {
 			parts[0] = configNamespace
 		}
-		if _, exists := out.listenerHosts[parts[0]]; !exists {
-			out.listenerHosts[parts[0]] = make([]host.Name, 0)
+		if _, exists := listenerHosts[parts[0]]; !exists {
+			listenerHosts[parts[0]] = make([]host.Name, 0)
 		}
-		out.listenerHosts[parts[0]] = append(out.listenerHosts[parts[0]], host.Name(parts[1]))
+		listenerHosts[parts[0]] = append(listenerHosts[parts[0]], host.Name(parts[1]))
 	}
 
-	out.virtualServices = SelectVirtualServices(ps.virtualServiceIndex, configNamespace, out.listenerHosts)
+	out.virtualServices = SelectVirtualServices(ps.virtualServiceIndex, configNamespace, listenerHosts)
 	svces := ps.servicesExportedToNamespace(configNamespace)
-	out.services = out.selectServices(svces, configNamespace, out.listenerHosts)
+	out.services = out.selectServices(svces, configNamespace, listenerHosts)
 
 	return out
 }


### PR DESCRIPTION
use local variable instead of struct field for better performance.

benchmark:
```code
$  go test -bench="ConvertIstioListenerToWrapper$" -test.benchmem -count=5 > old.txt # old code
$  go test -bench="ConvertIstioListenerToWrapper$" -test.benchmem -count=5 > new.txt # new code
$ benchstat old.txt new.txt
name                                               old time/op    new time/op    delta
ConvertIstioListenerToWrapper/small-exact-12          752ns ± 3%     614ns ± 0%  -18.32%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12       780ns ± 9%     611ns ± 0%  -21.60%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12      470ns ± 9%     291ns ± 1%  -38.08%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12        1.70µs ± 4%    1.48µs ± 2%  -12.52%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-wildcard-12     1.66µs ± 1%    1.60µs ±25%     ~     (p=0.151 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12     413ns ± 3%     291ns ± 1%  -29.64%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12           2.11µs ± 1%    1.92µs ± 1%   -9.18%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-wildcard-12        2.10µs ± 0%    1.90µs ± 1%   -9.18%  (p=0.016 n=4+5)
ConvertIstioListenerToWrapper/big-match-all-12        414ns ± 2%     291ns ± 1%  -29.77%  (p=0.008 n=5+5)

name                                               old alloc/op   new alloc/op   delta
ConvertIstioListenerToWrapper/small-exact-12           720B ± 0%      320B ± 0%  -55.56%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12        720B ± 0%      320B ± 0%  -55.56%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12       560B ± 0%      160B ± 0%  -71.43%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12        1.33kB ± 0%    0.93kB ± 0%  -30.12%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-wildcard-12     1.33kB ± 0%    0.93kB ± 0%  -30.12%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12      560B ± 0%      160B ± 0%  -71.43%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12           1.49kB ± 0%    1.09kB ± 0%  -26.88%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-wildcard-12        1.49kB ± 0%    1.09kB ± 0%  -26.88%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-match-all-12         560B ± 0%      160B ± 0%  -71.43%  (p=0.008 n=5+5)

name                                               old allocs/op  new allocs/op  delta
ConvertIstioListenerToWrapper/small-exact-12           10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12        10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12       6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12          19.0 ± 0%      17.0 ± 0%  -10.53%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-wildcard-12       19.0 ± 0%      17.0 ± 0%  -10.53%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12      6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12             24.0 ± 0%      22.0 ± 0%   -8.33%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-wildcard-12          24.0 ± 0%      22.0 ± 0%   -8.33%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-match-all-12         6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```