### PR TITLE
gateway deployment controller: handle backwards compatibility

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,6 +38,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/inject"
@@ -237,6 +239,11 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		log.Debug("skip disabled gateway")
 		return nil
 	}
+	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
+	if !shouldHandle {
+		log.Debugf("skipping gateway which is managed by controller version %v", existingControllerVersion)
+		return nil
+	}
 	log.Info("reconciling")
 
 	defaultName := getDefaultName(gw.Name, &gw.Spec)
@@ -259,6 +266,11 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		KubeVersion122: kube.IsAtLeastVersion(d.client, 22),
 	}
 
+	if overwriteControllerVersion {
+		if err := d.setGatewayControllerVersion(gw); err != nil {
+			return fmt.Errorf("update gateway annotation: %v", err)
+		}
+	}
 	rendered, err := d.render(gi.templates, input)
 	if err != nil {
 		return fmt.Errorf("failed to render template: %v", err)
@@ -271,6 +283,54 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 
 	log.Info("gateway updated")
 	return nil
+}
+
+const (
+	// ControllerVersionAnnotation is an annotation added to the Gateway by the controller specifying
+	// the "controller version". The original intent of this was to work around
+	// https://github.com/istio/istio/issues/44164, where we needed to transition from a global owner
+	// to a per-revision owner. The newer version number allows forcing ownership, even if the other
+	// version was otherwise expected to control the Gateway.
+	// The version number has no meaning other than "larger numbers win".
+	// Numbers are used to future-proof in case we need to do another migration in the future.
+	ControllerVersionAnnotation = "gateway.istio.io/controller-version"
+	// ControllerVersion is the current version of our controller logic. Known versions are:
+	//
+	// * 1.17 and older: version 1 OR no version at all, depending on patch release
+	// * 1.18+: version 5
+	//
+	// 2, 3, and 4 were intentionally skipped to allow for the (unlikely) event we need to insert
+	// another version between these
+	ControllerVersion = 5
+)
+
+// ManagedGatewayControllerVersion determines the version of the controller managing this Gateway,
+// and if we should manage this.
+// See ControllerVersionAnnotation for motivations.
+func ManagedGatewayControllerVersion(gw gateway.Gateway) (existing string, takeOver bool, manage bool) {
+	cur, f := gw.Annotations[ControllerVersionAnnotation]
+	if !f {
+		// No current owner, we should take it over.
+		return "", true, true
+	}
+	curNum, err := strconv.Atoi(cur)
+	if err != nil {
+		// We cannot parse it - must be some new schema we don't know about. We should assume we do not manage it.
+		// In theory, this should never happen, unless we decide a number was a bad idea in the future.
+		return cur, false, false
+	}
+	if curNum > ControllerVersion {
+		// A newer version owns this gateway, let them handle it
+		return cur, false, false
+	}
+	if curNum == ControllerVersion {
+		// We already manage this at this version
+		// We will manage it, but no need to attempt to apply the version annotation, which could race with newer versions
+		return cur, false, true
+	}
+	// We are either newer or the same version of the last owner - we can take over. We need to actually
+	// re-apply the annotation
+	return cur, true, true
 }
 
 type derivedInput struct {
@@ -307,6 +367,12 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 	}
 
 	return yml.SplitString(results), nil
+}
+
+func (d *DeploymentController) setGatewayControllerVersion(gws gateway.Gateway) error {
+	patch := fmt.Sprintf(`{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{"%s":"%d"}}}`,
+		ControllerVersionAnnotation, ControllerVersion)
+	return d.patcher(gvr.KubernetesGateway, gws.GetName(), gws.GetNamespace(), []byte(patch))
 }
 
 // apply server-side applies a template to the cluster.

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -375,7 +375,7 @@ func (d *DeploymentController) setGatewayControllerVersion(gws gateway.Gateway) 
 	patch := fmt.Sprintf(`{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{"%s":"%d"}}}`,
 		ControllerVersionAnnotation, ControllerVersion)
 
-	log.Debugf("applying %v", string(patch))
+	log.Debugf("applying %v", patch)
 	return d.patcher(gvr.KubernetesGateway, gws.GetName(), gws.GetNamespace(), []byte(patch))
 }
 

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -194,7 +194,7 @@ func TestVersionManagement(t *testing.T) {
 	wantReconcile := int32(0)
 	expectReconciled := func() {
 		t.Helper()
-		wantReconcile += 1
+		wantReconcile++
 		assert.EventuallyEqual(t, reconciles.Load, wantReconcile, retry.Timeout(time.Second), retry.Message("no reconciliation"))
 	}
 

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -17,11 +17,13 @@ package assert
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -81,5 +83,28 @@ func NoError(t test.Failer, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("expected no error but got: %v", err)
+	}
+}
+
+// ChannelHasItem asserts a channel has an element within 5s and returns the element
+func ChannelHasItem[T any](t test.Failer, c <-chan T) T {
+	t.Helper()
+	select {
+	case r := <-c:
+		return r
+	case <-time.After(time.Second * 5):
+		t.Fatalf("failed to receive event after 5s")
+	}
+	// Not reachable
+	return ptr.Empty[T]()
+}
+
+// ChannelIsEmpty asserts a channel is empty for at least 20ms
+func ChannelIsEmpty[T any](t test.Failer, c <-chan T) {
+	t.Helper()
+	select {
+	case r := <-c:
+		t.Fatalf("channel had element, expected empty: %v", r)
+	case <-time.After(time.Millisecond * 20):
 	}
 }


### PR DESCRIPTION
For https://github.com/istio/istio/issues/44164

This is the master version; we will backport similar changes to older branches.

This introduces a mechanism to tell older versions to stop managing a Gateway.

How this works:
* 1.17 controls all Gateways. Users will upgrade to a patched version (basically this PR backported) which annotates all Gateways with version=1. It also has logic to not control Gateways with version>1
* User installs 1.18 as canary revision. Any Gateways in canary revision will get version=2 set; at this point, the 1.17 controller will stop trying to manage it. Warning: if a user needs to remove 1.18 at this point, they would need to manual set the version label back to 1. This is not ideal, but it is the best we can do I think.
* User makes 1.18 the "default revision". At this point it does the same as above, but to a wider set of gateways.
* Eventually, if we somehow run into the same circumstance, we can change the logic again to version=3 in some future version and completely change how we do gateway ownership. That is, this solution is future proof.

In addition to this PR and https://github.com/istio/istio/pull/43993, we will have release notes and a pre-check warning indicating to users they need to update to an appropriate 1.17.x patch release before using 1.18 if they use managed Gateways.

Note this feature is fairly new and only went beta in 1.17, so we expect fairly small usage numbers.

There have been a variety of linked PRs to this area; a single release note will be added for all of them in the near future.

**Please provide a description of this PR:**