### PR TITLE
[1.18] deployment controller: add leaderelection back (#44746)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -24,3 +24,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["delete"]
 
+# For gateway deployment controller
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "update", "patch", "create"]

--- a/manifests/charts/istiod-remote/templates/role.yaml
+++ b/manifests/charts/istiod-remote/templates/role.yaml
@@ -25,4 +25,8 @@ rules:
   resources: ["configmaps"]
   verbs: ["delete"]
 
+# For gateway deployment controller
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "update", "patch", "create"]
 {{- end }}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -170,17 +170,25 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		})
 		if features.EnableGatewayAPIDeploymentController {
 			s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-				// We can only run this if the Gateway CRD is created
-				if configController.WaitForCRD(gvk.KubernetesGateway, stop) {
-					tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
-					controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID,
-						s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
-					// Start informers again. This fixes the case where informers for namespace do not start,
-					// as we create them only after the CRD is created.
-					s.kubeClient.RunAndWait(stop)
-					go tagWatcher.Run(stop)
-					controller.Run(stop)
-				}
+				leaderelection.
+					NewPerRevisionLeaderElection(args.Namespace, args.PodName, leaderelection.GatewayDeploymentController, args.Revision, s.kubeClient).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						// We can only run this if the Gateway CRD is created
+						if configController.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
+							tagWatcher := revisions.NewTagWatcher(s.kubeClient, args.Revision)
+							controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID,
+								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
+							// Start informers again. This fixes the case where informers for namespace do not start,
+							// as we create them only after acquiring the leader lock
+							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+							// basically lazy loading the informer, if we stop it when we lose the lock we will never
+							// recreate it again.
+							s.kubeClient.RunAndWait(stop)
+							go tagWatcher.Run(leaderStop)
+							controller.Run(leaderStop)
+						}
+					}).
+					Run(stop)
 				return nil
 			})
 		}


### PR DESCRIPTION
This is needed in 1.18 to avoid a regression in 1.18; this is new code in 1.18.

* Add per-revision leader election

* Add leader election for deployment controller

(cherry picked from commit acd30f96ef24f8bfc0cdd72a996ee90c27cea8d5)

Fixes https://github.com/istio/istio/issues/44763