### PR TITLE
Properly embed all files

### DIFF
--- a/manifests/manifest.go
+++ b/manifests/manifest.go
@@ -22,9 +22,7 @@ import (
 
 // FS embeds the manifests
 //
-//go:embed charts/* profiles/*
-//go:embed charts/gateways/istio-egress/templates/_affinity.tpl
-//go:embed charts/gateways/istio-ingress/templates/_affinity.tpl
+//go:embed all:charts/* profiles/*
 var FS embed.FS
 
 // BuiltinOrDir returns a FS for the provided directory. If no directory is passed, the compiled in


### PR DESCRIPTION
Without `all:`, leading underscores are skipped
Alternative to https://github.com/istio/istio/pull/43923