### PR TITLE
auto-register connected proxies at WorkloadGroup creation

### DIFF
--- a/pilot/pkg/autoregistration/connections.go
+++ b/pilot/pkg/autoregistration/connections.go
@@ -1,0 +1,114 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoregistration
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/maps"
+)
+
+// Connection from a proxy to a control plane.
+// This interface exists to avoid circular reference to xds.Connection as well
+// as keeps the API surface scoped to what we need for auto-registration logic.
+type Connection interface {
+	ID() string
+	Proxy() *model.Proxy
+	ConnectedAt() time.Time
+	Stop()
+}
+
+// a single proxy may have multiple connections, so we track them here
+// when a WorkloadGroup is deleted, we can force disconnects
+// when OnDisconnect occurs, we only trigger cleanup when there are no more connections for that proxy
+type adsConnections struct {
+	sync.Mutex
+
+	// keyed by proxy id, then connection id
+	byProxy map[proxyKey]map[string]Connection
+}
+
+func newAdsConnections() *adsConnections {
+	return &adsConnections{byProxy: map[proxyKey]map[string]Connection{}}
+}
+
+func (m *adsConnections) ConnectionsForGroup(wg types.NamespacedName) []Connection {
+	// collect the proxies that should be disconnected (don't remove them, OnDisconnect will)
+	m.Lock()
+	defer m.Unlock()
+	var conns []Connection
+	for key, connections := range m.byProxy {
+		if key.GroupName == wg.Name && key.Namespace == wg.Namespace {
+			conns = append(conns, maps.Values(connections)...)
+		}
+	}
+	return conns
+}
+
+func (m *adsConnections) Connect(conn Connection) {
+	m.Lock()
+	defer m.Unlock()
+	k := makeProxyKey(conn.Proxy())
+
+	connections := m.byProxy[k]
+	if connections == nil {
+		connections = make(map[string]Connection)
+		m.byProxy[k] = connections
+	}
+	connections[conn.ID()] = conn
+}
+
+// Disconnect tracks disconnect events of ads clients.
+// Returns false once there are no more connections for the given proxy.
+func (m *adsConnections) Disconnect(conn Connection) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	k := makeProxyKey(conn.Proxy())
+	connections := m.byProxy[k]
+	if connections == nil {
+		return false
+	}
+
+	id := conn.ID()
+	delete(connections, id)
+	if len(connections) == 0 {
+		delete(m.byProxy, k)
+		return false
+	}
+
+	return true
+}
+
+// keys required to uniquely ID a single proxy
+type proxyKey struct {
+	Network   string
+	IP        string
+	GroupName string
+	Namespace string
+}
+
+func makeProxyKey(proxy *model.Proxy) proxyKey {
+	return proxyKey{
+		Network:   string(proxy.Metadata.Network),
+		IP:        proxy.IPAddresses[0],
+		GroupName: proxy.Metadata.AutoRegisterGroup,
+		Namespace: proxy.Metadata.Namespace,
+	}
+}

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -220,7 +220,7 @@ func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
 // If connecting proxy represents a workload that is not using auto-registration,
 // the WorkloadEntry resource is expected to exist beforehand. Otherwise, no special
 // processing will be initiated, e.g. health status updates will be ignored.
-func (c *Controller) OnConnect(conn Connection) error {
+func (c *Controller) OnConnect(conn connection) error {
 	if c == nil {
 		return nil
 	}
@@ -429,7 +429,7 @@ func (c *Controller) changeWorkloadEntryStateToDisconnected(entryName string, pr
 //
 // If proxy represents a workload that is not using auto-registration, WorkloadEntry resource
 // will be scheduled to be marked unhealthy if the proxy does not reconnect within a grace period.
-func (c *Controller) OnDisconnect(conn Connection) {
+func (c *Controller) OnDisconnect(conn connection) {
 	if c == nil {
 		return
 	}

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -182,7 +182,9 @@ func (c *Controller) setupAutoRecreate() {
 				if entryName == "" {
 					continue
 				}
+				proxy.Lock()
 				proxy.WorkloadEntryAutoCreated = true
+				proxy.Unlock()
 				if err := c.registerWorkload(entryName, proxy, conn.ConnectedAt()); err != nil {
 					log.Error(err)
 				}
@@ -245,8 +247,11 @@ func (c *Controller) OnConnect(conn Connection) error {
 	if entryName == "" {
 		return nil
 	}
+
+	proxy.Lock()
 	proxy.WorkloadEntryName = entryName
 	proxy.WorkloadEntryAutoCreated = autoCreate
+	proxy.Unlock()
 
 	c.adsConnections.Connect(conn)
 
@@ -446,6 +451,8 @@ func (c *Controller) OnDisconnect(conn Connection) {
 		return
 	}
 
+	proxy.RLock()
+	defer proxy.RUnlock()
 	workload := &workItem{
 		entryName:   entryName,
 		autoCreated: conn.Proxy().WorkloadEntryAutoCreated,

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -52,7 +52,7 @@ func init() {
 	features.WorkloadEntryCleanupGracePeriod = 50 * time.Millisecond
 }
 
-var _ Connection = &fakeConn{}
+var _ connection = &fakeConn{}
 
 type fakeConn struct {
 	sync.RWMutex

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -62,7 +62,10 @@ type fakeConn struct {
 }
 
 func makeConn(proxy *model.Proxy, connTime time.Time) *fakeConn {
-	return &fakeConn{proxy: proxy, connTime: connTime}
+	// copy the proxy; two conns won't share the same struct
+	p := *proxy
+	p.RWMutex = sync.RWMutex{}
+	return &fakeConn{proxy: &p, connTime: connTime}
 }
 
 func (f *fakeConn) ID() string {

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -62,10 +62,7 @@ type fakeConn struct {
 }
 
 func makeConn(proxy *model.Proxy, connTime time.Time) *fakeConn {
-	// copy the proxy; two conns won't share the same struct
-	p := *proxy
-	p.RWMutex = sync.RWMutex{}
-	return &fakeConn{proxy: &p, connTime: connTime}
+	return &fakeConn{proxy: proxy, connTime: connTime}
 }
 
 func (f *fakeConn) ID() string {
@@ -839,7 +836,7 @@ func checkNoEntryOrFail(
 }
 
 func checkNoEntryHealth(store model.ConfigStoreController, proxy *model.Proxy) error {
-	name := proxy.WorkloadEntryName
+	name, _ := proxy.WorkloadEntry()
 	cfg := store.Get(gvk.WorkloadEntry, name, proxy.Metadata.Namespace)
 	if cfg == nil {
 		return fmt.Errorf("expected WorkloadEntry %s/%s to exist", proxy.Metadata.Namespace, name)
@@ -856,7 +853,7 @@ func checkNoEntryHealth(store model.ConfigStoreController, proxy *model.Proxy) e
 }
 
 func checkEntryHealth(store model.ConfigStoreController, proxy *model.Proxy, healthy bool) (err error) {
-	name := proxy.WorkloadEntryName
+	name, _ := proxy.WorkloadEntry()
 	cfg := store.Get(gvk.WorkloadEntry, name, proxy.Metadata.Namespace)
 	if cfg == nil || cfg.Status == nil {
 		err = multierror.Append(fmt.Errorf("expected workloadEntry %s/%s to exist", name, proxy.Metadata.Namespace))

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,6 +50,43 @@ import (
 
 func init() {
 	features.WorkloadEntryCleanupGracePeriod = 50 * time.Millisecond
+}
+
+var _ Connection = &fakeConn{}
+
+type fakeConn struct {
+	sync.RWMutex
+	proxy    *model.Proxy
+	connTime time.Time
+	stopped  bool
+}
+
+func makeConn(proxy *model.Proxy, connTime time.Time) *fakeConn {
+	return &fakeConn{proxy: proxy, connTime: connTime}
+}
+
+func (f *fakeConn) ID() string {
+	return fmt.Sprintf("%s-%v", f.proxy.IPAddresses[0], f.connTime)
+}
+
+func (f *fakeConn) Proxy() *model.Proxy {
+	return f.proxy
+}
+
+func (f *fakeConn) ConnectedAt() time.Time {
+	return f.connTime
+}
+
+func (f *fakeConn) Stop() {
+	f.Lock()
+	defer f.Unlock()
+	f.stopped = true
+}
+
+func (f *fakeConn) Stopped() bool {
+	f.RLock()
+	defer f.RUnlock()
+	return f.stopped
 }
 
 var (
@@ -140,7 +179,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			c.RegisterWorkload(tc, time.Now())
+			c.OnConnect(makeConn(tc, time.Now()))
 			items := store.List(gvk.WorkloadEntry, model.NamespaceAll)
 			if len(items) != 0 {
 				t.Fatalf("expected 0 WorkloadEntry")
@@ -164,74 +203,79 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 	defer close(stop2)
 	go c1.Run(stop1)
 	go c2.Run(stop2)
+	go store.Run(stop2)
 
 	n := fakeNode("reg1", "zone1", "subzone1")
 
+	var p1conn1, p1conn2 *fakeConn
 	p := fakeProxy("1.2.3.4", wgA, "nw1", "sa-a")
 	p.Locality = n.Locality
 
+	var p2conn1 *fakeConn
 	p2 := fakeProxy("1.2.3.4", wgA, "nw2", "sa-a")
 	p2.Locality = n.Locality
 
+	var p3conn1 *fakeConn
 	p3 := fakeProxy("1.2.3.5", wgA, "nw1", "sa-a")
 	p3.Locality = n.Locality
 
-	// allows associating a Register call with Unregister
-	var origConnTime time.Time
-
 	t.Run("initial registration", func(t *testing.T) {
 		// simply make sure the entry exists after connecting
-		c1.RegisterWorkload(p, time.Now())
+		p1conn1 = makeConn(p, time.Now())
+		c1.OnConnect(p1conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("multinetwork same ip", func(t *testing.T) {
 		// make sure we don't overrwrite a similar entry for a different network
-		c2.RegisterWorkload(p2, time.Now())
+		p2conn1 = makeConn(p2, time.Now())
+		c2.OnConnect(p2conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		checkEntryOrFail(t, store, wgA, p2, n, c2.instanceID)
+		c2.OnDisconnect(p2conn1) // cleanup for future tests
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
-			c1.QueueUnregisterWorkload(p, time.Now())
+			c1.OnDisconnect(p1conn1)
 			checkEntryOrFailAfter(t, store, wgA, p, n, "", features.WorkloadEntryCleanupGracePeriod/2)
 			// reconnect, ensure entry is there with the same instance id
-			origConnTime = time.Now()
-			c1.RegisterWorkload(p, origConnTime)
+			p1conn1 = makeConn(p, time.Now())
+			c1.OnConnect(p1conn1)
 			checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		})
 		t.Run("same instance: connect before disconnect ", func(t *testing.T) {
 			// reconnect, ensure entry is there with the same instance id
-			c1.RegisterWorkload(p, origConnTime.Add(10*time.Millisecond))
+			p1conn2 = makeConn(p, p1conn1.ConnectedAt().Add(10*time.Millisecond))
+			c1.OnConnect(p1conn2)
 			// disconnect (associated with original connect, not the reconnect)
 			// make sure entry is still there with disconnect meta
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(p1conn1)
 			checkEntryOrFailAfter(t, store, wgA, p, n, c1.instanceID, features.WorkloadEntryCleanupGracePeriod/2)
 		})
 		t.Run("different instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect metadata
-			c1.QueueUnregisterWorkload(p, time.Now())
+			c1.OnDisconnect(p1conn2)
 			checkEntryOrFailAfter(t, store, wgA, p, n, "", features.WorkloadEntryCleanupGracePeriod/2)
 			// reconnect, ensure entry is there with the new instance id
-			origConnTime = time.Now()
-			c2.RegisterWorkload(p, origConnTime)
+			p1conn1 = makeConn(p, time.Now())
+			c2.OnConnect(p1conn1)
 			checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
 		})
 	})
 	t.Run("slow reconnect", func(t *testing.T) {
 		// disconnect, wait and make sure entry is gone
-		c2.QueueUnregisterWorkload(p, origConnTime)
+		c2.OnDisconnect(p1conn1)
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkNoEntry(store, wgA, p)
 		})
 		// reconnect
-		origConnTime = time.Now()
-		c1.RegisterWorkload(p, origConnTime)
+		p1conn1 = makeConn(p, time.Now())
+		c1.OnConnect(p1conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("garbage collected if pilot stops after disconnect", func(t *testing.T) {
 		// disconnect, kill the cleanup queue from the first controller
-		c1.QueueUnregisterWorkload(p, origConnTime)
+		c1.OnDisconnect(p1conn1)
 		// stop processing the delayed close queue in c1, forces using periodic cleanup
 		close(stop1)
 		stopped1 = true
@@ -243,27 +287,49 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 
 	t.Run("garbage collected if pilot and workload stops simultaneously before pilot can do anything", func(t *testing.T) {
 		// simulate p3 has been registered long before
-		c2.RegisterWorkload(p3, time.Now().Add(-2*maxConnAge))
+		p3conn1 = makeConn(p3, time.Now().Add(-2*maxConnAge))
+		c2.OnConnect(p3conn1)
 
-		// keep silent to simulate the scenario
+		// keep silent to simulate the scenario (don't OnDisconnect to simulate pilot being down)
 
 		// unfortunately, this retry at worst could be twice as long as the sweep interval
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkNoEntry(store, wgA, p3)
 		}, retry.Timeout(time.Until(time.Now().Add(21*features.WorkloadEntryCleanupGracePeriod))))
+
+		c2.OnDisconnect(p3conn1) // cleanup the state for future tests
 	})
+	t.Run("workload group recreate", func(t *testing.T) {
+		p1conn1 = makeConn(p, time.Now())
+		c2.OnConnect(p1conn1)
+		checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
+
+		name := strings.Join([]string{wgA.Name, p.IPAddresses[0], string(p.Metadata.Network)}, "-")
+		if err := store.Delete(gvk.WorkloadGroup, wgA.Name, wgA.Namespace, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Delete(gvk.WorkloadEntry, name, wgA.Namespace, nil); err != nil {
+			t.Fatal(err)
+		}
+		createOrFail(t, store, wgA)
+
+		retry.UntilSuccessOrFail(t, func() error {
+			return checkEntry(store, wgA, p, n, c2.instanceID)
+		})
+	})
+	c2.OnDisconnect(p1conn1) // cleanup the state for future tests
 	t.Run("unverified client", func(t *testing.T) {
 		p := fakeProxy("1.2.3.6", wgA, "nw1", "")
 
 		// Should fail
-		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		assert.Error(t, c1.OnConnect(makeConn(p, time.Now())))
 		checkNoEntryOrFail(t, store, wgA, p)
 	})
 	t.Run("wrong SA client", func(t *testing.T) {
 		p := fakeProxy("1.2.3.6", wgA, "nw1", "wrong")
 
 		// Should fail
-		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		assert.Error(t, c1.OnConnect(makeConn(p, time.Now())))
 		checkNoEntryOrFail(t, store, wgA, p)
 	})
 	t.Run("wrong NS client", func(t *testing.T) {
@@ -271,7 +337,7 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		p.Metadata.Namespace = "wrong"
 
 		// Should fail
-		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		assert.Error(t, c1.OnConnect(makeConn(p, time.Now())))
 		checkNoEntryOrFail(t, store, wgA, p)
 	})
 	t.Run("no SA WG", func(t *testing.T) {
@@ -279,8 +345,8 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		n := fakeNode("reg0", "zone0", "subzone0")
 		p.Locality = n.Locality
 
-		// Should fail
-		assert.NoError(t, c1.RegisterWorkload(p, time.Now()))
+		// Should not fail
+		assert.NoError(t, c1.OnConnect(makeConn(p, time.Now())))
 		checkEntryOrFail(t, store, wgWithoutSA, p, n, c1.instanceID)
 	})
 	// TODO test garbage collection if pilot stops before disconnect meta is set (relies on heartbeat)
@@ -292,7 +358,8 @@ func TestUpdateHealthCondition(t *testing.T) {
 	go ig.Run(stop)
 	go ig2.Run(stop)
 	p := fakeProxy("1.2.3.4", wgA, "litNw", "sa-a")
-	ig.RegisterWorkload(p, time.Now())
+	p.XdsNode = fakeNode("reg1", "zone1", "subzone1")
+	ig.OnConnect(makeConn(p, time.Now()))
 	t.Run("auto registered healthy health", func(t *testing.T) {
 		ig.QueueWorkloadEntryHealth(p, HealthEvent{
 			Healthy: true,
@@ -392,7 +459,7 @@ func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_WorkloadEntryNotFo
 	// change proxy metadata to make it unsuitable for health checks
 	proxy.Metadata.WorkloadEntry = "non-exisiting-workload-entry"
 
-	err := c.RegisterWorkload(proxy, time.Now())
+	err := c.OnConnect(makeConn(proxy, time.Now()))
 	assert.Error(t, err)
 }
 
@@ -436,7 +503,7 @@ func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_ShouldNotBeTreated
 
 			proxy := tc.proxy(we)
 
-			err := c.RegisterWorkload(proxy, time.Now())
+			err := c.OnConnect(makeConn(proxy, time.Now()))
 			assert.NoError(t, err)
 
 			wle := store.Get(gvk.WorkloadEntry, we.Name, we.Namespace)
@@ -469,7 +536,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldBeTreatedAsCon
 
 			now := time.Now()
 
-			err := c.RegisterWorkload(proxy, now)
+			err := c.OnConnect(makeConn(proxy, now))
 			assert.NoError(t, err)
 
 			wle := store.Get(gvk.WorkloadEntry, we.Name, we.Namespace)
@@ -503,14 +570,14 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 	t.Run("initial connect", func(t *testing.T) {
 		// connect
 		origConnTime = time.Now()
-		c1.RegisterWorkload(p, origConnTime)
+		c1.OnConnect(makeConn(p, origConnTime))
 		// ensure the entry is connected
 		checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 	})
 	t.Run("reconnect", func(t *testing.T) {
 		t.Run("same instance: disconnect then connect", func(t *testing.T) {
 			// disconnect
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// wait until WE get updated asynchronously
 			retry.UntilSuccessOrFail(t, func() error {
 				return checkEntryDisconnected(store, weB)
@@ -519,7 +586,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, "")
 			// reconnect
 			origConnTime = time.Now()
-			c1.RegisterWorkload(p, origConnTime)
+			c1.OnConnect(makeConn(p, origConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 		})
@@ -530,17 +597,17 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 				origConnTime = nextConnTime
 			}()
 			// reconnect
-			c1.RegisterWorkload(p, nextConnTime)
+			c1.OnConnect(makeConn(p, nextConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 			// disconnect (associated with original connect, not the reconnect)
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 		})
 		t.Run("different instance: disconnect then connect", func(t *testing.T) {
 			// disconnect
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// wait until WE get updated asynchronously
 			retry.UntilSuccessOrFail(t, func() error {
 				return checkEntryDisconnected(store, weB)
@@ -549,7 +616,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, "")
 			// reconnect
 			origConnTime = time.Now()
-			c2.RegisterWorkload(p, origConnTime)
+			c2.OnConnect(makeConn(p, origConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 		})
@@ -560,11 +627,11 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 				origConnTime = nextConnTime
 			}()
 			// reconnect to the new instance
-			c2.RegisterWorkload(p, nextConnTime)
+			c2.OnConnect(makeConn(p, nextConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 			// disconnect (associated with original connect, not the reconnect)
-			c2.QueueUnregisterWorkload(p, origConnTime)
+			c2.OnDisconnect(makeConn(p, origConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 		})
@@ -577,7 +644,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 		// ensure health condition has been updated
 		checkHealthOrFail(t, store, p, true)
 		// disconnect
-		c2.QueueUnregisterWorkload(p, origConnTime)
+		c2.OnDisconnect(makeConn(p, origConnTime))
 		// wait until WE get updated asynchronously
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkEntryDisconnected(store, weB)
@@ -602,7 +669,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldUpdateHealthCo
 
 	p := fakeProxySuitableForHealthChecks(weB)
 
-	c1.RegisterWorkload(p, time.Now())
+	c1.OnConnect(makeConn(p, time.Now()))
 
 	t.Run("healthy", func(t *testing.T) {
 		// report workload is healthy

--- a/pilot/pkg/autoregistration/internal/health/controller.go
+++ b/pilot/pkg/autoregistration/internal/health/controller.go
@@ -68,7 +68,7 @@ func (c *Controller) QueueWorkloadEntryHealth(proxy *model.Proxy, event HealthEv
 	// we assume that the workload entry exists
 	// if auto registration does not exist, try looking
 	// up in NodeMetadata
-	entryName := proxy.WorkloadEntryName
+	entryName, _ := proxy.WorkloadEntry()
 	if entryName == "" {
 		log.Errorf("unable to derive WorkloadEntry for health update for %v", proxy.ID)
 		return

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -372,8 +372,8 @@ type Proxy struct {
 	// XdsNode is the xDS node identifier
 	XdsNode *core.Node
 
-	WorkloadEntryName        string
-	WorkloadEntryAutoCreated bool
+	workloadEntryName        string
+	workloadEntryAutoCreated bool
 
 	// LastPushContext stores the most recent push context for this proxy. This will be monotonically
 	// increasing in version. Requests should send config based on this context; not the global latest.
@@ -1316,6 +1316,19 @@ func (node *Proxy) WaypointScope() WaypointScope {
 		Namespace:      node.ConfigNamespace,
 		ServiceAccount: node.Metadata.Annotations[constants.WaypointServiceAccount],
 	}
+}
+
+func (node *Proxy) SetWorkloadEntry(name string, create bool) {
+	node.Lock()
+	defer node.Unlock()
+	node.workloadEntryName = name
+	node.workloadEntryAutoCreated = create
+}
+
+func (node *Proxy) WorkloadEntry() (string, bool) {
+	node.RLock()
+	defer node.RUnlock()
+	return node.workloadEntryName, node.workloadEntryAutoCreated
 }
 
 type GatewayController interface {

--- a/releasenotes/notes/45329.yaml
+++ b/releasenotes/notes/45329.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 45329
+releaseNotes:
+- |
+  **Fixed** when creating a `WorkloadGroup`, `WorkloadEntry` auto-registration will occur immediately for proxies
+  that are already connected.

--- a/tests/fuzz/autoregistration_controller_fuzzer.go
+++ b/tests/fuzz/autoregistration_controller_fuzzer.go
@@ -30,8 +30,6 @@ import (
 	"istio.io/istio/pkg/keepalive"
 )
 
-var _ autoregistration.Connection = &fakeConn{}
-
 type fakeConn struct {
 	proxy    *model.Proxy
 	connTime time.Time


### PR DESCRIPTION
If I have a few connected proxies before I create the WorkloadGroup we can end up in a state where the entries are never registered. 

This is mostly a UX improvement. A user might not realize the order matters. 
Accidental deletion of a WorkloadGroup can trigger cleanup due to owner refs. Recreating the WorkloadEntries would be delayed without either this patch, or forcing a reconnect to ads from each VM. 

