### PR TITLE
Fix unit test expectEndpoints potential issue

### DIFF
--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1079,7 +1079,7 @@ func TestEndpointsDeduping(t *testing.T) {
 			LabelSelectors: labels,
 		},
 	}, 80, []ServiceInstanceResponse{})
-	s.AssertEndpointConsistency()
+	retry.UntilSuccessOrFail(t, s.AssertEndpointConsistency, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
 }
 
 // TestEndpointSlicingServiceUpdate is a regression test to ensure we do not end up with duplicate endpoints when a service changes.
@@ -1203,7 +1203,8 @@ func expectEndpoints(t *testing.T, s *xds.FakeDiscoveryServer, cluster string, e
 		}
 		return nil
 	}, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
-	s.AssertEndpointConsistency()
+
+	retry.UntilSuccessOrFail(t, s.AssertEndpointConsistency, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))
 }
 
 // nolint: unparam

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -481,7 +481,7 @@ func (f *FakeDiscoveryServer) EnsureSynced(t test.Failer) {
 // AssertEndpointConsistency compares endpointShards - which are incrementally updated - with
 // InstancesByPort, which rebuilds the same state from the ground up. This ensures the two are kept in sync;
 // out of sync fields typically are bugs.
-func (f *FakeDiscoveryServer) AssertEndpointConsistency() {
+func (f *FakeDiscoveryServer) AssertEndpointConsistency() error {
 	f.t.Helper()
 	mock := &DiscoveryServer{
 		Env:   &model.Environment{EndpointIndex: model.NewEndpointIndex()},
@@ -539,8 +539,10 @@ func (f *FakeDiscoveryServer) AssertEndpointConsistency() {
 	if err := util.Compare(have, want); err != nil {
 		f.t.Logf("Endpoint Shards: %v", string(have))
 		f.t.Logf("Instances By Port: %v", string(want))
-		f.t.Fatal(err)
+		return err
 	}
+
+	return nil
 }
 
 func getKubernetesObjects(t test.Failer, opts FakeOptions) map[cluster.ID][]runtime.Object {


### PR DESCRIPTION
Fix issue https://github.com/istio/istio/issues/44107.

The svc `outbound|80||service.namespace.svc.cluster.local` has already been delete in last check. If we check again, it will return from `UntilSuccessOrFail` immediately and cause that the update of eds happens at the same time as checking the eds shard.