### PR TITLE
CNI uninstall doesn't clean up rules

### DIFF
--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -119,11 +119,16 @@ func buildKubeClient(kubeConfig string) (kube.Client, error) {
 }
 
 func (s *Server) Start() {
+	log.Debug("CNI ambient server starting")
 	s.kubeClient.RunAndWait(s.ctx.Done())
 	go func() {
 		s.queue.Run(s.ctx.Done())
-		s.cleanupNode()
 	}()
+}
+
+func (s *Server) Stop() {
+	log.Info("CNI ambient server terminating, cleaning up node net rules")
+	s.cleanupNode()
 }
 
 func (s *Server) UpdateConfig() {

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -95,6 +95,7 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("failed to create ambient informer service: %v", err)
 			}
 			server.Start()
+			defer server.Stop()
 		}
 
 		isReady := install.StartServer()


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix for https://github.com/istio/istio/issues/43601

1. Prior to https://github.com/istio/istio/pull/43578, we were doing the exact same cleanup of node-level networking rules in two spots
     - Within the CNI ambient watchserver (intended to happen on watchserver termination).
     - In the `daemonset` definition itself, as a `preStop` hook

2. https://github.com/istio/istio/pull/43578 removed that preStop hook, and it was noted that the CNI watchserver cleanup wasn't happening on daemonset termination (which could be verified by jumping into the node and checking `ip route/ip rule/ip link show`)

3. This fixes the CNI watchserver cleanup so it actually works on daemonset termination, and actually cleans up node-level rules properly at that point, in addition to the existing cleanup/recreate cycles on initialization and ztunnel updates.

Tested by 

1. Installing Istio with ambient profile and CNI
2. Ensuring host net rules are created and everything works
3. `istioctl uninstall --purge`
4. SSHing into host nodes and making sure the rules created in 2) are gone.

Note:

We've replaced pretty much all uses of the `ip` CLI executable with `netlink` analogs in the CNI code - with the exception of `netlink.RuleDel()` which I could not get working when supplying what should be the correct fields, so I left it invoking the `ip` binary as it was doing previously, which does work.