### PR TITLE
refactor mesh tls settings

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1116,7 +1116,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			}
 		}
 
-		ApplyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
+		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
 
 		if cb.isHttp2Cluster(c) {
 			// This is HTTP/2 cluster, advertise it with ALPN.
@@ -1171,7 +1171,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			}
 		}
 
-		ApplyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
+		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
 
 		if cb.isHttp2Cluster(c) {
 			// This is HTTP/2 cluster, advertise it with ALPN.
@@ -1181,8 +1181,8 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 	return tlsContext, nil
 }
 
-// ApplyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
-func ApplyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconfig.MeshConfig_TLSConfig) {
+// applyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
+func applyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconfig.MeshConfig_TLSConfig) {
 	if tlsDefaults == nil {
 		return
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1115,8 +1115,8 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				}
 			}
 		}
-		// Apply ECDH Curves from MeshConfig
-		ApplyECDHCurves(tlsContext, opts.mesh)
+
+		ApplyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
 
 		if cb.isHttp2Cluster(c) {
 			// This is HTTP/2 cluster, advertise it with ALPN.
@@ -1171,8 +1171,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			}
 		}
 
-		// Apply ECDH Curves from MeshConfig
-		ApplyECDHCurves(tlsContext, opts.mesh)
+		ApplyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
 
 		if cb.isHttp2Cluster(c) {
 			// This is HTTP/2 cluster, advertise it with ALPN.
@@ -1182,11 +1181,13 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 	return tlsContext, nil
 }
 
-// ApplyECDHCurves applies the ECDH curves from mesh config to UpstreamTlsContext
-// Used for building upstream TLS context for mesh external TLS/mTLS origination
-func ApplyECDHCurves(tlsContext *auth.UpstreamTlsContext, mesh *meshconfig.MeshConfig) {
-	if mesh != nil && mesh.TlsDefaults != nil && len(mesh.TlsDefaults.EcdhCurves) > 0 {
-		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = mesh.TlsDefaults.EcdhCurves
+// ApplyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
+func ApplyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconfig.MeshConfig_TLSConfig) {
+	if tlsDefaults == nil {
+		return
+	}
+	if len(tlsDefaults.EcdhCurves) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsDefaults.EcdhCurves
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -196,12 +196,12 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 		if len(mesh.TlsDefaults.EcdhCurves) > 0 {
 			tlsParamsOrNew(ctx.CommonTlsContext).EcdhCurves = mesh.TlsDefaults.EcdhCurves
 		}
-		// Set the minimum TLS version from server settings or mesh config.
-		if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
-			tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
-		} else if mesh.TlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
+		if mesh.TlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
 			tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = auth.TlsParameters_TlsProtocol(mesh.TlsDefaults.MinProtocolVersion)
 		}
+	}
+	if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
+		tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
 	}
 	if len(serverTLSSettings.CipherSuites) > 0 {
 		tlsParamsOrNew(ctx.CommonTlsContext).CipherSuites = serverTLSSettings.CipherSuites

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -191,15 +191,15 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 		}
 	}
 
-	// If Mesh TLSDefaults are set, use them.
-	if mesh.GetTlsDefaults() != nil && isSimpleOrMutual(serverTLSSettings.Mode) {
-		applyDownstreamTLSDefaults(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
-	}
+	applyDownstreamTLSDefaults(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
 	applyServerTLSSettings(serverTLSSettings, ctx.CommonTlsContext)
 	return ctx
 }
 
 func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ctx *auth.CommonTlsContext) {
+	if tlsDefaults == nil {
+		return
+	}
 	if len(tlsDefaults.EcdhCurves) > 0 {
 		tlsParamsOrNew(ctx).EcdhCurves = tlsDefaults.EcdhCurves
 	}
@@ -209,6 +209,9 @@ func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ct
 }
 
 func applyServerTLSSettings(serverTLSSettings *networking.ServerTLSSettings, ctx *auth.CommonTlsContext) {
+	if !isSimpleOrMutual(serverTLSSettings.Mode) {
+		return
+	}
 	if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
 		tlsParamsOrNew(ctx).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -197,8 +197,9 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 			tlsParamsOrNew(ctx.CommonTlsContext).EcdhCurves = mesh.TlsDefaults.EcdhCurves
 		}
 		// Set the minimum TLS version if server settings does not have but mesh config has.
-		if serverTLSSettings.MinProtocolVersion == networking.ServerTLSSettings_TLS_AUTO &&
-			mesh.TlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
+		if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
+			tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
+		} else if mesh.TlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
 			tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = auth.TlsParameters_TlsProtocol(mesh.TlsDefaults.MinProtocolVersion)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -191,8 +191,11 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 		}
 	}
 
-	applyDownstreamTLSDefaults(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
-	applyServerTLSSettings(serverTLSSettings, ctx.CommonTlsContext)
+	if isSimpleOrMutual(serverTLSSettings.Mode) {
+		// If Mesh TLSDefaults are set, use them.
+		applyDownstreamTLSDefaults(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
+		applyServerTLSSettings(serverTLSSettings, ctx.CommonTlsContext)
+	}
 	return ctx
 }
 
@@ -200,6 +203,7 @@ func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ct
 	if tlsDefaults == nil {
 		return
 	}
+
 	if len(tlsDefaults.EcdhCurves) > 0 {
 		tlsParamsOrNew(ctx).EcdhCurves = tlsDefaults.EcdhCurves
 	}
@@ -209,9 +213,6 @@ func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ct
 }
 
 func applyServerTLSSettings(serverTLSSettings *networking.ServerTLSSettings, ctx *auth.CommonTlsContext) {
-	if !isSimpleOrMutual(serverTLSSettings.Mode) {
-		return
-	}
 	if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
 		tlsParamsOrNew(ctx).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -196,7 +196,7 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 		if len(mesh.TlsDefaults.EcdhCurves) > 0 {
 			tlsParamsOrNew(ctx.CommonTlsContext).EcdhCurves = mesh.TlsDefaults.EcdhCurves
 		}
-		// Set the minimum TLS version if server settings does not have but mesh config has.
+		// Set the minimum TLS version from server settings or mesh config.
 		if serverTLSSettings.MinProtocolVersion != networking.ServerTLSSettings_TLS_AUTO {
 			tlsParamsOrNew(ctx.CommonTlsContext).TlsMinimumProtocolVersion = convertTLSProtocol(serverTLSSettings.MinProtocolVersion)
 		} else if mesh.TlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -188,6 +188,9 @@ func (a *v1beta1PolicyApplier) InboundMTLSSettings(
 		mc = a.push.Mesh
 	}
 	// Configure TLS version based on meshconfig TLS API.
+	// This is used to configure TLS version for inbound filter chain of ISTIO MUTUAL cases.
+	// For MUTUAL and SIMPLE TLS modes specified via ServerTLSSettings in Sidecar or Gateway,
+	// TLS version is configured in the BuildListenerContext.
 	minTLSVersion := authn_utils.GetMinTLSVersion(mc.GetMeshMTLS().GetMinProtocolVersion())
 	return authn.MTLSSettings{
 		Port: endpointPort,


### PR DESCRIPTION
Refactor TLS Settings logic
- Rename methods to be generic
- Apply MinTLSVersion when TLSDefaults has value specified in Mesh config

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure