### PR TITLE
CNI: refactor and fix memory leak/infinite loops

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -194,11 +194,6 @@ func registerStringParameter(name, value, usage string) {
 	registerEnvironment(name, value, usage)
 }
 
-func registerStringArrayParameter(name string, value []string, usage string) {
-	rootCmd.Flags().StringArray(name, value, usage)
-	registerEnvironment(name, strings.Join(value, ","), usage)
-}
-
 func registerIntegerParameter(name string, value int, usage string) {
 	rootCmd.Flags().Int(name, value, usage)
 	registerEnvironment(name, value, usage)

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -150,7 +150,6 @@ func init() {
 	registerStringParameter(constants.CNIConfName, "", "Name of the CNI configuration file")
 	registerBooleanParameter(constants.ChainedCNIPlugin, true, "Whether to install CNI plugin as a chained or standalone")
 	registerStringParameter(constants.CNINetworkConfig, "", "CNI configuration template as a string")
-	registerBooleanParameter(constants.CNIEnableReinstall, true, "Whether to reinstall CNI configuration and binary files")
 	registerStringParameter(constants.LogLevel, "warn", "Fallback value for log level in CNI config file, if not specified in helm template")
 
 	// Not configurable in CNI helm charts
@@ -237,7 +236,6 @@ func constructConfig() (*config.Config, error) {
 
 		CNINetworkConfigFile: viper.GetString(constants.CNINetworkConfigFile),
 		CNINetworkConfig:     viper.GetString(constants.CNINetworkConfig),
-		CNIEnableReinstall:   viper.GetBool(constants.CNIEnableReinstall),
 
 		LogLevel:           viper.GetString(constants.LogLevel),
 		KubeconfigFilename: viper.GetString(constants.KubeconfigFilename),

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -107,11 +107,11 @@ var rootCmd = &cobra.Command{
 
 		if err = installer.Run(ctx); err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				log.Infof("Installer exits with %v", err)
+				log.Infof("installer complete: %v", err)
 				// Error was caused by interrupt/termination signal
 				err = nil
 			} else {
-				log.Errorf("Installer exits with %v", err)
+				log.Errorf("installer failed: %v", err)
 			}
 		}
 
@@ -160,9 +160,6 @@ func init() {
 	registerIntegerParameter(constants.KubeconfigMode, constants.DefaultKubeconfigMode, "File mode of the kubeconfig file")
 	registerStringParameter(constants.KubeCAFile, "", "CA file for kubeconfig. Defaults to the same as install-cni pod")
 	registerBooleanParameter(constants.SkipTLSVerify, false, "Whether to use insecure TLS in kubeconfig file")
-	registerBooleanParameter(constants.UpdateCNIBinaries, true, "Whether to refresh existing binaries when installing CNI")
-	registerStringArrayParameter(constants.SkipCNIBinaries, []string{},
-		"Binaries that should not be installed. Currently Istio only installs one binary `istio-cni`")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
 	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
 	registerBooleanParameter(constants.AmbientEnabled, false, "Whether ambient controller is enabled")
@@ -247,12 +244,10 @@ func constructConfig() (*config.Config, error) {
 		K8sServicePort:     os.Getenv("KUBERNETES_SERVICE_PORT"),
 		K8sNodeName:        os.Getenv("KUBERNETES_NODE_NAME"),
 
-		CNIBinSourceDir:   constants.CNIBinDir,
-		CNIBinTargetDirs:  []string{constants.HostCNIBinDir, constants.SecondaryBinDir},
-		UpdateCNIBinaries: viper.GetBool(constants.UpdateCNIBinaries),
-		SkipCNIBinaries:   viper.GetStringSlice(constants.SkipCNIBinaries),
-		MonitoringPort:    viper.GetInt(constants.MonitoringPort),
-		LogUDSAddress:     viper.GetString(constants.LogUDSAddress),
+		CNIBinSourceDir:  constants.CNIBinDir,
+		CNIBinTargetDirs: []string{constants.HostCNIBinDir, constants.SecondaryBinDir},
+		MonitoringPort:   viper.GetInt(constants.MonitoringPort),
+		LogUDSAddress:    viper.GetString(constants.LogUDSAddress),
 
 		AmbientEnabled: viper.GetBool(constants.AmbientEnabled),
 		EbpfEnabled:    viper.GetBool(constants.EbpfEnabled),

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -150,7 +150,6 @@ func init() {
 	registerStringParameter(constants.CNIConfName, "", "Name of the CNI configuration file")
 	registerBooleanParameter(constants.ChainedCNIPlugin, true, "Whether to install CNI plugin as a chained or standalone")
 	registerStringParameter(constants.CNINetworkConfig, "", "CNI configuration template as a string")
-	registerBooleanParameter(constants.CNIEnableInstall, true, "Whether to install CNI configuration and binary files")
 	registerBooleanParameter(constants.CNIEnableReinstall, true, "Whether to reinstall CNI configuration and binary files")
 	registerStringParameter(constants.LogLevel, "warn", "Fallback value for log level in CNI config file, if not specified in helm template")
 
@@ -238,7 +237,6 @@ func constructConfig() (*config.Config, error) {
 
 		CNINetworkConfigFile: viper.GetString(constants.CNINetworkConfigFile),
 		CNINetworkConfig:     viper.GetString(constants.CNINetworkConfig),
-		CNIEnableInstall:     viper.GetBool(constants.CNIEnableInstall),
 		CNIEnableReinstall:   viper.GetBool(constants.CNIEnableReinstall),
 
 		LogLevel:           viper.GetString(constants.LogLevel),

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -64,11 +64,6 @@ type InstallConfig struct {
 	CNIBinSourceDir string
 	// Directories into which to copy the CNI binaries
 	CNIBinTargetDirs []string
-	// Whether to override existing CNI binaries
-	UpdateCNIBinaries bool
-
-	// The names of binaries to skip when copying
-	SkipCNIBinaries []string
 
 	// The HTTP port for monitoring
 	MonitoringPort int
@@ -139,8 +134,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("K8sServiceHost: " + c.K8sServiceHost + "\n")
 	b.WriteString("K8sServicePort: " + fmt.Sprint(c.K8sServicePort) + "\n")
 	b.WriteString("K8sNodeName: " + c.K8sNodeName + "\n")
-	b.WriteString("UpdateCNIBinaries: " + fmt.Sprint(c.UpdateCNIBinaries) + "\n")
-	b.WriteString("SkipCNIBinaries: " + fmt.Sprint(c.SkipCNIBinaries) + "\n")
 	b.WriteString("MonitoringPort: " + fmt.Sprint(c.MonitoringPort) + "\n")
 	b.WriteString("LogUDSAddress: " + fmt.Sprint(c.LogUDSAddress) + "\n")
 	b.WriteString("HostNSEnterExec: " + fmt.Sprint(c.HostNSEnterExec) + "\n")

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -39,8 +39,6 @@ type InstallConfig struct {
 	CNINetworkConfigFile string
 	// CNI config template string
 	CNINetworkConfig string
-	// Whether to install CNI configuration and binary files
-	CNIEnableInstall bool
 	// Whether to reinstall CNI configuration and binary files
 	CNIEnableReinstall bool
 
@@ -132,7 +130,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("ChainedCNIPlugin: " + fmt.Sprint(c.ChainedCNIPlugin) + "\n")
 	b.WriteString("CNINetworkConfigFile: " + c.CNINetworkConfigFile + "\n")
 	b.WriteString("CNINetworkConfig: " + c.CNINetworkConfig + "\n")
-	b.WriteString("CNIEnableInstall: " + fmt.Sprint(c.CNIEnableInstall) + "\n")
 	b.WriteString("CNIEnableReinstall: " + fmt.Sprint(c.CNIEnableReinstall) + "\n")
 
 	b.WriteString("LogLevel: " + c.LogLevel + "\n")

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -39,8 +39,6 @@ type InstallConfig struct {
 	CNINetworkConfigFile string
 	// CNI config template string
 	CNINetworkConfig string
-	// Whether to reinstall CNI configuration and binary files
-	CNIEnableReinstall bool
 
 	// Logging level
 	LogLevel string
@@ -130,7 +128,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("ChainedCNIPlugin: " + fmt.Sprint(c.ChainedCNIPlugin) + "\n")
 	b.WriteString("CNINetworkConfigFile: " + c.CNINetworkConfigFile + "\n")
 	b.WriteString("CNINetworkConfig: " + c.CNINetworkConfig + "\n")
-	b.WriteString("CNIEnableReinstall: " + fmt.Sprint(c.CNIEnableReinstall) + "\n")
 
 	b.WriteString("LogLevel: " + c.LogLevel + "\n")
 	b.WriteString("KubeconfigFilename: " + c.KubeconfigFilename + "\n")

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -28,8 +28,6 @@ const (
 	KubeconfigMode       = "kubeconfig-mode"
 	KubeCAFile           = "kube-ca-file"
 	SkipTLSVerify        = "skip-tls-verify"
-	SkipCNIBinaries      = "skip-cni-binaries"
-	UpdateCNIBinaries    = "update-cni-binaries"
 	MonitoringPort       = "monitoring-port"
 	LogUDSAddress        = "log-uds-address"
 	AmbientEnabled       = "ambient-enabled"

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -23,7 +23,6 @@ const (
 	ChainedCNIPlugin     = "chained-cni-plugin"
 	CNINetworkConfigFile = "cni-network-config-file"
 	CNINetworkConfig     = "cni-network-config"
-	CNIEnableInstall     = "cni-enable-install"
 	CNIEnableReinstall   = "cni-enable-reinstall"
 	LogLevel             = "log-level"
 	KubeconfigFilename   = "kubecfg-file-name"

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -23,7 +23,6 @@ const (
 	ChainedCNIPlugin     = "chained-cni-plugin"
 	CNINetworkConfigFile = "cni-network-config-file"
 	CNINetworkConfig     = "cni-network-config"
-	CNIEnableReinstall   = "cni-enable-reinstall"
 	LogLevel             = "log-level"
 	KubeconfigFilename   = "kubecfg-file-name"
 	KubeconfigMode       = "kubeconfig-mode"

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -52,16 +52,22 @@ const (
 )
 
 // Internal constants
-var (
-	CNIBinDir             = "/opt/cni/bin"
-	HostCNIBinDir         = "/host/opt/cni/bin"
-	SecondaryBinDir       = "/host/secondary-bin-dir"
-	ServiceAccountPath    = "/var/run/secrets/kubernetes.io/serviceaccount"
+const (
 	DefaultKubeconfigMode = 0o600
-	UDSLogPath            = "/log"
+
+	UDSLogPath      = "/log"
+	SecondaryBinDir = "/host/secondary-bin-dir"
 
 	// K8s liveness and readiness endpoints
 	LivenessEndpoint  = "/healthz"
 	ReadinessEndpoint = "/readyz"
-	Port              = "8000"
+	ReadinessPort     = "8000"
+)
+
+// Exposed for testing constants
+var (
+	CNIBinDir               = "/opt/cni/bin"
+	HostCNIBinDir           = "/host/opt/cni/bin"
+	ServiceAccountCAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	ServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -66,8 +66,7 @@ const (
 
 // Exposed for testing constants
 var (
-	CNIBinDir               = "/opt/cni/bin"
-	HostCNIBinDir           = "/host/opt/cni/bin"
-	ServiceAccountCAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	ServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	CNIBinDir          = "/opt/cni/bin"
+	HostCNIBinDir      = "/host/opt/cni/bin"
+	ServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 )

--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -19,11 +19,9 @@ import (
 	"path/filepath"
 
 	"istio.io/istio/pkg/file"
-	"istio.io/istio/pkg/util/sets"
 )
 
-func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipBinaries []string) error {
-	skipBinariesSet := sets.New(skipBinaries...)
+func copyBinaries(srcDir string, targetDirs []string) error {
 	for _, targetDir := range targetDirs {
 		if err := file.IsDirWriteable(targetDir); err != nil {
 			installLog.Infof("Directory %s is not writable, skipping.", targetDir)
@@ -41,16 +39,6 @@ func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipB
 			}
 
 			filename := f.Name()
-			if skipBinariesSet.Contains(filename) {
-				installLog.Infof("%s is in SKIP_CNI_BINARIES, skipping.", filename)
-				continue
-			}
-
-			targetFilepath := filepath.Join(targetDir, filename)
-			if _, err := os.Stat(targetFilepath); err == nil && !updateBinaries {
-				installLog.Infof("%s is already here and UPDATE_CNI_BINARIES isn't true, skipping", targetFilepath)
-				continue
-			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
 			err := file.AtomicCopy(srcFilepath, targetDir, filename)

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -15,19 +15,19 @@
 package install
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
+
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/file"
 )
 
 func TestCopyBinaries(t *testing.T) {
 	cases := []struct {
-		name           string
-		srcFiles       map[string]string // {filename: contents, ...}
-		existingFiles  map[string]string // {filename: contents, ...}
-		expectedFiles  map[string]string // {filename: contents. ...}
-		updateBinaries bool
-		skipBinaries   []string
+		name          string
+		srcFiles      map[string]string
+		existingFiles map[string]string
+		expectedFiles map[string]string
 	}{
 		{
 			name:          "basic",
@@ -35,24 +35,10 @@ func TestCopyBinaries(t *testing.T) {
 			expectedFiles: map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
 		},
 		{
-			name:           "update binaries",
-			updateBinaries: true,
-			srcFiles:       map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
-			existingFiles:  map[string]string{"istio-cni": "cni000", "istio-iptables": "iptables111"},
-			expectedFiles:  map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
-		},
-		{
-			name:           "don't update binaries",
-			updateBinaries: false,
-			srcFiles:       map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
-			existingFiles:  map[string]string{"istio-cni": "cni000", "istio-iptables": "iptables111"},
-			expectedFiles:  map[string]string{"istio-cni": "cni000", "istio-iptables": "iptables111"},
-		},
-		{
-			name:          "skip binaries",
-			skipBinaries:  []string{"istio-iptables"},
+			name:          "update binaries",
 			srcFiles:      map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
-			expectedFiles: map[string]string{"istio-cni": "cni111"},
+			existingFiles: map[string]string{"istio-cni": "cni000", "istio-iptables": "iptables111"},
+			expectedFiles: map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
 		},
 	}
 
@@ -60,33 +46,22 @@ func TestCopyBinaries(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			srcDir := t.TempDir()
 			for filename, contents := range c.srcFiles {
-				err := os.WriteFile(filepath.Join(srcDir, filename), []byte(contents), os.ModePerm)
-				if err != nil {
-					t.Fatal(err)
-				}
+				file.WriteOrFail(t, filepath.Join(srcDir, filename), []byte(contents))
 			}
 
 			targetDir := t.TempDir()
 			for filename, contents := range c.existingFiles {
-				err := os.WriteFile(filepath.Join(targetDir, filename), []byte(contents), os.ModePerm)
-				if err != nil {
-					t.Fatal(err)
-				}
+				file.WriteOrFail(t, filepath.Join(targetDir, filename), []byte(contents))
 			}
 
-			err := copyBinaries(srcDir, []string{targetDir}, c.updateBinaries, c.skipBinaries)
+			err := copyBinaries(srcDir, []string{targetDir})
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			for filename, expectedContents := range c.expectedFiles {
-				contents, err := os.ReadFile(filepath.Join(targetDir, filename))
-				if err != nil {
-					t.Fatal(err)
-				}
-				if string(contents) != expectedContents {
-					t.Fatalf("target file contents don't match source file; actual: %s", string(contents))
-				}
+				contents := file.AsStringOrFail(t, filepath.Join(targetDir, filename))
+				assert.Equal(t, contents, expectedContents)
 			}
 		})
 	}

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -78,13 +78,13 @@ func getCNIConfigVars(cfg *config.InstallConfig) cniConfigVars {
 	}
 }
 
-func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig, saToken string) (string, error) {
+func createCNIConfigFile(ctx context.Context, cfg *config.InstallConfig) (string, error) {
 	cniConfig, err := readCNIConfigTemplate(getCNIConfigTemplate(cfg))
 	if err != nil {
 		return "", err
 	}
 
-	cniConfig = replaceCNIConfigVars(cniConfig, getCNIConfigVars(cfg), saToken)
+	cniConfig = replaceCNIConfigVars(cniConfig, getCNIConfigVars(cfg))
 
 	return writeCNIConfig(ctx, cniConfig, getPluginConfig(cfg))
 }
@@ -107,7 +107,7 @@ func readCNIConfigTemplate(template cniConfigTemplate) ([]byte, error) {
 	return nil, fmt.Errorf("need CNI_NETWORK_CONFIG or CNI_NETWORK_CONFIG_FILE to be set")
 }
 
-func replaceCNIConfigVars(cniConfig []byte, vars cniConfigVars, saToken string) []byte {
+func replaceCNIConfigVars(cniConfig []byte, vars cniConfigVars) []byte {
 	cniConfigStr := string(cniConfig)
 
 	cniConfigStr = strings.ReplaceAll(cniConfigStr, "__LOG_LEVEL__", vars.logLevel)
@@ -118,11 +118,7 @@ func replaceCNIConfigVars(cniConfig []byte, vars cniConfigVars, saToken string) 
 	cniConfigStr = strings.ReplaceAll(cniConfigStr, "__KUBERNETES_SERVICE_PORT__", vars.k8sServicePort)
 	cniConfigStr = strings.ReplaceAll(cniConfigStr, "__KUBERNETES_NODE_NAME__", vars.k8sNodeName)
 
-	// Log the config file before inserting service account token.
-	// This way auth token is not visible in the logs.
 	installLog.Infof("CNI config: %s", cniConfigStr)
-
-	cniConfigStr = strings.ReplaceAll(cniConfigStr, "__SERVICEACCOUNT_TOKEN__", saToken)
 
 	return []byte(cniConfigStr)
 }

--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -271,6 +271,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Logf("delayed write to %v", filepath.Join(tempDir, c.delayedConfName))
 				} else if len(c.expectedConfName) > 0 {
 					t.Fatalf("timed out waiting for expected %s", expectedFilepath)
 				} else {
@@ -486,7 +487,7 @@ func TestCreateCNIConfigFile(t *testing.T) {
 
 				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 				defer cancel()
-				resultFilepath, err := createCNIConfigFile(ctx, &cfg, "")
+				resultFilepath, err := createCNIConfigFile(ctx, &cfg)
 				if err != nil {
 					assert.Equal(t, resultFilepath, "")
 					if err == context.DeadlineExceeded {

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -90,14 +90,11 @@ func (in *Installer) Run(ctx context.Context) (err error) {
 		}
 
 		installLog.Info("Detect changes to the CNI configuration and binaries, attempt reinstalling...")
-		if in.cfg.CNIEnableReinstall {
-			if err = in.install(ctx); err != nil {
-				return
-			}
-			installLog.Info("CNI configuration and binaries reinstalled.")
-		} else {
-			installLog.Info("Skip reinstalling CNI configuration and binaries.")
+		if err = in.install(ctx); err != nil {
+			return
 		}
+		installLog.Info("CNI configuration and binaries reinstalled.")
+
 	}
 }
 

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -79,14 +79,10 @@ func (in *Installer) install(ctx context.Context) (err error) {
 // Run starts the installation process, verifies the configuration, then sleeps.
 // If an invalid configuration is detected, the installation process will restart to restore a valid state.
 func (in *Installer) Run(ctx context.Context) (err error) {
-	if in.cfg.CNIEnableInstall {
-		if err = in.install(ctx); err != nil {
-			return
-		}
-		installLog.Info("Installation succeed, start watching for re-installation.")
-	} else {
-		installLog.Info("Skip installing CNI configuration and binaries.")
+	if err = in.install(ctx); err != nil {
+		return
 	}
+	installLog.Info("Installation succeed, start watching for re-installation.")
 
 	for {
 		if err = in.sleepCheckInstall(ctx); err != nil {
@@ -94,7 +90,7 @@ func (in *Installer) Run(ctx context.Context) (err error) {
 		}
 
 		installLog.Info("Detect changes to the CNI configuration and binaries, attempt reinstalling...")
-		if in.cfg.CNIEnableInstall && in.cfg.CNIEnableReinstall {
+		if in.cfg.CNIEnableReinstall {
 			if err = in.install(ctx); err != nil {
 				return
 			}
@@ -223,10 +219,6 @@ func (in *Installer) sleepCheckInstall(ctx context.Context) error {
 
 // checkInstall returns an error if an invalid CNI configuration is detected
 func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error {
-	// If the installation is skipped, don't check for invalid configurations.
-	if !cfg.CNIEnableInstall {
-		return nil
-	}
 	defaultCNIConfigFilename, err := getDefaultCNINetwork(cfg.MountedCNINetDir)
 	if err != nil {
 		return err

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -22,7 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/util"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/util/assert"
@@ -172,7 +175,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			}
 
 			t.Log("Expecting an invalid configuration log:")
-			if err := in.sleepCheckInstall(ctx); err != nil {
+			if err := in.sleepCheckInstall(ctx, nil); err != nil {
 				t.Fatalf("error should be nil due to invalid config, got: %v", err)
 			}
 			assert.Equal(t, isReady.Load(), false)
@@ -208,8 +211,13 @@ func TestSleepCheckInstall(t *testing.T) {
 			// Listen to sleepCheckInstall return value
 			// Should detect a valid configuration and wait indefinitely for a file modification
 			errChan := make(chan error)
+			watcher, err := util.CreateFileWatcher(append(slices.Clone(in.cfg.CNIBinTargetDirs), in.cfg.MountedCNINetDir)...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer watcher.Close()
 			go func(ctx context.Context) {
-				errChan <- in.sleepCheckInstall(ctx)
+				errChan <- in.sleepCheckInstall(ctx, watcher)
 			}(ctx)
 
 			select {
@@ -249,7 +257,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 				// Run sleepCheckInstall
 				go func(ctx context.Context, in *Installer) {
-					errChan <- in.sleepCheckInstall(ctx)
+					errChan <- in.sleepCheckInstall(ctx, nil)
 				}(ctx, in)
 			}
 

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -35,7 +35,6 @@ func TestCheckInstall(t *testing.T) {
 		cniConfigFilename string
 		cniConfName       string
 		chainedCNIPlugin  bool
-		skipInstall       bool
 		existingConfFiles map[string]string // {srcFilename: targetFilename, ...}
 	}{
 		{
@@ -63,12 +62,6 @@ func TestCheckInstall(t *testing.T) {
 		{
 			name:              "CNI config file removed",
 			expectedFailure:   true,
-			cniConfigFilename: "file-removed.conflist",
-		},
-		{
-			name:              "CNI config file non-existent but install skipped",
-			expectedFailure:   false,
-			skipInstall:       true,
 			cniConfigFilename: "file-removed.conflist",
 		},
 		{
@@ -113,7 +106,6 @@ func TestCheckInstall(t *testing.T) {
 				MountedCNINetDir: tempDir,
 				CNIConfName:      c.cniConfName,
 				ChainedCNIPlugin: c.chainedCNIPlugin,
-				CNIEnableInstall: !c.skipInstall,
 			}
 			err := checkInstall(cfg, filepath.Join(tempDir, c.cniConfigFilename))
 			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
@@ -161,7 +153,6 @@ func TestSleepCheckInstall(t *testing.T) {
 			cfg := &config.InstallConfig{
 				MountedCNINetDir: tempDir,
 				ChainedCNIPlugin: c.chainedCNIPlugin,
-				CNIEnableInstall: true,
 			}
 			cniConfigFilepath := filepath.Join(tempDir, c.cniConfigFilename)
 			isReady := &atomic.Value{}

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -160,8 +160,6 @@ func TestSleepCheckInstall(t *testing.T) {
 			in := NewInstaller(cfg, isReady)
 			in.cniConfigFilepath = cniConfigFilepath
 
-			in.saToken = "foo"
-			in.saTokenFilepath = filepath.Join(tempDir, c.saFilename)
 			if err := file.AtomicCopy(filepath.Join("testdata", c.saFilename), tempDir, c.saFilename); err != nil {
 				t.Fatal(err)
 			}

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -22,10 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"istio.io/istio/cni/pkg/config"
-	"istio.io/istio/cni/pkg/util"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/util/assert"
@@ -175,7 +172,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			}
 
 			t.Log("Expecting an invalid configuration log:")
-			if err := in.sleepCheckInstall(ctx, nil); err != nil {
+			if err := in.sleepCheckInstall(ctx); err != nil {
 				t.Fatalf("error should be nil due to invalid config, got: %v", err)
 			}
 			assert.Equal(t, isReady.Load(), false)
@@ -211,13 +208,8 @@ func TestSleepCheckInstall(t *testing.T) {
 			// Listen to sleepCheckInstall return value
 			// Should detect a valid configuration and wait indefinitely for a file modification
 			errChan := make(chan error)
-			watcher, err := util.CreateFileWatcher(append(slices.Clone(in.cfg.CNIBinTargetDirs), in.cfg.MountedCNINetDir)...)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer watcher.Close()
 			go func(ctx context.Context) {
-				errChan <- in.sleepCheckInstall(ctx, watcher)
+				errChan <- in.sleepCheckInstall(ctx)
 			}(ctx)
 
 			select {
@@ -257,7 +249,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 				// Run sleepCheckInstall
 				go func(ctx context.Context, in *Installer) {
-					errChan <- in.sleepCheckInstall(ctx, nil)
+					errChan <- in.sleepCheckInstall(ctx)
 				}(ctx, in)
 			}
 

--- a/cni/pkg/install/kubeconfig.go
+++ b/cni/pkg/install/kubeconfig.go
@@ -110,6 +110,10 @@ func writeKubeConfigFile(cfg *config.InstallConfig) error {
 
 	// Log with redaction
 	if err := api.RedactSecrets(kcfg); err == nil {
+		for _, c := range kcfg.Clusters {
+			// Not actually sensitive, just annoyingly verbose.
+			c.CertificateAuthority = "REDACTED"
+		}
 		lcfg, err := latest.Scheme.ConvertToVersion(kcfg, latest.ExternalVersion)
 		if err != nil {
 			return err

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -19,12 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"sigs.k8s.io/yaml"
-
 	"istio.io/istio/cni/pkg/config"
 	"istio.io/istio/cni/pkg/constants"
 	testutils "istio.io/istio/pilot/test/util"
-	"istio.io/istio/pkg/test/util/assert"
 )
 
 const (
@@ -93,15 +90,13 @@ func TestCreateKubeconfigFile(t *testing.T) {
 			} else if c.expectedFailure {
 				t.Fatalf("expected failure")
 			}
-			resultBytes, err := yaml.Marshal(result)
-			assert.NoError(t, err)
 
 			goldenFilepath := "testdata/kubeconfig-tls"
 			if c.skipTLSVerify {
 				goldenFilepath = "testdata/kubeconfig-skip-tls"
 			}
 
-			testutils.CompareContent(t, resultBytes, goldenFilepath)
+			testutils.CompareContent(t, []byte(result.Full), goldenFilepath)
 		})
 	}
 }

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -15,11 +15,14 @@
 package install
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/cni/pkg/config"
+	"istio.io/istio/cni/pkg/constants"
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -28,9 +31,13 @@ const (
 	k8sServiceHost = "10.96.0.1"
 	k8sServicePort = "443"
 	kubeCAFilepath = "testdata/kube-ca.crt"
+	saToken        = "service_account_token_string"
 )
 
 func TestCreateKubeconfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "token"), []byte(saToken), 0o644)
+	constants.ServiceAccountPath = tmp
 	cases := []struct {
 		name               string
 		expectedFailure    bool
@@ -76,7 +83,7 @@ func TestCreateKubeconfigFile(t *testing.T) {
 				K8sServicePort:     c.k8sServicePort,
 				SkipTLSVerify:      c.skipTLSVerify,
 			}
-			result, err := createKubeconfig(cfg)
+			result, err := createKubeConfig(cfg)
 			if err != nil {
 				if !c.expectedFailure {
 					t.Fatalf("did not expect failure: %v", err)

--- a/cni/pkg/install/monitoring.go
+++ b/cni/pkg/install/monitoring.go
@@ -20,7 +20,6 @@ var (
 	resultLabel                   = monitoring.MustCreateLabel("result")
 	resultSuccess                 = "SUCCESS"
 	resultCopyBinariesFailure     = "COPY_BINARIES_FAILURE"
-	resultReadSAFailure           = "READ_SERVICE_ACCOUNT_FAILURE"
 	resultCreateKubeConfigFailure = "CREATE_KUBECONFIG_FAILURE"
 	resultCreateCNIConfigFailure  = "CREATE_CNI_CONFIG_FAILURE"
 

--- a/cni/pkg/install/server.go
+++ b/cni/pkg/install/server.go
@@ -27,7 +27,7 @@ func StartServer() *atomic.Value {
 	isReady := initRouter(router)
 
 	go func() {
-		_ = http.ListenAndServe(":"+constants.Port, router)
+		_ = http.ListenAndServe(":"+constants.ReadinessPort, router)
 	}()
 
 	return isReady

--- a/cni/pkg/install/testdata/kubeconfig-skip-tls
+++ b/cni/pkg/install/testdata/kubeconfig-skip-tls
@@ -15,4 +15,4 @@ preferences: {}
 users:
 - name: istio-cni
   user:
-    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    token: service_account_token_string

--- a/cni/pkg/install/testdata/kubeconfig-skip-tls
+++ b/cni/pkg/install/testdata/kubeconfig-skip-tls
@@ -1,18 +1,18 @@
-# Kubeconfig file for Istio CNI plugin.
 apiVersion: v1
-kind: Config
 clusters:
-- name: local
-  cluster:
-    server: https://[10.96.0.1]:443
+- cluster:
     insecure-skip-tls-verify: true
+    server: https://10.96.0.1:443
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: istio-cni
+  name: istio-cni-context
+current-context: istio-cni-context
+kind: Config
+preferences: {}
 users:
 - name: istio-cni
   user:
-    token: "service_account_token_string"
-contexts:
-- name: istio-cni-context
-  context:
-    cluster: local
-    user: istio-cni
-current-context: istio-cni-context
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/cni/pkg/install/testdata/kubeconfig-tls
+++ b/cni/pkg/install/testdata/kubeconfig-tls
@@ -15,4 +15,4 @@ preferences: {}
 users:
 - name: istio-cni
   user:
-    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    token: service_account_token_string

--- a/cni/pkg/install/testdata/kubeconfig-tls
+++ b/cni/pkg/install/testdata/kubeconfig-tls
@@ -1,18 +1,18 @@
-# Kubeconfig file for Istio CNI plugin.
 apiVersion: v1
-kind: Config
 clusters:
-- name: local
-  cluster:
-    server: https://[10.96.0.1]:443
+- cluster:
     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1EZ3dOekF6TVRNek1Wb1hEVEk0TURnd05EQXpNVE16TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTmc4CkxYWWtOMi96LzJobHUxSVc2ZHdXR1lHM3JpZFI3bXFoQjVtZWZBRjdaNzFNTXJYUVJFNUhSRlppd2tLWlB2RHkKRzEzZGIwVUxJWWRYU000dkNiOFpjU2RGWlVCM2ZjOWVMUjViWG54Sksxby93ZU50ZU5ibEZIUktoYUFqSk5pRwoyUU0xM2VDb25GYXdUWU45SEFqS1VCS3orTUM4UzBuU2RYeTB6d0E4TGhvRGhiUzA1Tk8yV2RHamx4b2FQUjliCllVblh1QzNYbkYva0FnTVpNMjhPK1ZjQ1dmUXN5eWc3NEJJMTI5TEtESVNCTit0Z0pqMDdidnl0aWNtZU5sODQKZDFqVHBqTytEVWRjaXhMNlFhQnk0dkh0TWlNMWl6VU1uWHRWcEluTnpjbzhxaHBxVEV1NkpxNEhLLzdHMU9SagozdU1Xd3krWXE0U1ZjOUlDazFVQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFKQytBb3g3VEhKdWNqNEpCZWJOZmJyeGxaUjYKS0hRZ1N6cUg3MTFhbjYzdHM1QUcvVHM0Zm1hWlpSdjV1TEFFSXkyUUY5bW13bWdQUkJBYkM4cEJBVU1BNVhNOQpKRkRQTVRhaVlDZXhaRS9IZm8vVS81MEIwbDNIa3hQVCsrOHROZ0FvRm5tbFhqUzR4Q2JwelM5dFlRdVJ2UnJIClJPcVo4Smg3bStMUlNLZjNWQVBwSERqSUU0ZVYrYnZqZFhZRjMzNHVqcmFKWTB5NlFoOW1GZ01nOFRGWkh6Y3UKUXN4L01FMG14NklzMFFTRGxqNFFRSGQzWk5ZQ01Fb3ZwczNjYmFGS2xMbXdsRlZWTFJWS1Jac1FOSk9LUisrNQpoUzRncXVaRUxiNnl5MTZNNEU1K3NmZUhxQ0RnN3psQU15WFB6WmxxNWdWZ245OE1WanJXbEVHNVJSRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    server: https://10.96.0.1:443
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: istio-cni
+  name: istio-cni-context
+current-context: istio-cni-context
+kind: Config
+preferences: {}
 users:
 - name: istio-cni
   user:
-    token: "service_account_token_string"
-contexts:
-- name: istio-cni-context
-  context:
-    cluster: local
-    user: istio-cni
-current-context: istio-cni-context
+    tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -21,8 +21,6 @@ import (
 	"os"
 
 	"github.com/fsnotify/fsnotify"
-
-	"istio.io/istio/pkg/file"
 )
 
 type Watcher struct {
@@ -58,9 +56,6 @@ func CreateFileWatcher(dirs ...string) (*Watcher, error) {
 	go watchFiles(watcher, fileModified, errChan)
 
 	for _, dir := range dirs {
-		if file.IsDirWriteable(dir) != nil {
-			continue
-		}
 		if err := watcher.Add(dir); err != nil {
 			if closeErr := watcher.Close(); closeErr != nil {
 				err = fmt.Errorf("%s: %w", closeErr.Error(), err)

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -25,32 +25,58 @@ import (
 	"istio.io/istio/pkg/file"
 )
 
+type Watcher struct {
+	watcher *fsnotify.Watcher
+	Events  chan struct{}
+	Errors  chan error
+}
+
+// Waits until a file is modified (returns nil), the context is cancelled (returns context error), or returns error
+func (w *Watcher) Wait(ctx context.Context) error {
+	select {
+	case <-w.Events:
+		return nil
+	case err := <-w.Errors:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *Watcher) Close() {
+	_ = w.watcher.Close()
+}
+
 // Creates a file watcher that watches for any changes to the directory
-func CreateFileWatcher(dirs ...string) (watcher *fsnotify.Watcher, fileModified chan bool, errChan chan error, err error) {
-	watcher, err = fsnotify.NewWatcher()
+func CreateFileWatcher(dirs ...string) (*Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	fileModified, errChan = make(chan bool), make(chan error)
+	fileModified, errChan := make(chan struct{}), make(chan error)
 	go watchFiles(watcher, fileModified, errChan)
 
 	for _, dir := range dirs {
 		if file.IsDirWriteable(dir) != nil {
 			continue
 		}
-		if err = watcher.Add(dir); err != nil {
+		if err := watcher.Add(dir); err != nil {
 			if closeErr := watcher.Close(); closeErr != nil {
 				err = fmt.Errorf("%s: %w", closeErr.Error(), err)
 			}
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
-	return
+	return &Watcher{
+		watcher: watcher,
+		Events:  fileModified,
+		Errors:  errChan,
+	}, nil
 }
 
-func watchFiles(watcher *fsnotify.Watcher, fileModified chan bool, errChan chan error) {
+func watchFiles(watcher *fsnotify.Watcher, fileModified chan struct{}, errChan chan error) {
 	for {
 		select {
 		case event, ok := <-watcher.Events:
@@ -58,7 +84,7 @@ func watchFiles(watcher *fsnotify.Watcher, fileModified chan bool, errChan chan 
 				return
 			}
 			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
-				fileModified <- true
+				fileModified <- struct{}{}
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {
@@ -66,18 +92,6 @@ func watchFiles(watcher *fsnotify.Watcher, fileModified chan bool, errChan chan 
 			}
 			errChan <- err
 		}
-	}
-}
-
-// Waits until a file is modified (returns nil), the context is cancelled (returns context error), or returns error
-func WaitForFileMod(ctx context.Context, fileModified chan bool, errChan chan error) error {
-	select {
-	case <-fileModified:
-		return nil
-	case err := <-errChan:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 

--- a/cni/test/install_cni.go
+++ b/cni/test/install_cni.go
@@ -174,7 +174,7 @@ func runInstall(ctx context.Context, tempCNIConfDir, tempCNIBinDir,
 	tempK8sSvcAcctDir, cniConfFileName string, chainedCNIPlugin bool,
 ) {
 	root := cmd.GetCommand()
-	constants.ServiceAccountPath = tempK8sSvcAcctDir
+	constants.ServiceAccountCAPath = tempK8sSvcAcctDir + "/ca.crt"
 	constants.HostCNIBinDir = tempCNIBinDir
 	constants.CNIBinDir = filepath.Join(env.IstioSrc, "cni/test/testdata/bindir")
 	root.SetArgs([]string{

--- a/cni/test/install_cni.go
+++ b/cni/test/install_cni.go
@@ -174,7 +174,7 @@ func runInstall(ctx context.Context, tempCNIConfDir, tempCNIBinDir,
 	tempK8sSvcAcctDir, cniConfFileName string, chainedCNIPlugin bool,
 ) {
 	root := cmd.GetCommand()
-	constants.ServiceAccountCAPath = tempK8sSvcAcctDir + "/ca.crt"
+	constants.ServiceAccountPath = tempK8sSvcAcctDir
 	constants.HostCNIBinDir = tempCNIBinDir
 	constants.CNIBinDir = filepath.Join(env.IstioSrc, "cni/test/testdata/bindir")
 	root.SetArgs([]string{

--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -167,9 +167,18 @@ func ReadDir(filePath string, extensions ...string) ([]string, error) {
 }
 
 func ReadDirOrFail(t test.Failer, filePath string, extensions ...string) []string {
+	t.Helper()
 	res, err := ReadDir(filePath, extensions...)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return res
+}
+
+func WriteOrFail(t test.Failer, filePath string, contents []byte) {
+	t.Helper()
+	err := os.WriteFile(filePath, contents, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/releasenotes/notes/cni-refactor.yaml
+++ b/releasenotes/notes/cni-refactor.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Removed** the `CNI_ENABLE_INSTALL`, `CNI_ENABLE_REINSTALL`, `SKIP_CNI_BINARIES`, and `UPDATE_CNI_BINARIES` feature flags.


### PR DESCRIPTION
# Problem

Since the PR https://github.com/istio/istio/pull/39801 (1.15), there is a bug only when CNI_ENABLE_INSTALL is set. Actually there is a few bugs working together.

First, we enter a loop that is basically for { sleepCheckInstall }: https://github.com/istio/istio/blob/b7ffd8eae26583f234a8113412db8a1c1aa5022d/cni/pkg/install/install.go#L91-L105

We see sleepCheckInstall always returning quickly, causing the loop to spin.

Inside sleepCheckInstall, watchSAToken spawns a goroutine which only exits once the entire process shuts down. This is bug #1 and why this is presented as a memory leak.

In sleepCheckInstall we have another loop: https://github.com/istio/istio/blob/b7ffd8eae26583f234a8113412db8a1c1aa5022d/cni/pkg/install/install.go#L200-L221. This will exit immediately due to the watchSAToken function call above. This calls readServiceAccountToken and checks curToken != token. Token comes from reading a file (which should always be there). curToken is set during the install call: https://github.com/istio/istio/blob/b7ffd8eae26583f234a8113412db8a1c1aa5022d/cni/pkg/install/install.go#L61 which is skipped due to CNI_ENABLE_INSTALL=false. This is bug #2.

The end result is we have an infinite loop executing very often (basically as fast as we can read a file), each time spawning a goroutine.

# Fix

Drop variables to disable install/re-install, as they are broken and not useful. they were originally added by Google for, IMO, not great reasons. Remove these entirely.
Also removed two other variables that added complexity for no gain; they were only there because we copy+pasted them from Calico 5 years ago.

Fix the watching logic for SA. Just merge it into the main watcher, no need for 2 codepaths to just watch the same files.