### PR TITLE
istio-cni helm chart: Add istio.io/rev label to daemonset pods

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
+        istio.io/rev: {{ .Values.revision | default "default" }}
       annotations:
         sidecar.istio.io/inject: "false"
         # Add Prometheus Scrape annotations


### PR DESCRIPTION
Fix: #43714

**Please provide a description of this PR:**
Modifies the istio-cni helm chart to include the `istio.io/rev` label in the pod template of the istio-cni-node daemonset.