### PR TITLE
Reuse the VERSION variable in release scripts

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -486,4 +486,16 @@ export BOOKINFO_VERSION ?= 1.19.0
 bookinfo.build:
 	@samples/bookinfo/src/build-services.sh ${BOOKINFO_VERSION} ${HUB}
 
+#-----------------------------------------------------------------------------
+# Target: release scripts
+#-----------------------------------------------------------------------------
+
+.PHONY: release.commit release.test
+
+release.commit:
+	@prow/release-commit.sh
+
+release.test:
+	@prow/release-test.sh
+
 include common/Makefile.common.mk


### PR DESCRIPTION
This updates the release script to rely on the `VERSION` variable to be defined outside the script. It also creates `make` targets so it can be invoked using `make` and thus reuse the `VERSION` variable from the Makefile.

We will have to change the prow jobs to use the make targets instead of invoking these scripts directly.

With this change we no longer need to bump a VERSION variable in two places after cutting a branch.
