### PR TITLE
Adds a Separate Gateway API HTTPRoute for Bookinfo Example

### DIFF
--- a/samples/bookinfo/gateway-api/bookinfo-httproute.yaml
+++ b/samples/bookinfo/gateway-api/bookinfo-httproute.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: bookinfo
+spec:
+  parentRefs:
+  - name: bookinfo-gateway
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /productpage
+    - path:
+        type: PathPrefix
+        value: /static
+    - path:
+        type: Exact
+        value: /login
+    - path:
+        type: Exact
+        value: /logout
+    - path:
+        type: PathPrefix
+        value: /api/v1/products
+    backendRefs:
+    - name: productpage
+      port: 9080


### PR DESCRIPTION
**Please provide a description of this PR:**
Creates a separate HTTPRoute manifest for the bookinfo sample app. Separating the HTTPRoute from `samples/bookinfo/gateway-api/bookinfo-gateway.yaml` provides flexibility to support documenting Gateway API cross-namespace routing use cases such as https://github.com/istio/istio.io/pull/12932. After this PR merges and the Istio.io docs have been updated to reference `samples/bookinfo/gateway-api/bookinfo-httproute.yaml`, `samples/bookinfo/gateway-api/bookinfo-gateway.yaml` should be updated to remove the HTTPRoute.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
