### PR TITLE
[1.17] gateway deployment controller: handle backwards compatibility

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -231,9 +231,12 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 
 	if overwriteControllerVersion {
+		log.Debugf("write controller version, existing=%v", existingControllerVersion)
 		if err := d.setGatewayControllerVersion(&gw); err != nil {
 			return fmt.Errorf("update gateway annotation: %v", err)
 		}
+	} else {
+		log.Debugf("controller version existing=%v, no action needed", existingControllerVersion)
 	}
 	ingressSa := d.RenderServiceAccountApply(input)
 	_, err := d.client.Kube().
@@ -396,6 +399,7 @@ func (d *DeploymentController) setGatewayControllerVersion(gws *gateway.Gateway)
 	patch := fmt.Sprintf(`{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{"%s":"%d"}}}`,
 		ControllerVersionAnnotation, ControllerVersion)
 	gvr := collections.K8SGatewayApiV1Beta1Gateways.Resource().GroupVersionResource()
+	log.Debugf("applying %v", patch)
 	return d.patcher(gvr, gws.GetName(), gws.GetNamespace(), []byte(patch))
 }
 

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -40,6 +41,7 @@ import (
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -202,6 +204,11 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		log.Debug("skip unmanaged gateway")
 		return nil
 	}
+	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
+	if !shouldHandle {
+		log.Debugf("skipping gateway which is managed by controller version %v", existingControllerVersion)
+		return nil
+	}
 	log.Info("reconciling")
 
 	defaultName := getDefaultName(gw.Name, &gw.Spec)
@@ -223,6 +230,11 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		KubeVersion122: kube.IsAtLeastVersion(d.client, 22),
 	}
 
+	if overwriteControllerVersion {
+		if err := d.setGatewayControllerVersion(&gw); err != nil {
+			return fmt.Errorf("update gateway annotation: %v", err)
+		}
+	}
 	ingressSa := d.RenderServiceAccountApply(input)
 	_, err := d.client.Kube().
 		CoreV1().
@@ -273,6 +285,54 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("gateway updated")
 	return nil
+}
+
+const (
+	// ControllerVersionAnnotation is an annotation added to the Gateway by the controller specifying
+	// the "controller version". The original intent of this was to work around
+	// https://github.com/istio/istio/issues/44164, where we needed to transition from a global owner
+	// to a per-revision owner. The newer version number allows forcing ownership, even if the other
+	// version was otherwise expected to control the Gateway.
+	// The version number has no meaning other than "larger numbers win".
+	// Numbers are used to future-proof in case we need to do another migration in the future.
+	ControllerVersionAnnotation = "gateway.istio.io/controller-version"
+	// ControllerVersion is the current version of our controller logic. Known versions are:
+	//
+	// * 1.17 and older: version 1 OR no version at all, depending on patch release
+	// * 1.18+: version 5
+	//
+	// 2, 3, and 4 were intentionally skipped to allow for the (unlikely) event we need to insert
+	// another version between these
+	ControllerVersion = 1
+)
+
+// ManagedGatewayControllerVersion determines the version of the controller managing this Gateway,
+// and if we should manage this.
+// See ControllerVersionAnnotation for motivations.
+func ManagedGatewayControllerVersion(gw gateway.Gateway) (existing string, takeOver bool, manage bool) {
+	cur, f := gw.Annotations[ControllerVersionAnnotation]
+	if !f {
+		// No current owner, we should take it over.
+		return "", true, true
+	}
+	curNum, err := strconv.Atoi(cur)
+	if err != nil {
+		// We cannot parse it - must be some new schema we don't know about. We should assume we do not manage it.
+		// In theory, this should never happen, unless we decide a number was a bad idea in the future.
+		return cur, false, false
+	}
+	if curNum > ControllerVersion {
+		// A newer version owns this gateway, let them handle it
+		return cur, false, false
+	}
+	if curNum == ControllerVersion {
+		// We already manage this at this version
+		// We will manage it, but no need to attempt to apply the version annotation, which could race with newer versions
+		return cur, false, true
+	}
+	// We are either newer or the same version of the last owner - we can take over. We need to actually
+	// re-apply the annotation
+	return cur, true, true
 }
 
 func (d *DeploymentController) RenderServiceAccountApply(input MergedInput) *corev1ac.ServiceAccountApplyConfiguration {
@@ -330,6 +390,13 @@ func (d *DeploymentController) ApplyObject(obj controllers.Object, subresources 
 	log.Debugf("applying %v", string(j))
 
 	return d.patcher(gvr, obj.GetName(), obj.GetNamespace(), j, subresources...)
+}
+
+func (d *DeploymentController) setGatewayControllerVersion(gws *gateway.Gateway) error {
+	patch := fmt.Sprintf(`{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{"%s":"%d"}}}`,
+		ControllerVersionAnnotation, ControllerVersion)
+	gvr := collections.K8SGatewayApiV1Beta1Gateways.Resource().GroupVersionResource()
+	return d.patcher(gvr, gws.GetName(), gws.GetNamespace(), []byte(patch))
 }
 
 // Merge maps merges multiple maps. Latter maps take precedence over previous maps on overlapping fields

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -165,7 +165,7 @@ func TestVersionManagement(t *testing.T) {
 	wantReconcile := int32(0)
 	expectReconciled := func() {
 		t.Helper()
-		wantReconcile += 1
+		wantReconcile++
 		assert.EventuallyEqual(t, reconciles.Load, wantReconcile, retry.Timeout(time.Second), retry.Message("no reconciliation"))
 	}
 	d := NewDeploymentController(c)

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -16,6 +16,8 @@ package gateway
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +30,8 @@ import (
 
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	istiolog "istio.io/pkg/log"
 )
 
@@ -147,4 +151,88 @@ func TestConfigureIstioGateway(t *testing.T) {
 			util.CompareContent(t, resp, filepath.Join("testdata", "deployment", tt.name+".yaml"))
 		})
 	}
+}
+
+func TestVersionManagement(t *testing.T) {
+	log.SetOutputLevel(istiolog.DebugLevel)
+	writes := make(chan string, 10)
+	c := kube.NewFakeClient(
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "gw-istio", Namespace: "default"}})
+	d := NewDeploymentController(c)
+	d.patcher = func(g schema.GroupVersionResource, name string, namespace string, data []byte, subresources ...string) error {
+		if g.Resource == "gateways" && len(subresources) == 0 {
+			b, err := yaml.JSONToYAML(data)
+			if err != nil {
+				return err
+			}
+			writes <- string(b)
+		}
+		return nil
+	}
+	stop := test.NewStop(t)
+	go d.Run(stop)
+	c.RunAndWait(stop)
+
+	gws := c.GatewayAPI().GatewayV1beta1().Gateways("default")
+	ctx := context.Background()
+	// Create a gateway, we should mark our ownership
+	defaultGateway := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+		Spec: v1beta1.GatewaySpec{GatewayClassName: DefaultClassName},
+	}
+	gws.Create(ctx, defaultGateway, metav1.CreateOptions{})
+	assert.Equal(t, assert.ChannelHasItem(t, writes), buildPatch(ControllerVersion))
+	assert.ChannelIsEmpty(t, writes)
+
+	// Test fake doesn't actual do Apply, so manually do this
+	defaultGateway.Annotations = map[string]string{ControllerVersionAnnotation: fmt.Sprint(ControllerVersion)}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	// We shouldn't write in response to our write.
+	assert.ChannelIsEmpty(t, writes)
+
+	gw, _ := gws.Get(ctx, "gw", metav1.GetOptions{})
+	gw.Annotations["foo"] = "bar"
+	gws.Update(ctx, gw, metav1.UpdateOptions{})
+	// We should not be updating the version, its already set. Setting it introduces a possible race condition
+	// since we use SSA so there is no conflict checks.
+	assert.ChannelIsEmpty(t, writes)
+
+	// Somehow the annotation is removed - it should be added back
+	defaultGateway.Annotations = map[string]string{}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	assert.Equal(t, assert.ChannelHasItem(t, writes), buildPatch(ControllerVersion))
+	assert.ChannelIsEmpty(t, writes)
+	// Test fake doesn't actual do Apply, so manually do this
+	defaultGateway.Annotations = map[string]string{ControllerVersionAnnotation: fmt.Sprint(ControllerVersion)}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	// We shouldn't write in response to our write.
+	assert.ChannelIsEmpty(t, writes)
+
+	// Somehow the annotation is set to an older version - it should be added back
+	defaultGateway.Annotations = map[string]string{ControllerVersionAnnotation: fmt.Sprint(0)}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	assert.Equal(t, assert.ChannelHasItem(t, writes), buildPatch(ControllerVersion))
+	assert.ChannelIsEmpty(t, writes)
+	// Test fake doesn't actual do Apply, so manually do this
+	defaultGateway.Annotations = map[string]string{ControllerVersionAnnotation: fmt.Sprint(ControllerVersion)}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	// We shouldn't write in response to our write.
+	assert.ChannelIsEmpty(t, writes)
+
+	// Somehow the annotation is set to an new version - we should do nothing
+	defaultGateway.Annotations = map[string]string{ControllerVersionAnnotation: fmt.Sprint(3)}
+	gws.Update(ctx, defaultGateway, metav1.UpdateOptions{})
+	assert.ChannelIsEmpty(t, writes)
+}
+
+func buildPatch(version int) string {
+	return fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "%d"
+`, version)
 }

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -16,6 +16,7 @@ package assert
 
 import (
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -47,5 +48,29 @@ func NoError(t test.Failer, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("expected no error but got: %v", err)
+	}
+}
+
+// ChannelHasItem asserts a channel has an element within 5s and returns the element
+func ChannelHasItem[T any](t test.Failer, c <-chan T) T {
+	t.Helper()
+	select {
+	case r := <-c:
+		return r
+	case <-time.After(time.Second * 5):
+		t.Fatalf("failed to receive event after 5s")
+	}
+	// Not reachable
+	var empty T
+	return empty
+}
+
+// ChannelIsEmpty asserts a channel is empty for at least 20ms
+func ChannelIsEmpty[T any](t test.Failer, c <-chan T) {
+	t.Helper()
+	select {
+	case r := <-c:
+		t.Fatalf("channel had element, expected empty: %v", r)
+	case <-time.After(time.Millisecond * 20):
 	}
 }

--- a/releasenotes/notes/gateway-futureproof.yaml
+++ b/releasenotes/notes/gateway-futureproof.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 44164
+
+releaseNotes:
+- |
+  **Fixed** an issue with forward compatibility with Istio 1.18+ [Kubernetes Gateway Automated Deployment](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment).
+  To have a seamless upgrade to 1.18+, users of this feature should first adopt this patch release.


### PR DESCRIPTION
This introduces a mechanism to tell older versions to stop managing a Gateway.

How this works:

1.17 controls all Gateways. Users will upgrade to a patched version (basically this PR backported) which annotates all Gateways with version=1. It also has logic to not control Gateways with version>1
User installs 1.18 as canary revision. Any Gateways in canary revision will get version=2 set; at this point, the 1.17 controller will stop trying to manage it. Warning: if a user needs to remove 1.18 at this point, they would need to manual set the version label back to 1. This is not ideal, but it is the best we can do I think.
User makes 1.18 the "default revision". At this point it does the same as above, but to a wider set of gateways.
Eventually, if we somehow run into the same circumstance, we can change the logic again to version=3 in some future version and completely change how we do gateway ownership. That is, this solution is future proof.

This introduces forward compatibility with 1.18+.

This pr is _nearly_ a cherrypick of https://github.com/istio/istio/pull/44174, but there are a few differences (due to code drift, this one has version=1 set).