### PR TITLE
Speed up autoregistration lifecycle test

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -283,14 +283,15 @@ func (c *Controller) QueueUnregisterWorkload(proxy *model.Proxy, origConnect tim
 	}
 
 	c.mutex.Lock()
-	num := c.adsConnections[makeProxyKey(proxy)]
+	proxyKey := makeProxyKey(proxy)
+	num := c.adsConnections[proxyKey]
 	// if there is still ads connection, do not unregister.
 	if num > 1 {
-		c.adsConnections[makeProxyKey(proxy)] = num - 1
+		c.adsConnections[proxyKey] = num - 1
 		c.mutex.Unlock()
 		return
 	}
-	delete(c.adsConnections, makeProxyKey(proxy))
+	delete(c.adsConnections, proxyKey)
 	c.mutex.Unlock()
 
 	workload := &workItem{

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -45,7 +45,7 @@ import (
 func init() {
 	features.WorkloadEntryAutoRegistration = true
 	features.WorkloadEntryHealthChecks = true
-	features.WorkloadEntryCleanupGracePeriod = 200 * time.Millisecond
+	features.WorkloadEntryCleanupGracePeriod = 20 * time.Millisecond
 }
 
 var (

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -45,7 +45,7 @@ import (
 func init() {
 	features.WorkloadEntryAutoRegistration = true
 	features.WorkloadEntryHealthChecks = true
-	features.WorkloadEntryCleanupGracePeriod = 20 * time.Millisecond
+	features.WorkloadEntryCleanupGracePeriod = 25 * time.Millisecond
 }
 
 var (


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR speeds up `TestAutoregistrationLifecycle` (contributes to #37555 ), reducing `WorkloadEntryCleanupGracePeriod` from 200 milliseconds to 25 milliseconds.

stress tests also were executed and reliable 100% success was observed