### PR TITLE
Support customization of Envoy Node ID

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -661,6 +661,10 @@ type NodeMetadata struct {
 	// The istiod address when running ASM Managed Control Plane.
 	CloudrunAddr string `json:"CLOUDRUN_ADDR,omitempty"`
 
+	// Node ID template for Envoy. It is encoded with Base64URL to avoid additional escaping.
+	// The template can reference all the parameters which is defined in pkg/bootstrap/config.go.
+	EnvoyNodeIDTemplate string `json:"ENVOY_NODE_ID_TEMPLATE,omitempty"`
+
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
 	Raw map[string]any `json:"-"`

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -174,7 +174,20 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 	// TODO: allow reading a file with additional metadata (for example if created with
 	// 'envref'. This will allow Istio to generate the right config even if the pod info
 	// is not available (in particular in some multi-cluster cases)
-	return option.NewTemplateParams(opts...)
+	param, err := option.NewTemplateParams(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// To use all the parameters in the Node ID template, evaluate it at last.
+	if len(cfg.Metadata.EnvoyNodeIDTemplate) > 0 {
+		opt := option.EnvoyNodeIDTemplate(cfg.Metadata.EnvoyNodeIDTemplate, param)
+		if err := option.AddTemplateParam(param, opt); err != nil {
+			return nil, err
+		}
+	}
+
+	return param, nil
 }
 
 // substituteValues substitutes variables known to the bootstrap like pod_ip.

--- a/pkg/bootstrap/option/instance.go
+++ b/pkg/bootstrap/option/instance.go
@@ -35,6 +35,11 @@ func NewTemplateParams(is ...Instance) (map[string]any, error) {
 	return params, nil
 }
 
+// AddTemplateParam adds the given option to the existing golang template parameter map.
+func AddTemplateParam(params map[string]any, i Instance) error {
+	return i.apply(params)
+}
+
 // Name unique name for an option.
 type Name string
 

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -1,6 +1,10 @@
 {
   "node": {
+    {{- if .envoy_node_id_template }}
+    "id": "{{ .envoy_node_id_template }}",
+    {{- else }}
     "id": "{{ .nodeID }}",
+    {{- end }}
     "cluster": "{{ .cluster }}",
     "locality": {
       {{- if .region }}


### PR DESCRIPTION
Envoy Node ID is used for identifying a workload in the control plane.
When the control plane (like Istiod) is covering just a cluster in the cluster, it is sufficient to use the current Node ID format, which uniquely identifies a workload in a cluster.

However, when running the control plane shared by multi-clusters or multi-tenants, it is not proper format.
In addition, if it is possible to customize the Envoy Node ID, it is very help to implement a platform-specific features by appending more platform-specific information in the Envoy Node Id.

Therefore, this PR proposes to introduce customization of Envoy Node ID.
 
Change-Id: I752974904eae23dc2610d61e9f42ab7bef73e3fd
