### PR TITLE
kube: use our own informer factory

### DIFF
--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -16,7 +16,6 @@ package crdclient
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // import OIDC cluster authentication plugin, e.g. for Tectonic
 	"k8s.io/client-go/tools/cache"
@@ -81,12 +80,12 @@ func (h *cacheHandler) callHandlers(old config.Config, curr config.Config, event
 	}
 }
 
-func createCacheHandler(cl *Client, schema resource.Schema, i informers.GenericInformer) *cacheHandler {
+func createCacheHandler(cl *Client, schema resource.Schema, i kclient.Untyped) *cacheHandler {
 	scope.Debugf("registered CRD %v", schema.GroupVersionKind())
 	h := &cacheHandler{
 		client:   cl,
 		schema:   schema,
-		informer: kclient.NewUntyped(cl.client, i.Informer(), kclient.Filter{ObjectFilter: cl.namespacesFilter}),
+		informer: i,
 	}
 
 	kind := schema.Kind()

--- a/pilot/pkg/config/kube/crdclient/cache_handler_test.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler_test.go
@@ -156,7 +156,7 @@ func buildClientAndCacheHandler(t test.Failer, schema resource.Schema) (*Client,
 
 	// The informer isn't actually used in the test, but a real one is needed for
 	// constructing the cache handler, so just use an arbitrary one.
-	informer := kclient.NewUntyped(cl.client, gvr.Pod, kclient.Filter{})
+	informer := kclient.NewUntypedInformer(cl.client, gvr.Pod, kclient.Filter{})
 	h := createCacheHandler(cl, schema, informer)
 
 	return cl, h

--- a/pilot/pkg/config/kube/crdclient/cache_handler_test.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler_test.go
@@ -17,7 +17,6 @@ package crdclient
 import (
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -26,8 +25,10 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -155,9 +156,7 @@ func buildClientAndCacheHandler(t test.Failer, schema resource.Schema) (*Client,
 
 	// The informer isn't actually used in the test, but a real one is needed for
 	// constructing the cache handler, so just use an arbitrary one.
-	informer, err := cl.client.KubeInformer().ForResource(corev1.SchemeGroupVersion.WithResource("pods"))
-	assert.NoError(t, err)
-
+	informer := kclient.NewUntyped(cl.client, gvr.Pod, kclient.Filter{})
 	h := createCacheHandler(cl, schema, informer)
 
 	return cl, h

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -421,7 +421,7 @@ func handleCRDAdd(cl *Client, name string) {
 		cl.logger.Debugf("added resource that already exists: %v", resourceGVK)
 		return
 	}
-	inf := kclient.NewUntyped(cl.client, gvr, kclient.Filter{ObjectFilter: cl.namespacesFilter})
+	inf := kclient.NewUntypedInformer(cl.client, gvr, kclient.Filter{ObjectFilter: cl.namespacesFilter})
 	cl.kinds[resourceGVK] = createCacheHandler(cl, s, inf)
 	if w, f := cl.crdWatches[resourceGVK]; f {
 		cl.logger.Infof("notifying watchers %v was created", resourceGVK)
@@ -433,6 +433,6 @@ func handleCRDAdd(cl *Client, name string) {
 	// we will start all factories once we are ready to initialize.
 	// For dynamically added CRDs, we need to start immediately though
 	if cl.stop != nil {
-		cl.client.Run(cl.stop)
+		inf.Start(cl.stop)
 	}
 }

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/client-go/informers"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // import OIDC cluster authentication plugin, e.g. for Tectonic
 
@@ -49,6 +48,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/watcher/crdwatcher"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/log"
@@ -421,31 +421,8 @@ func handleCRDAdd(cl *Client, name string) {
 		cl.logger.Debugf("added resource that already exists: %v", resourceGVK)
 		return
 	}
-	var i informers.GenericInformer
-	var ifactory starter
-	var err error
-	switch s.Group() {
-	case gvk.KubernetesGateway.Group:
-		ifactory = cl.client.GatewayAPIInformer()
-		i, err = cl.client.GatewayAPIInformer().ForResource(gvr)
-	case gvk.Pod.Group, gvk.Deployment.Group, gvk.MutatingWebhookConfiguration.Group:
-		ifactory = cl.client.KubeInformer()
-		i, err = cl.client.KubeInformer().ForResource(gvr)
-	case gvk.CustomResourceDefinition.Group:
-		ifactory = cl.client.ExtInformer()
-		i, err = cl.client.ExtInformer().ForResource(gvr)
-	default:
-		ifactory = cl.client.IstioInformer()
-		i, err = cl.client.IstioInformer().ForResource(gvr)
-	}
-	if err != nil {
-		// Shouldn't happen
-		cl.logger.Errorf("failed to create informer for %v: %v", resourceGVK, err)
-		return
-	}
-	_ = i.Informer().SetTransform(kube.StripUnusedFields)
-
-	cl.kinds[resourceGVK] = createCacheHandler(cl, s, i)
+	inf := kclient.NewUntyped(cl.client, gvr, kclient.Filter{ObjectFilter: cl.namespacesFilter})
+	cl.kinds[resourceGVK] = createCacheHandler(cl, s, inf)
 	if w, f := cl.crdWatches[resourceGVK]; f {
 		cl.logger.Infof("notifying watchers %v was created", resourceGVK)
 		w.once.Do(func() {
@@ -456,10 +433,6 @@ func handleCRDAdd(cl *Client, name string) {
 	// we will start all factories once we are ready to initialize.
 	// For dynamically added CRDs, we need to start immediately though
 	if cl.stop != nil {
-		ifactory.Start(cl.stop)
+		cl.client.Run(cl.stop)
 	}
-}
-
-type starter interface {
-	Start(stopCh <-chan struct{})
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -596,12 +596,12 @@ func (c *Controller) informersSynced() bool {
 	// Because crdWatcher.HasSynced only indicates the cache synced, but does not guarantee the event handler called.
 	// So we wait get the CRD explicitly and if MCS installed, we wait until serviceImports and serviceExports sync.
 	if c.crdWatcher != nil {
-		if _, exists, _ := c.crdWatcher.GetByKey(mcs.ServiceImportGVR.Resource + "." + mcs.ServiceImportGVR.Group); exists {
+		if c.crdWatcher.Exists(mcs.ServiceImportGVR.Resource + "." + mcs.ServiceImportGVR.Group) {
 			if !c.imports.HasSynced() {
 				return false
 			}
 		}
-		if _, exists, _ := c.crdWatcher.GetByKey(mcs.ServiceExportGVR.Resource + "." + mcs.ServiceExportGVR.Group); exists {
+		if c.crdWatcher.Exists(mcs.ServiceExportGVR.Resource + "." + mcs.ServiceExportGVR.Group) {
 			if !c.exports.HasSynced() {
 				return false
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -202,11 +202,10 @@ func (ec *serviceExportCacheImpl) Run(stop <-chan struct{}) {
 	case <-stop:
 		return
 	}
-	dInformer := ec.client.DynamicInformer().ForResource(mcs.ServiceExportGVR).Informer()
-	ec.serviceExports = kclient.NewUntyped(ec.client, dInformer, kclient.Filter{ObjectFilter: ec.opts.GetFilter()})
+	ec.serviceExports = kclient.NewDynamic(ec.client, mcs.ServiceExportGVR, kclient.Filter{ObjectFilter: ec.opts.GetFilter()})
 	// Register callbacks for events.
 	registerHandlers(ec.Controller, ec.serviceExports, "ServiceExports", ec.onServiceExportEvent, nil)
-	go dInformer.Run(stop)
+	ec.client.Run(stop)
 	kube.WaitForCacheSync("service export", stop, ec.serviceExports.HasSynced)
 	ec.started.Store(true)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache.go
@@ -205,7 +205,7 @@ func (ec *serviceExportCacheImpl) Run(stop <-chan struct{}) {
 	ec.serviceExports = kclient.NewDynamic(ec.client, mcs.ServiceExportGVR, kclient.Filter{ObjectFilter: ec.opts.GetFilter()})
 	// Register callbacks for events.
 	registerHandlers(ec.Controller, ec.serviceExports, "ServiceExports", ec.onServiceExportEvent, nil)
-	ec.client.Run(stop)
+	ec.serviceExports.Start(stop)
 	kube.WaitForCacheSync("service export", stop, ec.serviceExports.HasSynced)
 	ec.started.Store(true)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -296,13 +296,12 @@ func (ic *serviceImportCacheImpl) Run(stop <-chan struct{}) {
 		return
 	}
 
-	dInformer := ic.client.DynamicInformer().ForResource(mcs.ServiceImportGVR).Informer()
-	ic.serviceImports = kclient.NewUntyped(ic.client, dInformer, kclient.Filter{ObjectFilter: ic.opts.GetFilter()})
+	ic.serviceImports = kclient.NewDynamic(ic.client, mcs.ServiceImportGVR, kclient.Filter{ObjectFilter: ic.opts.GetFilter()})
 	// Register callbacks for Service events anywhere in the mesh.
 	ic.opts.MeshServiceController.AppendServiceHandlerForCluster(ic.Cluster(), ic.onServiceEvent)
 	// Register callbacks for ServiceImport events in this cluster only.
 	registerHandlers(ic.Controller, ic.serviceImports, "ServiceImports", ic.onServiceImportEvent, nil)
-	go dInformer.Run(stop)
+	ic.client.Run(stop)
 	kubelib.WaitForCacheSync("service import", stop, ic.serviceImports.HasSynced)
 	ic.started.Store(true)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -301,7 +301,7 @@ func (ic *serviceImportCacheImpl) Run(stop <-chan struct{}) {
 	ic.opts.MeshServiceController.AppendServiceHandlerForCluster(ic.Cluster(), ic.onServiceEvent)
 	// Register callbacks for ServiceImport events in this cluster only.
 	registerHandlers(ic.Controller, ic.serviceImports, "ServiceImports", ic.onServiceImportEvent, nil)
-	ic.client.Run(stop)
+	ic.serviceImports.Start(stop)
 	kubelib.WaitForCacheSync("service import", stop, ic.serviceImports.HasSynced)
 	ic.started.Store(true)
 }

--- a/pkg/config/schema/codegen/templates/clients.go.tmpl
+++ b/pkg/config/schema/codegen/templates/clients.go.tmpl
@@ -1,4 +1,3 @@
-
 // GENERATED FILE -- DO NOT EDIT
 //
 
@@ -13,6 +12,9 @@ import (
 	kubeextinformer "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	ktypes "istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pilot/pkg/util/informermetric"
+	"istio.io/pkg/log"
+	"istio.io/istio/pkg/kube/informerfactory"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -27,38 +29,6 @@ import (
 	{{.ImportName}} "{{.PackageName}}"
 {{- end}}
 )
-
-type ClientGetter interface {
-	// Ext returns the API extensions client.
-	Ext() kubeext.Interface
-
-	// Kube returns the core kube client
-	Kube() kubernetes.Interface
-
-	// Dynamic client.
-	Dynamic() dynamic.Interface
-
-	// Metadata returns the Metadata kube client.
-	Metadata() metadata.Interface
-
-	// Istio returns the Istio kube client.
-	Istio() istioclient.Interface
-
-	// GatewayAPI returns the gateway-api kube client.
-	GatewayAPI() gatewayapiclient.Interface
-
-	// KubeInformer returns an informer for core kube client
-	KubeInformer() informers.SharedInformerFactory
-
-	// IstioInformer returns an informer for the istio client
-	IstioInformer() istioinformer.SharedInformerFactory
-
-	// GatewayAPIInformer returns an informer for the gateway-api client
-	GatewayAPIInformer() gatewayapiinformer.SharedInformerFactory
-
-	// ExtInformer returns an informer for the extension client
-	ExtInformer() kubeextinformer.SharedInformerFactory
-}
 
 func GetWriteClient[T runtime.Object](c ClientGetter, namespace string) ktypes.WriteAPI[T] {
 	switch any(ptr.Empty[T]()).(type) {
@@ -86,27 +56,40 @@ func GetClient[T, TL runtime.Object](c ClientGetter, namespace string) ktypes.Re
 	}
 }
 
-func GetInformerFiltered[T runtime.Object](c ClientGetter, opts ktypes.InformerOptions) cache.SharedIndexInformer {
+func gvrToObject(g schema.GroupVersionResource) runtime.Object {
+	switch g {
+{{- range .Entries }}
+	{{- if not .Resource.Synthetic }}
+	case gvr.{{ .Resource.Identifier }}:
+		return &{{ .IstioAwareClientImport }}.{{ .Resource.Kind }}{}
+	{{- end }}
+{{- end }}
+  default:
+    panic(fmt.Sprintf("Unknown type %v", g))
+	}
+}
+
+func getInformerFiltered(c ClientGetter, opts ktypes.InformerOptions, g schema.GroupVersionResource) informerfactory.StartableInformer {
 	var l func(options metav1.ListOptions) (runtime.Object, error)
 	var w func(options metav1.ListOptions) (watch.Interface, error)
 
-	switch any(ptr.Empty[T]()).(type) {
+	switch g {
 {{- range .Entries }}
 	{{- if not .Resource.Synthetic }}
-	case *{{ .IstioAwareClientImport }}.{{ .Resource.Kind }}:
+	case gvr.{{ .Resource.Identifier }}:
 		l = func(options metav1.ListOptions) (runtime.Object, error) {
-			return c.{{.ClientGetter}}().{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if not .Resource.ClusterScoped}}""{{end}}).List(context.Background(), options)
+			return c.{{.ClientGetter}}().{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if not .Resource.ClusterScoped}}opts.Namespace{{end}}).List(context.Background(), options)
 		}
 		w = func(options metav1.ListOptions) (watch.Interface, error) {
-			return c.{{.ClientGetter}}().{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if not .Resource.ClusterScoped}}""{{end}}).Watch(context.Background(), options)
+			return c.{{.ClientGetter}}().{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if not .Resource.ClusterScoped}}opts.Namespace{{end}}).Watch(context.Background(), options)
 		}
 	{{- end }}
 {{- end }}
   default:
-    panic(fmt.Sprintf("Unknown type %T", ptr.Empty[T]()))
+    panic(fmt.Sprintf("Unknown type %v", g))
 	}
-	return c.KubeInformer().InformerFor(*new(T), func(k kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
-		return cache.NewSharedIndexInformer(
+	return c.Informers().InformerFor(g, opts, func() cache.SharedIndexInformer {
+		inf := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 					options.FieldSelector = opts.FieldSelector
@@ -119,22 +102,11 @@ func GetInformerFiltered[T runtime.Object](c ClientGetter, opts ktypes.InformerO
 					return w(options)
 				},
 			},
-			*new(T),
-			resync,
+			gvrToObject(g),
+			0,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		)
+		setupInformer(opts, inf)
+		return inf
 	})
-}
-
-func GetInformer[T runtime.Object](c ClientGetter) cache.SharedIndexInformer {
-	switch any(ptr.Empty[T]()).(type) {
-{{- range .Entries }}
-	{{- if not .Resource.Synthetic }}
-	case *{{ .IstioAwareClientImport }}.{{ .Resource.Kind }}:
-		return  c.{{.ClientGetter}}Informer().{{ .InformerGroup }}.{{ .ClientTypePath }}().Informer()
-	{{- end }}
-{{- end }}
-  default:
-    panic(fmt.Sprintf("Unknown type %T", ptr.Empty[T]()))
-	}
 }

--- a/pkg/config/schema/kubeclient/common.go
+++ b/pkg/config/schema/kubeclient/common.go
@@ -85,6 +85,8 @@ func getInformerFilteredDynamic(c ClientGetter, opts ktypes.InformerOptions, g s
 					return c.Dynamic().Resource(g).Namespace(opts.Namespace).List(context.Background(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = opts.FieldSelector
+					options.LabelSelector = opts.LabelSelector
 					return c.Dynamic().Resource(g).Namespace(opts.Namespace).Watch(context.Background(), options)
 				},
 			},
@@ -110,6 +112,8 @@ func getInformerFilteredMetadata(c ClientGetter, opts ktypes.InformerOptions, g 
 					return c.Metadata().Resource(g).Namespace(opts.Namespace).List(context.Background(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = opts.FieldSelector
+					options.LabelSelector = opts.LabelSelector
 					return c.Metadata().Resource(g).Namespace(opts.Namespace).Watch(context.Background(), options)
 				},
 			},

--- a/pkg/config/schema/kubeclient/common.go
+++ b/pkg/config/schema/kubeclient/common.go
@@ -1,0 +1,153 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeclient
+
+import (
+	"context"
+
+	kubeext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/tools/cache"
+	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	istioclient "istio.io/client-go/pkg/clientset/versioned"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/util/informermetric"
+	"istio.io/istio/pkg/config/schema/kubetypes"
+	"istio.io/istio/pkg/kube/informerfactory"
+	ktypes "istio.io/istio/pkg/kube/kubetypes"
+	"istio.io/pkg/log"
+)
+
+type ClientGetter interface {
+	// Ext returns the API extensions client.
+	Ext() kubeext.Interface
+
+	// Kube returns the core kube client
+	Kube() kubernetes.Interface
+
+	// Dynamic client.
+	Dynamic() dynamic.Interface
+
+	// Metadata returns the Metadata kube client.
+	Metadata() metadata.Interface
+
+	// Istio returns the Istio kube client.
+	Istio() istioclient.Interface
+
+	// GatewayAPI returns the gateway-api kube client.
+	GatewayAPI() gatewayapiclient.Interface
+
+	// Informers returns an informer factory.
+	Informers() informerfactory.InformerFactory
+}
+
+func GetInformerFiltered[T runtime.Object](c ClientGetter, opts ktypes.InformerOptions) cache.SharedIndexInformer {
+	return GetInformerFilteredFromGVR(c, opts, kubetypes.GetGVR[T]())
+}
+
+func GetInformerFilteredFromGVR(c ClientGetter, opts ktypes.InformerOptions, g schema.GroupVersionResource) cache.SharedIndexInformer {
+	switch opts.InformerType {
+	case ktypes.DynamicInformer:
+		return getInformerFilteredDynamic(c, opts, g)
+	case ktypes.MetadataInformer:
+		return getInformerFilteredMetadata(c, opts, g)
+	default:
+		return getInformerFiltered(c, opts, g)
+	}
+}
+
+func getInformerFilteredDynamic(c ClientGetter, opts ktypes.InformerOptions, g schema.GroupVersionResource) cache.SharedIndexInformer {
+	return c.Informers().InformerFor(g, func() cache.SharedIndexInformer {
+		inf := cache.NewSharedIndexInformerWithOptions(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = opts.FieldSelector
+					options.LabelSelector = opts.LabelSelector
+					return c.Dynamic().Resource(g).Namespace(features.InformerWatchNamespace).List(context.Background(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return c.Dynamic().Resource(g).Namespace(features.InformerWatchNamespace).Watch(context.Background(), options)
+				},
+			},
+			&unstructured.Unstructured{},
+			cache.SharedIndexInformerOptions{
+				ResyncPeriod:      0,
+				Indexers:          cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				ObjectDescription: g.String(),
+			},
+		)
+		setupInformer(opts, inf)
+		return inf
+	})
+}
+
+func getInformerFilteredMetadata(c ClientGetter, opts ktypes.InformerOptions, g schema.GroupVersionResource) cache.SharedIndexInformer {
+	return c.Informers().InformerFor(g, func() cache.SharedIndexInformer {
+		inf := cache.NewSharedIndexInformerWithOptions(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = opts.FieldSelector
+					options.LabelSelector = opts.LabelSelector
+					return c.Metadata().Resource(g).Namespace(features.InformerWatchNamespace).List(context.Background(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return c.Metadata().Resource(g).Namespace(features.InformerWatchNamespace).Watch(context.Background(), options)
+				},
+			},
+			&metav1.PartialObjectMetadata{},
+			cache.SharedIndexInformerOptions{
+				ResyncPeriod:      0,
+				Indexers:          cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				ObjectDescription: g.String(),
+			},
+		)
+		setupInformer(opts, inf)
+		return inf
+	})
+}
+
+func setupInformer(opts ktypes.InformerOptions, inf cache.SharedIndexInformer) {
+	// It is important to set this in the newFunc rather than after InformerFor to avoid
+	// https://github.com/kubernetes/kubernetes/issues/117869
+	if opts.ObjectTransform != nil {
+		_ = inf.SetTransform(opts.ObjectTransform)
+	} else {
+		_ = inf.SetTransform(stripUnusedFields)
+	}
+	if err := inf.SetWatchErrorHandler(informermetric.ErrorHandlerForCluster(opts.Cluster)); err != nil {
+		log.Debugf("failed to set watch handler, informer may already be started: %v", err)
+	}
+}
+
+// stripUnusedFields is the transform function for shared informers,
+// it removes unused fields from objects before they are stored in the cache to save memory.
+func stripUnusedFields(obj any) (any, error) {
+	t, ok := obj.(metav1.ObjectMetaAccessor)
+	if !ok {
+		// shouldn't happen
+		return obj, nil
+	}
+	// ManagedFields is large and we never use it
+	t.GetObjectMeta().SetManagedFields(nil)
+	return obj, nil
+}

--- a/pkg/config/schema/kubetypes/common.go
+++ b/pkg/config/schema/kubetypes/common.go
@@ -27,7 +27,7 @@ func GetGVR[T runtime.Object]() schema.GroupVersionResource {
 	gk := GetGVK[T]()
 	gr, ok := gvk.ToGVR(gk)
 	if !ok {
-		panic(fmt.Sprintf("know GVR for GVK %v", gk))
+		panic(fmt.Sprintf("unknow GVR for GVK %v", gk))
 	}
 	return gr
 }

--- a/pkg/config/schema/kubetypes/common.go
+++ b/pkg/config/schema/kubetypes/common.go
@@ -1,0 +1,33 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubetypes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/pkg/config/schema/gvk"
+)
+
+func GetGVR[T runtime.Object]() schema.GroupVersionResource {
+	gk := GetGVK[T]()
+	gr, ok := gvk.ToGVR(gk)
+	if !ok {
+		panic(fmt.Sprintf("know GVR for GVK %v", gk))
+	}
+	return gr
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -125,7 +125,6 @@ type Client interface {
 	// RunAndWait starts all informers and waits for their caches to sync.
 	// Warning: this must be called AFTER .Informer() is called, which will register the informer.
 	RunAndWait(stop <-chan struct{})
-	Run(stop <-chan struct{})
 
 	// WaitForCacheSync waits for all cache functions to sync, as well as all informers started by the *fake* client.
 	WaitForCacheSync(name string, stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool

--- a/pkg/kube/informerfactory/factory.go
+++ b/pkg/kube/informerfactory/factory.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package informerfactory provides a "factory" to generate informers. This allows users to create the
+// same informers in multiple different locations, while still using the same underlying resources.
+// Additionally, aggregate operations like Start, Shutdown, and Wait are available.
+// Kubernetes core has informer factories with very similar logic. However, this has a few problems that
+// spurred a fork:
+// * Factories are per package. That means we have ~6 distinct factories, which makes management a hassle.
+// * Across these, the factories are often inconsistent in functionality. Changes to these takes >4 months.
+// * Lack of functionality we want (see below).
+//
+// Added functionality:
+// * Single factory for any type, including dynamic informers, meta informers, typed informers, etc.
+// * TODO: ability to run a single informer rather than all of them.
+// * TODO: ability to create multiple informers of the same type but with different filters.
+package informerfactory
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pkg/util/sets"
+)
+
+// NewInformerFunc returns a SharedIndexInformer.
+type NewInformerFunc func() cache.SharedIndexInformer
+
+// InformerFactory provides access to a shared informer factory
+type InformerFactory interface {
+	// Start initializes all requested informers. They are handled in goroutines
+	// which run until the stop channel gets closed.
+	Start(stopCh <-chan struct{})
+
+	// InformerFor returns the SharedIndexInformer the provided type.
+	InformerFor(resource schema.GroupVersionResource, newFunc NewInformerFunc) cache.SharedIndexInformer
+
+	// WaitForCacheSync blocks until all started informers' caches were synced
+	// or the stop channel gets closed.
+	WaitForCacheSync(stopCh <-chan struct{}) bool
+
+	// Shutdown marks a factory as shutting down. At that point no new
+	// informers can be started anymore and Start will return without
+	// doing anything.
+	//
+	// In addition, Shutdown blocks until all goroutines have terminated. For that
+	// to happen, the close channel(s) that they were started with must be closed,
+	// either before Shutdown gets called or while it is waiting.
+	//
+	// Shutdown may be called multiple times, even concurrently. All such calls will
+	// block until all goroutines have terminated.
+	Shutdown()
+}
+
+// NewSharedInformerFactory constructs a new instance of informerFactory for all namespaces.
+func NewSharedInformerFactory() InformerFactory {
+	return &informerFactory{
+		informers:        map[informerKey]cache.SharedIndexInformer{},
+		startedInformers: sets.New[informerKey](),
+	}
+}
+
+type informerKey struct {
+	gvr schema.GroupVersionResource
+}
+
+type informerFactory struct {
+	lock      sync.Mutex
+	informers map[informerKey]cache.SharedIndexInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers sets.Set[informerKey]
+
+	// wg tracks how many goroutines were started.
+	wg sync.WaitGroup
+	// shuttingDown is true when Shutdown has been called. It may still be running
+	// because it needs to wait for goroutines.
+	shuttingDown bool
+}
+
+var _ InformerFactory = &informerFactory{}
+
+func (f *informerFactory) InformerFor(resource schema.GroupVersionResource, newFunc NewInformerFunc) cache.SharedIndexInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := informerKey{
+		gvr: resource,
+	}
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = newFunc()
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *informerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.shuttingDown {
+		return
+	}
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers.Contains(informerType) {
+			f.wg.Add(1)
+			// We need a new variable in each loop iteration,
+			// otherwise the goroutine would use the loop variable
+			// and that keeps changing.
+			informer := informer
+			go func() {
+				defer f.wg.Done()
+				informer.Run(stopCh)
+			}()
+			f.startedInformers.Insert(informerType)
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *informerFactory) WaitForCacheSync(stopCh <-chan struct{}) bool {
+	informers := func() []cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		informers := make([]cache.SharedIndexInformer, 0, len(f.informers))
+		for informerKey, informer := range f.informers {
+			if f.startedInformers.Contains(informerKey) {
+				informers = append(informers, informer)
+			}
+		}
+		return informers
+	}()
+
+	for _, informer := range informers {
+		if !cache.WaitForCacheSync(stopCh, informer.HasSynced) {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *informerFactory) Shutdown() {
+	// Will return immediately if there is nothing to wait for.
+	defer f.wg.Wait()
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.shuttingDown = true
+}

--- a/pkg/kube/informerfactory/factory.go
+++ b/pkg/kube/informerfactory/factory.go
@@ -131,7 +131,7 @@ func (f *informerFactory) InformerFor(resource schema.GroupVersionResource, opts
 	inf, exists := f.informers[key]
 	if exists {
 		checkInformerOverlap(inf, resource, opts)
-		return f.makeStartedInformer(inf.informer, key)
+		return f.makeStartableInformer(inf.informer, key)
 	}
 
 	informer := newFunc()
@@ -140,7 +140,7 @@ func (f *informerFactory) InformerFor(resource schema.GroupVersionResource, opts
 		objectTransform: opts.ObjectTransform,
 	}
 
-	return f.makeStartedInformer(informer, key)
+	return f.makeStartableInformer(informer, key)
 }
 
 func checkInformerOverlap(inf builtInformer, resource schema.GroupVersionResource, opts kubetypes.InformerOptions) {
@@ -154,7 +154,7 @@ func checkInformerOverlap(inf builtInformer, resource schema.GroupVersionResourc
 	l("for type %v, registered conflicting ObjectTransform. Stack: %v", resource, string(debug.Stack()))
 }
 
-func (f *informerFactory) makeStartedInformer(informer cache.SharedIndexInformer, key informerKey) StartableInformer {
+func (f *informerFactory) makeStartableInformer(informer cache.SharedIndexInformer, key informerKey) StartableInformer {
 	return StartableInformer{
 		Informer: informer,
 		start: func(stopCh <-chan struct{}) {

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -85,8 +85,8 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	stop := make(chan struct{})
 	go w.Run(stop)
 	controller := w.(*configMapWatcher).c
-	kube.WaitForCacheSync("test", stop, controller.HasSynced)
 	client.RunAndWait(stop)
+	kube.WaitForCacheSync("test", stop, controller.HasSynced)
 
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)
 	steps := []struct {

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -185,8 +185,8 @@ func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) C
 	}
 }
 
-// NewUntyped returns an untyped client for a given GVR. This is read-only.
-func NewUntyped(c kube.Client, gvr schema.GroupVersionResource, filter Filter) Untyped {
+// NewUntypedInformer returns an untyped client for a given GVR. This is read-only.
+func NewUntypedInformer(c kube.Client, gvr schema.GroupVersionResource, filter Filter) Untyped {
 	inf := kubeclient.GetInformerFilteredFromGVR(c, toOpts(c, filter), gvr)
 	return ptr.Of(newInformerClient[controllers.Object](inf, filter))
 }

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -48,6 +48,12 @@ type Informer[T controllers.Object] interface {
 	// Warning: this only applies to handlers called via AddEventHandler; any handlers directly added
 	// to the underlying informer are not touched
 	ShutdownHandlers()
+	// Start starts just this informer. Typically, this is not used. Instead, the `kube.Client.Run()` is
+	// used to start all informers at once.
+	// However, in some cases we need to run individual informers directly.
+	// This function should only be called once. It does not wait for the informer to become ready nor does it block,
+	// so it should generally not be called in a goroutine.
+	Start(stop <-chan struct{})
 }
 
 type Writer[T controllers.Object] interface {

--- a/pkg/kube/kubetypes/types.go
+++ b/pkg/kube/kubetypes/types.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"istio.io/istio/pkg/cluster"
 )
 
 type InformerOptions struct {
@@ -28,7 +30,22 @@ type InformerOptions struct {
 	LabelSelector string
 	// A selector to restrict the list of returned objects by their fields.
 	FieldSelector string
+	// Cluster name for watch error handlers
+	Cluster cluster.ID
+	// ObjectTransform allows arbitrarily modifying objects stored in the underlying cache.
+	// If unset, a default transform is provided to remove ManagedFields (high cost, low value)
+	ObjectTransform func(obj any) (any, error)
+	// InformerType dictates the type of informer that should be created.
+	InformerType InformerType
 }
+
+type InformerType int
+
+const (
+	StandardInformer InformerType = iota
+	DynamicInformer
+	MetadataInformer
+)
 
 // Filter allows filtering read operations
 type Filter struct {

--- a/pkg/kube/kubetypes/types.go
+++ b/pkg/kube/kubetypes/types.go
@@ -30,6 +30,8 @@ type InformerOptions struct {
 	LabelSelector string
 	// A selector to restrict the list of returned objects by their fields.
 	FieldSelector string
+	// Namespace to watch.
+	Namespace string
 	// Cluster name for watch error handlers
 	Cluster cluster.ID
 	// ObjectTransform allows arbitrarily modifying objects stored in the underlying cache.
@@ -55,6 +57,9 @@ type Filter struct {
 	// A selector to restrict the list of returned objects by their fields.
 	// This is a *server side* filter.
 	FieldSelector string
+	// Namespace to watch.
+	// This is a *server side* filter.
+	Namespace string
 	// ObjectFilter allows arbitrary filtering logic.
 	// This is a *client side* filter. This means CPU/memory costs are still present for filtered objects.
 	// Use LabelSelector or FieldSelector instead, if possible.

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -16,7 +16,6 @@ package multicluster
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -25,13 +24,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -94,7 +89,7 @@ type Controller struct {
 	configClusterID     cluster.ID
 	configClusterClient kube.Client
 	queue               controllers.Queue
-	informer            cache.SharedIndexInformer
+	secrets             kclient.Client[*corev1.Secret]
 
 	DiscoveryNamespacesFilter filter.DiscoveryNamespacesFilter
 	cs                        *ClusterStore
@@ -126,20 +121,12 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 		informerClient = localKubeClient
 	}
 
-	secretsInformer := cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-				opts.LabelSelector = MultiClusterSecretLabel + "=true"
-				return informerClient.Kube().CoreV1().Secrets(namespace).List(context.TODO(), opts)
-			},
-			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-				opts.LabelSelector = MultiClusterSecretLabel + "=true"
-				return informerClient.Kube().CoreV1().Secrets(namespace).Watch(context.TODO(), opts)
-			},
-		},
-		&corev1.Secret{}, 0, cache.Indexers{},
-	)
-	_ = secretsInformer.SetTransform(kube.StripUnusedFields)
+	secrets := kclient.NewFiltered[*corev1.Secret](informerClient, kclient.Filter{
+		LabelSelector:   MultiClusterSecretLabel + "=true",
+		FieldSelector:   "",
+		ObjectFilter:    nil,
+		ObjectTransform: nil,
+	})
 
 	// init gauges
 	localClusters.Record(1.0)
@@ -150,7 +137,7 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 		configClusterID:     clusterID,
 		configClusterClient: kubeclientset,
 		cs:                  newClustersStore(),
-		informer:            secretsInformer,
+		secrets:             secrets,
 	}
 
 	namespaces := kclient.New[*corev1.Namespace](kubeclientset)
@@ -159,7 +146,7 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 		controllers.WithMaxAttempts(maxRetries),
 		controllers.WithReconciler(controller.processItem))
 
-	_, _ = secretsInformer.AddEventHandler(controllers.ObjectHandler(controller.queue.AddObject))
+	secrets.AddEventHandler(controllers.ObjectHandler(controller.queue.AddObject))
 	return controller
 }
 
@@ -179,9 +166,10 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 		t0 := time.Now()
 		log.Info("Starting multicluster remote secrets controller")
 
-		go c.informer.Run(stopCh)
+		// TODO: do we really need to start here, or can we use the global factory start?
+		c.secrets.Start(stopCh)
 
-		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.informer.HasSynced) {
+		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.secrets.HasSynced) {
 			return
 		}
 		log.Infof("multicluster remote secrets controller cache synced in %v", time.Since(t0))
@@ -212,13 +200,10 @@ func (c *Controller) HasSynced() bool {
 
 func (c *Controller) processItem(key types.NamespacedName) error {
 	log.Infof("processing secret event for secret %s", key)
-	obj, exists, err := c.informer.GetIndexer().GetByKey(key.String())
-	if err != nil {
-		return fmt.Errorf("error fetching object %s: %v", key, err)
-	}
-	if exists {
+	scrt := c.secrets.Get(key.Name, key.Namespace)
+	if scrt != nil {
 		log.Debugf("secret %s exists in informer cache, processing it", key)
-		if err := c.addSecret(key, obj.(*corev1.Secret)); err != nil {
+		if err := c.addSecret(key, scrt); err != nil {
 			return fmt.Errorf("error adding secret %s: %v", key, err)
 		}
 	} else {

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -191,7 +191,7 @@ func Test_SecretController(t *testing.T) {
 	t.Run("sync timeout", func(t *testing.T) {
 		retry.UntilOrFail(t, c.HasSynced, retry.Timeout(2*time.Second))
 	})
-	kube.WaitForCacheSync("test", stopCh, c.informer.HasSynced)
+	kube.WaitForCacheSync("test", stopCh, c.HasSynced)
 	clientset.RunAndWait(stopCh)
 
 	for _, step := range steps {

--- a/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
+++ b/pkg/kube/watcher/configmapwatcher/configmapwatcher.go
@@ -15,27 +15,22 @@
 package configmapwatcher
 
 import (
-	"fmt"
-	"time"
-
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/informers"
-	informersv1 "k8s.io/client-go/informers/core/v1"
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
 )
 
 // Controller watches a ConfigMap and calls the given callback when the ConfigMap changes.
 // The ConfigMap is passed to the callback, or nil if it doesn't exist.
 type Controller struct {
-	informer informersv1.ConfigMapInformer
-	queue    controllers.Queue
+	configmaps kclient.Client[*v1.ConfigMap]
+	queue      controllers.Queue
 
 	configMapNamespace string
 	configMapName      string
@@ -52,18 +47,14 @@ func NewController(client kube.Client, namespace, name string, callback func(*v1
 		callback:           callback,
 	}
 
-	// Although using a separate informer factory isn't ideal,
-	// this does so to limit watching to only the specified ConfigMap.
-	c.informer = informers.NewSharedInformerFactoryWithOptions(client.Kube(), 12*time.Hour,
-		informers.WithNamespace(namespace),
-		informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
-			listOptions.FieldSelector = fields.OneTermEqualSelector(metav1.ObjectNameField, name).String()
-		})).
-		Core().V1().ConfigMaps()
+	c.configmaps = kclient.NewFiltered[*v1.ConfigMap](client, kclient.Filter{
+		Namespace:     namespace,
+		FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, name).String(),
+	})
 
 	c.queue = controllers.NewQueue("configmap "+name, controllers.WithReconciler(c.processItem))
-	_, _ = c.informer.Informer().AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {
-		// Filter out configmaps
+	c.configmaps.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {
+		// Filter out other configmaps
 		return o.GetName() == name && o.GetNamespace() == namespace
 	}))
 
@@ -71,8 +62,11 @@ func NewController(client kube.Client, namespace, name string, callback func(*v1
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {
-	go c.informer.Informer().Run(stop)
-	if !kube.WaitForCacheSync("configmap "+c.configMapName, stop, c.informer.Informer().HasSynced) {
+	// Start informer immediately instead of with the rest. This is because we use configmapwatcher for
+	// single types (so its never shared), and for use cases where we need the results immediately
+	// during startup.
+	c.configmaps.Start(stop)
+	if !kube.WaitForCacheSync("configmap "+c.configMapName, stop, c.configmaps.HasSynced) {
 		return
 	}
 	c.queue.Run(stop)
@@ -84,13 +78,7 @@ func (c *Controller) HasSynced() bool {
 }
 
 func (c *Controller) processItem(name types.NamespacedName) error {
-	cm, err := c.informer.Lister().ConfigMaps(c.configMapNamespace).Get(c.configMapName)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("error fetching object %s error: %v", c.configMapName, err)
-		}
-		cm = nil
-	}
+	cm := c.configmaps.Get(name.Name, name.Namespace)
 	c.callback(cm)
 
 	c.hasSynced.Store(true)


### PR DESCRIPTION
This PR is a bit of a rabbit hole but I think ends up in a good state.

The original intent was to fix a race condition in our existing code. Calling SetTransform and SetErrorHandler is racy against other threads calling Run(): https://github.com/kubernetes/kubernetes/issues/117869. In that issue, a great idea was to start using `newFunc` of the informer factory.

This led to a few issues:
* Not all the factory types can do this
* We were already doing this, but always using the core `KubeInformer()` instead of the per-type one, which was inconsistent. We also missed features.InformerWatchNamespace in some places

I thought of just fixing these, but upstreaming the fix takes 4mo to land here, and there have actually been other things I have wanted out of the factory. I realized the factory is actually really simple, only about 50 lines, so we can kill a lot of birds with one stone by just making our own.

In addition to fixing this problem, it also enables us:
* Allow running a single informer in addition to "all of them"
* Allow registering multiple informers of the same type but with different filters. For example, we can use the standard informers for doing things like watch meshconfig configmap and ca-cert configmap.
I wasn't going to include these initial to avoid bloat, but it turns out it makes 1 particular problem much easier to solve if we just do it right away. So I just put it in a second commit instead of a new PR.