### PR TITLE
fix disabled tracing using "enableTracing: false"

### DIFF
--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -35,7 +35,7 @@ type ProxyConfigs struct {
 
 // EffectiveProxyConfig generates the correct merged ProxyConfig for a given ProxyConfigTarget.
 func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.MeshConfig) *meshconfig.ProxyConfig {
-	if p == nil || meta == nil {
+	if p == nil || meta == nil || mc == nil {
 		return nil
 	}
 

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -63,6 +63,12 @@ func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.M
 		}
 	}
 	effectiveProxyConfig = mergeWithPrecedence(workloadConfig, effectiveProxyConfig)
+	if !mc.EnableTracing {
+		// For sidecar, the proxyConfig needs to override the default implicit configuration explicitly
+		// therefore, if the user turns off tracing, we need to set the tracing configuration to empty
+		// in order to prevent sidecar to do unnecessary dns resolution for the default tracing server (zipkin server)
+		effectiveProxyConfig.Tracing = &meshconfig.Tracing{}
+	}
 
 	return effectiveProxyConfig
 }

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -64,7 +64,7 @@ func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.M
 	}
 	effectiveProxyConfig = mergeWithPrecedence(workloadConfig, effectiveProxyConfig)
 	if !mc.EnableTracing {
-		// For sidecar, the proxyConfig needs to override the default implicit configuration explicitly
+		// For sidecar, proxyConfig needs to be declared  explicitly to override the default implicit configuration.
 		// therefore, if the user turns off tracing, we need to set the tracing configuration to empty
 		// in order to prevent sidecar to do unnecessary dns resolution for the default tracing server (zipkin server)
 		effectiveProxyConfig.Tracing = &meshconfig.Tracing{}

--- a/pilot/pkg/model/proxy_config.go
+++ b/pilot/pkg/model/proxy_config.go
@@ -35,7 +35,7 @@ type ProxyConfigs struct {
 
 // EffectiveProxyConfig generates the correct merged ProxyConfig for a given ProxyConfigTarget.
 func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.MeshConfig) *meshconfig.ProxyConfig {
-	if p == nil || meta == nil || mc == nil {
+	if p == nil || meta == nil {
 		return nil
 	}
 
@@ -63,7 +63,7 @@ func (p *ProxyConfigs) EffectiveProxyConfig(meta *NodeMetadata, mc *meshconfig.M
 		}
 	}
 	effectiveProxyConfig = mergeWithPrecedence(workloadConfig, effectiveProxyConfig)
-	if !mc.EnableTracing {
+	if !mc.GetEnableTracing() {
 		// For sidecar, proxyConfig needs to be declared  explicitly to override the default implicit configuration.
 		// therefore, if the user turns off tracing, we need to set the tracing configuration to empty
 		// in order to prevent sidecar to do unnecessary dns resolution for the default tracing server (zipkin server)


### PR DESCRIPTION
xref: #43253 #31658

For sidecar, proxyConfig needs to be declared  explicitly to override the default implicit configuration。
therefore, if the user turns off tracing, we need to set the tracing configuration to empty  in order to prevent sidecar to do unnecessary dns resolution for the default tracing server (zipkin server)



- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure