### PR TITLE
Add more flexibility for running E2E tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -157,12 +157,20 @@ type Config struct {
 	// custom deployment for ingress and egress gateway on remote clusters.
 	GatewayValues string
 
-	// Custom deploymeny for east-west gateway
+	// Custom deployment for east-west gateway
 	EastWestGatewayValues string
 
 	// IngressGatewayServiceName is the service name to use to reference the ingressgateway
 	// This field should only be set when DeployIstio is false
 	IngressGatewayServiceName string
+
+	// IngressGatewayServiceNamespace allows overriding the namespace of the ingressgateway service (defaults to SystemNamespace)
+	// This field should only be set when DeployIstio is false
+	IngressGatewayServiceNamespace string
+
+	// IngressGatewayIstioLabel allows overriding the selector of the ingressgateway service (defaults to istio=ingressgateway)
+	// This field should only be set when DeployIstio is false
+	IngressGatewayIstioLabel string
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {
@@ -332,6 +340,8 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("OperatorOptions:                %v\n", c.OperatorOptions)
 	result += fmt.Sprintf("EnableCNI:                      %v\n", c.EnableCNI)
 	result += fmt.Sprintf("IngressGatewayServiceName:      %v\n", c.IngressGatewayServiceName)
+	result += fmt.Sprintf("IngressGatewayServiceNamespace: %v\n", c.IngressGatewayServiceNamespace)
+	result += fmt.Sprintf("IngressGatewayIstioLabel:     	 %v\n", c.IngressGatewayIstioLabel)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -45,4 +45,12 @@ func init() {
 		settingsFromCommandline.IngressGatewayServiceName,
 		`Specifies the name of the ingressgateway service to use when running tests in a preinstalled istio installation.
 		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.IngressGatewayServiceNamespace, "istio.test.kube.ingressGatewayServiceNamespace",
+		settingsFromCommandline.IngressGatewayServiceNamespace,
+		`Specifies the namespace of the ingressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.IngressGatewayIstioLabel, "istio.test.kube.ingressGatewayIstioLabel",
+		settingsFromCommandline.IngressGatewayIstioLabel,
+		`Specifies the istio label of the ingressgateway to search for when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
 }

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -127,11 +127,19 @@ func (i *istioImpl) Ingresses() ingress.Instances {
 
 func (i *istioImpl) IngressFor(c cluster.Cluster) ingress.Instance {
 	ingressServiceName := defaultIngressServiceName
+	ingressServiceNamespace := i.cfg.SystemNamespace
+	ingressServiceLabel := defaultIngressIstioLabel
 	if serviceNameOverride := i.cfg.IngressGatewayServiceName; serviceNameOverride != "" {
 		ingressServiceName = serviceNameOverride
 	}
-	name := types.NamespacedName{Name: ingressServiceName, Namespace: i.cfg.SystemNamespace}
-	return i.CustomIngressFor(c, name, defaultIngressIstioLabel)
+	if serviceNamespaceOverride := i.cfg.IngressGatewayServiceNamespace; serviceNamespaceOverride != "" {
+		ingressServiceNamespace = serviceNamespaceOverride
+	}
+	if serviceLabelOverride := i.cfg.IngressGatewayIstioLabel; serviceLabelOverride != "" {
+		ingressServiceLabel = fmt.Sprintf("istio=%s", serviceLabelOverride)
+	}
+	name := types.NamespacedName{Name: ingressServiceName, Namespace: ingressServiceNamespace}
+	return i.CustomIngressFor(c, name, ingressServiceLabel)
 }
 
 func (i *istioImpl) EastWestGatewayFor(c cluster.Cluster) ingress.Instance {

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -490,8 +490,14 @@ func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.authz-check").
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
+			istioLabel := "ingressgateway"
+			if labelOverride := i.Settings().IngressGatewayIstioLabel; labelOverride != "" {
+				istioLabel = labelOverride
+			}
 			t.ConfigIstio().File(apps.Namespace.Name(), "testdata/authz-a.yaml").ApplyOrFail(t)
-			t.ConfigIstio().File(i.Settings().SystemNamespace, "testdata/authz-b.yaml").ApplyOrFail(t)
+			t.ConfigIstio().EvalFile(i.Settings().SystemNamespace, map[string]any{
+				"GatewayIstioLabel": istioLabel,
+			}, "testdata/authz-b.yaml").ApplyOrFail(t)
 
 			gwPod, err := i.IngressFor(t.Clusters().Default()).PodID(0)
 			if err != nil {

--- a/tests/integration/pilot/testdata/authz-b.yaml
+++ b/tests/integration/pilot/testdata/authz-b.yaml
@@ -6,7 +6,7 @@ spec:
   action: ALLOW
   selector:
     matchLabels:
-      "istio": "ingressgateway"
+      "istio": {{.GatewayIstioLabel | default "ingressgateway"}}
   rules:
   - to:
     - operation:
@@ -20,7 +20,7 @@ spec:
   action: DENY
   selector:
     matchLabels:
-      "istio": "ingressgateway"
+      "istio": {{.GatewayIstioLabel | default "ingressgateway"}}
   rules:
   - to:
     - operation:
@@ -36,7 +36,7 @@ metadata:
   name: gateway
 spec:
   selector:
-    istio: ingressgateway
+    istio: {{.GatewayIstioLabel | default "ingressgateway"}}
   servers:
   - port:
       number: 18080

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -452,7 +452,9 @@ func TestAuthz_NotHost(t *testing.T) {
 			fromAndTo := to.Instances().Append(from)
 
 			config.New(t).
-				Source(config.File("testdata/authz/not-host.yaml.tmpl")).
+				Source(config.File("testdata/authz/not-host.yaml.tmpl").WithParams(param.Params{
+					"GatewayIstioLabel": i.Settings().IngressGatewayIstioLabel,
+				})).
 				BuildAll(nil, to).
 				Apply()
 
@@ -989,6 +991,7 @@ func TestAuthz_IngressGateway(t *testing.T) {
 				Source(config.File("testdata/authz/ingress-gateway.yaml.tmpl").WithParams(param.Params{
 					// The namespaces for each resource are specified in the file. Use "" as the ns to apply to.
 					param.Namespace.String(): "",
+					"GatewayIstioLabel":      i.Settings().IngressGatewayIstioLabel,
 				})).
 				BuildAll(nil, to).
 				Apply()

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -406,9 +406,11 @@ func TestIngressRequestAuthentication(t *testing.T) {
 				Source(config.File("testdata/requestauthn/global-jwt.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): istio.ClaimSystemNamespaceOrFail(t, t),
 					"Services":               apps.Ns1.All,
+					"GatewayIstioLabel":      i.Settings().IngressGatewayIstioLabel,
 				})).
 				Source(config.File("testdata/requestauthn/ingress.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Ns1.Namespace,
+					"GatewayIstioLabel":      i.Settings().IngressGatewayIstioLabel,
 				})).
 				BuildAll(nil, apps.Ns1.All).
 				Apply()

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -41,12 +41,14 @@ var (
 	authzServer      authz.Server
 	localAuthzServer authz.Server
 	jwtServer        jwt.Server
+
+	i istio.Instance
 )
 
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(istio.Setup(nil, func(c resource.Context, cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
 			if !c.Settings().EnableDualStack {
 				cfg.ControlPlaneValues = `
 values:

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -93,6 +93,7 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 							CredentialName: credName,
 							Host:           host,
 							ServiceName:    to.Config().Service,
+							GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 						})
 						return nil
 					}).
@@ -162,6 +163,7 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 							CredentialName: credName,
 							Host:           host,
 							ServiceName:    to.Config().Service,
+							GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 						})
 						return nil
 					}).
@@ -233,6 +235,7 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 							CredentialName: credName,
 							Host:           host,
 							ServiceName:    to.Config().Service,
+							GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 						})
 						return nil
 					}).
@@ -300,6 +303,7 @@ func TestSingleMTLSGatewayAndNotGeneric_CompoundSecretRotation(t *testing.T) {
 							CredentialName: credName,
 							Host:           host,
 							ServiceName:    to.Config().Service,
+							GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 						})
 						return nil
 					}).
@@ -479,6 +483,7 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 								CredentialName: c.secretName,
 								Host:           c.hostName,
 								ServiceName:    to.Config().Service,
+								GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 							})
 							return nil
 						}).
@@ -588,6 +593,7 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 								CredentialName: c.secretName,
 								Host:           c.hostName,
 								ServiceName:    to.Config().Service,
+								GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 							})
 							return nil
 						}).

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -417,6 +417,7 @@ type TestConfig struct {
 	CredentialName string
 	Host           string
 	ServiceName    string
+	GatewayLabel   string
 }
 
 const vsTemplate = `
@@ -447,7 +448,7 @@ metadata:
   name: {{.CredentialName}}
 spec:
   selector:
-    istio: ingressgateway # use istio default ingress gateway
+    istio: {{.GatewayLabel | default "ingressgateway"}}
   servers:
   - port:
       number: 443
@@ -484,6 +485,7 @@ func RunTestMultiMtlsGateways(ctx framework.TestContext, inst istio.Instance, ns
 					CredentialName: cred,
 					Host:           fmt.Sprintf("runtestmultimtlsgateways%d.example.com", i),
 					ServiceName:    to.Config().Service,
+					GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 				})
 				credNames = append(credNames, cred)
 			}
@@ -531,6 +533,7 @@ func RunTestMultiTLSGateways(t framework.TestContext, inst istio.Instance, ns na
 					CredentialName: cred,
 					Host:           fmt.Sprintf("runtestmultitlsgateways%d.example.com", i),
 					ServiceName:    to.Config().Service,
+					GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 				})
 				credNames = append(credNames, cred)
 			}
@@ -582,6 +585,7 @@ func RunTestMultiQUICGateways(t framework.TestContext, inst istio.Instance, call
 						CredentialName: cred,
 						Host:           fmt.Sprintf("runtestmultitlsgateways%d.example.com", i),
 						ServiceName:    to.Config().Service,
+						GatewayLabel:   inst.Settings().IngressGatewayIstioLabel,
 					})
 					credNames = append(credNames, cred)
 				}

--- a/tests/integration/security/testdata/authz/ingress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/ingress-gateway.yaml.tmpl
@@ -14,7 +14,7 @@ spec:
   action: DENY
   selector:
     matchLabels:
-      app: istio-ingressgateway
+      app: {{.GatewayIstioLabel | default "istio-ingressgateway"}}
   rules:
     - to:
         - operation:

--- a/tests/integration/security/testdata/authz/not-host.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/not-host.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: gw-{{ .To.ServiceName }}
 spec:
   selector:
-    istio: ingressgateway # use istio default ingress gateway
+    istio: {{.GatewayIstioLabel | default "ingressgateway"}}
   servers:
     - port:
         number: 80

--- a/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio: ingressgateway
+      istio: {{.GatewayIstioLabel | default "ingressgateway"}}
   rules:
   - to:
     - operation:

--- a/tests/integration/security/testdata/requestauthn/ingress.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/ingress.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: {{ .To.ServiceName }}-gateway
 spec:
   selector:
-    istio: ingressgateway # use istio default ingress gateway
+    istio: {{.GatewayIstioLabel | default "ingressgateway"}}
   servers:
     - port:
         number: 80


### PR DESCRIPTION
**Please provide a description of this PR:**
The Istio E2E tests still assume a lot about a pre-existing environment when running integration tests, specifically around the ingress gateway deployments. This PR allows the test runner to change the expected namespace and labels during the e2e tests


Similar to #43809 