### PR TITLE
skip non spiffee uris for trust domain expansion

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -31,7 +31,6 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -1443,14 +1442,7 @@ func (ps *PushContext) initServiceAccounts(env *Environment, services []*Service
 				if len(svc.ServiceAccounts) > 0 {
 					accounts = accounts.Copy().InsertAll(svc.ServiceAccounts...)
 				}
-				var sa []string
-				// Skip external services as service accounts for them (SANs in Service Entry)
-				// may not be in SPIFFE format.
-				if svc.Attributes.ServiceRegistry == provider.External {
-					sa = svc.ServiceAccounts
-				} else {
-					sa = sets.SortedList(spiffe.ExpandWithTrustDomains(accounts, ps.Mesh.TrustDomainAliases))
-				}
+				sa := sets.SortedList(spiffe.ExpandWithTrustDomains(accounts, ps.Mesh.TrustDomainAliases))
 				key := serviceAccountKey{
 					hostname:  svc.Hostname,
 					namespace: svc.Attributes.Namespace,

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -31,6 +31,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -1428,6 +1429,11 @@ func (ps *PushContext) initServiceAccounts(env *Environment, services []*Service
 	for _, svc := range services {
 		for _, port := range svc.Ports {
 			if port.Protocol == protocol.UDP {
+				continue
+			}
+			// Skip external services as service accounts for them (SANs in Service Entry)
+			// may not be in SPIFFE format.
+			if svc.Attributes.ServiceRegistry == provider.External {
 				continue
 			}
 			var accounts sets.String

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -139,6 +139,10 @@ func ExpandWithTrustDomains(spiffeIdentities sets.String, trustDomainAliases []s
 	out := sets.New[string]()
 	for id := range spiffeIdentities {
 		out.Insert(id)
+		// Skip if not a SPIFFE identity - This can happen for example if the identity is a DNS name.
+		if !strings.HasPrefix(id, URIPrefix) {
+			continue
+		}
 		// Expand with aliases set.
 		m, err := ParseIdentity(id)
 		if err != nil {

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -559,6 +559,16 @@ func TestExpandWithTrustDomains(t *testing.T) {
 				"spiffe://cluster.local/custom-suffix": {},
 			},
 		},
+		{
+			name:      "Non SPIFFE URI",
+			spiffeURI: []string{"testdns.com"},
+			trustDomains: []string{
+				"foo",
+			},
+			want: map[string]struct{}{
+				"testdns.com": {},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
For service entries, SANs may not be in SPIFFE format. So skip validating them

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure