### PR TITLE
Drop EndpointSlice test on 1.20

### DIFF
--- a/tests/integration/pilot/endpointsmode/endpointslice_test.go
+++ b/tests/integration/pilot/endpointsmode/endpointslice_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	// nolint: staticcheck
 	framework.
 		NewSuite(m).
-		RequireMinVersion(17).
+		RequireMinVersion(21).
 		Setup(istio.Setup(&i, func(t resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = fmt.Sprintf(`
 values:


### PR DESCRIPTION
We dropped support for this, endpointslice now requires 1.21

**Please provide a description of this PR:**