### PR TITLE
Set inject true for compatibility tests

### DIFF
--- a/tests/integration/pilot/gw_topology_test.go
+++ b/tests/integration/pilot/gw_topology_test.go
@@ -36,7 +36,11 @@ func TestXFFGateway(t *testing.T) {
 		NewTest(t).
 		Features("traffic.ingress.topology").
 		Run(func(t framework.TestContext) {
-			gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway"})
+			inject := false
+			if t.Settings().Compatibility {
+				inject = true
+			}
+			gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway", Inject: inject})
 			injectLabel := `sidecar.istio.io/inject: "true"`
 			if len(t.Settings().Revisions.Default()) > 0 {
 				injectLabel = fmt.Sprintf(`istio.io/rev: "%v"`, t.Settings().Revisions.Default())

--- a/tests/integration/pilot/gw_topology_test.go
+++ b/tests/integration/pilot/gw_topology_test.go
@@ -117,7 +117,11 @@ func TestProxyProtocolTCPGateway(t *testing.T) {
 		NewTest(t).
 		Features("traffic.ingress.topology").
 		Run(func(t framework.TestContext) {
-			gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway"})
+			inject := false
+			if t.Settings().Compatibility {
+				inject = true
+			}
+			gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway", Inject: inject})
 			injectLabel := `sidecar.istio.io/inject: "true"`
 			if len(t.Settings().Revisions.Default()) > 0 {
 				injectLabel = fmt.Sprintf(`istio.io/rev: "%v"`, t.Settings().Revisions.Default())

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -441,6 +441,10 @@ func TestCustomGateway(t *testing.T) {
 		NewTest(t).
 		Features("traffic.ingress.custom").
 		Run(func(t framework.TestContext) {
+			inject := false
+			if t.Settings().Compatibility {
+				inject = true
+			}
 			injectLabel := `sidecar.istio.io/inject: "true"`
 			if t.Settings().Revisions.Default() != "" {
 				injectLabel = fmt.Sprintf(`istio.io/rev: "%v"`, t.Settings().Revisions.Default())
@@ -454,7 +458,7 @@ func TestCustomGateway(t *testing.T) {
 			}
 
 			t.NewSubTest("minimal").Run(func(t framework.TestContext) {
-				gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway-minimal"})
+				gatewayNs := namespace.NewOrFail(t, t, namespace.Config{Prefix: "custom-gateway-minimal", Inject: inject})
 				_ = t.ConfigIstio().Eval(gatewayNs.Name(), templateParams, `apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
TestXFFGateway sets the image to auto which will cause the sidecar injector to automatically select the image to use, but in the current implementation, the sidecar injection is getting disabled for the compatibility tests

This PR sets inject to true for compatibility tests as the namespace creation implementation have a special condition for the compatibility tests which disables injection at the namespace (when inject is false), which ignores object selectors.
https://github.com/istio/istio/blob/master/pkg/test/framework/components/namespace/kube.go#L294

Made the similar fix for TestCustomGateway and TestProxyProtocolTCPGateway 