### PR TITLE
Add dns1123 validation to iop resource

### DIFF
--- a/operator/pkg/tpath/struct_test.go
+++ b/operator/pkg/tpath/struct_test.go
@@ -185,14 +185,16 @@ g:
         m: vm-slice2
 `,
 			path: "g.h[*].k.l.*",
-			wantYAMLS: []string{`vm
+			wantYAMLS: []string{
+				`vm
 `,
 				`vm
 `,
 				`p: vp
 `,
 				`vm-slice2
-`},
+`,
+			},
 			wantFound: true,
 		},
 	}

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -76,7 +76,7 @@ func CheckIstioOperatorSpec(is *v1alpha1.IstioOperatorSpec, checkRequiredFields 
 }
 
 func Validate2(validations map[string]ValidatorFunc, iop *v1alpha1.IstioOperatorSpec) (errs util.Errors) {
-	// Convert to map[string]interface{} so we can use tpath.
+	// Convert to map[string]interface{} to avoid GatewaySpec not found.
 	iopMap, err := iopSpecToMap(iop)
 	if err != nil {
 		return util.NewErrs(err)

--- a/operator/pkg/validate/validate_test.go
+++ b/operator/pkg/validate/validate_test.go
@@ -68,14 +68,14 @@ values:
 			yamlStr: `
 hub: ?illegal-tag!
 `,
-			wantErrs: makeErrors([]string{`invalid value Hub: ?illegal-tag!`}),
+			wantErrs: makeErrors([]string{`invalid value hub: ?illegal-tag!`}),
 		},
 		{
 			desc: "BadHub",
 			yamlStr: `
 hub: docker.io:tag/istio
 `,
-			wantErrs: makeErrors([]string{`invalid value Hub: docker.io:tag/istio`}),
+			wantErrs: makeErrors([]string{`invalid value hub: docker.io:tag/istio`}),
 		},
 		{
 			desc: "GoodURL",
@@ -92,7 +92,7 @@ components:
     name: istio@ingress-1
     enabled: true
 `,
-			wantErrs: makeErrors([]string{`invalid value Components.IngressGateways: istio@ingress-1`}),
+			wantErrs: makeErrors([]string{`invalid DNS1123 label specified: istio@ingress-1`}),
 		},
 		{
 			desc: "BadValuesIP",
@@ -162,6 +162,40 @@ meshConfig:
   defaultConfig:
     discoveryAddress: istiod:15012
 `,
+		},
+		{
+			desc: "bad gateway config",
+			yamlStr: `
+components:
+  ingressGateways:
+  - name: istio-ingressgateway
+    namespace: "invalid namespace"
+    k8s:
+      service:
+        ports:
+        - name: "invalid name"
+          port: 80
+        - name: "invalid name2"
+          port: 443
+  egressGateways:
+  - name: istio-egressgateway
+    namespace: "invalid namespace2"
+    k8s:
+      service:
+        ports:
+        - name: "invalid name3"
+          port: 80
+        - name: "invalid name4"
+          port: 443
+`,
+			wantErrs: makeErrors([]string{
+				`invalid DNS1123 label specified: invalid name3`,
+				`invalid DNS1123 label specified: invalid name4`,
+				`invalid DNS1123 label specified: invalid namespace2`,
+				`invalid DNS1123 label specified: invalid name`,
+				`invalid DNS1123 label specified: invalid name2`,
+				`invalid DNS1123 label specified: invalid namespace`,
+			}),
 		},
 	}
 

--- a/operator/pkg/validate/validate_values_test.go
+++ b/operator/pkg/validate/validate_values_test.go
@@ -149,6 +149,32 @@ cni:
 `,
 			wantErrs: makeErrors([]string{`unknown field "foo" in v1alpha1.CNIConfig`}),
 		},
+		{
+			desc: "bad cluster name",
+			yamlStr: `
+global:
+  multiCluster:
+    clusterName: "bad name"
+`,
+			wantErrs: makeErrors([]string{`invalid DNS1123 domain "bad name"`}),
+		},
+		{
+			desc: "bad network fromRegistry",
+			yamlStr: `
+global:
+  meshNetworks:
+    network1:
+      endpoints:
+      - fromRegistry: "bad name network1"
+    network2:
+      endpoints:
+      - fromRegistry: "bad name network2"
+`,
+			wantErrs: makeErrors([]string{
+				`invalid DNS1123 domain "bad name network1"`,
+				`invalid DNS1123 domain "bad name network2"`,
+			}),
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/44480.yaml
+++ b/releasenotes/notes/44480.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 36792
+releaseNotes:
+  - |
+    **Added** support for validating some IOP fields in compliance with DNS1123.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/36792

Also added a wildcard match to `getFromStructPath ` function, to allow more flexible field validation functions.
See https://github.com/istio/istio/pull/44480/files#diff-f294054d7d235bbc3f27d26b522ec025bd2eb76f27ce9f5f6f457b854086f044R37-R53