### PR TITLE
Fix: Initialize iptables helpers for both ambient CNI modes

### DIFF
--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -67,12 +67,13 @@ func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
 		kubeClient: client,
 	}
 
+	s.iptablesCommand = lazy.New(func() (string, error) {
+		return s.detectIptablesCommand(), nil
+	})
+
 	switch args.RedirectMode {
 	case IptablesMode:
 		s.redirectMode = IptablesMode
-		s.iptablesCommand = lazy.New(func() (string, error) {
-			return s.detectIptablesCommand(), nil
-		})
 		// We need to find our Host IP -- is there a better way to do this?
 		h, err := GetHostIP(s.kubeClient.Kube())
 		if err != nil || h == "" {


### PR DESCRIPTION
We autodetect the iptables command present on the host node, and this requires some init logic.

That init logic was skipped for eBPF ambient mode even though it still requires (minor) iptables config, 
which would result in the CNI DS segfaulting/crashlooping during init with eBPF mode enabled.