### PR TITLE
Use k8s 1.27.0 as the default node image for integration testing

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -37,7 +37,7 @@ setup_and_export_git_sha
 source "${ROOT}/common/scripts/kind_provisioner.sh"
 
 TOPOLOGY=SINGLE_CLUSTER
-NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.26.1"
+NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.27.0"
 KIND_CONFIG=""
 CLUSTER_TOPOLOGY_CONFIG_FILE="${ROOT}/prow/config/topology/multicluster.json"
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Test on k8s 1.27.0 as the default node image