### PR TITLE
install: cleanup warnings

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -149,8 +149,6 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 	return InstallCmdWithArgs(&RootArgs{}, &InstallArgs{}, logOpts)
 }
 
-
-
 func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOut io.Writer, l clog.Logger, p Printer) error {
 	kubeClient, client, err := KubernetesClients(iArgs.KubeConfigPath, iArgs.Context, l)
 	if err != nil {

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -177,7 +177,8 @@ func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOu
 
 	// Warn users if they use `istioctl install` without any config args.
 	if !rootArgs.DryRun && !iArgs.SkipConfirmation {
-		prompt := fmt.Sprintf("This will install the Istio %s %q profile (with components: %s) into the cluster. Proceed? (y/N)", tag, profile, humanReadableJoin(enabledComponents))
+		prompt := fmt.Sprintf("This will install the Istio %s %q profile (with components: %s) into the cluster. Proceed? (y/N)",
+			tag, profile, humanReadableJoin(enabledComponents))
 		if profile == "empty" {
 			prompt = fmt.Sprintf("This will install the Istio %s %s profile into the cluster. Proceed? (y/N)", tag, profile)
 		}


### PR DESCRIPTION
Now:

```
WARNING: Istio is being upgraded from 1.18.0 to 1.19.0.
         Running this command will overwrite it; use revisions to upgrade alongside the existing version.
         Before upgrading, you may wish to use 'istioctl x precheck' to check for upgrade warnings.
This will install the Istio 1.19.0 "default" profile (with components: Istio core, Istiod, and Ingress gateways) into the cluster. Proceed? (y/N)
```

Before:
```
WARNING: Istio control planes installed: 1.18.0.
WARNING: A newer installed version of Istio has been detected. Running this command will overwrite it.
This will install the Istio 1.19.0 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N)
```

I think this is much more clear. The old text sounds like we are overwriting a newer version; we are overwriting an old version though.