### PR TITLE
tf: set fixed delay between retry attempts

### DIFF
--- a/pilot/pkg/model/network_test.go
+++ b/pilot/pkg/model/network_test.go
@@ -113,7 +113,7 @@ func TestGatewayHostnames(t *testing.T) {
 			// addresses should be updated
 			retry.UntilOrFail(t, func() bool {
 				return !reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL))
+			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 
@@ -133,7 +133,7 @@ func TestGatewayHostnames(t *testing.T) {
 			retry.UntilOrFail(t, func() bool {
 				return len(env.NetworkManager.AllGateways()) != 0 &&
 					!reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL))
+			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
In this test we want to check the condition after 30ms in 60ms(timeout). It should use fixed delay instead of 2x backoff(default)
```
Before:
check -> 10ms -> check -> 20ms -> check(flaky) -> timeout

After:
check -> 10ms -> check -> 10ms -> check -> 10ms -> check(flaky) -> 3 more retries(should succeed)
```
For https://github.com/istio/istio/issues/44776