### PR TITLE
Run test sequentially

### DIFF
--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -477,7 +477,7 @@ func TestAuthz_NotHost(t *testing.T) {
 					for _, c := range cases {
 						c := c
 						testName := fmt.Sprintf("%s(%s)/http", c.host, c.allow)
-						t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+						t.NewSubTest(testName).Run(func(t framework.TestContext) {
 							wantCode := http.StatusOK
 							if !c.allow {
 								wantCode = http.StatusForbidden
@@ -1125,7 +1125,7 @@ func TestAuthz_IngressGateway(t *testing.T) {
 						if len(c.ip) > 0 {
 							testName = c.ip + "->" + testName
 						}
-						t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+						t.NewSubTest(testName).Run(func(t framework.TestContext) {
 							wantCode := http.StatusOK
 							if !c.allow {
 								wantCode = http.StatusForbidden
@@ -1412,7 +1412,7 @@ func TestAuthz_Conditions(t *testing.T) {
 							xfooHeader = "?x-foo=" + c.headers.Get("x-foo")
 						}
 						testName := fmt.Sprintf("%s%s(%s)/http", c.path, xfooHeader, c.allow)
-						t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+						t.NewSubTest(testName).Run(func(t framework.TestContext) {
 							if c.skipFn != nil {
 								c.skipFn(t)
 							}
@@ -1507,7 +1507,7 @@ func TestAuthz_PathNormalization(t *testing.T) {
 					for _, c := range cases {
 						c := c
 						testName := fmt.Sprintf("%s(%s)/http", c.path, c.allow)
-						t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+						t.NewSubTest(testName).Run(func(t framework.TestContext) {
 							newAuthzTest().
 								From(from).
 								To(to).
@@ -1635,7 +1635,7 @@ func TestAuthz_CustomServer(t *testing.T) {
 										params = fmt.Sprintf("?%s=%s", authz.XExtAuthz, c.headers.Get(authz.XExtAuthz))
 									}
 									testName := fmt.Sprintf("%s%s(%s)/%s", c.path, params, c.allow, tst.opts.Port.Name)
-									t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+									t.NewSubTest(testName).Run(func(t framework.TestContext) {
 										if c.path == authzPath {
 											tst.opts.Check = check.And(tst.opts.Check, provider.Check(tst.opts, c.allow.Bool()))
 										}
@@ -1813,7 +1813,7 @@ func (tsts authzTests) RunAll(t framework.TestContext) {
 	if len(tsts) == 1 {
 		// Testing a single port. Just run a single test.
 		testName := fmt.Sprintf("%s%s(%s)/%s", firstTest.prefix, firstTest.opts.HTTP.Path, firstTest.allow, firstTest.opts.Port.Name)
-		t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+		t.NewSubTest(testName).Run(func(t framework.TestContext) {
 			firstTest.BuildAndRun(t)
 		})
 		return
@@ -1824,10 +1824,10 @@ func (tsts authzTests) RunAll(t framework.TestContext) {
 	// Testing multiple ports...
 	// Name outer test with constant info. Name inner test with port.
 	outerTestName := fmt.Sprintf("%s%s(%s)", firstTest.prefix, firstTest.opts.HTTP.Path, firstTest.allow)
-	t.NewSubTest(outerTestName).RunParallel(func(t framework.TestContext) {
+	t.NewSubTest(outerTestName).Run(func(t framework.TestContext) {
 		for _, tst := range tsts {
 			tst := tst
-			t.NewSubTest(tst.opts.Port.Name).RunParallel(func(t framework.TestContext) {
+			t.NewSubTest(tst.opts.Port.Name).Run(func(t framework.TestContext) {
 				tst.BuildAndRun(t)
 			})
 		}

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -64,7 +64,7 @@ func TestRequestAuthentication(t *testing.T) {
 
 					newTrafficTest(t, apps.Ns1.All.Instances()).Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 						for _, c := range cases {
-							t.NewSubTest(c.name).RunParallel(func(t framework.TestContext) {
+							t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 								opts := echo.CallOptions{
 									To: to,
 									Port: echo.Port{
@@ -437,7 +437,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 				newTrafficTest(t, apps.Ns1.All.Instances()).
 					Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 						for _, c := range cases {
-							t.NewSubTest(c.name).RunParallel(func(t framework.TestContext) {
+							t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 								opts := echo.CallOptions{
 									To: to,
 									Port: echo.Port{
@@ -560,7 +560,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 				newTrafficTest(t, apps.Ns1.All.Instances()).
 					RunViaIngress(func(t framework.TestContext, from ingress.Instance, to echo.Target) {
 						for _, c := range cases {
-							t.NewSubTest(c.name).RunParallel(func(t framework.TestContext) {
+							t.NewSubTest(c.name).Run(func(t framework.TestContext) {
 								opts := echo.CallOptions{
 									Port: echo.Port{
 										Protocol: protocol.HTTP,

--- a/tests/integration/security/normalization_test.go
+++ b/tests/integration/security/normalization_test.go
@@ -234,7 +234,7 @@ pathNormalization:
 						Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 							for _, expected := range tt.expectations {
 								expected := expected
-								t.NewSubTest(expected.in).RunParallel(func(t framework.TestContext) {
+								t.NewSubTest(expected.in).Run(func(t framework.TestContext) {
 									checker := check.URL(expected.out)
 									if expected.out == "400" {
 										checker = check.Status(http.StatusBadRequest)

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -429,7 +429,7 @@ spec:
 									mtlsString = "plaintext"
 								}
 								testName := fmt.Sprintf("%s/%s(%s)", mtlsString, p.Name, allow)
-								t.NewSubTest(testName).RunParallel(func(t framework.TestContext) {
+								t.NewSubTest(testName).Run(func(t framework.TestContext) {
 									from.CallOrFail(t, opts)
 								})
 							}


### PR DESCRIPTION
This PR moves securiyt tests to use sequential mode instead of parallel. This seems to have no impact on test runtime:

Security MC test run, 4 attempts:
This PR: 46m,38m,37m,33m
Master: 37m,39m,45m,44m

(lots of noise)

This seems to reduce the likelihood that we hit https://github.com/envoyproxy/envoy/issues/22583 which should reduce flakiness while we debug it.