### PR TITLE
kube-probe: avoid duplicate probe headers

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -45,6 +45,7 @@ import (
 	grpcHealth "google.golang.org/grpc/health/grpc_health_v1"
 	grpcStatus "google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/strings/slices"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/grpcready"
@@ -706,25 +707,11 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Forward incoming headers to the application.
+	appReq.Host = req.Host
 	for name, values := range req.Header {
-		newValues := make([]string, len(values))
-		copy(newValues, values)
-		appReq.Header[name] = newValues
-	}
-
-	// If there are custom HTTPHeaders, it will override the forwarding header
-	if headers := prober.HTTPGet.HTTPHeaders; len(headers) != 0 {
-		for _, h := range headers {
-			delete(appReq.Header, h.Name)
-		}
-		for _, h := range headers {
-			if h.Name == "Host" || h.Name == ":authority" {
-				// Probe has specific host header override; honor it
-				appReq.Host = h.Value
-				appReq.Header.Set(h.Name, h.Value)
-			} else {
-				appReq.Header.Add(h.Name, h.Value)
-			}
+		appReq.Header[name] = slices.Clone(values)
+		if len(values) > 0 && (strings.EqualFold(name, "Host") || name == ":authority") {
+			appReq.Host = values[0]
 		}
 	}
 


### PR DESCRIPTION
This is a regression of https://github.com/istio/istio/issues/28466 from https://github.com/istio/istio/pull/31866

The 31866 fixed the k8s spec having duplicates, but we end up duplicating all headers twice - the kubelet adds the header from HTTPHeaders and we also add from HTTPHeaders, resulting in 2x every header.

Instead, we simply copy the incoming request headers and host, making us a fairly transparent proxy.

cc @Monkeyanator @wzshiming 