### PR TITLE
ambient: properly opt-out sidecar pods 

### DIFF
--- a/cni/pkg/ambient/ambientpod/podutil.go
+++ b/cni/pkg/ambient/ambientpod/podutil.go
@@ -42,10 +42,18 @@ func ShouldPodBeInMesh(namespace *corev1.Namespace, pod *corev1.Pod, ignoreNotRu
 	// - If mesh is in namespace mode, must be in active namespace
 	if (ignoreNotRunning || (isRunning(pod) && hasPodIP(pod))) &&
 		!PodHasSidecar(pod) &&
+		!PodHasOptOut(pod) &&
 		IsNamespaceActive(namespace) {
 		return true
 	}
 
+	return false
+}
+
+func PodHasOptOut(pod *corev1.Pod) bool {
+	if val, ok := pod.Annotations[constants.AmbientRedirection]; ok {
+		return val == constants.AmbientRedirectionDisabled
+	}
 	return false
 }
 

--- a/cni/pkg/ambient/ambientpod/podutil.go
+++ b/cni/pkg/ambient/ambientpod/podutil.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/kube/inject"
 	"istio.io/pkg/log"
 )
 
@@ -46,11 +45,6 @@ func PodZtunnelEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
 func podHasSidecar(pod *corev1.Pod) bool {
 	if _, f := pod.Annotations[annotation.SidecarStatus.Name]; f {
 		return true
-	}
-	for _, c := range pod.Spec.Containers {
-		if c.Name == inject.ProxyContainerName {
-			return true
-		}
 	}
 	return false
 }

--- a/cni/pkg/ambient/ambientpod/podutil.go
+++ b/cni/pkg/ambient/ambientpod/podutil.go
@@ -26,38 +26,24 @@ import (
 	"istio.io/pkg/log"
 )
 
-func hasPodIP(pod *corev1.Pod) bool {
-	return pod.Status.PodIP != ""
-}
-
-func isRunning(pod *corev1.Pod) bool {
-	return pod.Status.Phase == corev1.PodRunning
-}
-
-func ShouldPodBeInMesh(namespace *corev1.Namespace, pod *corev1.Pod, ignoreNotRunning bool) bool {
-	// Pod must:
-	// - Be running
-	// - Have an IP address
-	// - Cannot have a legacy label (istio.io/rev or istio-injection=enabled)
-	// - If mesh is in namespace mode, must be in active namespace
-	if (ignoreNotRunning || (isRunning(pod) && hasPodIP(pod))) &&
-		!PodHasSidecar(pod) &&
-		!PodHasOptOut(pod) &&
-		IsNamespaceActive(namespace) {
-		return true
+// PodZtunnelEnabled determines if a pod is eligible for ztunnel redirection
+func PodZtunnelEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
+	if namespace.GetLabels()[constants.DataplaneMode] != constants.DataplaneModeAmbient {
+		// Namespace does not have ambient mode enabled
+		return false
 	}
-
-	return false
-}
-
-func PodHasOptOut(pod *corev1.Pod) bool {
-	if val, ok := pod.Annotations[constants.AmbientRedirection]; ok {
-		return val == constants.AmbientRedirectionDisabled
+	if podHasSidecar(pod) {
+		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
+		return false
 	}
-	return false
+	if pod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionDisabled {
+		// Pod explicitly asked to not have redirection enabled
+		return false
+	}
+	return true
 }
 
-func PodHasSidecar(pod *corev1.Pod) bool {
+func podHasSidecar(pod *corev1.Pod) bool {
 	if _, f := pod.Annotations[annotation.SidecarStatus.Name]; f {
 		return true
 	}
@@ -66,18 +52,6 @@ func PodHasSidecar(pod *corev1.Pod) bool {
 			return true
 		}
 	}
-	return false
-}
-
-func IsNamespaceActive(namespace *corev1.Namespace) bool {
-	//   - Namespace cannot have "legacy" labels (ie. istio.io/rev or istio-injection=enabled)
-	//   - Namespace must have label istio.io/dataplane-mode=ambient
-	if namespace != nil &&
-		!HasLegacyLabel(namespace.GetLabels()) &&
-		namespace.GetLabels()[constants.DataplaneMode] == constants.DataplaneModeAmbient {
-		return true
-	}
-
 	return false
 }
 

--- a/cni/pkg/ambient/informers.go
+++ b/cni/pkg/ambient/informers.go
@@ -116,7 +116,7 @@ func (s *Server) Reconcile(input any) error {
 		// For update, we just need to handle opt outs
 		newPod := event.New.(*corev1.Pod)
 		oldPod := event.Old.(*corev1.Pod)
-		if ambientpod.PodHasOptOut(newPod) && !ambientpod.PodHasOptOut(oldPod) {
+		if ambientpod.PodHasSidecar(newPod) && !ambientpod.PodHasSidecar(oldPod) {
 			log.Debugf("Pod %s matches opt out, but was not before, removing from mesh", newPod.Name)
 			s.DelPodFromMesh(newPod)
 			return nil
@@ -124,7 +124,7 @@ func (s *Server) Reconcile(input any) error {
 
 		if event.New == event.Old {
 			// This is a bit of a hack, but in this case we are queued from namespace handler
-			if ambientpod.PodHasOptOut(pod) {
+			if ambientpod.PodHasSidecar(pod) {
 				log.Debugf("Pod %s matches opt out, skipping", pod.Name)
 				return nil
 			}
@@ -140,7 +140,7 @@ func (s *Server) Reconcile(input any) error {
 		}
 		return nil
 	}
-	if ambientpod.PodHasOptOut(pod) {
+	if ambientpod.PodHasSidecar(pod) {
 		log.Debugf("Pod %s matches opt out, skipping", pod.Name)
 		return nil
 	}

--- a/cni/pkg/ambient/options.go
+++ b/cni/pkg/ambient/options.go
@@ -15,8 +15,6 @@
 package ambient
 
 import (
-	klabels "k8s.io/apimachinery/pkg/labels"
-
 	ipsetlib "istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/pkg/env"
@@ -33,10 +31,6 @@ var (
 var Ipset = &ipsetlib.IPSet{
 	Name: "ztunnel-pods-ips",
 }
-
-var ambientSelectors = klabels.SelectorFromValidatedSet(map[string]string{
-	constants.DataplaneMode: constants.DataplaneModeAmbient,
-})
 
 type RedirectMode int
 

--- a/cni/pkg/ambient/util.go
+++ b/cni/pkg/ambient/util.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type ExecList struct {
@@ -72,10 +71,6 @@ func execute(cmd string, args ...string) error {
 	}
 
 	return nil
-}
-
-func (s *Server) matchesAmbientSelectors(lbl map[string]string) bool {
-	return ambientSelectors.Matches(labels.Set(lbl))
 }
 
 func getEnvFromPod(pod *corev1.Pod, envName string) string {

--- a/cni/pkg/plugin/ambient.go
+++ b/cni/pkg/plugin/ambient.go
@@ -51,11 +51,7 @@ func checkAmbient(conf Config, ambientConfig ambient.AmbientConfigFile, podName,
 		return false, err
 	}
 
-	if ambientpod.HasLegacyLabel(ns.Labels) {
-		return false, fmt.Errorf("ambient: pod %s/%s or namespace has legacy labels", podNamespace, podName)
-	}
-
-	if ambientpod.ShouldPodBeInMesh(ns, pod, true) {
+	if ambientpod.PodZtunnelEnabled(ns, pod) {
 		if ambientConfig.RedirectMode == ambient.EbpfMode.String() {
 			ifIndex, mac, err := ambient.GetIndexAndPeerMac(podIfname, podNetNs)
 			if err != nil {

--- a/cni/pkg/plugin/ambient.go
+++ b/cni/pkg/plugin/ambient.go
@@ -51,7 +51,7 @@ func checkAmbient(conf Config, ambientConfig ambient.AmbientConfigFile, podName,
 		return false, err
 	}
 
-	if ambientpod.HasLegacyLabel(pod.Labels) || ambientpod.HasLegacyLabel(ns.Labels) {
+	if ambientpod.HasLegacyLabel(ns.Labels) {
 		return false, fmt.Errorf("ambient: pod %s/%s or namespace has legacy labels", podNamespace, podName)
 	}
 

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
+        ambient.istio.io/redirection: disabled
         # Add Prometheus Scrape annotations
         prometheus.io/scrape: 'true'
         prometheus.io/port: "15014"

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2169,6 +2169,7 @@ spec:
         istio.io/rev: default
         install.operator.istio.io/owning-resource: unknown
         sidecar.istio.io/inject: "false"
+        ambient.istio.io/redirection: disabled
         operator.istio.io/component: "Pilot"
         istio: pilot
       annotations:

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2169,12 +2169,12 @@ spec:
         istio.io/rev: default
         install.operator.istio.io/owning-resource: unknown
         sidecar.istio.io/inject: "false"
-        ambient.istio.io/redirection: disabled
         operator.istio.io/component: "Pilot"
         istio: pilot
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
+        ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istiod

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
+        ambient.istio.io/redirection: disabled
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}
         istio: istiod

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
-        ambient.istio.io/redirection: disabled
         operator.istio.io/component: "Pilot"
         {{- if ne .Values.revision "" }}
         istio: istiod
@@ -53,6 +52,7 @@ spec:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         {{- end }}
+        ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
         {{- if .Values.pilot.podAnnotations }}
 {{ toYaml .Values.pilot.podAnnotations | indent 8 }}

--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -35,6 +35,11 @@ spec:
       privileged: true
       ambient:
         enabled: true
+
+      # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
+      excludeNamespaces:
+      - kube-system
+
       # TODO: https://github.com/istio/istio/issues/43243
       # variant: distroless
     telemetry:


### PR DESCRIPTION
Currently, we try to skip sidecar pods by looking for some labels on the
pod. This is not accurate, as it misses some cases where we get
sidecars. Instead, actually look to see if there is the sidecar, instead
of using labels.

This fixes a case where we may accidentally attempt to add ztunnel
redirection AND sidecars which is broken
