### PR TITLE
set workingDNSServer ttl to 0 and incremented MinGatewayTTL

### DIFF
--- a/pilot/pkg/model/network_test.go
+++ b/pilot/pkg/model/network_test.go
@@ -36,10 +36,10 @@ import (
 )
 
 func TestGatewayHostnames(t *testing.T) {
-	test.SetForTest(t, &model.MinGatewayTTL, 30*time.Millisecond)
+	test.SetForTest(t, &model.MinGatewayTTL, 110*time.Millisecond)
 
 	gwHost := "test.gw.istio.io"
-	workingDNSServer := newFakeDNSServer(":15353", 1, sets.New(gwHost))
+	workingDNSServer := newFakeDNSServer(":15353", 0, sets.New(gwHost))
 	failingDNSServer := newFakeDNSServer(":25353", 1, sets.NewWithLength[string](0))
 	model.NetworkGatewayTestDNSServers = []string{
 		// try resolving with the failing server first to make sure the next upstream is retried


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR speeds up the execution of TestGatewayHostnames from ~3s to ~0.46s by:
- setting `workingDNSServer` to 0
- incrementing `MinGatewayTTL` to 110millis

when ttl is 0, the ttl becomes `MinGatewayTTL`, so we can have ttl = 110millis and run the test faster (see [here](https://github.com/istio/istio/blob/master/pilot/pkg/model/network.go#L442-L444))

contributes to #37555 