### PR TITLE
Refactor kube pkg a bit to drop binary sizes

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -218,8 +218,8 @@ LINUX_AGENT_BINARIES:=./cni/cmd/istio-cni \
 
 BINARIES:=$(STANDARD_BINARIES) $(AGENT_BINARIES) $(LINUX_AGENT_BINARIES)
 
-# List of binaries included in releases
-RELEASE_BINARIES:=pilot-discovery pilot-agent istioctl bug-report
+# List of binaries that have their size tested
+RELEASE_SIZE_TEST_BINARIES:=pilot-discovery pilot-agent istioctl bug-report envoy ztunnel
 
 .PHONY: build
 build: depend ## Builds all go binaries.
@@ -372,7 +372,7 @@ ${TARGET_OUT}/release/_istioctl: ${LOCAL_OUT}/istioctl
 
 .PHONY: binaries-test
 binaries-test:
-	go test ${GOBUILDFLAGS} ./tests/binary/... -v --base-dir ${TARGET_OUT} --binaries="$(RELEASE_BINARIES)"
+	go test ${GOBUILDFLAGS} ./tests/binary/... -v --base-dir ${TARGET_OUT} --binaries="$(RELEASE_SIZE_TEST_BINARIES)"
 
 # istioctl-all makes all of the non-static istioctl executables for each supported OS
 .PHONY: istioctl-all

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -71,7 +71,7 @@ The command also supports reading from a standalone config dump file with flag -
 			}
 			podName, podNamespace, err := handlers.InferPodInfoFromTypedResource(args[0],
 				handlers.HandleNamespace(namespace, defaultNamespace),
-				kubeClient.UtilFactory())
+				MakeKubeFactory(kubeClient))
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/checkinject.go
+++ b/istioctl/cmd/checkinject.go
@@ -70,7 +70,7 @@ Checks associated resources of the given resource, and running webhooks to exami
 			if len(args) == 1 {
 				podName, podNs, err = handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(namespace, defaultNamespace),
-					client.UtilFactory())
+					MakeKubeFactory(client))
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -297,7 +297,7 @@ func envoyDashCmd() *cobra.Command {
 			} else {
 				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(envoyDashNs, defaultNamespace),
-					client.UtilFactory())
+					MakeKubeFactory(client))
 				if err != nil {
 					return err
 				}
@@ -368,7 +368,7 @@ func controlZDashCmd() *cobra.Command {
 			} else {
 				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(addonNamespace, defaultNamespace),
-					client.UtilFactory())
+					MakeKubeFactory(client))
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/kubectl_factory.go
+++ b/istioctl/cmd/kubectl_factory.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/istioctl/cmd/kubectl_factory.go
+++ b/istioctl/cmd/kubectl_factory.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/resource"
+	openapiclient "k8s.io/client-go/openapi"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/openapi"
+	"k8s.io/kubectl/pkg/validation"
+
+	"istio.io/istio/pkg/kube"
+)
+
+type Factory struct {
+	kube.PartialFactory
+	full util.Factory
+}
+
+func (f Factory) NewBuilder() *resource.Builder {
+	return f.full.NewBuilder()
+}
+
+func (f Factory) ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return f.full.ClientForMapping(mapping)
+}
+
+func (f Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return f.full.UnstructuredClientForMapping(mapping)
+}
+
+func (f Factory) Validator(validationDirective string) (validation.Schema, error) {
+	return f.full.Validator(validationDirective)
+}
+
+func (f Factory) OpenAPISchema() (openapi.Resources, error) {
+	return f.full.OpenAPISchema()
+}
+
+func (f Factory) OpenAPIV3Client() (openapiclient.Client, error) {
+	return f.full.OpenAPIV3Client()
+}
+
+var _ util.Factory = Factory{}
+
+// MakeKubeFactory turns a partial kubetl factory from CLIClient into a full util.Factory
+// This is done under istioctl/ to avoid excessive binary bloat in other packages; this pulls in around 10mb of
+// dependencies.
+var MakeKubeFactory = func(k kube.CLIClient) util.Factory {
+	kf := k.UtilFactory()
+	return Factory{
+		PartialFactory: kf,
+		full:           util.NewFactory(kf),
+	}
+}

--- a/istioctl/cmd/mock_test.go
+++ b/istioctl/cmd/mock_test.go
@@ -75,19 +75,19 @@ func (c MockClient) EnvoyDoWithPort(ctx context.Context, podName, podNamespace, 
 	return results, nil
 }
 
-// UtilFactory mock's kubectl's utility factory.  This code sets up a fake factory,
-// similar to the one in https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/describe/describe_test.go
-func (c MockClient) UtilFactory() util.Factory {
-	tf := cmdtesting.NewTestFactory()
-	_, _, codec := cmdtesting.NewExternalScheme()
-	tf.UnstructuredClient = &fake.RESTClient{
-		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
-		Resp: &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     cmdtesting.DefaultHeader(),
-			Body: cmdtesting.ObjBody(codec,
-				cmdtesting.NewInternalType("", "", "foo")),
-		},
+func init() {
+	MakeKubeFactory = func(k kube.CLIClient) util.Factory {
+		tf := cmdtesting.NewTestFactory()
+		_, _, codec := cmdtesting.NewExternalScheme()
+		tf.UnstructuredClient = &fake.RESTClient{
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     cmdtesting.DefaultHeader(),
+				Body: cmdtesting.ObjBody(codec,
+					cmdtesting.NewInternalType("", "", "foo")),
+			},
+		}
+		return tf
 	}
-	return tf
 }

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -1424,7 +1424,7 @@ func getPodNames(podflag string) ([]string, string, error) {
 	}
 	podNames, ns, err := handlers.InferPodsFromTypedResource(podflag,
 		handlers.HandleNamespace(namespace, defaultNamespace),
-		kubeClient.UtilFactory())
+		MakeKubeFactory(kubeClient))
 	if err != nil {
 		log.Errorf("pods lookup failed")
 		return []string{}, "", err
@@ -1444,7 +1444,7 @@ func getPodNameWithNamespace(podflag, ns string) (string, string, error) {
 	var podName, podNamespace string
 	podName, podNamespace, err = handlers.InferPodInfoFromTypedResource(podflag,
 		handlers.HandleNamespace(namespace, ns),
-		kubeClient.UtilFactory())
+		MakeKubeFactory(kubeClient))
 	if err != nil {
 		return "", "", err
 	}

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -74,7 +74,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			if len(args) > 0 {
 				podName, ns, err := handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(namespace, defaultNamespace),
-					kubeClient.UtilFactory())
+					MakeKubeFactory(kubeClient))
 				if err != nil {
 					return err
 				}
@@ -200,7 +200,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			if len(args) > 0 {
 				podName, ns, err := handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(namespace, defaultNamespace),
-					kubeClient.UtilFactory())
+					MakeKubeFactory(kubeClient))
 				if err != nil {
 					return err
 				}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -68,7 +68,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubectl/pkg/cmd/util"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapibeta "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
@@ -227,7 +226,7 @@ type CLIClient interface {
 		expirationSeconds int64) (credentials.PerRPCCredentials, error)
 
 	// UtilFactory returns a kubectl factory
-	UtilFactory() util.Factory
+	UtilFactory() PartialFactory
 
 	// SetPortManager overrides the default port manager to provision local ports
 	SetPortManager(PortManager)
@@ -330,7 +329,7 @@ type fakeClient interface {
 
 // Client is a helper wrapper around the Kube RESTClient for istioctl -> Pilot/Envoy/Mesh related things
 type client struct {
-	clientFactory util.Factory
+	clientFactory *clientFactory
 	config        *rest.Config
 	clusterID     cluster.ID
 
@@ -1069,7 +1068,7 @@ func (c *client) CreatePerRPCCredentials(_ context.Context, tokenNamespace, toke
 	return NewRPCCredentials(c, tokenNamespace, tokenServiceAccount, audiences, expirationSeconds, 60)
 }
 
-func (c *client) UtilFactory() util.Factory {
+func (c *client) UtilFactory() PartialFactory {
 	return c.clientFactory
 }
 

--- a/pkg/kube/client_factory.go
+++ b/pkg/kube/client_factory.go
@@ -147,7 +147,11 @@ func (c *clientFactory) KubernetesClientSet() (*kubernetes.Clientset, error) {
 }
 
 func (c *clientFactory) RESTClient() (*rest.RESTClient, error) {
-	return c.RESTClient()
+	clientConfig, err := c.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return rest.RESTClientFor(clientConfig)
 }
 
 type rESTClientGetter interface {

--- a/pkg/kube/client_factory.go
+++ b/pkg/kube/client_factory.go
@@ -21,30 +21,26 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	diskcached "k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	openapiclient "k8s.io/client-go/openapi"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/openapi"
-	"k8s.io/kubectl/pkg/validation"
 
 	"istio.io/istio/pkg/lazy"
 )
 
-var _ util.Factory = &clientFactory{}
+var _ PartialFactory = &clientFactory{}
 
-// clientFactory implements the kubectl util.Factory, which is provides access to various k8s clients.
+// clientFactory partially implements the kubectl util.Factory, which is provides access to various k8s clients.
+// The full Factory can be built with MakeKubeFactory.
+// This split is to avoid huge dependencies.
 type clientFactory struct {
 	clientConfig clientcmd.ClientConfig
-	factory      util.Factory
 
 	expander lazy.Lazy[meta.RESTMapper]
 	mapper   lazy.Lazy[meta.ResettableRESTMapper]
@@ -58,7 +54,6 @@ func newClientFactory(clientConfig clientcmd.ClientConfig, diskCache bool) *clie
 		clientConfig: clientConfig,
 	}
 
-	out.factory = util.NewFactory(out)
 	out.discoveryClient = lazy.NewWithRetry(func() (discovery.CachedDiscoveryInterface, error) {
 		restConfig, err := out.ToRESTConfig()
 		if err != nil {
@@ -152,29 +147,29 @@ func (c *clientFactory) KubernetesClientSet() (*kubernetes.Clientset, error) {
 }
 
 func (c *clientFactory) RESTClient() (*rest.RESTClient, error) {
-	return c.factory.RESTClient()
+	return c.RESTClient()
 }
 
-func (c *clientFactory) NewBuilder() *resource.Builder {
-	return c.factory.NewBuilder()
+type rESTClientGetter interface {
+	// ToRESTConfig returns restconfig
+	ToRESTConfig() (*rest.Config, error)
+	// ToDiscoveryClient returns discovery client
+	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	// ToRESTMapper returns a restmapper
+	ToRESTMapper() (meta.RESTMapper, error)
+	// ToRawKubeConfigLoader return kubeconfig loader as-is
+	ToRawKubeConfigLoader() clientcmd.ClientConfig
 }
 
-func (c *clientFactory) ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
-	return c.factory.ClientForMapping(mapping)
-}
+type PartialFactory interface {
+	rESTClientGetter
 
-func (c *clientFactory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
-	return c.factory.UnstructuredClientForMapping(mapping)
-}
+	// DynamicClient returns a dynamic client ready for use
+	DynamicClient() (dynamic.Interface, error)
 
-func (c *clientFactory) Validator(validationDirective string) (validation.Schema, error) {
-	return c.factory.Validator(validationDirective)
-}
+	// KubernetesClientSet gives you back an external clientset
+	KubernetesClientSet() (*kubernetes.Clientset, error)
 
-func (c *clientFactory) OpenAPISchema() (openapi.Resources, error) {
-	return c.factory.OpenAPISchema()
-}
-
-func (c *clientFactory) OpenAPIV3Client() (openapiclient.Client, error) {
-	return c.factory.OpenAPIV3Client()
+	// Returns a RESTClient for accessing Kubernetes resources or an error.
+	RESTClient() (*rest.RESTClient, error)
 }

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/version"
 )
 
@@ -40,6 +41,9 @@ func TestMain(m *testing.M) {
 
 func TestVersion(t *testing.T) {
 	runBinariesTest(t, func(t *testing.T, name string) {
+		if nonGoBinaries.Contains(name) {
+			return
+		}
 		cmd := path.Join(*releasedir, name)
 		args := []string{"version", "-ojson"}
 		if name == "istioctl" {
@@ -66,9 +70,14 @@ func TestVersion(t *testing.T) {
 	})
 }
 
+var nonGoBinaries = sets.New("ztunnel", "envoy")
+
 // Test that flags do not get polluted with unexpected flags
 func TestFlags(t *testing.T) {
 	runBinariesTest(t, func(t *testing.T, name string) {
+		if nonGoBinaries.Contains(name) {
+			return
+		}
 		cmd := path.Join(*releasedir, name)
 		out, err := exec.Command(cmd, "--help").Output()
 		if err != nil {
@@ -92,10 +101,12 @@ func TestBinarySizes(t *testing.T) {
 		// TODO: shrink the ranges here once the active work to reduce binary size is complete
 		// For now, having two small a range will result in lots of "merge conflicts"
 		"istioctl":    {60, 100},
-		"pilot-agent": {30, 47},
+		"pilot-agent": {30, 44},
 		// TODO(https://github.com/kubernetes/kubernetes/issues/101384) bump this down a bit?
-		"pilot-discovery": {60, 99},
-		"bug-report":      {60, 100},
+		"pilot-discovery": {60, 85},
+		"bug-report":      {60, 85},
+		"envoy":      {60, 105},
+		"ztunnel":      {15, 25},
 	}
 
 	runBinariesTest(t, func(t *testing.T, name string) {

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -105,8 +105,8 @@ func TestBinarySizes(t *testing.T) {
 		// TODO(https://github.com/kubernetes/kubernetes/issues/101384) bump this down a bit?
 		"pilot-discovery": {60, 85},
 		"bug-report":      {60, 85},
-		"envoy":      {60, 105},
-		"ztunnel":      {15, 25},
+		"envoy":           {60, 110},
+		"ztunnel":         {15, 25},
 	}
 
 	runBinariesTest(t, func(t *testing.T, name string) {


### PR DESCRIPTION
Trims 10mb off the istiod binary by removing kubectl dependency.

Also update the binary test to "lock in" the improvement.