### PR TITLE
lint: allow repo specific configs

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -21,6 +21,8 @@
 BUILD_WITH_CONTAINER ?= 1
 CONTAINER_OPTIONS = --mount type=bind,source=/tmp,destination=/tmp --net=host
 
+export COMMONFILES_POSTPROCESS = tools/commonfiles-postprocess.sh
+
 ifeq ($(BUILD_WITH_CONTAINER),1)
 # create phony targets for the top-level items in the repo
 PHONYS := $(shell ls | grep -v Makefile)

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -4,6 +4,7 @@
 # If you're looking at this file in a different repo and want to make a change, please go to the
 # common-files repo, make the change there and check it in. Then come back to this repo and run
 # "make update-common".
+
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
   golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -4,7 +4,6 @@
 # If you're looking at this file in a different repo and want to make a change, please go to the
 # common-files repo, make the change there and check it in. Then come back to this repo and run
 # "make update-common".
-
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the istio/tools repo.
   golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -233,6 +233,9 @@ linters-settings:
   depguard:
     packages-with-error-message:
       - github.com/gogo/protobuf: "gogo/protobuf is deprecated, use golang/protobuf"
+        golang.org/x/net/http2/h2c: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"
+      - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
+      - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
   gosec:
     includes:
       - G401

--- a/tools/commonfiles-postprocess.sh
+++ b/tools/commonfiles-postprocess.sh
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# shellcheck disable=SC2016
 yq ea '. as $item ireduce ({}; . *d $item )' ./common/config/.golangci.yml ./tools/golangci-override.yaml > ./common/config/.golangci.yml.tmp
 mv ./common/config/.golangci.yml.tmp ./common/config/.golangci.yml

--- a/tools/commonfiles-postprocess.sh
+++ b/tools/commonfiles-postprocess.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+yq ea '. as $item ireduce ({}; . *d $item )' ./common/config/.golangci.yml ./tools/golangci-override.yaml > ./common/config/.golangci.yml.tmp
+mv ./common/config/.golangci.yml.tmp ./common/config/.golangci.yml

--- a/tools/commonfiles-postprocess.sh
+++ b/tools/commonfiles-postprocess.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 yq ea '. as $item ireduce ({}; . *d $item )' ./common/config/.golangci.yml ./tools/golangci-override.yaml > ./common/config/.golangci.yml.tmp
 mv ./common/config/.golangci.yml.tmp ./common/config/.golangci.yml

--- a/tools/golangci-override.yaml
+++ b/tools/golangci-override.yaml
@@ -1,0 +1,6 @@
+linters-settings:
+  depguard:
+    packages-with-error-message:
+    - golang.org/x/net/http2/h2c: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"
+    - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
+    - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"


### PR DESCRIPTION
This is part of this, rest is in common-files. Basically, move per-repo settings into the repo. This allows us to expand our checks more aggresively where they don't make sense outside the repo.

This is done by overriding the actual stored file which is a bit more managageble than overriding it on the fly since golangci-lint doesn't support config from stdin.

**Please provide a description of this PR:**