### PR TITLE
Fix wrong analysis results for file chunks with multiple empty lines

### DIFF
--- a/pilot/pkg/config/file/store.go
+++ b/pilot/pkg/config/file/store.go
@@ -290,6 +290,9 @@ func (s *KubeSource) parseContent(r *collection.Schemas, name, yamlText string) 
 		}
 
 		chunk := bytes.TrimSpace(doc)
+		if len(chunk) == 0 {
+			continue
+		}
 		chunkResources, err := s.parseChunk(r, name, lineNum, chunk)
 		if err != nil {
 			var uerr *unknownSchemaError

--- a/pkg/config/analysis/analyzers/testdata/absolute-envoy-filter-operation.yaml
+++ b/pkg/config/analysis/analyzers/testdata/absolute-envoy-filter-operation.yaml
@@ -127,3 +127,5 @@ spec:
                     address: "internal.org.net"
                     port_value: 8888
 ---
+
+


### PR DESCRIPTION
**Please provide a description of this PR:**
If there's a file that has multiple empty new lines, the analyzer will throw a no kind parse error, but however the actual chunk content is empty. We need to skip this situation to avoid wrong analysis results.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
