### PR TITLE
Run sidecars with dynamically-determined user IDs

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -284,7 +284,8 @@ refresh-goldens:
 		./pkg/bootstrap/... \
 		./pkg/kube/inject/... \
 		./pilot/pkg/security/authz/builder/... \
-		./cni/pkg/plugin/...
+		./cni/pkg/plugin/... \
+		./istioctl/cmd/...
 
 update-golden: refresh-goldens
 

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -39,6 +39,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)
+	viper.Set(constants.ProxyGID, rdrct.noRedirectGID)
 	viper.Set(constants.InboundInterceptionMode, rdrct.redirectMode)
 	viper.Set(constants.ServiceCidr, rdrct.includeIPCidrs)
 	viper.Set(constants.LocalExcludePorts, rdrct.excludeInboundPorts)

--- a/cni/pkg/plugin/kubernetes.go
+++ b/cni/pkg/plugin/kubernetes.go
@@ -38,6 +38,8 @@ type PodInfo struct {
 	Labels            map[string]string
 	Annotations       map[string]string
 	ProxyEnvironments map[string]string
+	ProxyUID          *int64
+	ProxyGID          *int64
 }
 
 // newK8sClient returns a Kubernetes client
@@ -83,6 +85,10 @@ func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (
 			// Get proxy container env variable, and extract out ProxyConfig from it.
 			for _, e := range container.Env {
 				pi.ProxyEnvironments[e.Name] = e.Value
+			}
+			if container.SecurityContext != nil {
+				pi.ProxyUID = container.SecurityContext.RunAsUser
+				pi.ProxyGID = container.SecurityContext.RunAsGroup
 			}
 			continue
 		}

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -32,6 +32,7 @@ const (
 	defaultProxyStatusPort       = "15020"
 	defaultRedirectToPort        = "15001"
 	defaultNoRedirectUID         = "1337"
+	defaultNoRedirectGID         = "1337"
 	defaultRedirectMode          = redirectModeREDIRECT
 	defaultRedirectIPCidr        = "*"
 	defaultRedirectExcludeIPCidr = ""
@@ -77,6 +78,7 @@ type Redirect struct {
 	targetPort           string
 	redirectMode         string
 	noRedirectUID        string
+	noRedirectGID        string
 	includeIPCidrs       string
 	excludeIPCidrs       string
 	excludeInboundPorts  string
@@ -216,6 +218,13 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			"redirectMode", isFound, valErr)
 	}
 	redir.noRedirectUID = defaultNoRedirectUID
+	if pi.ProxyUID != nil {
+		redir.noRedirectUID = fmt.Sprintf("%d", *pi.ProxyUID)
+	}
+	redir.noRedirectGID = defaultNoRedirectGID
+	if pi.ProxyGID != nil {
+		redir.noRedirectGID = fmt.Sprintf("%d", *pi.ProxyGID)
+	}
 	isFound, redir.includeIPCidrs, valErr = getAnnotationOrDefault("includeIPCidrs", pi.Annotations)
 	if valErr != nil {
 		return nil, fmt.Errorf("annotation value error for value %s; annotationFound = %t: %v",

--- a/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
@@ -29,6 +29,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         name: hello
         ports:

--- a/istioctl/cmd/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-test
         name: istio-init

--- a/istioctl/cmd/testdata/deployment/hello.yaml.iop.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.iop.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-testiop
         name: istio-init

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -164,6 +164,7 @@ data:
         "alwaysInjectSelector": [],
         "defaultTemplates": [],
         "enableNamespacesByDefault": false,
+        "incrementUID": false,
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "rewriteAppHTTPProbe": true,
@@ -178,6 +179,7 @@ data:
   # to fine tune it or use it with kube-inject.
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+    incrementUID: false
     defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -27,6 +27,7 @@ data:
     - {{ . }}
 {{- end }}
     {{- else }}
+    incrementUID: {{ $.Values.sidecarInjectorWebhook.incrementUID  | default `false` }}
     defaultTemplates: [sidecar]
     {{- end }}
     policy: {{ .Values.global.proxy.autoInject }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -125,6 +125,12 @@ sidecarInjectorWebhook:
   #
   # defaultTemplates: ["sidecar", "hello"]
   defaultTemplates: []
+
+  # Enable sidecar to auto-increment the runAsUID used by the proxy.
+  # Used by the Openshift profile to avoid the need to manually apply the anyuid policy.
+  incrementUID: false
+
+
 istiodRemote:
   # Sidecar injector mutating webhook configuration clientConfig.url value.
   # For example: https://$remotePilotAddress:15017/inject

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -27,6 +27,7 @@ data:
     - {{ . }}
 {{- end }}
     {{- else }}
+    incrementUID: {{ $.Values.sidecarInjectorWebhook.incrementUID  | default `false` }}
     defaultTemplates: [sidecar]
     {{- end }}
     policy: {{ .Values.global.proxy.autoInject }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -104,6 +104,9 @@ sidecarInjectorWebhook:
   #
   # defaultTemplates: ["sidecar", "hello"]
   defaultTemplates: []
+  # Enable sidecar to auto-increment the runAsUID used by the proxy.
+  # Used by the Openshift profile to avoid the need to manually apply the anyuid policy.
+  incrementUID: false
 istiodRemote:
   # Sidecar injector mutating webhook configuration clientConfig.url value.
   # For example: https://$remotePilotAddress:15017/inject

--- a/manifests/profiles/openshift.yaml
+++ b/manifests/profiles/openshift.yaml
@@ -5,6 +5,49 @@ spec:
     cni:
       enabled: true
       namespace: kube-system
+      k8s:
+        overlays:
+          - kind: DaemonSet
+            name: istio-cni-node
+            patches:
+              - path: spec.template.spec.securityContext
+          - kind: ClusterRole
+            name: istio-cni
+            patches:
+              - path: rules[-1] # [-1] works like an array push
+                value:
+                  apiGroups:
+                    - security.openshift.io
+                  resources:
+                    - securitycontextconstraints
+                  resourceNames:
+                    - privileged
+                  verbs:
+                    - 'use'
+    pilot:
+      k8s:
+        overlays:
+          - kind: Deployment
+            name: istiod
+            patches:
+              - path: spec.template.spec.containers.[name:discovery].securityContext
+              - path: spec.template.spec.securityContext
+    ingressGateways:
+      - name: istio-ingressgateway
+        k8s:
+          overlays:
+            - kind: Deployment
+              name: istio-ingressgateway
+              patches:
+                - path: spec.template.spec.securityContext
+    egressGateways:
+      - name: istio-egressgateway
+        k8s:
+          overlays:
+            - kind: Deployment
+              name: istio-egressgateway
+              patches:
+                - path: spec.template.spec.securityContext
   values:
     cni:
       cniBinDir: /var/lib/cni/bin
@@ -17,5 +60,6 @@ spec:
       logLevel: info
       privileged: true
     sidecarInjectorWebhook:
+      incrementUID: true
       injectedAnnotations:
         k8s.v1.cni.cncf.io/networks: istio-cni

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -4306,6 +4306,9 @@ type SidecarInjectorConfig struct {
 	Templates *structpb.Struct `protobuf:"bytes,23,opt,name=templates,proto3" json:"templates,omitempty"`
 	// defaultTemplates: ["sidecar", "hello"]
 	DefaultTemplates []string `protobuf:"bytes,24,rep,name=defaultTemplates,proto3" json:"defaultTemplates,omitempty"`
+	// Enable sidecar to auto-increment the runAsUID used by the proxy.
+	// Used by the Openshift profile to avoid the need to manually apply the anyuid policy.
+	IncrementUID *wrapperspb.BoolValue `protobuf:"bytes,25,opt,name=incrementUID,proto3" json:"incrementUID,omitempty"`
 	// If enabled, the legacy webhook selection logic will be used. This relies on filtering of webhook
 	// requests in Istiod, rather than at the webhook selection level.
 	// This is option is intended for migration purposes only and will be removed in Istio 1.10.
@@ -4405,6 +4408,13 @@ func (x *SidecarInjectorConfig) GetTemplates() *structpb.Struct {
 func (x *SidecarInjectorConfig) GetDefaultTemplates() []string {
 	if x != nil {
 		return x.DefaultTemplates
+	}
+	return nil
+}
+
+func (x *SidecarInjectorConfig) GetIncrementUID() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.IncrementUID
 	}
 	return nil
 }
@@ -6162,7 +6172,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x0c, 0x65, 0x78, 0x74, 0x65, 0x72, 0x6e, 0x61,
 	0x6c, 0x50, 0x6f, 0x72, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20,
 	0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70,
-	0x65, 0x18, 0x12, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x22, 0xba, 0x05,
+	0x65, 0x18, 0x12, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x22, 0xfa, 0x05,
 	0x0a, 0x15, 0x53, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x49, 0x6e, 0x6a, 0x65, 0x63, 0x74, 0x6f,
 	0x72, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x58, 0x0a, 0x19, 0x65, 0x6e, 0x61, 0x62, 0x6c,
 	0x65, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x73, 0x42, 0x79, 0x44, 0x65, 0x66,
@@ -6201,7 +6211,11 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x75, 0x63, 0x74, 0x52, 0x09, 0x74, 0x65, 0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x12, 0x2a,
 	0x0a, 0x10, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x54, 0x65, 0x6d, 0x70, 0x6c, 0x61, 0x74,
 	0x65, 0x73, 0x18, 0x18, 0x20, 0x03, 0x28, 0x09, 0x52, 0x10, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c,
-	0x74, 0x54, 0x65, 0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x12, 0x4e, 0x0a, 0x12, 0x75, 0x73,
+	0x74, 0x54, 0x65, 0x6d, 0x70, 0x6c, 0x61, 0x74, 0x65, 0x73, 0x12, 0x3e, 0x0a, 0x0c, 0x69, 0x6e,
+	0x63, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x55, 0x49, 0x44, 0x18, 0x19, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+	0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x0c, 0x69, 0x6e,
+	0x63, 0x72, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x55, 0x49, 0x44, 0x12, 0x4e, 0x0a, 0x12, 0x75, 0x73,
 	0x65, 0x4c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x73,
 	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c,
@@ -6593,37 +6607,38 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
 	60,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
 	60,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
 	60,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	58,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
-	44,  // 161: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
-	45,  // 162: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
-	46,  // 163: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
-	47,  // 164: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	58,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	58,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	58,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	58,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	5,   // 169: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
-	16,  // 170: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
-	17,  // 171: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
-	25,  // 172: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	59,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	28,  // 174: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
-	42,  // 175: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
-	5,   // 176: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIConfig
-	59,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	48,  // 178: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
-	49,  // 179: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	58,  // 180: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	62,  // 181: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	63,  // 182: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	60,  // 183: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.gateway:type_name -> google.protobuf.Struct
-	60,  // 184: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.inboundSidecar:type_name -> google.protobuf.Struct
-	60,  // 185: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.outboundSidecar:type_name -> google.protobuf.Struct
-	186, // [186:186] is the sub-list for method output_type
-	186, // [186:186] is the sub-list for method input_type
-	186, // [186:186] is the sub-list for extension type_name
-	186, // [186:186] is the sub-list for extension extendee
-	0,   // [0:186] is the sub-list for field type_name
+	58,  // 160: v1alpha1.SidecarInjectorConfig.incrementUID:type_name -> google.protobuf.BoolValue
+	58,  // 161: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	44,  // 162: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
+	45,  // 163: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
+	46,  // 164: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
+	47,  // 165: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
+	58,  // 166: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	58,  // 167: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	58,  // 168: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	58,  // 169: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	5,   // 170: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
+	16,  // 171: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
+	17,  // 172: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
+	25,  // 173: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
+	59,  // 174: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	28,  // 175: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
+	42,  // 176: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
+	5,   // 177: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIConfig
+	59,  // 178: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	48,  // 179: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
+	49,  // 180: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
+	58,  // 181: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	62,  // 182: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	63,  // 183: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	60,  // 184: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.gateway:type_name -> google.protobuf.Struct
+	60,  // 185: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.inboundSidecar:type_name -> google.protobuf.Struct
+	60,  // 186: v1alpha1.TelemetryV2PrometheusConfig.ConfigOverride.outboundSidecar:type_name -> google.protobuf.Struct
+	187, // [187:187] is the sub-list for method output_type
+	187, // [187:187] is the sub-list for method input_type
+	187, // [187:187] is the sub-list for extension type_name
+	187, // [187:187] is the sub-list for extension extendee
+	0,   // [0:187] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -1075,6 +1075,10 @@ message SidecarInjectorConfig {
   // defaultTemplates: ["sidecar", "hello"]
   repeated string defaultTemplates = 24;
 
+  // Enable sidecar to auto-increment the runAsUID used by the proxy.
+  // Used by the Openshift profile to avoid the need to manually apply the anyuid policy.
+  google.protobuf.BoolValue incrementUID = 25;
+
   // If enabled, the legacy webhook selection logic will be used. This relies on filtering of webhook
   // requests in Istiod, rather than at the webhook selection level.
   // This is option is intended for migration purposes only and will be removed in Istio 1.10.

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
@@ -50,6 +51,13 @@ import (
 // InjectionPolicy determines the policy for injecting the
 // sidecar proxy into the watched namespace(s).
 type InjectionPolicy string
+
+// Defaults values for injecting istio proxy into kubernetes
+// resources.
+const (
+	DefaultSidecarProxyUID = int64(1337)
+	DefaultSidecarProxyGID = int64(1337)
+)
 
 const (
 	// InjectionPolicyDisabled specifies that the sidecar injector
@@ -103,6 +111,8 @@ type SidecarTemplateData struct {
 	Values         map[string]any
 	Revision       string
 	ProxyImage     string
+	ProxyUID       *int64
+	ProxyGID       *int64
 }
 
 type (
@@ -147,6 +157,9 @@ type Config struct {
 	// InjectedAnnotations are additional annotations that will be added to the pod spec after injection
 	// This is primarily to support PSP annotations.
 	InjectedAnnotations map[string]string `json:"injectedAnnotations"`
+
+	// Increment the runAsUID of the proxy by 1
+	IncrementUID bool `json:"incrementUID"`
 
 	// Templates is a pre-parsed copy of RawTemplates
 	Templates Templates `json:"-"`
@@ -403,6 +416,8 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		Values:         params.valuesConfig.asMap,
 		Revision:       params.revision,
 		ProxyImage:     ProxyImage(params.valuesConfig.asStruct, params.proxyConfig.Image, strippedPod.Annotations),
+		ProxyUID:       params.proxyUID,
+		ProxyGID:       params.proxyGID,
 	}
 
 	mergedPod = params.pod
@@ -754,6 +769,8 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 			revision:            revision,
 			proxyEnvs:           map[string]string{},
 			injectedAnnotations: nil,
+			proxyUID:            pointer.Int64Ptr(DefaultSidecarProxyUID),
+			proxyGID:            pointer.Int64Ptr(DefaultSidecarProxyGID),
 		}
 		patchBytes, err = injectPod(params)
 	}

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -321,6 +321,11 @@ func TestInjection(t *testing.T) {
 				m.DefaultConfig.Tracing = &meshapi.Tracing{}
 			},
 		},
+		{
+			// Verifies securityContext.runAsUser is respected in proxy
+			in:   "hello-sc-runas.yaml",
+			want: "hello-sc-runas.yaml.injected",
+		},
 	}
 	// Keep track of tests we add options above
 	// We will search for all test files and skip these ones
@@ -587,6 +592,8 @@ spec:
     - name: hello
       image: fake.docker.io/google-samples/hello-go-gke:1.0
     - name: istio-proxy
+      securityContext:
+        runAsUser: 1337
       image: proxy
 `
 	runWebhook(t, webhook, []byte(input), []byte(fmt.Sprintf(expected, "sidecar,init")), false)

--- a/pkg/kube/inject/testdata/inject/gateway.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway.yaml.injected
@@ -104,6 +104,8 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 3
         resources: {}
+        securityContext:
+          runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket

--- a/pkg/kube/inject/testdata/inject/hello-sc-runas.yaml
+++ b/pkg/kube/inject/testdata/inject/hello-sc-runas.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels: 
+      app: hello
+      tier: backend
+      track: stable
+  template:
+    metadata:
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80
+          securityContext:
+            runAsUser: 1000

--- a/pkg/kube/inject/testdata/inject/hello-sc-runas.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-sc-runas.yaml.injected
@@ -2,49 +2,42 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
-  name: grpc
+  name: hello
 spec:
+  replicas: 7
   selector:
     matchLabels:
-      app: grpc
+      app: hello
+      tier: backend
+      track: stable
   strategy: {}
   template:
     metadata:
       annotations:
-        inject.istio.io/templates: grpc-agent
-        kubectl.kubernetes.io/default-container: traffic
-        kubectl.kubernetes.io/default-logs-container: traffic
+        kubectl.kubernetes.io/default-container: hello
+        kubectl.kubernetes.io/default-logs-container: hello
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
-        sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"initContainers":null,"containers":["istio-proxy","traffic"],"volumes":["workload-socket","workload-certs","istio-xds","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+        sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
-        app: grpc
-        service.istio.io/canonical-name: grpc
+        app: hello
+        security.istio.io/tlsMode: istio
+        service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest
+        tier: backend
+        track: stable
     spec:
       containers:
-      - env:
-        - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-          value: "true"
-        - name: GRPC_XDS_BOOTSTRAP
-          value: /etc/istio/proxy/grpc-bootstrap.json
-        image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        readinessProbe:
-          httpGet:
-            port: 80
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
         resources: {}
-        volumeMounts:
-        - mountPath: /var/lib/istio/data
-          name: istio-data
-        - mountPath: /etc/istio/proxy
-          name: istio-xds
-        - mountPath: /var/run/secrets/workload-spiffe-credentials
-          name: workload-certs
+        securityContext:
+          runAsUser: 1000
       - args:
         - proxy
         - sidecar
@@ -54,10 +47,6 @@ spec:
         - --proxyComponentLogLevel=misc:error
         - --log_output_level=default:info
         env:
-        - name: ISTIO_META_GENERATOR
-          value: grpc
-        - name: OUTPUT_CERTS
-          value: /var/lib/istio/data
         - name: JWT_POLICY
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
@@ -84,51 +73,48 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "0"
+              resource: limits.cpu
         - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
+                {"name":"http","containerPort":80}
             ]
         - name: ISTIO_META_APP_CONTAINERS
-          value: traffic
+          value: hello
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         - name: ISTIO_META_WORKLOAD_NAME
-          value: grpc
+          value: hello
         - name: ISTIO_META_OWNER
-          value: kubernetes://apis/apps/v1/namespaces/default/deployments/grpc
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
-        - name: ISTIO_META_DNS_CAPTURE
-          value: "false"
-        - name: DISABLE_ENVOY
-          value: "true"
         image: gcr.io/istio-testing/proxyv2:latest
-        lifecycle:
-          postStart:
-            exec:
-              command:
-              - pilot-agent
-              - wait
-              - --url=http://localhost:15020/healthz/ready
         name: istio-proxy
         ports:
-        - containerPort: 15020
-          name: mesh-metrics
+        - containerPort: 15090
+          name: http-envoy-prom
           protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
             path: /healthz/ready
-            port: 15020
+            port: 15021
           initialDelaySeconds: 1
           periodSeconds: 2
           timeoutSeconds: 3
@@ -140,10 +126,20 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
         - mountPath: /var/run/secrets/workload-spiffe-credentials
           name: workload-certs
         - mountPath: /var/run/secrets/istio
@@ -151,17 +147,60 @@ spec:
         - mountPath: /var/lib/istio/data
           name: istio-data
         - mountPath: /etc/istio/proxy
-          name: istio-xds
+          name: istio-envoy
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      initContainers:
+      - args:
+        - istio-iptables
+        - -p
+        - "15001"
+        - -z
+        - "15006"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - '*'
+        - -d
+        - 15090,15021,15020
+        - --log_output_level=default:info
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-init
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
       volumes:
       - name: workload-socket
+      - name: credential-socket
       - name: workload-certs
       - emptyDir:
           medium: Memory
-        name: istio-xds
+        name: istio-envoy
       - emptyDir: {}
         name: istio-data
       - downwardAPI:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -134,7 +134,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: false
-          runAsUser: 0
+          runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -115,6 +115,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -115,6 +115,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -117,6 +117,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.values.gen.yaml
@@ -114,6 +114,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1,4 +1,5 @@
 # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+incrementUID: false
 defaultTemplates: [sidecar]
 policy: enabled
 alwaysInjectSelector:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -113,6 +113,7 @@
     "alwaysInjectSelector": [],
     "defaultTemplates": [],
     "enableNamespacesByDefault": false,
+    "incrementUID": false,
     "injectedAnnotations": {},
     "neverInjectSelector": [],
     "rewriteAppHTTPProbe": true,

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -971,7 +971,10 @@ func TestRunAndServe(t *testing.T) {
     "path": "/spec/containers/1",
     "value": {
         "name": "istio-proxy",
-        "resources": {}
+        "resources": {},
+		"securityContext": {
+		    "runAsUser": 1337
+		}
     }
 },
 {


### PR DESCRIPTION
The sidecar injector sets the securityContext.runAsUser field regardless if it is specified in the sidecar template or not. This is to allow the sidecar template to not include the field, which is required to ensure that istioctl kube-inject outputs manifests that pass the SCC admission controller (if the runAsUser is specified, the SCC controller will reject the pod, as the uid won't be in the proper range). The sidecar injector then injects the correct runAsUser id even if it isn't specified in the template.

The Openshift profile is updated to
* enable the incrementUUID flag
* overlay the default deployments to allow Openshift to default securityContext

------
Co-authored-by: Marko Lukša <marko.luksa@gmail.com>
Co-authored-by: Brian Avery <bavery@redhat.com>
Co-authored-by: rcernich <rcernich@redhat.com>
Co-authored-by: Jacek Ewertowski <jewertow@redhat.com>

-----

These changes remove the need for the any anyuid setup as described in the Istio Openshift install Docs; 
https://istio.io/latest/docs/setup/platform-setup/openshift/  (separate pr coming) 