### PR TITLE
istioctl: Replace package alias 'protio' with package name 'proto'

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/cluster.go
+++ b/istioctl/pkg/writer/envoy/configdump/cluster.go
@@ -24,7 +24,7 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"sigs.k8s.io/yaml"
 
-	protio "istio.io/istio/istioctl/pkg/util/proto"
+	"istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
@@ -109,7 +109,7 @@ func (c *ConfigWriter) PrintClusterDump(filter ClusterFilter, outputFormat strin
 	if err != nil {
 		return err
 	}
-	filteredClusters := make(protio.MessageSlice, 0, len(clusters))
+	filteredClusters := make(proto.MessageSlice, 0, len(clusters))
 	for _, cluster := range clusters {
 		if filter.Verify(cluster) {
 			filteredClusters = append(filteredClusters, cluster)

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -27,7 +27,7 @@ import (
 	anypb "github.com/golang/protobuf/ptypes/any"
 	"sigs.k8s.io/yaml"
 
-	protio "istio.io/istio/istioctl/pkg/util/proto"
+	"istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
@@ -92,7 +92,7 @@ func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter, outputFormat string
 	if err != nil {
 		return err
 	}
-	marshaller := make(protio.MessageSlice, 0, len(dump))
+	marshaller := make(proto.MessageSlice, 0, len(dump))
 	for _, eds := range dump {
 		marshaller = append(marshaller, eds)
 	}

--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -30,7 +30,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"sigs.k8s.io/yaml"
 
-	protio "istio.io/istio/istioctl/pkg/util/proto"
+	"istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -550,7 +550,7 @@ func (c *ConfigWriter) PrintListenerDump(filter ListenerFilter, outputFormat str
 	if err != nil {
 		return err
 	}
-	filteredListeners := protio.MessageSlice{}
+	filteredListeners := proto.MessageSlice{}
 	for _, listener := range listeners {
 		if filter.Verify(listener) {
 			filteredListeners = append(filteredListeners, listener)

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -26,7 +26,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"sigs.k8s.io/yaml"
 
-	protio "istio.io/istio/istioctl/pkg/util/proto"
+	"istio.io/istio/istioctl/pkg/util/proto"
 	pilot_util "istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/util/sets"
@@ -176,7 +176,7 @@ func (c *ConfigWriter) PrintRouteDump(filter RouteFilter, outputFormat string) e
 	if err != nil {
 		return err
 	}
-	filteredRoutes := make(protio.MessageSlice, 0, len(routes))
+	filteredRoutes := make(proto.MessageSlice, 0, len(routes))
 	for _, route := range routes {
 		if filter.Verify(route) {
 			filteredRoutes = append(filteredRoutes, route)


### PR DESCRIPTION
**Please provide a description of this PR:**

Replace package alias 'protio' with package name 'proto'.

**AS-IS**

```go
import (
  protio "istio.io/istio/istioctl/pkg/util/proto"
)

filteredClusters := make(protio.MessageSlice, 0, len(clusters))
```

**TO-BE**

```go
import (
  "istio.io/istio/istioctl/pkg/util/proto"
)

filteredClusters := make(proto.MessageSlice, 0, len(clusters))
```