### PR TITLE
Add logging to all cache sync waits

### DIFF
--- a/cni/pkg/repair/repaircontroller.go
+++ b/cni/pkg/repair/repaircontroller.go
@@ -97,7 +97,7 @@ func (rc *Controller) mayAddToWorkQueue(obj any) {
 
 func (rc *Controller) Run(stopCh <-chan struct{}) {
 	go rc.podController.Run(stopCh)
-	if !kube.WaitForCacheSync(stopCh, rc.podController.HasSynced) {
+	if !kube.WaitForCacheSync("repair controller", stopCh, rc.podController.HasSynced) {
 		repairLog.Error("timed out waiting for pod caches to sync")
 		return
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -820,11 +820,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
 	expected := s.XDSServer.InboundUpdates.Load()
-	if !kubelib.WaitForCacheSync("push context", stop, func() bool { return s.pushContextReady(expected) }) {
-		return false
-	}
-
-	return true
+	return kubelib.WaitForCacheSync("push context", stop, func() bool { return s.pushContextReady(expected) })
 }
 
 // pushContextReady indicates whether pushcontext has processed all inbound config updates.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -809,7 +809,7 @@ func (s *Server) addTerminatingStartFunc(name string, fn server.Component) {
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	start := time.Now()
 	log.Info("Waiting for caches to be synced")
-	if !kubelib.WaitForCacheSync(stop, s.cachesSynced) {
+	if !kubelib.WaitForCacheSync("server", stop, s.cachesSynced) {
 		log.Errorf("Failed waiting for cache sync")
 		return false
 	}
@@ -820,8 +820,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
 	expected := s.XDSServer.InboundUpdates.Load()
-	if !kubelib.WaitForCacheSync(stop, func() bool { return s.pushContextReady(expected) }) {
-		log.Errorf("Failed waiting for push context initialization")
+	if !kubelib.WaitForCacheSync("push context", stop, func() bool { return s.pushContextReady(expected) }) {
 		return false
 	}
 

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -195,7 +195,7 @@ func (cl *Client) Run(stop <-chan struct{}) {
 
 	cl.stop = stop
 
-	if !kube.WaitForCacheSync(stop, cl.informerSynced) {
+	if !kube.WaitForCacheSync("crdclient", stop, cl.informerSynced) {
 		cl.logger.Errorf("Failed to sync Pilot K8S CRD controller cache")
 		return
 	}

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -56,7 +56,7 @@ func makeClient(t *testing.T, schemas collection.Schemas) (model.ConfigStoreCont
 	}
 	go config.Run(stop)
 	fake.RunAndWait(stop)
-	kube.WaitForCacheSync(stop, config.HasSynced)
+	kube.WaitForCacheSync("test", stop, config.HasSynced)
 	return config, fake
 }
 
@@ -366,7 +366,7 @@ func TestClientInitialSyncSkipsOtherRevisions(t *testing.T) {
 	fake.RunAndWait(stop)
 	go store.Run(stop)
 
-	kube.WaitForCacheSync(stop, store.HasSynced)
+	kube.WaitForCacheSync("test", stop, store.HasSynced)
 
 	// The order of the events doesn't matter, so sort the two slices so the ordering is consistent
 	sortFunc := func(a, b config.Config) bool {
@@ -428,7 +428,7 @@ func TestClientSync(t *testing.T) {
 	})
 	go c.Run(stop)
 	fake.RunAndWait(stop)
-	kube.WaitForCacheSync(stop, c.HasSynced)
+	kube.WaitForCacheSync("test", stop, c.HasSynced)
 	// This MUST have been called by the time HasSynced returns true
 	assert.Equal(t, events.Load(), 1)
 }

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -206,7 +206,7 @@ func TestNamespaceEvent(t *testing.T) {
 
 	stop := test.NewStop(t)
 	c.Run(stop)
-	kube.WaitForCacheSync(stop, c.HasSynced)
+	kube.WaitForCacheSync("test", stop, c.HasSynced)
 	c.state.ReferencedNamespaceKeys = sets.String{"allowed": struct{}{}}
 
 	ns1 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -215,6 +215,7 @@ func NewDeploymentController(client kube.Client, clusterID cluster.ID,
 
 func (d *DeploymentController) Run(stop <-chan struct{}) {
 	kube.WaitForCacheSync(
+		"deployment controller",
 		stop,
 		d.namespaces.HasSynced,
 		d.deployments.HasSynced,

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -222,7 +222,7 @@ func TestVersionManagement(t *testing.T) {
 	go tw.Run(stop)
 	go d.Run(stop)
 	c.RunAndWait(stop)
-	kube.WaitForCacheSync(stop, d.queue.HasSynced)
+	kube.WaitForCacheSync("test", stop, d.queue.HasSynced)
 	// Create a gateway, we should mark our ownership
 	defaultGateway := &v1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -116,7 +116,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 }
 
 func (c *controller) Run(stop <-chan struct{}) {
-	kube.WaitForCacheSync(stop, c.ingress.HasSynced, c.services.HasSynced, c.classes.HasSynced)
+	kube.WaitForCacheSync("ingress", stop, c.ingress.HasSynced, c.services.HasSynced, c.classes.HasSynced)
 	c.queue.Run(stop)
 	controllers.ShutdownAll(c.ingress, c.services, c.classes)
 }

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -492,6 +492,6 @@ func createFakeClient(t test.Failer, objects ...runtime.Object) kclient.Client[*
 	stop := test.NewStop(t)
 	services := kclient.New[*corev1.Service](kc)
 	kc.RunAndWait(stop)
-	kube.WaitForCacheSync(stop, services.HasSynced)
+	kube.WaitForCacheSync("test", stop, services.HasSynced)
 	return services
 }

--- a/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/autoserviceexportcontroller.go
@@ -78,7 +78,7 @@ func newAutoServiceExportController(opts autoServiceExportOptions) *autoServiceE
 }
 
 func (c *autoServiceExportController) Run(stopCh <-chan struct{}) {
-	kube.WaitForCacheSync(stopCh, c.services.HasSynced)
+	kube.WaitForCacheSync("auto service export", stopCh, c.services.HasSynced)
 	c.queue.Run(stopCh)
 	c.services.ShutdownHandlers()
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -634,7 +634,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	go c.imports.Run(stop)
 	go c.exports.Run(stop)
 
-	kubelib.WaitForCacheSync(stop, c.informersSynced)
+	kubelib.WaitForCacheSync("kube controller", stop, c.informersSynced)
 	log.Infof("kube controller for %s synced after %v", c.opts.ClusterID, time.Since(st))
 	// after the in-order sync we can start processing the queue
 	c.queue.Run(stop)

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -113,7 +113,7 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 
 	if !opts.SkipRun {
 		go c.Run(c.stop)
-		kubelib.WaitForCacheSync(c.stop, c.HasSynced)
+		kubelib.WaitForCacheSync("test", c.stop, c.HasSynced)
 	}
 
 	return &FakeController{c}, fx

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -82,7 +82,7 @@ func initController(client kube.CLIClient, ns string, stop <-chan struct{}, mc *
 	sc := multicluster.NewController(client, ns, "cluster-1", mesh.NewFixedWatcher(nil))
 	sc.AddHandler(mc)
 	_ = sc.Run(stop)
-	kube.WaitForCacheSync(stop, sc.HasSynced)
+	kube.WaitForCacheSync("test", stop, sc.HasSynced)
 }
 
 func Test_KubeSecretController(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -108,8 +108,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
-	if !kube.WaitForCacheSync(stopCh, nc.namespaces.HasSynced, nc.configmaps.HasSynced) {
-		log.Error("Failed to sync namespace controller cache")
+	if !kube.WaitForCacheSync("namespace controller", stopCh, nc.namespaces.HasSynced, nc.configmaps.HasSynced) {
 		return
 	}
 	go nc.startCaBundleWatcher(stopCh)

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -207,7 +207,7 @@ func (ec *serviceExportCacheImpl) Run(stop <-chan struct{}) {
 	// Register callbacks for events.
 	registerHandlers(ec.Controller, ec.serviceExports, "ServiceExports", ec.onServiceExportEvent, nil)
 	go dInformer.Run(stop)
-	kube.WaitForCacheSync(stop, ec.serviceExports.HasSynced)
+	kube.WaitForCacheSync("service export", stop, ec.serviceExports.HasSynced)
 	ec.started.Store(true)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -303,7 +303,7 @@ func (ic *serviceImportCacheImpl) Run(stop <-chan struct{}) {
 	// Register callbacks for ServiceImport events in this cluster only.
 	registerHandlers(ic.Controller, ic.serviceImports, "ServiceImports", ic.onServiceImportEvent, nil)
 	go dInformer.Run(stop)
-	kubelib.WaitForCacheSync(stop, ic.serviceImports.HasSynced)
+	kubelib.WaitForCacheSync("service import", stop, ic.serviceImports.HasSynced)
 	ic.started.Store(true)
 }
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -323,7 +323,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	cg.ServiceEntryRegistry.XdsUpdater = s
 	// Now that handlers are added, get everything started
 	cg.Run()
-	kubelib.WaitForCacheSync(stop,
+	kubelib.WaitForCacheSync("fake", stop,
 		cg.Registry.HasSynced,
 		cg.Store().HasSynced)
 	cg.ServiceEntryRegistry.ResyncEDS()

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -123,7 +123,7 @@ func (sa *IstiodAnalyzer) ReAnalyze(cancel <-chan struct{}) (AnalysisResult, err
 	result.ExecutedAnalyzers = sa.analyzer.AnalyzerNames()
 	result.SkippedAnalyzers = sa.analyzer.RemoveSkipped(store.Schemas())
 
-	kubelib.WaitForCacheSync(cancel, store.HasSynced)
+	kubelib.WaitForCacheSync("istiod analyzer", cancel, store.HasSynced)
 
 	ctx := NewContext(store, cancel, sa.collectionReporter)
 

--- a/pkg/config/mesh/kubemesh/watcher.go
+++ b/pkg/config/mesh/kubemesh/watcher.go
@@ -57,7 +57,7 @@ func NewConfigMapWatcher(client kube.Client, namespace, name, key string, multiW
 	go c.Run(stop)
 
 	// Ensure the ConfigMap is initially loaded if present.
-	if !client.WaitForCacheSync(stop, c.HasSynced) {
+	if !client.WaitForCacheSync("configmap watcher", stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 	return w
@@ -70,7 +70,7 @@ func AddUserMeshConfig(client kube.Client, watcher mesh.Watcher, namespace, key,
 	})
 
 	go c.Run(stop)
-	if !client.WaitForCacheSync(stop, c.HasSynced) {
+	if !client.WaitForCacheSync("user mesh config", stop, c.HasSynced) {
 		log.Error("failed to wait for cache sync")
 	}
 }

--- a/pkg/kube/controllers/example_test.go
+++ b/pkg/kube/controllers/example_test.go
@@ -98,7 +98,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 	// First, wait for pods to sync. Once this is complete, we know the event handler for Pods will have
 	// ran for each item and enqueued everything.
-	kube.WaitForCacheSync(stop, c.pods.HasSynced)
+	kube.WaitForCacheSync("pod controller", stop, c.pods.HasSynced)
 
 	// Now we can run the queue. This will block until `stop` is closed.
 	c.queue.Run(stop)
@@ -149,7 +149,7 @@ func Example() {
 	// Now run our controller (in goroutine)
 	go controller.Run(stop)
 	// Wait for it to be ready
-	kube.WaitForCacheSync(stop, controller.HasSynced)
+	kube.WaitForCacheSync("test", stop, controller.HasSynced)
 
 	// In a test, we can also use a wrapped client that calls t.Fatal on errors
 	// pods := clienttest.Wrap(t, controller.pods)

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -85,7 +85,7 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	stop := make(chan struct{})
 	go w.Run(stop)
 	controller := w.(*configMapWatcher).c
-	kube.WaitForCacheSync(stop, controller.HasSynced)
+	kube.WaitForCacheSync("test", stop, controller.HasSynced)
 	client.RunAndWait(stop)
 
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -181,8 +181,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 
 		go c.informer.Run(stopCh)
 
-		if !kube.WaitForCacheSync(stopCh, c.informer.HasSynced) {
-			log.Error("Failed to sync multicluster remote secrets controller cache")
+		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.informer.HasSynced) {
 			return
 		}
 		log.Infof("multicluster remote secrets controller cache synced in %v", time.Since(t0))

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -191,7 +191,7 @@ func Test_SecretController(t *testing.T) {
 	t.Run("sync timeout", func(t *testing.T) {
 		retry.UntilOrFail(t, c.HasSynced, retry.Timeout(2*time.Second))
 	})
-	kube.WaitForCacheSync(stopCh, c.informer.HasSynced)
+	kube.WaitForCacheSync("test", stopCh, c.informer.HasSynced)
 	clientset.RunAndWait(stopCh)
 
 	for _, step := range steps {

--- a/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
@@ -29,7 +29,6 @@ import (
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/pkg/log"
 )
 
 // Controller watches a ConfigMap and calls the given callback when the ConfigMap changes.
@@ -73,8 +72,7 @@ func NewController(client kube.Client, namespace, name string, callback func(*v1
 
 func (c *Controller) Run(stop <-chan struct{}) {
 	go c.informer.Informer().Run(stop)
-	if !kube.WaitForCacheSync(stop, c.informer.Informer().HasSynced) {
-		log.Error("failed to wait for cache sync")
+	if !kube.WaitForCacheSync("configmap "+c.configMapName, stop, c.informer.Informer().HasSynced) {
 		return
 	}
 	c.queue.Run(stop)

--- a/pkg/kube/watcher/configmapwatcher/configmapwatcher_test.go
+++ b/pkg/kube/watcher/configmapwatcher/configmapwatcher_test.go
@@ -99,7 +99,7 @@ func Test_ConfigMapWatcher(t *testing.T) {
 	stop := make(chan struct{})
 	c := NewController(client, configMapNamespace, configMapName, callback)
 	go c.Run(stop)
-	kube.WaitForCacheSync(stop, c.HasSynced)
+	kube.WaitForCacheSync("test", stop, c.HasSynced)
 
 	cms := client.Kube().CoreV1().ConfigMaps(configMapNamespace)
 	for i, step := range steps {

--- a/pkg/revisions/default_watcher.go
+++ b/pkg/revisions/default_watcher.go
@@ -65,7 +65,7 @@ func NewDefaultWatcher(client kube.Client, revision string) DefaultWatcher {
 }
 
 func (p *defaultWatcher) Run(stopCh <-chan struct{}) {
-	kube.WaitForCacheSync(stopCh, p.webhooks.HasSynced)
+	kube.WaitForCacheSync("default revision", stopCh, p.webhooks.HasSynced)
 	p.queue.Run(stopCh)
 }
 

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -25,7 +25,6 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/util/sets"
-	"istio.io/pkg/log"
 )
 
 // TagWatcher keeps track of the current tags and can notify watchers
@@ -72,8 +71,7 @@ func NewTagWatcher(client kube.Client, revision string) TagWatcher {
 }
 
 func (p *tagWatcher) Run(stopCh <-chan struct{}) {
-	if !kube.WaitForCacheSync(stopCh, p.webhooks.HasSynced) {
-		log.Errorf("failed to sync tag watcher")
+	if !kube.WaitForCacheSync("tag watcher", stopCh, p.webhooks.HasSynced) {
 		return
 	}
 	// Notify handlers of initial state

--- a/pkg/revisions/tag_watcher_test.go
+++ b/pkg/revisions/tag_watcher_test.go
@@ -41,7 +41,7 @@ func TestTagWatcher(t *testing.T) {
 		track.Record(strings.Join(sets.SortedList(s), ","))
 	})
 	go tw.Run(stop)
-	kube.WaitForCacheSync(stop, tw.HasSynced)
+	kube.WaitForCacheSync("test", stop, tw.HasSynced)
 	track.WaitOrdered("revision")
 	assert.Equal(t, tw.GetMyTags(), sets.New("revision"))
 

--- a/pkg/test/csrctrl/controllers/csr_controller.go
+++ b/pkg/test/csrctrl/controllers/csr_controller.go
@@ -102,7 +102,7 @@ func (s *Signer) Reconcile(key types.NamespacedName) error {
 }
 
 func (s *Signer) Run(stop <-chan struct{}) {
-	kube.WaitForCacheSync(stop, s.csrs.HasSynced)
+	kube.WaitForCacheSync("csr", stop, s.csrs.HasSynced)
 	s.queue.Run(stop)
 }
 

--- a/pkg/test/csrctrl/controllers/start_csrctrl.go
+++ b/pkg/test/csrctrl/controllers/start_csrctrl.go
@@ -63,7 +63,7 @@ func RunCSRController(signerNames string, stop <-chan struct{}, clients []kube.C
 		signer := NewSigner(cl, signersMap)
 		go signer.Run(stop)
 		cl.RunAndWait(stop)
-		kube.WaitForCacheSync(stop, signer.HasSynced)
+		kube.WaitForCacheSync("csr", stop, signer.HasSynced)
 	}
 
 	return rootCertSignerArr, nil

--- a/pkg/test/framework/components/echo/kube/pod_controller.go
+++ b/pkg/test/framework/components/echo/kube/pod_controller.go
@@ -83,7 +83,7 @@ func newPodController(cfg echo.Config, handlers podHandlers) *podController {
 
 func (c *podController) Run(stop <-chan struct{}) {
 	go c.informer.Run(stop)
-	kube.WaitForCacheSync(stop, c.informer.HasSynced)
+	kube.WaitForCacheSync("pod controller", stop, c.informer.HasSynced)
 	c.q.Run(stop)
 }
 

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -168,7 +168,7 @@ func (c *Controller) Reconcile(key types.NamespacedName) error {
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {
-	kube.WaitForCacheSync(stop, c.webhooks.HasSynced)
+	kube.WaitForCacheSync("validation", stop, c.webhooks.HasSynced)
 	go c.startCaBundleWatcher(stop)
 	c.queue.Run(stop)
 }

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -166,7 +166,7 @@ func createTestController(t *testing.T) (*Controller, *atomic.Pointer[error]) {
 	stop := test.NewStop(t)
 	c.RunAndWait(stop)
 	go control.Run(stop)
-	kube.WaitForCacheSync(stop, control.queue.HasSynced)
+	kube.WaitForCacheSync("test", stop, control.queue.HasSynced)
 
 	gatewayError := atomic.NewPointer[error](nil)
 	c.Istio().(*istiofake.Clientset).PrependReactor("*", "gateways", func(action ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -89,7 +89,7 @@ func newWebhookPatcherQueue(reconciler controllers.ReconcilerFn) controllers.Que
 // Run runs the WebhookCertPatcher
 func (w *WebhookCertPatcher) Run(stopChan <-chan struct{}) {
 	go w.startCaBundleWatcher(stopChan)
-	kubelib.WaitForCacheSync(stopChan, w.webhooks.HasSynced)
+	kubelib.WaitForCacheSync("webhook patcher", stopChan, w.webhooks.HasSynced)
 	w.queue.Run(stopChan)
 }
 

--- a/security/pkg/server/ca/node_auth_test.go
+++ b/security/pkg/server/ca/node_auth_test.go
@@ -177,7 +177,7 @@ func TestNodeAuthorizer(t *testing.T) {
 				t.Fatal(err)
 			}
 			c.RunAndWait(test.NewStop(t))
-			kube.WaitForCacheSync(test.NewStop(t), na.pods.HasSynced)
+			kube.WaitForCacheSync("test", test.NewStop(t), na.pods.HasSynced)
 
 			err = na.authenticateImpersonation(tt.caller, tt.requestedIdentityString)
 			if tt.wantErr == "" && err != nil {


### PR DESCRIPTION
This is to aide in debugging. At debug level, we get high verbosity about all caches. At info level, we get logs about slow syncs and failed syncs.

**Please provide a description of this PR:**