### PR TITLE
echo: trim dependencies

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -219,7 +219,7 @@ LINUX_AGENT_BINARIES:=./cni/cmd/istio-cni \
 BINARIES:=$(STANDARD_BINARIES) $(AGENT_BINARIES) $(LINUX_AGENT_BINARIES)
 
 # List of binaries that have their size tested
-RELEASE_SIZE_TEST_BINARIES:=pilot-discovery pilot-agent istioctl bug-report envoy ztunnel
+RELEASE_SIZE_TEST_BINARIES:=pilot-discovery pilot-agent istioctl bug-report envoy ztunnel client server
 
 .PHONY: build
 build: depend ## Builds all go binaries.

--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -41,7 +41,6 @@ import (
 	"google.golang.org/grpc/xds"
 	"k8s.io/utils/env"
 
-	"istio.io/istio/pkg/istio-agent/grpcxds"
 	"istio.io/istio/pkg/test/echo"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/proto"
@@ -202,7 +201,7 @@ func (s *grpcInstance) certsFromBootstrapForReady() (cert string, key string, ca
 	} else if data := os.Getenv("GRPC_XDS_BOOTSTRAP_CONFIG"); len(data) > 0 {
 		bootstrapData = []byte(data)
 	}
-	var bootstrap grpcxds.Bootstrap
+	var bootstrap Bootstrap
 	if uerr := json.Unmarshal(bootstrapData, &bootstrap); uerr != nil {
 		err = uerr
 		return

--- a/pkg/test/echo/server/endpoint/grpcbootstrap.go
+++ b/pkg/test/echo/server/endpoint/grpcbootstrap.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import "encoding/json"
+
+// Mirror types from grpc to avoid pulling in a bunch of deps
+
+const FileWatcherCertProviderName = "file_watcher"
+
+type FileWatcherCertProviderConfig struct {
+	CertificateFile   string          `json:"certificate_file,omitempty"`
+	PrivateKeyFile    string          `json:"private_key_file,omitempty"`
+	CACertificateFile string          `json:"ca_certificate_file,omitempty"`
+	RefreshDuration   json.RawMessage `json:"refresh_interval,omitempty"`
+}
+
+// FileWatcherProvider returns the FileWatcherCertProviderConfig if one exists in CertProviders
+func (b *Bootstrap) FileWatcherProvider() *FileWatcherCertProviderConfig {
+	if b == nil || b.CertProviders == nil {
+		return nil
+	}
+	for _, provider := range b.CertProviders {
+		if provider.PluginName == FileWatcherCertProviderName {
+			cfg, ok := provider.Config.(FileWatcherCertProviderConfig)
+			if !ok {
+				return nil
+			}
+			return &cfg
+		}
+	}
+	return nil
+}
+
+type Bootstrap struct {
+	CertProviders map[string]CertificateProvider `json:"certificate_providers,omitempty"`
+}
+
+type CertificateProvider struct {
+	PluginName string `json:"plugin_name,omitempty"`
+	Config     any    `json:"config,omitempty"`
+}

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -44,6 +44,9 @@ func TestVersion(t *testing.T) {
 		if nonGoBinaries.Contains(name) {
 			return
 		}
+		if nonVersionBinaries.Contains(name) {
+			return
+		}
 		cmd := path.Join(*releasedir, name)
 		args := []string{"version", "-ojson"}
 		if name == "istioctl" {
@@ -70,7 +73,10 @@ func TestVersion(t *testing.T) {
 	})
 }
 
-var nonGoBinaries = sets.New("ztunnel", "envoy")
+var (
+	nonGoBinaries      = sets.New("ztunnel", "envoy")
+	nonVersionBinaries = sets.New("client", "server")
+)
 
 // Test that flags do not get polluted with unexpected flags
 func TestFlags(t *testing.T) {
@@ -105,6 +111,8 @@ func TestBinarySizes(t *testing.T) {
 		// TODO(https://github.com/kubernetes/kubernetes/issues/101384) bump this down a bit?
 		"pilot-discovery": {60, 85},
 		"bug-report":      {60, 85},
+		"client":          {20, 30},
+		"server":          {20, 30},
 		"envoy":           {60, 110},
 		"ztunnel":         {15, 25},
 	}


### PR DESCRIPTION
This cuts about 20mb off the binary. There was some concern from k8s folks, who are now using this in gateway-api, about bloat.

**Please provide a description of this PR:**