### PR TITLE
connect: delete and consolidate more code

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -36,6 +36,9 @@ const (
 	// EnvoyServerName for istio's envoy
 	EnvoyServerName = "istio-envoy"
 
+	// EnvoyWaypoint for ambient waypoint
+	EnvoyWaypoint = "waypoint-envoy"
+
 	celFilter                          = "envoy.access_loggers.extension_filters.cel"
 	listenerEnvoyAccessLogFriendlyName = "listener_envoy_accesslog"
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -168,7 +168,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, proxy, instances, inboundPatcher)...)
-		clusters = append(clusters, configgen.buildInboundHBONEClusters(cb, proxy)...)
+		clusters = append(clusters, configgen.buildInboundHBONEClusters(proxy)...)
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)

--- a/pilot/pkg/networking/util/internal_upstream.go
+++ b/pilot/pkg/networking/util/internal_upstream.go
@@ -23,37 +23,18 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 )
 
-var IstioHostMetadata = &internalupstream.InternalUpstreamTransport_MetadataValueSource{
-	Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Host_{
-		Host: &metadata.MetadataKind_Host{},
-	}},
-	Name: IstioMetadataKey,
-}
-
-var IstioClusterMetadata = &internalupstream.InternalUpstreamTransport_MetadataValueSource{
-	Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Cluster_{
-		Cluster: &metadata.MetadataKind_Cluster{},
-	}},
-	Name: IstioMetadataKey,
-}
-
 var TunnelHostMetadata = &internalupstream.InternalUpstreamTransport_MetadataValueSource{
 	Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Host_{Host: &metadata.MetadataKind_Host{}}},
 	Name: "tunnel",
 }
 
-var TunnelClusterMetadata = &internalupstream.InternalUpstreamTransport_MetadataValueSource{
-	Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Cluster_{Cluster: &metadata.MetadataKind_Cluster{}}},
-	Name: "tunnel",
-}
-
 func InternalUpstreamTransportSocket(passthroughMetadata ...*internalupstream.InternalUpstreamTransport_MetadataValueSource) *core.TransportSocket {
 	return &core.TransportSocket{
-		Name: "envoy.transport_sockets.internal_upstream",
+		Name: "internal_upstream",
 		ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&internalupstream.InternalUpstreamTransport{
 			PassthroughMetadata: passthroughMetadata,
 			TransportSocket: &core.TransportSocket{
-				Name:       "envoy.transport_sockets.raw_buffer",
+				Name:       "raw_buffer",
 				ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&rawbuffer.RawBuffer{})},
 			},
 		})},


### PR DESCRIPTION
List of changes:
* delete dead or duplicated code;
* report different server name header for waypoints;
* **major**: disable forwarding XFCC, that doesn't work for CONNECT termination;
* **major**: require client certificates for mTLS in CONNECT termination listener.