### PR TITLE
bug-report: skip coredump and netstat commands for distroless installation

### DIFF
--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -28,7 +28,6 @@ import (
 	admitv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apimachinery_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
@@ -44,6 +43,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/constants"
 	"istio.io/istio/pkg/kube"
 )
 
@@ -87,15 +87,7 @@ var (
 	}
 )
 
-var (
-	istioOperatorGVR = apimachinery_schema.GroupVersionResource{
-		Group:    iopv1alpha1.SchemeGroupVersion.Group,
-		Version:  iopv1alpha1.SchemeGroupVersion.Version,
-		Resource: "istiooperators",
-	}
-
-	revArgs = revisionArgs{}
-)
+var revArgs = revisionArgs{}
 
 func revisionCommand() *cobra.Command {
 	revisionCmd := &cobra.Command{
@@ -466,7 +458,7 @@ func printSummaryTable(writer io.Writer, verbose bool, revisions map[string]*tag
 }
 
 func getAllMergedIstioOperatorCRs(client kube.CLIClient, logger clog.Logger) ([]*iopv1alpha1.IstioOperator, error) {
-	ucrs, err := client.Dynamic().Resource(istioOperatorGVR).
+	ucrs, err := client.Dynamic().Resource(constants.IstioOperatorGVR).
 		List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return []*iopv1alpha1.IstioOperator{}, fmt.Errorf("cannot retrieve IstioOperator CRs: %v", err)

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	apimachinery_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -42,14 +41,9 @@ import (
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/constants"
 	"istio.io/istio/pkg/kube"
 )
-
-var istioOperatorGVR = apimachinery_schema.GroupVersionResource{
-	Group:    v1alpha1.SchemeGroupVersion.Group,
-	Version:  v1alpha1.SchemeGroupVersion.Version,
-	Resource: "istiooperators",
-}
 
 // StatusVerifier checks status of certain resources like deployment,
 // jobs and also verifies count of certain resource types.
@@ -462,7 +456,7 @@ func fixTimestampRelatedUnmarshalIssues(un *unstructured.Unstructured) {
 // Find all IstioOperator in the cluster.
 func AllOperatorsInCluster(client dynamic.Interface) ([]*v1alpha1.IstioOperator, error) {
 	ul, err := client.
-		Resource(istioOperatorGVR).
+		Resource(constants.IstioOperatorGVR).
 		List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package constants
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,13 @@
+package constants
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+)
+
+var IstioOperatorGVR = schema.GroupVersionResource{
+	Group:    v1alpha1.SchemeGroupVersion.Group,
+	Version:  v1alpha1.SchemeGroupVersion.Version,
+	Resource: "istiooperators",
+}

--- a/releasenotes/notes/43880.yaml
+++ b/releasenotes/notes/43880.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: environments
+area: istioctl
 issue:
   - 37235
 releaseNotes:

--- a/releasenotes/notes/43880.yaml
+++ b/releasenotes/notes/43880.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: environments
+issue:
+  - 37235
+releaseNotes:
+  - |
+    **Fixed** bug-report to skip coredump and netstat commands for distroless installation

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -55,6 +55,8 @@ import (
 
 const (
 	bugReportDefaultTimeout = 30 * time.Minute
+	istiodDeployment        = "istiod"
+	owningResourceLabel     = "install.operator.istio.io/owning-resource"
 )
 
 var (
@@ -214,7 +216,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 
 func isDistroless(ctx context.Context, client kube.CLIClient, clientset *kubernetes.Clientset, brConfig *config.BugReportConfig) (bool, error) {
 	// Get istiod deployment
-	deploy, err := clientset.AppsV1().Deployments(brConfig.IstioNamespace).Get(ctx, "istiod", metav1.GetOptions{})
+	deploy, err := clientset.AppsV1().Deployments(brConfig.IstioNamespace).Get(ctx, istiodDeployment, metav1.GetOptions{})
 	if err != nil {
 		return false, fmt.Errorf("error while retrieving to Istiod deployment - %v", err)
 	}
@@ -223,7 +225,7 @@ func isDistroless(ctx context.Context, client kube.CLIClient, clientset *kuberne
 	}
 
 	// owning resource is iop
-	owningRes := deploy.Labels["install.operator.istio.io/owning-resource"]
+	owningRes := deploy.Labels[owningResourceLabel]
 	iops, err := client.Dynamic().Resource(constants.IstioOperatorGVR).
 		Namespace(brConfig.IstioNamespace).
 		List(ctx, metav1.ListOptions{})

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -168,7 +168,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	common.LogAndPrintf("\n\nFetching proxy logs for the following containers:\n\n%s\n", strings.Join(paths, "\n"))
 
 	// Determine whether the installation is distroless.
-	distroless, err := isDistroless(client, config, clusterResourcesCtx)
+	distroless, err := isDistroless(clusterResourcesCtx, client, config)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	return nil
 }
 
-func isDistroless(client kube.CLIClient, brConfig *config.BugReportConfig, ctx context.Context) (bool, error) {
+func isDistroless(ctx context.Context, client kube.CLIClient, brConfig *config.BugReportConfig) (bool, error) {
 	iops, err := client.Dynamic().Resource(istioOperatorGVR).
 		Namespace(brConfig.IstioNamespace).
 		List(ctx, metav1.ListOptions{})

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/kr/pretty"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	label2 "istio.io/api/label"
 	operator_istio "istio.io/istio/operator/pkg/apis/istio"
@@ -48,8 +50,6 @@ import (
 	"istio.io/istio/tools/bug-report/pkg/processlog"
 	"istio.io/pkg/log"
 	"istio.io/pkg/version"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -29,12 +29,11 @@ import (
 	"github.com/kr/pretty"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	label2 "istio.io/api/label"
 	operator_istio "istio.io/istio/operator/pkg/apis/istio"
-	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/pkg/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/proxy"
@@ -60,12 +59,6 @@ var (
 	bugReportDefaultIstioNamespace = "istio-system"
 	bugReportDefaultInclude        = []string{""}
 	bugReportDefaultExclude        = []string{strings.Join(sets.SortedList(inject.IgnoredNamespaces), ",")}
-
-	istioOperatorGVR = schema.GroupVersionResource{
-		Group:    iopv1alpha1.SchemeGroupVersion.Group,
-		Version:  iopv1alpha1.SchemeGroupVersion.Version,
-		Resource: "istiooperators",
-	}
 )
 
 // Cmd returns a cobra command for bug-report.
@@ -218,7 +211,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 }
 
 func isDistroless(ctx context.Context, client kube.CLIClient, brConfig *config.BugReportConfig) (bool, error) {
-	iops, err := client.Dynamic().Resource(istioOperatorGVR).
+	iops, err := client.Dynamic().Resource(constants.IstioOperatorGVR).
 		Namespace(brConfig.IstioNamespace).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**

Issue: #37235 

Distroless containers do not have utilities like `netstat` and `find`. So commands ran to gather these information for bug report were failing.

This PR determines whether the installation is distroless or not. If it is distroless, it'll skip execution of those commands.