### PR TITLE
Add gateway support for minReadySeconds

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR addresses an old issue https://github.com/istio/istio/issues/25029 to ensure ingress gateways can slow down their restarts to prevent external LB targets from being stale causing downtime.