### PR TITLE
[TF] add retry to default service account patch command

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
 )
 
@@ -241,11 +242,14 @@ func (n *kubeNamespace) createInCluster(c cluster.Cluster, cfg Config) error {
 		if err := c.ApplyYAMLFiles(n.name, s.Image.PullSecret); err != nil {
 			return err
 		}
-		_, err := c.Kube().CoreV1().ServiceAccounts(n.name).Patch(context.TODO(),
-			"default",
-			types.JSONPatchType,
-			[]byte(`[{"op": "add", "path": "/imagePullSecrets", "value": [{"name": "test-gcr-secret"}]}]`),
-			metav1.PatchOptions{})
+		err := retry.UntilSuccess(func() error {
+			_, err := c.Kube().CoreV1().ServiceAccounts(n.name).Patch(context.TODO(),
+				"default",
+				types.JSONPatchType,
+				[]byte(`[{"op": "add", "path": "/imagePullSecrets", "value": [{"name": "test-gcr-secret"}]}]`),
+				metav1.PatchOptions{})
+			return err
+		}, retry.Delay(1*time.Second), retry.Timeout(10*time.Second))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
The image pull secret is added to the default service account just after the namespace creation. The service account creation might get delayed. So adding a retry for the patch command.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
