### PR TITLE
add support for security.istio.io/v1beta1 api in authz tests for revisions < 1.17

### DIFF
--- a/tests/integration/pilot/testdata/a.yaml
+++ b/tests/integration/pilot/testdata/a.yaml
@@ -32,7 +32,7 @@ spec:
     labels:
       version: v1
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: integ-test

--- a/tests/integration/pilot/testdata/authz-a.yaml
+++ b/tests/integration/pilot/testdata/authz-a.yaml
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: allow-policy
@@ -9,7 +9,7 @@ spec:
     - operation:
         methods: ["*"]
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: deny-policy

--- a/tests/integration/pilot/testdata/authz-b.yaml
+++ b/tests/integration/pilot/testdata/authz-b.yaml
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: allow-policy
@@ -12,7 +12,7 @@ spec:
     - operation:
         notPorts: ["100"]
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: deny-policy

--- a/tests/integration/security/https_jwt/testdata/remotehttps.yaml.tmpl
+++ b/tests/integration/security/https_jwt/testdata/remotehttps.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: request-authn

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -86,7 +86,7 @@ spec:
   mtls:
     mode: DISABLE
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: authz

--- a/tests/integration/security/remote_jwks/testdata/requestauthn-no-se.yaml.tmpl
+++ b/tests/integration/security/remote_jwks/testdata/requestauthn-no-se.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: request-authn

--- a/tests/integration/security/remote_jwks/testdata/requestauthn-with-se.yaml.tmpl
+++ b/tests/integration/security/remote_jwks/testdata/requestauthn-with-se.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: request-authn

--- a/tests/integration/security/testdata/authz/allow-namespace.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/allow-namespace.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/allow-principal.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/allow-principal.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/conditions.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-request-headers
@@ -21,7 +21,7 @@ spec:
         notValues: [ "bar" ]
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-source-ip
@@ -44,7 +44,7 @@ spec:
         notValues: {{ .Denied.MustWorkloads.Addresses | toJson }}
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-source-namespace
@@ -67,7 +67,7 @@ spec:
         notValues: [ "{{ .Denied.NamespaceName }}" ]
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-source-principal
@@ -90,7 +90,7 @@ spec:
         notValues: [ "{{ .Denied.ServiceAccountName }}" ]
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-destination-ip
@@ -119,7 +119,7 @@ spec:
         notValues: {{ .To.MustWorkloads.Addresses | toJson }}
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-destination-port
@@ -148,7 +148,7 @@ spec:
         notValues: [ "{{ ( .To.PortForName `http` ).WorkloadPort }}" ]
 ---
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-connection-sni

--- a/tests/integration/security/testdata/authz/custom-provider.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/custom-provider.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: custom-{{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/deny-global.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/deny-global.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies access to path /global-deny for all workloads
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-deny-system

--- a/tests/integration/security/testdata/authz/deny-namespace.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/deny-namespace.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/deny-principal.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/deny-principal.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: default
@@ -10,7 +10,7 @@ spec:
     - issuer: "test-issuer-2@istio.io"
       jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: egressgateway

--- a/tests/integration/security/testdata/authz/ingress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/ingress-gateway.yaml.tmpl
@@ -5,7 +5,7 @@
 # and denies access to "remoteipattr.{{ .To.ServiceName }}.company.com" when the
 # remote ip is 10.242.5.7 or in the network 10.124.99.0/24.
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/jwt.yaml.tmpl
@@ -2,7 +2,7 @@
 
 # The following policy enables JWT authentication on destination service.
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: default
@@ -23,7 +23,7 @@ spec:
 # - Allow request with valid JWT token of presenter foo to access path with suffix "/presenter"
 # - Allow request with valid JWT token of audiences bar to access path with suffix "/audiences"
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/not-host.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/not-host.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
             port:
               number: {{ (.To.PortForName "http").ServicePort }}
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: allow-{{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/not-method.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/not-method.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-allow

--- a/tests/integration/security/testdata/authz/not-namespace.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/not-namespace.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-deny

--- a/tests/integration/security/testdata/authz/not-port.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/not-port.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}-allow

--- a/tests/integration/security/testdata/authz/path-normalization.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-normalization.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/path-precedence.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-precedence.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy denies access to path /allow/admin.
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .To.ServiceName }}-deny
@@ -16,7 +16,7 @@ spec:
 ---
 # The following policy allows access to path with prefix /allow.
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .To.ServiceName }}-allow

--- a/tests/integration/security/testdata/authz/plaintext.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/plaintext.yaml.tmpl
@@ -27,7 +27,7 @@ spec:
 # This authz policy denies access to the service if the request was not mTLS, since
 # mTLS is required in order to match source principals.
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/workload-bad.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/workload-bad.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects a non-exist workload
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .To.ServiceName }}-bad

--- a/tests/integration/security/testdata/authz/workload-ns.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/workload-ns.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects all workloads in namespace 1
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .Namespace.Prefix }}-all

--- a/tests/integration/security/testdata/authz/workload-system-ns.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/workload-system-ns.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects workloads for the service in all namespaces
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-system-{{ .To.ServiceName }}

--- a/tests/integration/security/testdata/authz/workload.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/workload.yaml.tmpl
@@ -1,6 +1,6 @@
 # The following policy selects the workload
 
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: policy-{{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/aud.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/aud.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}-part1
@@ -16,7 +16,7 @@ spec:
     audiences:
     - "bar"
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}-part2

--- a/tests/integration/security/testdata/requestauthn/authn-authz.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/authn-authz.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}
@@ -11,7 +11,7 @@ spec:
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
 ---
 # The following policy enables authorization on workload dst.
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/authn-only.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/authn-only.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/forward.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/forward.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/global-jwt.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: "default"
@@ -9,7 +9,7 @@ spec:
   - issuer: "test-issuer-2@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: authz-ingress

--- a/tests/integration/security/testdata/requestauthn/headers-params.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/headers-params.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}
@@ -19,7 +19,7 @@ spec:
     - "secondary_token"
 ---
 # The following policy enables authorization on workload dst.
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/invalid-jwks.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/invalid-jwks.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/security/testdata/requestauthn/remote.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/remote.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: {{ .To.ServiceName }}

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_audit/v1beta1-audit-authorization-policy.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_audit/v1beta1-audit-authorization-policy.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/policy_allow.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/policy_allow.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/policy_deny.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/policy_deny.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_allow_matched.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_allow_matched.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_both_matched.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_both_matched.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"
@@ -12,7 +12,7 @@ spec:
     - source:
         principals: ["*"]
 ---
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"

--- a/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_deny_matched.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/security_authz_dry_run/tcp_policy_deny_matched.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   namespace: "{{ .Namespace }}"


### PR DESCRIPTION

Testing multiple istio versions involves older istio versions which uses the v1beta1 api. This change will start using v1 for 1.17+ and v1beta1 for 1.16-.

**Please provide a description of this PR:**