### PR TITLE
ambient: introduce Service for waypoint proxy

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1539,6 +1539,30 @@ data:
                 - name: {{ . }}
                 {{- end }}
               {{- end }}
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+          labels:
+            {{ toJsonMap .Labels | nindent 4}}
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          ownerReferences:
+          - apiVersion: gateway.networking.k8s.io/v1beta1
+            kind: Gateway
+            name: "{{.Name}}"
+            uid: "{{.UID}}"
+        spec:
+          ports:
+          - name: https-hbone
+            port: 15008
+            protocol: TCP
+            appProtocol: https
+          selector:
+            istio.io/gateway-name: "{{.Name}}"
+        ---
       kube-gateway: |
         apiVersion: v1
         kind: ServiceAccount
@@ -1832,7 +1856,7 @@ data:
           name: {{.DeploymentName | quote}}
           namespace: {{.Namespace | quote}}
           ownerReferences:
-          - apiVersion: gateway.networking.k8s.io/v1alpha2
+          - apiVersion: gateway.networking.k8s.io/v1beta1
             kind: Gateway
             name: {{.Name}}
             uid: {{.UID}}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -290,7 +290,7 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: {{.Name}}
     uid: {{.UID}}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -211,3 +211,27 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+  labels:
+    {{ toJsonMap .Labels | nindent 4}}
+  name: {{.DeploymentName | quote}}
+  namespace: {{.Namespace | quote}}
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: "{{.Name}}"
+    uid: "{{.UID}}"
+spec:
+  ports:
+  - name: https-hbone
+    port: 15008
+    protocol: TCP
+    appProtocol: https
+  selector:
+    istio.io/gateway-name: "{{.Name}}"
+---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -192,7 +192,7 @@ metadata:
   name: default
   namespace: default
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: default
     uid: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -189,7 +189,7 @@ metadata:
   name: default
   namespace: default
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: default
     uid: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -189,7 +189,7 @@ metadata:
   name: default-istio
   namespace: default
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: default
     uid: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -194,7 +194,7 @@ metadata:
   name: default
   namespace: default
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: default
     uid: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -189,7 +189,7 @@ metadata:
   name: default-istio
   namespace: default
   ownerReferences:
-  - apiVersion: gateway.networking.k8s.io/v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
     name: default
     uid: null

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -198,7 +198,6 @@ metadata:
     name: namespace
     uid: ""
 spec:
-  clusterIP: None
   ports:
   - appProtocol: https
     name: https-hbone

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -184,3 +184,26 @@ spec:
           name: istio-ca-root-cert
         name: istiod-ca-cert
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+  name: namespace-istio-waypoint
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: https
+    name: https-hbone
+    port: 15008
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: namespace
+---

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -57,6 +57,11 @@ type AmbientIndex struct {
 	byPod map[string]*model.WorkloadInfo
 
 	// Map of ServiceAccount -> IP
+	// TODO: currently, this is derived from pods. To be agnostic to the implementation,
+	// we should actually be looking at Gateway.status.addresses.
+	// This may be an external address (possibly even a DNS name we need to resolve), an arbitrary IP,
+	// or a reference to a service.
+	// If its a reference to a Service then we can find the underlying pods in that service, as an optimization.
 	waypoints map[model.WaypointScope]sets.String
 
 	// serviceVipIndex maintains an index of VIP -> Service

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1360,6 +1360,30 @@ templates:
             - name: {{ . }}
             {{- end }}
           {{- end }}
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+      labels:
+        {{ toJsonMap .Labels | nindent 4}}
+      name: {{.DeploymentName | quote}}
+      namespace: {{.Namespace | quote}}
+      ownerReferences:
+      - apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        name: "{{.Name}}"
+        uid: "{{.UID}}"
+    spec:
+      ports:
+      - name: https-hbone
+        port: 15008
+        protocol: TCP
+        appProtocol: https
+      selector:
+        istio.io/gateway-name: "{{.Name}}"
+    ---
   kube-gateway: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1653,7 +1677,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
-      - apiVersion: gateway.networking.k8s.io/v1alpha2
+      - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
         name: {{.Name}}
         uid: {{.UID}}


### PR DESCRIPTION
This is only step 1, some TODOs left in comments to do this properly.

Currently, we rely on assumptions that waypoints are implemented in the cluster as pods with specific labels. Really, Waypoints can be anything
- the Gateway already has a way to reference how to reach the Gateway, and we should use that.

As step one of this, we give each Waypoint a headless service and associate it with the Gateway in the status. This at least allows some other implementation to properly reach a waypoint just by reading the Gateway status.

**Please provide a description of this PR:**