### PR TITLE
Attempt to deflake audit log tests

### DIFF
--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_audit_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -112,7 +111,7 @@ func TestStackdriverHTTPAuditLogging(t *testing.T) {
 						}
 
 						return fmt.Errorf(strings.Join(errs, "\n"))
-					}, retry.Delay(5*time.Second), retry.Timeout(20*time.Second))
+					}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
For https://github.com/istio/istio/issues/44503.

From the logs, as far as I can tell we are sending the right audit logs. So might just be taking a bit longer than expected... Will see if this clears things up 