### PR TITLE
kube: fix assertion failure due to analysis

### DIFF
--- a/pkg/kube/informerfactory/factory.go
+++ b/pkg/kube/informerfactory/factory.go
@@ -29,7 +29,6 @@ package informerfactory
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/config/schema/gvr"
 	"runtime/debug"
 	"sync"
 
@@ -37,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"

--- a/pkg/kube/informerfactory/factory.go
+++ b/pkg/kube/informerfactory/factory.go
@@ -29,6 +29,7 @@ package informerfactory
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"runtime/debug"
 	"sync"
 
@@ -143,12 +144,19 @@ func (f *informerFactory) InformerFor(resource schema.GroupVersionResource, opts
 	return f.makeStartableInformer(informer, key)
 }
 
+func allowedOverlap(resource schema.GroupVersionResource) bool {
+	// We register an optimized Pod watcher for standard flow, but for the experimental analysis feature we need the full pod,
+	// so we start another watch.
+	// We may want to reconsider this if the analysis feature becomes stable.
+	return features.EnableAnalysis && resource == gvr.Pod
+}
+
 func checkInformerOverlap(inf builtInformer, resource schema.GroupVersionResource, opts kubetypes.InformerOptions) {
 	if fmt.Sprintf("%p", inf.objectTransform) == fmt.Sprintf("%p", opts.ObjectTransform) {
 		return
 	}
 	l := log.Warnf
-	if features.EnableUnsafeAssertions {
+	if features.EnableUnsafeAssertions && !allowedOverlap(resource) {
 		l = log.Fatalf
 	}
 	l("for type %v, registered conflicting ObjectTransform. Stack: %v", resource, string(debug.Stack()))


### PR DESCRIPTION
Example
https://storage.googleapis.com/istio-prow/logs/integ-assertion_istio_postsubmit/1659456885373276160/artifacts/pilot-analysis-426d538e8d6e41fa/_suite_context/istio-state-3871476243/primary-0/istiod-58dc66d79d-bgvxg_discovery.previous.log
