### PR TITLE
Improve resilience for bootstrap

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -363,6 +364,9 @@ func (m *Multicluster) checkShouldLead(client kubelib.Client, systemNamespace st
 		_ = b.RetryWithContext(ctx, func() error {
 			namespace, err := client.Kube().CoreV1().Namespaces().Get(context.TODO(), systemNamespace, metav1.GetOptions{})
 			if err != nil {
+				if errors.IsNotFound(err) {
+					return nil
+				}
 				return err
 			}
 			// found same system namespace on the remote cluster so check if we are a selected istiod to lead

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -279,49 +278,53 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 	// run after WorkloadHandler is added
 	m.opts.MeshServiceController.AddRegistryAndRun(kubeRegistry, clusterStopCh)
 
-	shouldLead := m.checkShouldLead(client, options.SystemNamespace)
-	log.Infof("should join leader-election for cluster %s: %t", cluster.ID, shouldLead)
-
-	if m.startNsController && (shouldLead || configCluster) {
-		// Block server exit on graceful termination of the leader controller.
-		m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
-			log.Infof("joining leader-election for %s in %s on cluster %s",
-				leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
-			election := leaderelection.
-				NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
-				AddRunFunction(func(leaderStop <-chan struct{}) {
-					log.Infof("starting namespace controller for cluster %s", cluster.ID)
-					nc := NewNamespaceController(client, m.caBundleWatcher, discoveryNamespacesFilter)
-					// Start informers again. This fixes the case where informers for namespace do not start,
-					// as we create them only after acquiring the leader lock
-					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-					// basically lazy loading the informer, if we stop it when we lose the lock we will never
-					// recreate it again.
-					client.RunAndWait(clusterStopCh)
-					nc.Run(leaderStop)
-				})
-			election.Run(clusterStopCh)
-			return nil
-		})
-	}
-	// Set up injection webhook patching for remote clusters we are controlling.
-	// The config cluster has this patching set up elsewhere. We may eventually want to move it here.
-	// We can not use leader election for webhook patching because each revision needs to patch its own
-	// webhook.
-	if shouldLead && !configCluster && m.caBundleWatcher != nil {
-		// Patch injection webhook cert
-		// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
-		// operator or CI/CD
-		if features.InjectionWebhookConfigName != "" {
-			log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
-			if err != nil {
-				log.Errorf("could not initialize webhook cert patcher: %v", err)
-			} else {
-				go patcher.Run(clusterStopCh)
+	go func() {
+		var shouldLead bool
+		if !configCluster {
+			shouldLead = m.checkShouldLead(client, options.SystemNamespace, clusterStopCh)
+			log.Infof("should join leader-election for cluster %s: %t", cluster.ID, shouldLead)
+		}
+		if m.startNsController && (shouldLead || configCluster) {
+			// Block server exit on graceful termination of the leader controller.
+			m.s.RunComponentAsyncAndWait("namespace controller", func(_ <-chan struct{}) error {
+				log.Infof("joining leader-election for %s in %s on cluster %s",
+					leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
+				election := leaderelection.
+					NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						log.Infof("starting namespace controller for cluster %s", cluster.ID)
+						nc := NewNamespaceController(client, m.caBundleWatcher, discoveryNamespacesFilter)
+						// Start informers again. This fixes the case where informers for namespace do not start,
+						// as we create them only after acquiring the leader lock
+						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+						// basically lazy loading the informer, if we stop it when we lose the lock we will never
+						// recreate it again.
+						client.RunAndWait(clusterStopCh)
+						nc.Run(leaderStop)
+					})
+				election.Run(clusterStopCh)
+				return nil
+			})
+		}
+		// Set up injection webhook patching for remote clusters we are controlling.
+		// The config cluster has this patching set up elsewhere. We may eventually want to move it here.
+		// We can not use leader election for webhook patching because each revision needs to patch its own
+		// webhook.
+		if shouldLead && !configCluster && m.caBundleWatcher != nil {
+			// Patch injection webhook cert
+			// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
+			// operator or CI/CD
+			if features.InjectionWebhookConfigName != "" {
+				log.Infof("initializing injection webhook cert patcher for cluster %s", cluster.ID)
+				patcher, err := webhooks.NewWebhookCertPatcher(client, m.revision, webhookName, m.caBundleWatcher)
+				if err != nil {
+					log.Errorf("could not initialize webhook cert patcher: %v", err)
+				} else {
+					go patcher.Run(clusterStopCh)
+				}
 			}
 		}
-	}
+	}()
 
 	// setting up the serviceexport controller if and only if it is turned on in the meshconfig.
 	if features.EnableMCSAutoExport {
@@ -354,12 +357,18 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 }
 
 // checkShouldLead returns true if the caller should attempt leader election for a remote cluster.
-func (m *Multicluster) checkShouldLead(client kubelib.Client, systemNamespace string) bool {
+func (m *Multicluster) checkShouldLead(client kubelib.Client, systemNamespace string, stop <-chan struct{}) bool {
 	var res bool
 	if features.ExternalIstiod {
 		b := backoff.NewExponentialBackOff(backoff.DefaultOption())
-		// context for both timeout and channel, whichever stops first, the context will be done
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			select {
+			case <-stop:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
 		defer cancel()
 		_ = b.RetryWithContext(ctx, func() error {
 			namespace, err := client.Kube().CoreV1().Namespaces().Get(context.TODO(), systemNamespace, metav1.GetOptions{})


### PR DESCRIPTION
**Please provide a description of this PR:**


Currently when we get namespace failed, we may enter a bad state, that istiod wrongly lead remote clusters