### PR TITLE
Remove RunAsUser from bookinfo deployments

### DIFF
--- a/releasenotes/notes/bookinfo-openshift.yaml
+++ b/releasenotes/notes/bookinfo-openshift.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: documentation
+docs:
+- 'https://istio.io/latest/docs/setup/platform-setup/openshift/'
+releaseNotes:
+- |
+    **Improved** Bookinfo samples can now be used in OpenShift without the `anyuid` SCC privilege

--- a/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
@@ -56,6 +56,4 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -43,6 +43,4 @@ spec:
         env:
         - name: DO_NOT_ENCRYPT
           value: "true"
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -54,6 +54,4 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
@@ -78,8 +78,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Ratings service
@@ -133,8 +131,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Reviews service
@@ -196,8 +192,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -238,8 +232,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -280,8 +272,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -347,8 +337,6 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: tmp
         emptyDir: {}

--- a/samples/bookinfo/platform/kube/bookinfo-psa.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-psa.yaml
@@ -69,7 +69,6 @@ spec:
         ports:
         - containerPort: 9080
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -127,7 +126,6 @@ spec:
         ports:
         - containerPort: 9080
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -193,7 +191,6 @@ spec:
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -240,7 +237,6 @@ spec:
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -287,7 +283,6 @@ spec:
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -357,7 +352,6 @@ spec:
         - name: tmp
           mountPath: /tmp
         securityContext:
-          runAsUser: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
@@ -56,6 +56,4 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -50,6 +50,4 @@ spec:
             value: password
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -53,6 +53,4 @@ spec:
             value: password
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -60,6 +60,4 @@ spec:
             value: mongodb://mongodb:27017/test
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -54,6 +54,4 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -48,8 +48,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -76,8 +76,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Ratings service
@@ -129,8 +127,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Reviews service
@@ -190,8 +186,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -232,8 +226,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -274,8 +266,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -339,8 +329,6 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: tmp
         emptyDir: {}

--- a/samples/bookinfo/src/details/Dockerfile
+++ b/samples/bookinfo/src/details/Dockerfile
@@ -25,3 +25,5 @@ EXPOSE 9080
 WORKDIR /opt/microservices
 
 CMD ["ruby", "details.rb", "9080"]
+
+USER 1000

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -36,3 +36,5 @@ WORKDIR /opt/microservices
 RUN python -m unittest discover
 
 CMD ["python", "productpage.py", "9080"]
+
+USER 1000

--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:12.18.1-slim
+FROM node:18.16-slim
 
 #hadolint ignore=DL3008
 RUN apt-get update \
@@ -29,3 +29,5 @@ RUN npm install
 
 EXPOSE 9080
 CMD ["node", "/opt/microservices/ratings.js", "9080"]
+
+USER 1000


### PR DESCRIPTION
They were put in place so that containers do not run as UID 0.

OpenShift has some contraints around the `RunAsUser` field, not allowing "random" values such as 1000 in it.

Changing the docker images to run as user 1000 fixes the issue on both Kubernetes and OpenShift.

When the `RunAsUser` field is not present, Kubernetes will honor the value specified in the Dockefile, and OpenShift will automatically assign a UID that satisfies its requirements.
