### PR TITLE
gateway: remove internal annotation from propogating

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1338,7 +1338,7 @@ data:
           name: {{.DeploymentName | quote}}
           namespace: {{.Namespace | quote}}
           annotations:
-            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
           labels:
             {{- toJsonMap .Labels | nindent 4 }}
           ownerReferences:
@@ -1354,7 +1354,7 @@ data:
             metadata:
               annotations:
                 {{- toJsonMap
-                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
                   (strdict
                     "ambient.istio.io/redirection" "disabled"
                     "prometheus.io/path" "/stats/prometheus"
@@ -1544,7 +1544,7 @@ data:
         kind: Service
         metadata:
           annotations:
-            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
           labels:
             {{ toJsonMap .Labels | nindent 4}}
           name: {{.DeploymentName | quote}}
@@ -1576,7 +1576,7 @@ data:
           name: {{.DeploymentName | quote}}
           namespace: {{.Namespace | quote}}
           annotations:
-            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+            {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
           labels:
             {{- toJsonMap .Labels | nindent 4 }}
           ownerReferences:
@@ -1592,7 +1592,7 @@ data:
             metadata:
               annotations:
                 {{- toJsonMap
-                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+                  (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
                   (strdict
                     "prometheus.io/path" "/stats/prometheus"
                     "prometheus.io/port" "15020"
@@ -1850,7 +1850,7 @@ data:
         kind: Service
         metadata:
           annotations:
-            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+            {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
           labels:
             {{ toJsonMap .Labels | nindent 4}}
           name: {{.DeploymentName | quote}}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   annotations:
-    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{- toJsonMap .Labels | nindent 4 }}
   ownerReferences:
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         {{- toJsonMap
-          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict
             "prometheus.io/path" "/stats/prometheus"
             "prometheus.io/port" "15020"
@@ -284,7 +284,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{ toJsonMap .Labels | nindent 4}}
   name: {{.DeploymentName | quote}}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   annotations:
-    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{- toJsonMap .Labels | nindent 4 }}
   ownerReferences:
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         {{- toJsonMap
-          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict
             "ambient.istio.io/redirection" "disabled"
             "prometheus.io/path" "/stats/prometheus"
@@ -216,7 +216,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{ toJsonMap .Labels | nindent 4}}
   name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1159,7 +1159,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1175,7 +1175,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1365,7 +1365,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}
@@ -1397,7 +1397,7 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap .Labels | nindent 4 }}
       ownerReferences:
@@ -1413,7 +1413,7 @@ templates:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account")
+              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
@@ -1671,7 +1671,7 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account") | nindent 4 }}
+        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{ toJsonMap .Labels | nindent 4}}
       name: {{.DeploymentName | quote}}


### PR DESCRIPTION
Without this, if someone accidentally removes the annotation from the gateway (say, a poor CI/CD that isn't merging), it will cause a blip in the deployment and spin a pod up+down. This is confusing and wasteful. 

Just remove the annotation on child objects; it isn't needed.