### PR TITLE
CNI: Install a global NetworkAttachmentDefinition

### DIFF
--- a/manifests/charts/base/crds/network-attachment-definition.yaml
+++ b/manifests/charts/base/crds/network-attachment-definition.yaml
@@ -1,0 +1,45 @@
+# Extracted from https://github.com/k8snetworkplumbingwg/multus-cni/blob/1b01e3e48670c2440c22b827a68c983af47bf4a9/deployments/multus-daemonset.yml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+            Working Group to express the intent for attaching pods to one or more logical or physical
+            networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this represen
+                tation of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+              type: object
+              properties:
+                config:
+                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                  type: string

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -7252,6 +7252,54 @@ spec:
 ---
 
 ---
+# Source: crds/network-attachment-definition.yaml
+# Extracted from https://github.com/k8snetworkplumbingwg/multus-cni/blob/1b01e3e48670c2440c22b827a68c983af47bf4a9/deployments/multus-daemonset.yml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+            Working Group to express the intent for attaching pods to one or more logical or physical
+            networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this represen
+                tation of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+              type: object
+              properties:
+                config:
+                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                  type: string
+
+---
 # Source: base/templates/reader-serviceaccount.yaml
 # This service account aggregates reader permissions for the revisions in a given cluster
 # Should be used for remote secret creation.

--- a/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
+++ b/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
@@ -1,0 +1,5 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+  namespace: default

--- a/manifests/profiles/openshift.yaml
+++ b/manifests/profiles/openshift.yaml
@@ -18,4 +18,4 @@ spec:
       privileged: true
     sidecarInjectorWebhook:
       injectedAnnotations:
-        k8s.v1.cni.cncf.io/networks: istio-cni
+        k8s.v1.cni.cncf.io/networks: default/istio-cni

--- a/releasenotes/notes/global-nad.yaml
+++ b/releasenotes/notes/global-nad.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+docs:
+-  'https://istio.io/latest/docs/setup/platform-setup/openshift/'
+releaseNotes:
+- |
+    **Improved** Usage on OpenShift clusters is simplified by removing the need of manually creating a `NetworkAttachmentDefinition` resource on every application namespace.


### PR DESCRIPTION
This simplifies installation and operation on OpenShift clusters. By having a global NetworkAttachmentDefinition installed on the `default` namespace users don't need to install them in each application namespace.

The pod injection - in the openshift profile - needs to point to the global resource in the `default` namespace for this to work.

With this change we can remove the [last section in the OpenShift Setup page](https://istio.io/v1.16/docs/setup/platform-setup/openshift/#additional-requirements-for-the-application-namespace).
