### PR TITLE
connect: consolidate HCM configs

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1210,7 +1210,10 @@ func (node *Proxy) EnableHBONE() bool {
 	return node.IsAmbient() || (features.EnableHBONE && bool(node.Metadata.EnableHBONE))
 }
 
-// WaypointScope is either an entire namespace or an individual service account in the namespace.
+// WaypointScope is either an entire namespace or an individual service account
+// in the namespace. This setting dictates the upstream TLS verification
+// strategy, depending on the binding of the waypoints to its backend
+// workloads.
 type WaypointScope struct {
 	Namespace      string
 	ServiceAccount string // optional

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -20,20 +20,15 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	internalupstream "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	anypb "github.com/golang/protobuf/ptypes/any"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
@@ -51,7 +46,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
-	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -207,7 +201,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 
 	// OutboundTunnel cluster is needed for sidecar and gateway.
 	if proxy.EnableHBONE() {
-		clusters = append(clusters, outboundTunnelCluster(proxy, req.Push))
+		clusters = append(clusters, cb.buildConnectOriginate(proxy, req.Push, nil))
 	}
 
 	// if credential socket exists, create a cluster for it
@@ -1071,33 +1065,6 @@ var InternalUpstreamSocket = &core.TransportSocket{
 		},
 		TransportSocket: xdsfilters.RawBufferTransportSocket,
 	})},
-}
-
-func outboundTunnelCluster(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
-	return &cluster.Cluster{
-		Name:                 util.OutboundTunnel,
-		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
-		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
-		ConnectTimeout:       proto.Clone(push.Mesh.ConnectTimeout).(*durationpb.Duration),
-		CleanupInterval:      durationpb.New(60 * time.Second),
-		TypedExtensionProtocolOptions: map[string]*anypb.Any{
-			v3.HttpProtocolOptionsType: protoconv.MessageToAny(&http.HttpProtocolOptions{
-				UpstreamProtocolOptions: &http.HttpProtocolOptions_ExplicitHttpConfig_{ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
-					ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-						Http2ProtocolOptions: &core.Http2ProtocolOptions{
-							AllowConnect: true,
-						},
-					},
-				}},
-			}),
-		},
-		TransportSocket: &core.TransportSocket{
-			Name: wellknown.TransportSocketTls,
-			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&tls.UpstreamTlsContext{
-				CommonTlsContext: buildHBONECommonTLSContext(proxy, push),
-			})},
-		},
-	}
 }
 
 func buildHBONECommonTLSContext(proxy *model.Proxy, push *model.PushContext) *tls.CommonTlsContext {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -25,7 +25,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	internalupstream "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
-	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -39,10 +38,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
-	"istio.io/istio/pilot/pkg/networking/plugin/authn"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authnmodel "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
@@ -1065,18 +1062,4 @@ var InternalUpstreamSocket = &core.TransportSocket{
 		},
 		TransportSocket: xdsfilters.RawBufferTransportSocket,
 	})},
-}
-
-func buildHBONECommonTLSContext(proxy *model.Proxy, push *model.PushContext) *tls.CommonTlsContext {
-	ctx := &tls.CommonTlsContext{}
-	authnmodel.ApplyToCommonTLSContext(ctx, proxy, nil, authn.TrustDomainsForValidation(push.Mesh), false)
-
-	ctx.AlpnProtocols = util.ALPNH2Only
-
-	ctx.TlsParams = &tls.TlsParameters{
-		// Ensure TLS 1.3 is used everywhere for HBONE
-		TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
-		TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_3,
-	}
-	return ctx
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1039,17 +1039,6 @@ func getOrCreateIstioMetadata(cluster *cluster.Cluster) *structpb.Struct {
 	return cluster.Metadata.FilterMetadata[util.IstioMetadataKey]
 }
 
-func (cb *ClusterBuilder) buildInternalListenerCluster(clusterName string, listenerName string) *MutableCluster {
-	clusterType := cluster.Cluster_STATIC
-	port := &model.Port{}
-	localCluster := cb.buildDefaultCluster(clusterName, clusterType, util.BuildInternalEndpoint(listenerName, nil),
-		model.TrafficDirectionInbound, port, nil, nil)
-	// no TLS
-	localCluster.cluster.TransportSocketMatches = nil
-	localCluster.cluster.TransportSocket = InternalUpstreamSocket
-	return localCluster
-}
-
 var HboneOrPlaintextSocket = []*cluster.Cluster_TransportSocketMatch{
 	{
 		Name:            "hbone",

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -177,7 +177,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, proxy, instances, inboundPatcher)...)
-		clusters = append(clusters, configgen.buildInboundHBONEClusters(cb, proxy, instances)...)
+		clusters = append(clusters, configgen.buildInboundHBONEClusters(cb, proxy)...)
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -45,8 +45,8 @@ func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters(cb *ClusterBuild
 	}
 	// This TCP cluster routes to "internal" listener.
 	clusterType := cluster.Cluster_STATIC
-	llb := util.BuildInternalEndpoint("internal", nil)
-	localCluster := cb.buildDefaultCluster("internal", clusterType, llb,
+	llb := util.BuildInternalEndpoint(InternalName, nil)
+	localCluster := cb.buildDefaultCluster(InternalName, clusterType, llb,
 		model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 	localCluster.cluster.TransportSocketMatches = nil
 	localCluster.cluster.TransportSocket = util.InternalUpstreamTransportSocket()
@@ -60,7 +60,7 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 	svcs map[host.Name]*model.Service,
 ) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
-	// Creates "internal" cluster to route to the main "internal" listener.
+	// Creates "internal" cluster to route to the main listener.
 	// Creates "encap" listener to route to the encap listener.
 	clusters = append(clusters, cb.buildWaypointInboundInternal()...)
 	// Creates per-VIP load balancing upstreams.
@@ -123,8 +123,8 @@ func (cb *ClusterBuilder) buildWaypointInboundInternal() []*cluster.Cluster {
 	{
 		// This TCP cluster routes to "internal" listener.
 		clusterType := cluster.Cluster_STATIC
-		llb := util.BuildInternalEndpoint("internal", nil)
-		localCluster := cb.buildDefaultCluster("internal", clusterType, llb,
+		llb := util.BuildInternalEndpoint(InternalName, nil)
+		localCluster := cb.buildDefaultCluster(InternalName, clusterType, llb,
 			model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 		localCluster.cluster.TransportSocketMatches = nil
 		localCluster.cluster.TransportSocket = util.InternalUpstreamTransportSocket()

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -45,8 +45,8 @@ func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters(cb *ClusterBuild
 	}
 	// This TCP cluster routes to "internal" listener.
 	clusterType := cluster.Cluster_STATIC
-	llb := util.BuildInternalEndpoint(InternalName, nil)
-	localCluster := cb.buildDefaultCluster(InternalName, clusterType, llb,
+	llb := util.BuildInternalEndpoint(MainInternalName, nil)
+	localCluster := cb.buildDefaultCluster(MainInternalName, clusterType, llb,
 		model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 	localCluster.cluster.TransportSocketMatches = nil
 	localCluster.cluster.TransportSocket = util.InternalUpstreamTransportSocket()
@@ -60,13 +60,13 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 	svcs map[host.Name]*model.Service,
 ) []*cluster.Cluster {
 	clusters := make([]*cluster.Cluster, 0)
-	// Creates "internal" cluster to route to the main listener.
+	// Creates "main_internal" cluster to route to the main internal listener.
 	// Creates "encap" listener to route to the encap listener.
 	clusters = append(clusters, cb.buildWaypointInboundInternal()...)
 	// Creates per-VIP load balancing upstreams.
 	clusters = append(clusters, cb.buildWaypointInboundVIP(svcs)...)
 	// Upstream of the "encap" listener.
-	clusters = append(clusters, cb.buildWaypointInboundConnect(proxy, push))
+	clusters = append(clusters, cb.buildWaypointConnectOriginate(proxy, push))
 
 	for _, c := range clusters {
 		if c.TransportSocket != nil && c.TransportSocketMatches != nil {
@@ -123,8 +123,8 @@ func (cb *ClusterBuilder) buildWaypointInboundInternal() []*cluster.Cluster {
 	{
 		// This TCP cluster routes to "internal" listener.
 		clusterType := cluster.Cluster_STATIC
-		llb := util.BuildInternalEndpoint(InternalName, nil)
-		localCluster := cb.buildDefaultCluster(InternalName, clusterType, llb,
+		llb := util.BuildInternalEndpoint(MainInternalName, nil)
+		localCluster := cb.buildDefaultCluster(MainInternalName, clusterType, llb,
 			model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 		localCluster.cluster.TransportSocketMatches = nil
 		localCluster.cluster.TransportSocket = util.InternalUpstreamTransportSocket()
@@ -133,7 +133,7 @@ func (cb *ClusterBuilder) buildWaypointInboundInternal() []*cluster.Cluster {
 	{
 		// This TCP/HTTP cluster routes from "internal" listener.
 		clusterType := cluster.Cluster_STATIC
-		llb := util.BuildInternalEndpoint("connect_originate", nil)
+		llb := util.BuildInternalEndpoint(ConnectOriginate, nil)
 		localCluster := cb.buildDefaultCluster("encap", clusterType, llb,
 			model.TrafficDirectionInbound, &model.Port{Protocol: protocol.TCP}, nil, nil)
 		localCluster.cluster.TransportSocketMatches = nil
@@ -179,10 +179,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(svcs map[host.Name]*model.Serv
 }
 
 // CONNECT origination cluster
-func (cb *ClusterBuilder) buildWaypointInboundConnect(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
-	ctx := &tls.CommonTlsContext{}
-	security.ApplyToCommonTLSContext(ctx, proxy, nil, nil, true)
-
+func (cb *ClusterBuilder) buildWaypointConnectOriginate(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
 	// Restrict upstream SAN to waypoint scope.
 	scope := proxy.WaypointScope()
 	m := &matcher.StringMatcher{}
@@ -195,13 +192,22 @@ func (cb *ClusterBuilder) buildWaypointInboundConnect(proxy *model.Proxy, push *
 			Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + scope.Namespace + "/sa/",
 		}
 	}
+	return cb.buildConnectOriginate(proxy, push, m)
+}
+
+func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.PushContext, uriSanMatcher *matcher.StringMatcher) *cluster.Cluster {
+	ctx := &tls.CommonTlsContext{}
+	security.ApplyToCommonTLSContext(ctx, proxy, nil, nil, true)
+
 	validationCtx := ctx.GetCombinedValidationContext().DefaultValidationContext
 
 	// NB: Un-typed SAN validation is ignored when typed is used, so only typed version must be used.
-	validationCtx.MatchTypedSubjectAltNames = append(validationCtx.MatchTypedSubjectAltNames, &tls.SubjectAltNameMatcher{
-		SanType: tls.SubjectAltNameMatcher_URI,
-		Matcher: m,
-	})
+	if uriSanMatcher != nil {
+		validationCtx.MatchTypedSubjectAltNames = append(validationCtx.MatchTypedSubjectAltNames, &tls.SubjectAltNameMatcher{
+			SanType: tls.SubjectAltNameMatcher_URI,
+			Matcher: uriSanMatcher,
+		})
+	}
 	aliases := authn.TrustDomainsForValidation(push.Mesh)
 	if len(aliases) > 0 {
 		matchers := util.StringToPrefixMatch(security.AppendURIPrefixToTrustDomain(aliases))
@@ -220,7 +226,7 @@ func (cb *ClusterBuilder) buildWaypointInboundConnect(proxy *model.Proxy, push *
 		TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_3,
 	}
 	return &cluster.Cluster{
-		Name:                          "connect_originate",
+		Name:                          ConnectOriginate,
 		ClusterDiscoveryType:          &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		LbPolicy:                      cluster.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -113,7 +113,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	l := builder.getListeners()
 	if builder.node.EnableHBONE() {
 		if !builder.node.IsAmbient() {
-			l = append(l, sidecarOutboundTunnelListener(builder.push, builder.node))
+			l = append(l, sidecarOutboundTunnelListener(builder.node))
 		}
 	}
 	return l
@@ -1652,7 +1652,7 @@ func listenerKey(bind string, port int) string {
 const baggageFormat = "k8s.cluster.name=%s,k8s.namespace.name=%s,k8s.%s.name=%s,service.name=%s,service.version=%s"
 
 // sidecarOutboundTunnelListener builds a listener that originates an HBONE tunnel. The original dst is passed through
-func sidecarOutboundTunnelListener(push *model.PushContext, proxy *model.Proxy) *listener.Listener {
+func sidecarOutboundTunnelListener(proxy *model.Proxy) *listener.Listener {
 	canonicalName := proxy.Labels[model.IstioCanonicalServiceLabelName]
 	canonicalRevision := proxy.Labels[model.IstioCanonicalServiceRevisionLabelName]
 	baggage := fmt.Sprintf(baggageFormat,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -24,7 +24,6 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoyquicv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/quic/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -113,9 +112,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	builder.patchListeners()
 	l := builder.getListeners()
 	if builder.node.EnableHBONE() {
-		if builder.node.IsAmbient() {
-			l = append(l, outboundTunnelListener(builder.push, builder.node))
-		} else {
+		if !builder.node.IsAmbient() {
 			l = append(l, sidecarOutboundTunnelListener(builder.push, builder.node))
 		}
 	}
@@ -1656,36 +1653,13 @@ const baggageFormat = "k8s.cluster.name=%s,k8s.namespace.name=%s,k8s.%s.name=%s,
 
 // sidecarOutboundTunnelListener builds a listener that originates an HBONE tunnel. The original dst is passed through
 func sidecarOutboundTunnelListener(push *model.PushContext, proxy *model.Proxy) *listener.Listener {
-	name := util.OutboundTunnel
 	canonicalName := proxy.Labels[model.IstioCanonicalServiceLabelName]
 	canonicalRevision := proxy.Labels[model.IstioCanonicalServiceRevisionLabelName]
-	p := &tcp.TcpProxy{
-		StatPrefix:       name,
-		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: name},
-		TunnelingConfig: &tcp.TcpProxy_TunnelingConfig{
-			Hostname: "%DOWNSTREAM_LOCAL_ADDRESS%",
-			HeadersToAdd: []*core.HeaderValueOption{
-				{Header: &core.HeaderValue{
-					Key: "baggage",
-					Value: fmt.Sprintf(baggageFormat,
-						proxy.Metadata.ClusterID, proxy.ConfigNamespace,
-						// TODO do not hardcode deployment. But I think we ignore it anyways?
-						"deployment", proxy.Metadata.WorkloadName,
-						canonicalName, canonicalRevision,
-					),
-				}},
-			},
-		},
-	}
-
-	l := &listener.Listener{
-		Name:              name,
-		UseOriginalDst:    wrappers.Bool(false),
-		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
-		ListenerFilters:   []*listener.ListenerFilter{xdsfilters.SetDstAddress},
-		FilterChains: []*listener.FilterChain{{
-			Filters: []*listener.Filter{setAccessLogAndBuildTCPFilter(push, proxy, p, istionetworking.ListenerClassSidecarOutbound)},
-		}},
-	}
-	return l
+	baggage := fmt.Sprintf(baggageFormat,
+		proxy.Metadata.ClusterID, proxy.ConfigNamespace,
+		// TODO do not hardcode deployment. But I think we ignore it anyways?
+		"deployment", proxy.Metadata.WorkloadName,
+		canonicalName, canonicalRevision,
+	)
+	return buildConnectOriginateListener(baggage)
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -165,18 +165,18 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 				ConnectConfig: &route.RouteAction_UpgradeConfig_ConnectConfig{},
 			}},
 
-			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: InternalName},
+			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: MainInternalName},
 		}},
 		TypedPerFilterConfig: map[string]*anypb.Any{
-			// Note the difference with the waypoint below.
+			// Note the difference with the waypoint below in the connect authority filter config.
 			xdsfilters.ConnectAuthorityFilter.Name: xdsfilters.ConnectAuthorityEnabledSidecar,
 		},
 	}}
-	terminate := lb.buildTerminateConnectListener(routes)
+	terminate := lb.buildConnectTerminateListener(routes)
 	// Now we have top level listener... but we must have an internal listener for each standard filter chain
 	// 1 listener per port; that listener will do protocol detection.
 	l := &listener.Listener{
-		Name:              InternalName,
+		Name:              MainInternalName,
 		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
 		TrafficDirection:  core.TrafficDirection_INBOUND,
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -158,22 +158,7 @@ func (lb *ListenerBuilder) buildHCMTerminateConnectChain(routes []*route.Route) 
 	}
 }
 
-func (lb *ListenerBuilder) buildWaypointInboundTerminateConnect() *listener.Listener {
-	routes := []*route.Route{{
-		Match: &route.RouteMatch{
-			PathSpecifier: &route.RouteMatch_ConnectMatcher_{ConnectMatcher: &route.RouteMatch_ConnectMatcher{}},
-		},
-		Action: &route.Route_Route{Route: &route.RouteAction{
-			UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
-				UpgradeType:   "CONNECT",
-				ConnectConfig: &route.RouteAction_UpgradeConfig_ConnectConfig{},
-			}},
-			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "internal"},
-		}},
-		TypedPerFilterConfig: map[string]*any.Any{
-			xdsfilters.ConnectAuthorityFilter.Name: xdsfilters.ConnectAuthorityEnabled,
-		},
-	}}
+func (lb *ListenerBuilder) buildTerminateConnectListener(routes []*route.Route) *listener.Listener {
 	actualWildcard, _ := getActualWildcardAndLocalHost(lb.node)
 	l := &listener.Listener{
 		Name:    ConnectTerminate,
@@ -192,6 +177,25 @@ func (lb *ListenerBuilder) buildWaypointInboundTerminateConnect() *listener.List
 		},
 	}
 	return l
+}
+
+func (lb *ListenerBuilder) buildWaypointInboundTerminateConnect() *listener.Listener {
+	routes := []*route.Route{{
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_ConnectMatcher_{ConnectMatcher: &route.RouteMatch_ConnectMatcher{}},
+		},
+		Action: &route.Route_Route{Route: &route.RouteAction{
+			UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+				UpgradeType:   "CONNECT",
+				ConnectConfig: &route.RouteAction_UpgradeConfig_ConnectConfig{},
+			}},
+			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "internal"},
+		}},
+		TypedPerFilterConfig: map[string]*any.Any{
+			xdsfilters.ConnectAuthorityFilter.Name: xdsfilters.ConnectAuthorityEnabled,
+		},
+	}}
+	return lb.buildTerminateConnectListener(routes)
 }
 
 func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs map[host.Name]*model.Service) *listener.Listener {

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -349,6 +349,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 func buildWaypointConnectOriginateListener() *listener.Listener {
 	return buildConnectOriginateListener("")
 }
+
 func buildConnectOriginateListener(baggage string) *listener.Listener {
 	var headers []*core.HeaderValueOption
 	if baggage != "" {

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -55,6 +55,14 @@ import (
 	"istio.io/pkg/log"
 )
 
+const (
+	// ConnectTerminate is the name for the resources associated with the termination of HTTP CONNECT.
+	ConnectTerminate = "connect_terminate"
+
+	// InternalName is the name for the resources associated with the main (non-tunnel) internal listener.
+	InternalName = "internal"
+)
+
 type WorkloadAndServices struct {
 	WorkloadInfo *model.WorkloadInfo
 	Services     []*model.Service
@@ -103,8 +111,6 @@ func (lb *ListenerBuilder) buildWaypointInbound() []*listener.Listener {
 
 	return listeners
 }
-
-const ConnectTerminate = "connect_terminate"
 
 func (lb *ListenerBuilder) buildHCMTerminateConnectChain(routes []*route.Route) []*listener.Filter {
 	h := &hcm.HttpConnectionManager{
@@ -189,7 +195,7 @@ func (lb *ListenerBuilder) buildWaypointInboundTerminateConnect() *listener.List
 				UpgradeType:   "CONNECT",
 				ConnectConfig: &route.RouteAction_UpgradeConfig_ConnectConfig{},
 			}},
-			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "internal"},
+			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: InternalName},
 		}},
 		TypedPerFilterConfig: map[string]*any.Any{
 			xdsfilters.ConnectAuthorityFilter.Name: xdsfilters.ConnectAuthorityEnabled,
@@ -311,7 +317,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []WorkloadAndServices, svcs
 		}
 	}
 	l := &listener.Listener{
-		Name:              "internal",
+		Name:              InternalName,
 		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
 		ListenerFilters: []*listener.ListenerFilter{
 			util.InternalListenerSetAddressFilter(),

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	typev3 "github.com/cncf/xds/go/xds/type/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -66,8 +65,6 @@ const (
 	// Passthrough is the name of the virtual host used to forward traffic to the
 	// PassthroughCluster
 	Passthrough = "allow_any"
-	// OutboundTunnel is HBONE's outbound cluster.
-	OutboundTunnel = "outbound-tunnel"
 
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
@@ -813,19 +810,4 @@ func MaybeBuildStatefulSessionFilterConfig(svc *model.Service) *statefulsession.
 		}
 	}
 	return nil
-}
-
-// InternalListenerSetAddressFilter is a filter for internal listeners that overrides the address based on the metadata
-// from BuildTunnelMetadata
-func InternalListenerSetAddressFilter() *listener.ListenerFilter {
-	v, _ := structpb.NewStruct(map[string]interface{}{})
-	return &listener.ListenerFilter{
-		Name: "set_dst_address",
-		ConfigType: &listener.ListenerFilter_TypedConfig{
-			TypedConfig: protoconv.MessageToAny(&typev3.TypedStruct{
-				TypeUrl: "type.googleapis.com/istio.set_internal_dst_address.v1.Config",
-				Value:   v,
-			}),
-		},
-	}
 }

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
-	networkutils "istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -993,7 +992,7 @@ func expectAmbient(strings []string, ambient bool) []string {
 	}
 	var out []string
 	for _, s := range strings {
-		out = append(out, networkutils.OutboundTunnel+";"+s)
+		out = append(out, "connect_originate;"+s)
 	}
 	return out
 }


### PR DESCRIPTION
CONNECT termination/origination xDS generation shares resources between waypoints and sidecars, with the same limits (<100 streams per connection) and policy (TLS 1.3, validation).