### PR TITLE
Relax gateway name format restrict

### DIFF
--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -37,12 +37,16 @@ const (
 	// In Kubernetes, label names can start with a DNS name followed by a '/':
 	dnsNamePrefixFmt       = dns1123LabelFmt + `(?:\.` + dns1123LabelFmt + `)*/`
 	dnsNamePrefixMaxLength = 253
+
+	dnsSubDomainMaxLength = 253
+	dnsSubDomainFmt       = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
 )
 
 var (
 	tagRegexp            = regexp.MustCompile("^(" + dnsNamePrefixFmt + ")?(" + qualifiedNameFmt + ")$") // label value can be an empty string
 	labelValueRegexp     = regexp.MustCompile("^" + "(" + qualifiedNameFmt + ")?" + "$")
 	dns1123LabelRegexp   = regexp.MustCompile("^" + dns1123LabelFmt + "$")
+	dnsSubDomainRegexp   = regexp.MustCompile("^" + dnsSubDomainFmt + "$")
 	wildcardPrefixRegexp = regexp.MustCompile("^" + wildcardPrefix + "$")
 )
 
@@ -107,6 +111,12 @@ func (i Instance) Validate() error {
 // DNS (RFC 1123).
 func IsDNS1123Label(value string) bool {
 	return len(value) <= DNS1123LabelMaxLength && dns1123LabelRegexp.MatchString(value)
+}
+
+// IsDNS1123SubDomain tests for a string that conforms to the definition of a sub domain in
+// DNS (RFC 1123).
+func IsDNS1123SubDomain(value string) bool {
+	return len(value) <= dnsSubDomainMaxLength && dnsSubDomainRegexp.MatchString(value)
 }
 
 // IsWildcardDNS1123Label tests for a string that conforms to the definition of a label in DNS (RFC 1123), but allows

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -468,8 +468,8 @@ var ValidateGateway = registerValidateFunc("ValidateGateway",
 	func(cfg config.Config) (Warning, error) {
 		name := cfg.Name
 		v := Validation{}
-		// Gateway name must conform to the DNS label format (no dots)
-		if !labels.IsDNS1123Label(name) {
+		// Gateway name must conform to the DNS sub domain format.
+		if !labels.IsDNS1123SubDomain(name) {
 			v = appendValidation(v, fmt.Errorf("invalid gateway name: %q", name))
 		}
 		value, ok := cfg.Spec.(*networking.Gateway)
@@ -2831,12 +2831,13 @@ func validateGatewayNames(gatewayNames []string) (errs Validation) {
 			errs = appendValidation(errs, fmt.Errorf("config namespace and gateway name cannot be empty"))
 		}
 
-		// namespace and name must be DNS labels
+		// namespace must be DNS labels
 		if !labels.IsDNS1123Label(parts[0]) {
 			errs = appendValidation(errs, fmt.Errorf("invalid value for namespace: %q", parts[0]))
 		}
 
-		if !labels.IsDNS1123Label(parts[1]) {
+		// name must be DNS sub domain
+		if !labels.IsDNS1123SubDomain(parts[1]) {
 			errs = appendValidation(errs, fmt.Errorf("invalid value for gateway name: %q", parts[1]))
 		}
 	}


### PR DESCRIPTION
In our gitops workflow, when we apply `Gateway` and `VirtaulService` resources for any dividual host, we prefer to name the resources as the actul domain name. It is very convenient for us to manage the configuration of different domain names. 
```
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: test.com
  namespace: default
spec:
  selector:
    app: my-gateway-controller
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - test.com
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: test.com
spec:
  hosts:
  - test.com
  gateways:
  - default/test.com
  http:
  - match:
    - headers:
        cookie:
          exact: "user=dev-123"
    route:
    - destination:
        port:
          number: 7777
        host: reviews.qa.svc.cluster.local
```

However, the format of config name in istio is restrict to dns label format.

According to the doc [K8s object name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/), the config name can conform the dns sub domain format. So can we just relax the current restrict on the gateway name? This pr will not break the existing `Gateway` or `VirtualService` validation.

WDYT @howardjohn @hzxuzhonghu 