### PR TITLE
fix cleaning up workloadentry with same ip and network

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -608,5 +608,11 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 }
 
 func makeProxyKey(proxy *model.Proxy) string {
-	return string(proxy.Metadata.Network) + proxy.IPAddresses[0]
+	key := strings.Join([]string{
+		string(proxy.Metadata.Network),
+		proxy.IPAddresses[0],
+		proxy.Metadata.AutoRegisterGroup,
+		proxy.Metadata.Namespace,
+	}, "~")
+	return key
 }

--- a/releasenotes/notes/43951.yaml
+++ b/releasenotes/notes/43951.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 43950
+
+releaseNotes:
+- |
+  **Fixed** WorkloadEntry resources never being cleaned up if multiple
+  WorkloadEntries were auto-registered with the same IP and network.
+


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/43950

Could also use the `autoregisteredWorkloadEntryName` with less validation. 

This keys the resource to be cleaned up as well as the input. 

If there were already multiple same network/IP workloadentries, that's it's own problem. This just keeps it from being worse with stuck resources. 