### PR TITLE
[1.17] Use safer dedupe for config (#44502)

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -114,7 +115,7 @@ func (cr *store) List(typ config.GroupVersionKind, namespace string) ([]config.C
 	var errs *multierror.Error
 	var configs []config.Config
 	// Used to remove duplicated config
-	configMap := sets.New[string]()
+	configMap := sets.New[types.NamespacedName]()
 
 	for _, store := range cr.stores[typ] {
 		storeConfigs, err := store.List(typ, namespace)
@@ -122,8 +123,7 @@ func (cr *store) List(typ config.GroupVersionKind, namespace string) ([]config.C
 			errs = multierror.Append(errs, err)
 		}
 		for _, cfg := range storeConfigs {
-			key := cfg.GroupVersionKind.Kind + cfg.Namespace + cfg.Name
-			if !configMap.InsertContains(key) {
+			if !configMap.InsertContains(config.NamespacedName(cfg)) {
 				configs = append(configs, cfg)
 			}
 		}


### PR DESCRIPTION
This is just appending them, there is no guarantee of conflicts being avoided

Fixes https://github.com/istio/istio/issues/44520

(cherry picked from commit 3b7ca81a32ee6d091b9a1779736e5484ea65b4e4)

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
