### PR TITLE
Add mexRetries in namespace Controller

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -33,6 +33,13 @@ import (
 const (
 	// CACertNamespaceConfigMap is the name of the ConfigMap in each namespace storing the root cert of non-Kube CA.
 	CACertNamespaceConfigMap = "istio-ca-root-cert"
+
+	// maxRetries is the number of times a namespace will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuing of a namespace.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms
+	maxRetries = 5
 )
 
 var configMapLabel = map[string]string{"istio.io/config": "true"}
@@ -58,7 +65,9 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 		caBundleWatcher:           caBundleWatcher,
 		DiscoveryNamespacesFilter: discoveryNamespacesFilter,
 	}
-	c.queue = controllers.NewQueue("namespace controller", controllers.WithReconciler(c.insertDataForNamespace))
+	c.queue = controllers.NewQueue("namespace controller",
+		controllers.WithReconciler(c.insertDataForNamespace),
+		controllers.WithMaxAttempts(maxRetries))
 
 	c.configmaps = kclient.New[*v1.ConfigMap](kubeClient)
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)


### PR DESCRIPTION
**Please provide a description of this PR:**

Add mexRetries in namespace Controller to avoid the following problems:
```
2023-03-30T07:01:03.836412Z	info	ads	XDS: Pushing:2023-03-30T07:01:03Z/1 Services:5 ConnectedEndpoints:0 Version:2023-03-30T07:01:03Z/1
2023-03-30T07:01:03.849081Z	info	ads	All caches have been synced up in 594.470143ms, marking server ready
2023-03-30T07:01:03.849196Z	info	starting secure gRPC discovery service at [::]:15012
2023-03-30T07:01:03.849237Z	info	starting webhook service at [::]:15017
2023-03-30T07:01:03.849196Z	info	starting gRPC discovery service at [::]:15010
2023-03-30T07:01:03.922389Z	info	controllers	starting	controller=namespace controller
2023-03-30T07:01:03.941166Z	error	controllers	error handling istio-system/istio-ca-root-cert, and retry budget exceeded: error when updating configmap istio-ca-root-cert: Operation cannot be fulfilled on configmaps "istio-ca-root-cert": the object has been modified; please apply your changes to the latest version and try again	controller=namespace controller
```