### PR TITLE
Fix multi-cluster issue by increasing the timeout of listing CRDs

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -344,7 +344,7 @@ func (cl *Client) kind(r config.GroupVersionKind) (*cacheHandler, bool) {
 // knownCRDs returns all CRDs present in the cluster, with timeout and retries.
 func knownCRDs(crdClient apiextensionsclient.Interface) (map[string]struct{}, error) {
 	var res *crd.CustomResourceDefinitionList
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	var err error
 	res, err = crdClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
When a new secret is added, a watcher will be created based on the remote secret. The process can fail if the API server doesn't respond in 10 seconds which can be the case if the cluster contains a lot of CRDs. This PR bumps the timeout to 60 seconds which is the default timeout value (specified in --request-timeout) for requests to API server.

**Please provide a description of this PR:**