### PR TITLE
Set the WorkloadSelector of ServiceEntry only if the label is not empty

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -75,11 +75,13 @@ func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Confi
 		//  - ClientSideLB - regular ClusterIP clusters (VIP, resolved via EDS)
 		//  - DNSLB - if ExternalName is specified. Also meshExternal is set.
 
-		WorkloadSelector: &networking.WorkloadSelector{Labels: svc.Attributes.LabelSelectors},
-
 		// This is based on alpha.istio.io/canonical-serviceaccounts and
 		//  alpha.istio.io/kubernetes-serviceaccounts.
 		SubjectAltNames: svc.ServiceAccounts,
+	}
+
+	if len(svc.Attributes.LabelSelectors) > 0 {
+		se.WorkloadSelector = &networking.WorkloadSelector{Labels: svc.Attributes.LabelSelectors}
 	}
 
 	// Based on networking.istio.io/exportTo annotation


### PR DESCRIPTION
**Please provide a description of this PR:**

When the label is empty, we should set the workloadselector of SE to nil.
Related to https://github.com/istio/istio/pull/44159#issuecomment-1489589957
cc @howardjohn 