### PR TITLE
Support WE in Ambient

### DIFF
--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -277,7 +277,7 @@ func (s *Server) AddPodToMesh(pod *corev1.Pod) {
 	}
 }
 
-func (s *Server) DelPodFromMesh(pod *corev1.Pod, event controllers.Event) {
+func (s *Server) DelPodFromMesh(pod *corev1.Pod, event controllers.Event[*corev1.Pod]) {
 	log.Debugf("Pod %s/%s is now stopped or opt out... cleaning up.", pod.Namespace, pod.Name)
 	switch s.redirectMode {
 	case IptablesMode:

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -342,7 +342,7 @@ func (cl *Client) addCRD(name string) {
 	if s.IsBuiltin() {
 		kc = kclient.NewUntypedInformer(cl.client, gvr, filter)
 	} else {
-		kc = kclient.NewDelayedInformer(
+		kc = kclient.NewDelayedInformer[controllers.Object](
 			cl.client,
 			gvr,
 			kubetypes.StandardInformer,

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -211,8 +211,8 @@ func TestAmbientIndex(t *testing.T) {
 	fx.Clear()
 
 	addWorkloadEntry("127.0.0.9", "we1", "sa1", map[string]string{"app": "a"}, nil)
-	assertWorkloads("", "name1", "name2", "name3", "we1")
-	assertWorkloads("127.0.0.9", "we1")
+	assertAddresses("", "name1", "name2", "name3", "we1")
+	assertAddresses("testnetwork/127.0.0.9", "we1")
 
 	addService("svc1", "ns1",
 		map[string]string{},
@@ -246,7 +246,7 @@ func TestAmbientIndex(t *testing.T) {
 	addService("svc1", "ns1",
 		map[string]string{},
 		map[string]string{},
-		[]int32{80}, map[string]string{"app": "a", "other": "label"}, t)
+		[]int32{80}, map[string]string{"app": "a", "other": "label"}, "10.0.0.1")
 	setEndpoints("svc1", "ns1", "127.0.0.2")
 	assertAddresses("", "name1", "name2", "name3", "svc1", "we1")
 	assertAddresses("testnetwork/10.0.0.1", "name2", "svc1")

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2219,6 +2219,7 @@ func generatePod(ip, name, namespace, saName, node string, labels map[string]str
 				},
 			},
 			PodIP:  ip,
+			PodIPs: []corev1.PodIP{{IP: ip}},
 			HostIP: ip,
 			Phase:  corev1.PodRunning,
 		},

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -60,7 +60,7 @@ func newServiceExportCache(c *Controller) serviceExportCache {
 			Controller: c,
 		}
 
-		ec.serviceExports = kclient.NewDelayedInformer(ec.client, mcs.ServiceExportGVR, kubetypes.DynamicInformer, kclient.Filter{
+		ec.serviceExports = kclient.NewDelayedInformer[controllers.Object](ec.client, mcs.ServiceExportGVR, kubetypes.DynamicInformer, kclient.Filter{
 			ObjectFilter: ec.opts.GetFilter(),
 		})
 		// Register callbacks for events.

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -76,7 +76,7 @@ func newServiceImportCache(c *Controller) serviceImportCache {
 			Controller: c,
 		}
 
-		sic.serviceImports = kclient.NewDelayedInformer(sic.client, mcs.ServiceImportGVR, kubetypes.DynamicInformer, kclient.Filter{
+		sic.serviceImports = kclient.NewDelayedInformer[controllers.Object](sic.client, mcs.ServiceImportGVR, kubetypes.DynamicInformer, kclient.Filter{
 			ObjectFilter: sic.opts.GetFilter(),
 		})
 		// Register callbacks for events.

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -184,8 +184,8 @@ func newController(store model.ConfigStore, xdsUpdater model.XDSUpdater, options
 	return s
 }
 
-// convertWorkloadEntry convert wle from Config.Spec and populate the metadata labels into it.
-func convertWorkloadEntry(cfg config.Config) *networking.WorkloadEntry {
+// ConvertWorkloadEntry convert wle from Config.Spec and populate the metadata labels into it.
+func ConvertWorkloadEntry(cfg config.Config) *networking.WorkloadEntry {
 	wle := cfg.Spec.(*networking.WorkloadEntry)
 	if wle == nil {
 		return nil
@@ -211,9 +211,9 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 	log.Debugf("Handle event %s for workload entry %s/%s", event, curr.Namespace, curr.Name)
 	var oldWle *networking.WorkloadEntry
 	if old.Spec != nil {
-		oldWle = convertWorkloadEntry(old)
+		oldWle = ConvertWorkloadEntry(old)
 	}
-	wle := convertWorkloadEntry(curr)
+	wle := ConvertWorkloadEntry(curr)
 	curr.Spec = wle
 	key := configKey{
 		kind:      workloadEntryConfigType,
@@ -223,7 +223,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 
 	// If an entry is unhealthy, we will mark this as a delete instead
 	// This ensures we do not track unhealthy endpoints
-	if features.WorkloadEntryHealthChecks && !isHealthy(curr) {
+	if features.WorkloadEntryHealthChecks && !IsHealthy(curr) {
 		event = model.EventDelete
 	}
 
@@ -999,9 +999,9 @@ func makeConfigKey(svc *model.Service) model.ConfigKey {
 	}
 }
 
-// isHealthy checks that the provided WorkloadEntry is healthy. If health checks are not enabled,
+// IsHealthy checks that the provided WorkloadEntry is healthy. If health checks are not enabled,
 // it is assumed to always be healthy
-func isHealthy(cfg config.Config) bool {
+func IsHealthy(cfg config.Config) bool {
 	if parseHealthAnnotation(cfg.Annotations[status.WorkloadEntryHealthCheckAnnotation]) {
 		// We default to false if the condition is not set. This ensures newly created WorkloadEntries
 		// are treated as unhealthy until we prove they are healthy by probe success.

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -408,7 +408,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 // Convenience function to convert a workloadEntry into a WorkloadInstance object encoding the endpoint (without service
 // port names) and the namespace - k8s will consume this workload instance when selecting workload entries
 func (s *Controller) convertWorkloadEntryToWorkloadInstance(cfg config.Config, clusterID cluster.ID) *model.WorkloadInstance {
-	we := convertWorkloadEntry(cfg)
+	we := ConvertWorkloadEntry(cfg)
 	addr := we.GetAddress()
 	dnsServiceEntryOnly := false
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1280,6 +1280,7 @@ func makePod(t *testing.T, c kubernetes.Interface, pod *v1.Pod) {
 	// Apiserver doesn't allow Create/Update to modify the pod status. Creating doesn't result in
 	// events - since PodIP will be "".
 	newPod.Status.PodIP = pod.Status.PodIP
+	newPod.Status.PodIPs = []v1.PodIP{{IP: pod.Status.PodIP}}
 	newPod.Status.Phase = v1.PodRunning
 
 	// Also need to sets the pod to be ready as now we only add pod into service entry endpoint when it's ready

--- a/pkg/kube/controllers/common.go
+++ b/pkg/kube/controllers/common.go
@@ -314,6 +314,8 @@ func Extract[T any](obj any) T {
 			log.Errorf("tombstone contained object that is not an object (key:%v, obj:%T)", tombstone.Key, tombstone.Obj)
 			return empty
 		}
+		log.Errorf("failed to cast %T to %T", obj, empty)
+		return empty
 	}
 	return o
 }

--- a/pkg/kube/controllers/queue.go
+++ b/pkg/kube/controllers/queue.go
@@ -200,9 +200,6 @@ func (q Queue) WaitForClose(timeout time.Duration) error {
 }
 
 func formatKey(key any) string {
-	if t, ok := key.(Event); ok {
-		key = t.Latest()
-	}
 	if t, ok := key.(types.NamespacedName); ok {
 		return t.String()
 	}

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -202,7 +202,7 @@ func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) C
 // begin returning results.
 // HasSynced will only return true if the CRD was not present upon creation OR the watch is fully synced. This ensures the creation
 // is fully consistent if the CRD was present during creation; otherwise it is eventually consistent.
-func NewDelayedInformer(c kube.Client, gvr schema.GroupVersionResource, informerType kubetypes.InformerType, filter Filter) Untyped {
+func NewDelayedInformer[T controllers.ComparableObject](c kube.Client, gvr schema.GroupVersionResource, informerType kubetypes.InformerType, filter Filter) Informer[T] {
 	watcher := c.CrdWatcher()
 	if watcher == nil {
 		log.Fatalf("NewDelayedInformer called without a CrdWatcher enabled")
@@ -213,7 +213,7 @@ func NewDelayedInformer(c kube.Client, gvr schema.GroupVersionResource, informer
 		opts.InformerType = informerType
 		return kubeclient.GetInformerFilteredFromGVR(c, opts, gvr)
 	}
-	return newDelayedInformer[controllers.Object](gvr, inf, delay, filter)
+	return newDelayedInformer[T](gvr, inf, delay, filter)
 }
 
 // NewUntypedInformer returns an untyped client for a given GVR. This is read-only.

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -40,7 +40,7 @@ func TestSwappingClient(t *testing.T) {
 	t.Run("CRD partially ready", func(t *testing.T) {
 		stop := test.NewStop(t)
 		c := kube.NewFakeClient()
-		wasm := kclient.NewDelayedInformer(c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
+		wasm := kclient.NewDelayedInformer[*istioclient.WasmPlugin](c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
 		wt := clienttest.NewWriter[*istioclient.WasmPlugin](t, c)
 		tracker := assert.NewTracker[string](t)
 		wasm.AddEventHandler(clienttest.TrackerHandler(tracker))
@@ -67,7 +67,7 @@ func TestSwappingClient(t *testing.T) {
 		c.RunAndWait(stop)
 
 		// Now that CRD is synced, we create the client
-		wasm := kclient.NewDelayedInformer(c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
+		wasm := kclient.NewDelayedInformer[*istioclient.WasmPlugin](c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
 		wt := clienttest.NewWriter[*istioclient.WasmPlugin](t, c)
 		tracker := assert.NewTracker[string](t)
 		wasm.AddEventHandler(clienttest.TrackerHandler(tracker))
@@ -88,7 +88,7 @@ func TestSwappingClient(t *testing.T) {
 		c := kube.NewFakeClient()
 
 		// Client created before CRDs are ready
-		wasm := kclient.NewDelayedInformer(c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
+		wasm := kclient.NewDelayedInformer[*istioclient.WasmPlugin](c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
 		wt := clienttest.NewWriter[*istioclient.WasmPlugin](t, c)
 		tracker := assert.NewTracker[string](t)
 		wasm.AddEventHandler(clienttest.TrackerHandler(tracker))
@@ -114,7 +114,7 @@ func TestSwappingClient(t *testing.T) {
 		c := kube.NewFakeClient()
 
 		// Client created before CRDs are ready
-		wasm := kclient.NewDelayedInformer(c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
+		wasm := kclient.NewDelayedInformer[*istioclient.WasmPlugin](c, gvr.WasmPlugin, kubetypes.StandardInformer, kubetypes.Filter{})
 		wt := clienttest.NewWriter[*istioclient.WasmPlugin](t, c)
 		tracker := assert.NewTracker[string](t)
 		wasm.AddEventHandler(clienttest.TrackerHandler(tracker))
@@ -141,7 +141,7 @@ func TestSwappingClient(t *testing.T) {
 }
 
 // setup some calls to ensure we trigger the race detector, if there was a race.
-func constantlyAccessForRaceDetection(stop chan struct{}, wt kclient.Untyped) {
+func constantlyAccessForRaceDetection(stop chan struct{}, wt kclient.Informer[*istioclient.WasmPlugin]) {
 	for {
 		select {
 		case <-time.After(time.Millisecond):

--- a/pkg/kube/kclient/collection.go
+++ b/pkg/kube/kclient/collection.go
@@ -102,11 +102,6 @@ func (f *DerivedCollection[T]) AddEventHandler(h cache.ResourceEventHandler) {
 	f.handlers = append(f.handlers, h)
 }
 
-func (f *DerivedCollection[T]) RecomputeE(name types.NamespacedName) error {
-	f.Recompute(name)
-	return nil
-}
-
 func (f *DerivedCollection[T]) Recompute(name types.NamespacedName) {
 	res := f.compute(name)
 	f.mu.Lock()

--- a/pkg/kube/kclient/collection.go
+++ b/pkg/kube/kclient/collection.go
@@ -1,0 +1,151 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kclient
+
+import (
+	"sync"
+
+	"golang.org/x/exp/slices"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/kube/controllers"
+)
+
+// DerivedCollection defines a collection of resources. Unlike an informer, which reads from Kubernetes,
+// this is intended to be used for derived resources. For instance, we could combine a Pod and
+// Service into a ServiceInstance.
+type DerivedCollection[T comparable] struct {
+	compute  func(name types.NamespacedName) T
+	equality func(a, b T) bool
+	mu       sync.RWMutex
+	objects  map[types.NamespacedName]T
+	handlers []cache.ResourceEventHandler
+}
+
+// NewDerivedCollection creates a new collection.
+// required: compute, used to build the resource.
+// Optional: equality; if set, we will not trigger events if the previous and new result is the same.
+func NewDerivedCollection[T comparable](compute func(name types.NamespacedName) T, equality func(a, b T) bool) *DerivedCollection[T] {
+	return &DerivedCollection[T]{
+		compute:  compute,
+		equality: equality,
+		objects:  map[types.NamespacedName]T{},
+	}
+}
+
+// Ensure we implement the same interface to make things a bit more abstract.
+var _ Informer[any] = &DerivedCollection[any]{}
+
+func (f *DerivedCollection[T]) equals(a, b T) bool {
+	if f.equality == nil {
+		// No equality defined, just assume its always changed
+		return false
+	}
+	return f.equality(a, b)
+}
+
+func (f *DerivedCollection[T]) List(namespace string, selector klabels.Selector) []T {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	res := []T{}
+	for k, v := range f.objects {
+		// TODO support selector
+		if namespace == "" || k.Namespace == namespace {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+func (f *DerivedCollection[T]) ListUnfiltered(namespace string, selector klabels.Selector) []T {
+	return f.List(namespace, selector)
+}
+
+func (f *DerivedCollection[T]) HasSynced() bool {
+	// TODO: we have no meaningful way to implement this
+	return true
+}
+
+func (f *DerivedCollection[T]) ShutdownHandlers() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = nil
+}
+
+func (f *DerivedCollection[T]) Get(name, namespace string) T {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.objects[types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}]
+}
+
+func (f *DerivedCollection[T]) AddEventHandler(h cache.ResourceEventHandler) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = append(f.handlers, h)
+}
+
+func (f *DerivedCollection[T]) RecomputeE(name types.NamespacedName) error {
+	f.Recompute(name)
+	return nil
+}
+
+func (f *DerivedCollection[T]) Recompute(name types.NamespacedName) {
+	res := f.compute(name)
+	f.mu.Lock()
+	old, oldExists := f.objects[name]
+	var event model.Event
+	if controllers.IsNil(res) {
+		if !oldExists {
+			// No object for this key, and no existing object. Nothing to do
+			f.mu.Unlock()
+			return
+		}
+		// This is a delete
+		event = model.EventDelete
+		delete(f.objects, name)
+	} else if oldExists {
+		event = model.EventUpdate
+		if f.equals(old, res) {
+			// no action needed, it was a NOP change
+			f.mu.Unlock()
+			return
+		}
+		f.objects[name] = res
+	} else {
+		event = model.EventAdd
+		f.objects[name] = res
+	}
+	handlers := slices.Clone(f.handlers)
+	f.mu.Unlock()
+	for _, h := range handlers {
+		switch event {
+		case model.EventAdd:
+			h.OnAdd(res, false)
+		case model.EventDelete:
+			h.OnDelete(old)
+		case model.EventUpdate:
+			h.OnUpdate(old, res)
+		}
+	}
+}
+
+func (f *DerivedCollection[T]) Start(stop <-chan struct{}) {
+}

--- a/pkg/kube/kclient/index.go
+++ b/pkg/kube/kclient/index.go
@@ -20,16 +20,48 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/util/sets"
 )
 
 // Index maintains a simple index over an informer
-type Index[K comparable, O controllers.ComparableObject] struct {
+type Index[K comparable, O comparable] struct {
 	mu      sync.RWMutex
 	objects map[K]sets.Set[types.NamespacedName]
-	client  Informer[O]
+	client  Indexer[O]
+}
+
+type Indexer[T any] interface {
+	Get(name, namespace string) T
+	AddEventHandler(h cache.ResourceEventHandler)
+}
+
+type configStoreWatch struct {
+	gvk config.GroupVersionKind
+	cs  model.ConfigStoreController
+}
+
+func (c configStoreWatch) Get(name, namespace string) *config.Config {
+	return c.cs.Get(c.gvk, name, namespace)
+}
+
+func (c configStoreWatch) AddEventHandler(h cache.ResourceEventHandler) {
+	c.cs.RegisterEventHandler(c.gvk, func(oldObj config.Config, newObj config.Config, event model.Event) {
+		switch event {
+		case model.EventAdd:
+			h.OnAdd(&newObj, false)
+		case model.EventUpdate:
+			h.OnUpdate(&oldObj, &newObj)
+		case model.EventDelete:
+			h.OnDelete(&newObj)
+		}
+	})
+}
+
+func IndexerFromConfigStore(g config.GroupVersionKind, c model.ConfigStoreController) Indexer[*config.Config] {
+	return configStoreWatch{g, c}
 }
 
 // Lookup finds all objects matching a given key
@@ -48,6 +80,32 @@ func (i *Index[K, O]) Lookup(k K) []O {
 	return res
 }
 
+// KeyCount returns the number of keys known
+func (i *Index[K, O]) KeyCount() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.objects)
+}
+
+func CreateIndexFromStore[K comparable](
+	g config.GroupVersionKind,
+	store model.ConfigStoreController,
+	extract func(o *config.Config) []K,
+	delegate cache.ResourceEventHandler,
+) *Index[K, *config.Config] {
+	i := IndexerFromConfigStore(g, store)
+	return internal[K, *config.Config](i, extract, delegate)
+}
+
+// CreateIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
+// Informer.AddIndex, but is easier to use and can be added after an informer has already started.
+func CreateIndex[K comparable, O controllers.ComparableObject](
+	client Informer[O],
+	extract func(o O) []K,
+) *Index[K, O] {
+	return CreateIndexWithDelegate(client, extract, nil)
+}
+
 // CreateIndexWithDelegate creates a simple index, keyed by key K, over an informer for O. This is similar to
 // Informer.AddIndex, but is easier to use and can be added after an informer has already started.
 // An additional ResourceEventHandler can be passed in that is guaranteed to happen *after* the index is updated.
@@ -58,22 +116,33 @@ func CreateIndexWithDelegate[K comparable, O controllers.ComparableObject](
 	extract func(o O) []K,
 	delegate cache.ResourceEventHandler,
 ) *Index[K, O] {
+	return internal[K, O](client, extract, delegate)
+}
+
+type comparableNamer interface {
+	comparable
+	config.Namer
+}
+
+func internal[K comparable, O comparableNamer](
+	client Indexer[O],
+	extract func(o O) []K,
+	delegate cache.ResourceEventHandler,
+) *Index[K, O] {
 	idx := Index[K, O]{
 		objects: make(map[K]sets.Set[types.NamespacedName]),
 		client:  client,
 		mu:      sync.RWMutex{},
 	}
 	addObj := func(obj any) {
-		ro := controllers.ExtractObject(obj)
-		o := ro.(O)
+		o := controllers.Extract[O](obj)
 		objectKey := config.NamespacedName(o)
 		for _, indexKey := range extract(o) {
 			sets.InsertOrNew(idx.objects, indexKey, objectKey)
 		}
 	}
 	deleteObj := func(obj any) {
-		ro := controllers.ExtractObject(obj)
-		o := ro.(O)
+		o := controllers.Extract[O](obj)
 		objectKey := config.NamespacedName(o)
 		for _, indexKey := range extract(o) {
 			sets.DeleteCleanupLast(idx.objects, indexKey, objectKey)
@@ -108,13 +177,4 @@ func CreateIndexWithDelegate[K comparable, O controllers.ComparableObject](
 	}
 	client.AddEventHandler(handler)
 	return &idx
-}
-
-// CreateIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
-// Informer.AddIndex, but is easier to use and can be added after an informer has already started.
-func CreateIndex[K comparable, O controllers.ComparableObject](
-	client Informer[O],
-	extract func(o O) []K,
-) *Index[K, O] {
-	return CreateIndexWithDelegate(client, extract, nil)
 }

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -25,7 +25,7 @@ type Untyped = Informer[controllers.Object]
 
 // Reader wraps a Kubernetes client providing cached read access.
 // This is based on informers, so most of the same caveats to informers apply here.
-type Reader[T controllers.Object] interface {
+type Reader[T any] interface {
 	// Get looks up an object by name and namespace. If it does not exist, nil is returned
 	Get(name, namespace string) T
 	// List looks up an object by namespace and labels.
@@ -33,7 +33,7 @@ type Reader[T controllers.Object] interface {
 	List(namespace string, selector klabels.Selector) []T
 }
 
-type Informer[T controllers.Object] interface {
+type Informer[T any] interface {
 	Reader[T]
 	// ListUnfiltered is like List but ignores any *client side* filters previously configured.
 	ListUnfiltered(namespace string, selector klabels.Selector) []T

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -18,6 +18,8 @@ package slices
 import (
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
+
+	"istio.io/istio/pkg/ptr"
 )
 
 // Equal reports whether two slices are equal: the same length and all
@@ -111,4 +113,12 @@ func Head[E any](s []E) *E {
 		return nil
 	}
 	return &s[0]
+}
+
+// HeadOk returns the first element in the list, if there is one
+func HeadOk[E any](s []E) (E, bool) {
+	if len(s) == 0 {
+		return ptr.Empty[E](), false
+	}
+	return s[0], true
 }

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -104,3 +104,11 @@ func Map[E any, O any](s []E, f func(E) O) []O {
 	}
 	return n
 }
+
+// Head returns the first element in the list, if there is one
+func Head[E any](s []E) *E {
+	if len(s) == 0 {
+		return nil
+	}
+	return &s[0]
+}

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -71,7 +71,7 @@ func EventuallyEqual[T any](t test.Failer, fetchA func() T, b T, opts ...retry.O
 		return nil
 	}, ro...)
 	if err != nil {
-		t.Fatalf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
+		t.Fatalf("found diff: %v\nGot: %v\nWant: %v", cmp.Diff(a, b, cmpOpts...), a, b)
 	}
 }
 


### PR DESCRIPTION
This refactors the Workload implemention in ambient. This changes from drawing only from Pod and Service to reading multiple sources.

This is an implementation of part of https://docs.google.com/document/d/1V5wkeBHbLSLMzAMbwFlFZNHdZPyUEspG4lHbnB0UaCg/edit.

This re-architectures the flow a bit.

At its core, we now have one function that takes in an IP and returns a Workload resource.

We have an abstraction over this, DerivedCollection, which handles maintaining the state of all known Workloads, allowing Get/List operations on them and sending event handlers notifications on changes.

Finally, for each type that may impact a IP, we enqueue the IP for recomputation.  For example, for Service we lookup all pods and WE selected by the service and enqueue them. Note this may enqueue too many things, which is fine: DerivedCollection will supress them (although this has some cost). The opposite, failing to enqueue, will result in stale data. Note this stale case can be fixed by https://docs.google.com/document/d/1-ywpCnOfubqg7WAXSPf4YgbaFDBEU9HIqMWcxZLhzwE/edit, but this PR does not go that far -- the design described there is a lot more complicated. However, this is a good stepping stone in that direction.

Benefits:
* Cleaner design with less manual cache building
* Support WorkloadEntry
* Support manual endpoints
* Better pod-service readiness