### PR TITLE
store: make List infallible

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -424,11 +424,7 @@ func (c *Controller) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-ticker.C:
-			wles, err := c.store.List(gvk.WorkloadEntry, metav1.NamespaceAll)
-			if err != nil {
-				log.Warnf("error listing WorkloadEntry for cleanup: %v", err)
-				continue
-			}
+			wles := c.store.List(gvk.WorkloadEntry, metav1.NamespaceAll)
 			for _, wle := range wles {
 				wle := wle
 				if c.shouldCleanupEntry(wle) {

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -92,10 +92,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			c.RegisterWorkload(tc, time.Now())
-			items, err := store.List(gvk.WorkloadEntry, model.NamespaceAll)
-			if err != nil {
-				t.Fatalf("failed listing WorkloadEntry: %v", err)
-			}
+			items := store.List(gvk.WorkloadEntry, model.NamespaceAll)
 			if len(items) != 0 {
 				t.Fatalf("expected 0 WorkloadEntry")
 			}

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -107,20 +107,16 @@ func (cr *store) Get(typ config.GroupVersionKind, name, namespace string) *confi
 }
 
 // List all configs in the stores.
-func (cr *store) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (cr *store) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	if len(cr.stores[typ]) == 0 {
-		return nil, nil
+		return nil
 	}
-	var errs *multierror.Error
 	var configs []config.Config
 	// Used to remove duplicated config
 	configMap := sets.New[string]()
 
 	for _, store := range cr.stores[typ] {
-		storeConfigs, err := store.List(typ, namespace)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-		}
+		storeConfigs := store.List(typ, namespace)
 		for _, cfg := range storeConfigs {
 			key := cfg.GroupVersionKind.Kind + cfg.Namespace + cfg.Name
 			if !configMap.InsertContains(key) {
@@ -128,7 +124,7 @@ func (cr *store) List(typ config.GroupVersionKind, namespace string) ([]config.C
 			}
 		}
 	}
-	return configs, errs.ErrorOrNil()
+	return configs
 }
 
 func (cr *store) Delete(typ config.GroupVersionKind, name, namespace string, resourceVersion *string) error {

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -116,8 +116,7 @@ func TestAggregateStoreList(t *testing.T) {
 	store, err := makeStore(stores, nil)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	l, err := store.List(gvk.HTTPRoute, "")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	l := store.List(gvk.HTTPRoute, "")
 	g.Expect(l).To(gomega.HaveLen(2))
 }
 
@@ -141,21 +140,18 @@ func TestAggregateStoreWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	la, err := store.List(gvk.HTTPRoute, "")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	la := store.List(gvk.HTTPRoute, "")
 	g.Expect(la).To(gomega.HaveLen(1))
 	g.Expect(la[0].Name).To(gomega.Equal("other"))
 
-	l, err := store1.List(gvk.HTTPRoute, "")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	l := store1.List(gvk.HTTPRoute, "")
 	g.Expect(l).To(gomega.HaveLen(1))
 	g.Expect(l[0].Name).To(gomega.Equal("other"))
 
 	// Check the aggregated and individual store return identical response
 	g.Expect(la).To(gomega.BeEquivalentTo(l))
 
-	l, err = store2.List(gvk.HTTPRoute, "")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	l = store2.List(gvk.HTTPRoute, "")
 	g.Expect(l).To(gomega.HaveLen(0))
 }
 

--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -80,11 +80,8 @@ func (s *KubeSource) Get(typ config.GroupVersionKind, name, namespace string) *c
 	return s.inner.Get(typ, name, namespace)
 }
 
-func (s *KubeSource) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
-	configs, err := s.inner.List(typ, namespace)
-	if err != nil {
-		return nil, err
-	}
+func (s *KubeSource) List(typ config.GroupVersionKind, namespace string) []config.Config {
+	configs := s.inner.List(typ, namespace)
 	if s.namespacesFilter != nil {
 		var out []config.Config
 		for _, config := range configs {
@@ -92,9 +89,9 @@ func (s *KubeSource) List(typ config.GroupVersionKind, namespace string) ([]conf
 				out = append(out, config)
 			}
 		}
-		return out, err
+		return out
 	}
-	return configs, nil
+	return configs
 }
 
 func (s *KubeSource) Create(config config.Config) (revision string, err error) {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -313,8 +313,7 @@ func (cl *Client) Get(typ config.GroupVersionKind, name, namespace string) *conf
 	}
 	obj, err := h.lister(namespace).Get(name)
 	if err != nil {
-		// TODO we should be returning errors not logging
-		cl.logger.Warnf("couldn't find %s/%s in informer index", namespace, name)
+		cl.logger.Debugf("couldn't find %s/%s in informer index", namespace, name)
 		return nil
 	}
 
@@ -382,15 +381,15 @@ func (cl *Client) Delete(typ config.GroupVersionKind, name, namespace string, re
 }
 
 // List implements store interface
-func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (cl *Client) List(kind config.GroupVersionKind, namespace string) []config.Config {
 	h, f := cl.kind(kind)
 	if !f {
-		return nil, nil
+		return nil
 	}
 
 	list, err := h.lister(namespace).List(klabels.Everything())
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	out := make([]config.Config, 0, len(list))
@@ -401,7 +400,7 @@ func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config
 		}
 	}
 
-	return out, nil
+	return out
 }
 
 func (cl *Client) objectInRevision(o *config.Config) bool {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -389,6 +389,11 @@ func (cl *Client) List(kind config.GroupVersionKind, namespace string) []config.
 
 	list, err := h.lister(namespace).List(klabels.Everything())
 	if err != nil {
+		// Should never happen
+		if features.EnableUnsafeAssertions {
+			cl.logger.Fatalf("lister returned err for %v: %v", namespace, err)
+		}
+		cl.logger.Errorf("lister returned err for %v: %v", namespace, err)
 		return nil
 	}
 

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -82,12 +82,7 @@ func TestClientNoCRDs(t *testing.T) {
 		t.Fatalf("Create => got %v", err)
 	}
 	retry.UntilSuccessOrFail(t, func() error {
-		l, err := store.List(r.GroupVersionKind(), configMeta.Namespace)
-		// List should actually not return an error in this case; this allows running with missing CRDs
-		// Instead, we just return an empty list.
-		if err != nil {
-			return fmt.Errorf("expected no error, but got %v", err)
-		}
+		l := store.List(r.GroupVersionKind(), configMeta.Namespace)
 		if len(l) != 0 {
 			return fmt.Errorf("expected no items returned for unknown CRD")
 		}
@@ -123,12 +118,7 @@ func TestClientDelayedCRDs(t *testing.T) {
 	}
 
 	retry.UntilSuccessOrFail(t, func() error {
-		l, err := store.List(r.GroupVersionKind(), configMeta.Namespace)
-		// List should actually not return an error in this case; this allows running with missing CRDs
-		// Instead, we just return an empty list.
-		if err != nil {
-			return fmt.Errorf("expected no error, but got %v", err)
-		}
+		l := store.List(r.GroupVersionKind(), configMeta.Namespace)
 		if len(l) != 0 {
 			return fmt.Errorf("expected no items returned for unknown CRD")
 		}
@@ -138,12 +128,7 @@ func TestClientDelayedCRDs(t *testing.T) {
 	createCRD(t, fake, r)
 
 	retry.UntilSuccessOrFail(t, func() error {
-		l, err := store.List(r.GroupVersionKind(), configMeta.Namespace)
-		// List should actually not return an error in this case; this allows running with missing CRDs
-		// Instead, we just return an empty list.
-		if err != nil {
-			return fmt.Errorf("expected no error, but got %v", err)
-		}
+		l := store.List(r.GroupVersionKind(), configMeta.Namespace)
 		if len(l) != 1 {
 			return fmt.Errorf("expected items returned")
 		}
@@ -190,10 +175,7 @@ func TestClient(t *testing.T) {
 
 			// Validate it shows up in List
 			retry.UntilSuccessOrFail(t, func() error {
-				cfgs, err := store.List(r.GroupVersionKind(), configMeta.Namespace)
-				if err != nil {
-					return err
-				}
+				cfgs := store.List(r.GroupVersionKind(), configMeta.Namespace)
 				if len(cfgs) != 1 {
 					return fmt.Errorf("expected 1 config, got %v", len(cfgs))
 				}

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -149,20 +149,20 @@ func (c *Controller) Get(typ config.GroupVersionKind, name, namespace string) *c
 	return nil
 }
 
-func (c *Controller) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (c *Controller) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	if typ != gvk.Gateway && typ != gvk.VirtualService {
-		return nil, errUnsupportedType
+		return nil
 	}
 
 	c.stateMu.RLock()
 	defer c.stateMu.RUnlock()
 	switch typ {
 	case gvk.Gateway:
-		return filterNamespace(c.state.Gateway, namespace), nil
+		return filterNamespace(c.state.Gateway, namespace)
 	case gvk.VirtualService:
-		return filterNamespace(c.state.VirtualService, namespace), nil
+		return filterNamespace(c.state.VirtualService, namespace)
 	default:
-		return nil, errUnsupportedType
+		return nil
 	}
 }
 
@@ -184,30 +184,12 @@ func (c *Controller) Reconcile(ps *model.PushContext) error {
 	defer func() {
 		log.Debugf("reconcile complete in %v", time.Since(t0))
 	}()
-	gatewayClass, err := c.cache.List(gvk.GatewayClass, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type GatewayClass: %v", err)
-	}
-	gateway, err := c.cache.List(gvk.KubernetesGateway, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type Gateway: %v", err)
-	}
-	httpRoute, err := c.cache.List(gvk.HTTPRoute, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type HTTPRoute: %v", err)
-	}
-	tcpRoute, err := c.cache.List(gvk.TCPRoute, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type TCPRoute: %v", err)
-	}
-	tlsRoute, err := c.cache.List(gvk.TLSRoute, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type TLSRoute: %v", err)
-	}
-	referenceGrant, err := c.cache.List(gvk.ReferenceGrant, metav1.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("failed to list type BackendPolicy: %v", err)
-	}
+	gatewayClass := c.cache.List(gvk.GatewayClass, metav1.NamespaceAll)
+	gateway := c.cache.List(gvk.KubernetesGateway, metav1.NamespaceAll)
+	httpRoute := c.cache.List(gvk.HTTPRoute, metav1.NamespaceAll)
+	tcpRoute := c.cache.List(gvk.TCPRoute, metav1.NamespaceAll)
+	tlsRoute := c.cache.List(gvk.TLSRoute, metav1.NamespaceAll)
+	referenceGrant := c.cache.List(gvk.ReferenceGrant, metav1.NamespaceAll)
 
 	input := KubernetesResources{
 		GatewayClass:   deepCopyStatus(gatewayClass),

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -47,10 +47,7 @@ import (
 
 var log = istiolog.RegisterScope("gateway", "gateway-api controller", 0)
 
-var (
-	errUnsupportedOp   = fmt.Errorf("unsupported operation: the gateway config store is a read-only view")
-	errUnsupportedType = fmt.Errorf("unsupported type: this operation only supports gateway and virtual service resource type")
-)
+var errUnsupportedOp = fmt.Errorf("unsupported operation: the gateway config store is a read-only view")
 
 // Controller defines the controller for the gateway-api. The controller acts a bit different from most.
 // Rather than watching the CRs directly, we depend on the existing model.ConfigStoreController which

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -95,9 +95,8 @@ func TestListInvalidGroupVersionKind(t *testing.T) {
 	controller := NewController(clientSet, store, AlwaysReady, nil, controller.Options{})
 
 	typ := config.GroupVersionKind{Kind: "wrong-kind"}
-	c, err := controller.List(typ, "ns1")
+	c := controller.List(typ, "ns1")
 	g.Expect(c).To(HaveLen(0))
-	g.Expect(err).To(HaveOccurred())
 }
 
 func TestListGatewayResourceType(t *testing.T) {
@@ -136,8 +135,7 @@ func TestListGatewayResourceType(t *testing.T) {
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 	g.Expect(controller.Reconcile(cg.PushContext())).ToNot(HaveOccurred())
-	cfg, err := controller.List(gvk.Gateway, "ns1")
-	g.Expect(err).ToNot(HaveOccurred())
+	cfg := controller.List(gvk.Gateway, "ns1")
 	g.Expect(cfg).To(HaveLen(1))
 	for _, c := range cfg {
 		g.Expect(c.GroupVersionKind).To(Equal(gvk.Gateway))
@@ -181,8 +179,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 	g.Expect(controller.Reconcile(cg.PushContext())).ToNot(HaveOccurred())
-	cfg, err := controller.List(gvk.VirtualService, "ns1")
-	g.Expect(err).ToNot(HaveOccurred())
+	cfg := controller.List(gvk.VirtualService, "ns1")
 	g.Expect(cfg).To(HaveLen(1))
 	for _, c := range cfg {
 		g.Expect(c.GroupVersionKind).To(Equal(gvk.VirtualService))

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -306,15 +306,15 @@ func sortIngressByCreationTime(configs []any) []*knetworking.Ingress {
 	return ingr
 }
 
-func (c *controller) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (c *controller) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	if typ != gvk.Gateway &&
 		typ != gvk.VirtualService {
-		return nil, errUnsupportedOp
+		return nil
 	}
 
 	list, err := c.filteredIngressInformer.List(namespace)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	out := make([]config.Config, 0)
@@ -322,7 +322,7 @@ func (c *controller) List(typ config.GroupVersionKind, namespace string) ([]conf
 	for _, ingress := range sortIngressByCreationTime(list) {
 		process, err := c.shouldProcessIngress(c.meshWatcher.Mesh(), ingress)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		if !process {
 			continue
@@ -343,7 +343,7 @@ func (c *controller) List(typ config.GroupVersionKind, namespace string) ([]conf
 		}
 	}
 
-	return out, nil
+	return out
 }
 
 func (c *controller) Create(_ config.Config) (string, error) {

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -166,11 +166,8 @@ func (c *Controller) Delete(kind config.GroupVersionKind, key, namespace string,
 	return errors.New("Delete failure: config" + key + "does not exist")
 }
 
-func (c *Controller) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
-	configs, err := c.configStore.List(kind, namespace)
-	if err != nil {
-		return nil, err
-	}
+func (c *Controller) List(kind config.GroupVersionKind, namespace string) []config.Config {
+	configs := c.configStore.List(kind, namespace)
 	if c.namespacesFilter != nil {
 		var out []config.Config
 		for _, config := range configs {
@@ -178,7 +175,7 @@ func (c *Controller) List(kind config.GroupVersionKind, namespace string) ([]con
 				out = append(out, config)
 			}
 		}
-		return out, err
+		return out
 	}
-	return configs, nil
+	return configs
 }

--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -92,12 +92,12 @@ func (cr *store) Get(kind config.GroupVersionKind, name, namespace string) *conf
 	return &config
 }
 
-func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (cr *store) List(kind config.GroupVersionKind, namespace string) []config.Config {
 	cr.mutex.RLock()
 	defer cr.mutex.RUnlock()
 	data, exists := cr.data[kind]
 	if !exists {
-		return nil, nil
+		return nil
 	}
 	out := make([]config.Config, 0, len(cr.data[kind]))
 	if namespace == "" {
@@ -109,13 +109,13 @@ func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.
 	} else {
 		ns, exists := data[namespace]
 		if !exists {
-			return nil, nil
+			return nil
 		}
 		for _, value := range ns {
 			out = append(out, value.(config.Config))
 		}
 	}
-	return out, nil
+	return out
 }
 
 func (cr *store) Delete(kind config.GroupVersionKind, name, namespace string, resourceVersion *string) error {

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -113,8 +113,7 @@ func TestMonitorForChange(t *testing.T) {
 		}
 	}()
 	g.Eventually(func() error {
-		c, err := store.List(gvk.Gateway, "")
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		c := store.List(gvk.Gateway, "")
 
 		if len(c) != 1 {
 			return errors.New("no configs")
@@ -128,8 +127,7 @@ func TestMonitorForChange(t *testing.T) {
 	}).Should(gomega.Succeed())
 
 	g.Eventually(func() error {
-		c, err := store.List(gvk.Gateway, "")
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		c := store.List(gvk.Gateway, "")
 		if len(c) == 0 {
 			return errors.New("no config")
 		}
@@ -142,7 +140,7 @@ func TestMonitorForChange(t *testing.T) {
 		return nil
 	}).Should(gomega.Succeed())
 
-	g.Eventually(func() ([]config.Config, error) {
+	g.Eventually(func() []config.Config {
 		return store.List(gvk.Gateway, "")
 	}).Should(gomega.HaveLen(0))
 }
@@ -218,8 +216,7 @@ func TestMonitorForError(t *testing.T) {
 	// nil data return and error return keeps the existing data aka createConfigSet
 	<-delay
 	g.Eventually(func() error {
-		c, err := store.List(gvk.Gateway, "")
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		c := store.List(gvk.Gateway, "")
 
 		if len(c) != 1 {
 			return errors.New("config files erased on Copilot error")

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -97,7 +97,7 @@ type AuthenticationPolicies struct {
 
 // initAuthenticationPolicies creates a new AuthenticationPolicies struct and populates with the
 // authentication policies in the mesh environment.
-func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, error) {
+func initAuthenticationPolicies(env *Environment) *AuthenticationPolicies {
 	policy := &AuthenticationPolicies{
 		requestAuthentications: map[string][]config.Config{},
 		peerAuthentications:    map[string][]config.Config{},
@@ -105,22 +105,10 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 		rootNamespace:          env.Mesh().GetRootNamespace(),
 	}
 
-	if configs, err := env.List(
-		gvk.RequestAuthentication, NamespaceAll); err == nil {
-		sortConfigByCreationTime(configs)
-		policy.addRequestAuthentication(configs)
-	} else {
-		return nil, err
-	}
+	policy.addRequestAuthentication(sortConfigByCreationTime(env.List(gvk.RequestAuthentication, NamespaceAll)))
+	policy.addPeerAuthentication(sortConfigByCreationTime(env.List(gvk.PeerAuthentication, NamespaceAll)))
 
-	if configs, err := env.List(
-		gvk.PeerAuthentication, NamespaceAll); err == nil {
-		policy.addPeerAuthentication(configs)
-	} else {
-		return nil, err
-	}
-
-	return policy, nil
+	return policy
 }
 
 func (policy *AuthenticationPolicies) addRequestAuthentication(configs []config.Config) {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -700,12 +700,8 @@ func getTestAuthenticationPolicies(configs []*config.Config, t *testing.T) *Auth
 		ConfigStore: configStore,
 		Watcher:     mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: rootNamespace}),
 	}
-	authnPolicy, err := initAuthenticationPolicies(environment)
-	if err != nil {
-		t.Fatalf("getTestAuthenticationPolicies %v", err)
-	}
 
-	return authnPolicy
+	return initAuthenticationPolicies(environment)
 }
 
 func createTestRequestAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector) *config.Config {

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -18,10 +18,7 @@ import (
 	authpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/gvk"
-	istiolog "istio.io/pkg/log"
 )
-
-var authzLog = istiolog.RegisterScope("authorization", "Istio Authorization Policy", 0)
 
 type AuthorizationPolicy struct {
 	Name        string                      `json:"name"`

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -40,16 +40,13 @@ type AuthorizationPolicies struct {
 }
 
 // GetAuthorizationPolicies returns the AuthorizationPolicies for the given environment.
-func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) {
+func GetAuthorizationPolicies(env *Environment) *AuthorizationPolicies {
 	policy := &AuthorizationPolicies{
 		NamespaceToPolicies: map[string][]AuthorizationPolicy{},
 		RootNamespace:       env.Mesh().GetRootNamespace(),
 	}
 
-	policies, err := env.List(gvk.AuthorizationPolicy, NamespaceAll)
-	if err != nil {
-		return nil, err
-	}
+	policies := env.List(gvk.AuthorizationPolicy, NamespaceAll)
 	sortConfigByCreationTime(policies)
 	for _, config := range policies {
 		authzConfig := AuthorizationPolicy{
@@ -61,7 +58,7 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 		policy.NamespaceToPolicies[config.Namespace] = append(policy.NamespaceToPolicies[config.Namespace], authzConfig)
 	}
 
-	return policy, nil
+	return policy
 }
 
 type AuthorizationPoliciesResult struct {

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -345,10 +345,7 @@ func createFakeAuthorizationPolicies(configs []config.Config, t *testing.T) *Aut
 		ConfigStore: store,
 		Watcher:     mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-config"}),
 	}
-	authzPolicies, err := GetAuthorizationPolicies(environment)
-	if err != nil {
-		t.Fatalf("GetAuthorizationPolicies failed: %v", err)
-	}
+	authzPolicies := GetAuthorizationPolicies(environment)
 	return authzPolicies
 }
 
@@ -391,7 +388,7 @@ func (fs *authzFakeStore) Get(_ config.GroupVersionKind, _, _ string) *config.Co
 	return nil
 }
 
-func (fs *authzFakeStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (fs *authzFakeStore) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	var configs []config.Config
 	for _, data := range fs.data {
 		if data.typ == typ {
@@ -401,7 +398,7 @@ func (fs *authzFakeStore) List(typ config.GroupVersionKind, namespace string) ([
 			configs = append(configs, data.cfg)
 		}
 	}
-	return configs, nil
+	return configs
 }
 
 func (fs *authzFakeStore) Delete(_ config.GroupVersionKind, _, _ string, _ *string) error {

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -317,7 +317,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			authzPolicies := createFakeAuthorizationPolicies(tc.configs, t)
+			authzPolicies := createFakeAuthorizationPolicies(tc.configs)
 
 			result := authzPolicies.ListAuthorizationPolicies(tc.ns, tc.workloadLabels)
 			if !reflect.DeepEqual(tc.wantAllow, result.Allow) {
@@ -336,7 +336,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 	}
 }
 
-func createFakeAuthorizationPolicies(configs []config.Config, t *testing.T) *AuthorizationPolicies {
+func createFakeAuthorizationPolicies(configs []config.Config) *AuthorizationPolicies {
 	store := &authzFakeStore{}
 	for _, cfg := range configs {
 		store.add(cfg)

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -162,7 +162,7 @@ type ConfigStore interface {
 
 	// List returns objects by type and namespace.
 	// Use "" for the namespace to list across namespaces.
-	List(typ config.GroupVersionKind, namespace string) ([]config.Config, error)
+	List(typ config.GroupVersionKind, namespace string) []config.Config
 
 	// Create adds a new configuration object to the store. If an object with the
 	// same name and namespace for the type already exists, the operation fails
@@ -338,7 +338,7 @@ func mostSpecificHostWildcardMatch[V any](needle string, wildcard map[host.Name]
 }
 
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
-func sortConfigByCreationTime(configs []config.Config) {
+func sortConfigByCreationTime(configs []config.Config) []config.Config {
 	sort.Slice(configs, func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
@@ -350,6 +350,7 @@ func sortConfigByCreationTime(configs []config.Config) {
 		}
 		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
 	})
+	return configs
 }
 
 // key creates a key from a reference's name and namespace.

--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -39,19 +39,19 @@ func (s *FakeStore) Schemas() collection.Schemas {
 
 func (*FakeStore) Get(typ config.GroupVersionKind, name, namespace string) *config.Config { return nil }
 
-func (s *FakeStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (s *FakeStore) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	nsConfigs := s.store[typ]
 	if nsConfigs == nil {
-		return nil, nil
+		return nil
 	}
 	var res []config.Config
 	if namespace == NamespaceAll {
 		for _, configs := range nsConfigs {
 			res = append(res, configs...)
 		}
-		return res, nil
+		return res
 	}
-	return nsConfigs[namespace], nil
+	return nsConfigs[namespace]
 }
 
 func (s *FakeStore) Create(cfg config.Config) (revision string, err error) {

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -73,21 +73,18 @@ func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.M
 	return effectiveProxyConfig
 }
 
-func GetProxyConfigs(store ConfigStore, mc *meshconfig.MeshConfig) (*ProxyConfigs, error) {
+func GetProxyConfigs(store ConfigStore, mc *meshconfig.MeshConfig) *ProxyConfigs {
 	proxyconfigs := &ProxyConfigs{
 		namespaceToProxyConfigs: map[string][]*v1beta1.ProxyConfig{},
 		rootNamespace:           mc.GetRootNamespace(),
 	}
-	resources, err := store.List(gvk.ProxyConfig, NamespaceAll)
-	if err != nil {
-		return nil, err
-	}
+	resources := store.List(gvk.ProxyConfig, NamespaceAll)
 	sortConfigByCreationTime(resources)
 	ns := proxyconfigs.namespaceToProxyConfigs
 	for _, resource := range resources {
 		ns[resource.Namespace] = append(ns[resource.Namespace], resource.Spec.(*v1beta1.ProxyConfig))
 	}
-	return proxyconfigs, nil
+	return proxyconfigs
 }
 
 func (p *ProxyConfigs) mergedGlobalConfig() *meshconfig.ProxyConfig {

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -25,10 +25,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/proto/merge"
 	"istio.io/istio/pkg/util/protomarshal"
-	istiolog "istio.io/pkg/log"
 )
-
-var pclog = istiolog.RegisterScope("proxyconfig", "Istio ProxyConfig", 0)
 
 // ProxyConfigs organizes ProxyConfig configuration by namespace.
 type ProxyConfigs struct {

--- a/pilot/pkg/model/proxy_config_test.go
+++ b/pilot/pkg/model/proxy_config_test.go
@@ -413,10 +413,7 @@ func TestEffectiveProxyConfig(t *testing.T) {
 				DefaultConfig: tc.defaultConfig,
 			}
 			original, _ := protomarshal.ToJSON(m)
-			pcs, err := GetProxyConfigs(store, m)
-			if err != nil {
-				t.Fatalf("failed to list proxyconfigs: %v", err)
-			}
+			pcs := GetProxyConfigs(store, m)
 			merged := pcs.EffectiveProxyConfig(tc.proxy, m)
 			pc := mesh.DefaultProxyConfig()
 			proto.Merge(pc, tc.expected)

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -445,9 +445,7 @@ func TestEnvoyFilterOrder(t *testing.T) {
 
 	// Init a new push context
 	pc := NewPushContext()
-	if err := pc.initEnvoyFilters(env); err != nil {
-		t.Fatal(err)
-	}
+	pc.initEnvoyFilters(env)
 	gotns := make([]string, 0)
 	for _, filter := range pc.envoyFiltersByNamespace["testns"] {
 		gotns = append(gotns, filter.Keys()...)
@@ -693,9 +691,7 @@ func TestWasmPlugins(t *testing.T) {
 	// Init a new push context
 	pc := NewPushContext()
 	pc.Mesh = m
-	if err := pc.initWasmPlugins(env); err != nil {
-		t.Fatal(err)
-	}
+	pc.initWasmPlugins(env)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1121,9 +1117,7 @@ func TestSidecarScope(t *testing.T) {
 	_, _ = configStore.Create(rootConfig)
 
 	env.ConfigStore = configStore
-	if err := ps.initSidecarScopes(env); err != nil {
-		t.Fatalf("init sidecar scope failed: %v", err)
-	}
+	ps.initSidecarScopes(env)
 	cases := []struct {
 		proxy    *Proxy
 		labels   labels.Instance
@@ -1301,9 +1295,7 @@ func TestBestEffortInferServiceMTLSMode(t *testing.T) {
 	}, securityBeta.PeerAuthentication_MutualTLS_DISABLE))
 
 	env.ConfigStore = configStore
-	if err := ps.initAuthnPolicies(env); err != nil {
-		t.Fatalf("init authn policies failed: %v", err)
-	}
+	ps.initAuthnPolicies(env)
 
 	instancePlainText := &ServiceInstance{
 		Endpoint: &IstioEndpoint{
@@ -2307,9 +2299,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 
 	env.ConfigStore = configStore
 	ps.initDefaultExportMaps()
-	if err := ps.initVirtualServices(env); err != nil {
-		t.Fatalf("init virtual services failed: %v", err)
-	}
+	ps.initVirtualServices(env)
 
 	cases := []struct {
 		proxyNs   string
@@ -2444,9 +2434,7 @@ func TestInitVirtualService(t *testing.T) {
 
 	env.ConfigStore = configStore
 	ps.initDefaultExportMaps()
-	if err := ps.initVirtualServices(env); err != nil {
-		t.Fatalf("init virtual services failed: %v", err)
-	}
+	ps.initVirtualServices(env)
 
 	t.Run("resolve shortname", func(t *testing.T) {
 		rules := ps.VirtualServicesForGateway("ns1", gatewayName)
@@ -2512,9 +2500,7 @@ func TestServiceWithExportTo(t *testing.T) {
 		services: []*Service{svc1, svc2, svc3, svc4},
 	}
 	ps.initDefaultExportMaps()
-	if err := ps.initServiceRegistry(env); err != nil {
-		t.Fatalf("init services failed: %v", err)
-	}
+	ps.initServiceRegistry(env)
 
 	cases := []struct {
 		proxyNs   string
@@ -2638,9 +2624,7 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 	env.ConfigStore = configStore
 	ps.initTelemetry(env)
 	ps.initDefaultExportMaps()
-	if err := ps.initVirtualServices(env); err != nil {
-		t.Fatalf("init virtual services failed: %v", err)
-	}
+	ps.initVirtualServices(env)
 	got := sets.String{}
 	addHostsFromMeshConfig(ps, got)
 	assert.Equal(t, []string{"otel.foo.svc.cluster.local"}, sets.SortedList(got))

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -108,7 +108,7 @@ type metricsKey struct {
 }
 
 // getTelemetries returns the Telemetry configurations for the given environment.
-func getTelemetries(env *Environment) (*Telemetries, error) {
+func getTelemetries(env *Environment) *Telemetries {
 	telemetries := &Telemetries{
 		NamespaceToTelemetries: map[string][]Telemetry{},
 		RootNamespace:          env.Mesh().GetRootNamespace(),
@@ -117,10 +117,7 @@ func getTelemetries(env *Environment) (*Telemetries, error) {
 		computedLoggingConfig:  map[loggingKey][]LoggingConfig{},
 	}
 
-	fromEnv, err := env.List(gvk.Telemetry, NamespaceAll)
-	if err != nil {
-		return nil, err
-	}
+	fromEnv := env.List(gvk.Telemetry, NamespaceAll)
 	sortConfigByCreationTime(fromEnv)
 	for _, config := range fromEnv {
 		telemetry := Telemetry{
@@ -131,7 +128,7 @@ func getTelemetries(env *Environment) (*Telemetries, error) {
 		telemetries.NamespaceToTelemetries[config.Namespace] = append(telemetries.NamespaceToTelemetries[config.Namespace], telemetry)
 	}
 
-	return telemetries, nil
+	return telemetries
 }
 
 type metricsConfig struct {

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -44,10 +44,7 @@ import (
 	"istio.io/istio/pkg/config/xds"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
-	istiolog "istio.io/pkg/log"
 )
-
-var telemetryLog = istiolog.RegisterScope("telemetry", "Istio Telemetry", 0)
 
 // Telemetry holds configuration for Telemetry API resources.
 type Telemetry struct {

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -84,10 +84,7 @@ func createTestTelemetries(configs []config.Config, t *testing.T) (*Telemetries,
 		ConfigStore: store,
 		Watcher:     mesh.NewFixedWatcher(m),
 	}
-	telemetries, err := getTelemetries(environment)
-	if err != nil {
-		t.Fatalf("getTelemetries failed: %v", err)
-	}
+	telemetries := getTelemetries(environment)
 
 	ctx := NewPushContext()
 	ctx.Mesh = m
@@ -135,7 +132,7 @@ func (ts *telemetryStore) Get(_ config.GroupVersionKind, _, _ string) *config.Co
 	return nil
 }
 
-func (ts *telemetryStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+func (ts *telemetryStore) List(typ config.GroupVersionKind, namespace string) []config.Config {
 	var configs []config.Config
 	for _, data := range ts.data {
 		if data.typ == typ {
@@ -145,7 +142,7 @@ func (ts *telemetryStore) List(typ config.GroupVersionKind, namespace string) ([
 			configs = append(configs, data.cfg)
 		}
 	}
-	return configs, nil
+	return configs
 }
 
 func newTracingConfig(providerName string, disabled bool) *TracingConfig {

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -89,16 +89,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, re
 		return resp, model.DefaultXdsLogDetails, nil
 	}
 
-	// TODO: what is the proper way to handle errors ?
-	// Normally once istio is 'ready' List can't return errors on a valid config -
-	// even if k8s is disconnected, we still cache all previous results.
-	// This needs further consideration - I don't think XDS or MCP transports
-	// have a clear recommendation.
-	cfg, err := g.store.List(rgvk, "")
-	if err != nil {
-		log.Warnf("ADS: Error reading resource %s %v", w.TypeUrl, err)
-		return resp, model.DefaultXdsLogDetails, nil
-	}
+	cfg := g.store.List(rgvk, "")
 	for _, c := range cfg {
 		// Right now model.Config is not a proto - until we change it, mcp.Resource.
 		// This also helps migrating MCP users.

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -65,11 +65,11 @@ func TestAPIGen(t *testing.T) {
 			t.Fatal("Failed to receive lds", err)
 		}
 
-		ses, _ := adscConn.Store.List(gvk.ServiceEntry, "")
+		ses := adscConn.Store.List(gvk.ServiceEntry, "")
 		for _, se := range ses {
 			t.Log(se)
 		}
-		sec, _ := adscConn.Store.List(gvk.EnvoyFilter, "")
+		sec := adscConn.Store.List(gvk.EnvoyFilter, "")
 		for _, se := range sec {
 			t.Log(se)
 		}

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -422,12 +422,9 @@ func newAuthzPolicies(t *testing.T, policies []*config.Config) *model.Authorizat
 		}
 	}
 
-	authzPolicies, err := model.GetAuthorizationPolicies(&model.Environment{
+	authzPolicies := model.GetAuthorizationPolicies(&model.Environment{
 		ConfigStore: store,
 	})
-	if err != nil {
-		t.Fatalf("newAuthzPolicies: %v", err)
-	}
 	return authzPolicies
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -221,11 +221,7 @@ func (a *AmbientIndex) matchesScope(scope model.WaypointScope, w *model.Workload
 }
 
 func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []*workloadapi.Authorization {
-	cfgs, err := c.configController.List(gvk.AuthorizationPolicy, metav1.NamespaceAll)
-	if err != nil {
-		log.Warnf("failed to list policies")
-		return nil
-	}
+	cfgs := c.configController.List(gvk.AuthorizationPolicy, metav1.NamespaceAll)
 	l := len(cfgs)
 	if len(requested) > 0 {
 		l = len(requested)
@@ -258,14 +254,8 @@ func (c *Controller) selectorAuthorizationPolicies(ns string, lbls map[string]st
 	if isNil(c.configController) {
 		return nil
 	}
-	global, err := c.configController.List(gvk.AuthorizationPolicy, c.meshWatcher.Mesh().GetRootNamespace())
-	if err != nil {
-		return nil
-	}
-	local, err := c.configController.List(gvk.AuthorizationPolicy, ns)
-	if err != nil {
-		return nil
-	}
+	global := c.configController.List(gvk.AuthorizationPolicy, c.meshWatcher.Mesh().GetRootNamespace())
+	local := c.configController.List(gvk.AuthorizationPolicy, ns)
 	res := sets.New[string]()
 	matches := func(c config.Config) bool {
 		sel := c.Spec.(*v1beta1.AuthorizationPolicy).Selector

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -256,7 +256,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		}
 	}
 
-	cfgs, _ := s.store.List(gvk.ServiceEntry, curr.Namespace)
+	cfgs := s.store.List(gvk.ServiceEntry, curr.Namespace)
 	currSes := getWorkloadServiceEntries(cfgs, wle)
 	var oldSes map[types.NamespacedName]*config.Config
 	if oldWle != nil {
@@ -501,7 +501,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 	}
 
 	// We will only select entries in the same namespace
-	cfgs, _ := s.store.List(gvk.ServiceEntry, wi.Namespace)
+	cfgs := s.store.List(gvk.ServiceEntry, wi.Namespace)
 	if len(cfgs) == 0 {
 		s.mutex.Unlock()
 		return

--- a/pilot/pkg/serviceregistry/serviceentry/namespace_handler.go
+++ b/pilot/pkg/serviceregistry/serviceentry/namespace_handler.go
@@ -28,13 +28,13 @@ func (s *Controller) NamespaceDiscoveryHandler(namespace string, event model.Eve
 		log.Debugf("Handle event namespace %s selected", namespace)
 	}
 
-	cfgs, _ := s.store.List(gvk.WorkloadEntry, namespace)
+	cfgs := s.store.List(gvk.WorkloadEntry, namespace)
 	for _, cfg := range cfgs {
 		s.workloadEntryHandler(cfg, cfg, event)
 	}
 
 	if !s.workloadEntryController {
-		cfgs, _ := s.store.List(gvk.ServiceEntry, namespace)
+		cfgs := s.store.List(gvk.ServiceEntry, namespace)
 		for _, cfg := range cfgs {
 			s.serviceEntryHandler(cfg, cfg, event)
 		}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -462,7 +462,7 @@ func (s *DiscoveryServer) configz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	s.Env.ConfigStore.Schemas().ForEach(func(schema resource.Schema) bool {
-		cfg, _ := s.Env.ConfigStore.List(schema.GroupVersionKind(), "")
+		cfg := s.Env.ConfigStore.List(schema.GroupVersionKind(), "")
 		for _, c := range cfg {
 			configs = append(configs, kubernetesConfig{c})
 		}

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -208,7 +208,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 	}
 
 	// check for missing type
-	if l, _ := r.List(config2.GroupVersionKind{}, namespace); len(l) > 0 {
+	if l := r.List(config2.GroupVersionKind{}, namespace); len(l) > 0 {
 		t.Errorf("unexpected objects for missing type")
 	}
 
@@ -236,10 +236,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 	}
 
 	// list elements
-	l, err := r.List(mockGvk, namespace)
-	if err != nil {
-		t.Errorf("List error %#v, %v", l, err)
-	}
+	l := r.List(mockGvk, namespace)
 	if len(l) != n {
 		t.Errorf("wanted %d element(s), got %d in %v", n, len(l), l)
 	}
@@ -250,7 +247,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 		elt.Spec.(*config.MockConfig).Pairs[0].Value += "(updated)"
 		elt.ResourceVersion = revs[i]
 		elts[i] = elt
-		if _, err = r.Update(elt); err != nil {
+		if _, err := r.Update(elt); err != nil {
 			t.Error(err)
 		}
 	}
@@ -265,16 +262,13 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 
 	// delete all elements
 	for i := range elts {
-		if err = r.Delete(mockGvk, elts[i].Name, elts[i].Namespace, nil); err != nil {
+		if err := r.Delete(mockGvk, elts[i].Name, elts[i].Namespace, nil); err != nil {
 			t.Error(err)
 		}
 	}
 	log.Info("Delete elements")
 
-	l, err = r.List(mockGvk, namespace)
-	if err != nil {
-		t.Error(err)
-	}
+	l = r.List(mockGvk, namespace)
 	if len(l) != 0 {
 		t.Errorf("wanted 0 element(s), got %d in %v", len(l), l)
 	}
@@ -362,7 +356,7 @@ func CheckCacheFreshness(cache model.ConfigStoreController, namespace string, t 
 
 	// validate cache consistency
 	cache.RegisterEventHandler(mockGvk, func(_, config config2.Config, ev model.Event) {
-		elts, _ := cache.List(mockGvk, namespace)
+		elts := cache.List(mockGvk, namespace)
 		elt := cache.Get(o.GroupVersionKind, o.Name, o.Namespace)
 		switch ev {
 		case model.EventAdd:
@@ -440,7 +434,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreController, 
 	defer close(stop)
 	go cache.Run(stop)
 	retry.UntilOrFail(t, cache.HasSynced, retry.Message("HasSynced"))
-	os, _ := cache.List(mockGvk, namespace)
+	os := cache.List(mockGvk, namespace)
 	if len(os) != n {
 		t.Errorf("cache.List => Got %d, expected %d", len(os), n)
 	}
@@ -454,7 +448,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreController, 
 
 	// check again in the controller cache
 	retry.UntilOrFail(t, func() bool {
-		os, _ = cache.List(mockGvk, namespace)
+		os = cache.List(mockGvk, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(os), 0)
 		return len(os) == 0
 	}, retry.Message("no elements in cache"))
@@ -468,8 +462,8 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreController, 
 
 	// check directly through the client
 	retry.UntilOrFail(t, func() bool {
-		cs, _ := cache.List(mockGvk, namespace)
-		os, _ := store.List(mockGvk, namespace)
+		cs := cache.List(mockGvk, namespace)
+		os := store.List(mockGvk, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(cs), n)
 		log.Infof("store.List => Got %d, expected %d", len(os), n)
 		return len(os) == n && len(cs) == n

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -1220,11 +1220,7 @@ func (a *ADSC) handleMCP(groupVersionKind config.GroupVersionKind, resources []*
 		return
 	}
 
-	existingConfigs, err := a.Store.List(groupVersionKind, "")
-	if err != nil {
-		adscLog.Warnf("Error listing existing configs %v", err)
-		return
-	}
+	existingConfigs := a.Store.List(groupVersionKind, "")
 
 	received := make(map[string]*config.Config)
 	for _, rsc := range resources {
@@ -1283,7 +1279,7 @@ func (a *ADSC) handleMCP(groupVersionKind config.GroupVersionKind, resources []*
 				continue
 			}
 			if a.LocalCacheDir != "" {
-				err = os.Remove(a.LocalCacheDir + "_res." +
+				err := os.Remove(a.LocalCacheDir + "_res." +
 					config.GroupVersionKind.Kind + "." + config.Namespace + "." + config.Name + ".json")
 				if err != nil {
 					adscLog.Warnf("Error deleting received MCP config to local file %v", err)

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -487,7 +487,7 @@ func TestADSC_handleMCP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			adsc.handleMCP(gvk.ServiceEntry, tt.resources)
-			configs, _ := adsc.Store.List(gvk.ServiceEntry, "")
+			configs := adsc.Store.List(gvk.ServiceEntry, "")
 			if len(configs) != len(tt.expectedResources) {
 				t.Errorf("expected %v got %v", len(tt.expectedResources), len(configs))
 			}

--- a/pkg/config/analysis/local/context.go
+++ b/pkg/config/analysis/local/context.go
@@ -114,12 +114,7 @@ func (i *istiodContext) ForEach(col config.GroupVersionKind, fn analysis.Iterato
 		return
 	}
 	// TODO: this needs to include file source as well
-	cfgs, err := i.store.List(colschema.GroupVersionKind(), "")
-	if err != nil {
-		// TODO: demote this log before merging
-		log.Errorf("collection %s could not be listed: %s", col.String(), err)
-		return
-	}
+	cfgs := i.store.List(colschema.GroupVersionKind(), "")
 	broken := false
 	cache := map[resource.FullName]*resource.Instance{}
 	for _, cfg := range cfgs {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -899,7 +899,7 @@ func createWebhook(t testing.TB, cfg *Config, pcResources int) *Webhook {
 			},
 		}))
 	}
-	pcs, _ := model.GetProxyConfigs(store, m)
+	pcs := model.GetProxyConfigs(store, m)
 	env := model.Environment{
 		Watcher: mesh.NewFixedWatcher(m),
 		PushContext: &model.PushContext{


### PR DESCRIPTION
Currently, List returns an error. This is impossible to trigger, as the Listing is done against an informer which doesn't even return an error unless you do things terribly wrong like listing an index that doesn't exist, something that we cannot in the way things are structured.

This PR removes the error from list, simplifying usage across the codebase.

If you need more convincing that this is safe, Get() is the ~same as List but it has never had an error and has never caused issues.
