### PR TITLE
Remove release note approval by release-managers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,7 +43,8 @@ Makefile*                                                        @istio/wg-test-
 /pkg/webhooks/                                                   @istio/wg-environments-maintainers
 /prow/                                                           @istio/wg-test-and-release-maintainers
 /release/                                                        @istio/wg-test-and-release-maintainers
-/releasenotes/                                                   @istio/wg-test-and-release-maintainers @istio/release-managers
+/releasenotes/                                                   @istio/wg-test-and-release-maintainers
+/releasenotes/notes
 /samples/                                                        @istio/wg-docs-maintainers-english
 /samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-environments-maintainers
 /samples/multicluster                                            @istio/wg-networking-maintainers


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/44378

Remove the requirement for release managers to approval relate notes within a PR. The release notes will be edited at release time.