### PR TITLE
Fix registerHandlers: when the handler called current obj should neve…

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -323,11 +323,12 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 			c.namespaces,
 			"Namespaces",
 			func(old *v1.Namespace, cur *v1.Namespace, event model.Event) error {
-				return c.onSystemNamespaceEvent(old, cur, event)
+				if cur.Namespace == c.opts.SystemNamespace {
+					return c.onSystemNamespaceEvent(old, cur, event)
+				}
+				return nil
 			},
-			func(old, cur *v1.Namespace) bool {
-				return cur.Namespace != c.opts.SystemNamespace
-			},
+			nil,
 		)
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -326,7 +326,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 				return c.onSystemNamespaceEvent(old, cur, event)
 			},
 			func(old, cur *v1.Namespace) bool {
-				return cur.Namespace == c.opts.SystemNamespace
+				return cur.Namespace != c.opts.SystemNamespace
 			},
 		)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -638,7 +639,7 @@ func registerHandlers[T controllers.Object](c *Controller,
 ) {
 	wrappedHandler := func(prev, curr T, event model.Event) error {
 		curr = informer.Get(curr.GetName(), curr.GetNamespace())
-		if curr == nil {
+		if reflect.ValueOf(curr).IsNil() {
 			// this can happen when an immediate delete after update
 			// the delete event can be handled later
 			return nil

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -145,10 +145,6 @@ func (e *endpointsController) sync(name, ns string, event model.Event, filtered 
 }
 
 func (e *endpointsController) onEvent(_, ep *v1.Endpoints, event model.Event) error {
-	if ep == nil {
-		return nil
-	}
-
 	return processEndpointEvent(e.c, e, ep.Name, ep.Namespace, event, ep)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -86,9 +86,6 @@ func (esc *endpointSliceController) sync(name, ns string, event model.Event, fil
 }
 
 func (esc *endpointSliceController) onEvent(_, ep *v1.EndpointSlice, event model.Event) error {
-	if ep == nil {
-		return nil
-	}
 	esLabels := ep.GetLabels()
 	if endpointSliceSelector.Matches(klabels.Set(esLabels)) {
 		return processEndpointEvent(esc.c, esc, serviceNameForEndpointSlice(esLabels), ep.GetNamespace(), event, ep)

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -143,10 +143,6 @@ func (pc *PodCache) labelFilter(old, cur *v1.Pod) bool {
 
 // onEvent updates the IP-based index (pc.podsByIP).
 func (pc *PodCache) onEvent(_, pod *v1.Pod, ev model.Event) error {
-	if pod == nil {
-		return nil
-	}
-
 	ip := pod.Status.PodIP
 	// PodIP will be empty when pod is just created, but before the IP is assigned
 	// via UpdateStatus.

--- a/pkg/kube/kclient/untyped.go
+++ b/pkg/kube/kclient/untyped.go
@@ -53,7 +53,7 @@ func newReadClient[T controllers.Object](c kube.Client, inf cache.SharedIndexInf
 		log.Debugf("failed to set watch handler, informer may already be started: %v", err)
 	}
 	return readClient[T]{
-		inf:    inf,
-		filter: filter.ObjectFilter,
+		informer: inf,
+		filter:   filter.ObjectFilter,
 	}
 }


### PR DESCRIPTION
…r be nil

**Please provide a description of this PR:**

Instead of letting the caller check, the function lib should prevent passing nil object to handler, which is also consistent with k8s usage.
To replace https://github.com/istio/istio/pull/43956


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
