### PR TITLE
tag watcher: add unit tests

### DIFF
--- a/pkg/kube/kclient/clienttest/test_helpers.go
+++ b/pkg/kube/kclient/clienttest/test_helpers.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 type TestCached[T controllers.Object] struct {
@@ -71,5 +72,20 @@ func Wrap[T controllers.Object](t test.Failer, c kclient.Client[T]) TestCached[T
 	return TestCached[T]{
 		c: c,
 		t: t,
+	}
+}
+
+// TrackerHandler returns an object handler that records each event
+func TrackerHandler(tracker *assert.Tracker[string]) controllers.EventHandler[controllers.Object] {
+	return controllers.EventHandler[controllers.Object]{
+		AddFunc: func(obj controllers.Object) {
+			tracker.Record("add/" + obj.GetName())
+		},
+		UpdateFunc: func(oldObj, newObj controllers.Object) {
+			tracker.Record("update/" + newObj.GetName())
+		},
+		DeleteFunc: func(obj controllers.Object) {
+			tracker.Record("delete/" + obj.GetName())
+		},
 	}
 }

--- a/pkg/kube/kclient/index.go
+++ b/pkg/kube/kclient/index.go
@@ -48,11 +48,15 @@ func (i *Index[O, K]) Lookup(k K) []O {
 	return res
 }
 
-// CreateIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
+// CreateIndexWithDelegate creates a simple index, keyed by key K, over an informer for O. This is similar to
 // Informer.AddIndex, but is easier to use and can be added after an informer has already started.
-func CreateIndex[O controllers.ComparableObject, K comparable](
+// An additional ResourceEventHandler can be passed in that is guaranteed to happen *after* the index is updated.
+// This allows the delegate to depend on the contents of the index.
+// TODO(https://github.com/kubernetes/kubernetes/pull/117046) remove this.
+func CreateIndexWithDelegate[O controllers.ComparableObject, K comparable](
 	client Reader[O],
 	extract func(o O) []K,
+	delegate cache.ResourceEventHandler,
 ) *Index[O, K] {
 	idx := Index[O, K]{
 		objects: make(map[K]sets.Set[types.NamespacedName]),
@@ -75,24 +79,42 @@ func CreateIndex[O controllers.ComparableObject, K comparable](
 			sets.DeleteCleanupLast(idx.objects, indexKey, objectKey)
 		}
 	}
-	handler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
+	handler := cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj any, initialList bool) {
 			idx.mu.Lock()
-			defer idx.mu.Unlock()
 			addObj(obj)
+			idx.mu.Unlock()
+			if delegate != nil {
+				delegate.OnAdd(obj, initialList)
+			}
 		},
 		UpdateFunc: func(oldObj, newObj any) {
 			idx.mu.Lock()
-			defer idx.mu.Unlock()
 			deleteObj(oldObj)
 			addObj(newObj)
+			idx.mu.Unlock()
+			if delegate != nil {
+				delegate.OnUpdate(oldObj, newObj)
+			}
 		},
 		DeleteFunc: func(obj any) {
 			idx.mu.Lock()
-			defer idx.mu.Unlock()
 			deleteObj(obj)
+			idx.mu.Unlock()
+			if delegate != nil {
+				delegate.OnDelete(obj)
+			}
 		},
 	}
 	client.AddEventHandler(handler)
 	return &idx
+}
+
+// CreateIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
+// Informer.AddIndex, but is easier to use and can be added after an informer has already started.
+func CreateIndex[O controllers.ComparableObject, K comparable](
+	client Reader[O],
+	extract func(o O) []K,
+) *Index[O, K] {
+	return CreateIndexWithDelegate(client, extract, nil)
 }

--- a/pkg/kube/kclient/index_test.go
+++ b/pkg/kube/kclient/index_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
@@ -147,4 +149,54 @@ func TestIndex(t *testing.T) {
 		defer index.mu.RUnlock()
 		return len(index.objects)
 	}, 0)
+}
+
+func TestIndexDelegate(t *testing.T) {
+	c := kube.NewFakeClient()
+	pods := New[*corev1.Pod](c)
+	c.RunAndWait(test.NewStop(t))
+	var index *Index[*corev1.Pod, string]
+	adds := atomic.NewInt32(0)
+	index = CreateIndexWithDelegate[*corev1.Pod](pods, func(pod *corev1.Pod) []string {
+		return []string{pod.Spec.ServiceAccountName}
+	}, controllers.EventHandler[*corev1.Pod]{
+		AddFunc: func(obj *corev1.Pod) {
+			// Assert that our handler sees the incoming update (and doesn't run before)
+			sa := obj.Spec.ServiceAccountName
+			got := index.Lookup(sa)
+			for _, p := range got {
+				if p.Name == obj.Name {
+					adds.Inc()
+					return
+				}
+			}
+			t.Fatalf("pod %v/%v not found in index, have %v", obj.Name, sa, got)
+		},
+	})
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa",
+			NodeName:           "node",
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "ns",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa2",
+			NodeName:           "node",
+		},
+	}
+
+	c.Kube().CoreV1().Pods("ns").Create(context.Background(), pod1, metav1.CreateOptions{})
+	assert.EventuallyEqual(t, adds.Load, 1)
+
+	c.Kube().CoreV1().Pods("ns").Create(context.Background(), pod2, metav1.CreateOptions{})
+	assert.EventuallyEqual(t, adds.Load, 2)
 }

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -15,8 +15,6 @@
 package revisions
 
 import (
-	"sync"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -37,7 +35,6 @@ type TagWatcher interface {
 	HasSynced() bool
 	AddHandler(handler TagHandler)
 	GetMyTags() sets.Set[string]
-	GetAllTags() sets.Set[string]
 }
 
 // TagHandler is a callback for when the tags revision change.
@@ -47,42 +44,44 @@ type tagWatcher struct {
 	revision string
 	handlers []TagHandler
 
-	queue           controllers.Queue
-	webhookInformer kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
-	mu              sync.RWMutex
-	tagsToRevisions map[string]string
-	revisionsToTags map[string][]string
+	queue    controllers.Queue
+	webhooks kclient.Client[*admissionregistrationv1.MutatingWebhookConfiguration]
+	index    *kclient.Index[*admissionregistrationv1.MutatingWebhookConfiguration, string]
 }
 
 func NewTagWatcher(client kube.Client, revision string) TagWatcher {
 	p := &tagWatcher{
-		revision:        revision,
-		mu:              sync.RWMutex{},
-		tagsToRevisions: map[string]string{},
-		revisionsToTags: map[string][]string{},
+		revision: revision,
 	}
-	p.queue = controllers.NewQueue("tag", controllers.WithReconciler(p.updateTags))
-	p.webhookInformer = kclient.NewFiltered[*admissionregistrationv1.MutatingWebhookConfiguration](client, kubetypes.Filter{
+	p.queue = controllers.NewQueue("tag", controllers.WithReconciler(func(key types.NamespacedName) error {
+		p.notifyHandlers()
+		return nil
+	}))
+	p.webhooks = kclient.NewFiltered[*admissionregistrationv1.MutatingWebhookConfiguration](client, kubetypes.Filter{
 		ObjectFilter: isTagWebhook,
 	})
-	p.webhookInformer.AddEventHandler(controllers.ObjectHandler(p.queue.AddObject))
-
+	p.index = kclient.CreateIndexWithDelegate[*admissionregistrationv1.MutatingWebhookConfiguration, string](p.webhooks, func(o *admissionregistrationv1.MutatingWebhookConfiguration) []string {
+		rev := o.GetLabels()[label.IoIstioRev.Name]
+		if rev == "" {
+			return nil
+		}
+		return []string{rev}
+	}, controllers.ObjectHandler(p.queue.AddObject))
 	return p
 }
 
 func (p *tagWatcher) Run(stopCh <-chan struct{}) {
-	if !kube.WaitForCacheSync(stopCh, p.webhookInformer.HasSynced) {
+	if !kube.WaitForCacheSync(stopCh, p.webhooks.HasSynced) {
 		log.Errorf("failed to sync tag watcher")
 		return
 	}
-
+	// Notify handlers of initial state
+	p.notifyHandlers()
 	p.queue.Run(stopCh)
 }
 
 // AddHandler registers a new handler for updates to tag changes.
 func (p *tagWatcher) AddHandler(handler TagHandler) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.handlers = append(p.handlers, handler)
 }
 
@@ -90,55 +89,20 @@ func (p *tagWatcher) HasSynced() bool {
 	return p.queue.HasSynced()
 }
 
-func (p *tagWatcher) GetMyTags() sets.Set[string] {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	result := sets.New(p.revisionsToTags[p.revision]...)
-	result.Insert(p.revision)
-	return result
-}
-
-func (p *tagWatcher) GetAllTags() sets.Set[string] {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	result := sets.New[string]()
-	for k, v := range p.tagsToRevisions {
-		result.InsertAll(k, v)
+func (p *tagWatcher) GetMyTags() sets.String {
+	res := sets.New(p.revision)
+	for _, wh := range p.index.Lookup(p.revision) {
+		res.Insert(wh.GetLabels()[tag.IstioTagLabel])
 	}
-	return result
+	return res
 }
 
 // notifyHandlers notifies all registered handlers on tag change.
 func (p *tagWatcher) notifyHandlers() {
 	myTags := p.GetMyTags()
-	handlers := []TagHandler{}
-	p.mu.RLock()
-	handlers = append(handlers, p.handlers...)
-	p.mu.RUnlock()
-	for _, handler := range handlers {
+	for _, handler := range p.handlers {
 		handler(myTags)
 	}
-}
-
-func (p *tagWatcher) updateTags(key types.NamespacedName) error {
-	var revision, tagName string
-	wh := p.webhookInformer.Get(key.Name, "")
-	if wh != nil {
-		revision = wh.GetLabels()[label.IoIstioRev.Name]
-		tagName = wh.GetLabels()[tag.IstioTagLabel]
-	}
-	p.mu.Lock()
-	defer func() {
-		p.mu.Unlock()
-		p.notifyHandlers()
-	}()
-	p.tagsToRevisions[tagName] = revision
-	reverseMap := map[string][]string{}
-	for key, val := range p.tagsToRevisions {
-		reverseMap[val] = append(reverseMap[val], key)
-	}
-	p.revisionsToTags = reverseMap
-	return nil
 }
 
 func isTagWebhook(uobj any) bool {

--- a/pkg/revisions/tag_watcher_test.go
+++ b/pkg/revisions/tag_watcher_test.go
@@ -1,0 +1,80 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revisions
+
+import (
+	"strings"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/label"
+	"istio.io/istio/istioctl/pkg/tag"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/sets"
+)
+
+func TestTagWatcher(t *testing.T) {
+	c := kube.NewFakeClient()
+	tw := NewTagWatcher(c, "revision").(*tagWatcher)
+	whs := clienttest.Wrap(t, tw.webhooks)
+	stop := test.NewStop(t)
+	c.RunAndWait(stop)
+	track := assert.NewTracker[string](t)
+	tw.AddHandler(func(s sets.Set[string]) {
+		track.Record(strings.Join(sets.SortedList(s), ","))
+	})
+	go tw.Run(stop)
+	kube.WaitForCacheSync(stop, tw.HasSynced)
+	track.WaitOrdered("revision")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision"))
+
+	whs.Create(makeTag("revision", "tag-foo"))
+	track.WaitOrdered("revision,tag-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-foo"))
+
+	whs.Create(makeTag("revision", "tag-bar"))
+	track.WaitOrdered("revision,tag-bar,tag-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-foo", "tag-bar"))
+
+	whs.Update(makeTag("not-revision", "tag-bar"))
+	track.WaitOrdered("revision,tag-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-foo"))
+
+	whs.Delete(makeTag("revision", "tag-foo").Name, "")
+	track.WaitOrdered("revision")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision"))
+
+	whs.Create(makeTag("revision", "tag-foo"))
+	track.WaitOrdered("revision,tag-foo")
+	assert.Equal(t, tw.GetMyTags(), sets.New("revision", "tag-foo"))
+}
+
+func makeTag(revision string, tg string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tg,
+			Labels: map[string]string{
+				label.IoIstioRev.Name: revision,
+				tag.IstioTagLabel:     tg,
+			},
+		},
+	}
+}

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -60,13 +60,16 @@ func Equal[T any](t test.Failer, a, b T, context ...string) {
 func EventuallyEqual[T any](t test.Failer, fetchA func() T, b T, opts ...retry.Option) {
 	t.Helper()
 	var a T
+	// Unit tests typically need shorter default; opts can override though
+	ro := []retry.Option{retry.Timeout(time.Second * 2)}
+	ro = append(ro, opts...)
 	err := retry.UntilSuccess(func() error {
 		a = fetchA()
 		if !cmp.Equal(a, b, cmpOpts...) {
 			return fmt.Errorf("not equal")
 		}
 		return nil
-	}, opts...)
+	}, ro...)
 	if err != nil {
 		t.Fatalf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
 	}

--- a/pkg/test/util/assert/tracker.go
+++ b/pkg/test/util/assert/tracker.go
@@ -1,0 +1,60 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assert
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+type Tracker[T comparable] struct {
+	t      test.Failer
+	mu     sync.Mutex
+	events []T
+}
+
+// NewTracker builds a tracker which records events that occur
+func NewTracker[T comparable](t test.Failer) *Tracker[T] {
+	return &Tracker[T]{t: t}
+}
+
+// Record that an event occurred.
+func (t *Tracker[T]) Record(event T) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+// WaitOrdered waits for an event to happen, in order
+func (t *Tracker[T]) WaitOrdered(event T) {
+	t.t.Helper()
+	retry.UntilSuccessOrFail(t.t, func() error {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if len(t.events) == 0 {
+			return fmt.Errorf("no events")
+		}
+		if t.events[0] != event {
+			return fmt.Errorf("got events %v, want %v", t.events, event)
+		}
+		// clear the event
+		t.events = t.events[1:]
+		return nil
+	}, retry.Timeout(time.Second))
+}


### PR DESCRIPTION
This PR started out as just adding some unit tests, but scope creeped pretty hard.

I found during the impl that we don't handle deletes properly. I started adding the logic for this, but it turned out to be pretty annoyingly complex. What we really need was just an index of revision->webhooks.

Fortunately, we have code to do just that! But it needed some tweaks to allow associated handlers, as handlers are un-ordered in k8s. I added that.

In testing both of these, I also found a `tracker` abstraction we had used previously was useful, so I moved that out into common code.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
