### PR TITLE
cni: conditionally mount bpf fs

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -160,9 +160,11 @@ spec:
             - mountPath: /var/run/netns
               mountPropagation: HostToContainer
               name: cni-netns-dir
+            {{- if eq .Values.cni.ambient.redirectMode "ebpf"}}
             - mountPath: /sys/fs/bpf
               mountPropagation: Bidirectional
               name: cni-bpffs-dir
+            {{- end }}
             {{ end }}
           resources:
 {{- if .Values.cni.resources }}
@@ -217,6 +219,8 @@ spec:
         - name: cni-netns-dir
           hostPath:
             path: /var/run/netns
+        {{- if eq .Values.cni.ambient.redirectMode "ebpf"}}
         - name: cni-bpffs-dir
           hostPath:
             path: /sys/fs/bpf
+        {{- end }}


### PR DESCRIPTION
**Please provide a description of this PR:**
When [trying out ambient mesh](https://preliminary.istio.io/latest/docs/ops/ambient/getting-started/), I got:
```
Error: failed to generate container  
spec: failed to apply OCI options: failed to mkdir "/sys/fs/bpf": mkdir /sys/fs/bpf: no such file or directory
```
This is because the bpf file system does not exist in older kernels, we should mount it only if eBPF redirection is enabled