### PR TITLE
vwh: speedup reconcilation and fix test flake

### DIFF
--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -117,9 +117,11 @@ func newController(o Options, client kube.Client) *Controller {
 		controllers.WithReconciler(c.Reconcile),
 		// Webhook patching has to be retried forever. But the retries would be rate limited.
 		controllers.WithMaxAttempts(math.MaxInt),
-		// Try first few(5) retries quickly so that we can detect true conflicts by multiple Istiod instances fast.
-		// If there is a conflict beyond this, it means Istiods are seeing different ca certs and are in inconsistent
-		// state for longer duration. Slowdown the retries, so that we do not overload kube api server and etcd.
+		// Retry with backoff. Failures could be from conflicts of other instances (quick retry helps), or
+		// longer lasting concerns which will eventually be retried on 1min interval.
+		// Unlike the mutating webhook controller, we do not use NewItemFastSlowRateLimiter. This is because
+		// the validation controller waits for its own service to be ready, so typically this takes a few seconds
+		// before we are ready; using FastSlow means we tend to always take the Slow time (1min)
 		controllers.WithRateLimiter(workqueue.NewItemFastSlowRateLimiter(100*time.Millisecond, 1*time.Minute, 5)))
 
 	c.webhooks = kclient.NewFiltered[*kubeApiAdmission.ValidatingWebhookConfiguration](client, kclient.Filter{
@@ -198,6 +200,8 @@ func (c *Controller) readyForFailClose() bool {
 		}
 		scope.Info("Endpoint successfully rejected invalid config. Switching to fail-close.")
 		c.dryRunOfInvalidConfigRejected = true
+		// Sync all webhooks; this ensures if we have multiple webhooks all of them are updated
+		c.syncAll()
 	}
 	return true
 }


### PR DESCRIPTION
Fixes
https://prow.istio.io/view/gs/istio-prow/logs/integ-pilot-cpp_istio_postsubmit/1651656748131422208 failure

This is a  1.18 regression since we changed the queue backoff. This fixes it in 2 ways:
* Make sure we don't ahve to wait 1min every time
* Make sure once one webhook succeeds, all of them do

This also makes the test more robust to wait for all webhooks instead of just one.

User impact: webhook will be set to Fail faster. Before it usually took 1min.