### PR TITLE
[1.16] gateway deployment controller: handle backwards compatibility …

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -39,6 +40,7 @@ import (
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -184,8 +186,21 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		log.Debug("skip unmanaged gateway")
 		return nil
 	}
+	existingControllerVersion, overwriteControllerVersion, shouldHandle := ManagedGatewayControllerVersion(gw)
+	if !shouldHandle {
+		log.Debugf("skipping gateway which is managed by controller version %v", existingControllerVersion)
+		return nil
+	}
 	log.Info("reconciling")
 
+	if overwriteControllerVersion {
+		log.Debugf("write controller version, existing=%v", existingControllerVersion)
+		if err := d.setGatewayControllerVersion(&gw); err != nil {
+			return fmt.Errorf("update gateway annotation: %v", err)
+		}
+	} else {
+		log.Debugf("controller version existing=%v, no action needed", existingControllerVersion)
+	}
 	svc := serviceInput{Gateway: &gw, Ports: extractServicePorts(gw)}
 	if err := d.ApplyTemplate("service.yaml", svc); err != nil {
 		return fmt.Errorf("update service: %v", err)
@@ -221,6 +236,54 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("gateway updated")
 	return nil
+}
+
+const (
+	// ControllerVersionAnnotation is an annotation added to the Gateway by the controller specifying
+	// the "controller version". The original intent of this was to work around
+	// https://github.com/istio/istio/issues/44164, where we needed to transition from a global owner
+	// to a per-revision owner. The newer version number allows forcing ownership, even if the other
+	// version was otherwise expected to control the Gateway.
+	// The version number has no meaning other than "larger numbers win".
+	// Numbers are used to future-proof in case we need to do another migration in the future.
+	ControllerVersionAnnotation = "gateway.istio.io/controller-version"
+	// ControllerVersion is the current version of our controller logic. Known versions are:
+	//
+	// * 1.17 and older: version 1 OR no version at all, depending on patch release
+	// * 1.18+: version 5
+	//
+	// 2, 3, and 4 were intentionally skipped to allow for the (unlikely) event we need to insert
+	// another version between these
+	ControllerVersion = 1
+)
+
+// ManagedGatewayControllerVersion determines the version of the controller managing this Gateway,
+// and if we should manage this.
+// See ControllerVersionAnnotation for motivations.
+func ManagedGatewayControllerVersion(gw gateway.Gateway) (existing string, takeOver bool, manage bool) {
+	cur, f := gw.Annotations[ControllerVersionAnnotation]
+	if !f {
+		// No current owner, we should take it over.
+		return "", true, true
+	}
+	curNum, err := strconv.Atoi(cur)
+	if err != nil {
+		// We cannot parse it - must be some new schema we don't know about. We should assume we do not manage it.
+		// In theory, this should never happen, unless we decide a number was a bad idea in the future.
+		return cur, false, false
+	}
+	if curNum > ControllerVersion {
+		// A newer version owns this gateway, let them handle it
+		return cur, false, false
+	}
+	if curNum == ControllerVersion {
+		// We already manage this at this version
+		// We will manage it, but no need to attempt to apply the version annotation, which could race with newer versions
+		return cur, false, true
+	}
+	// We are either newer or the same version of the last owner - we can take over. We need to actually
+	// re-apply the annotation
+	return cur, true, true
 }
 
 // ApplyTemplate renders a template with the given input and (server-side) applies the results to the cluster.
@@ -262,6 +325,14 @@ func (d *DeploymentController) ApplyObject(obj controllers.Object, subresources 
 	log.Debugf("applying %v", string(j))
 
 	return d.patcher(gvr, obj.GetName(), obj.GetNamespace(), j, subresources...)
+}
+
+func (d *DeploymentController) setGatewayControllerVersion(gws *gateway.Gateway) error {
+	patch := fmt.Sprintf(`{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{"%s":"%d"}}}`,
+		ControllerVersionAnnotation, ControllerVersion)
+	gvr := collections.K8SGatewayApiV1Beta1Gateways.Resource().GroupVersionResource()
+	log.Debugf("applying %v", patch)
+	return d.patcher(gvr, gws.GetName(), gws.GetNamespace(), []byte(patch))
 }
 
 // Merge maps merges multiple maps. Latter maps take precedence over previous maps on overlapping fields

--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
+    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{ toYamlMap .Labels
       (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")
@@ -23,7 +23,7 @@ spec:
       annotations:
         {{ toYamlMap
           (strdict "inject.istio.io/templates" "gateway")
-          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration")
+          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/controller-version")
           | nindent 8}}
       labels:
         {{ toYamlMap

--- a/pilot/pkg/config/kube/gateway/templates/service.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration") | nindent 4 }}
+    {{ toYamlMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{ toYamlMap .Labels
       (strdict "gateway.istio.io/managed" "istio.io-gateway-controller")

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -1,3 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "1"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -15,13 +15,16 @@
 package assert
 
 import (
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 // Equal
@@ -47,5 +50,46 @@ func NoError(t test.Failer, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("expected no error but got: %v", err)
+	}
+}
+
+// ChannelHasItem asserts a channel has an element within 5s and returns the element
+func ChannelHasItem[T any](t test.Failer, c <-chan T) T {
+	t.Helper()
+	select {
+	case r := <-c:
+		return r
+	case <-time.After(time.Second * 5):
+		t.Fatalf("failed to receive event after 5s")
+	}
+	// Not reachable
+	var empty T
+	return empty
+}
+
+// ChannelIsEmpty asserts a channel is empty for at least 20ms
+func ChannelIsEmpty[T any](t test.Failer, c <-chan T) {
+	t.Helper()
+	select {
+	case r := <-c:
+		t.Fatalf("channel had element, expected empty: %v", r)
+	case <-time.After(time.Millisecond * 20):
+	}
+}
+
+var cmpOpts = []cmp.Option{protocmp.Transform(), cmpopts.EquateEmpty()}
+
+func EventuallyEqual[T any](t test.Failer, fetchA func() T, b T, opts ...retry.Option) {
+	t.Helper()
+	var a T
+	err := retry.UntilSuccess(func() error {
+		a = fetchA()
+		if !cmp.Equal(a, b, cmpOpts...) {
+			return fmt.Errorf("not equal")
+		}
+		return nil
+	}, opts...)
+	if err != nil {
+		t.Fatalf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
 	}
 }

--- a/releasenotes/notes/gateway-futureproof.yaml
+++ b/releasenotes/notes/gateway-futureproof.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 44164
+
+releaseNotes:
+- |
+  **Fixed** an issue with forward compatibility with Istio 1.18+ [Kubernetes Gateway Automated Deployment](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment).
+  To have a seamless upgrade to 1.18+, users of this feature should first adopt this patch release.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/44215

* Future proof Gateway deployment controller

This introduces a mechanism to tell older versions to stop managing a Gateway.

How this works:

1.17 controls all Gateways. Users will upgrade to a patched version (basically this PR backported) which annotates all Gateways with version=1. It also has logic to not control Gateways with version>1 User installs 1.18 as canary revision. Any Gateways in canary revision will get version=2 set; at this point, the 1.17 controller will stop trying to manage it. Warning: if a user needs to remove 1.18 at this point, they would need to manual set the version label back to 1. This is not ideal, but it is the best we can do I think. User makes 1.18 the "default revision". At this point it does the same as above, but to a wider set of gateways. Eventually, if we somehow run into the same circumstance, we can change the logic again to version=3 in some future version and completely change how we do gateway ownership. That is, this solution is future proof.

* improvements from master

* lint

(cherry picked from commit b8b08a18116c779bbc9388a2903335b28112dd16)

**Please provide a description of this PR:**