### PR TITLE
Break system namespace and ingressgateway assumptions 

### DIFF
--- a/pkg/test/framework/components/istio/cleanup.go
+++ b/pkg/test/framework/components/istio/cleanup.go
@@ -84,15 +84,15 @@ func (i *istioImpl) Dump(ctx resource.Context) {
 	for _, c := range ctx.Clusters().Kube().Primaries() {
 		c := c
 		g.Go(func() error {
-			kube2.DumpDebug(ctx, c, d, "configz")
+			kube2.DumpDebug(ctx, c, d, "configz", ns)
 			return nil
 		})
 		g.Go(func() error {
-			kube2.DumpDebug(ctx, c, d, "mcsz")
+			kube2.DumpDebug(ctx, c, d, "mcsz", ns)
 			return nil
 		})
 		g.Go(func() error {
-			kube2.DumpDebug(ctx, c, d, "clusterz")
+			kube2.DumpDebug(ctx, c, d, "clusterz", ns)
 			return nil
 		})
 	}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -159,6 +159,10 @@ type Config struct {
 
 	// Custom deploymeny for east-west gateway
 	EastWestGatewayValues string
+
+	// IngressGatewayServiceName is the service name to use to reference the ingressgateway
+	// This field should only be set when DeployIstio is false
+	IngressGatewayServiceName string
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {
@@ -327,6 +331,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("IstiodlessRemotes:              %v\n", c.IstiodlessRemotes)
 	result += fmt.Sprintf("OperatorOptions:                %v\n", c.OperatorOptions)
 	result += fmt.Sprintf("EnableCNI:                      %v\n", c.EnableCNI)
+	result += fmt.Sprintf("IngressGatewayServiceName:      %v\n", c.IngressGatewayServiceName)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -41,7 +41,8 @@ func init() {
 		e.g. components.cni.enabled=true,components.cni.namespace=kube-system`)
 	flag.BoolVar(&settingsFromCommandline.EnableCNI, "istio.test.istio.enableCNI", settingsFromCommandline.EnableCNI,
 		"Deploy Istio with CNI enabled.")
-	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceName, "istio.test.kube.ingressgatewayServiceName", settingsFromCommandline.IngressGatewayServiceName,
+	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceName, "istio.test.kube.ingressgatewayServiceName",
+		settingsFromCommandline.IngressGatewayServiceName,
 		`Specifies the name of the ingressgateway service to use when running tests in a preinstalled istio installation.
 		Should only be set when istio.test.kube.deploy=false`)
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -41,7 +41,7 @@ func init() {
 		e.g. components.cni.enabled=true,components.cni.namespace=kube-system`)
 	flag.BoolVar(&settingsFromCommandline.EnableCNI, "istio.test.istio.enableCNI", settingsFromCommandline.EnableCNI,
 		"Deploy Istio with CNI enabled.")
-	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceName, "istio.test.kube.ingressgatewayServiceName",
+	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceName, "istio.test.kube.ingressGatewayServiceName",
 		settingsFromCommandline.IngressGatewayServiceName,
 		`Specifies the name of the ingressgateway service to use when running tests in a preinstalled istio installation.
 		Should only be set when istio.test.kube.deploy=false`)

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -21,7 +21,7 @@ import (
 // init registers the command-line flags that we can exposed for "go test".
 func init() {
 	flag.StringVar(&settingsFromCommandline.SystemNamespace, "istio.test.kube.systemNamespace", settingsFromCommandline.SystemNamespace,
-		"Deprecated, specifies the namespace where the Istio components (<=1.1) reside in a typical deployment.")
+		"Specifies the namespace where the istiod resides in a typical deployment. Defaults to istio-system")
 	flag.StringVar(&settingsFromCommandline.TelemetryNamespace, "istio.test.kube.telemetryNamespace", settingsFromCommandline.TelemetryNamespace,
 		"Specifies the namespace in which kiali, tracing providers, graphana, prometheus are deployed.")
 	flag.BoolVar(&settingsFromCommandline.DeployIstio, "istio.test.kube.deploy", settingsFromCommandline.DeployIstio,

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -41,4 +41,7 @@ func init() {
 		e.g. components.cni.enabled=true,components.cni.namespace=kube-system`)
 	flag.BoolVar(&settingsFromCommandline.EnableCNI, "istio.test.istio.enableCNI", settingsFromCommandline.EnableCNI,
 		"Deploy Istio with CNI enabled.")
+	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceName, "istio.test.kube.ingressgatewayServiceName", settingsFromCommandline.IngressGatewayServiceName,
+		`Specifies the name of the ingressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
 }

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -126,7 +126,11 @@ func (i *istioImpl) Ingresses() ingress.Instances {
 }
 
 func (i *istioImpl) IngressFor(c cluster.Cluster) ingress.Instance {
-	name := types.NamespacedName{Name: defaultIngressServiceName, Namespace: i.cfg.SystemNamespace}
+	ingressServiceName := defaultIngressServiceName
+	if serviceNameOverride := i.cfg.IngressGatewayServiceName; serviceNameOverride != "" {
+		ingressServiceName = serviceNameOverride
+	}
+	name := types.NamespacedName{Name: ingressServiceName, Namespace: i.cfg.SystemNamespace}
 	return i.CustomIngressFor(c, name, defaultIngressIstioLabel)
 }
 

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -587,7 +587,7 @@ func checkIfVM(pod corev1.Pod) bool {
 	return false
 }
 
-func DumpDebug(ctx resource.Context, c cluster.Cluster, workDir string, endpoint string) {
+func DumpDebug(ctx resource.Context, c cluster.Cluster, workDir, endpoint, namespace string) {
 	ik, err := istioctl.New(ctx, istioctl.Config{Cluster: c})
 	if err != nil {
 		scopes.Framework.Warnf("failed dumping %s (cluster %s): %v", endpoint, c.Name(), err)
@@ -596,6 +596,9 @@ func DumpDebug(ctx resource.Context, c cluster.Cluster, workDir string, endpoint
 	args := []string{"x", "internal-debug", "--all", endpoint}
 	if ctx.Settings().Revisions.Default() != "" {
 		args = append(args, "--revision", ctx.Settings().Revisions.Default())
+	}
+	if namespace != "" && namespace != "istio-system" {
+		args = append(args, "--istioNamespace", namespace)
 	}
 	scopes.Framework.Debugf("dump %s (cluster %s): %v", endpoint, c.Name(), args)
 	stdout, _, err := ik.Invoke(args)

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -285,7 +285,8 @@ func ValidatingWebhookConfigurationsExists(a kubernetes.Interface, names []strin
 		return false
 	}
 
-	if len(cfgs.Items) != len(names) {
+	// Target cluster could have other validating webhook configurations
+	if len(cfgs.Items) < len(names) {
 		return false
 	}
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1024,7 +1024,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: cross-network-gateway-test
-  namespace: istio-system
+  namespace: {{.SystemNamespace}}
 spec:
   selector:
     istio: ingressgateway
@@ -1039,6 +1039,15 @@ spec:
         - "*.local"
 `,
 			children: childs,
+			templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
+				systemNamespace := "istio-system"
+				if t.Istio.Settings().SystemNamespace != "" {
+					systemNamespace = t.Istio.Settings().SystemNamespace
+				}
+				return map[string]any{
+					"SystemNamespace": systemNamespace,
+				}
+			},
 		})
 	}
 }
@@ -1159,7 +1168,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-redirect-config
-  namespace: istio-system
+  namespace: {{.SystemNamespace}}
 spec:
   configPatches:
   - applyTo: NETWORK_FILTER
@@ -1195,10 +1204,15 @@ spec:
 		setupOpts: fqdnHostHeader,
 		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               dest.PortForName(ports.HTTP.Name).ServicePort,
+				"SystemNamespace":    systemNamespace,
 			}
 		},
 	})
@@ -1290,7 +1304,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-redirect-config
-  namespace: istio-system
+  namespace: {{.SystemNamespace}}
 spec:
   configPatches:
   - applyTo: NETWORK_FILTER
@@ -1325,11 +1339,16 @@ spec:
 		},
 		setupOpts: fqdnHostHeader,
 		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			dest := dests[0]
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               443,
+				"SystemNamespace":    systemNamespace,
 			}
 		},
 	})
@@ -1414,10 +1433,15 @@ spec:
 		setupOpts: fqdnHostHeader,
 		templateVars: func(_ echo.Callers, dests echo.Instances) map[string]any {
 			dest := dests[0]
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Gateway":            "gateway",
 				"VirtualServiceHost": dest.Config().ClusterLocalFQDN(),
 				"Port":               dest.PortForName(ports.AutoHTTP.Name).ServicePort,
+				"SystemNamespace":    systemNamespace,
 			}
 		},
 	})
@@ -3200,7 +3224,7 @@ apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: default
-  namespace: istio-system
+  namespace: {{.SystemNamespace}}
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
@@ -3250,8 +3274,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"X-Jwt-Nested-Key", "exact", "valueC"}},
+				"Headers":         []configData{{"X-Jwt-Nested-Key", "exact", "valueC"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3273,11 +3302,16 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Headers": []configData{
 					{"X-Jwt-Nested-Key", "exact", "valueC"},
 					{"X-Jwt-Iss", "exact", "test-issuer-1@istio.io"},
 				},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3299,8 +3333,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"x-jwt-wrong-header", "exact", "header_to_be_deleted"}},
+				"Headers":         []configData{{"x-jwt-wrong-header", "exact", "header_to_be_deleted"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3322,8 +3361,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"Headers":         []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3345,8 +3389,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.sub", "prefix", "sub"}},
+				"Headers":         []configData{{"@request.auth.claims.sub", "prefix", "sub"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3368,11 +3417,16 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Headers": []configData{
 					{"@request.auth.claims.sub", "regex", "(\\W|^)(sub-1|sub-2)(\\W|$)"},
 					{"@request.auth.claims.nested.key1", "regex", "(\\W|^)value[AB](\\W|$)"},
 				},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3394,11 +3448,16 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Headers": []configData{
 					{"@request.auth.claims.nested.key1", "exact", "valueA"},
 					{"@request.auth.claims.sub", "prefix", "sub"},
 				},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3420,8 +3479,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"WithoutHeaders": []configData{{"@request.auth.claims.nested.key1", "exact", "value-not-matched"}},
+				"WithoutHeaders":  []configData{{"@request.auth.claims.nested.key1", "exact", "value-not-matched"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3443,8 +3507,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"WithoutHeaders": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"WithoutHeaders":  []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3466,12 +3535,17 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Headers": []configData{{"@request.auth.claims.sub", "prefix", "sub"}},
 				"WithoutHeaders": []configData{
 					{"@request.auth.claims.nested.key1", "exact", "value-not-matched"},
 					{"@request.auth.claims.nested.key1", "regex", "(\\W|^)value\\s{0,3}not{0,1}\\s{0,3}matched(\\W|$)"},
 				},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3493,11 +3567,16 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
 				"Headers": []configData{
 					{"@request.auth.claims.nested.key1", "exact", "valueA"},
 					{"@request.auth.claims.sub", "prefix", "value-not-matched"},
 				},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3519,8 +3598,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.sub", "exact", "value-not-matched"}},
+				"Headers":         []configData{{"@request.auth.claims.sub", "exact", "value-not-matched"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3542,8 +3626,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"Headers":         []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3565,8 +3654,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"Headers":         []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3588,8 +3682,13 @@ spec:
 		viaIngress:       true,
 		config:           configAll,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"Headers":         []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{
@@ -3612,8 +3711,13 @@ spec:
 		viaIngress:       true,
 		config:           configRoute,
 		templateVars: func(src echo.Callers, dest echo.Instances) map[string]any {
+			systemNamespace := "istio-system"
+			if t.Istio.Settings().SystemNamespace != "" {
+				systemNamespace = t.Istio.Settings().SystemNamespace
+			}
 			return map[string]any{
-				"Headers": []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"Headers":         []configData{{"@request.auth.claims.nested.key1", "exact", "valueA"}},
+				"SystemNamespace": systemNamespace,
 			}
 		},
 		opts: echo.CallOptions{

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1024,7 +1024,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: cross-network-gateway-test
-  namespace: {{.SystemNamespace}}
+  namespace: {{.SystemNamespace | default "istio-system"}}
 spec:
   selector:
     istio: ingressgateway
@@ -1168,7 +1168,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-redirect-config
-  namespace: {{.SystemNamespace}}
+  namespace: {{.SystemNamespace | default "istio-system"}}
 spec:
   configPatches:
   - applyTo: NETWORK_FILTER
@@ -1304,7 +1304,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-redirect-config
-  namespace: {{.SystemNamespace}}
+  namespace: {{.SystemNamespace | default "istio-system"}}
 spec:
   configPatches:
   - applyTo: NETWORK_FILTER
@@ -3224,7 +3224,7 @@ apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: default
-  namespace: {{.SystemNamespace}}
+  namespace: {{.SystemNamespace | default "istio-system"}}
 spec:
   jwtRules:
   - issuer: "test-issuer-1@istio.io"

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -208,9 +208,16 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 				t.SkipNow()
 			}
 		}
+		// we only apply to config clusters
 		if len(c.config) > 0 {
-			cfg := yml.MustApplyNamespace(t, c.config, namespace)
-			// we only apply to config clusters
+			tmplData := map[string]any{}
+			if c.templateVars != nil {
+				// we don't have echo instances so just pass nil
+				for k, v := range c.templateVars(nil, nil) {
+					tmplData[k] = v
+				}
+			}
+			cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(c.config, tmplData), namespace)
 			t.ConfigIstio().YAML("", cfg).ApplyOrFail(t, apply.CleanupConditionally)
 		}
 

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -61,6 +61,7 @@ func TestGateway(t *testing.T) {
 				false, t.Clusters().Configs()...)
 			ingressutil.CreateIngressKubeSecret(t, "test-gateway-cert-cross", ingressutil.TLS, ingressutil.IngressCredentialB,
 				false, t.Clusters().Configs()...)
+				
 
 			retry.UntilSuccessOrFail(t, func() error {
 				err := t.ConfigIstio().YAML("", fmt.Sprintf(`

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -61,7 +61,6 @@ func TestGateway(t *testing.T) {
 				false, t.Clusters().Configs()...)
 			ingressutil.CreateIngressKubeSecret(t, "test-gateway-cert-cross", ingressutil.TLS, ingressutil.IngressCredentialB,
 				false, t.Clusters().Configs()...)
-				
 
 			retry.UntilSuccessOrFail(t, func() error {
 				err := t.ConfigIstio().YAML("", fmt.Sprintf(`


### PR DESCRIPTION
**Please provide a description of this PR:**
Several integration tests assume that the system namespace is istio-system and that the ingress gateway service name is istio-ingressgateway. Since the integration tests suite can run on pre-existing istio installs (via the kube.deploy flag), the tests should also allow for customizing these fields for a test run.

Part of #43717 