### PR TITLE
Add `istio.io/meshID` annotation to injection templates

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         sidecar.istio.io/inject: "false"
       annotations:
         istio.io/rev: {{ .Values.revision | default "default" }}
+        istio.io/meshID: {{ .Values.global.meshID | default "default" }}
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         sidecar.istio.io/inject: "false"
       annotations:
         istio.io/rev: {{ .Values.revision | default "default" }}
+        istio.io/meshID: {{ .Values.global.meshID | default "default" }}
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -6,6 +6,7 @@ metadata:
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
   annotations: {
     istio.io/rev: {{ .Revision | default "default" | quote }},
+    istio.io/meshID: {{ .MeshID | default "default" | quote }},
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2207,6 +2207,7 @@ spec:
         operator.istio.io/component: "Pilot"
         istio: pilot
       annotations:
+        istio.io/meshID: "default"
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         ambient.istio.io/redirection: disabled

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1362,6 +1362,7 @@ data:
                 {{- toJsonMap
                   (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
                   (strdict "istio.io/rev" (.Revision | default "default"))
+                  (strdict "istio.io/meshID" (.MeshID | default "default"))
                   (strdict
                     "ambient.istio.io/redirection" "disabled"
                     "prometheus.io/path" "/stats/prometheus"
@@ -1601,6 +1602,7 @@ data:
                 {{- toJsonMap
                   (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
                   (strdict "istio.io/rev" (.Revision | default "default"))
+                  (strdict "istio.io/meshID" (.MeshID | default "default"))
                   (strdict
                     "prometheus.io/path" "/stats/prometheus"
                     "prometheus.io/port" "15020"

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2275,6 +2275,8 @@ spec:
             valueFrom:
               resourceFieldRef:
                 resource: limits.memory
+          - name: MESH_ID
+            value: "default"
           resources:
             requests:
               cpu: 500m

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -226,6 +226,7 @@ data:
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
           annotations: {
             istio.io/rev: {{ .Revision | default "default" | quote }},
+            istio.io/meshID: {{ .MeshID | default "default" | quote }},
             {{- if ge (len $containers) 1 }}
             {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -713,6 +714,7 @@ data:
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
           annotations: {
             istio.io/rev: {{ .Revision | default "default" | quote }},
+            istio.io/meshID: {{ .MeshID | default "default" | quote }},
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -1043,6 +1045,7 @@ data:
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
           annotations: {
             istio.io/rev: {{ .Revision | default "default" }},
+            istio.io/meshID: {{ .MeshID | default "default" }},
             {{- if ge (len $containers) 1 }}
             {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -2279,7 +2279,7 @@ spec:
               resourceFieldRef:
                 resource: limits.memory
           - name: MESH_ID
-            value: "default"
+            value: ""
           resources:
             requests:
               cpu: 500m

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -33,6 +33,7 @@ metadata:
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
   annotations: {
     istio.io/rev: {{ .Revision | default "default" }},
+    istio.io/meshID: {{ .MeshID | default "default" }},
     {{- if ge (len $containers) 1 }}
     {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -36,6 +36,7 @@ metadata:
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
   annotations: {
     istio.io/rev: {{ .Revision | default "default" | quote }},
+    istio.io/meshID: {{ .MeshID | default "default" | quote }},
     {{- if ge (len $containers) 1 }}
     {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toJsonMap
           (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict "istio.io/rev" (.Revision | default "default"))
+          (strdict "istio.io/meshID" (.MeshID | default "default"))
           (strdict
             "prometheus.io/path" "/stats/prometheus"
             "prometheus.io/port" "15020"

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toJsonMap
           (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict "istio.io/rev" (.Revision | default "default"))
+          (strdict "istio.io/meshID" (.MeshID | default "default"))
           (strdict
             "ambient.istio.io/redirection" "disabled"
             "prometheus.io/path" "/stats/prometheus"

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -172,6 +172,8 @@ spec:
             valueFrom:
               resourceFieldRef:
                 resource: limits.memory
+          - name: MESH_ID
+            value: "{{ .Values.global.meshID | default `default` }}"
           resources:
 {{- if .Values.pilot.resources }}
 {{ toYaml .Values.pilot.resources | trim | indent 12 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
               resourceFieldRef:
                 resource: limits.memory
           - name: MESH_ID
-            value: "{{ .Values.global.meshID | default `default` }}"
+            value: "{{ .Values.global.meshID }}"
           resources:
 {{- if .Values.pilot.resources }}
 {{ toYaml .Values.pilot.resources | trim | indent 12 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
         {{ $key }}: "{{ $val }}"
         {{- end }}
       annotations:
+        istio.io/meshID: "{{ .Values.global.meshID | default `default` }}"
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -6,6 +6,7 @@ metadata:
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
   annotations: {
     istio.io/rev: {{ .Revision | default "default" | quote }},
+    istio.io/meshID: {{ .MeshID | default "default" | quote }},
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -36,6 +36,7 @@ metadata:
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
   annotations: {
     istio.io/rev: {{ .Revision | default "default" | quote }},
+    istio.io/meshID: {{ .MeshID | default "default" | quote }},
     {{- if ge (len $containers) 1 }}
     {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -177,7 +177,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 						if configController.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
 							tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
 							controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID,
-								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
+								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision, args.MeshID)
 							// Start informers again. This fixes the case where informers for namespace do not start,
 							// as we create them only after acquiring the leader lock
 							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -63,6 +63,7 @@ type PilotArgs struct {
 	KeepaliveOptions   *keepalive.Options
 	ShutdownDuration   time.Duration
 	JwtRule            string
+	MeshID             string
 }
 
 // DiscoveryServerOptions contains options for create a new discovery server instance.
@@ -115,6 +116,7 @@ var (
 	PodName      = env.Register("POD_NAME", "", "").Get()
 	JwtRule      = env.Register("JWT_RULE", "",
 		"The JWT rule used by istiod authentication").Get()
+	MeshID = env.Register("MESH_ID", "", "").Get()
 )
 
 // Revision is the value of the Istio control plane revision, e.g. "canary",
@@ -142,6 +144,7 @@ func (p *PilotArgs) applyDefaults() {
 	p.PodName = PodName
 	p.Revision = Revision
 	p.JwtRule = JwtRule
+	p.MeshID = MeshID
 	p.KeepaliveOptions = keepalive.DefaultOption()
 	p.RegistryOptions.DistributionTrackingEnabled = features.EnableDistributionTracking
 	p.RegistryOptions.DistributionCacheRetention = features.DistributionHistoryRetention

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -80,6 +80,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		Env:      s.environment,
 		Mux:      s.httpsMux,
 		Revision: args.Revision,
+		MeshID:   args.MeshID,
 	}
 
 	wh, err := inject.NewWebhook(parameters)

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -192,7 +192,7 @@ func TestVersionManagement(t *testing.T) {
 	writes := make(chan string, 10)
 	c := kube.NewFakeClient()
 	tw := revisions.NewTagWatcher(c, "default")
-	d := NewDeploymentController(c, "", testInjectionConfig(t), func(fn func()) {}, tw, "")
+	d := NewDeploymentController(c, "", testInjectionConfig(t), func(fn func()) {}, tw, "", "")
 	reconciles := atomic.NewInt32(0)
 	wantReconcile := int32(0)
 	expectReconciled := func() {

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -33,6 +33,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         networking.istio.io/service-type: ClusterIP
         prometheus.io/path: /stats/prometheus

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -32,6 +32,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -32,6 +32,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -33,6 +33,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -32,6 +32,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -33,6 +33,7 @@ spec:
     metadata:
       annotations:
         ambient.istio.io/redirection: disabled
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -103,6 +103,7 @@ type SidecarTemplateData struct {
 	Values         map[string]any
 	Revision       string
 	ProxyImage     string
+	MeshID         string
 }
 
 type (
@@ -403,6 +404,7 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		Values:         params.valuesConfig.asMap,
 		Revision:       params.revision,
 		ProxyImage:     ProxyImage(params.valuesConfig.asStruct, params.proxyConfig.Image, strippedPod.Annotations),
+		MeshID:         params.meshID,
 	}
 
 	mergedPod = params.pod

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -7,6 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -27,6 +27,7 @@ items:
     template:
       metadata:
         annotations:
+          istio.io/meshID: default
           istio.io/rev: default
           kubectl.kubernetes.io/default-container: hello
           kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: nginx
         kubectl.kubernetes.io/default-logs-container: nginx

--- a/pkg/kube/inject/testdata/inject/gateway.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway.yaml.injected
@@ -12,6 +12,7 @@ spec:
     metadata:
       annotations:
         inject.istio.io/templates: gateway
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -12,6 +12,7 @@ spec:
     metadata:
       annotations:
         inject.istio.io/templates: grpc-agent
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         k8s.v1.cni.cncf.io/networks: istio-cni
         kubectl.kubernetes.io/default-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         k8s.v1.cni.cncf.io/networks: '[{"name": "alt_cni"}, {"name": "istio-cni"}]'
         kubectl.kubernetes.io/default-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         k8s.v1.cni.cncf.io/networks: alt_cni, istio-cni
         kubectl.kubernetes.io/default-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello
@@ -242,6 +243,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -7,6 +7,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: pi
         kubectl.kubernetes.io/default-logs-container: pi

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -29,6 +29,7 @@ items:
     template:
       metadata:
         annotations:
+          istio.io/meshID: default
           istio.io/rev: default
           kubectl.kubernetes.io/default-container: nginx
           kubectl.kubernetes.io/default-logs-container: nginx

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -17,6 +17,7 @@ items:
     template:
       metadata:
         annotations:
+          istio.io/meshID: default
           istio.io/rev: default
           kubectl.kubernetes.io/default-container: hello
           kubectl.kubernetes.io/default-logs-container: hello
@@ -243,6 +244,7 @@ items:
     template:
       metadata:
         annotations:
+          istio.io/meshID: default
           istio.io/rev: default
           kubectl.kubernetes.io/default-container: hello
           kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: name1
         kubectl.kubernetes.io/default-logs-container: name1

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -12,6 +12,7 @@ spec:
     metadata:
       annotations:
         inject.istio.io/templates: sidecar,sidecar,sidecar
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    istio.io/meshID: default
     istio.io/rev: default
     kubectl.kubernetes.io/default-container: hello
     kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    istio.io/meshID: default
     istio.io/rev: default
     kubectl.kubernetes.io/default-container: hello
     kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
+    istio.io/meshID: default
     istio.io/rev: default
     kubectl.kubernetes.io/default-container: hello
     kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -10,6 +10,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: nginx
         kubectl.kubernetes.io/default-logs-container: nginx

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: resource
         kubectl.kubernetes.io/default-logs-container: resource

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: status
         kubectl.kubernetes.io/default-logs-container: status

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: status
         kubectl.kubernetes.io/default-logs-container: status

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: status
         kubectl.kubernetes.io/default-logs-container: status

--- a/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes-disabled.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: traffic
         kubectl.kubernetes.io/default-logs-container: traffic

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: hello
         kubectl.kubernetes.io/default-logs-container: hello

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshID: default
         istio.io/rev: default
         kubectl.kubernetes.io/default-container: user-volume
         kubectl.kubernetes.io/default-logs-container: user-volume

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.38.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -47,6 +47,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -534,6 +535,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" | quote }},
+        istio.io/meshID: {{ .MeshID | default "default" | quote }},
         {{- if eq (len $containers) 1 }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
@@ -864,6 +866,7 @@ templates:
         service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
       annotations: {
         istio.io/rev: {{ .Revision | default "default" }},
+        istio.io/meshID: {{ .MeshID | default "default" }},
         {{- if ge (len $containers) 1 }}
         {{- if not (isset .ObjectMeta.Annotations `kubectl.kubernetes.io/default-logs-container`) }}
         kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1183,6 +1183,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
@@ -1422,6 +1423,7 @@ templates:
             {{- toJsonMap
               (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
+              (strdict "istio.io/meshID" (.MeshID | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -108,6 +108,7 @@ type Webhook struct {
 
 	env      *model.Environment
 	revision string
+	meshID   string
 }
 
 func (wh *Webhook) GetConfig() WebhookConfig {
@@ -176,6 +177,9 @@ type WebhookParameters struct {
 
 	// The istio.io/rev this injector is responsible for
 	Revision string
+
+	// MeshID is used to inject istio.io/meshID
+	MeshID string
 }
 
 // NewWebhook creates a new instance of a mutating webhook for automatic sidecar injection.
@@ -189,6 +193,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		meshConfig: p.Env.Mesh(),
 		env:        p.Env,
 		revision:   p.Revision,
+		meshID:     p.MeshID,
 	}
 
 	mc := NewMulticast(p.Watcher, wh.GetConfig)
@@ -343,6 +348,7 @@ type InjectionParameters struct {
 	revision            string
 	proxyEnvs           map[string]string
 	injectedAnnotations map[string]string
+	meshID              string
 }
 
 func checkPreconditions(params InjectionParameters) {
@@ -1008,6 +1014,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		revision:            wh.revision,
 		injectedAnnotations: wh.Config.InjectedAnnotations,
 		proxyEnvs:           parseInjectEnvs(path),
+		meshID:              wh.meshID,
 	}
 	wh.mu.RUnlock()
 

--- a/releasenotes/notes/44242.yaml
+++ b/releasenotes/notes/44242.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** injection of `istio.io/meshID` annotation to sidecars and gateways.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds injection of `istio.io/meshID` to all istio-proxies: sidecars, default gateways, injected gateways, k8s api gateways, grpc-agent and waypoint.

This annotation will distinct metrics collected in multi-tenant meshes or in multi-cluster meshes with global Prometheus.