### PR TITLE
Fix `istioctl pc log` ztunnel pod not working

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -852,9 +852,6 @@ func logCmd() *cobra.Command {
 					loggerNames[name] = Envoy
 				}
 			}
-			if err != nil {
-				return err
-			}
 
 			destLoggerLevels := map[string]Level{}
 			if reset {

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -881,7 +881,7 @@ func logCmd() *cobra.Command {
 						loggerLevel := regexp.MustCompile(`[:=]`).Split(ol, 2)
 						for logName, typ := range loggerNames {
 							if typ == Ztunnel {
-								// TODO validate ztunnel logger name when available
+								// TODO validate ztunnel logger name when available: https://github.com/istio/ztunnel/issues/426
 								continue
 							}
 							if !strings.Contains(logName, loggerLevel[0]) {

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -40,6 +40,7 @@ func TestProxyConfig(t *testing.T) {
 	loggingConfig := map[string][]byte{
 		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile(t, "../pkg/writer/envoy/logging/testdata/logging.txt"),
 		"httpbin-794b576b6c-qx6pf":    []byte("{}"),
+		"ztunnel-9v7nw":               []byte("current log level is debug"),
 	}
 	cases := []execTestCase{
 		{
@@ -158,6 +159,12 @@ func TestProxyConfig(t *testing.T) {
 			args:             strings.Split("pc route httpbin-794b576b6c-qx6pf", " "),
 			expectedString:   `config dump has no configuration type`,
 			wantException:    true,
+		},
+		{ // set ztunnel logging level
+			execClientConfig: loggingConfig,
+			args:             strings.Split("proxy-config log ztunnel-9v7nw --level debug", " "),
+			expectedString:   "current log level is debug",
+			wantException:    false,
 		},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/43588
```
./out/linux_amd64/istioctl pc log ztunnel-9v7nw.istio-system --level=ztunnel=debug
ztunnel-9v7nw.istio-system:
current log level is ztunnel=debug,info

./out/linux_amd64/istioctl pc log ztunnel-9v7nw.istio-system --level=warning
ztunnel-9v7nw.istio-system:
current log level is ztunnel=debug,warn

./out/linux_amd64/istioctl pc log ztunnel-9v7nw.istio-system --reset
2023-02-27T03:21:44.209092Z	warn	unable to get logLevel from ConfigMap istio-sidecar-injector, using default value "warning" for envoy proxies and "info" for ztunnel
ztunnel-9v7nw.istio-system:
current log level is info
```