### PR TITLE
Refactor multi network manage

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -71,7 +71,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.ClusterID = s.clusterID
 	args.RegistryOptions.KubeOptions.Metrics = s.environment
 	args.RegistryOptions.KubeOptions.XDSUpdater = s.XDSServer
-	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
+	args.RegistryOptions.KubeOptions.MeshNetworksWatcher = s.environment.NetworksWatcher
 	args.RegistryOptions.KubeOptions.MeshWatcher = s.environment.Watcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
 	args.RegistryOptions.KubeOptions.MeshServiceController = s.ServiceController()

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -296,7 +296,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		beginSync:                  atomic.NewBool(false),
 		initialSync:                atomic.NewBool(false),
 
-		networkManager: initNetworkManager(),
+		networkManager: initNetworkManager(options),
 		configCluster:  options.ConfigCluster,
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -16,7 +16,6 @@ package controller
 
 import (
 	"fmt"
-	"net"
 	"sort"
 	"sync"
 	"time"
@@ -115,7 +114,7 @@ type Options struct {
 
 	DomainSuffix string
 
-	// ClusterID identifies the remote cluster in a multicluster env.
+	// ClusterID identifies the cluster which the controller communicate with.
 	ClusterID cluster.ID
 
 	// ClusterAliases are aliase names for cluster. When a proxy connects with a cluster ID
@@ -128,8 +127,8 @@ type Options struct {
 	// XDSUpdater will push changes to the xDS server.
 	XDSUpdater model.XDSUpdater
 
-	// NetworksWatcher observes changes to the mesh networks config.
-	NetworksWatcher mesh.NetworksWatcher
+	// MeshNetworksWatcher observes changes to the mesh networks config.
+	MeshNetworksWatcher mesh.NetworksWatcher
 
 	// MeshWatcher observes changes to the mesh config
 	MeshWatcher mesh.Watcher
@@ -267,7 +266,7 @@ type Controller struct {
 	// index over workload instances from workload entries
 	workloadInstancesIndex workloadinstances.Index
 
-	multinetwork
+	networkManager
 
 	// beginSync is set to true when calling SyncAll, it indicates the controller has began sync resources.
 	beginSync *atomic.Bool
@@ -297,8 +296,8 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		beginSync:                  atomic.NewBool(false),
 		initialSync:                atomic.NewBool(false),
 
-		multinetwork:  initMultinetwork(),
-		configCluster: options.ConfigCluster,
+		networkManager: initNetworkManager(),
+		configCluster:  options.ConfigCluster,
 	}
 
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)
@@ -365,6 +364,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.imports = newServiceImportCache(c)
 
 	c.meshWatcher = options.MeshWatcher
+	if c.opts.MeshNetworksWatcher != nil {
+		c.opts.MeshNetworksWatcher.AddNetworksHandler(func() {
+			c.reloadMeshNetworks()
+			c.onNetworkChange()
+		})
+		c.reloadMeshNetworks()
+	}
 
 	return c
 }
@@ -414,39 +420,6 @@ func (c *Controller) MCSServices() []model.MCSServiceInfo {
 	}
 
 	return out
-}
-
-func (c *Controller) networkFromMeshNetworks(endpointIP string) network.ID {
-	c.RLock()
-	defer c.RUnlock()
-	if c.networkForRegistry != "" {
-		return c.networkForRegistry
-	}
-
-	if c.ranger != nil {
-		ip := net.ParseIP(endpointIP)
-		if ip == nil {
-			return ""
-		}
-		entries, err := c.ranger.ContainingNetworks(ip)
-		if err != nil {
-			log.Errorf("error getting cidr ranger entry from endpoint ip %s", endpointIP)
-			return ""
-		}
-		if len(entries) > 1 {
-			log.Warnf("Found multiple networks CIDRs matching the endpoint IP: %s. Using the first match.", endpointIP)
-		}
-		if len(entries) > 0 {
-			return (entries[0].(namedRangerEntry)).name
-		}
-	}
-	return ""
-}
-
-func (c *Controller) networkFromSystemNamespace() network.ID {
-	c.RLock()
-	defer c.RUnlock()
-	return c.network
 }
 
 func (c *Controller) Network(endpointIP string, labels labels.Instance) network.ID {
@@ -775,11 +748,6 @@ func (c *Controller) Run(stop <-chan struct{}) {
 		})
 	}
 	st := time.Now()
-	if c.opts.NetworksWatcher != nil {
-		c.opts.NetworksWatcher.AddNetworksHandler(c.reloadNetworkLookup)
-		c.reloadMeshNetworks()
-		c.reloadNetworkGateways()
-	}
 
 	go c.imports.Run(stop)
 	go c.exports.Run(stop)
@@ -1138,15 +1106,10 @@ func (c *Controller) onSystemNamespaceEvent(_, ns *v1.Namespace, ev model.Event)
 	if ev == model.EventDelete {
 		return nil
 	}
-	nw := ns.Labels[label.TopologyNetwork.Name]
-	c.Lock()
-	oldDefaultNetwork := c.network
-	c.network = network.ID(nw)
-	c.Unlock()
-	// network changed, rarely happen
-	if oldDefaultNetwork != c.network {
+	if c.setNetworkFromNamespace(ns) {
+		// network changed, rarely happen
 		// refresh pods/endpoints/services
-		c.onDefaultNetworkChange()
+		c.onNetworkChange()
 	}
 	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -78,7 +78,7 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 		DomainSuffix:              domainSuffix,
 		XDSUpdater:                xdsUpdater,
 		Metrics:                   &model.Environment{},
-		NetworksWatcher:           opts.NetworksWatcher,
+		MeshNetworksWatcher:       opts.NetworksWatcher,
 		MeshWatcher:               opts.MeshWatcher,
 		EndpointMode:              opts.Mode,
 		ClusterID:                 opts.ClusterID,

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -27,13 +27,16 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/network"
 )
 
 type networkManager struct {
 	sync.RWMutex
 	// CIDR ranger based on path-compressed prefix trie
-	ranger cidranger.Ranger
+	ranger              cidranger.Ranger
+	clusterID           cluster.ID
+	meshNetworksWatcher mesh.NetworksWatcher
 
 	// Network name for to be used when the meshNetworks fromRegistry nor network label on pod is specified
 	// This is defined by a topology.istio.io/network label on the system namespace.
@@ -49,8 +52,10 @@ type networkManager struct {
 	model.NetworkGatewaysHandler
 }
 
-func initNetworkManager() networkManager {
+func initNetworkManager(options Options) networkManager {
 	return networkManager{
+		clusterID:           options.ClusterID,
+		meshNetworksWatcher: options.MeshNetworksWatcher,
 		// zero values are a workaround structcheck issue: https://github.com/golangci/golangci-lint/issues/826
 		ranger:                      nil,
 		network:                     "",
@@ -129,36 +134,36 @@ func (c *Controller) onNetworkChange() {
 
 // reloadMeshNetworks will read the mesh networks configuration to setup
 // fromRegistry and cidr based network lookups for this registry
-func (c *Controller) reloadMeshNetworks() {
-	c.networkManager.Lock()
-	defer c.networkManager.Unlock()
-	c.networkFromMeshConfig = ""
+func (n *networkManager) reloadMeshNetworks() {
+	n.Lock()
+	defer n.Unlock()
+	n.networkFromMeshConfig = ""
 	ranger := cidranger.NewPCTrieRanger()
 
-	c.networkFromMeshConfig = ""
-	c.registryServiceNameGateways = make(map[host.Name][]model.NetworkGateway)
+	n.networkFromMeshConfig = ""
+	n.registryServiceNameGateways = make(map[host.Name][]model.NetworkGateway)
 
-	meshNetworks := c.opts.MeshNetworksWatcher.Networks()
+	meshNetworks := n.meshNetworksWatcher.Networks()
 	if meshNetworks == nil || len(meshNetworks.Networks) == 0 {
 		return
 	}
-	for n, v := range meshNetworks.Networks {
+	for id, v := range meshNetworks.Networks {
 		// track endpoints items from this registry are a part of this network
 		fromRegistry := false
 		for _, ep := range v.Endpoints {
 			if ep.GetFromCidr() != "" {
 				_, nw, err := net.ParseCIDR(ep.GetFromCidr())
 				if err != nil {
-					log.Warnf("unable to parse CIDR %q for network %s", ep.GetFromCidr(), n)
+					log.Warnf("unable to parse CIDR %q for network %s", ep.GetFromCidr(), id)
 					continue
 				}
 				rangerEntry := namedRangerEntry{
-					name:    network.ID(n),
+					name:    network.ID(id),
 					network: *nw,
 				}
 				_ = ranger.Insert(rangerEntry)
 			}
-			if ep.GetFromRegistry() != "" && cluster.ID(ep.GetFromRegistry()) == c.Cluster() {
+			if ep.GetFromRegistry() != "" && cluster.ID(ep.GetFromRegistry()) == n.clusterID {
 				fromRegistry = true
 			}
 		}
@@ -166,20 +171,20 @@ func (c *Controller) reloadMeshNetworks() {
 		// fromRegistry field specified this cluster
 		if fromRegistry {
 			// treat endpoints in this cluster as part of this network
-			if c.networkFromMeshConfig != "" {
+			if n.networkFromMeshConfig != "" {
 				log.Warnf("multiple networks specify %s in fromRegistry; endpoints from %s will continue to be treated as part of %s",
-					c.Cluster(), c.Cluster(), c.networkFromMeshConfig)
+					n.clusterID, n.clusterID, n.networkFromMeshConfig)
 			} else {
-				c.networkFromMeshConfig = network.ID(n)
+				n.networkFromMeshConfig = network.ID(id)
 			}
 
 			// services in this registry matching the registryServiceName and port are part of this network
 			for _, gw := range v.Gateways {
 				if gwSvcName := gw.GetRegistryServiceName(); gwSvcName != "" {
 					svc := host.Name(gwSvcName)
-					c.registryServiceNameGateways[svc] = append(c.registryServiceNameGateways[svc], model.NetworkGateway{
-						Network: network.ID(n),
-						Cluster: c.Cluster(),
+					n.registryServiceNameGateways[svc] = append(n.registryServiceNameGateways[svc], model.NetworkGateway{
+						Network: network.ID(id),
+						Cluster: n.clusterID,
 						Port:    gw.GetPort(),
 					})
 				}
@@ -187,7 +192,7 @@ func (c *Controller) reloadMeshNetworks() {
 		}
 
 	}
-	c.ranger = ranger
+	n.ranger = ranger
 }
 
 func (c *Controller) NetworkGateways() []model.NetworkGateway {
@@ -239,11 +244,11 @@ func (c *Controller) reloadNetworkGateways() {
 
 // extractGatewaysInner performs the logic for extractGatewaysFromService without locking the controller.
 // Returns true if any gateways changed.
-func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
-	c.networkManager.Lock()
-	defer c.networkManager.Unlock()
-	previousGateways := c.networkGatewaysBySvc[svc.Hostname]
-	gateways := c.getGatewayDetails(svc)
+func (n *networkManager) extractGatewaysInner(svc *model.Service) bool {
+	n.Lock()
+	defer n.Unlock()
+	previousGateways := n.networkGatewaysBySvc[svc.Hostname]
+	gateways := n.getGatewayDetails(svc)
 	// short circuit for most services.
 	if len(previousGateways) == 0 && len(gateways) == 0 {
 		return false
@@ -253,12 +258,12 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	// check if we have node port mappings
 	nodePortMap := make(map[uint32]uint32)
 	if svc.Attributes.ClusterExternalPorts != nil {
-		if npm, exists := svc.Attributes.ClusterExternalPorts[c.Cluster()]; exists {
+		if npm, exists := svc.Attributes.ClusterExternalPorts[n.clusterID]; exists {
 			nodePortMap = npm
 		}
 	}
 
-	for _, addr := range svc.Attributes.ClusterExternalAddresses.GetAddressesFor(c.Cluster()) {
+	for _, addr := range svc.Attributes.ClusterExternalAddresses.GetAddressesFor(n.clusterID) {
 		for _, gw := range gateways {
 			// what we now have is a service port. If there is a mapping for cluster external ports,
 			// look it up and get the node port for the remote port
@@ -266,7 +271,7 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 				gw.Port = nodePort
 			}
 
-			gw.Cluster = c.Cluster()
+			gw.Cluster = n.clusterID
 			gw.Addr = addr
 			newGateways.Add(gw)
 		}
@@ -274,16 +279,16 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 
 	gatewaysChanged := !newGateways.Equals(previousGateways)
 	if len(newGateways) > 0 {
-		c.networkGatewaysBySvc[svc.Hostname] = newGateways
+		n.networkGatewaysBySvc[svc.Hostname] = newGateways
 	} else {
-		delete(c.networkGatewaysBySvc, svc.Hostname)
+		delete(n.networkGatewaysBySvc, svc.Hostname)
 	}
 
 	return gatewaysChanged
 }
 
 // getGatewayDetails returns gateways without the address populated, only the network and (unmapped) port for a given service.
-func (c *Controller) getGatewayDetails(svc *model.Service) []model.NetworkGateway {
+func (n *networkManager) getGatewayDetails(svc *model.Service) []model.NetworkGateway {
 	// TODO should we start checking if svc's Ports contain the gateway port?
 
 	// label based gateways
@@ -300,7 +305,7 @@ func (c *Controller) getGatewayDetails(svc *model.Service) []model.NetworkGatewa
 	}
 
 	// meshNetworks registryServiceName+fromRegistry
-	if gws, ok := c.registryServiceNameGateways[svc.Hostname]; ok {
+	if gws, ok := n.registryServiceNameGateways[svc.Hostname]; ok {
 		out := append(make([]model.NetworkGateway, 0, len(gws)), gws...)
 		return out
 	}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -45,7 +45,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/config/xds"
-	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
@@ -917,7 +916,7 @@ func (s *DiscoveryServer) pushStatusHandler(w http.ResponseWriter, req *http.Req
 // PushContextDebug holds debug information for push context.
 type PushContextDebug struct {
 	AuthorizationPolicies *model.AuthorizationPolicies
-	NetworkGateways       map[network.ID][]model.NetworkGateway
+	NetworkGateways       []model.NetworkGateway
 }
 
 // pushContextHandler dumps the current PushContext
@@ -929,7 +928,7 @@ func (s *DiscoveryServer) pushContextHandler(w http.ResponseWriter, req *http.Re
 	}
 	push.AuthorizationPolicies = pc.AuthzPolicies
 	if pc.NetworkManager() != nil {
-		push.NetworkGateways = pc.NetworkManager().GatewaysByNetwork()
+		push.NetworkGateways = pc.NetworkManager().AllGateways()
 	}
 
 	writeJSON(w, push, req)

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -129,7 +129,5 @@ func (w *internalNetworkWatcher) SetNetworks(meshNetworks *meshconfig.MeshNetwor
 func (w *internalNetworkWatcher) AddNetworksHandler(h func()) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-
-	// hack: prepend handlers; the last to be added will be run first and block other handlers
-	w.handlers = append([]func(){h}, w.handlers...)
+	w.handlers = append(w.handlers, h)
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Actually it does:

1. remove duplicate handler for meshnetwork change
2. move service registry gateway network handling into controller/network.go
3. rename some structs