### PR TITLE
pkg/queue: add HasSynced

### DIFF
--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -83,7 +83,7 @@ func (q *pq) Peek() any {
 
 // Delayed implements queue such that tasks are executed after a specified delay.
 type Delayed interface {
-	Instance
+	baseInstance
 	PushDelayed(t Task, delay time.Duration)
 }
 

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -97,7 +97,7 @@ func (q *queueImpl) get() (task Task, shutdown bool) {
 		q.cond.Wait()
 	}
 
-	if q.closing && len(q.tasks) == 0 {
+	if q.closing {
 		// We must be shutting down.
 		return nil, true
 	}

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -21,6 +21,9 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 func BenchmarkQueue(b *testing.B) {
@@ -164,4 +167,23 @@ func TestClosed(t *testing.T) {
 			t.Error("task ran on closed queue")
 		}
 	})
+}
+
+func TestSync(t *testing.T) {
+	handles := atomic.NewInt32(0)
+	task := func() error {
+		handles.Inc()
+		return nil
+	}
+	q := NewQueue(0)
+	q.Push(task)
+	stop := make(chan struct{})
+	go q.Run(stop)
+	retry.UntilOrFail(t, q.HasSynced, retry.Delay(time.Microsecond))
+	assert.Equal(t, handles.Load(), 1)
+	q.Push(task)
+	close(stop)
+	assert.NoError(t, WaitForClose(q, time.Second))
+	// event 2 is guaranteed to happen from WaitForClose
+	assert.Equal(t, handles.Load(), 2)
 }

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -180,10 +180,8 @@ func TestSync(t *testing.T) {
 	stop := make(chan struct{})
 	go q.Run(stop)
 	retry.UntilOrFail(t, q.HasSynced, retry.Delay(time.Microsecond))
+	// Must always be 1 since we are synced
 	assert.Equal(t, handles.Load(), 1)
-	q.Push(task)
 	close(stop)
 	assert.NoError(t, WaitForClose(q, time.Second))
-	// event 2 is guaranteed to happen from WaitForClose
-	assert.Equal(t, handles.Load(), 2)
 }


### PR DESCRIPTION
Split out of https://github.com/istio/istio/pull/43725. This mirrors the queue in controllers package. HasSynced allows a safe mechanism to do a full synco f a controller (see
https://github.com/istio/istio/blob/821a703e4d0f954d363a13297f00debe75bbe778/pkg/kube/controllers/example_test.go#L107 for details).

**Please provide a description of this PR:**