### PR TITLE
ServiceEntry IP allocation: Stable IP when used in multiple namespaces

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -890,7 +890,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 		// 3. the hostname is not a wildcard
 		if svc.DefaultAddress == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
 			svc.Resolution != model.Passthrough {
-			hash.Write([]byte(svc.Attributes.Namespace + "/" + svc.Hostname.String()))
+			hash.Write([]byte(makeServiceKey(svc)))
 			// First hash is calculated by
 			s := hash.Sum32()
 			firstHash := s % uint32(maxIPs)
@@ -933,7 +933,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 			}
 			continue
 		}
-		n := svc.Hostname.String()
+		n := makeServiceKey(svc)
 		if v, ok := hnMap[n]; ok {
 			log.Debugf("Reuse IP for domain %s", n)
 			setAutoAllocatedIPs(svc, v)
@@ -953,6 +953,10 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 		}
 	}
 	return services
+}
+
+func makeServiceKey(svc *model.Service) string {
+	return svc.Attributes.Namespace + "/" + svc.Hostname.String()
 }
 
 func setAutoAllocatedIPs(svc *model.Service, octets octetPair) {

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1687,6 +1687,37 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "collision",
+			inServices: []*model.Service{
+				{
+					Hostname:       "a17061.example.com",
+					Resolution:     model.DNSLB,
+					DefaultAddress: "0.0.0.0",
+				},
+				{
+					Hostname:       "a44155.example.com",
+					Resolution:     model.DNSLB,
+					DefaultAddress: "0.0.0.0",
+				},
+			},
+			wantServices: []*model.Service{
+				{
+					Hostname:                 "a17061.example.com",
+					Resolution:               model.DNSLB,
+					DefaultAddress:           "0.0.0.0",
+					AutoAllocatedIPv4Address: "240.240.0.1",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:1",
+				},
+				{
+					Hostname:                 "a44155.example.com",
+					Resolution:               model.DNSLB,
+					DefaultAddress:           "0.0.0.0",
+					AutoAllocatedIPv4Address: "240.240.75.79",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:4b4f",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1690,14 +1690,16 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := autoAllocateIPs(tt.inServices)
-			if got[0].AutoAllocatedIPv4Address != tt.wantServices[0].AutoAllocatedIPv4Address {
-				t.Errorf("autoAllocateIPs() AutoAllocatedIPv4Address = %v, want %v",
-					got[0].AutoAllocatedIPv4Address, tt.wantServices[0].AutoAllocatedIPv4Address)
-			}
-			if got[0].AutoAllocatedIPv6Address != tt.wantServices[0].AutoAllocatedIPv6Address {
-				t.Errorf("autoAllocateIPs() AutoAllocatedIPv4Address = %v, want %v",
-					got[0].AutoAllocatedIPv6Address, tt.wantServices[0].AutoAllocatedIPv6Address)
+			gotServices := autoAllocateIPs(tt.inServices)
+			for i, got := range gotServices {
+				if got.AutoAllocatedIPv4Address != tt.wantServices[i].AutoAllocatedIPv4Address {
+					t.Errorf("autoAllocateIPs() AutoAllocatedIPv4Address = %v, want %v",
+						got.AutoAllocatedIPv4Address, tt.wantServices[i].AutoAllocatedIPv4Address)
+				}
+				if got.AutoAllocatedIPv6Address != tt.wantServices[i].AutoAllocatedIPv6Address {
+					t.Errorf("autoAllocateIPs() AutoAllocatedIPv4Address = %v, want %v",
+						got.AutoAllocatedIPv6Address, tt.wantServices[i].AutoAllocatedIPv6Address)
+				}
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1696,6 +1696,8 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 					DefaultAddress: "0.0.0.0",
 				},
 				{
+					// hashes to the same value as the hostname above,
+					// a new collision needs to be found if the hash algorithm changes
 					Hostname:       "a44155.example.com",
 					Resolution:     model.DNSLB,
 					DefaultAddress: "0.0.0.0",
@@ -1715,6 +1717,59 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 					DefaultAddress:           "0.0.0.0",
 					AutoAllocatedIPv4Address: "240.240.75.79",
 					AutoAllocatedIPv6Address: "2001:2::f0f0:4b4f",
+				},
+			},
+		},
+		{
+			name: "stable IP - baseline test",
+			inServices: []*model.Service{
+				{
+					Hostname:       "a.example.com",
+					Resolution:     model.DNSLB,
+					DefaultAddress: "0.0.0.0",
+					Attributes:     model.ServiceAttributes{Namespace: "a"},
+				},
+			},
+			wantServices: []*model.Service{
+				{
+					Hostname:                 "a.example.com",
+					Resolution:               model.DNSLB,
+					DefaultAddress:           "0.0.0.0",
+					AutoAllocatedIPv4Address: "240.240.163.38",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:a326",
+				},
+			},
+		},
+		{
+			name: "stable IP - not affected by other namespace",
+			inServices: []*model.Service{
+				{
+					Hostname:       "a.example.com",
+					Resolution:     model.DNSLB,
+					DefaultAddress: "0.0.0.0",
+					Attributes:     model.ServiceAttributes{Namespace: "a"},
+				},
+				{
+					Hostname:       "a.example.com",
+					Resolution:     model.DNSLB,
+					DefaultAddress: "0.0.0.0",
+					Attributes:     model.ServiceAttributes{Namespace: "b"},
+				},
+			},
+			wantServices: []*model.Service{
+				{
+					Hostname:                 "a.example.com",
+					Resolution:               model.DNSLB,
+					DefaultAddress:           "0.0.0.0",
+					AutoAllocatedIPv4Address: "240.240.163.38",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:a326",
+				},
+				{
+					Hostname:                 "a.example.com",
+					Resolution:               model.DNSLB,
+					DefaultAddress:           "0.0.0.0",
+					AutoAllocatedIPv4Address: "240.240.114.198",
+					AutoAllocatedIPv6Address: "2001:2::f0f0:72c6",
 				},
 			},
 		},

--- a/releasenotes/notes/43858.yaml
+++ b/releasenotes/notes/43858.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 43858
+
+releaseNotes:
+- |
+  **Fixed** an issue where auto allocated service entry IPs change on host reuse


### PR DESCRIPTION
**Please provide a description of this PR:**

Istio 1.17 introduces a change to IP allocation, to make them more stable. If the same hostname is used in multiple namespaces that are created and deleted frequently, like developer "workspaces", IPs are not as stable as they could be. This leads to BlackHoleClusted when DNS in the main application does not detect the new IP quickly.

This update introduces a small helper function makeServiceKey to make
sure the same key is used both places for stable allocation. A
regression test has also been added.

Fixes #43858