### PR TITLE
envoyfilter: reduce unnecessary deepcopy when patching to single http_route

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -253,7 +254,7 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 			routeMatch(virtualHost.Routes[routeIndex], rp) {
 			if !*clonedVhostRoutes {
 				// different virtualHosts may share same routes pointer
-				virtualHost.Routes = cloneVhostRoutes(virtualHost.Routes)
+				virtualHost.Routes = slices.Clone(virtualHost.Routes)
 				*clonedVhostRoutes = true
 			}
 			if rp.Operation == networking.EnvoyFilter_Patch_REMOVE {
@@ -261,6 +262,7 @@ func patchHTTPRoute(patchContext networking.EnvoyFilter_PatchContext,
 				*routesRemoved = true
 				return
 			} else if rp.Operation == networking.EnvoyFilter_Patch_MERGE {
+				cloneVhostRouteByRouteIndex(virtualHost, routeIndex)
 				merge.Merge(virtualHost.Routes[routeIndex], rp.Value)
 			}
 			applied = true
@@ -395,11 +397,6 @@ func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper)
 	return true
 }
 
-func cloneVhostRoutes(routes []*route.Route) []*route.Route {
-	out := make([]*route.Route, len(routes))
-	for i := 0; i < len(routes); i++ {
-		clone := proto.Clone(routes[i]).(*route.Route)
-		out[i] = clone
-	}
-	return out
+func cloneVhostRouteByRouteIndex(virtualHost *route.VirtualHost, routeIndex int) {
+	virtualHost.Routes[routeIndex] = proto.Clone(virtualHost.Routes[routeIndex]).(*route.Route)
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch_test.go
@@ -1115,3 +1115,53 @@ func TestPatchHTTPRoute(t *testing.T) {
 		})
 	}
 }
+
+func TestCloneVhostRouteByRouteIndex(t *testing.T) {
+	type args struct {
+		vh1 *route.VirtualHost
+		vh2 *route.VirtualHost
+	}
+	cloneRouter := route.Route{
+		Name: "clone",
+		Action: &route.Route_Route{
+			Route: &route.RouteAction{
+				PrefixRewrite: "/clone",
+			},
+		},
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantClone bool
+	}{
+		{
+			name: "clone",
+			args: args{
+				vh1: &route.VirtualHost{
+					Name:    "vh1",
+					Domains: []string{"*"},
+					Routes: []*route.Route{
+						&cloneRouter,
+					},
+				},
+				vh2: &route.VirtualHost{
+					Name:    "vh2",
+					Domains: []string{"*"},
+					Routes: []*route.Route{
+						&cloneRouter,
+					},
+				},
+			},
+			wantClone: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cloneRouter.Name = "test"
+			cloneVhostRouteByRouteIndex(tt.args.vh1, 0)
+			if tt.args.vh1.Routes[0].Name != tt.args.vh2.Routes[0].Name && tt.wantClone {
+				t.Errorf("CloneVhostRouteByRouteIndex(): %s (-wantClone +got):%v", tt.name, tt.wantClone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please provide a description of this PR:**

keep [`cloneVhostRouteByRouteIndex`](https://github.com/istio/istio/pull/40986) when patch http_route, also see https://github.com/istio/istio/pull/44823#discussion_r1190077374