### PR TITLE
Fix MCS integration tests that were implictly skipped

### DIFF
--- a/tests/integration/pilot/mcs/autoexport/autoexport_test.go
+++ b/tests/integration/pilot/mcs/autoexport/autoexport_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 		RequireMinVersion(17).
 		Setup(common.InstallMCSCRDs).
 		Setup(istio.Setup(&i, enableMCSAutoExport)).
-		Setup(common.DeployEchosFunc("se", &echos)).
+		Setup(common.DeployEchosFunc("se", &echos, nil)).
 		Run()
 }
 

--- a/tests/integration/pilot/mcs/common/common.go
+++ b/tests/integration/pilot/mcs/common/common.go
@@ -125,7 +125,7 @@ func DeployEchosFunc(nsPrefix string, d *EchoDeployment) func(t resource.Context
 
 		// Create echo instances in each cluster.
 		d.Instances, err = deployment.New(t).
-			WithClusters(GetSingleNetworkClusters(t.Clusters())...).
+			WithClusters(GetClustersFromSameNetwork(t.Clusters())...).
 			WithConfig(echo.Config{
 				Service:   ServiceA,
 				Namespace: ns,
@@ -140,6 +140,11 @@ func DeployEchosFunc(nsPrefix string, d *EchoDeployment) func(t resource.Context
 	}
 }
 
-func GetSingleNetworkClusters(clusters cluster.Clusters) cluster.Clusters {
-	return clusters.ByNetwork()[clusters.GetByName("primary").NetworkName()]
+func GetClustersFromSameNetwork(clusters cluster.Clusters) cluster.Clusters {
+	for _, clustersInNetwork := range clusters.ByNetwork() {
+		if len(clustersInNetwork) > 1 {
+			return clustersInNetwork
+		}
+	}
+	panic("did not find clusters in the same network")
 }

--- a/tests/integration/pilot/mcs/common/common.go
+++ b/tests/integration/pilot/mcs/common/common.go
@@ -125,7 +125,7 @@ func DeployEchosFunc(nsPrefix string, d *EchoDeployment) func(t resource.Context
 
 		// Create echo instances in each cluster.
 		d.Instances, err = deployment.New(t).
-			WithClusters(t.Clusters()...).
+			WithClusters(GetSingleNetworkClusters(t.Clusters())...).
 			WithConfig(echo.Config{
 				Service:   ServiceA,
 				Namespace: ns,
@@ -138,4 +138,8 @@ func DeployEchosFunc(nsPrefix string, d *EchoDeployment) func(t resource.Context
 			}).Build()
 		return err
 	}
+}
+
+func GetSingleNetworkClusters(clusters cluster.Clusters) cluster.Clusters {
+	return clusters.ByNetwork()[clusters.GetByName("primary").NetworkName()]
 }

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -20,7 +20,6 @@ package discoverability
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"sort"
 	"sync"
 	"testing"
@@ -44,6 +43,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -357,7 +357,6 @@ func createAndCleanupServiceExport(t framework.TestContext, service string, expo
 	}
 
 	// Now wait for ServiceImport to be created
-	//importClusters := serviceA.GetMatches(echos.Instances).Clusters()
 	if common.IsMCSControllerEnabled(t) {
 		scopes.Framework.Infof("Waiting for the MCS Controller to create ServiceImport in each cluster")
 		for _, c := range exportClusters {

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -96,7 +96,7 @@ func TestMeshWide(t *testing.T) {
 		Features("traffic.mcs.servicediscovery").
 		Run(func(t framework.TestContext) {
 			// Export service B in all clusters.
-			createAndCleanupServiceExport(t, common.ServiceB, common.GetSingleNetworkClusters(t.Clusters()))
+			createAndCleanupServiceExport(t, common.ServiceB, common.GetClustersFromSameNetwork(t.Clusters()))
 			serviceA = match.ServiceName(echo.NamespacedName{Name: common.ServiceA, Namespace: echos.Namespace})
 			serviceB = match.ServiceName(echo.NamespacedName{Name: common.ServiceB, Namespace: echos.Namespace})
 			for _, ht := range hostTypes {

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -458,7 +458,7 @@ func createServiceEntry(t framework.TestContext, c cluster.Cluster, svcName, ns 
 		},
 	}
 	if _, err := c.Istio().NetworkingV1alpha3().ServiceEntries(ns).Create(context.TODO(), &svcEntry, metav1.CreateOptions{}); err != nil {
-		t.Errorf("failed to apply service entry: %s", err)
+		t.Errorf("failed to create service entry: %s", err)
 	}
 }
 

--- a/tests/integration/pilot/mcs/discoverability/discoverability_test.go
+++ b/tests/integration/pilot/mcs/discoverability/discoverability_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 		RequireMinClusters(2).
 		Setup(common.InstallMCSCRDs).
 		Setup(istio.Setup(&i, enableMCSServiceDiscovery)).
-		Setup(common.DeployEchosFunc("mcs", &echos)).
+		Setup(common.DeployEchosFunc("mcs", &echos, common.GetClustersFromSameNetwork)).
 		Run()
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

I noticed that MCS tests are silently skipped - look at a random [output](https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/44581/integ-pilot-multicluster_istio/1653051842805895168/build-log.txt) of successful pilot multi-cluster test and you can see the following logs:
```
=== RUN   TestMeshWide
2023-05-01T15:21:42.838305Z	info	tf	=== BEGIN: Test: 'pilot_mcs_discoverability[TestMeshWide]' ===
2023-05-01T15:21:42.838371Z	info	tf	=== BEGIN: Create ServiceExport[cross-network-primary primary remote] ===
2023-05-01T15:21:42.838628Z	info	tf	No MCS Controller running. Manually creating ServiceImport in each cluster
2023-05-01T15:21:42.847031Z	info	tf	=== DONE (success): Create ServiceExport[primary remote cross-network-primary] (8.656724ms) ===
=== RUN   TestMeshWide/clusterset.local
2023-05-01T15:21:42.847284Z	info	tf	=== BEGIN: Test: 'pilot_mcs_discoverability[TestMeshWide/clusterset.local]' ===
    run.go:54: Running tests with: sources [] -> destinations []
2023-05-01T15:21:42.851001Z	info	tf	=== DONE (passed):  Test: 'pilot_mcs_discoverability[TestMeshWide/clusterset.local] (3.70504ms)' ===
=== RUN   TestMeshWide/cluster.local
2023-05-01T15:21:42.851295Z	info	tf	=== BEGIN: Test: 'pilot_mcs_discoverability[TestMeshWide/cluster.local]' ===
    run.go:54: Running tests with: sources [] -> destinations []
2023-05-01T15:21:42.855040Z	info	tf	=== DONE (passed):  Test: 'pilot_mcs_discoverability[TestMeshWide/cluster.local] (3.736767ms)' ===
2023-05-01T15:21:42.855105Z	info	tf	=== DONE (passed):  Test: 'pilot_mcs_discoverability[TestMeshWide] (16.803365ms)' ===
--- PASS: TestMeshWide (0.03s)
    --- PASS: TestMeshWide/clusterset.local (0.00s)
    --- PASS: TestMeshWide/cluster.local (0.00s)
```
Sources and destinations are empty, so actually no test was executed. That was caused by wrong service selector, but when I fixed that, it turned out that the test fails. To make `TesMeshWide` work, I had to add the following changes:
1. Test requests for `*.clusterset.local` are send to/from services only in primary and remote clusters, because when no MCS controller exists, we don't have direct service-to-service connectivity between clusters in different networks, e.g. primary -> cross-network-primary. In other words, without MCS controller we are not able to create VIP that would route traffic across services in all clusters from the cluster set.
2. Services in `*.clusterset.local` were not resolvable, so I enabled DNS proxying and created service entries without addresses to avoid DNS query failure.

I also removed `TestClusterLocal`, because its functionality was already covered by `TestMeshWide` and the only difference was checking that `clusterset.local` is not resolvable by default, so I think it does not make sense to maintain that test.