### PR TITLE
operator: drop last-applied-configuration annotation when using SSA

### DIFF
--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -162,8 +162,10 @@ func (h *HelmReconciler) ApplyObject(obj *unstructured.Unstructured, serverSideA
 		return errs.ToError()
 	}
 
-	if err := kubectlutil.CreateApplyAnnotation(obj, unstructured.UnstructuredJSONScheme); err != nil {
-		scope.Errorf("unexpected error adding apply annotation to object: %s", err)
+	if !serverSideApply {
+		if err := kubectlutil.CreateApplyAnnotation(obj, unstructured.UnstructuredJSONScheme); err != nil {
+			scope.Errorf("unexpected error adding apply annotation to object: %s", err)
+		}
 	}
 
 	objectKey := client.ObjectKeyFromObject(obj)


### PR DESCRIPTION
Pretty sure we don't need this when using SSA, its design only for non-SSA.

**Please provide a description of this PR:**