### PR TITLE
router: include attempt count for response in virtual hosts

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -450,11 +450,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 						}
 					}
 					newVHost := &route.VirtualHost{
-						Name:                       util.DomainName(string(hostname), port),
-						Domains:                    buildGatewayVirtualHostDomains(node, string(hostname), port),
-						Routes:                     routes,
-						TypedPerFilterConfig:       perRouteFilters,
-						IncludeRequestAttemptCount: true,
+						Name:                          util.DomainName(string(hostname), port),
+						Domains:                       buildGatewayVirtualHostDomains(node, string(hostname), port),
+						Routes:                        routes,
+						TypedPerFilterConfig:          perRouteFilters,
+						IncludeRequestAttemptCount:    true,
+						IncludeAttemptCountInResponse: true,
 					}
 					if server.Tls != nil && server.Tls.HttpsRedirect {
 						newVHost.RequireTls = route.VirtualHost_ALL
@@ -475,10 +476,11 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				continue
 			}
 			newVHost := &route.VirtualHost{
-				Name:                       util.DomainName(hostname, port),
-				Domains:                    buildGatewayVirtualHostDomains(node, hostname, port),
-				IncludeRequestAttemptCount: true,
-				RequireTls:                 route.VirtualHost_ALL,
+				Name:                          util.DomainName(hostname, port),
+				Domains:                       buildGatewayVirtualHostDomains(node, hostname, port),
+				IncludeRequestAttemptCount:    true,
+				IncludeAttemptCountInResponse: true,
+				RequireTls:                    route.VirtualHost_ALL,
 			}
 			vHostDedupMap[host.Name(hostname)] = newVHost
 		}
@@ -577,6 +579,9 @@ func collapseDuplicateRoutes(input map[host.Name]*route.VirtualHost) map[host.Na
 // We explicitly do not check domains or name, as those are the keys for the merge
 func vhostMergeable(a, b *route.VirtualHost) bool {
 	if a.IncludeRequestAttemptCount != b.IncludeRequestAttemptCount {
+		return false
+	}
+	if a.IncludeAttemptCountInResponse != b.IncludeAttemptCountInResponse {
 		return false
 	}
 	if a.RequireTls != b.RequireTls {

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -2148,7 +2148,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 			for _, h := range r.VirtualHosts {
 				vh[h.Name] = h.Domains
 				hr[h.Name] = len(h.Routes)
-				if h.Name != "blackhole:80" && !h.IncludeRequestAttemptCount {
+				if h.Name != "blackhole:80" && !h.IncludeRequestAttemptCount && !h.IncludeAttemptCountInResponse {
 					t.Errorf("expected attempt count to be set in virtual host, but not found")
 				}
 				if tt.redirect != (h.RequireTls == route.VirtualHost_ALL) {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -444,11 +444,12 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 				perRouteFilters[util.StatefulSessionFilter] = protoconv.MessageToAny(perRouteStatefulSession)
 			}
 			return &route.VirtualHost{
-				Name:                       name,
-				Domains:                    domains,
-				Routes:                     vhwrapper.Routes,
-				IncludeRequestAttemptCount: true,
-				TypedPerFilterConfig:       perRouteFilters,
+				Name:                          name,
+				Domains:                       domains,
+				Routes:                        vhwrapper.Routes,
+				IncludeRequestAttemptCount:    true,
+				IncludeAttemptCountInResponse: true,
+				TypedPerFilterConfig:          perRouteFilters,
 			}
 		}
 
@@ -797,7 +798,8 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 					},
 				},
 			},
-			IncludeRequestAttemptCount: true,
+			IncludeRequestAttemptCount:    true,
+			IncludeAttemptCountInResponse: true,
 		}
 	}
 
@@ -817,7 +819,8 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 				},
 			},
 		},
-		IncludeRequestAttemptCount: true,
+		IncludeRequestAttemptCount:    true,
+		IncludeAttemptCountInResponse: true,
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -1559,7 +1559,11 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 		}
 
 		if !vhost.GetIncludeRequestAttemptCount() {
-			t.Fatal("Expected that include request attempt count is set to true, but set to false")
+			t.Fatal("Expected that include request attempt count in request is set to true, but set to false")
+		}
+
+		if !vhost.GetIncludeAttemptCountInResponse() {
+			t.Fatal("Expected that include request attempt count in response is set to true, but set to false")
 		}
 	}
 	if (expectedRoutes >= 0) && (numberOfRoutes != expectedRoutes) {


### PR DESCRIPTION
Following the same logic as https://github.com/istio/istio/pull/21198

Where https://github.com/istio/istio/pull/21198 included x-envoy-attempt-count for the upstream requests, this PR adds the same header to the respective downstream responses.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
