### PR TITLE
spiffe: fix handling of trust bundles with multiple keys

### DIFF
--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -267,24 +267,20 @@ func RetrieveSpiffeBundleRootCerts(config map[string]string, caCertPool *x509.Ce
 			return nil, fmt.Errorf("trust domain [%s] at URL [%s] failed to decode bundle: %v", trustDomain, endpoint, err)
 		}
 
-		var cert *x509.Certificate
+		var certs []*x509.Certificate
 		for i, key := range doc.Keys {
 			if key.Use == "x509-svid" {
 				if len(key.Certificates) != 1 {
 					return nil, fmt.Errorf("trust domain [%s] at URL [%s] expected 1 certificate in x509-svid entry %d; got %d",
 						trustDomain, endpoint, i, len(key.Certificates))
 				}
-				cert = key.Certificates[0]
+				certs = append(certs, key.Certificates[0])
 			}
 		}
-		if cert == nil {
+		if len(certs) == 0 {
 			return nil, fmt.Errorf("trust domain [%s] at URL [%s] does not provide a X509 SVID", trustDomain, endpoint)
 		}
-		if certs, ok := ret[trustDomain]; ok {
-			ret[trustDomain] = append(certs, cert)
-		} else {
-			ret[trustDomain] = []*x509.Certificate{cert}
-		}
+		ret[trustDomain] = certs
 	}
 	for trustDomain, certs := range ret {
 		spiffeLog.Infof("Loaded SPIFFE trust bundle for: %v, containing %d certs", trustDomain, len(certs))

--- a/releasenotes/notes/spiffe-bundle-multiple-certs.yaml
+++ b/releasenotes/notes/spiffe-bundle-multiple-certs.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 44831
+releaseNotes:
+  - |
+    **Fixed** handling of remote SPIFFE trust bundles containing multiple certs.


### PR DESCRIPTION
This is a cherry-pick for #44831 (with modifications in the tests to avoid conflicts). This was cherry-picked in 1.17 as #44909.