### PR TITLE
disable automount SA token only on tests with min istio revisions >= 1.16

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -159,6 +159,11 @@ func (c *Config) fillDefaults(ctx resource.Context) error {
 func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 	var defaultConfigs []echo.Config
 
+	disableAutomountSAToken := true
+	if t.Settings().Revisions.Minimum() < "1.16" {
+		disableAutomountSAToken = false
+	}
+
 	a := echo.Config{
 		Service:                 ASvc,
 		ServiceAccount:          true,
@@ -166,7 +171,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 		Subsets:                 []echo.SubsetConfig{{}},
 		Locality:                "region.zone.subzone",
 		IncludeExtAuthz:         c.IncludeExtAuthz,
-		DisableAutomountSAToken: true,
+		DisableAutomountSAToken: disableAutomountSAToken,
 	}
 
 	b := echo.Config{


### PR DESCRIPTION
Testing multiple istio versions involves older istio versions which doesn't support sidecars with disable automount SA token. This was enabled form 1.16 onwards.

**Please provide a description of this PR:**