### PR TITLE
[Cherry-Pick] Skip runtime resources when analyzing files 

### DIFF
--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -62,4 +63,15 @@ func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
 	err := errorIfMessagesExceedThreshold(msgs)
 
 	g.Expect(err).To(BeNil())
+}
+
+func TestSkipPodsInFiles(t *testing.T) {
+	c := testCase{
+		args: strings.Split(
+			"analyze -A --use-kube=false --failure-threshold ERROR testdata/analyze-file/public-gateway.yaml",
+			" "),
+		wantException: false,
+	}
+
+	verifyOutput(t, c)
 }

--- a/istioctl/cmd/testdata/analyze-file/public-gateway.yaml
+++ b/istioctl/cmd/testdata/analyze-file/public-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: public-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: gateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -890,12 +890,6 @@ func setupAnalyzerForCase(tc testCase, cr local.CollectionReporterFn) (*local.Is
 		}
 	}
 
-	// Include default resources
-	err := sa.AddDefaultResources()
-	if err != nil {
-		return nil, fmt.Errorf("error adding default resources: %v", err)
-	}
-
 	// Gather test files
 	var files []local.ReaderSource
 	for _, f := range tc.inputFiles {
@@ -907,9 +901,15 @@ func setupAnalyzerForCase(tc testCase, cr local.CollectionReporterFn) (*local.Is
 	}
 
 	// Include resources from test files
-	err = sa.AddReaderKubeSource(files)
+	err := sa.AddTestReaderKubeSource(files)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up file kube source on testcase %s: %v", tc.name, err)
+	}
+
+	// Include default resources
+	err = sa.AddDefaultResources()
+	if err != nil {
+		return nil, fmt.Errorf("error adding default resources: %v", err)
 	}
 
 	return sa, nil

--- a/pkg/config/legacy/util/kuberesource/resources.go
+++ b/pkg/config/legacy/util/kuberesource/resources.go
@@ -19,59 +19,30 @@ import (
 
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
-func SkipExcludedCollections(requiredCols collection.Names, excludedResourceKinds []string, enableServiceDiscovery bool) collection.Schemas {
+func ConvertInputsToSchemas(inputs collection.Names) collection.Schemas {
 	resultBuilder := collection.NewSchemasBuilder()
-	for _, name := range requiredCols {
-		s, f := collections.All.Find(name.String())
+	for _, cn := range inputs {
+		s, f := collections.All.Find(cn.String())
 		if !f {
 			continue
 		}
-		disabled := false
-		if isKindExcluded(excludedResourceKinds, s.Resource().Kind()) {
-			// Found a matching exclude directive for this KubeResource. Disable the resource.
-			disabled = true
-
-			// Check and see if this is needed for Service Discovery. If needed, we will need to re-enable.
-			if enableServiceDiscovery {
-				if IsRequiredForServiceDiscovery(s.Resource()) {
-					// This is needed for service discovery. Re-enable.
-					disabled = false
-				}
-			}
-		}
-
-		if disabled {
-			continue
-		}
-
 		_ = resultBuilder.Add(s)
 	}
 
 	return resultBuilder.Build()
 }
 
-// DefaultExcludedResourceKinds returns the default list of resource kinds to exclude.
-func DefaultExcludedResourceKinds() []string {
-	resources := make([]string, 0)
+func DefaultExcludedSchemas() collection.Schemas {
+	resultBuilder := collection.NewSchemasBuilder()
 	for _, r := range collections.Kube.All() {
-		if IsDefaultExcluded(r.Resource()) {
-			resources = append(resources, r.Resource().Kind())
-		}
-	}
-	return resources
-}
-
-func isKindExcluded(excludedResourceKinds []string, kind string) bool {
-	for _, excludedKind := range excludedResourceKinds {
-		if kind == excludedKind {
-			return true
+		if IsDefaultExcluded(r) {
+			_ = resultBuilder.Add(r)
 		}
 	}
 
-	return false
+	return resultBuilder.Build()
 }
 
 // the following code minimally duplicates logic from galley/pkg/config/source/kube/rt/known.go
@@ -92,12 +63,8 @@ func asTypesKey(group, kind string) string {
 	return fmt.Sprintf("%s/%s", group, kind)
 }
 
-func IsRequiredForServiceDiscovery(res resource.Schema) bool {
-	key := asTypesKey(res.Group(), res.Kind())
+func IsDefaultExcluded(res collection.Schema) bool {
+	key := asTypesKey(res.Resource().Group(), res.Resource().Kind())
 	_, ok := knownTypes[key]
 	return ok
-}
-
-func IsDefaultExcluded(res resource.Schema) bool {
-	return IsRequiredForServiceDiscovery(res)
 }

--- a/releasenotes/notes/44506.yaml
+++ b/releasenotes/notes/44506.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 40861
+releaseNotes:
+  - |
+    **Fixed** `istioctl analyze` no longer expects pods and runtime resources when analyzing files.

--- a/tests/integration/pilot/analyze_test.go
+++ b/tests/integration/pilot/analyze_test.go
@@ -136,9 +136,9 @@ func TestDirectoryWithRecursion(t *testing.T) {
 
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
-			// Recursive is true, so we should see two errors (SchemaValidationError and UnknownAnnotation).
+			// Recursive is true, so we should see one error (SchemaValidationError).
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, "--recursive=true", dirWithConfig)
-			expectMessages(t, g, output, msg.SchemaValidationError, msg.UnknownAnnotation)
+			expectMessages(t, g, output, msg.SchemaValidationError)
 			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
@@ -195,7 +195,8 @@ func TestJsonInputFile(t *testing.T) {
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
 			// Validation error if we have a gateway with invalid selector.
-			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, jsonGatewayFile)
+			applyFileOrFail(t, ns.Name(), jsonGatewayFile)
+			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
 			expectMessages(t, g, output, msg.ReferencedResourceNotFound)
 			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
@@ -216,30 +217,18 @@ func TestJsonOutput(t *testing.T) {
 
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 
-			testcases := []struct {
-				name     string
-				args     []string
-				messages []*diag.MessageType
-			}{
-				{
-					name:     "no other output except analysis json output",
-					args:     []string{jsonGatewayFile, jsonOutput},
-					messages: []*diag.MessageType{msg.ReferencedResourceNotFound},
-				},
-				{
-					name:     "invalid file does not output error in stdout",
-					args:     []string{invalidExtensionFile, jsonOutput},
-					messages: []*diag.MessageType{},
-				},
-			}
+			t.NewSubTest("no other output except analysis json output").Run(func(t framework.TestContext) {
+				applyFileOrFail(t, ns.Name(), jsonGatewayFile)
+				stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), true, jsonOutput)
+				expectJSONMessages(t, g, stdout, msg.ReferencedResourceNotFound)
+				g.Expect(err).To(BeNil())
+			})
 
-			for _, tc := range testcases {
-				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
-					stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), false, tc.args...)
-					expectJSONMessages(t, g, stdout, tc.messages...)
-					g.Expect(err).To(BeNil())
-				})
-			}
+			t.NewSubTest("invalid file does not output error in stdout").Run(func(t framework.TestContext) {
+				stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), false, invalidExtensionFile, jsonOutput)
+				expectJSONMessages(t, g, stdout)
+				g.Expect(err).To(BeNil())
+			})
 		})
 }
 
@@ -427,7 +416,7 @@ func expectJSONMessages(t test.Failer, g *GomegaWithT, output string, expected .
 
 	var j []map[string]any
 	if err := json.Unmarshal([]byte(output), &j); err != nil {
-		t.Fatal(err)
+		t.Fatal(err, output)
 	}
 
 	g.Expect(j).To(HaveLen(len(expected)))


### PR DESCRIPTION
Cherry-Pick of #44506

Fixes #44662 

* Skip runtime resources when analyzing files

* add test data and fmt

* add support for tests to analyze pods

* update analyze test to respect file exclusions

* show failed json in message

* fix json formatting

* differentiate json analyzer tests

* add release note
