### PR TITLE
Make istio_cni.enabled explicit in chart values

### DIFF
--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -415,3 +415,6 @@ base:
   # it works to have multiple redundant validations, this adds complexity and operational risks.
   # Users should consider enabling this if they want full gateway-api validation but don't have other validation servers.
   validateGateway: false
+# set to true if the corresponding istio-cni chart has been installed
+istio_cni:
+  enabled: false


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR fixes #43632, by making the option to enable the istio-cni explict in the istiod chart. The improvement is mostly UX - rather than having to scrounge around docs, a user deploying the helm chart should be able to scan `values.yaml` and identify all the options which change the behavior of the installation.

Given istio-cni is important enough to have its own chart, it's important enough to have a default false (so this change is backwards-compatible) entry in `values.yaml`. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
