### PR TITLE
istiod: drop Alpha Gateway API types by default

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -900,7 +900,7 @@ func (s *Server) initRegistryEventHandlers() {
 		}
 		schemas := collections.Pilot.All()
 		if features.EnableGatewayAPI {
-			schemas = collections.PilotGatewayAPI.All()
+			schemas = collections.PilotGatewayAPI().All()
 		}
 		for _, schema := range schemas {
 			// This resource type was handled in external/servicediscovery.go, no need to rehandle here.

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -30,7 +30,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 	log.Info("initializing config validator")
 	// always start the validation server
 	params := server.Options{
-		Schemas:      collections.PilotGatewayAPI,
+		Schemas:      collections.PilotGatewayAPI(),
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,
 		Mux:          s.httpsMux,
 	}

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -181,7 +181,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]config.Config, []Istio
 		}
 
 		gvk := obj.GroupVersionKind()
-		s, exists := collections.PilotGatewayAPI.FindByGroupVersionAliasesKind(resource.FromKubernetesGVK(&gvk))
+		s, exists := collections.PilotGatewayAPI().FindByGroupVersionAliasesKind(resource.FromKubernetesGVK(&gvk))
 		if !exists {
 			log.Debugf("unrecognized type %v", obj.Kind)
 			others = append(others, obj)

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -102,7 +102,7 @@ var _ model.ConfigStoreController = &Client{}
 func New(client kube.Client, opts Option) (*Client, error) {
 	schemas := collections.Pilot
 	if features.EnableGatewayAPI {
-		schemas = collections.PilotGatewayAPI
+		schemas = collections.PilotGatewayAPI()
 	}
 	return NewForSchemas(client, opts, schemas)
 }

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -139,11 +139,11 @@ func TestClientDelayedCRDs(t *testing.T) {
 
 // CheckIstioConfigTypes validates that an empty store can do CRUD operators on all given types
 func TestClient(t *testing.T) {
-	store, _ := makeClient(t, collections.PilotGatewayAPI.Union(collections.Kube))
+	store, _ := makeClient(t, collections.PilotGatewayAPI().Union(collections.Kube))
 	configName := "test"
 	configNamespace := "test-ns"
 	timeout := retry.Timeout(time.Millisecond * 200)
-	for _, r := range collections.PilotGatewayAPI.All() {
+	for _, r := range collections.PilotGatewayAPI().All() {
 		name := r.Kind()
 		t.Run(name, func(t *testing.T) {
 			configMeta := config.Meta{

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -351,6 +351,7 @@ D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
 )
 
 func TestConvertResources(t *testing.T) {
+	features.EnableAlphaGatewayAPI = true
 	features.EnableAmbientControllers = true
 	validator := crdvalidation.NewIstioValidator(t)
 	cases := []struct {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -370,6 +370,10 @@ var (
 		"If this is set to true, support for Kubernetes gateway-api (github.com/kubernetes-sigs/gateway-api) will "+
 			" be enabled. In addition to this being enabled, the gateway-api CRDs need to be installed.").Get()
 
+	EnableAlphaGatewayAPI = env.Register("PILOT_ENABLE_ALPHA_GATEWAY_API", false,
+		"If this is set to true, support for alpha APIs in the Kubernetes gateway-api (github.com/kubernetes-sigs/gateway-api) will "+
+			" be enabled. In addition to this being enabled, the gateway-api CRDs need to be installed.").Get()
+
 	EnableGatewayAPIStatus = env.Register("PILOT_ENABLE_GATEWAY_API_STATUS", true,
 		"If this is set to true, gateway-api resources will have status written to them").Get()
 

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -122,7 +122,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	configs := getConfigs(t, opts)
 	cc := opts.ConfigController
 	if cc == nil {
-		cc = memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI))
+		cc = memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
 	}
 	controllers := []model.ConfigStoreController{cc}
 	if opts.CreateConfigStore != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -51,7 +51,7 @@ import (
 
 func TestAmbientIndex(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
-	cfg := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI))
+	cfg := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{
 		ConfigController: cfg,
 		MeshWatcher:      mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"}),
@@ -328,7 +328,7 @@ func TestAmbientIndex(t *testing.T) {
 
 func TestPodLifecycleWorkloadGates(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
-	cfg := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI))
+	cfg := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{
 		ConfigController: cfg,
 		MeshWatcher:      mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"}),

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -173,7 +173,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	s.Generators[v3.SecretType] = NewSecretGen(creds, s.Cache, opts.DefaultClusterName, nil)
 	s.Generators[v3.ExtensionConfigurationType].(*EcdsGenerator).SetCredController(creds)
 
-	configController := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI))
+	configController := memory.NewSyncController(memory.MakeSkipValidation(collections.PilotGatewayAPI()))
 	for k8sCluster, objs := range k8sObjects {
 		client := kubelib.NewFakeClientWithVersion(opts.KubernetesVersion, objs...)
 		if opts.KubeClientModifier != nil {
@@ -270,7 +270,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}
 	schemas := collections.Pilot.All()
 	if features.EnableGatewayAPI {
-		schemas = collections.PilotGatewayAPI.All()
+		schemas = collections.PilotGatewayAPI().All()
 	}
 	for _, schema := range schemas {
 		// This resource type was handled in external/servicediscovery.go, no need to rehandle here.

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -554,8 +554,8 @@ var (
 	{{- end }}
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
-	pilotGatewayAPI = collection.NewSchemasBuilder().
+	// PilotGatewayAPI() contains only collections used by Pilot, including the full Gateway API.
+	PilotGatewayAPI() = collection.NewSchemasBuilder().
 	{{- range .Entries }}
 		{{- if or (contains .Resource.Group "istio.io") (contains .Resource.Group "gateway.networking.k8s.io") }}
 		MustAdd({{ .Resource.Identifier }}).

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -554,8 +554,8 @@ var (
 	{{- end }}
 		Build()
 
-	// PilotGatewayAPI() contains only collections used by Pilot, including the full Gateway API.
-	PilotGatewayAPI() = collection.NewSchemasBuilder().
+	// pilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	pilotGatewayAPI = collection.NewSchemasBuilder().
 	{{- range .Entries }}
 		{{- if or (contains .Resource.Group "istio.io") (contains .Resource.Group "gateway.networking.k8s.io") }}
 		MustAdd({{ .Resource.Identifier }}).

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -554,10 +554,24 @@ var (
 	{{- end }}
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
-	PilotGatewayAPI = collection.NewSchemasBuilder().
+	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	pilotGatewayAPI = collection.NewSchemasBuilder().
 	{{- range .Entries }}
 		{{- if or (contains .Resource.Group "istio.io") (contains .Resource.Group "gateway.networking.k8s.io") }}
+		MustAdd({{ .Resource.Identifier }}).
+		{{- end}}
+	{{- end }}
+		Build()
+
+	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
+	pilotStableGatewayAPI = collection.NewSchemasBuilder().
+	{{- range .Entries }}
+		{{- if or
+       (contains .Resource.Group "istio.io")
+       (and
+          (contains .Resource.Group "gateway.networking.k8s.io")
+          (not (contains .Resource.Version "alpha")))
+    }}
 		MustAdd({{ .Resource.Identifier }}).
 		{{- end}}
 	{{- end }}

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -331,8 +331,8 @@ var (
 		MustAdd(WorkloadGroup).
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
-	PilotGatewayAPI = collection.NewSchemasBuilder().
+	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	pilotGatewayAPI = collection.NewSchemasBuilder().
 			MustAdd(AuthorizationPolicy).
 			MustAdd(DestinationRule).
 			MustAdd(EnvoyFilter).
@@ -348,4 +348,22 @@ var (
 			MustAdd(WorkloadEntry).
 			MustAdd(WorkloadGroup).
 			Build()
+
+	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
+	pilotStableGatewayAPI = collection.NewSchemasBuilder().
+				MustAdd(AuthorizationPolicy).
+				MustAdd(DestinationRule).
+				MustAdd(EnvoyFilter).
+				MustAdd(Gateway).
+				MustAdd(PeerAuthentication).
+				MustAdd(ProxyConfig).
+				MustAdd(RequestAuthentication).
+				MustAdd(ServiceEntry).
+				MustAdd(Sidecar).
+				MustAdd(Telemetry).
+				MustAdd(VirtualService).
+				MustAdd(WasmPlugin).
+				MustAdd(WorkloadEntry).
+				MustAdd(WorkloadGroup).
+				Build()
 )

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -331,8 +331,8 @@ var (
 		MustAdd(WorkloadGroup).
 		Build()
 
-	// PilotGatewayAPI() contains only collections used by Pilot, including the full Gateway API.
-	PilotGatewayAPI() = collection.NewSchemasBuilder().
+	// pilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	pilotGatewayAPI = collection.NewSchemasBuilder().
 			MustAdd(AuthorizationPolicy).
 			MustAdd(DestinationRule).
 			MustAdd(EnvoyFilter).

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -331,8 +331,8 @@ var (
 		MustAdd(WorkloadGroup).
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
-	pilotGatewayAPI = collection.NewSchemasBuilder().
+	// PilotGatewayAPI() contains only collections used by Pilot, including the full Gateway API.
+	PilotGatewayAPI() = collection.NewSchemasBuilder().
 			MustAdd(AuthorizationPolicy).
 			MustAdd(DestinationRule).
 			MustAdd(EnvoyFilter).

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -761,8 +761,8 @@ var (
 		MustAdd(WorkloadGroup).
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including experimental Service Api.
-	PilotGatewayAPI = collection.NewSchemasBuilder().
+	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	pilotGatewayAPI = collection.NewSchemasBuilder().
 			MustAdd(AuthorizationPolicy).
 			MustAdd(DestinationRule).
 			MustAdd(EnvoyFilter).
@@ -786,4 +786,25 @@ var (
 			MustAdd(WorkloadEntry).
 			MustAdd(WorkloadGroup).
 			Build()
+
+	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
+	pilotStableGatewayAPI = collection.NewSchemasBuilder().
+				MustAdd(AuthorizationPolicy).
+				MustAdd(DestinationRule).
+				MustAdd(EnvoyFilter).
+				MustAdd(Gateway).
+				MustAdd(GatewayClass).
+				MustAdd(HTTPRoute).
+				MustAdd(KubernetesGateway).
+				MustAdd(PeerAuthentication).
+				MustAdd(ProxyConfig).
+				MustAdd(RequestAuthentication).
+				MustAdd(ServiceEntry).
+				MustAdd(Sidecar).
+				MustAdd(Telemetry).
+				MustAdd(VirtualService).
+				MustAdd(WasmPlugin).
+				MustAdd(WorkloadEntry).
+				MustAdd(WorkloadGroup).
+				Build()
 )

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -798,6 +798,7 @@ var (
 				MustAdd(KubernetesGateway).
 				MustAdd(PeerAuthentication).
 				MustAdd(ProxyConfig).
+				MustAdd(ReferenceGrant).
 				MustAdd(RequestAuthentication).
 				MustAdd(ServiceEntry).
 				MustAdd(Sidecar).

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -761,7 +761,7 @@ var (
 		MustAdd(WorkloadGroup).
 		Build()
 
-	// PilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
+	// pilotGatewayAPI contains only collections used by Pilot, including the full Gateway API.
 	pilotGatewayAPI = collection.NewSchemasBuilder().
 			MustAdd(AuthorizationPolicy).
 			MustAdd(DestinationRule).

--- a/pkg/config/schema/collections/extras.go
+++ b/pkg/config/schema/collections/extras.go
@@ -21,9 +21,9 @@ import (
 
 var Istio = Pilot.Add(MeshNetworks).Add(MeshConfig)
 
-var PilotGatewayAPI = func() collection.Schemas {
+func PilotGatewayAPI() collection.Schemas {
 	if features.EnableAlphaGatewayAPI {
 		return pilotGatewayAPI
 	}
 	return pilotStableGatewayAPI
-}()
+}

--- a/pkg/config/schema/collections/extras.go
+++ b/pkg/config/schema/collections/extras.go
@@ -14,4 +14,16 @@
 
 package collections
 
+import (
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config/schema/collection"
+)
+
 var Istio = Pilot.Add(MeshNetworks).Add(MeshConfig)
+
+var PilotGatewayAPI = func() collection.Schemas {
+	if features.EnableAlphaGatewayAPI {
+		return pilotGatewayAPI
+	}
+	return pilotStableGatewayAPI
+}()

--- a/releasenotes/notes/drop-gateway-alpha.yaml
+++ b/releasenotes/notes/drop-gateway-alpha.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: traffic-managment
+area: traffic-management
 releaseNotes:
 - |
   **Removed** `alpha` Gateway API types by default. They can be explicitly re-enabled with `PILOT_ENABLE_ALPHA_GATEWAY_API=true`.

--- a/releasenotes/notes/drop-gateway-alpha.yaml
+++ b/releasenotes/notes/drop-gateway-alpha.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: traffic-managment
 releaseNotes:
 - |
-  **Removed** `alpha` Gateway API types by default. These can be explicitly re-enabled with `PILOT_ENABLE_ALPHA_GATEWAY_API=true`.
+  **Removed** `alpha` Gateway API types by default. They can be explicitly re-enabled with `PILOT_ENABLE_ALPHA_GATEWAY_API=true`.

--- a/releasenotes/notes/drop-gateway-alpha.yaml
+++ b/releasenotes/notes/drop-gateway-alpha.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-managment
+releaseNotes:
+- |
+  **Removed** `alpha` Gateway API types by default. These can be explicitly re-enabled with `PILOT_ENABLE_ALPHA_GATEWAY_API=true`.

--- a/tests/integration/base.yaml
+++ b/tests/integration/base.yaml
@@ -19,6 +19,7 @@ spec:
       env:
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
+        PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
     global:
       proxy:
         resources:


### PR DESCRIPTION
This is problematic because most providers will not install Alpha CRDs. So once these promote to Beta, clusters will have *only* beta version in the CRD. We would detect the CRD and attempt to watch, but fail as alpha does not exist.

This makes the alpha enablement an explicit opt-in to avoid this.

An alternative could be to read the actual CRD to check it has the version we want. However, this is not safe -- a user may silently stop reading critical configurations.

This is not needed for Istio CRDs as we don't remove old versions.

**Please provide a description of this PR:**