### PR TITLE
Ordering of rbac filter relative to tcp filters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -831,25 +830,9 @@ func (lb *ListenerBuilder) buildInboundNetworkFilters(fcc inboundChainConfig) []
 		filters = append(filters, buildMetadataExchangeNetworkFilters(istionetworking.ListenerClassSidecarInbound)...)
 	}
 	filters = append(filters, lb.authzCustomBuilder.BuildTCP()...)
-	filters = append(filters, lb.authzBuilder.BuildTCP()...)
 	filters = append(filters, buildMetricsNetworkFilters(lb.push, lb.node, istionetworking.ListenerClassSidecarInbound)...)
 	filters = append(filters, buildNetworkFiltersStack(fcc.port.Protocol, tcpFilter, statPrefix, fcc.clusterName)...)
-
-	sort.SliceStable(filters, func(i, j int) bool {
-		iName := filters[i].Name
-		jName := filters[j].Name
-		iMysql := strings.HasSuffix(iName, "mysql_proxy")
-		jMysql := strings.HasSuffix(jName, "mysql_proxy")
-		iRbac := strings.HasSuffix(iName, "rbac")
-		jRbac := strings.HasSuffix(jName, "rbac")
-		if iMysql && jRbac {
-			return true
-		} else if jMysql && iRbac {
-			return false
-		} else {
-			return i < j
-		}
-	})
+	filters = append(filters, lb.authzBuilder.BuildTCP()...)
 
 	return filters
 }

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -124,6 +124,7 @@ func TestMysqlWithRbacFilterOrder(t *testing.T) {
 	}
 
 	listenerBuilder := NewListenerBuilder(cg.SetupProxy(nil), pushContext)
+
 	listenerFilters := listenerBuilder.buildInboundNetworkFilters(fcc)
 
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
**Please provide a description of this PR:**

A description of the issue can be reviewed with issue #41013
The PR addresses the issue by altering the ordering of the network filters so that the rbac filter comes after the mysql and tcp proxies.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Networking
- [ ] Security