### PR TITLE
controllers: unify xds updater

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -193,7 +194,7 @@ func TestNamespaceEvent(t *testing.T) {
 	clientSet := kube.NewFakeClient()
 	store := memory.NewController(memory.Make(collections.All))
 	c := NewController(clientSet, store, AlwaysReady, nil, controller.Options{})
-	s := controller.NewFakeXDS()
+	s := xdsfake.NewFakeXDS()
 
 	c.RegisterEventHandler(gvk.Namespace, func(_, cfg config.Config, _ model.Event) {
 		s.ConfigUpdate(&model.PushRequest{
@@ -225,7 +226,7 @@ func TestNamespaceEvent(t *testing.T) {
 	s.AssertEmpty(t, time.Millisecond*10)
 
 	clientSet.Kube().CoreV1().Namespaces().Create(ctx, &ns2, metav1.CreateOptions{})
-	s.WaitOrFail(t, "xds")
+	s.WaitOrFail(t, "xds full")
 
 	ns1.Annotations = map[string]string{"foo": "bar"}
 	clientSet.Kube().CoreV1().Namespaces().Update(ctx, &ns1, metav1.UpdateOptions{})
@@ -241,13 +242,13 @@ func TestNamespaceEvent(t *testing.T) {
 
 	ns2.Labels["foo"] = "bar"
 	clientSet.Kube().CoreV1().Namespaces().Update(ctx, &ns2, metav1.UpdateOptions{})
-	s.WaitOrFail(t, "xds")
+	s.WaitOrFail(t, "xds full")
 
 	ns1.Labels["allowed"] = "true"
 	clientSet.Kube().CoreV1().Namespaces().Update(ctx, &ns1, metav1.UpdateOptions{})
-	s.WaitOrFail(t, "xds")
+	s.WaitOrFail(t, "xds full")
 
 	ns2.Labels["allowed"] = "false"
 	clientSet.Kube().CoreV1().Namespaces().Update(ctx, &ns2, metav1.UpdateOptions{})
-	s.WaitOrFail(t, "xds")
+	s.WaitOrFail(t, "xds full")
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -103,17 +104,7 @@ func TestAmbientIndex(t *testing.T) {
 	assertEvent := func(ip ...string) {
 		t.Helper()
 		want := strings.Join(ip, ",")
-		attempts := 0
-		for attempts < 10 {
-			attempts++
-			ev := fx.WaitOrFail(t, "xds")
-			if ev.ID != want {
-				t.Logf("skip event %v, wanted %v", ev.ID, want)
-			} else {
-				return
-			}
-		}
-		t.Fatalf("didn't find event for %v", ip)
+		fx.MatchOrFail(t, xdsfake.Event{Type: "xds", ID: want})
 	}
 	deletePod := func(name string) {
 		t.Helper()
@@ -374,17 +365,7 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 	assertEvent := func(ip ...string) {
 		t.Helper()
 		want := strings.Join(ip, ",")
-		attempts := 0
-		for attempts < 10 {
-			attempts++
-			ev := fx.WaitOrFail(t, "xds")
-			if ev.ID != want {
-				t.Logf("skip event %v, wanted %v", ev.ID, want)
-			} else {
-				return
-			}
-		}
-		t.Fatalf("didn't find event for %v", ip)
+		fx.MatchOrFail(t, xdsfake.Event{Type: "xds", ID: want})
 	}
 	addPods := func(ip string, name, sa string, labels map[string]string, markReady bool, phase corev1.PodPhase) {
 		t.Helper()

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -15,13 +15,12 @@
 package controller
 
 import (
-	"sort"
-	"strings"
 	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh"
 	kubelib "istio.io/istio/pkg/kube"
@@ -34,136 +33,6 @@ import (
 const (
 	defaultFakeDomainSuffix = "company.com"
 )
-
-// FakeXdsUpdater is used to test the registry.
-type FakeXdsUpdater struct {
-	// Events tracks notifications received by the updater
-	Events chan FakeXdsEvent
-}
-
-var _ model.XDSUpdater = &FakeXdsUpdater{}
-
-func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
-	names := []string{}
-	if req != nil && len(req.ConfigsUpdated) > 0 {
-		for key := range req.ConfigsUpdated {
-			names = append(names, key.Name)
-		}
-	}
-	sort.Strings(names)
-	id := strings.Join(names, ",")
-	select {
-	case fx.Events <- FakeXdsEvent{Type: "xds", ID: id}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) ProxyUpdate(_ cluster.ID, _ string) {
-	select {
-	case fx.Events <- FakeXdsEvent{Type: "proxy"}:
-	default:
-	}
-}
-
-// FakeXdsEvent is used to watch XdsEvents
-type FakeXdsEvent struct {
-	// Type of the event
-	Type string
-
-	// The id of the event
-	ID string
-
-	// The endpoints associated with an EDS push if any
-	Endpoints []*model.IstioEndpoint
-}
-
-// NewFakeXDS creates a XdsUpdater reporting events via a channel.
-func NewFakeXDS() *FakeXdsUpdater {
-	return &FakeXdsUpdater{
-		Events: make(chan FakeXdsEvent, 100),
-	}
-}
-
-func (fx *FakeXdsUpdater) EDSUpdate(_ model.ShardKey, hostname string, _ string, entry []*model.IstioEndpoint) {
-	if len(entry) > 0 {
-		select {
-		case fx.Events <- FakeXdsEvent{Type: "eds", ID: hostname, Endpoints: entry}:
-		default:
-		}
-	}
-}
-
-func (fx *FakeXdsUpdater) EDSCacheUpdate(_ model.ShardKey, hostname, _ string, entry []*model.IstioEndpoint) {
-	if len(entry) > 0 {
-		select {
-		case fx.Events <- FakeXdsEvent{Type: "eds cache", ID: hostname, Endpoints: entry}:
-		default:
-		}
-	}
-}
-
-// SvcUpdate is called when a service port mapping definition is updated.
-// This interface is WIP - labels, annotations and other changes to service may be
-// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
-// LDS/RDS.
-func (fx *FakeXdsUpdater) SvcUpdate(_ model.ShardKey, hostname string, _ string, _ model.Event) {
-	select {
-	case fx.Events <- FakeXdsEvent{Type: "service", ID: hostname}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) RemoveShard(shardKey model.ShardKey) {
-	select {
-	case fx.Events <- FakeXdsEvent{Type: "removeShard", ID: shardKey.String()}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) WaitOrFail(t test.Failer, et string) *FakeXdsEvent {
-	t.Helper()
-	for {
-		select {
-		case e := <-fx.Events:
-			if e.Type == et {
-				return &e
-			}
-			log.Infof("skipping event %q want %q", e.Type, et)
-			continue
-		case <-time.After(time.Second * 5):
-			t.Fatalf("timed out waiting for %v", et)
-		}
-	}
-}
-
-// Clear any pending event
-func (fx *FakeXdsUpdater) Clear() {
-	wait := true
-	for wait {
-		select {
-		case <-fx.Events:
-		default:
-			wait = false
-		}
-	}
-}
-
-// AssertEmpty ensures there are no events in the channel
-func (fx *FakeXdsUpdater) AssertEmpty(t test.Failer, dur time.Duration) {
-	if dur == 0 {
-		select {
-		case e := <-fx.Events:
-			t.Fatalf("got unexpected event %+v", e)
-		default:
-		}
-	} else {
-		select {
-		case e := <-fx.Events:
-			t.Fatalf("got unexpected event %+v", e)
-		case <-time.After(dur):
-		}
-	}
-}
 
 type FakeControllerOptions struct {
 	Client                    kubelib.Client
@@ -185,10 +54,10 @@ type FakeController struct {
 	*Controller
 }
 
-func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*FakeController, *FakeXdsUpdater) {
+func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*FakeController, *xdsfake.Updater) {
 	xdsUpdater := opts.XDSUpdater
 	if xdsUpdater == nil {
-		xdsUpdater = NewFakeXDS()
+		xdsUpdater = xdsfake.NewFakeXDS()
 	}
 
 	domainSuffix := defaultFakeDomainSuffix
@@ -237,8 +106,8 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 		c.stop = test.NewStop(t)
 	}
 	opts.Client.RunAndWait(c.stop)
-	var fx *FakeXdsUpdater
-	if x, ok := xdsUpdater.(*FakeXdsUpdater); ok {
+	var fx *xdsfake.Updater
+	if x, ok := xdsUpdater.(*xdsfake.Updater); ok {
 		fx = x
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
@@ -35,7 +36,7 @@ import (
 // Prepare k8s. This can be used in multiple tests, to
 // avoid duplicating creation, which can be tricky. It can be used with the fake or
 // standalone apiserver.
-func initTestEnv(t *testing.T, ki kubernetes.Interface, fx *FakeXdsUpdater) {
+func initTestEnv(t *testing.T, ki kubernetes.Interface, fx *xdsfake.Updater) {
 	cleanup(ki)
 	for _, n := range []string{"nsa", "nsb"} {
 		_, err := ki.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/kube/mcs"
 	istiotest "istio.io/istio/pkg/test"
@@ -201,7 +202,7 @@ func (ec *serviceExportCacheImpl) unExport(t *testing.T) {
 func (ec *serviceExportCacheImpl) waitForXDS(t *testing.T, exported bool) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {
-		event := ec.opts.XDSUpdater.(*FakeXdsUpdater).WaitOrFail(t, "eds")
+		event := ec.opts.XDSUpdater.(*xdsfake.Updater).WaitOrFail(t, "eds")
 		if len(event.Endpoints) != 1 {
 			return fmt.Errorf("waitForXDS failed: expected 1 endpoint, found %d", len(event.Endpoints))
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/kube/mcs"
 	"istio.io/istio/pkg/test"
@@ -506,16 +507,9 @@ func (ic *serviceImportCacheImpl) isImported(name types.NamespacedName) bool {
 	return ic.serviceImports.Get(name.Name, name.Namespace) != nil
 }
 
-func (ic *serviceImportCacheImpl) checkXDS(t test.Failer) error {
+func (ic *serviceImportCacheImpl) checkXDS(t test.Failer) {
 	t.Helper()
-	event := ic.opts.XDSUpdater.(*FakeXdsUpdater).WaitOrFail(t, "service")
-
-	// The name of the event will be the cluster-local hostname.
-	eventID := serviceImportClusterSetHost.String()
-	if event.ID != eventID {
-		return fmt.Errorf("waitForXDS failed: expected event id=%s, but found %s", eventID, event.ID)
-	}
-	return nil
+	ic.opts.XDSUpdater.(*xdsfake.Updater).MatchOrFail(t, xdsfake.Event{Type: "service", ID: serviceImportClusterSetHost.String()})
 }
 
 func (ic *serviceImportCacheImpl) clusterLocalHost() host.Name {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pilot/test/xdstest"
@@ -60,16 +61,12 @@ func setupTest(t *testing.T) (
 	*serviceentry.Controller,
 	model.ConfigStoreController,
 	kubernetes.Interface,
-	*xds.FakeXdsUpdater,
+	*xdsfake.Updater,
 ) {
 	t.Helper()
 	client := kubeclient.NewFakeClient()
 
-	eventch := make(chan xds.FakeXdsEvent, 100)
-
-	xdsUpdater := &xds.FakeXdsUpdater{
-		Events: eventch,
-	}
+	xdsUpdater := xdsfake.NewFakeXDS()
 	meshWatcher := mesh.NewFixedWatcher(&meshconfig.MeshConfig{})
 	kc := kubecontroller.NewController(
 		client,
@@ -214,23 +211,23 @@ func TestWorkloadInstances(t *testing.T) {
 	t.Run("Kubernetes pod labels update", func(t *testing.T) {
 		_, _, _, kube, xdsUpdater := setupTest(t)
 		makeService(t, kube, service)
-		xdsUpdater.WaitOrFail(t, "svcupdate")
+		xdsUpdater.WaitOrFail(t, "service")
 		makePod(t, kube, pod)
-		xdsUpdater.WaitOrFail(t, "proxy update")
+		xdsUpdater.WaitOrFail(t, "proxy")
 		newPod := pod.DeepCopy()
 		newPod.Labels["newlabel"] = "new"
 		makePod(t, kube, newPod)
-		xdsUpdater.WaitOrFail(t, "proxy update")
+		xdsUpdater.WaitOrFail(t, "proxy")
 	})
 
 	t.Run("Kubernetes only: headless service", func(t *testing.T) {
 		kc, _, _, kube, xdsUpdater := setupTest(t)
 		makeService(t, kube, headlessService)
-		xdsUpdater.WaitOrFail(t, "svcupdate")
+		xdsUpdater.WaitOrFail(t, "service")
 		makePod(t, kube, pod)
 		createEndpoints(t, kube, service.Name, namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{pod.Status.PodIP})
 		xdsUpdater.WaitOrFail(t, "eds")
-		xdsUpdater.WaitOrFail(t, "xds")
+		xdsUpdater.WaitOrFail(t, "xds full")
 		instances := []ServiceInstanceResponse{{
 			Hostname:   expectedSvc.Hostname,
 			Namestring: expectedSvc.Attributes.Namespace,
@@ -241,15 +238,15 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Kubernetes only: endpoint occur earlier", func(t *testing.T) {
-		kc, _, _, kube, xdsUpdater := setupTest(t)
+		kc, _, _, kube, fx := setupTest(t)
 		makePod(t, kube, pod)
 
 		createEndpoints(t, kube, service.Name, namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{pod.Status.PodIP})
-		waitForEdsUpdate(t, xdsUpdater, 1)
+		waitForEdsUpdate(t, fx, 1)
 
 		// make service populated later than endpoint
 		makeService(t, kube, service)
-		waitForEdsUpdate(t, xdsUpdater, 1)
+		fx.WaitOrFail(t, "eds cache")
 
 		instances := []ServiceInstanceResponse{{
 			Hostname:   expectedSvc.Hostname,
@@ -459,21 +456,14 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects WorkloadEntry: wle occur earlier", func(t *testing.T) {
-		kc, _, store, kube, xdsUpdater := setupTest(t)
+		kc, _, store, kube, fx := setupTest(t)
 		makeIstioObject(t, store, workloadEntry)
 		// 	Other than proxy update, no event pushed when workload entry created as no service entry
-		xdsUpdater.WaitOrFail(t, "proxy update")
-		select {
-		case ev := <-xdsUpdater.Events:
-			t.Fatalf("Got %s event, expect none", ev.Kind)
-		case <-time.After(40 * time.Millisecond):
-		}
+		fx.WaitOrFail(t, "proxy")
+		fx.AssertEmpty(t, 40*time.Millisecond)
 
 		makeService(t, kube, service)
-		event := xdsUpdater.WaitOrFail(t, "edscache")
-		if event.Endpoints != 1 {
-			t.Errorf("expecting 1 endpoints, but got %d ", event.Endpoints)
-		}
+		fx.MatchOrFail(t, xdsfake.Event{Type: "eds cache", EndpointCount: 1})
 
 		instances := []ServiceInstanceResponse{{
 			Hostname:   expectedSvc.Hostname,
@@ -487,7 +477,7 @@ func TestWorkloadInstances(t *testing.T) {
 	t.Run("Service selects both pods and WorkloadEntry", func(t *testing.T) {
 		kc, _, store, kube, xdsUpdater := setupTest(t)
 		makeService(t, kube, service)
-		xdsUpdater.WaitOrFail(t, "svcupdate")
+		xdsUpdater.WaitOrFail(t, "service")
 
 		makeIstioObject(t, store, workloadEntry)
 		xdsUpdater.WaitOrFail(t, "eds")
@@ -514,23 +504,19 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects both pods and WorkloadEntry: wle occur earlier", func(t *testing.T) {
-		kc, _, store, kube, xdsUpdater := setupTest(t)
+		kc, _, store, kube, fx := setupTest(t)
 		makeIstioObject(t, store, workloadEntry)
 
 		// 	Other than proxy update, no event pushed when workload entry created as no service entry
-		xdsUpdater.WaitOrFail(t, "proxy update")
-		select {
-		case ev := <-xdsUpdater.Events:
-			t.Fatalf("Got %s event, expect none", ev.Kind)
-		case <-time.After(200 * time.Millisecond):
-		}
+		fx.WaitOrFail(t, "proxy")
+		fx.AssertEmpty(t, 200*time.Millisecond)
 
 		makePod(t, kube, pod)
 		createEndpoints(t, kube, service.Name, namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{pod.Status.PodIP})
-		waitForEdsUpdate(t, xdsUpdater, 1)
+		waitForEdsUpdate(t, fx, 1)
 
 		makeService(t, kube, service)
-		waitForEdsUpdate(t, xdsUpdater, 2)
+		fx.WaitOrFail(t, "eds cache")
 
 		instances := []ServiceInstanceResponse{
 			{
@@ -1016,15 +1002,9 @@ func setHealth(cfg config.Config, healthy bool) config.Config {
 	})
 }
 
-func waitForEdsUpdate(t *testing.T, xdsUpdater *xds.FakeXdsUpdater, expected int) {
+func waitForEdsUpdate(t *testing.T, xdsUpdater *xdsfake.Updater, expected int) {
 	t.Helper()
-	retry.UntilSuccessOrFail(t, func() error {
-		event := xdsUpdater.WaitOrFail(t, "eds", "edscache")
-		if event.Endpoints != expected {
-			return fmt.Errorf("expecting %d endpoints, but got %d", expected, event.Endpoints)
-		}
-		return nil
-	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second))
+	xdsUpdater.MatchOrFail(t, xdsfake.Event{Type: "eds", EndpointCount: expected})
 }
 
 func TestEndpointsDeduping(t *testing.T) {
@@ -1131,11 +1111,11 @@ func TestEndpointSlicingServiceUpdate(t *testing.T) {
 					ClusterIP: "9.9.9.9",
 				},
 			})
-			xdsUpdater := s.XdsUpdater.(*xds.FakeXdsUpdater)
+			fx := s.XdsUpdater.(*xdsfake.Updater)
 			createEndpointSlice(t, s.KubeClient().Kube(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
 			createEndpointSlice(t, s.KubeClient().Kube(), "slice2", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
 			expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"}, nil)
-			xdsUpdater.WaitOrFail(t, "svcupdate")
+			fx.WaitOrFail(t, "service")
 
 			// Trigger a service updates
 			makeService(t, s.KubeClient().Kube(), &v1.Service{
@@ -1156,7 +1136,7 @@ func TestEndpointSlicingServiceUpdate(t *testing.T) {
 					ClusterIP: "9.9.9.9",
 				},
 			})
-			xdsUpdater.WaitOrFail(t, "svcupdate")
+			fx.WaitOrFail(t, "service")
 			expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"}, nil)
 		})
 	}
@@ -1188,7 +1168,7 @@ func TestSameIPEndpointSlicing(t *testing.T) {
 			ClusterIP: "9.9.9.9",
 		},
 	})
-	xdsUpdater := s.XdsUpdater.(*xds.FakeXdsUpdater)
+	fx := s.XdsUpdater.(*xdsfake.Updater)
 
 	// Delete endpoints with same IP
 	createEndpointSlice(t, s.KubeClient().Kube(), "slice1", "service", namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{"1.2.3.4"})
@@ -1197,10 +1177,10 @@ func TestSameIPEndpointSlicing(t *testing.T) {
 
 	// delete slice 1, it should still exist
 	_ = s.KubeClient().Kube().DiscoveryV1().EndpointSlices(namespace).Delete(context.TODO(), "slice1", metav1.DeleteOptions{})
-	xdsUpdater.WaitOrFail(t, "eds")
+	fx.WaitOrFail(t, "eds")
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"}, nil)
 	_ = s.KubeClient().Kube().DiscoveryV1().EndpointSlices(namespace).Delete(context.TODO(), "slice2", metav1.DeleteOptions{})
-	xdsUpdater.WaitOrFail(t, "eds")
+	fx.WaitOrFail(t, "eds")
 	expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", nil, nil)
 }
 

--- a/pilot/pkg/serviceregistry/util/xdsfake/updater.go
+++ b/pilot/pkg/serviceregistry/util/xdsfake/updater.go
@@ -1,0 +1,221 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdsfake
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/exp/slices"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/test"
+	"istio.io/pkg/log"
+)
+
+// NewFakeXDS creates a XdsUpdater reporting events via a channel.
+func NewFakeXDS() *Updater {
+	return &Updater{
+		Events: make(chan Event, 100),
+	}
+}
+
+// NewWithDelegate creates a XdsUpdater reporting events via a channel.
+func NewWithDelegate(delegate model.XDSUpdater) *Updater {
+	return &Updater{
+		Events:   make(chan Event, 100),
+		Delegate: delegate,
+	}
+}
+
+// Updater is used to test the registry.
+type Updater struct {
+	// Events tracks notifications received by the updater
+	Events   chan Event
+	Delegate model.XDSUpdater
+}
+
+var _ model.XDSUpdater = &Updater{}
+
+func (fx *Updater) ConfigUpdate(req *model.PushRequest) {
+	names := []string{}
+	if req != nil && len(req.ConfigsUpdated) > 0 {
+		for key := range req.ConfigsUpdated {
+			names = append(names, key.Name)
+		}
+	}
+	sort.Strings(names)
+	id := strings.Join(names, ",")
+	event := "xds"
+	if req.Full {
+		event += " full"
+	}
+	select {
+	case fx.Events <- Event{Type: event, ID: id}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.ConfigUpdate(req)
+	}
+}
+
+func (fx *Updater) ProxyUpdate(c cluster.ID, ip string) {
+	select {
+	case fx.Events <- Event{Type: "proxy", ID: ip}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.ProxyUpdate(c, ip)
+	}
+}
+
+// Event is used to watch XdsEvents
+type Event struct {
+	// Type of the event
+	Type string
+
+	// The id of the event
+	ID string
+
+	Namespace string
+
+	// The endpoints associated with an EDS push if any
+	Endpoints []*model.IstioEndpoint
+
+	// EndpointCount, used in matches only
+	EndpointCount int
+}
+
+func (fx *Updater) EDSUpdate(c model.ShardKey, hostname string, ns string, entry []*model.IstioEndpoint) {
+	select {
+	case fx.Events <- Event{Type: "eds", ID: hostname, Endpoints: entry, Namespace: ns}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.EDSUpdate(c, hostname, ns, entry)
+	}
+}
+
+func (fx *Updater) EDSCacheUpdate(c model.ShardKey, hostname, ns string, entry []*model.IstioEndpoint) {
+	select {
+	case fx.Events <- Event{Type: "eds cache", ID: hostname, Endpoints: entry, Namespace: ns}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.EDSCacheUpdate(c, hostname, ns, entry)
+	}
+}
+
+// SvcUpdate is called when a service port mapping definition is updated.
+// This interface is WIP - labels, annotations and other changes to service may be
+// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
+// LDS/RDS.
+func (fx *Updater) SvcUpdate(c model.ShardKey, hostname string, ns string, ev model.Event) {
+	select {
+	case fx.Events <- Event{Type: "service", ID: hostname, Namespace: ns}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.SvcUpdate(c, hostname, ns, ev)
+	}
+}
+
+func (fx *Updater) RemoveShard(shardKey model.ShardKey) {
+	select {
+	case fx.Events <- Event{Type: "removeShard", ID: shardKey.String()}:
+	default:
+	}
+	if fx.Delegate != nil {
+		fx.Delegate.RemoveShard(shardKey)
+	}
+}
+
+func (fx *Updater) WaitOrFail(t test.Failer, et string) *Event {
+	t.Helper()
+	for {
+		select {
+		case e := <-fx.Events:
+			if e.Type == et {
+				return &e
+			}
+			log.Infof("skipping event %q want %q", e.Type, et)
+			continue
+		case <-time.After(time.Second * 5):
+			t.Fatalf("timed out waiting for %v", et)
+		}
+	}
+}
+
+func (fx *Updater) MatchOrFail(t test.Failer, events ...Event) {
+	t.Helper()
+
+	for {
+		if len(events) == 0 {
+			return
+		}
+		select {
+		case e := <-fx.Events:
+			found := false
+			for i, want := range events {
+				if e.Type == want.Type &&
+					(want.ID == "" || e.ID == want.ID) &&
+					(want.Namespace == "" || want.Namespace == e.Namespace) &&
+					(want.EndpointCount == 0 || want.EndpointCount == len(e.Endpoints)) {
+					// Matched - delete event from desired
+					events = slices.Delete(events, i, i+1)
+					found = true
+					break
+				}
+			}
+			if !found {
+				log.Infof("skipping event %q/%v", e.Type, e.ID)
+			}
+			continue
+		case <-time.After(time.Second * 5):
+			t.Fatalf("timed out waiting for %v", events)
+		}
+	}
+}
+
+// Clear any pending event
+func (fx *Updater) Clear() {
+	wait := true
+	for wait {
+		select {
+		case <-fx.Events:
+		default:
+			wait = false
+		}
+	}
+}
+
+// AssertEmpty ensures there are no events in the channel
+func (fx *Updater) AssertEmpty(t test.Failer, dur time.Duration) {
+	if dur == 0 {
+		select {
+		case e := <-fx.Events:
+			t.Fatalf("got unexpected event %+v", e)
+		default:
+		}
+	} else {
+		select {
+		case e := <-fx.Events:
+			t.Fatalf("got unexpected event %+v", e)
+		case <-time.After(dur):
+		}
+	}
+}


### PR DESCRIPTION
Today we have 3 xds updaters, which do the same thing, but each one does some things poorly. Instead, just use a single one that does things the "right" way