### PR TITLE
fix env vars since they collide with kubernetes

### DIFF
--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -59,11 +59,11 @@ Bootstrap(app)
 
 servicesDomain = "" if (os.environ.get("SERVICES_DOMAIN") is None) else "." + os.environ.get("SERVICES_DOMAIN")
 detailsHostname = "details" if (os.environ.get("DETAILS_HOSTNAME") is None) else os.environ.get("DETAILS_HOSTNAME")
-detailsPort = "9080" if (os.environ.get("DETAILS_PORT") is None) else os.environ.get("DETAILS_PORT")
+detailsPort = "9080" if (os.environ.get("DETAILS_APP_PORT") is None) else os.environ.get("DETAILS_APP_PORT")
 ratingsHostname = "ratings" if (os.environ.get("RATINGS_HOSTNAME") is None) else os.environ.get("RATINGS_HOSTNAME")
-ratingsPort = "9080" if (os.environ.get("RATINGS_PORT") is None) else os.environ.get("RATINGS_PORT")
+ratingsPort = "9080" if (os.environ.get("RATINGS_APP_PORT") is None) else os.environ.get("RATINGS_APP_PORT")
 reviewsHostname = "reviews" if (os.environ.get("REVIEWS_HOSTNAME") is None) else os.environ.get("REVIEWS_HOSTNAME")
-reviewsPort = "9080" if (os.environ.get("REVIEWS_PORT") is None) else os.environ.get("REVIEWS_PORT")
+reviewsPort = "9080" if (os.environ.get("REVIEWS_APP_PORT") is None) else os.environ.get("REVIEWS_APP_PORT")
 
 flood_factor = 0 if (os.environ.get("FLOOD_FACTOR") is None) else int(os.environ.get("FLOOD_FACTOR"))
 

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -59,11 +59,11 @@ Bootstrap(app)
 
 servicesDomain = "" if (os.environ.get("SERVICES_DOMAIN") is None) else "." + os.environ.get("SERVICES_DOMAIN")
 detailsHostname = "details" if (os.environ.get("DETAILS_HOSTNAME") is None) else os.environ.get("DETAILS_HOSTNAME")
-detailsPort = "9080" if (os.environ.get("DETAILS_APP_PORT") is None) else os.environ.get("DETAILS_APP_PORT")
+detailsPort = "9080" if (os.environ.get("DETAILS_SERVICE_PORT") is None) else os.environ.get("DETAILS_SERVICE_PORT")
 ratingsHostname = "ratings" if (os.environ.get("RATINGS_HOSTNAME") is None) else os.environ.get("RATINGS_HOSTNAME")
-ratingsPort = "9080" if (os.environ.get("RATINGS_APP_PORT") is None) else os.environ.get("RATINGS_APP_PORT")
+ratingsPort = "9080" if (os.environ.get("RATINGS_SERVICE_PORT") is None) else os.environ.get("RATINGS_SERVICE_PORT")
 reviewsHostname = "reviews" if (os.environ.get("REVIEWS_HOSTNAME") is None) else os.environ.get("REVIEWS_HOSTNAME")
-reviewsPort = "9080" if (os.environ.get("REVIEWS_APP_PORT") is None) else os.environ.get("REVIEWS_APP_PORT")
+reviewsPort = "9080" if (os.environ.get("REVIEWS_SERVICE_PORT") is None) else os.environ.get("REVIEWS_SERVICE_PORT")
 
 flood_factor = 0 if (os.environ.get("FLOOD_FACTOR") is None) else int(os.environ.get("FLOOD_FACTOR"))
 

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -40,7 +40,7 @@ public class LibertyRestEndpoint extends Application {
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
     private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
-    private final static String ratings_port = System.getenv("RATINGS_PORT") == null ? "9080" : System.getenv("RATINGS_PORT");
+    private final static String ratings_port = System.getenv("RATINGS_APP_PORT") == null ? "9080" : System.getenv("RATINGS_APP_PORT");
     private final static String ratings_service = String.format("http://%s%s:%s/ratings", ratings_hostname, services_domain, ratings_port);
     private final static String pod_hostname = System.getenv("HOSTNAME");
     private final static String clustername = System.getenv("CLUSTER_NAME");

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -40,7 +40,7 @@ public class LibertyRestEndpoint extends Application {
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
     private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
-    private final static String ratings_port = System.getenv("RATINGS_APP_PORT") == null ? "9080" : System.getenv("RATINGS_APP_PORT");
+    private final static String ratings_port = System.getenv("RATINGS_SERVICE_PORT") == null ? "9080" : System.getenv("RATINGS_SERVICE_PORT");
     private final static String ratings_service = String.format("http://%s%s:%s/ratings", ratings_hostname, services_domain, ratings_port);
     private final static String pod_hostname = System.getenv("HOSTNAME");
     private final static String clustername = System.getenv("CLUSTER_NAME");


### PR DESCRIPTION
**Please provide a description of this PR:**
The previous PR introduced an issue.
The env vars (i.e. DETAILS_PORT) is used by kubernetes. It was needed to use different env var to make it work in kubernetes with default port.

Below the env vars when deploying productpage on kubernetes. Notice that `DETAILS_PORT` is populated already by kubernetes. This is due to [this](https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables). Easiest solution is to change the name for the envvar.

```
I have no name!@productpage-v1-5fcf6f85b-88c8f:/opt/microservices$ env | grep -i details_port
DETAILS_PORT_9080_TCP_PORT=9080
DETAILS_PORT=tcp://10.1.76.19:9080
DETAILS_PORT_9080_TCP_PROTO=tcp
DETAILS_PORT_9080_TCP=tcp://10.1.76.19:9080
DETAILS_PORT_9080_TCP_ADDR=10.1.76.19
```