### PR TITLE
Bump ztunnel to hyper 1.0.0

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "b32cc7a9174811d6b6d8db79ec7209a2a0596308"
+    "lastStableSHA": "719985743665be2b1b5539d6ab155427f870803e"
   }
 ]


### PR DESCRIPTION
This is a big change, so important to get in testing/ for 1.18