### PR TITLE
kube: use protobuf in client

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -753,6 +753,10 @@ var (
 	InformerWatchNamespace = env.Register("ISTIO_WATCH_NAMESPACE", "",
 		"If set, limit Kubernetes watches to a single namespace. "+
 			"Warning: only a single namespace can be set.").Get()
+
+	// This is a feature flag, can be removed if protobuf proves universally better.
+	KubernetesClientContentType = env.Register("ISTIO_KUBE_CLIENT_CONTENT_TYPE", "protobuf",
+		"The content type to use for Kubernetes clients. Defaults to protobuf. Valid options: [protobuf, json]").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -404,9 +404,6 @@ func newClientInternal(clientFactory *clientFactory, revision string) (*client, 
 		return nil, err
 	}
 
-	config := rest.CopyConfig(c.config)
-	config.ContentType = runtime.ContentTypeProtobuf
-
 	c.kube, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return nil, err

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config"
 	istioversion "istio.io/pkg/version"
 )
@@ -147,7 +148,12 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 		}
 	}
 	if len(config.ContentType) == 0 {
-		config.ContentType = runtime.ContentTypeJSON
+		if features.KubernetesClientContentType == "json" {
+			config.ContentType = runtime.ContentTypeJSON
+		} else {
+			config.ContentType = runtime.ContentTypeProtobuf
+			config.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
+		}
 	}
 	if config.NegotiatedSerializer == nil {
 		// This codec factory ensures the resources are not converted. Therefore, resources

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -151,8 +151,12 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 		if features.KubernetesClientContentType == "json" {
 			config.ContentType = runtime.ContentTypeJSON
 		} else {
-			config.ContentType = runtime.ContentTypeProtobuf
+			// Prefer to accept protobuf, but send JSON. This is due to some types (CRDs)
+			// not accepting protobuf.
+			// If we end up writing many core types in the future we may want to set ContentType to
+			// ContentTypeProtobuf only for the core client.
 			config.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
+			config.ContentType = runtime.ContentTypeJSON
 		}
 	}
 	if config.NegotiatedSerializer == nil {


### PR DESCRIPTION
This was attempted in #38658 but the `config` set is never used there.

Also add an opt-out and AcceptContentTypes to allow json fallback as recommended by k8s

In a 40k pod cluster this reduced Istiod memory by 50%