### PR TITLE
Use the skip cleanup flag on integration test

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -133,6 +133,10 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   export HUB
 fi
 
+if [[ "${SKIP_CLEANUP}" = true ]]; then
+  export CLEANUP=false
+fi
+
 # Setup junit report and verbose logging
 export T="${T:-"-v -count=1"}"
 export CI="true"

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -133,7 +133,7 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   export HUB
 fi
 
-if [[ "${SKIP_CLEANUP}" = true ]]; then
+if [[ "${SKIP_CLEANUP:-}" = true ]]; then
   export CLEANUP=false
 fi
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently the `--skip-cleanup` flag is being ignored.
This PR uses the flag to actually skip cleanup when running the script with the flag.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [X] Developer Infrastructure