### PR TITLE
controller: assert EDS event consistency

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -449,7 +449,7 @@ type IstioEndpoint struct {
 
 	// EnvoyEndpoint is a cached LbEndpoint, converted from the data, to
 	// avoid recomputation
-	EnvoyEndpoint *endpoint.LbEndpoint
+	EnvoyEndpoint *endpoint.LbEndpoint `json:"-"`
 
 	// ServiceAccount holds the associated service account.
 	ServiceAccount string

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -754,22 +754,8 @@ func (s *Controller) buildEndpoints(keys map[instancesKey]struct{}) map[instance
 	if len(allInstances) > 0 {
 		endpoints = make(map[instancesKey][]*model.IstioEndpoint)
 		for _, instance := range allInstances {
-			port := instance.ServicePort
 			key := makeInstanceKey(instance)
-			endpoints[key] = append(endpoints[key],
-				&model.IstioEndpoint{
-					Address:         instance.Endpoint.Address,
-					EndpointPort:    instance.Endpoint.EndpointPort,
-					ServicePortName: port.Name,
-					Labels:          instance.Endpoint.Labels,
-					ServiceAccount:  instance.Endpoint.ServiceAccount,
-					Network:         instance.Endpoint.Network,
-					Locality:        instance.Endpoint.Locality,
-					LbWeight:        instance.Endpoint.LbWeight,
-					TLSMode:         instance.Endpoint.TLSMode,
-					WorkloadName:    instance.Endpoint.WorkloadName,
-					Namespace:       instance.Endpoint.Namespace,
-				})
+			endpoints[key] = append(endpoints[key], instance.Endpoint)
 		}
 
 	}

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1079,6 +1079,7 @@ func TestEndpointsDeduping(t *testing.T) {
 			LabelSelectors: labels,
 		},
 	}, 80, []ServiceInstanceResponse{})
+	s.AssertEndpointConsistency()
 }
 
 // TestEndpointSlicingServiceUpdate is a regression test to ensure we do not end up with duplicate endpoints when a service changes.
@@ -1202,6 +1203,7 @@ func expectEndpoints(t *testing.T, s *xds.FakeDiscoveryServer, cluster string, e
 		}
 		return nil
 	}, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
+	s.AssertEndpointConsistency()
 }
 
 // nolint: unparam


### PR DESCRIPTION
We have two endpoint models - incremental updates and InstancesByPort. This adds a check that the two are in sync.

In doing so, it fixes a few bugs:
* ServiceEntry didn't copy HealthStatus properly
* EndpointSlice could return duplicate addresses

**Please provide a description of this PR:**