### PR TITLE
optimize slice growth

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -864,22 +864,17 @@ func addHostsFromMeshConfig(ps *PushContext, hosts sets.String) {
 // servicesExportedToNamespace returns the list of services that are visible to a namespace.
 // namespace "" indicates all namespaces
 func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
-	var capacity int
-	if ns == NamespaceAll {
-		capacity = len(ps.ServiceIndex.privateByNamespace) + len(ps.ServiceIndex.public)
-	} else {
-		capacity = len(ps.ServiceIndex.privateByNamespace[ns]) +
-			len(ps.ServiceIndex.exportedToNamespace[ns]) +
-			len(ps.ServiceIndex.public)
-	}
-	out := make([]*Service, 0, capacity)
+	var out []*Service
 
 	// First add private services and explicitly exportedTo services
 	if ns == NamespaceAll {
+		out = make([]*Service, 0, len(ps.ServiceIndex.privateByNamespace)+len(ps.ServiceIndex.public))
 		for _, privateServices := range ps.ServiceIndex.privateByNamespace {
 			out = append(out, privateServices...)
 		}
 	} else {
+		out = make([]*Service, 0, len(ps.ServiceIndex.privateByNamespace[ns])+
+			len(ps.ServiceIndex.exportedToNamespace[ns])+len(ps.ServiceIndex.public))
 		out = append(out, ps.ServiceIndex.privateByNamespace[ns]...)
 		out = append(out, ps.ServiceIndex.exportedToNamespace[ns]...)
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -864,7 +864,15 @@ func addHostsFromMeshConfig(ps *PushContext, hosts sets.String) {
 // servicesExportedToNamespace returns the list of services that are visible to a namespace.
 // namespace "" indicates all namespaces
 func (ps *PushContext) servicesExportedToNamespace(ns string) []*Service {
-	out := make([]*Service, 0)
+	var capacity int
+	if ns == NamespaceAll {
+		capacity = len(ps.ServiceIndex.privateByNamespace) + len(ps.ServiceIndex.public)
+	} else {
+		capacity = len(ps.ServiceIndex.privateByNamespace[ns]) +
+			len(ps.ServiceIndex.exportedToNamespace[ns]) +
+			len(ps.ServiceIndex.public)
+	}
+	out := make([]*Service, 0, capacity)
 
 	// First add private services and explicitly exportedTo services
 	if ns == NamespaceAll {


### PR DESCRIPTION
This PR contains 2 commits, both for optimizing slice growth:
- commit 1: Calculate the capacity in two cases, and then use `make` to allocate at one time
- commit 2: Use two for loops instead of splitting into "sidecarConfigWithSelector" and "sidecarConfigWithoutSelector" and then merging. In this way, slice growth and GC consumption during splitting are omitted

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
