### PR TITLE
Fix invalid XDS configuration for wildcard Ingress HTTP path

### DIFF
--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -207,8 +207,14 @@ func ConvertIngressVirtualService(ingress knetworking.Ingress, domainSuffix stri
 		// see https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches
 		vs := ingressByHost[host].Spec.(*networking.VirtualService)
 		sort.SliceStable(vs.Http, func(i, j int) bool {
-			r1Len, r1Ex := getMatchURILength(vs.Http[i].Match[0])
-			r2Len, r2Ex := getMatchURILength(vs.Http[j].Match[0])
+			var r1Len, r2Len int
+			var r1Ex, r2Ex bool
+			if vs.Http[i].Match != nil || len(vs.Http[i].Match) != 0 {
+				r1Len, r1Ex = getMatchURILength(vs.Http[i].Match[0])
+			}
+			if vs.Http[j].Match != nil || len(vs.Http[j].Match) != 0 {
+				r2Len, r2Ex = getMatchURILength(vs.Http[j].Match[0])
+			}
 			// TODO: default at the end
 			if r1Len == r2Len {
 				return r1Ex && !r2Ex

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -200,6 +200,24 @@ func TestConversion(t *testing.T) {
 						},
 					},
 				},
+				{
+					Host: "my4.host.com",
+					IngressRuleValue: knetworking.IngressRuleValue{
+						HTTP: &knetworking.HTTPIngressRuleValue{
+							Paths: []knetworking.HTTPIngressPath{
+								{
+									Path: "/*",
+									Backend: knetworking.IngressBackend{
+										Service: &knetworking.IngressServiceBackend{
+											Name: "bar",
+											Port: knetworking.ServiceBackendPort{Number: 8000},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -255,8 +273,8 @@ func TestConversion(t *testing.T) {
 	ConvertIngressVirtualService(ingress, "mydomain", cfgs, serviceLister)
 	ConvertIngressVirtualService(ingress2, "mydomain", cfgs, serviceLister)
 
-	if len(cfgs) != 3 {
-		t.Error("VirtualServices, expected 3 got ", len(cfgs))
+	if len(cfgs) != 4 {
+		t.Error("VirtualServices, expected 4 got ", len(cfgs))
 	}
 
 	expectedLength := [5]int{13, 13, 9, 6, 5}
@@ -278,6 +296,16 @@ func TestConversion(t *testing.T) {
 					t.Errorf("Unexpected rule at idx:%d, want {length:%d, exact:%v}, got {length:%d, exact: %v}",
 						i, expectedLength[i], expectedExact[i], length, exact)
 				}
+			}
+		} else if n == "my4.host.com" {
+			if vs.Hosts[0] != "my4.host.com" {
+				t.Error("Unexpected host", vs)
+			}
+			if len(vs.Http) != 1 {
+				t.Error("Unexpected rules", vs.Http)
+			}
+			if vs.Http[0].Match != nil {
+				t.Error("Expected HTTPMatchRequest to be nil")
 			}
 		}
 	}

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -305,7 +305,7 @@ func TestConversion(t *testing.T) {
 				t.Error("Unexpected rules", vs.Http)
 			}
 			if vs.Http[0].Match != nil {
-				t.Error("Expected HTTPMatchRequest to be nil")
+				t.Error("Expected HTTPMatchRequest to be nil, got {}")
 			}
 		}
 	}

--- a/pilot/pkg/config/kube/ingress/testdata/overlay.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/overlay.yaml.golden
@@ -55,9 +55,7 @@ spec:
         port:
           number: 4200
       weight: 100
-  - match:
-    - {}
-    route:
+  - route:
     - destination:
         host: service1.ns.svc.mydomain
         port:

--- a/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/tls-no-secret.yaml.golden
@@ -12,10 +12,7 @@ spec:
   hosts:
   - foo.org
   http:
-  - match:
-    - uri:
-        prefix: ""
-    route:
+  - route:
     - destination:
         host: httpbin.bar.svc.mydomain
         port:

--- a/pilot/pkg/config/kube/ingress/testdata/tls.yaml.golden
+++ b/pilot/pkg/config/kube/ingress/testdata/tls.yaml.golden
@@ -12,10 +12,7 @@ spec:
   hosts:
   - foo.org
   http:
-  - match:
-    - uri:
-        prefix: ""
-    route:
+  - route:
     - destination:
         host: httpbin.bar.svc.mydomain
         port:


### PR DESCRIPTION
**Please provide a description of this PR:**

Updates Ingress to VirtualService translation to not create an HTTPRequestMatch when the URI is nil. The URI is nil when the path is a wildcard or is empty and the pathType is nil or ImplementationSpecific. This change prevents an Envoy failure. Envoy regex fails when the path separated prefix is empty or has a trailing "/".

Resolves #44882

**Reproducing Error:**

Reproduced the error seen in #44882 by applying the following Ingress after installing Istio with the demo profile:

```yaml
kubectl apply -f - <<EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: istio
  name: ingress
spec:
  rules:
  - host: httpbin.example.com
    http:
      paths:
      - path: /*
        pathType: ImplementationSpecific
        backend:
          service:
            name: httpbin
            port:
              number: 8000
EOF
```

Following the [Kubernetes Ingress tutorial](https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/), the httpbin resources were deployed in the default ns. The following curl command failed:

```sh
curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/status/200"
```

The ingress-gateway resource had the following error in the logs:

```txt
warning envoy config external/envoy/source/common/config/grpc_subscription_impl.cc:128  gRPC config for type.googleapis.com/envoy.config.route.v3.RouteConfiguration rejected: Proto constraint validation failed (RouteConfigurationValidationError.VirtualHosts[0]: embedded message failed validation | caused by VirtualHostValidationError.Routes[0]: embedded message failed validation | caused by RouteValidationError.Match: embedded message failed validation | caused by RouteMatchValidationError.PathSeparatedPrefix: value does not match regex pattern "^[^?#]+[^?#/]$"): name: "http.8080"
```

**Validation:**

Validated the changes included in this PR result in a valid XDS configuration in the same setup.

```sh
$ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/headers"

HTTP/1.1 200 OK
server: istio-envoy
date: Mon, 15 May 2023 16:46:46 GMT
content-type: application/json
content-length: 599
access-control-allow-origin: *
access-control-allow-credentials: true
x-envoy-upstream-service-time: 3

```

