### PR TITLE
Revise IncludeRequestHeadersInCheck to use new envoy allowed_headers field

### DIFF
--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -266,10 +266,9 @@ func generateHTTPConfig(hostname, cluster string, status *envoytypev3.HttpStatus
 			Value: config.IncludeAdditionalHeadersInCheck[k],
 		})
 	}
-	if allowedHeaders != nil || len(headersToAdd) != 0 {
+	if len(headersToAdd) != 0 {
 		service.AuthorizationRequest = &extauthzhttp.AuthorizationRequest{
-			AllowedHeaders: allowedHeaders,
-			HeadersToAdd:   headersToAdd,
+			HeadersToAdd: headersToAdd,
 		}
 	}
 
@@ -290,6 +289,9 @@ func generateHTTPConfig(hostname, cluster string, status *envoytypev3.HttpStatus
 		},
 		FilterEnabledMetadata: generateFilterMatcher(wellknown.HTTPRoleBasedAccessControl),
 		WithRequestBody:       withBodyRequest(config.IncludeRequestBodyInCheck),
+	}
+	if allowedHeaders != nil {
+		http.AllowedHeaders = allowedHeaders
 	}
 	return &builtExtAuthz{http: http}
 }

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-out2.yaml
@@ -1,6 +1,14 @@
 name: envoy.filters.http.ext_authz
 typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  allowedHeaders:
+    patterns:
+    - exact: x-custom-id
+      ignoreCase: true
+    - ignoreCase: true
+      prefix: x-prefix-
+    - ignoreCase: true
+      suffix: -suffix
   failureModeAllow: true
   filterEnabledMetadata:
     filter: envoy.filters.http.rbac
@@ -11,14 +19,6 @@ typedConfig:
         prefix: istio-ext-authz
   httpService:
     authorizationRequest:
-      allowedHeaders:
-        patterns:
-        - exact: x-custom-id
-          ignoreCase: true
-        - ignoreCase: true
-          prefix: x-prefix-
-        - ignoreCase: true
-          suffix: -suffix
       headersToAdd:
       - key: x-header-1
         value: value-1


### PR DESCRIPTION
**Please provide a description of this PR:**
The old field is deprecated in https://github.com/envoyproxy/envoy/pull/22877. The new field maintains the same behavior as the old one.
Verified it is working as expected.