### PR TITLE
inject: remove unknown fields from template

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
@@ -1,5 +1,6 @@
 metadata:
-  sidecar.istio.io/rewriteAppHTTPProbers: "false"
+  annotations:
+    sidecar.istio.io/rewriteAppHTTPProbers: "false"
 spec:
   initContainers:
     - name: grpc-bootstrap-init

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -155,7 +155,6 @@ spec:
       runAsUser: 1337
       runAsNonRoot: true
     {{- end }}
-    restartPolicy: Always
   {{ end -}}
   {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
   - name: enable-core-dump
@@ -345,7 +344,6 @@ spec:
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -365,7 +363,6 @@ spec:
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -155,7 +155,6 @@ spec:
       runAsUser: 1337
       runAsNonRoot: true
     {{- end }}
-    restartPolicy: Always
   {{ end -}}
   {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
   - name: enable-core-dump
@@ -345,7 +344,6 @@ spec:
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -365,7 +363,6 @@ spec:
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       runAsGroup: 1337
-      fsGroup: 1337
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0

--- a/pkg/kube/inject/testdata/inject/grpc-simple.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-simple.yaml.injected
@@ -16,6 +16,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         proxy.istio.io/overrides: '{"containers":[{"name":"traffic","image":"fake.docker.io/google-samples/traffic-go-gke:1.0","resources":{},"readinessProbe":{"httpGet":{"port":80}}}]}'
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
         sidecar.istio.io/status: '{"initContainers":["grpc-bootstrap-init"],"containers":["traffic"],"volumes":["grpc-io-proxyless-bootstrap"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -166,7 +166,6 @@ templates:
           runAsUser: 1337
           runAsNonRoot: true
         {{- end }}
-        restartPolicy: Always
       {{ end -}}
       {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
       - name: enable-core-dump
@@ -356,7 +355,6 @@ templates:
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -376,7 +374,6 @@ templates:
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           runAsGroup: 1337
-          fsGroup: 1337
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
@@ -757,7 +754,8 @@ templates:
       {{- end }}
   grpc-simple: |
     metadata:
-      sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
     spec:
       initContainers:
         - name: grpc-bootstrap-init


### PR DESCRIPTION
We have a number of cases where we insert unknown fields into the template. This eventually gets marshalled into a `v1.Pod`, so the unknown fields are dropped. So it has no impact, but it is "wrong".

However, one of the fields we have (restartPolicy) is actually going to be a valid field in future k8s, so would start breaking at that point. So this *will* be a critical bug for future k8s versions.

Test with:

Replace applyOverlayYAML with

```
	decoder := json.NewDecoder(bytes.NewReader(patched))
	decoder.DisallowUnknownFields()
	if err := decoder.Decode(&pod); err != nil {
		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
	}
```

Its probably a nice idea to keep it as non-strict to be resilient to unexpected issues?

**Please provide a description of this PR:**