### PR TITLE
gateway-api: set LastTransitionTime properly

### DIFF
--- a/pilot/pkg/config/kube/gateway/conditions.go
+++ b/pilot/pkg/config/kube/gateway/conditions.go
@@ -16,7 +16,6 @@ package gateway
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 
 	"golang.org/x/exp/slices"
@@ -143,7 +142,7 @@ func createRouteStatus(gateways []routeParentReference, obj config.Config, curre
 
 		var currentConditions []metav1.Condition
 		idx := slices.IndexFunc(current, func(s k8sbeta.RouteParentStatus) bool {
-			return reflect.DeepEqual(s.ParentRef, gw.OriginalReference)
+			return parentRefString(s.ParentRef) == parentRefString(gw.OriginalReference)
 		})
 		if idx != -1 {
 			currentConditions = current[idx].Conditions

--- a/pilot/pkg/config/kube/gateway/conditions_test.go
+++ b/pilot/pkg/config/kube/gateway/conditions_test.go
@@ -1,0 +1,111 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+func Test_createRouteStatus(t *testing.T) {
+	lastTransitionTime := metav1.Now()
+	parentRef := httpRouteSpec.ParentRefs[0]
+	parentStatus := []k8s.RouteParentStatus{
+		{
+			ParentRef:      parentRef,
+			ControllerName: ControllerName,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(k8s.RouteReasonAccepted),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: lastTransitionTime,
+					Message:            "Route was valid",
+				},
+				{
+					Type:               string(k8s.RouteConditionResolvedRefs),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: lastTransitionTime,
+					Message:            "All references resolved",
+				},
+			},
+		},
+	}
+
+	httpRoute := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.HTTPRoute,
+			Namespace:        "foo",
+			Name:             "bar",
+			Generation:       1,
+		},
+		Spec: &httpRouteSpec,
+		Status: &k8s.HTTPRouteStatus{
+			RouteStatus: k8s.RouteStatus{
+				Parents: parentStatus,
+			},
+		},
+	}
+
+	type args struct {
+		gateways []routeParentReference
+		obj      config.Config
+		current  []k8s.RouteParentStatus
+		routeErr *ConfigError
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantEqual bool
+	}{
+		{
+			name: "no error",
+			args: args{
+				gateways: []routeParentReference{{OriginalReference: parentRef}},
+				obj:      httpRoute,
+				current:  parentStatus,
+			},
+			wantEqual: true,
+		},
+		{
+			name: "route status error",
+			args: args{
+				gateways: []routeParentReference{{OriginalReference: parentRef}},
+				obj:      httpRoute,
+				current:  parentStatus,
+				routeErr: &ConfigError{
+					Reason: ConfigErrorReason(k8s.RouteReasonRefNotPermitted),
+				},
+			},
+			wantEqual: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := createRouteStatus(tt.args.gateways, tt.args.obj, tt.args.current, tt.args.routeErr)
+			equal := reflect.DeepEqual(got, tt.args.current)
+			if equal != tt.wantEqual {
+				t.Errorf("route status: old: %+v, new: %+v", tt.args.current, got)
+			}
+		})
+	}
+}

--- a/pilot/pkg/config/kube/gateway/conditions_test.go
+++ b/pilot/pkg/config/kube/gateway/conditions_test.go
@@ -22,6 +22,7 @@ import (
 	k8s "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -31,7 +32,7 @@ func TestCreateRouteStatus(t *testing.T) {
 	parentStatus := []k8s.RouteParentStatus{
 		{
 			ParentRef:      parentRef,
-			ControllerName: ControllerName,
+			ControllerName: constants.ManagedGatewayController,
 			Conditions: []metav1.Condition{
 				{
 					Type:               string(k8s.RouteReasonAccepted),

--- a/pilot/pkg/config/kube/gateway/conditions_test.go
+++ b/pilot/pkg/config/kube/gateway/conditions_test.go
@@ -25,7 +25,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
-func Test_createRouteStatus(t *testing.T) {
+func TestCreateRouteStatus(t *testing.T) {
 	lastTransitionTime := metav1.Now()
 	parentRef := httpRouteSpec.ParentRefs[0]
 	parentStatus := []k8s.RouteParentStatus{

--- a/pilot/pkg/model/kstatus/helper_test.go
+++ b/pilot/pkg/model/kstatus/helper_test.go
@@ -1,0 +1,103 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kstatus
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestUpdateConditionIfChanged(t *testing.T) {
+	original := metav1.Condition{
+		Type:               string(k8s.RouteConditionResolvedRefs),
+		Reason:             string(k8s.RouteReasonResolvedRefs),
+		Status:             StatusTrue,
+		Message:            "All references resolved",
+		LastTransitionTime: metav1.Now(),
+	}
+	transitionTime := metav1.NewTime(original.LastTransitionTime.Add(1 * time.Second))
+	statusChanged := metav1.Condition{
+		Type:               string(k8s.RouteConditionResolvedRefs),
+		Reason:             string(k8s.RouteReasonResolvedRefs),
+		Status:             StatusFalse,
+		Message:            "invalid backend",
+		LastTransitionTime: transitionTime,
+	}
+	messageChanged := metav1.Condition{
+		Type:               string(k8s.RouteConditionResolvedRefs),
+		Reason:             string(k8s.RouteReasonResolvedRefs),
+		Status:             StatusTrue,
+		Message:            "foo",
+		LastTransitionTime: transitionTime,
+	}
+	anotherType := metav1.Condition{
+		Type:               string(k8s.RouteConditionAccepted),
+		Reason:             string(k8s.RouteReasonAccepted),
+		Status:             StatusTrue,
+		Message:            "Route was valid",
+		LastTransitionTime: transitionTime,
+	}
+
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		condition  metav1.Condition
+		want       []metav1.Condition
+	}{
+		{
+			name:       "unchanged",
+			conditions: []metav1.Condition{original},
+			condition: func() metav1.Condition {
+				c := original
+				c.LastTransitionTime = transitionTime
+				return c
+			}(),
+			want: []metav1.Condition{original},
+		},
+		{
+			name:       "status changed",
+			conditions: []metav1.Condition{original},
+			condition:  statusChanged,
+			want:       []metav1.Condition{statusChanged},
+		},
+		{
+			name:       "message changed",
+			conditions: []metav1.Condition{original},
+			condition:  messageChanged,
+			want: []metav1.Condition{func() metav1.Condition {
+				c := messageChanged
+				c.LastTransitionTime = original.LastTransitionTime
+				return c
+			}()},
+		},
+		{
+			name:       "another type",
+			conditions: []metav1.Condition{original},
+			condition:  anotherType,
+			want:       []metav1.Condition{original, anotherType},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UpdateConditionIfChanged(tt.conditions, tt.condition); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateConditionIfChanged got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**
We should not always set `LastTransitionTime` to now because it
- unnessarily refreshes all routes' status to the api server when one service/route/gateway is updated. These status updates can trigger reconciliation again and we will end up with an infinite loop. In practice this process is usually fast enough that `LastTransitionTime` still keeps the same(the protobuf is accurate to a second IIRC) and breaks the loop, but it's still problematic and leads to pushing xDS at least 2x
- does not conform the API semantics anyways

ref: https://github.com/kubernetes/kubernetes/blob/v1.26.3/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go#L38-L39