### PR TITLE
AccessLogging: fix the issue where disable accesslogging does not take effect

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -211,9 +211,15 @@ type TracingSpec struct {
 }
 
 type LoggingConfig struct {
+	Disabled  bool
 	AccessLog *accesslog.AccessLog
 	Provider  *meshconfig.MeshConfig_ExtensionProvider
 	Filter    *tpb.AccessLogging_Filter
+}
+
+type loggingSpec struct {
+	Disabled bool
+	Filter   *tpb.AccessLogging_Filter
 }
 
 func workloadMode(class networking.ListenerClass) tpb.WorkloadMode {
@@ -233,8 +239,8 @@ func workloadMode(class networking.ListenerClass) tpb.WorkloadMode {
 }
 
 // AccessLogging returns the logging configuration for a given proxy and listener class.
-// If nil is returned, access logs are not configured via Telemetry and should use fallback mechanisms.
-// If a non-nil but empty configuration is passed, access logging is explicitly disabled.
+// If nil or empty configuration is returned, access logs are not configured via Telemetry and should use fallback mechanisms.
+// If access logging is explicitly disabled, a configuration with disabled set to true is returned.
 func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class networking.ListenerClass) []LoggingConfig {
 	ct := t.applicableTelemetries(proxy)
 	if len(ct.Logging) == 0 && len(t.meshConfig.GetDefaultProviders().GetAccessLogging()) == 0 {
@@ -255,7 +261,7 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 
 	providers := mergeLogs(ct.Logging, t.meshConfig, workloadMode(class))
 	cfgs := make([]LoggingConfig, 0, len(providers))
-	for p, f := range providers {
+	for p, v := range providers {
 		fp := t.fetchProvider(p)
 		if fp == nil {
 			log.Debugf("fail to fetch provider %s", p)
@@ -263,7 +269,8 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 		}
 		cfg := LoggingConfig{
 			Provider: fp,
-			Filter:   f,
+			Filter:   v.Filter,
+			Disabled: v.Disabled,
 		}
 
 		al := telemetryAccessLog(push, fp)
@@ -492,7 +499,10 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 	// The above result is in a nested map to deduplicate responses. This loses ordering, so we convert to
 	// a list to retain stable naming
 	allKeys := sets.New[string]()
-	for k := range tml {
+	for k, v := range tml {
+		if v.Disabled {
+			continue
+		}
 		allKeys.Insert(k)
 	}
 	for k := range tmm {
@@ -513,7 +523,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 			metricsConfig: tmm[k],
 			AccessLogging: logging,
 			Metrics:       metrics,
-			LogsFilter:    tml[p.Name],
+			LogsFilter:    tml[p.Name].Filter,
 			NodeType:      proxy.Type,
 		}
 		m = append(m, cfg)
@@ -535,18 +545,18 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 
 // mergeLogs returns the set of providers for the given logging configuration.
 // The provider names are mapped to any applicable access logging filter that has been applied in provider configuration.
-func mergeLogs(logs []*computedAccessLogging, mesh *meshconfig.MeshConfig, mode tpb.WorkloadMode) map[string]*tpb.AccessLogging_Filter {
-	providers := map[string]*tpb.AccessLogging_Filter{}
+func mergeLogs(logs []*computedAccessLogging, mesh *meshconfig.MeshConfig, mode tpb.WorkloadMode) map[string]loggingSpec {
+	providers := map[string]loggingSpec{}
 
 	if len(logs) == 0 {
 		for _, dp := range mesh.GetDefaultProviders().GetAccessLogging() {
 			// Insert the default provider.
-			providers[dp] = nil
+			providers[dp] = loggingSpec{}
 		}
 		return providers
 	}
 	providerNames := mesh.GetDefaultProviders().GetAccessLogging()
-	filters := map[string]*tpb.AccessLogging_Filter{}
+	filters := map[string]loggingSpec{}
 	for _, m := range logs {
 		names := sets.New[string]()
 		for _, p := range m.Logging {
@@ -557,7 +567,9 @@ func mergeLogs(logs []*computedAccessLogging, mesh *meshconfig.MeshConfig, mode 
 			names.InsertAll(subProviders...)
 
 			for _, prov := range subProviders {
-				filters[prov] = p.Filter
+				filters[prov] = loggingSpec{
+					Filter: p.Filter,
+				}
 			}
 		}
 
@@ -588,7 +600,7 @@ func mergeLogs(logs []*computedAccessLogging, mesh *meshconfig.MeshConfig, mode 
 
 				// see UT: server - multi filters disabled
 				if m.GetDisabled().GetValue() {
-					delete(providers, provider)
+					providers[provider] = loggingSpec{Disabled: true}
 					continue
 				}
 

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -666,6 +666,9 @@ func TestAccessLogging(t *testing.T) {
 			if cfgs != nil {
 				got = []string{}
 				for _, p := range cfgs {
+					if p.Disabled {
+						continue
+					}
 					got = append(got, p.Provider.Name)
 				}
 				sort.Strings(got)

--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -105,6 +105,9 @@ func (b *AccessLogBuilder) setTCPAccessLog(push *model.PushContext, proxy *model
 func buildAccessLogFromTelemetry(cfgs []model.LoggingConfig, forListener bool) []*accesslog.AccessLog {
 	als := make([]*accesslog.AccessLog, 0, len(cfgs))
 	for _, c := range cfgs {
+		if c.Disabled {
+			continue
+		}
 		filters := make([]*accesslog.AccessLogFilter, 0, 2)
 		if forListener {
 			filters = append(filters, addAccessLogFilter())

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
@@ -302,6 +303,30 @@ func newTestEnviroment() *model.Environment {
 			},
 		},
 	})
+	configStore.Create(config.Config{
+		Meta: config.Meta{
+			Name:             "test-disable-accesslog",
+			Namespace:        "default",
+			GroupVersionKind: gvk.Telemetry,
+		},
+		Spec: &tpb.Telemetry{
+			Selector: &v1beta1.WorkloadSelector{
+				MatchLabels: map[string]string{
+					"app": "test-disable-accesslog",
+				},
+			},
+			AccessLogging: []*tpb.AccessLogging{
+				{
+					Providers: []*tpb.ProviderRef{
+						{
+							Name: "envoy",
+						},
+					},
+					Disabled: wrapperspb.Bool(true),
+				},
+			},
+		},
+	})
 
 	env := model.NewEnvironment()
 	env.ServiceDiscovery = serviceDiscovery
@@ -413,6 +438,18 @@ func TestSetTCPAccessLog(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "disable-accesslog",
+			push: env.PushContext,
+			proxy: &model.Proxy{
+				ConfigNamespace: "default",
+				Labels:          map[string]string{"app": "test-disable-accesslog"},
+				Metadata:        &model.NodeMetadata{Labels: map[string]string{"app": "test-disable-accesslog"}},
+			},
+			tcp:      &tcp.TcpProxy{},
+			class:    networking.ListenerClassSidecarInbound,
+			expected: &tcp.TcpProxy{},
+		},
 	}
 
 	for _, tc := range cases {
@@ -492,6 +529,18 @@ func TestSetHttpAccessLog(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "disable-accesslog",
+			push: env.PushContext,
+			proxy: &model.Proxy{
+				ConfigNamespace: "default",
+				Labels:          map[string]string{"app": "test-disable-accesslog"},
+				Metadata:        &model.NodeMetadata{Labels: map[string]string{"app": "test-disable-accesslog"}},
+			},
+			hcm:      &hcm.HttpConnectionManager{},
+			class:    networking.ListenerClassSidecarInbound,
+			expected: &hcm.HttpConnectionManager{},
 		},
 	}
 
@@ -587,6 +636,18 @@ func TestSetListenerAccessLog(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "disable-accesslog",
+			push: env.PushContext,
+			proxy: &model.Proxy{
+				ConfigNamespace: "default",
+				Labels:          map[string]string{"app": "test-disable-accesslog"},
+				Metadata:        &model.NodeMetadata{Labels: map[string]string{"app": "test-disable-accesslog"}},
+			},
+			listener: &listener.Listener{},
+			class:    networking.ListenerClassSidecarInbound,
+			expected: &listener.Listener{},
 		},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix a bug introduced in #43372

This configuration did not take effect.

```yaml
accessLogging:
- disabled: true
  providers:
  - name: envoy
```