### PR TITLE
Cleanup legacy ENABLE_LEGACY_LB_ALGORITHM_DEFAULT flag

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -316,13 +316,6 @@ var (
 			"ENABLE_MCS_HOST also be enabled.").Get() &&
 		EnableMCSHost
 
-	EnableLegacyLBAlgorithmDefault = env.Register(
-		"ENABLE_LEGACY_LB_ALGORITHM_DEFAULT",
-		false,
-		"If enabled, destinations for which no LB algorithm is specified will use the legacy "+
-			"default, ROUND_ROBIN. Care should be taken when using ROUND_ROBIN in general as it can "+
-			"overburden endpoints, especially when weights are used.").Get()
-
 	EnableAnalysis = env.Register(
 		"PILOT_ENABLE_ANALYSIS",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -744,9 +744,6 @@ func applyOutlierDetection(c *cluster.Cluster, outlier *networking.OutlierDetect
 }
 
 func defaultLBAlgorithm() cluster.Cluster_LbPolicy {
-	if features.EnableLegacyLBAlgorithmDefault {
-		return cluster.Cluster_ROUND_ROBIN
-	}
 	return cluster.Cluster_LEAST_REQUEST
 }
 

--- a/releasenotes/notes/drop-legacy-lb-flag.yaml
+++ b/releasenotes/notes/drop-legacy-lb-flag.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Removed** the `ENABLE_LEGACY_LB_ALGORITHM_DEFAULT` feature flag.


### PR DESCRIPTION
This has been around for 1 year and was added for backwards compat opt-out; time to remove