### PR TITLE
Fix ztunnel secret state in configdump

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -82,6 +83,9 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 	fmt.Fprintln(w, "NAME\tTYPE\tSTATUS\tVALID CERT\tSERIAL NUMBER\tNOT AFTER\tNOT BEFORE")
 
 	for _, secret := range secretDump {
+		if strings.Contains(secret.State, "Unavailable") {
+			secret.State = "Unavailable"
+		}
 		if len(secret.CaCert) == 0 && len(secret.CertChain) == 0 {
 			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 				secret.Identity, valueOrNA(""), secret.State, false, valueOrNA(""), valueOrNA(""), valueOrNA(""))

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/dump.json
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/dump.json
@@ -386,6 +386,12 @@
       "state": "Unavailable: the identity is no longer needed",
       "ca_cert": [],
       "cert_chain": []
+    },
+    {
+      "identity": "spiffe://cluster.local/ns/istio-system/sa/istiod",
+      "state": "Unavailable: signing gRPC error (The service is currently unavailable): error trying to connect: TLS handshake failed: cert verification failed - unable to get local issuer certificate [CERTIFICATE_VERIFY_FAILED]",
+      "ca_cert": [],
+      "cert_chain": []
     }
   ]
 }

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
@@ -1,5 +1,6 @@
-NAME                                                     TYPE           STATUS                                            VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
-spiffe://cluster.local/ns/istio-system/sa/istiod         CA             Available                                         true           e5dfb59150b2ba7f108d93dcec5aa613     2033-03-22T13:04:57Z     2023-03-21T13:02:57Z
-spiffe://cluster.local/ns/istio-system/sa/istiod         Cert Chain     Available                                         false          8a516645c40ce76c2c0d27ab4e2461c1     2022-03-18T13:04:49Z     2022-03-21T13:04:49Z
-spiffe://cluster.local/ns/istio-system/sa/ztunnel        NA             Initializing                                      false          NA                                   NA                       NA
-spiffe://cluster.local/ns/istio-system/sa/another-sa     NA             Unavailable: the identity is no longer needed     false          NA                                   NA                       NA
+NAME                                                     TYPE           STATUS           VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
+spiffe://cluster.local/ns/istio-system/sa/istiod         CA             Available        true           e5dfb59150b2ba7f108d93dcec5aa613     2033-03-22T13:04:57Z     2023-03-21T13:02:57Z
+spiffe://cluster.local/ns/istio-system/sa/istiod         Cert Chain     Available        false          8a516645c40ce76c2c0d27ab4e2461c1     2022-03-18T13:04:49Z     2022-03-21T13:04:49Z
+spiffe://cluster.local/ns/istio-system/sa/ztunnel        NA             Initializing     false          NA                                   NA                       NA
+spiffe://cluster.local/ns/istio-system/sa/another-sa     NA             Unavailable      false          NA                                   NA                       NA
+spiffe://cluster.local/ns/istio-system/sa/istiod         NA             Unavailable      false          NA                                   NA                       NA


### PR DESCRIPTION
**Please provide a description of this PR:**
The summary of the secret dump will be difficult to read when the `Unavailable` state contains long messages. The message may be useful for other formats, so I have truncated it only in the summary.

/cc @GregHanson 