### PR TITLE
samples: use multiarch httpbin image

### DIFF
--- a/samples/httpbin/README.md
+++ b/samples/httpbin/README.md
@@ -4,9 +4,7 @@ This sample runs [httpbin](https://httpbin.org) as an Istio service.
 Httpbin is a well known HTTP testing service that can be used for experimenting
 with all kinds of Istio features.
 
-The upstream repo for httpbin is https://github.com/postmanlabs/httpbin and this 
-sample uses a [fork with multiarch image support](https://github.com/Kong/httpbin)
-
+This sample uses a fork of the [upstream httpbin repo](https://github.com/postmanlabs/httpbin) with [multiarch image support](https://github.com/Kong/httpbin)
 
 To use it:
 

--- a/samples/httpbin/README.md
+++ b/samples/httpbin/README.md
@@ -4,6 +4,10 @@ This sample runs [httpbin](https://httpbin.org) as an Istio service.
 Httpbin is a well known HTTP testing service that can be used for experimenting
 with all kinds of Istio features.
 
+The upstream repo for httpbin is https://github.com/postmanlabs/httpbin and this 
+sample uses a [fork with multiarch image support](https://github.com/Kong/httpbin)
+
+
 To use it:
 
 1. Install Istio by following the [istio install instructions](https://istio.io/docs/setup/).

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: docker.io/kennethreitz/httpbin
+      - image: docker.io/kong/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:


### PR DESCRIPTION
#### Tiny nit/convenience 

Most of our images work for both arm64/amd64 linux. 

`httpbin` is frequently used in testing, but upstream (now https://github.com/postmanlabs/httpbin) is infrequently updated and doesn't publish multiarch docker images.

This switches to a drop-in replacement fork (https://github.com/Kong/httpbin) which does nothing but build and publish multiarch `httpbin` images, to avoid `exec format error` when testing with `httpbin` in otherwise-supported linux/arm64 envs.