### PR TITLE
reduce cpu consumption when calculating envoyfilter metric name

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -50,6 +50,7 @@ type EnvoyFilterConfigPatchWrapper struct {
 	ProxyPrefixMatch string
 	Name             string
 	Namespace        string
+	FullName         string
 }
 
 // wellKnownVersions defines a mapping of well known regex matches to prefix matches
@@ -94,6 +95,7 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 		cpw := &EnvoyFilterConfigPatchWrapper{
 			Name:      local.Name,
 			Namespace: local.Namespace,
+			FullName:  genFullName(local.Namespace, local.Name),
 			ApplyTo:   cp.ApplyTo,
 			Match:     cp.Match,
 			Operation: cp.Patch.Operation,
@@ -200,9 +202,19 @@ func (efw *EnvoyFilterWrapper) KeysApplyingTo(applyTo ...networking.EnvoyFilter_
 	return sets.SortedList(keys)
 }
 
+func genFullName(namespace, name string) string {
+	b := strings.Builder{}
+	b.Grow(len(namespace) + len(name) + 1)
+
+	b.WriteString(namespace)
+	b.WriteString("/")
+	b.WriteString(name)
+	return b.String()
+}
+
 func (cpw *EnvoyFilterConfigPatchWrapper) Key() string {
 	if cpw == nil {
 		return ""
 	}
-	return cpw.Namespace + "/" + cpw.Name
+	return cpw.FullName
 }

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -142,24 +142,29 @@ func TestKeysApplyingTo(t *testing.T) {
 				{
 					Name:      "http",
 					Namespace: "ns",
+					FullName:  genFullName("ns", "http"),
 				},
 			},
 			networking.EnvoyFilter_NETWORK_FILTER: {
 				{
 					Name:      "b",
 					Namespace: "ns",
+					FullName:  genFullName("ns", "b"),
 				},
 				{
 					Name:      "c",
 					Namespace: "ns",
+					FullName:  genFullName("ns", "c"),
 				},
 				{
 					Name:      "a",
 					Namespace: "ns",
+					FullName:  genFullName("ns", "a"),
 				},
 				{
 					Name:      "a",
 					Namespace: "ns",
+					FullName:  genFullName("ns", "a"),
 				},
 			},
 		},


### PR DESCRIPTION
The `IncrementEnvoyFilterMetric` function repeatedly calls `EnvoyFilterConfigPatchWrapper.Key()`, and each call needs to concatenate the string.

When there are a large number of envoyfilters, even if the envoyfilter metric is not enabled, a lot of cpu will be consumed. This PR adds a field named `FullName` to store the results of pre-computation, which is used to reduce cpu consumption, at the cost of adding very little memory.

before:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/14371864/228867022-5e359caa-576f-4d93-b475-18bb0b82a240.png">


after:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/14371864/228868386-4d0bb1f0-9424-42ea-9e43-d7c70ed04240.png">