### PR TITLE
Portforward should close after start success

### DIFF
--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -444,11 +444,11 @@ func istiodLogCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not build port forwarder for ControlZ %s: %v", podName, err)
 			}
-			defer portForwarder.Close()
 			err = portForwarder.Start()
 			if err != nil {
 				return fmt.Errorf("could not start port forwarder for ControlZ %s: %v", podName, err)
 			}
+			defer portForwarder.Close()
 
 			ctrlzClient := &ControlzClient{
 				baseURL: &url.URL{


### PR DESCRIPTION
**Please provide a description of this PR:**

Maybe should close portforward after `Start()` success just like:
* https://github.com/istio/istio/blob/965788550c9a2582cdb91c1839501fba824e5006/istioctl/pkg/multixds/gather.go#L123-L131
* https://github.com/istio/istio/blob/965788550c9a2582cdb91c1839501fba824e5006/istioctl/pkg/multixds/gather.go#L160-L168