### PR TITLE
Fix bug-report specifying temp directory not working

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -181,6 +181,9 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	common.LogAndPrintf("Creating an archive at %s.\n", outPath)
 
 	archiveDir := archive.DirToArchive(tempDir)
+	if tempDir != "" {
+		archiveDir = tempDir
+	}
 	if err := archive.Create(archiveDir, outPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/43835

The `archiveDir` directory is incorrect, with a value of `.`, if the `--dir` option is specified, which means that all files in the current directory will be included in the report. If I'm running a bug report in the Istio project, it will have an other error like:
```
Creating an archive at /root/workspace/istio/bug-report.tar.gz.
Error: archive/tar: write too long
```
Since the entire Istio project will be included as well. This bug fix is to set the temp dir to the right one when specifying the `--dir` flag.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
