### PR TITLE
spiffe: fix handling of trust bundles with multiple keys

### DIFF
--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -235,24 +235,20 @@ func RetrieveSpiffeBundleRootCerts(config map[string]string, caCertPool *x509.Ce
 			return nil, fmt.Errorf("trust domain [%s] at URL [%s] failed to decode bundle: %v", trustDomain, endpoint, err)
 		}
 
-		var cert *x509.Certificate
+		var certs []*x509.Certificate
 		for i, key := range doc.Keys {
 			if key.Use == "x509-svid" {
 				if len(key.Certificates) != 1 {
 					return nil, fmt.Errorf("trust domain [%s] at URL [%s] expected 1 certificate in x509-svid entry %d; got %d",
 						trustDomain, endpoint, i, len(key.Certificates))
 				}
-				cert = key.Certificates[0]
+				certs = append(certs, key.Certificates[0])
 			}
 		}
-		if cert == nil {
+		if len(certs) == 0 {
 			return nil, fmt.Errorf("trust domain [%s] at URL [%s] does not provide a X509 SVID", trustDomain, endpoint)
 		}
-		if certs, ok := ret[trustDomain]; ok {
-			ret[trustDomain] = append(certs, cert)
-		} else {
-			ret[trustDomain] = []*x509.Certificate{cert}
-		}
+		ret[trustDomain] = certs
 	}
 	for trustDomain, certs := range ret {
 		spiffeLog.Infof("Loaded SPIFFE trust bundle for: %v, containing %d certs", trustDomain, len(certs))

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -35,6 +35,60 @@ import (
 )
 
 var (
+	// nolint: lll
+	validSpiffeX509Bundle = `{
+  "keys": [
+    {
+      "use": "x509-svid",
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "8JAyuuX9TpQJUUCQdKIX4NUG5a2FmzWFORz-VEkET6k",
+      "y": "HX1rdVwFy7NAsLcWtmt0D9IxtbwmU3oDJfji9T4ZXDs",
+      "x5c": [
+        "MIIBnTCCAUOgAwIBAgIBATAKBggqhkjOPQQDAjAkMSIwIAYDVQQDExlSb290IENBIGZvciB0cnVzdGRvbWFpbi5hMB4XDTA5MTExMDIzMDAwMFoXDTEwMTExMDIzMDAwMFowJDEiMCAGA1UEAxMZUm9vdCBDQSBmb3IgdHJ1c3Rkb21haW4uYTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPCQMrrl/U6UCVFAkHSiF+DVBuWthZs1hTkc/lRJBE+pHX1rdVwFy7NAsLcWtmt0D9IxtbwmU3oDJfji9T4ZXDujZjBkMA4GA1UdDwEB/wQEAwICBDASBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBTm7xwcyW6KEkYeXRSFTn6Ngjcl9TAfBgNVHR4BAf8EFTAToBEwD4YNdHJ1c3Rkb21haW4uYTAKBggqhkjOPQQDAgNIADBFAiEA3uhdfxgrSehr+s7wSnD9QRpZjaiUcogPhAXyS73Qn9ACICUGj8pqxqfejMpdHEnz803lc6bHzaoUbd6cgemL7MRn"
+      ]
+    }
+  ]
+}`
+
+	// nolint: lll
+	validSpiffeX509BundleWithMultipleCerts = `{
+  "keys": [
+    {
+      "use": "x509-svid",
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "HFlg42KnDPaiGvQrAIaKWDqJw_4ngCwZ_687jLrBUVE",
+      "y": "ActNT7SNmcX3tQD9YZgRueiajOgmYv-rANQ8_H8GBEU",
+      "x5c": [
+        "MIIBnTCCAUOgAwIBAgIBAjAKBggqhkjOPQQDAjAkMSIwIAYDVQQDExlSb290IENBIGZvciB0cnVzdGRvbWFpbi5iMB4XDTA5MTExMDIzMDAwMFoXDTEwMTExMDIzMDAwMFowJDEiMCAGA1UEAxMZUm9vdCBDQSBmb3IgdHJ1c3Rkb21haW4uYjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABBxZYONipwz2ohr0KwCGilg6icP+J4AsGf+vO4y6wVFRActNT7SNmcX3tQD9YZgRueiajOgmYv+rANQ8/H8GBEWjZjBkMA4GA1UdDwEB/wQEAwICBDASBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBTR41Rmvs/3JBw24dDjlwgLuFB13zAfBgNVHR4BAf8EFTAToBEwD4YNdHJ1c3Rkb21haW4uYjAKBggqhkjOPQQDAgNIADBFAiEA243KZVSU5IUTmoj0OCvcBYnKo3a1p/kQal1qqFcE0BgCIBZB+2OJU/dPRs1AoGilH6AZqVC5KZlSPZq9bv6Pm5UG"
+      ]
+    },
+    {
+      "use": "x509-svid",
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "vzhUQgVXLcdwrDmP6REclI3lusWR6MHM6i5bXXq87Pk",
+      "y": "-407emssjw1NjyK1gs33mczZapiqHoWMesi2sUudgsw",
+      "x5c": [
+        "MIIBnTCCAUOgAwIBAgIBAjAKBggqhkjOPQQDAjAkMSIwIAYDVQQDExlSb290IENBIGZvciB0cnVzdGRvbWFpbi5iMB4XDTA5MTExMDIzMDAwMFoXDTEwMTExMDIzMDAwMFowJDEiMCAGA1UEAxMZUm9vdCBDQSBmb3IgdHJ1c3Rkb21haW4uYjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABL84VEIFVy3HcKw5j+kRHJSN5brFkejBzOouW116vOz5+407emssjw1NjyK1gs33mczZapiqHoWMesi2sUudgsyjZjBkMA4GA1UdDwEB/wQEAwICBDASBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBQSZLzOBu77lDJGEP5uxqAJgze0+zAfBgNVHR4BAf8EFTAToBEwD4YNdHJ1c3Rkb21haW4uYjAKBggqhkjOPQQDAgNIADBFAiA9KU1cfQilqatMt7cWoIPUeq72rso1B0RAN9MxcZV9ugIhAOHbu0dHR1Pq3iuHCrwSCiM1xQ+fnay6m64B/Hv78q2W"
+      ]
+    }
+  ]
+}`
+
+	invalidSpiffeX509Bundle = `{
+  "keys": [
+    {
+      "use": "x509-svid",
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "8JAyuuX9TpQJUUCQdKIX4NUG5a2FmzWFORz-VEkET6k",
+      "y": "HX1rdVwFy7NAsLcWtmt0D9IxtbwmU3oDJfji9T4ZXDs"
+    }
+  ]
+}`
+
 	// validRootCertFile, validIntCertFile and validWorkloadCertFile are in a certification chain.
 	// They are generated using tools/certs/Makefile. Replace "cluster.local" with "foo.domain.com"
 	// export INTERMEDIATE_DAYS=3650
@@ -137,6 +191,144 @@ func TestGetSetTrustDomain(t *testing.T) {
 func TestMustGenSpiffeURI(t *testing.T) {
 	if nonsense := MustGenSpiffeURI("", ""); nonsense != "spiffe://cluster.local/ns//sa/" {
 		t.Errorf("Unexpected spiffe URI for empty namespace and service account: %s", nonsense)
+	}
+}
+
+type handler struct {
+	statusCode int
+	body       []byte
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(h.statusCode)
+	w.Write(h.body)
+}
+
+func TestRetrieveSpiffeBundleRootCerts(t *testing.T) {
+	// Create a fake handler whose response can be overridden for each test case.
+	h := &handler{}
+
+	// Create servers that will act as SPIFFE bundle endpoints.
+	s1 := httptest.NewTLSServer(h)
+	s2 := httptest.NewTLSServer(h)
+
+	// The system needs to trust these server certs to securely connect to
+	// the SPIFFE bundle endpoints.
+	serverCerts := []*x509.Certificate{s1.Certificate(), s2.Certificate()}
+
+	input1 := map[string]string{
+		"foo": s1.Listener.Addr().String(),
+	}
+	// This simulates the case when there are multiple different servers to talk to.
+	input2 := map[string]string{
+		"foo": s1.Listener.Addr().String(),
+		"bar": s2.Listener.Addr().String(),
+	}
+
+	cases := []struct {
+		name         string
+		in           map[string]string
+		extraCerts   []*x509.Certificate
+		statusCode   int
+		body         string
+		errContains  string
+		wantNumCerts int
+	}{
+		{
+			name:         "Success with one trust domain",
+			in:           input1,
+			extraCerts:   serverCerts,
+			statusCode:   http.StatusOK,
+			body:         validSpiffeX509Bundle,
+			wantNumCerts: 1,
+		},
+		{
+			name:         "Success with multiple trust domains",
+			in:           input2,
+			extraCerts:   serverCerts,
+			statusCode:   http.StatusOK,
+			body:         validSpiffeX509Bundle,
+			wantNumCerts: 1,
+		},
+		{
+			name:         "Success when response contains multiple certs",
+			in:           input1,
+			extraCerts:   serverCerts,
+			statusCode:   http.StatusOK,
+			body:         validSpiffeX509BundleWithMultipleCerts,
+			wantNumCerts: 2,
+		},
+		{
+			name:        "Bundle endpoint is not trusted",
+			in:          input1,
+			extraCerts:  nil,
+			statusCode:  http.StatusOK,
+			body:        validSpiffeX509Bundle,
+			errContains: "x509: certificate signed by unknown authority",
+		},
+		{
+			name:        "Bundle endpoint returns non-200 status",
+			in:          input1,
+			extraCerts:  serverCerts,
+			statusCode:  http.StatusServiceUnavailable,
+			body:        `{"error": "system down"}`,
+			errContains: `unexpected status: 503, fetching bundle: {"error": "system down"}`,
+		},
+		{
+			name:        "Bundle contains no certificate",
+			in:          input1,
+			extraCerts:  serverCerts,
+			statusCode:  http.StatusOK,
+			body:        invalidSpiffeX509Bundle,
+			errContains: "expected 1 certificate in x509-svid entry 0; got 0",
+		},
+		{
+			name:        "Bundle cannot be decoded",
+			in:          input1,
+			extraCerts:  serverCerts,
+			statusCode:  http.StatusOK,
+			body:        "NOT JSON",
+			errContains: "failed to decode bundle",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h.body = []byte(c.body)
+			h.statusCode = c.statusCode
+
+			caCertPool, err := x509.SystemCertPool()
+			if err != nil {
+				t.Fatalf("failed to get SystemCertPool: %v", err)
+			}
+			for _, cert := range c.extraCerts {
+				caCertPool.AddCert(cert)
+			}
+
+			// This is the system-under-test.
+			rootCertMap, err := RetrieveSpiffeBundleRootCerts(c.in, caCertPool, time.Millisecond*50)
+
+			if c.errContains != "" {
+				if err == nil {
+					t.Fatalf("got nil error; wanted error to contain %q", c.errContains)
+				}
+				if !strings.Contains(err.Error(), c.errContains) {
+					t.Fatalf("got error: %q; wanted error to contain %q", err, c.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("got error: %q; wanted no error", err)
+				}
+				if rootCertMap == nil {
+					t.Errorf("returned root cert map is nil")
+				}
+				for k, v := range rootCertMap {
+					if len(v) != c.wantNumCerts {
+						t.Errorf("got %d certs for %s; wanted %d certs", len(v), k, c.wantNumCerts)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/releasenotes/notes/spiffe-bundle-multiple-certs.yaml
+++ b/releasenotes/notes/spiffe-bundle-multiple-certs.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 44831
+releaseNotes:
+  - |
+    **Fixed** handling of remote SPIFFE trust bundles containing multiple certs.


### PR DESCRIPTION
**Please provide a description of this PR:**
In the existing implementation, we were overriding the `cert` while iterating over doc.Keys. This commit fixes that.

Further, there was an unnecessary check for the existence of `ret[trustDomain]`. We are iterating over a map with `trustDomain` as keys, maps don't have duplicate keys, and so `ret[trustDomain]` would never have had a key before we set it in this iteration.