### PR TITLE
reduced tokenWaitBackoff from 1 second to 10 millis

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -112,12 +112,17 @@ func TestCreateRemoteSecrets(t *testing.T) {
 	prevOutputWriterStub := makeOutputWriterTestHook
 	defer func() { makeOutputWriterTestHook = prevOutputWriterStub }()
 
+	prevTokenWaitBackoff := tokenWaitBackoff
+	defer func() { tokenWaitBackoff = prevTokenWaitBackoff }()
+
 	sa := makeServiceAccount("saSecret")
 	sa2 := makeServiceAccount("saSecret", "saSecret2")
 	saSecret := makeSecret("saSecret", "caData", "token")
 	saSecret2 := makeSecret("saSecret2", "caData", "token")
 	saSecretMissingToken := makeSecret("saSecret", "caData", "")
 	badStartingConfigErrStr := "could not find cluster for context"
+
+	tokenWaitBackoff = 10 * time.Millisecond
 
 	cases := []struct {
 		testName string


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR reduces `TestCreateRemoteSecrets` execution from 5sec to 0.07sec by changing `tokenWaitBackoff` from 1s to 10millis for the duration of the test.

Contributes to #37555 