### PR TITLE
kube: refactor multicluster startup

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1136,16 +1136,7 @@ func (s *Server) initMulticluster(args *PilotArgs) {
 	s.multiclusterController = multicluster.NewController(s.kubeClient, args.Namespace, s.clusterID, s.environment.Watcher)
 	s.XDSServer.ListRemoteClusters = s.multiclusterController.ListRemoteClusters
 	s.addStartFunc("multicluster controller", func(stop <-chan struct{}) error {
-		go func() {
-			err := s.multiclusterController.Run(stop)
-			if err != nil {
-				log.Error(err)
-				os.Exit(1)
-			}
-			// because multi cluster controller.Run will init the config cluster service registry, we need to run the client after the informer created.
-			s.kubeClient.RunAndWait(stop)
-		}()
-		return nil
+		return s.multiclusterController.Run(stop)
 	})
 }
 

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -159,13 +159,13 @@ func (c *Controller) AddHandler(h ClusterHandler) {
 
 // Run starts the controller until it receives a message over stopCh
 func (c *Controller) Run(stopCh <-chan struct{}) error {
-	// wait for namespace informer synced
+	// Normally, we let informers start after all controllers. However, in this case we need namespaces to start and sync
+	// first, so we have DiscoveryNamespacesFilter ready to go. This avoids processing objects that would be filtered during startup.
+	c.namespaces.Start(stopCh)
+	// Wait for namespace informer synced, which implies discovery filter is synced as well
 	if !kube.WaitForCacheSync("namespace", stopCh, c.namespaces.HasSynced) {
 		return fmt.Errorf("failed to sync namespaces")
 	}
-	// run discovery namespace filter initiation before kube registry run
-	// otherwise istio may do some useless xds push for partial resources before namespace filter has been been completely initiated.
-	c.DiscoveryNamespacesFilter.SyncNamespaces()
 	// run handlers for the config cluster; do not store this *Cluster in the ClusterStore or give it a SyncTimeout
 	// this is done outside the goroutine, we should block other Run/startFuncs until this is registered
 	configCluster := &Cluster{Client: c.configClusterClient, ID: c.configClusterID}


### PR DESCRIPTION
This is refactoring after https://github.com/istio/istio/commit/16ff353b180a1f461bd380be6ef2d1809b8c1fba.

* No need to sync namespaces, if the namespace informer is synced then the filter is as well
* I did not feel great about using the exit vs returning error, signals something is wrong with our startup sequence. Instead, just explicitly start the namespace informer and wait for it, then we do not need to run in a goroutine