### PR TITLE
Don't fire mesh removal events for ztunnel (#44762)

### DIFF
--- a/cni/pkg/ambient/informers.go
+++ b/cni/pkg/ambient/informers.go
@@ -56,6 +56,7 @@ func (s *Server) ReconcileNamespaces() {
 }
 
 // EnqueueNamespace takes a Namespace and enqueues all Pod objects that make need an update
+// TODO it is sort of pointless/confusing/implicit to populate Old and New with the same reference here
 func (s *Server) EnqueueNamespace(o controllers.Object) {
 	namespace := o.GetName()
 	matchAmbient := o.GetLabels()[constants.DataplaneMode] == constants.DataplaneModeAmbient
@@ -71,10 +72,16 @@ func (s *Server) EnqueueNamespace(o controllers.Object) {
 	} else {
 		log.Infof("Namespace %s is disabled from ambient mesh", namespace)
 		for _, pod := range s.pods.List(namespace, klabels.Everything()) {
-			s.queue.Add(controllers.Event{
-				New:   pod,
-				Event: controllers.EventDelete,
-			})
+			// ztunnel pods are never "removed from the mesh", so do not fire
+			// spurious Delete events for them to avoid triggering extra
+			// ztunnel node reconciliation checks.
+			if !ztunnelPod(pod) {
+				s.queue.Add(controllers.Event{
+					New:   pod,
+					Old:   pod,
+					Event: controllers.EventDelete,
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

As mentioned in https://github.com/istio/istio/issues/44762, spurious eventdeletes are fired for ztunnels during namespace reconciliation - this is incorrect (ztunnel pods are never "removed from the mesh"), functionally harmless, but confusing, and causes ztunnel reconciliation to (potentially) trigger more often than it should, which isn't ideal.