### PR TITLE
Add excludeInterfaces support in pilot-agent (#41271)

### DIFF
--- a/releasenotes/notes/44777.yaml
+++ b/releasenotes/notes/44777.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: 
+  - 41271
+releaseNotes:
+  - |
+    **Added** support for traffic.sidecar.istio.io/excludeInterfaces annotation in proxy.


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR helps to provide an option to scenarios/issues such as #41271 where the user can choose to exclude interfaces handled by proxy in a pod with multiple interfaces. The current behaviour fails to start the pilot-agent where ipv6 is expected to be primary but ipv4 is selected instead by proxy as primary.
Excludeinterfaces option via annotations is available for istio-iptables. So, added workflow in pilot-agent startup to handle excluded interfaces.





cc: @abasitt (reporter of the issue)