### PR TITLE
Manually update latest client-go and api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,8 +88,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.11.1
-	istio.io/api v0.0.0-20230306190845-6bbcb3e795fa
-	istio.io/client-go v1.18.0-alpha.0.0.20230306195646-17225abb7f8c
+	istio.io/api v0.0.0-20230306191145-5e59387fbd49
+	istio.io/client-go v1.18.0-alpha.0.0.20230307014051-0cfc02bec78c
 	istio.io/pkg v0.0.0-20230302202707-0023da60c4c9
 	k8s.io/api v0.26.1
 	k8s.io/apiextensions-apiserver v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -1419,10 +1419,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20230306190845-6bbcb3e795fa h1:EJmiK50Ikf9OXJjTe+26Hp/+vjGn/Hpv/VVmmhTMdUs=
-istio.io/api v0.0.0-20230306190845-6bbcb3e795fa/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
-istio.io/client-go v1.18.0-alpha.0.0.20230306195646-17225abb7f8c h1:a3U0J0Mz48kowck4Ru9vWU4LQ/Gt8qG2/zp4erurhQE=
-istio.io/client-go v1.18.0-alpha.0.0.20230306195646-17225abb7f8c/go.mod h1:sOvpGUrkIvfmDVWau5jK9bC0bXrQFpWF5YBQMulCkCA=
+istio.io/api v0.0.0-20230306191145-5e59387fbd49 h1:JJGkcRk1xBrvP0U9hmbKEek+JT8QUtpBwxkLvRA7K7k=
+istio.io/api v0.0.0-20230306191145-5e59387fbd49/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
+istio.io/client-go v1.18.0-alpha.0.0.20230307014051-0cfc02bec78c h1:parjwNO9Lw2VRXtUTHPbSVH7pAybvYN7nLbBdgBACWw=
+istio.io/client-go v1.18.0-alpha.0.0.20230307014051-0cfc02bec78c/go.mod h1:LHfMFOAZk/eNkkeZgBMs5OS9TWb6iFP2yI1cWsOxZT0=
 istio.io/pkg v0.0.0-20230302202707-0023da60c4c9 h1:Sev/MB9yFBXS6GpN6xu5Jy0J+DsuXMkFO6cLYSPcxdM=
 istio.io/pkg v0.0.0-20230302202707-0023da60c4c9/go.mod h1:Zg0jJwKNfGnlcyk6A30vXI5O+HkHN+VQoEX2T3QOK/s=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
**Please provide a description of this PR:**

The pipeline is having some issues, it seem with doing `go get`s with a full commit sha. Need to watch and see if that's a continuing issue (may move to the shortened sha if it is since that seems to still work). In the mean time, here is a manual update for the failing pipeline job. 