### PR TITLE
Fix analyzing not caught some messages in default namespace

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -371,6 +371,14 @@ var testGrid = []testCase{
 		expected:   []message{},
 	},
 	{
+		name:       "serviceWithNoSelector",
+		inputFiles: []string{"testdata/deployment-service-no-selector.yaml"},
+		analyzer:   &deployment.ServiceAssociationAnalyzer{},
+		expected: []message{
+			{msg.DeploymentRequiresServiceAssociated, "Deployment default/helloworld-v2"},
+		},
+	},
+	{
 		name: "regexes",
 		inputFiles: []string{
 			"testdata/virtualservice_regexes.yaml",

--- a/pkg/config/analysis/analyzers/deployment/services.go
+++ b/pkg/config/analysis/analyzers/deployment/services.go
@@ -152,7 +152,7 @@ func (s *ServiceAssociationAnalyzer) findMatchingServices(r *resource.Instance, 
 
 		sSelector := klabels.SelectorFromSet(s.Selector)
 		pLabels := klabels.Set(d.Template.Labels)
-		if sSelector.Matches(pLabels) && r.Metadata.FullName.Namespace.String() == deploymentNS {
+		if !sSelector.Empty() && sSelector.Matches(pLabels) && r.Metadata.FullName.Namespace.String() == deploymentNS {
 			matchingSvcs = append(matchingSvcs, ServiceSpecWithName{r.Metadata.FullName.String(), s})
 		}
 

--- a/pkg/config/analysis/analyzers/testdata/deployment-service-no-selector.yaml
+++ b/pkg/config/analysis/analyzers/testdata/deployment-service-no-selector.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-no-selector
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 6443
+---
+# this deployment is not associated with any service, so it should generate a warning
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld-v2
+  namespace: default
+  labels:
+    app: helloworld
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helloworld
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: helloworld
+        version: v2
+        sidecar.istio.io/inject: "true"
+    spec:
+      containers:
+        - name: helloworld
+          image: docker.io/istio/examples-helloworld-v2
+          resources:
+            requests:
+              cpu: "100m"
+          imagePullPolicy: IfNotPresent #Always
+          ports:
+            - containerPort: 5000

--- a/releasenotes/notes/43652.yaml
+++ b/releasenotes/notes/43652.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
   - |
-    **Fixed** analyzing not caught some messages when there's services with no selector exist in the analyzed namespace.
+    **Fixed** a bug in `istioctl analyze` where some messages are missed when there are services with no selector in the analyzed namespace.

--- a/releasenotes/notes/43652.yaml
+++ b/releasenotes/notes/43652.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** analyzing not caught some messages when there's services with no selector exist in the analyzed namespace.


### PR DESCRIPTION
**Please provide a description of this PR:**
Found here: https://github.com/istio/istio/pull/43626#pullrequestreview-1315927487
When there's any service with no selector in a namespace, `DeploymentRequiresServiceAssociated` message won't be reported because the no selector service will match all the deployments which actually have no associated service.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
