### PR TITLE
change the cert serial number output to hex

### DIFF
--- a/istioctl/pkg/writer/compare/sds/util.go
+++ b/istioctl/pkg/writer/compare/sds/util.go
@@ -223,7 +223,7 @@ func secretMetaFromCert(rawCert []byte) (SecretMeta, error) {
 	}
 
 	return SecretMeta{
-		SerialNumber: fmt.Sprintf("%d", cert.SerialNumber),
+		SerialNumber: fmt.Sprintf("%x", cert.SerialNumber),
 		NotAfter:     cert.NotAfter.Format(time.RFC3339),
 		NotBefore:    cert.NotBefore.Format(time.RFC3339),
 		Type:         certType,

--- a/releasenotes/notes/43765.yaml
+++ b/releasenotes/notes/43765.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 43765
+releaseNotes:
+  - |
+    **Improved** the `istioctl pc secret` output to include certificate serial number in HEX.

--- a/releasenotes/notes/43765.yaml
+++ b/releasenotes/notes/43765.yaml
@@ -5,4 +5,4 @@ issue:
   - 43765
 releaseNotes:
   - |
-    **Improved** the `istioctl pc secret` output to include certificate serial number in HEX.
+    **Improved** the `istioctl pc secret` output to display the certificate serial number in HEX.


### PR DESCRIPTION
**Please provide a description of this PR:**
Change the output of `istioctl pc secret` to show the cert serial number as hex, instead of a number. Ref: #43765 