### PR TITLE
Adds Gateway API Weighted Routing Bookinfo Example

### DIFF
--- a/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: reviews
+spec:
+  parentRefs:
+  - kind: Service
+    name: reviews
+    port: 9080
+  rules:
+  - backendRefs:
+    - name: reviews-v1
+      port: 9080
+      weight: 90
+    - name: reviews-v2
+      port: 9080
+      weight: 10


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds sample manifest for Gateway API weight-based routing for the bookinfo reviews v1/v2 service.

In support of https://github.com/istio/istio.io/issues/12803.