### PR TITLE
use network/IP for workload  ResourceName

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -848,7 +848,7 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 
 func (i WorkloadInfo) ResourceName() string {
 	ii, _ := netip.AddrFromSlice(i.Address)
-	return fmt.Sprintf("%s/%s", i.Network, ii.String())
+	return i.Network + "/" + ii.String()
 }
 
 // MCSServiceInfo combines the name of a service with a particular Kubernetes cluster. This

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -848,7 +848,7 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 
 func (i WorkloadInfo) ResourceName() string {
 	ii, _ := netip.AddrFromSlice(i.Address)
-	return ii.String()
+	return fmt.Sprintf("%s/%s", i.Network, ii.String())
 }
 
 // MCSServiceInfo combines the name of a service with a particular Kubernetes cluster. This

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -843,8 +843,14 @@ func (c *Controller) PodInformation(addresses sets.Set[types.NamespacedName]) ([
 	var wls []*model.WorkloadInfo
 	var removed []string
 	for p := range addresses {
-		cNetwork := c.Network(p.Name, make(labels.Instance, 0)).String()
-		wl := c.ambientIndex.Lookup(cNetwork + "/" + p.Name)
+		wname := p.Name
+		// GenerateDeltas has the formatted wname from the xds request, but not sure if other callers
+		// have the format enforced
+		if found := strings.Count(p.Name, "/"); found == 0 {
+			cNetwork := c.Network(p.Name, make(labels.Instance, 0)).String()
+			wname = cNetwork + "/" + p.Name
+		}
+		wl := c.ambientIndex.Lookup(wname)
 		if len(wl) == 0 {
 			removed = append(removed, p.Name)
 		} else {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -107,14 +107,6 @@ func TestAmbientIndex(t *testing.T) {
 		for attempts < 10 {
 			attempts++
 			ev := fx.WaitOrFail(t, "xds")
-			// // trim the resource name to just the IP
-			// resourceNames := strings.Split(ev.ID, ",")
-			// eventIPs := []string{}
-			// for _, r := range resourceNames {
-			// 	eventIPs = append(eventIPs, strings.Split(r, "/")[0])
-			// }
-			// if strings.Join(eventIPs, ",") != want {
-			// 	t.Logf("skip event %v, wanted %v", eventIPs, want)
 			if ev.ID != want {
 				t.Logf("skip event %v, wanted %v", ev.ID, want)
 			} else {
@@ -386,14 +378,6 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 		for attempts < 10 {
 			attempts++
 			ev := fx.WaitOrFail(t, "xds")
-			// // trim the resource name to just the IP
-			// resourceNames := strings.Split(ev.ID, ",")
-			// eventIPs := []string{}
-			// for _, r := range resourceNames {
-			// 	eventIPs = append(eventIPs, strings.Split(r, "/")[0])
-			// }
-			// if strings.Join(eventIPs, ",") != want {
-			// 	t.Logf("skip event %v, wanted %v", ev.ID, want)
 			if ev.ID != want {
 				t.Logf("skip event %v, wanted %v", ev.ID, want)
 			} else {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -107,8 +107,14 @@ func TestAmbientIndex(t *testing.T) {
 		for attempts < 10 {
 			attempts++
 			ev := fx.WaitOrFail(t, "xds")
-			if ev.ID != want {
-				t.Logf("skip event %v, wanted %v", ev.ID, want)
+			// trim the resource name to just the IP
+			resourceNames := strings.Split(ev.ID, ",")
+			eventIPs := []string{}
+			for _, r := range resourceNames {
+				eventIPs = append(eventIPs, strings.Split(r, "/")[0])
+			}
+			if strings.Join(eventIPs, ",") != want {
+				t.Logf("skip event %v, wanted %v", eventIPs, want)
 			} else {
 				return
 			}
@@ -378,7 +384,13 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 		for attempts < 10 {
 			attempts++
 			ev := fx.WaitOrFail(t, "xds")
-			if ev.ID != want {
+			// trim the resource name to just the IP
+			resourceNames := strings.Split(ev.ID, ",")
+			eventIPs := []string{}
+			for _, r := range resourceNames {
+				eventIPs = append(eventIPs, strings.Split(r, "/")[0])
+			}
+			if strings.Join(eventIPs, ",") != want {
 				t.Logf("skip event %v, wanted %v", ev.ID, want)
 			} else {
 				return

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -80,7 +80,7 @@ func TestWorkloadReconnect(t *testing.T) {
 
 	// Now subscribe to the pod, should get it back
 	resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
-		ResourceNamesSubscribe: []string{"127.0.0.1"},
+		ResourceNamesSubscribe: []string{"/127.0.0.1"},
 	})
 	expect(resp, "/127.0.0.1")
 	ads.Cleanup()
@@ -91,7 +91,7 @@ func TestWorkloadReconnect(t *testing.T) {
 		ResourceNamesSubscribe:   []string{"*"},
 		ResourceNamesUnsubscribe: []string{"*"},
 		InitialResourceVersions: map[string]string{
-			"127.0.0.1": "",
+			"/127.0.0.1": "",
 		},
 	})
 	expect(ads.ExpectResponse(), "/127.0.0.1")

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -82,7 +82,7 @@ func TestWorkloadReconnect(t *testing.T) {
 	resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
 		ResourceNamesSubscribe: []string{"127.0.0.1"},
 	})
-	expect(resp, "127.0.0.1")
+	expect(resp, "/127.0.0.1")
 	ads.Cleanup()
 
 	// Reconnect
@@ -94,7 +94,7 @@ func TestWorkloadReconnect(t *testing.T) {
 			"127.0.0.1": "",
 		},
 	})
-	expect(ads.ExpectResponse(), "127.0.0.1")
+	expect(ads.ExpectResponse(), "/127.0.0.1")
 }
 
 func TestWorkload(t *testing.T) {
@@ -117,41 +117,41 @@ func TestWorkload(t *testing.T) {
 
 		// Now subscribe to it, should get it back
 		resp := ads.RequestResponseAck(&discovery.DeltaDiscoveryRequest{
-			ResourceNamesSubscribe: []string{"127.0.0.1"},
+			ResourceNamesSubscribe: []string{"/127.0.0.1"},
 		})
-		expect(resp, "127.0.0.1")
+		expect(resp, "/127.0.0.1")
 
 		// Subscribe to unknown pod
 		ads.Request(&discovery.DeltaDiscoveryRequest{
-			ResourceNamesSubscribe: []string{"127.0.0.2"},
+			ResourceNamesSubscribe: []string{"/127.0.0.2"},
 		})
 		// "Removed" is a misnomer, but per the spec this is how we report "not found"
-		expectRemoved(ads.ExpectResponse(), "127.0.0.2")
+		expectRemoved(ads.ExpectResponse(), "/127.0.0.2")
 
 		// Once we create it, we should get a push
 		createPod(s, "pod2", "sa", "127.0.0.2", "node")
-		expect(ads.ExpectResponse(), "127.0.0.2")
+		expect(ads.ExpectResponse(), "/127.0.0.2")
 
 		// TODO: implement pod update; this actually cannot really be done without waypoints or VIPs
 		deletePod(s, "pod")
-		expectRemoved(ads.ExpectResponse(), "127.0.0.1")
+		expectRemoved(ads.ExpectResponse(), "/127.0.0.1")
 
 		// Create pod we are not subscribed to; due to same-node optimization this will push
 		createPod(s, "pod-same-node", "sa", "127.0.0.3", "node")
-		expect(ads.ExpectResponse(), "127.0.0.3")
+		expect(ads.ExpectResponse(), "/127.0.0.3")
 		deletePod(s, "pod-same-node")
-		expectRemoved(ads.ExpectResponse(), "127.0.0.3")
+		expectRemoved(ads.ExpectResponse(), "/127.0.0.3")
 
 		// Add service: we should not get any new resources, but updates to existing ones
 		// Note: we are not subscribed to svc1 explicitly, but it impacts pods we are subscribed to
 		createService(s, "svc1", "default", map[string]string{"app": "sa"})
-		expect(ads.ExpectResponse(), "127.0.0.2")
+		expect(ads.ExpectResponse(), "/127.0.0.2")
 		// Creating a pod in the service should send an update as usual
 		createPod(s, "pod", "sa", "127.0.0.1", "node")
-		expect(ads.ExpectResponse(), "127.0.0.1")
+		expect(ads.ExpectResponse(), "/127.0.0.1")
 		// Make service not select workload should also update things
 		createService(s, "svc1", "default", map[string]string{"app": "not-sa"})
-		expect(ads.ExpectResponse(), "127.0.0.1", "127.0.0.2")
+		expect(ads.ExpectResponse(), "/127.0.0.1", "/127.0.0.2")
 
 		// Now create pods in the service...
 		createPod(s, "pod4", "not-sa", "127.0.0.4", "not-node")
@@ -160,17 +160,17 @@ func TestWorkload(t *testing.T) {
 
 		// Now we subscribe to the service explicitly
 		ads.Request(&discovery.DeltaDiscoveryRequest{
-			ResourceNamesSubscribe: []string{"10.0.0.1"},
+			ResourceNamesSubscribe: []string{"/10.0.0.1"},
 		})
 		// Should get updates for all pods in the service
-		expect(ads.ExpectResponse(), "127.0.0.4")
-		// Adding a pod in the service should trigger an update for that pod, even if we didn't explicitly subscribe
+		expect(ads.ExpectResponse(), "/127.0.0.4")
+		// Adding a pod in the service should not trigger an update for that pod; we didn't explicitly subscribe
 		createPod(s, "pod5", "not-sa", "127.0.0.5", "not-node")
-		expect(ads.ExpectResponse(), "127.0.0.5")
+		ads.ExpectNoResponse()
 
-		// And if the service changes to no longer select them, we should see them *removed* (not updated)
+		// And if the service changes to no longer select the pod, we should see it *removed* (not updated)
 		createService(s, "svc1", "default", map[string]string{"app": "nothing"})
-		expect(ads.ExpectResponse(), "127.0.0.4", "127.0.0.5")
+		expect(ads.ExpectResponse(), "/127.0.0.4")
 	})
 	t.Run("wildcard", func(t *testing.T) {
 		expect := buildExpect(t)
@@ -185,26 +185,26 @@ func TestWorkload(t *testing.T) {
 
 		// Create pod, due to wildcard subscribe we should receive it
 		createPod(s, "pod", "sa", "127.0.0.1", "not-node")
-		expect(ads.ExpectResponse(), "127.0.0.1")
+		expect(ads.ExpectResponse(), "/127.0.0.1")
 
 		// A new pod should push only that one
 		createPod(s, "pod2", "sa", "127.0.0.2", "node")
-		expect(ads.ExpectResponse(), "127.0.0.2")
+		expect(ads.ExpectResponse(), "/127.0.0.2")
 
 		// TODO: implement pod update; this actually cannot really be done without waypoints or VIPs
 		deletePod(s, "pod")
-		expectRemoved(ads.ExpectResponse(), "127.0.0.1")
+		expectRemoved(ads.ExpectResponse(), "/127.0.0.1")
 
 		// Add service: we should not get any new resources, but updates to existing ones
 		createService(s, "svc1", "default", map[string]string{"app": "sa"})
-		expect(ads.ExpectResponse(), "127.0.0.2")
+		expect(ads.ExpectResponse(), "/127.0.0.2")
 		// Creating a pod in the service should send an update as usual
 		createPod(s, "pod", "sa", "127.0.0.3", "node")
-		expect(ads.ExpectResponse(), "127.0.0.3")
+		expect(ads.ExpectResponse(), "/127.0.0.3")
 
 		// Make service not select workload should also update things
 		createService(s, "svc1", "default", map[string]string{"app": "not-sa"})
-		expect(ads.ExpectResponse(), "127.0.0.2", "127.0.0.3")
+		expect(ads.ExpectResponse(), "/127.0.0.2", "/127.0.0.3")
 	})
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

network/IP as key in ambientindex. Part of ngoing discussion in [Ambient XDS doc](https://docs.google.com/document/d/1V5wkeBHbLSLMzAMbwFlFZNHdZPyUEspG4lHbnB0UaCg/edit) 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ X ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ X ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
