### PR TITLE
Add ztunnel to dependencies

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -36,7 +36,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=52e63e25a8d2fff5ac04c33e7cee9dbe4826b51b
+BUILDER_SHA=d4d2dd8ddfe2c44dfd1f39f7b48c3042e7f9a2a8
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha
@@ -79,6 +79,9 @@ ${DEPENDENCIES:-$(cat <<EOD
   release-builder:
     git: https://github.com/istio/release-builder
     sha: ${BUILDER_SHA}
+  ztunnel:
+    git: https://github.com/istio/ztunnel
+    auto: deps
 architectures: [linux/amd64, linux/arm64]
 EOD
 )}


### PR DESCRIPTION
**Please provide a description of this PR:**

In prow/release-commit.sh, bump release-builder hash to grab https://github.com/istio/release-builder/commit/fc4fd75a62e0021d62b4823d5ed780c581b5493c (which added ztunnel as a release artifact), and adds ztunnel to the manifest with `auto: deps`. This ensures that the ztunnel dependency is listed in the generated manifest.yaml file with the commit hash that is included in the build. Useful for debugging alpha builds to track which ztunnel is included.