### PR TITLE
rbac: honor useAuthenticated

### DIFF
--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -258,7 +258,7 @@ func (r rule) principal(forTCP bool, useAuthenticated bool, action rbacpb.RBAC_A
 	var principals []*rbacpb.Principal
 	var or []*rbacpb.Principal
 	for _, value := range r.values {
-		p, err := r.g.principal(r.key, value, forTCP, false)
+		p, err := r.g.principal(r.key, value, forTCP, useAuthenticated)
 		if err := r.checkError(action, err); err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -15,12 +15,13 @@
 package model
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
-
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	authzpb "istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -278,6 +279,148 @@ when:
 				if strings.Contains(gotYaml, notWant) {
 					t.Errorf("got:\n%s but not want %s", gotYaml, notWant)
 				}
+			}
+		})
+	}
+}
+
+func TestRule_Principal(t *testing.T) {
+	tests := []struct {
+		name             string
+		r                rule
+		forTCP           bool
+		useAuthenticated bool
+		action           rbacpb.RBAC_Action
+		want             []*rbacpb.Principal
+	}{
+		{
+			name: "useAuthenticated:true",
+			r: rule{
+				key:       "foo",
+				values:    []string{"value"},
+				notValues: []string{"notValue"},
+				g:         srcPrincipalGenerator{},
+			},
+			forTCP:           true,
+			useAuthenticated: true,
+			action:           rbacpb.RBAC_ALLOW,
+			want: []*rbacpb.Principal{
+				{
+					Identifier: &rbacpb.Principal_OrIds{
+						OrIds: &rbacpb.Principal_Set{
+							Ids: []*rbacpb.Principal{
+								{
+									Identifier: &rbacpb.Principal_Authenticated_{
+										Authenticated: &rbacpb.Principal_Authenticated{
+											PrincipalName: &matcherv3.StringMatcher{
+												MatchPattern: &matcherv3.StringMatcher_Exact{
+													Exact: "spiffe://value",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Identifier: &rbacpb.Principal_NotId{
+						NotId: &rbacpb.Principal{
+							Identifier: &rbacpb.Principal_OrIds{
+								OrIds: &rbacpb.Principal_Set{
+									Ids: []*rbacpb.Principal{
+										{
+											Identifier: &rbacpb.Principal_Authenticated_{
+												Authenticated: &rbacpb.Principal_Authenticated{
+													PrincipalName: &matcherv3.StringMatcher{
+														MatchPattern: &matcherv3.StringMatcher_Exact{
+															Exact: "spiffe://notValue",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "useAuthenticated:false",
+			r: rule{
+				key:       "foo",
+				values:    []string{"value"},
+				notValues: []string{"notValue"},
+				g:         srcNamespaceGenerator{},
+			},
+			forTCP:           false,
+			useAuthenticated: false,
+			action:           rbacpb.RBAC_ALLOW,
+			want: []*rbacpb.Principal{
+				{
+					Identifier: &rbacpb.Principal_OrIds{
+						OrIds: &rbacpb.Principal_Set{
+							Ids: []*rbacpb.Principal{
+								{
+									Identifier: &rbacpb.Principal_FilterState{
+										FilterState: &matcherv3.FilterStateMatcher{
+											Key: "io.istio.peer_principal",
+											Matcher: &matcherv3.FilterStateMatcher_StringMatch{
+												StringMatch: &matcherv3.StringMatcher{
+													MatchPattern: &matcherv3.StringMatcher_SafeRegex{
+														SafeRegex: &matcherv3.RegexMatcher{
+															Regex: ".*/ns/value/.*",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Identifier: &rbacpb.Principal_NotId{
+						NotId: &rbacpb.Principal{
+							Identifier: &rbacpb.Principal_OrIds{
+								OrIds: &rbacpb.Principal_Set{
+									Ids: []*rbacpb.Principal{
+										{
+											Identifier: &rbacpb.Principal_FilterState{
+												FilterState: &matcherv3.FilterStateMatcher{
+													Key: "io.istio.peer_principal",
+													Matcher: &matcherv3.FilterStateMatcher_StringMatch{
+														StringMatch: &matcherv3.StringMatcher{
+															MatchPattern: &matcherv3.StringMatcher_SafeRegex{
+																SafeRegex: &matcherv3.RegexMatcher{
+																	Regex: ".*/ns/notValue/.*",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := tt.r.principal(tt.forTCP, tt.useAuthenticated, tt.action)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("rule.principal got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/releasenotes/notes/invalid-rbac-filter.yaml
+++ b/releasenotes/notes/invalid-rbac-filter.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - https://github.com/istio/istio/issues/43785
+releaseNotes:
+  - |
+    **Fixed** an issue where old proxies cannot get RBAC updates after upgrading istiod to 1.17.


### PR DESCRIPTION
**Please provide a description of this PR:**
Sending `Principal_FilterState` to old proxies will cause NACKs, which is dangerous since proxies cannot get rbac updates 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
