### PR TITLE
Support cleanup ambient node level rules based on controller status

### DIFF
--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -12,6 +12,11 @@ rules:
 - apiGroups: [""]
   resources: ["pods","nodes","namespaces"]
   verbs: ["get", "list", "watch"]
+{{- if .Values.cni.ambient.enabled }}
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 {{- if .Values.cni.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -140,6 +140,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: LOG_LEVEL
               value: {{ .Values.cni.logLevel | quote }}
             {{- if .Values.cni.ambient.enabled }}


### PR DESCRIPTION
**Please provide a description of this PR:**

Refer to daemonset controller's status to determine whether we're in uninstall or upgrade/restart stage. Some background discussion is in #44208 

With this change, 
* while istio-cni restarting or upgrading, no node level rule will be cleaned up, traffic will keep being redirected to ztunnel.
* while uninstall istio or uninstall istio-cni daemonset, node level rules will be cleaned up.