### PR TITLE
Bump iptables image for ztunnel

### DIFF
--- a/pilot/docker/Dockerfile.ztunnel
+++ b/pilot/docker/Dockerfile.ztunnel
@@ -12,7 +12,7 @@ FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 # This image is a custom built debian11 distroless image with multiarchitecture support.
 # It is built on the base distroless image, with iptables binary and libraries added
 # The source can be found at https://github.com/istio/distroless/tree/iptables
-# This version is from commit 6faf2f9348d382c6a95bbc3171b89406103cb0ad.
+# This version is from commit a8b3fb577adb785211ce704fdf892983fc268b11.
 FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:4be99c4dbc0a158fc4404d66198bf18f321292ffeff55201e9c8fa518a54b81e as distroless
 
 # This will build the final image based on either debug or distroless from above


### PR DESCRIPTION
**Please provide a description of this PR:**

Update base distroless image for ztunnel since there are fixed CVEs
