### PR TITLE
add validation for empty prefix header match

### DIFF
--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2857,6 +2857,16 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: false},
+		{name: "empty prefix header match", route: &networking.HTTPRoute{
+			Route: []*networking.HTTPRouteDestination{{
+				Destination: &networking.Destination{Host: "foo.bar"},
+			}},
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"emptyprefix": {MatchType: &networking.StringMatch_Prefix{Prefix: ""}},
+				},
+			}},
+		}, valid: false},
 		{name: "nil match", route: &networking.HTTPRoute{
 			Route: []*networking.HTTPRouteDestination{{
 				Destination: &networking.Destination{Host: "foo.bar"},

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -142,12 +142,9 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 					}
 
-					switch header.GetMatchType().(type) {
-					case *networking.StringMatch_Prefix:
-						{
-							if header.GetPrefix() == "" {
-								errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
-							}
+					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
+						if header.GetPrefix() == "" {
+							errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
 						}
 					}
 
@@ -172,12 +169,9 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 					}
 
-					switch header.GetMatchType().(type) {
-					case *networking.StringMatch_Prefix:
-						{
-							if header.GetPrefix() == "" {
-								errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
-							}
+					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
+						if header.GetPrefix() == "" {
+							errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
 						}
 					}
 

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -141,6 +141,16 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 					if header == nil {
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 					}
+
+					switch header.GetMatchType().(type) {
+					case *networking.StringMatch_Prefix:
+						{
+							if header.GetPrefix() == "" {
+								errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
+							}
+						}
+					}
+
 					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 					errs = appendErrors(errs, validateStringMatchRegexp(header, "headers"))
 				}
@@ -161,6 +171,16 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 					if header == nil {
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 					}
+
+					switch header.GetMatchType().(type) {
+					case *networking.StringMatch_Prefix:
+						{
+							if header.GetPrefix() == "" {
+								errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
+							}
+						}
+					}
+
 					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 				}
 				for name, param := range match.QueryParams {

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -144,7 +144,7 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 
 					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
 						if header.GetPrefix() == "" {
-							errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
+							errs = appendErrors(errs, fmt.Errorf("header match %v may not be empty", name))
 						}
 					}
 
@@ -171,7 +171,7 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 
 					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
 						if header.GetPrefix() == "" {
-							errs = appendErrors(errs, fmt.Errorf("header prefix match %v must have a value", name))
+							errs = appendErrors(errs, fmt.Errorf("header match %v may not be empty", name))
 						}
 					}
 

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -144,7 +144,7 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 
 					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
 						if header.GetPrefix() == "" {
-							errs = appendErrors(errs, fmt.Errorf("header match %v may not be empty", name))
+							errs = appendErrors(errs, fmt.Errorf("header prefix match %v may not be empty", name))
 						}
 					}
 
@@ -171,7 +171,7 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 
 					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
 						if header.GetPrefix() == "" {
-							errs = appendErrors(errs, fmt.Errorf("header match %v may not be empty", name))
+							errs = appendErrors(errs, fmt.Errorf("header prefix match %v may not be empty", name))
 						}
 					}
 

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -221,6 +221,21 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 			}, valid: true,
 		},
 		{
+			name: "empty prefix header match (delegate)", route: &networking.HTTPRoute{
+				Delegate: &networking.Delegate{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Match: []*networking.HTTPMatchRequest{{
+					Headers: map[string]*networking.StringMatch{
+						"header": {
+							MatchType: &networking.StringMatch_Prefix{Prefix: ""},
+						},
+					},
+				}},
+			}, valid: false,
+		},
+		{
 			name: "exact header match", route: &networking.HTTPRoute{
 				Delegate: &networking.Delegate{
 					Name:      "test",
@@ -369,6 +384,15 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 				Uri:       "/",
 				Authority: "foo.biz",
 			},
+		}, valid: false},
+		{name: "empty prefix header match", route: &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{
+				Headers: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Prefix{Prefix: ""},
+					},
+				},
+			}},
 		}, valid: false},
 	}
 

--- a/releasenotes/notes/44424.yaml
+++ b/releasenotes/notes/44424.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 44424
+
+releaseNotes:
+- |
+  **Updated** the VirtualService validation to fail on empty prefix header matcher.


### PR DESCRIPTION
Adds validation for empty prefix header match. This fails silently when VS is applied, and the istioctl validate doesn't catch the issue either. 

Fixes: https://github.com/istio/istio/issues/44424 