### PR TITLE
ambient: don't annotate pods on delete

### DIFF
--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -286,6 +286,7 @@ func (s *Server) DelPodFromMesh(pod *corev1.Pod, event controllers.Event) {
 			log.Errorf("failed to del POD ebpf: %v", err)
 		}
 	}
+	// event.New will be nil if the pod is deleted
 	if event.New != nil {
 		if err := AnnotateUnenrollPod(s.kubeClient.Kube(), pod); err != nil {
 			log.Errorf("failed to annotate pod unenrollment: %v", err)

--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -23,11 +23,13 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	pconstants "istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	istiolog "istio.io/pkg/log"
 )
@@ -50,10 +52,6 @@ func RouteExists(rte []string) bool {
 
 func AddPodToMesh(client kubernetes.Interface, pod *corev1.Pod, ip string) {
 	addPodToMeshWithIptables(pod, ip)
-
-	if err := AnnotateEnrolledPod(client, pod); err != nil {
-		log.Errorf("failed to annotate pod enrollment: %v", err)
-	}
 }
 
 func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
@@ -145,6 +143,9 @@ func AnnotateUnenrollPod(client kubernetes.Interface, pod *corev1.Pod) error {
 			annotationRemovePatch,
 			metav1.PatchOptions{},
 		)
+	if errors.IsNotFound(err) {
+		return nil
+	}
 	return err
 }
 
@@ -172,10 +173,6 @@ func DelPodFromMesh(client kubernetes.Interface, pod *corev1.Pod) {
 		if err != nil {
 			log.Warnf("Failed to delete route (%s) for pod %s: %v", rte, pod.Name, err)
 		}
-	}
-
-	if err := AnnotateUnenrollPod(client, pod); err != nil {
-		log.Errorf("failed to annotate pod unenrollment: %v", err)
 	}
 }
 
@@ -269,13 +266,14 @@ func (s *Server) AddPodToMesh(pod *corev1.Pod) {
 		if err := s.updatePodEbpfOnNode(pod); err != nil {
 			log.Errorf("failed to update POD ebpf: %v", err)
 		}
-		if err := AnnotateEnrolledPod(s.kubeClient.Kube(), pod); err != nil {
-			log.Errorf("failed to annotate pod enrollment: %v", err)
-		}
+	}
+	if err := AnnotateEnrolledPod(s.kubeClient.Kube(), pod); err != nil {
+		log.Errorf("failed to annotate pod enrollment: %v", err)
 	}
 }
 
-func (s *Server) DelPodFromMesh(pod *corev1.Pod) {
+func (s *Server) DelPodFromMesh(pod *corev1.Pod, event controllers.Event) {
+	log.Debugf("Pod %s/%s is now stopped or opt out... cleaning up.", pod.Namespace, pod.Name)
 	switch s.redirectMode {
 	case IptablesMode:
 		DelPodFromMesh(s.kubeClient.Kube(), pod)
@@ -287,6 +285,8 @@ func (s *Server) DelPodFromMesh(pod *corev1.Pod) {
 		if err := s.delPodEbpfOnNode(pod.Status.PodIP); err != nil {
 			log.Errorf("failed to del POD ebpf: %v", err)
 		}
+	}
+	if event.New != nil {
 		if err := AnnotateUnenrollPod(s.kubeClient.Kube(), pod); err != nil {
 			log.Errorf("failed to annotate pod unenrollment: %v", err)
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
Each time a pod is deleted, istio-cni reports an error:
```
failed to annotate pod unenrollment: pods "xxx" not found
```
We should not annotate the pod if it no longer exists