### PR TITLE
vm: fix assigning label from metadata

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -566,8 +566,11 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 	if group.Metadata != nil && group.Metadata.Labels != nil {
 		entry.Labels = mergeLabels(entry.Labels, group.Metadata.Labels)
 	}
-	if proxy.Labels != nil {
-		entry.Labels = mergeLabels(entry.Labels, proxy.Labels)
+	// Explicitly do not use proxy.Labels, as it is only initialized *after* we register the workload,
+	// and it would be circular, as it will set the labels based on the WorkloadEntry -- but we are creating
+	// the workload entry.
+	if proxy.Metadata.Labels != nil {
+		entry.Labels = mergeLabels(entry.Labels, proxy.Metadata.Labels)
 	}
 
 	annotations := map[string]string{AutoRegistrationGroupAnnotation: groupCfg.Name}

--- a/pilot/pkg/xds/vm_test.go
+++ b/pilot/pkg/xds/vm_test.go
@@ -1,0 +1,74 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+// TestRegistration is an e2e test for registration. Most tests are in autoregister package, but this
+// exercises the full XDS flow.
+func TestRegistration(t *testing.T) {
+	ds := NewFakeDiscoveryServer(t, FakeOptions{})
+	ds.Store().Create(config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadGroup,
+			Name:             "wg",
+			Namespace:        "namespace",
+		},
+		Spec: &v1alpha3.WorkloadGroup{
+			Template: &v1alpha3.WorkloadEntry{
+				Labels: map[string]string{
+					"merge": "wg",
+					"wg":    "1",
+				},
+			},
+		},
+		Status: nil,
+	})
+	proxy := &model.Proxy{
+		Labels:      map[string]string{"merge": "me"},
+		IPAddresses: []string{"1.1.1.1"},
+		Metadata: &model.NodeMetadata{
+			AutoRegisterGroup: "wg",
+			Namespace:         "namespace",
+			Network:           "network1",
+			Labels:            map[string]string{"merge": "meta", "meta": "2"},
+		},
+	}
+	ds.Connect(ds.SetupProxy(proxy), nil, nil)
+	var we *config.Config
+	retry.UntilSuccessOrFail(t, func() error {
+		we = ds.Store().Get(gvk.WorkloadEntry, "wg-1.1.1.1-network1", "namespace")
+		if we == nil {
+			return fmt.Errorf("no WE found")
+		}
+		return nil
+	}, retry.Timeout(time.Second*10))
+	assert.Equal(t, we.Spec.(*v1alpha3.WorkloadEntry).Labels, map[string]string{
+		"merge": "meta",
+		"meta":  "2",
+		"wg":    "1",
+	})
+}

--- a/releasenotes/notes/vm-label.yaml
+++ b/releasenotes/notes/vm-label.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 32210
+releaseNotes:
+- |
+  **Fixed** an issue causing VMs using auto-registration to ignore labels other than those defined in a WorkloadGroup.


### PR DESCRIPTION
https://github.com/istio/istio/commit/1b214cea711412973d49aa759aef3ac626017894 introduces a regression, as we changed from computingl labels from proxy.Metadata.Labels to proxy.Labels. This works for all parts of the code *except* the auto registration, which happens before we compute proxy.Labels.

This reverts to using the metadata labels and adds a test

**Please provide a description of this PR:**