### PR TITLE
remove deprecated proxy_init.resources from default profile

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -77,13 +77,6 @@ spec:
         tracer: "zipkin"
       proxy_init:
         image: proxyv2
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-          requests:
-            cpu: 10m
-            memory: 10Mi
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       imagePullPolicy: ""

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -76,17 +76,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -75,17 +75,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -75,17 +75,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -76,17 +76,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -78,17 +78,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -75,17 +75,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
@@ -75,17 +75,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -74,17 +74,7 @@
       "tracer": "zipkin"
     },
     "proxy_init": {
-      "image": "proxyv2",
-      "resources": {
-        "limits": {
-          "cpu": "2000m",
-          "memory": "1024Mi"
-        },
-        "requests": {
-          "cpu": "10m",
-          "memory": "10Mi"
-        }
-      }
+      "image": "proxyv2"
     },
     "remotePilotAddress": "",
     "sds": {


### PR DESCRIPTION
**Please provide a description of this PR:**

The proxy_init.resources value is deprecated and has no effect since the value of proxy.resources is actually used for setting this. It can be removed from the default profile.