### PR TITLE
Add support for yaml output to istioctl admin log

### DIFF
--- a/releasenotes/notes/44931.yaml
+++ b/releasenotes/notes/44931.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** support for yaml output to `istioctl admin log`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Add yaml format output for istioctl admin log

The test result:
![image](https://github.com/istio/istio/assets/76980726/c1ca06ab-e6af-4da0-b10a-2bf52d4ffbfd)
