### PR TITLE
Support additional address in listeners output

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -59,8 +59,18 @@ func (l *ListenerFilter) Verify(listener *listener.Listener) bool {
 	if l.Address == "" && l.Port == 0 && l.Type == "" {
 		return true
 	}
-	if l.Address != "" && !strings.EqualFold(retrieveListenerAddress(listener), l.Address) {
-		return false
+	if l.Address != "" {
+		addresses := retrieveListenerAdditionalAddresses(listener)
+		addresses = append(addresses, retrieveListenerAddress(listener))
+		found := false
+		for _, address := range addresses {
+			if strings.EqualFold(address, l.Address) {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
 	}
 	if l.Port != 0 && retrieveListenerPort(listener) != l.Port {
 		return false
@@ -119,6 +129,17 @@ func retrieveListenerAddress(l *listener.Listener) string {
 	}
 
 	return ""
+}
+
+func retrieveListenerAdditionalAddresses(l *listener.Listener) []string {
+	var addrs []string
+	socketAddresses := l.GetAdditionalAddresses()
+	for _, socketAddr := range socketAddresses {
+		addr := socketAddr.Address
+		addrs = append(addrs, addr.GetSocketAddress().Address)
+	}
+
+	return addrs
 }
 
 func retrieveListenerPort(l *listener.Listener) uint32 {
@@ -291,7 +312,7 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 		return iType < jType
 	})
 
-	printStr := "ADDRESS\tPORT"
+	printStr := "ADDRESS\tPORT\tADDITIONAL ADDRESSES"
 	if includeConfigType {
 		printStr = "NAME\t" + printStr
 	}
@@ -303,6 +324,7 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 	fmt.Fprintln(w, printStr)
 	for _, l := range verifiedListeners {
 		address := retrieveListenerAddress(l)
+		addresses := retrieveListenerAdditionalAddresses(l)
 		port := retrieveListenerPort(l)
 		if filter.Verbose {
 
@@ -313,18 +335,18 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 			for _, match := range matches {
 				if includeConfigType {
 					l.Name = fmt.Sprintf("listener/%s", l.Name)
-					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", l.Name, address, port, match.match, match.destination)
+					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n", l.Name, address, port, strings.Join(addresses, ","), match.match, match.destination)
 				} else {
-					fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", address, port, match.match, match.destination)
+					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", address, port, strings.Join(addresses, ","), match.match, match.destination)
 				}
 			}
 		} else {
 			listenerType := retrieveListenerType(l)
 			if includeConfigType {
 				l.Name = fmt.Sprintf("listener/%s", l.Name)
-				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", l.Name, address, port, listenerType)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", l.Name, address, port, strings.Join(addresses, ","), listenerType)
 			} else {
-				fmt.Fprintf(w, "%v\t%v\t%v\n", address, port, listenerType)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", address, port, strings.Join(addresses, ","), listenerType)
 			}
 		}
 	}

--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -312,7 +312,7 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 		return iType < jType
 	})
 
-	printStr := "ADDRESS\tPORT\tADDITIONAL ADDRESSES"
+	printStr := "ADDRESSES\tPORT"
 	if includeConfigType {
 		printStr = "NAME\t" + printStr
 	}
@@ -323,8 +323,8 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 	}
 	fmt.Fprintln(w, printStr)
 	for _, l := range verifiedListeners {
-		address := retrieveListenerAddress(l)
-		addresses := retrieveListenerAdditionalAddresses(l)
+		addresses := []string{retrieveListenerAddress(l)}
+		addresses = append(addresses, retrieveListenerAdditionalAddresses(l)...)
 		port := retrieveListenerPort(l)
 		if filter.Verbose {
 
@@ -335,18 +335,18 @@ func (c *ConfigWriter) PrintListenerSummary(filter ListenerFilter) error {
 			for _, match := range matches {
 				if includeConfigType {
 					l.Name = fmt.Sprintf("listener/%s", l.Name)
-					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n", l.Name, address, port, strings.Join(addresses, ","), match.match, match.destination)
+					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", l.Name, strings.Join(addresses, ","), port, match.match, match.destination)
 				} else {
-					fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", address, port, strings.Join(addresses, ","), match.match, match.destination)
+					fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", strings.Join(addresses, ","), port, match.match, match.destination)
 				}
 			}
 		} else {
 			listenerType := retrieveListenerType(l)
 			if includeConfigType {
 				l.Name = fmt.Sprintf("listener/%s", l.Name)
-				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", l.Name, address, port, strings.Join(addresses, ","), listenerType)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", l.Name, strings.Join(addresses, ","), port, listenerType)
 			} else {
-				fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", address, port, strings.Join(addresses, ","), listenerType)
+				fmt.Fprintf(w, "%v\t%v\t%v\n", strings.Join(addresses, ","), port, listenerType)
 			}
 		}
 	}

--- a/istioctl/pkg/writer/envoy/configdump/listener_test.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener_test.go
@@ -54,6 +54,29 @@ func TestListenerFilter_Verify(t *testing.T) {
 			expect: false,
 		},
 		{
+			desc: "addtl-addrs-dont-match",
+			inFilter: &ListenerFilter{
+				Address: "0.0.0.0",
+			},
+			inListener: &listener.Listener{
+				Address: &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{Address: "1.1.1.1"},
+					},
+				},
+				AdditionalAddresses: []*listener.AdditionalAddress{
+					{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{Address: "1:1:1::1"},
+							},
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
 			desc: "ports-dont-match",
 			inFilter: &ListenerFilter{
 				Port: 10,

--- a/releasenotes/notes/istioctl-additional-address.yaml
+++ b/releasenotes/notes/istioctl-additional-address.yaml
@@ -5,4 +5,4 @@ issue: []
 
 releaseNotes:
   - |
-    **Added** output to support additional addresses for dual stack listeners.
+    **Added** support for displaying multiple addresses of listeners in `istioctl proxy-config listeners`.

--- a/releasenotes/notes/istioctl-additional-address.yaml
+++ b/releasenotes/notes/istioctl-additional-address.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue: []
+
+releaseNotes:
+  - |
+    **Added** output to support additional addresses for dual stack listeners.


### PR DESCRIPTION
**Please provide a description of this PR:**

Support for dual-stack listeners.

Add `ADDITIONAL ADDRESSES` column and support additional listeners in `--address` flag.

```bash
$ ./out/linux_amd64/istioctl pc listeners sleep-645b966fc4-w2xgk  --address "::"                                                                                                                                            130 ↵
ADDRESS PORT  ADDITIONAL ADDRESSES MATCH                                                                                           DESTINATION
0.0.0.0 80    ::                   Trans: raw_buffer; App: http/1.1,h2c                                                            Route: 80
0.0.0.0 80    ::                   ALL                                                                                             PassthroughCluster
0.0.0.0 8000  ::                   Trans: raw_buffer; App: http/1.1,h2c                                                            Route: 8000
0.0.0.0 8000  ::                   ALL                                                                                             PassthroughCluster
0.0.0.0 15001 ::                   ALL                                                                                             PassthroughCluster
0.0.0.0 15001 ::                   Addr: *:15001                                                                                   Non-HTTP/Non-TCP
0.0.0.0 15006 ::                   Addr: *:15006                                                                                   Non-HTTP/Non-TCP
0.0.0.0 15006 ::                   Trans: raw_buffer; Addr: ::/0                                                                   InboundPassthroughClusterIpv6
0.0.0.0 15006 ::                   Trans: tls; App: istio-http/1.0,istio-http/1.1,istio-h2; Addr: ::/0                             InboundPassthroughClusterIpv6
0.0.0.0 15006 ::                   Trans: raw_buffer; App: http/1.1,h2c; Addr: ::/0                                                InboundPassthroughClusterIpv6
0.0.0.0 15006 ::                   Trans: tls; App: TCP TLS; Addr: ::/0                                                            InboundPassthroughClusterIpv6
0.0.0.0 15006 ::                   Trans: tls; Addr: ::/0                                                                          InboundPassthroughClusterIpv6
0.0.0.0 15006 ::                   Trans: raw_buffer; App: http/1.1,h2c; Addr: 0.0.0.0/0                                           InboundPassthroughClusterIpv4
0.0.0.0 15006 ::                   Trans: tls; App: TCP TLS; Addr: 0.0.0.0/0                                                       InboundPassthroughClusterIpv4
0.0.0.0 15006 ::                   Trans: raw_buffer; Addr: 0.0.0.0/0                                                              InboundPassthroughClusterIpv4
0.0.0.0 15006 ::                   Trans: tls; Addr: 0.0.0.0/0                                                                     InboundPassthroughClusterIpv4
0.0.0.0 15006 ::                   Trans: tls; App: istio-http/1.0,istio-http/1.1,istio-h2; Addr: 0.0.0.0/0                        InboundPassthroughClusterIpv4
0.0.0.0 15006 ::                   Trans: tls; App: istio,istio-peer-exchange,istio-http/1.0,istio-http/1.1,istio-h2; Addr: *:8000 Cluster: inbound|8000||
0.0.0.0 15006 ::                   Trans: raw_buffer; Addr: *:8000                                                                 Cluster: inbound|8000||
0.0.0.0 15010 ::                   Trans: raw_buffer; App: http/1.1,h2c                                                            Route: 15010
0.0.0.0 15010 ::                   ALL                                                                                             PassthroughCluster
0.0.0.0 15014 ::                   Trans: raw_buffer; App: http/1.1,h2c                                                            Route: 15014
0.0.0.0 15014 ::                   ALL                                                                                             PassthroughCluster
```