### PR TITLE
Remove iop resource name check for operator reconcile

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -279,13 +279,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 		}
 	}
 
-	// for backward compatibility, the previous applied installed-state CR does not have the ignore reconcile annotation
-	// TODO(richardwxn): remove this check and rely on annotation check only
-	if strings.HasPrefix(iop.Name, name.InstalledSpecCRPrefix) {
-		scope.Infof("Ignoring the installed-state IstioOperator CR %s ", iopName)
-		return reconcile.Result{}, nil
-	}
-
 	var err error
 	iopMerged := &iopv1alpha1.IstioOperator{}
 	*iopMerged = *iop

--- a/releasenotes/notes/44152.yaml
+++ b/releasenotes/notes/44152.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** operator skip reconcile for iop resources named starting with `installed-state`, and now it only relies on annotation `install.istio.io/ignoreReconcile`.
+    This won't affect the behavior of `istioctl install`.

--- a/releasenotes/notes/44152.yaml
+++ b/releasenotes/notes/44152.yaml
@@ -1,7 +1,9 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: installation
+issue:
+  - 29394
 releaseNotes:
   - |
-    **Fixed** operator skip reconcile for iop resources named starting with `installed-state`, and now it only relies on annotation `install.istio.io/ignoreReconcile`.
+    **Removed** operator skip reconcile for iop resources with names starting with `installed-state`. It now relies solely on the annotation `install.istio.io/ignoreReconcile`.
     This won't affect the behavior of `istioctl install`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Since we have been using the annotation `install.istio.io/ignoreReconcile` for a long time now, and since the file name check is not 100% accurate, we should rely solely on this annotation for our needs, and remove the file name check.

Fix https://github.com/istio/istio/issues/29394

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
