### PR TITLE
[bugfix] Use ReadHeaderTimeout instead of ReadTimeout when gRPC is multiplexed

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -620,6 +620,10 @@ func (s *Server) initServers(args *PilotArgs) {
 		ReadTimeout: 30 * time.Second,
 	}
 	if multiplexGRPC {
+		// To allow the gRPC handler to make per-request decision,
+		// use ReadHeaderTimeout instead of ReadTimeout.
+		s.httpServer.ReadTimeout = 0
+		s.httpServer.ReadHeaderTimeout = 30 * time.Second
 		s.httpServer.Handler = multiplexHandler
 	}
 


### PR DESCRIPTION
Currently, "httpServer" of pilot is configured with "ReadTimeout: 30s".
When it is used with the config "multiplexGRPC", gRPC stream connection is disconnected after 30s. 

It is because "ReadTimeout" is a timeout for reading a request body, so gRPC stream is closed by the timeout. 

To avoid this situation, this PR proposes to use "ReadHeaderTimeout" instead of "ReadTimeout" based on the guidance in https://github.com/golang/go/blob/f5c7416511de979433a500735c1617cf03dc46c2/src/net/http/server.go#L2638-L2641

To minimize the impact, "ReadHeaderTimeout" is only used when gRPC multiplexing is used.

Change-Id: I807c886152b57e48a2a7102ad543b70eb9d359d8
