### PR TITLE
deployment controller: add leaderelection back

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -24,3 +24,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["delete"]
 
+# For gateway deployment controller
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "update", "patch", "create"]

--- a/manifests/charts/istiod-remote/templates/role.yaml
+++ b/manifests/charts/istiod-remote/templates/role.yaml
@@ -25,4 +25,8 @@ rules:
   resources: ["configmaps"]
   verbs: ["delete"]
 
+# For gateway deployment controller
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "update", "patch", "create"]
 {{- end }}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -170,17 +170,25 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		})
 		if features.EnableGatewayAPIDeploymentController {
 			s.addTerminatingStartFunc("gateway deployment controller", func(stop <-chan struct{}) error {
-				// We can only run this if the Gateway CRD is created
-				if configController.WaitForCRD(gvk.KubernetesGateway, stop) {
-					tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
-					controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID,
-						s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
-					// Start informers again. This fixes the case where informers for namespace do not start,
-					// as we create them only after the CRD is created.
-					s.kubeClient.RunAndWait(stop)
-					go tagWatcher.Run(stop)
-					controller.Run(stop)
-				}
+				leaderelection.
+					NewPerRevisionLeaderElection(args.Namespace, args.PodName, leaderelection.GatewayDeploymentController, args.Revision, s.kubeClient).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						// We can only run this if the Gateway CRD is created
+						if configController.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
+							tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
+							controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID,
+								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
+							// Start informers again. This fixes the case where informers for namespace do not start,
+							// as we create them only after acquiring the leader lock
+							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+							// basically lazy loading the informer, if we stop it when we lose the lock we will never
+							// recreate it again.
+							s.kubeClient.RunAndWait(stop)
+							go tagWatcher.Run(leaderStop)
+							controller.Run(leaderStop)
+						}
+					}).
+					Run(stop)
 				return nil
 			})
 		}

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -47,6 +47,13 @@ const (
 	GatewayStatusController = "istio-gateway-status-leader"
 	StatusController        = "istio-status-leader"
 	AnalyzeController       = "istio-analyze-leader"
+	// GatewayDeploymentController controls translating Kubernetes Gateway objects into various derived
+	// resources (Service, Deployment, etc).
+	// Unlike other types which use ConfigMaps, we use a Lease here. This is because:
+	// * Others use configmap for backwards compatibility
+	// * This type is per-revision, so it is higher cost. Leases are cheaper
+	// * Other types use "prioritized leader election", which isn't implemented for Lease
+	GatewayDeploymentController = "istio-gateway-deployment"
 )
 
 // Leader election key prefix for remote istiod managed clusters
@@ -67,6 +74,7 @@ type LeaderElection struct {
 
 	// Criteria to determine leader priority.
 	revision       string
+	perRevision    bool
 	remote         bool
 	defaultWatcher revisions.DefaultWatcher
 
@@ -140,7 +148,7 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 	if l.remote {
 		key = remoteIstiodPrefix + key
 	}
-	lock := k8sresourcelock.ConfigMapLock{
+	var lock k8sresourcelock.Interface = &k8sresourcelock.ConfigMapLock{
 		ConfigMapMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
 		Client:        l.client.CoreV1(),
 		LockConfig: k8sresourcelock.ResourceLockConfig{
@@ -148,9 +156,19 @@ func (l *LeaderElection) create() (*k8sleaderelection.LeaderElector, error) {
 			Key:      key,
 		},
 	}
+	if l.perRevision {
+		lock = &k8sresourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
+			Client:    l.client.CoordinationV1(),
+			// Note: Key is NOT used. This is not implemented in the library for Lease nor needed, since this is already per-revision.
+			LockConfig: k8sresourcelock.ResourceLockConfig{
+				Identity: l.name,
+			},
+		}
+	}
 
 	config := k8sleaderelection.LeaderElectionConfig{
-		Lock:          &lock,
+		Lock:          lock,
 		LeaseDuration: l.ttl,
 		RenewDeadline: l.ttl / 2,
 		RetryPeriod:   l.ttl / 4,
@@ -189,11 +207,22 @@ func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) *LeaderEle
 	return l
 }
 
+// NewLeaderElection creates a leader election instance with the provided ID. This follows standard Kubernetes
+// elections, with one difference: the "default" revision will steal the lock from other revisions.
 func NewLeaderElection(namespace, name, electionID, revision string, client kube.Client) *LeaderElection {
-	return NewLeaderElectionMulticluster(namespace, name, electionID, revision, false, client)
+	return newLeaderElection(namespace, name, electionID, revision, false, false, client)
+}
+
+// NewPerRevisionLeaderElection creates a *per revision* leader election. This means there will be one leader for each revision.
+func NewPerRevisionLeaderElection(namespace, name, electionID, revision string, client kube.Client) *LeaderElection {
+	return newLeaderElection(namespace, name, electionID, revision, true, false, client)
 }
 
 func NewLeaderElectionMulticluster(namespace, name, electionID, revision string, remote bool, client kube.Client) *LeaderElection {
+	return newLeaderElection(namespace, name, electionID, revision, false, true, client)
+}
+
+func newLeaderElection(namespace, name, electionID, revision string, perRevision bool, remote bool, client kube.Client) *LeaderElection {
 	var watcher revisions.DefaultWatcher
 	if features.EnableLeaderElection {
 		watcher = revisions.NewDefaultWatcher(client, revision)
@@ -202,12 +231,16 @@ func NewLeaderElectionMulticluster(namespace, name, electionID, revision string,
 		hn, _ := os.Hostname()
 		name = fmt.Sprintf("unknown-%s", hn)
 	}
+	if perRevision && revision != "" {
+		electionID += "-" + revision
+	}
 	return &LeaderElection{
 		namespace:      namespace,
 		name:           name,
 		client:         client.Kube(),
 		electionID:     electionID,
 		revision:       revision,
+		perRevision:    perRevision,
 		enabled:        features.EnableLeaderElection,
 		remote:         remote,
 		defaultWatcher: watcher,


### PR DESCRIPTION
This effectively reverts https://github.com/istio/istio/pull/44234, which has not been released.

After thinking this through more, I don't think its safe to have no leader elections. This relies on the assumption that within a revision all instances will behave identically. However, we have seen multiple cases where this is not true. When this happens, the result is an endless cycle of reconciling the deployments back and forth, causing churn and confusion. This can happen from something as simple as a rolling upgrade, for example.

The reason to remove it was simplicity and performance. This would be the first per-revision leader election, which means it scales with number of revisions instead of O(1). However, we can mitigate this. We have been using configmaps for locks, but kubernetes has a purpose-built API for this - Lease - which is far cheaper. So by adopting Lease (which is pretty simple) we can mitigate most of the perf overhead, and still use leader election.