### PR TITLE
Convert ztunnel Dockerfile registry to ARG

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -13,7 +13,7 @@ FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 # It is built on the base distroless image, with iptables binary and libraries added
 # The source can be found at https://github.com/istio/distroless/tree/iptables
 # This version is from commit a8b3fb577adb785211ce704fdf892983fc268b11.
-FROM gcr.io/istio-release/iptables@sha256:4be99c4dbc0a158fc4404d66198bf18f321292ffeff55201e9c8fa518a54b81e as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:4be99c4dbc0a158fc4404d66198bf18f321292ffeff55201e9c8fa518a54b81e as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.ztunnel
+++ b/pilot/docker/Dockerfile.ztunnel
@@ -3,16 +3,17 @@ ARG BASE_DISTRIBUTION=debug
 
 # Version is the base image version from the TLD Makefile
 ARG BASE_VERSION=latest
+ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM gcr.io/istio-release/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # This image is a custom built debian11 distroless image with multiarchitecture support.
 # It is built on the base distroless image, with iptables binary and libraries added
 # The source can be found at https://github.com/istio/distroless/tree/iptables
 # This version is from commit 6faf2f9348d382c6a95bbc3171b89406103cb0ad.
-FROM gcr.io/istio-release/iptables@sha256:64ba191166d2c3f87815148cc1a9f530b770e0dfe81acb164ab79cbb31da582c as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:64ba191166d2c3f87815148cc1a9f530b770e0dfe81acb164ab79cbb31da582c as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
**Please provide a description of this PR:**

Convert ztunnel Dockerfile base registry to ISTIO_BASE_REGISTRY ARG.
And add the same one in at the proxyv2.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- Test and Release

**Please check any characteristics that apply to this pull request.**

- Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
