### PR TITLE
Fixes selector logic of service and endpoint

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -930,7 +930,7 @@ func (c *Controller) serviceInstancesFromWorkloadInstances(svc *model.Service, r
 		if wi.Namespace != svc.Attributes.Namespace {
 			return
 		}
-		if selector.SubsetOf(wi.Endpoint.Labels) {
+		if selector.Match(wi.Endpoint.Labels) {
 			instance := serviceInstanceFromWorkloadInstance(svc, servicePort, targetPort, wi)
 			if instance != nil {
 				out = append(out, instance)

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -125,11 +125,7 @@ func findServiceTargetPort(servicePort *model.Port, k8sService *v1.Service) serv
 func getPodServices(allServices []*v1.Service, pod *v1.Pod) []*v1.Service {
 	var services []*v1.Service
 	for _, service := range allServices {
-		if service.Spec.Selector == nil {
-			// services with nil selectors match nothing, not everything.
-			continue
-		}
-		if labels.Instance(service.Spec.Selector).SubsetOf(pod.Labels) {
+		if labels.Instance(service.Spec.Selector).Match(pod.Labels) {
 			services = append(services, service)
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -512,7 +512,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 	fullPush := false
 	for _, cfg := range cfgs {
 		se := cfg.Spec.(*networking.ServiceEntry)
-		if se.WorkloadSelector == nil || !labels.Instance(se.WorkloadSelector.Labels).SubsetOf(wi.Endpoint.Labels) {
+		if se.WorkloadSelector == nil || !labels.Instance(se.WorkloadSelector.Labels).Match(wi.Endpoint.Labels) {
 			// Not a match, skip this one
 			continue
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/util.go
+++ b/pilot/pkg/serviceregistry/serviceentry/util.go
@@ -26,7 +26,7 @@ func getWorkloadServiceEntries(ses []config.Config, wle *networking.WorkloadEntr
 	out := make(map[types.NamespacedName]*config.Config)
 	for i, cfg := range ses {
 		se := cfg.Spec.(*networking.ServiceEntry)
-		if se.WorkloadSelector != nil && labels.Instance(se.WorkloadSelector.Labels).SubsetOf(wle.Labels) {
+		if se.WorkloadSelector != nil && labels.Instance(se.WorkloadSelector.Labels).Match(wle.Labels) {
 			out[config.NamespacedName(cfg)] = &ses[i]
 		}
 	}

--- a/pilot/pkg/serviceregistry/util/workloadinstances/selector.go
+++ b/pilot/pkg/serviceregistry/util/workloadinstances/selector.go
@@ -23,7 +23,7 @@ import (
 // of a given service.
 func ByServiceSelector(namespace string, selector labels.Instance) func(*model.WorkloadInstance) bool {
 	return func(wi *model.WorkloadInstance) bool {
-		return wi.Namespace == namespace && selector.SubsetOf(wi.Endpoint.Labels)
+		return wi.Namespace == namespace && selector.Match(wi.Endpoint.Labels)
 	}
 }
 

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -73,6 +73,16 @@ func (i Instance) SubsetOf(that Instance) bool {
 	return true
 }
 
+// Match is true if the label has same values for the keys.
+// if len(i) == 0, will return false. It is mainly used for service -> workload
+func (i Instance) Match(that Instance) bool {
+	if len(i) == 0 {
+		return false
+	}
+
+	return i.SubsetOf(that)
+}
+
 // Equals returns true if the labels are equal.
 func (i Instance) Equals(that Instance) bool {
 	return maps.Equal(i, that)

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -21,54 +21,66 @@ import (
 )
 
 func TestInstance(t *testing.T) {
+	type result struct {
+		subsetOf bool
+		selected bool
+	}
+
 	cases := []struct {
 		left     labels.Instance
 		right    labels.Instance
-		expected bool
+		expected result
 	}{
 		{
 			left:     nil,
 			right:    labels.Instance{"app": "a"},
-			expected: true,
+			expected: result{true, false},
+		},
+		{
+			left:     labels.Instance{},
+			right:    labels.Instance{"app": "a"},
+			expected: result{true, false},
 		},
 		{
 			left:     labels.Instance{"app": "a"},
 			right:    nil,
-			expected: false,
+			expected: result{false, false},
 		},
 		{
 			left:     labels.Instance{"app": "a"},
 			right:    labels.Instance{"app": "a", "prod": "env"},
-			expected: true,
+			expected: result{true, true},
 		},
 		{
 			left:     labels.Instance{"app": "a", "prod": "env"},
 			right:    labels.Instance{"app": "a"},
-			expected: false,
+			expected: result{false, false},
 		},
 		{
 			left:     labels.Instance{"app": "a"},
 			right:    labels.Instance{"app": "b", "prod": "env"},
-			expected: false,
+			expected: result{false, false},
 		},
 		{
 			left:     labels.Instance{"foo": ""},
 			right:    labels.Instance{"app": "a"},
-			expected: false,
+			expected: result{false, false},
 		},
 		{
 			left:     labels.Instance{"foo": ""},
 			right:    labels.Instance{"app": "a", "foo": ""},
-			expected: true,
+			expected: result{true, true},
 		},
 		{
 			left:     labels.Instance{"app": "a", "foo": ""},
 			right:    labels.Instance{"foo": ""},
-			expected: false,
+			expected: result{false, false},
 		},
 	}
 	for _, c := range cases {
-		got := c.left.SubsetOf(c.right)
+		var got result
+		got.subsetOf = c.left.SubsetOf(c.right)
+		got.selected = c.left.Match(c.right)
 		if got != c.expected {
 			t.Errorf("%v.SubsetOf(%v) got %v, expected %v", c.left, c.right, got, c.expected)
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1939,37 +1939,41 @@ func ValidateControlPlaneAuthPolicy(policy meshconfig.AuthenticationPolicy) erro
 	return fmt.Errorf("unrecognized control plane auth policy %q", policy)
 }
 
-func validateWorkloadSelector(selector *type_beta.WorkloadSelector) error {
-	var errs error
+func validateWorkloadSelector(selector *type_beta.WorkloadSelector) Validation {
+	validation := Validation{}
 	if selector != nil {
 		for k, v := range selector.MatchLabels {
 			if k == "" {
-				errs = appendErrors(errs,
-					fmt.Errorf("empty key is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))
+				err := fmt.Errorf("empty key is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v))
+				validation = appendValidation(validation, err)
 			}
 			if strings.Contains(k, "*") || strings.Contains(v, "*") {
-				errs = appendErrors(errs,
-					fmt.Errorf("wildcard is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v)))
+				err := fmt.Errorf("wildcard is not supported in selector: %q", fmt.Sprintf("%s=%s", k, v))
+				validation = appendValidation(validation, err)
 			}
+		}
+		if len(selector.MatchLabels) == 0 {
+			warning := fmt.Errorf("workload selector specified without labels") // nolint: stylecheck
+			validation = appendValidation(validation, WrapWarning(warning))
 		}
 	}
 
-	return errs
+	return validation
 }
 
 // ValidateAuthorizationPolicy checks that AuthorizationPolicy is well-formed.
 var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPolicy",
 	func(cfg config.Config) (Warning, error) {
-		var warning Warning
 		in, ok := cfg.Spec.(*security_beta.AuthorizationPolicy)
 		if !ok {
 			return nil, fmt.Errorf("cannot cast to AuthorizationPolicy")
 		}
 
 		var errs error
-		if err := validateWorkloadSelector(in.Selector); err != nil {
-			errs = appendErrors(errs, err)
-		}
+		var warnings Warning
+		validation := validateWorkloadSelector(in.Selector)
+		errs = appendErrors(errs, validation)
+		warnings = appendErrors(warnings, validation.Warning)
 
 		if in.Action == security_beta.AuthorizationPolicy_CUSTOM {
 			if in.Rules == nil {
@@ -2115,12 +2119,14 @@ var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPol
 
 			if ((fromRuleExist && !toRuleExist && !tcpRulesInFrom) || (toRuleExist && !tcpRulesInTo)) &&
 				in.Action == security_beta.AuthorizationPolicy_DENY {
-				warning = fmt.Errorf("configured AuthorizationPolicy will deny all traffic " +
+				warning := fmt.Errorf("configured AuthorizationPolicy will deny all traffic " +
 					"to TCP ports under its scope due to the use of only HTTP attributes in a DENY rule; " +
 					"it is recommended to explicitly specify the port")
+				warnings = appendErrors(warnings, warning)
+
 			}
 		}
-		return warning, multierror.Prefix(errs, fmt.Sprintf("invalid policy %s.%s:", cfg.Name, cfg.Namespace))
+		return warnings, multierror.Prefix(errs, fmt.Sprintf("invalid policy %s.%s:", cfg.Name, cfg.Namespace))
 	})
 
 // ValidateRequestAuthentication checks that request authentication spec is well-formed.
@@ -2131,13 +2137,14 @@ var ValidateRequestAuthentication = registerValidateFunc("ValidateRequestAuthent
 			return nil, errors.New("cannot cast to RequestAuthentication")
 		}
 
-		var errs error
-		errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
+		errs := Validation{}
+		validation := validateWorkloadSelector(in.Selector)
+		errs = appendValidation(errs, validation)
 
 		for _, rule := range in.JwtRules {
-			errs = appendErrors(errs, validateJwtRule(rule))
+			errs = appendValidation(errs, validateJwtRule(rule))
 		}
-		return nil, errs
+		return errs.Unwrap()
 	})
 
 func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
@@ -2225,9 +2232,10 @@ var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthenticatio
 			}
 		}
 
-		errs = appendErrors(errs, validateWorkloadSelector(in.Selector))
+		validation := validateWorkloadSelector(in.Selector)
+		errs = appendErrors(errs, validation)
 
-		return nil, errs
+		return validation.Warning, errs
 	})
 
 // ValidateVirtualService checks that a v1alpha3 route rule is well-formed.

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3496,9 +3496,10 @@ func checkValidationMessage(t *testing.T, gotWarning Warning, gotError error, wa
 
 func TestValidateDestinationRule(t *testing.T) {
 	cases := []struct {
-		name  string
-		in    proto.Message
-		valid bool
+		name    string
+		in      proto.Message
+		valid   bool
+		warning bool
 	}{
 		{name: "simple destination rule", in: &networking.DestinationRule{
 			Host: "reviews",
@@ -3507,6 +3508,15 @@ func TestValidateDestinationRule(t *testing.T) {
 				{Name: "v2", Labels: map[string]string{"version": "v2"}},
 			},
 		}, valid: true},
+
+		{name: "simple destination rule with empty selector labels", in: &networking.DestinationRule{
+			Host: "reviews",
+			Subsets: []*networking.Subset{
+				{Name: "v1", Labels: map[string]string{"version": "v1"}},
+				{Name: "v2", Labels: map[string]string{"version": "v2"}},
+			},
+			WorkloadSelector: &api.WorkloadSelector{},
+		}, valid: true, warning: true},
 
 		{name: "missing destination name", in: &networking.DestinationRule{
 			Host: "",
@@ -3649,15 +3659,20 @@ func TestValidateDestinationRule(t *testing.T) {
 		}, valid: true},
 	}
 	for _, c := range cases {
-		if _, got := ValidateDestinationRule(config.Config{
+		warn, got := ValidateDestinationRule(config.Config{
 			Meta: config.Meta{
 				Name:      someName,
 				Namespace: someNamespace,
 			},
 			Spec: c.in,
-		}); (got == nil) != c.valid {
+		})
+		if (got == nil) != c.valid {
 			t.Errorf("ValidateDestinationRule failed on %v: got valid=%v but wanted valid=%v: %v",
 				c.name, got == nil, c.valid, got)
+		}
+		if (warn == nil) == c.warning {
+			t.Errorf("ValidateDestinationRule failed on %v: got warn=%v but wanted warn=%v: %v",
+				c.name, warn == nil, c.warning, warn)
 		}
 	}
 }
@@ -5329,6 +5344,14 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "selector-empty-labels",
+			in: &security_beta.AuthorizationPolicy{
+				Selector: &api.WorkloadSelector{},
+			},
+			valid:   true,
+			Warning: true,
+		},
+		{
 			name: "selector-wildcard-value",
 			in: &security_beta.AuthorizationPolicy{
 				Selector: &api.WorkloadSelector{
@@ -6039,9 +6062,10 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			Spec: c.in,
 		})
 		if (got == nil) != c.valid {
-			t.Errorf("error: got: %v\nwant: %v", got, c.valid)
-		} else if (war != nil) != c.Warning {
-			t.Errorf("warning: got: %v\nwant: %v", war, c.valid)
+			t.Errorf("test: %q error: got: %v\nwant: %v", c.name, got, c.valid)
+		}
+		if (war != nil) != c.Warning {
+			t.Errorf("test: %q warning: got: %v\nwant: %v", c.name, war, c.valid)
 		}
 	}
 }
@@ -7242,6 +7266,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 		annotations map[string]string
 		in          proto.Message
 		valid       bool
+		warning     bool
 	}{
 		{
 			name:       "empty spec",
@@ -7255,7 +7280,8 @@ func TestValidateRequestAuthentication(t *testing.T) {
 			in: &security_beta.RequestAuthentication{
 				Selector: &api.WorkloadSelector{},
 			},
-			valid: true,
+			valid:   true,
+			warning: true,
 		},
 		{
 			name:       "empty spec with non default name",
@@ -7533,15 +7559,19 @@ func TestValidateRequestAuthentication(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if _, got := ValidateRequestAuthentication(config.Config{
+			warn, got := ValidateRequestAuthentication(config.Config{
 				Meta: config.Meta{
 					Name:        c.configName,
 					Namespace:   someNamespace,
 					Annotations: c.annotations,
 				},
 				Spec: c.in,
-			}); (got == nil) != c.valid {
-				t.Errorf("got(%v) != want(%v)\n", got, c.valid)
+			})
+			if (got == nil) != c.valid {
+				t.Errorf("test: %q got(%v) != want(%v)\n", c.name, got, c.valid)
+			}
+			if (warn == nil) == c.warning {
+				t.Errorf("test: %q warn(%v) != want(%v)\n", c.name, warn, c.warning)
 			}
 		})
 	}
@@ -7553,6 +7583,7 @@ func TestValidatePeerAuthentication(t *testing.T) {
 		configName string
 		in         proto.Message
 		valid      bool
+		warning    bool
 	}{
 		{
 			name:       "empty spec",
@@ -7561,12 +7592,13 @@ func TestValidatePeerAuthentication(t *testing.T) {
 			valid:      true,
 		},
 		{
-			name:       "empty mtls",
+			name:       "empty mtls with selector of empty labels",
 			configName: constants.DefaultAuthenticationPolicyName,
 			in: &security_beta.PeerAuthentication{
 				Selector: &api.WorkloadSelector{},
 			},
-			valid: true,
+			valid:   true,
+			warning: true,
 		},
 		{
 			name:       "empty spec with non default name",
@@ -7654,14 +7686,18 @@ func TestValidatePeerAuthentication(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if _, got := ValidatePeerAuthentication(config.Config{
+			warn, got := ValidatePeerAuthentication(config.Config{
 				Meta: config.Meta{
 					Name:      c.configName,
 					Namespace: someNamespace,
 				},
 				Spec: c.in,
-			}); (got == nil) != c.valid {
+			})
+			if (got == nil) != c.valid {
 				t.Errorf("got(%v) != want(%v)\n", got, c.valid)
+			}
+			if (warn == nil) == c.warning {
+				t.Errorf("warn(%v) != want(%v)\n", warn, c.warning)
 			}
 		})
 	}

--- a/releasenotes/notes/44159.yaml
+++ b/releasenotes/notes/44159.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** Fixes selector logic of service and endpoint.

--- a/releasenotes/notes/44159.yaml
+++ b/releasenotes/notes/44159.yaml
@@ -3,4 +3,5 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
   - |
-    **Fixed** Fixes selector logic of service and endpoint.
+    **Fixed** an issue where ServiceEntry and Service had undefined or empty workload selectors. If the workload selector is undefined or empty, 
+    ServiceEntry and Service should not select any WorkloadEntry or endpoint.


### PR DESCRIPTION
**Please provide a description of this PR:**

In the following code snippet, se.WorkloadSelector != nil, but se.Selector.WorkloadSelector is nil or an empty map, the se will select all workload instance.
https://github.com/istio/istio/blob/4157e1887071037b369fd82cb4559dc7628bb57b/pilot/pkg/serviceregistry/serviceentry/controller.go#L513-L521

However, in normal logic, any WorkloadInstance and Endpoint should not be selected when se's selector is empty.