### PR TITLE
Fix persistent sessions scale down with envoy

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -267,8 +267,14 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			// DRAINING endpoints to be kept as 'UNHEALTHY' coarse status in envoy.
 			// Will not be used for normal traffic, only when explicit override.
 			if service.Attributes.Labels[features.PersistentSessionLabel] != "" {
+				// Default is UNKNOWN, HEALTHY, DEGRADED. Without this change, Envoy will drop endpoints with any other
+				// status received in EDS. With this setting, the DRAINING and UNHEALTHY endpoints are kept - both marked
+				// as UNHEALTHY ('coarse state'), which is what will show in config dumps.
+				// DRAINING/UNHEALTHY will not be used normally for new requests. They will be used if cookie/header
+				// selects them.
 				defaultCluster.cluster.CommonLbConfig.OverrideHostStatus = &core.HealthStatusSet{
-					Statuses: []core.HealthStatus{core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY, core.HealthStatus_DRAINING},
+					Statuses: []core.HealthStatus{core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY,
+						core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED},
 				}
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -273,8 +273,10 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 				// DRAINING/UNHEALTHY will not be used normally for new requests. They will be used if cookie/header
 				// selects them.
 				defaultCluster.cluster.CommonLbConfig.OverrideHostStatus = &core.HealthStatusSet{
-					Statuses: []core.HealthStatus{core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY,
-						core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED},
+					Statuses: []core.HealthStatus{
+						core.HealthStatus_HEALTHY,
+						core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED,
+					},
 				}
 			}
 

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -21,9 +21,9 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"istio.io/istio/pilot/pkg/features"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	corexds "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -133,8 +133,10 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 		if b.svc.Attributes.Labels[features.PersistentSessionLabel] != "" {
 			// see core/v1alpha3/cluster.go
 			defaultCluster.CommonLbConfig.OverrideHostStatus = &core.HealthStatusSet{
-				Statuses: []core.HealthStatus{core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY,
-					core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED},
+				Statuses: []core.HealthStatus{
+					core.HealthStatus_HEALTHY,
+					core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED,
+				},
 			}
 		}
 	}

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -21,6 +21,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"istio.io/istio/pilot/pkg/features"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -129,6 +130,13 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 	var defaultCluster *cluster.Cluster
 	if b.filter.Contains(b.defaultClusterName) {
 		defaultCluster = edsCluster(b.defaultClusterName)
+		if b.svc.Attributes.Labels[features.PersistentSessionLabel] != "" {
+			// see core/v1alpha3/cluster.go
+			defaultCluster.CommonLbConfig.OverrideHostStatus = &core.HealthStatusSet{
+				Statuses: []core.HealthStatus{core.HealthStatus_HEALTHY, core.HealthStatus_UNHEALTHY,
+					core.HealthStatus_DRAINING, core.HealthStatus_UNKNOWN, core.HealthStatus_DEGRADED},
+			}
+		}
 	}
 
 	subsetClusters := b.applyDestinationRule(defaultCluster)


### PR DESCRIPTION
Without it envoy will drop the draining endpoints and scale down will break.

Istiod does generate the DRAINING endpoints - and proxyless gRPC can use them, but in
envoy they don't show up in the EDS. This per-cluster flag allows them to be held - they will
not show up as DRAINING but as UNHEALTHY ( called 'coarse state' in envoy, quite confusing ).


**Please provide a description of this PR:**