### PR TITLE
Allow setting ztunnel K8S Pod property `terminationGracePeriodSeconds` via Helm

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -108,6 +108,7 @@ spec:
           name: istiod-ca-cert
         - mountPath: /var/run/secrets/tokens
           name: istio-token
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
       - name: istio-token
         projected:

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -53,3 +53,9 @@ meshConfig:
 
 # Ambient redirection mode: "iptables" or "ebpf"
 redirectMode: "iptables"
+
+# This value defines:
+# 1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value)
+# 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
+# Default K8S value is 30 seconds
+terminationGracePeriodSeconds: 30

--- a/releasenotes/notes/ztunnel-chart-termgrace.yaml
+++ b/releasenotes/notes/ztunnel-chart-termgrace.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** Allow setting terminationGracePeriodSeconds for ztunnel pod via Helm chart.


### PR DESCRIPTION
This allows Helm configuration of 2 preexisting ztunnel config knobs:

1. Allow `terminationGracePeriodSeconds` (standard Kube param, Kube/our current default is 30, this changes it to helm-defined value + 1) to be set for the ztunnel Pod. This is the duration Kube waits after sending a SIGTERM before sending a more agressive/destructive TERM sig.
   
2. Reuses that Helm-defined value to populate ztunnel's existing `TERMINATION_GRACE_PERIOD` env var, which is related, and is the duration ztunnel waits, after getting a SIGTERM, to finish draining its own proxied connections.


(I'm open to better ways to handle this than just adding one second - having 2 separate values seems potentially more confusing/error-prone - the important thing is that one value is always bigger than the other by a reasonable margin)