### PR TITLE
fix wrong example for admin log

### DIFF
--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -389,8 +389,11 @@ func istiodLogCmd() *cobra.Command {
   # Update levels of the specified loggers.
   istioctl admin log --level ads:debug,authorization:debug
 
+  # Retrieve information about istiod logging levels for a specified revision.
+  istioctl admin log --revision v1
+
   # Reset levels of all the loggers to default value (info).
-  istioctl admin log -r
+  istioctl admin log --reset
 `,
 		Aliases: []string{"l"},
 		Args: func(logCmd *cobra.Command, args []string) error {


### PR DESCRIPTION
**Please provide a description of this PR:**
The `-r` parameter is used to specify the revision, and `--reset` should be used here.