### PR TITLE
telemetry: deflake access log tests

### DIFF
--- a/tests/integration/telemetry/api/accesslogs_test.go
+++ b/tests/integration/telemetry/api/accesslogs_test.go
@@ -160,7 +160,7 @@ func runAccessLogsTests(t framework.TestContext, expectLogs bool) {
 				return fmt.Errorf("expected logs '%v', got %v", expectLogs, count)
 			}
 			return nil
-		}, retry.Timeout(time.Second*10))
+		}, retry.Timeout(framework.TelemetryRetryTimeout))
 		if err != nil {
 			t.Fatalf("expected logs but got nil, err: %v", err)
 		}
@@ -233,7 +233,7 @@ func runAccessLogFilterTests(t framework.TestContext, expectLogs bool) {
 				return fmt.Errorf("expected logs '%v', got %v", expectLogs, count)
 			}
 			return nil
-		}, retry.Timeout(time.Second*10))
+		}, retry.Timeout(framework.TelemetryRetryTimeout))
 		if err != nil {
 			t.Fatalf("expected logs but got nil, err: %v", err)
 		}
@@ -292,7 +292,7 @@ func runAccessLogModeTests(t framework.TestContext, exceptClientLog, exceptServe
 		}
 
 		return nil
-	}, retry.Timeout(time.Second*10))
+	}, retry.Timeout(framework.TelemetryRetryTimeout))
 	if err != nil {
 		t.Fatalf("expected logs but got err: %v", err)
 	}


### PR DESCRIPTION
Example failure:
https://prow.istio.io/view/gs/istio-prow/pr-logs/directory/integ-telemetry_istio/1652008195079540736

It looks like the XDS push is just causing too much load and it takes more than 10s to process. We see during XDS push /stats/prometheus also times out.

**Please provide a description of this PR:**