### PR TITLE
Missing Envoy config dump info 

### DIFF
--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -196,6 +196,9 @@ func GetProxyInfo(p *Params) (map[string]string, error) {
 		}
 		ret[url] = out
 	}
+	if len(errStr) == 0 {
+		return ret, nil
+	}
 	return ret, fmt.Errorf(strings.Join(errStr, "\n"))
 }
 

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -183,18 +183,20 @@ func GetIstiodInfo(p *Params) (map[string]string, error) {
 
 // GetProxyInfo returns internal proxy debug info.
 func GetProxyInfo(p *Params) (map[string]string, error) {
+	var errStr []string
 	if p.Namespace == "" || p.Pod == "" {
-		return nil, fmt.Errorf("getIstiodInfo requires namespace and pod")
+		return nil, fmt.Errorf("getProxyInfo requires namespace and pod")
 	}
 	ret := make(map[string]string)
 	for _, url := range common.ProxyDebugURLs(p.ClusterVersion) {
 		out, err := p.Runner.EnvoyGet(p.Namespace, p.Pod, url, p.DryRun)
 		if err != nil {
-			return nil, err
+			errStr = append(errStr, err.Error())
+			continue
 		}
 		ret[url] = out
 	}
-	return ret, nil
+	return ret, fmt.Errorf(strings.Join(errStr, "\n"))
 }
 
 func GetZtunnelInfo(p *Params) (map[string]string, error) {

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/pkg/config/analysis/analyzers"
 	"istio.io/istio/pkg/config/analysis/diag"


### PR DESCRIPTION
The current envoy config dump will skip all when detecting one err from one envoy config debug url. Change the logic to iterate them all. 

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure