### PR TITLE
[release-1.16] Fix duplicate response_code entry in envoy_bootstrap.json

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -44,11 +44,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -44,11 +44,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -39,11 +39,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -54,11 +54,7 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)",
-        "tag_name": "response_code"
-      },
-      {
-        "regex": "_rq(_(\\d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
         "tag_name": "response_code"
       },
       {


### PR DESCRIPTION
This fixes an issue when running with an old (1.14) sidecar:
```
critical    envoy main    error initializing configuration 'etc/istio/proxy/envoy-rev.json': Tag name 'response_code' specified twice.
```

It mixes the two regular expressions into one to avoid the error. A [different approach was merged in master](https://github.com/istio/istio/pull/44154), but it's not compatible with 1.16.

Related issue: https://github.com/istio/istio/issues/42716
