### PR TITLE
csr: modernize to v1 API

### DIFF
--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -18,54 +18,28 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net"
 	"os"
 	"time"
 
-	certv1 "k8s.io/api/certificates/v1"
-	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	cert "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	rand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
 )
 
 const (
-	randomLength  = 18
-	csrRetriesMax = 3
-	// cert-manager use below annotation on kubernetes CSR to control TTL for the generated cert.
-	RequestLifeTimeAnnotationForCertManager = "experimental.cert-manager.io/request-duration"
-
-	// IstioDNSSecretType is the Istio DNS secret annotation type
-	IstioDNSSecretType = "istio.io/dns-key-and-cert"
-
 	// The size of a private key for a leaf certificate.
 	keySize = 2048
-
-	// The number of tries for reading a certificate
-	maxNumCertRead = 10
-
-	// The interval for reading a certificate
-	certReadInterval = 500 * time.Millisecond
 )
 
 var certWatchTimeout = 60 * time.Second
-
-type CsrNameGenerator func(string, string) string
-
-// GenCsrName : Generate CSR Name for Resource. Guarantees returning a resource name that doesn't already exist
-func GenCsrName() string {
-	name := fmt.Sprintf("csr-workload-%s", rand.String(randomLength))
-	return name
-}
 
 // GenKeyCertK8sCA : Generates a key pair and gets public certificate signed by K8s_CA
 // Options are meant to sign DNS certs
@@ -86,11 +60,11 @@ func GenKeyCertK8sCA(client clientset.Interface, dnsName,
 		log.Errorf("CSR generation error (%v)", err)
 		return nil, nil, nil, err
 	}
-	usages := []certv1.KeyUsage{
-		certv1.UsageDigitalSignature,
-		certv1.UsageKeyEncipherment,
-		certv1.UsageServerAuth,
-		certv1.UsageClientAuth,
+	usages := []cert.KeyUsage{
+		cert.UsageDigitalSignature,
+		cert.UsageKeyEncipherment,
+		cert.UsageServerAuth,
+		cert.UsageClientAuth,
 	}
 	if signerName == "" {
 		signerName = "kubernetes.io/legacy-unknown"
@@ -105,41 +79,33 @@ func GenKeyCertK8sCA(client clientset.Interface, dnsName,
 // 2. Approve a CSR
 // 3. Read the signed certificate
 // 4. Clean up the artifacts (e.g., delete CSR)
-func SignCSRK8s(client clientset.Interface, csrData []byte, signerName string, usages []certv1.KeyUsage,
+func SignCSRK8s(client clientset.Interface, csrData []byte, signerName string, usages []cert.KeyUsage,
 	dnsName, caFilePath string, approveCsr, appendCaCert bool, requestedLifetime time.Duration,
 ) ([]byte, []byte, error) {
-	var err error
-	v1Req := false
-
 	// 1. Submit the CSR
-
-	csrName, v1CsrReq, v1Beta1CsrReq, err := submitCSR(client, csrData, signerName, usages, csrRetriesMax, requestedLifetime)
+	csr, err := submitCSR(client, csrData, signerName, usages, requestedLifetime)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to submit CSR request (%v). Error: %v", csrName, err)
+		return nil, nil, err
 	}
-	log.Debugf("CSR (%v) has been created", csrName)
-	if v1CsrReq != nil {
-		v1Req = true
-	}
+	log.Debugf("CSR (%v) has been created", csr.Name)
 
 	// clean up certificate request after deletion
 	defer func() {
-		_ = cleanUpCertGen(client, v1Req, csrName)
+		_ = cleanupCSR(client, csr)
 	}()
 
 	// 2. Approve the CSR
 	if approveCsr {
-		csrMsg := fmt.Sprintf("CSR (%s) for the certificate (%s) is approved", csrName, dnsName)
-		err = approveCSR(csrName, csrMsg, client, v1CsrReq, v1Beta1CsrReq)
+		approvalMessage := fmt.Sprintf("CSR (%s) for the certificate (%s) is approved", csr.Name, dnsName)
+		err = approveCSR(client, csr, approvalMessage)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to approve CSR request. Error: %v", err)
+			return nil, nil, fmt.Errorf("failed to approve CSR request: %v", err)
 		}
-		log.Debugf("CSR (%v) is approved", csrName)
+		log.Debugf("CSR (%v) is approved", csr.Name)
 	}
 
 	// 3. Read the signed certificate
-	certChain, caCert, err := readSignedCertificate(client,
-		csrName, certWatchTimeout, certReadInterval, maxNumCertRead, caFilePath, appendCaCert, v1Req)
+	certChain, caCert, err := readSignedCertificate(client, csr, certWatchTimeout, caFilePath, appendCaCert)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -185,321 +151,148 @@ func isTCPReachable(host string, port int) bool {
 	return true
 }
 
-func submitCSR(clientset clientset.Interface,
-	csrData []byte, signerName string,
-	usages []certv1.KeyUsage, numRetries int, requestedLifetime time.Duration) (string, *certv1.CertificateSigningRequest,
-	*certv1beta1.CertificateSigningRequest, error,
-) {
-	var lastErr error
-	useV1 := true
-	csrName := ""
-	for i := 0; i < numRetries; i++ {
-		if csrName == "" {
-			csrName = GenCsrName()
-		}
-		if useV1 && len(usages) > 0 && len(signerName) > 0 && signerName != "kubernetes.io/legacy-unknown" {
-			log.Debugf("trial %v using v1 api to create CSR (%v)", i+1, csrName)
-			csr := &certv1.CertificateSigningRequest{
-				// Username, UID, Groups will be injected by API server.
-				TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: csrName,
-				},
-				Spec: certv1.CertificateSigningRequestSpec{
-					Request:    csrData,
-					Usages:     usages,
-					SignerName: signerName,
-				},
-			}
-			if requestedLifetime != time.Duration(0) {
-				csr.ObjectMeta.Annotations = map[string]string{RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
-			}
-			v1req, err := clientset.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
-			if err == nil {
-				return csrName, v1req, nil, nil
-			}
-			lastErr = err
-			if kerrors.IsAlreadyExists(err) {
-				csrName = ""
-				continue
-			} else if kerrors.IsNotFound(err) {
-				// don't attempt to use older api unless we get an API error
-				useV1 = false
-			} else {
-				continue
-			}
-		}
-		// Only exercise v1beta1 logic if v1 api was not found
-		log.Debugf("trial %v using v1beta1 api for csr %v", i+1, csrName)
-		// convert relevant bits to v1beta1
-		v1beta1csr := &certv1beta1.CertificateSigningRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: csrName,
-			},
-			Spec: certv1beta1.CertificateSigningRequestSpec{
-				SignerName: &signerName,
-				Request:    csrData,
-			},
-		}
-		for _, usage := range usages {
-			v1beta1csr.Spec.Usages = append(v1beta1csr.Spec.Usages, certv1beta1.KeyUsage(usage))
-		}
-		if requestedLifetime != time.Duration(0) {
-			v1beta1csr.ObjectMeta.Annotations = map[string]string{RequestLifeTimeAnnotationForCertManager: requestedLifetime.String()}
-		}
-		// create v1beta1 certificate request
-		v1beta1req, err := clientset.CertificatesV1beta1().CertificateSigningRequests().Create(context.TODO(), v1beta1csr, metav1.CreateOptions{})
-		if err == nil {
-			return csrName, nil, v1beta1req, nil
-		}
-		lastErr = err
-		if kerrors.IsAlreadyExists(err) {
-			csrName = ""
-		}
+func submitCSR(
+	client clientset.Interface,
+	csrData []byte,
+	signerName string,
+	usages []cert.KeyUsage,
+	requestedLifetime time.Duration,
+) (*cert.CertificateSigningRequest, error) {
+	log.Debugf("create CSR for signer %v", signerName)
+	csr := &cert.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "csr-workload-",
+		},
+		Spec: cert.CertificateSigningRequestSpec{
+			Request:    csrData,
+			Usages:     usages,
+			SignerName: signerName,
+		},
 	}
-	log.Errorf("retry attempts exceeded when creating csr request %v", csrName)
-	return "", nil, nil, lastErr
+	if requestedLifetime != time.Duration(0) {
+		csr.Spec.ExpirationSeconds = ptr.Of(int32(requestedLifetime.Seconds()))
+	}
+	resp, err := client.CertificatesV1().CertificateSigningRequests().Create(context.Background(), csr, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CSR: %v", err)
+	}
+	return resp, nil
 }
 
-func approveCSR(csrName string, csrMsg string, client clientset.Interface,
-	v1CsrReq *certv1.CertificateSigningRequest, v1Beta1CsrReq *certv1beta1.CertificateSigningRequest,
-) error {
-	err := errors.New("invalid CSR")
-
-	if v1Beta1CsrReq != nil {
-		v1Beta1CsrReq.Status.Conditions = append(v1Beta1CsrReq.Status.Conditions, certv1beta1.CertificateSigningRequestCondition{
-			Type:    certv1beta1.CertificateApproved,
-			Reason:  csrMsg,
-			Message: csrMsg,
-		})
-		_, err = client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(context.TODO(), v1Beta1CsrReq, metav1.UpdateOptions{})
-		if err != nil {
-			log.Errorf("failed to approve CSR (%v): %v", csrName, err)
-			return err
-		}
-	} else if v1CsrReq != nil {
-		v1CsrReq.Status.Conditions = append(v1CsrReq.Status.Conditions, certv1.CertificateSigningRequestCondition{
-			Type:    certv1.CertificateApproved,
-			Reason:  csrMsg,
-			Message: csrMsg,
-			Status:  corev1.ConditionTrue,
-		})
-		_, err = client.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.TODO(), csrName, v1CsrReq, metav1.UpdateOptions{})
-		if err != nil {
-			log.Errorf("failed to approve CSR (%v): %v", csrName, err)
-			return err
-		}
+func approveCSR(client clientset.Interface, csr *cert.CertificateSigningRequest, approvalMessage string) error {
+	csr.Status.Conditions = append(csr.Status.Conditions, cert.CertificateSigningRequestCondition{
+		Type:    cert.CertificateApproved,
+		Reason:  approvalMessage,
+		Message: approvalMessage,
+		Status:  corev1.ConditionTrue,
+	})
+	_, err := client.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.TODO(), csr.Name, csr, metav1.UpdateOptions{})
+	if err != nil {
+		log.Errorf("failed to approve CSR (%v): %v", csr.Name, err)
+		return err
 	}
-	return err
+	return nil
 }
 
 // Read the signed certificate
 // verify and append CA certificate to certChain if appendCaCert is true
-func readSignedCertificate(client clientset.Interface, csrName string,
-	watchTimeout, readInterval time.Duration,
-	maxNumRead int, caCertPath string, appendCaCert bool, usev1 bool,
+func readSignedCertificate(client clientset.Interface, csr *cert.CertificateSigningRequest,
+	watchTimeout time.Duration, caCertPath string, appendCaCert bool,
 ) ([]byte, []byte, error) {
 	// First try to read the signed CSR through a watching mechanism
-	certPEM := readSignedCsr(client, csrName, watchTimeout, readInterval, maxNumRead, usev1)
-
+	certPEM, err := readSignedCsr(client, csr.Name, watchTimeout)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(certPEM) == 0 {
-		return []byte{}, []byte{}, fmt.Errorf("no certificate returned for the CSR: %q", csrName)
+		return nil, nil, fmt.Errorf("no certificate returned for the CSR: %q", csr.Name)
 	}
 	certsParsed, _, err := util.ParsePemEncodedCertificateChain(certPEM)
 	if err != nil {
 		return nil, nil, fmt.Errorf("decoding certificate failed")
 	}
-	caCert := []byte{}
-	certChain := []byte{}
-	certChain = append(certChain, certPEM...)
-	if appendCaCert && caCertPath != "" {
-		caCert, err = readCACert(caCertPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error when retrieving CA cert: (%v)", err)
-		}
-		// Verify the certificate chain before returning the certificate
-		roots := x509.NewCertPool()
-		if roots == nil {
-			return nil, nil, fmt.Errorf("failed to create cert pool")
-		}
-		if ok := roots.AppendCertsFromPEM(caCert); !ok {
-			return nil, nil, fmt.Errorf("failed to append CA certificate")
-		}
-		intermediates := x509.NewCertPool()
-		if len(certsParsed) > 1 {
-			for _, cert := range certsParsed[1:] {
-				intermediates.AddCert(cert)
-			}
-		}
-		_, err = certsParsed[0].Verify(x509.VerifyOptions{
-			Roots:         roots,
-			Intermediates: intermediates,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to verify the certificate chain: %v", err)
-		}
-		certChain = append(certChain, caCert...)
+	if !appendCaCert || caCertPath == "" {
+		return certPEM, nil, nil
 	}
-	return certChain, caCert, nil
-}
+	caCert, err := readCACert(caCertPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error when retrieving CA cert: (%v)", err)
+	}
+	// Verify the certificate chain before returning the certificate
+	roots := x509.NewCertPool()
+	if roots == nil {
+		return nil, nil, fmt.Errorf("failed to create cert pool")
+	}
+	if ok := roots.AppendCertsFromPEM(caCert); !ok {
+		return nil, nil, fmt.Errorf("failed to append CA certificate")
+	}
+	intermediates := x509.NewCertPool()
+	if len(certsParsed) > 1 {
+		for _, cert := range certsParsed[1:] {
+			intermediates.AddCert(cert)
+		}
+	}
+	_, err = certsParsed[0].Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to verify the certificate chain: %v", err)
+	}
 
-func checkDuplicateCsr(client clientset.Interface, csrName string) (*certv1.CertificateSigningRequest, *certv1beta1.CertificateSigningRequest) {
-	v1CsrReq, err := client.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
-	if err == nil {
-		return v1CsrReq, nil
-	}
-	v1Beta1CsrReq, err := client.CertificatesV1beta1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
-	if err == nil {
-		return nil, v1Beta1CsrReq
-	}
-	return nil, nil
-}
-
-func getSignedCsr(client clientset.Interface, csrName string, readInterval time.Duration, maxNumRead int, usev1 bool) []byte {
-	var err error
-	if usev1 {
-		var r *certv1.CertificateSigningRequest
-		for i := 0; i < maxNumRead; i++ {
-			r, err = client.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
-			if err == nil && r.Status.Certificate != nil {
-				// Certificate is ready
-				return r.Status.Certificate
-			}
-			time.Sleep(readInterval)
-		}
-		if err != nil || r.Status.Certificate == nil {
-			if err != nil {
-				log.Errorf("failed to read the CSR (%v): %v", csrName, err)
-			} else if r.Status.Certificate == nil {
-				for _, c := range r.Status.Conditions {
-					if c.Type == certv1.CertificateDenied {
-						log.Errorf("CertificateDenied, name: %v, uid: %v, cond-type: %v, cond: %s",
-							r.Name, r.UID, c.Type, c.String())
-						break
-					}
-				}
-			}
-			return []byte{}
-		}
-	} else {
-		var r *certv1beta1.CertificateSigningRequest
-		for i := 0; i < maxNumRead; i++ {
-			r, err = client.CertificatesV1beta1().CertificateSigningRequests().Get(context.TODO(), csrName, metav1.GetOptions{})
-			if err == nil && r.Status.Certificate != nil {
-				// Certificate is ready
-				return r.Status.Certificate
-			}
-			time.Sleep(readInterval)
-		}
-		if err != nil || r.Status.Certificate == nil {
-			if err != nil {
-				log.Errorf("failed to read the CSR (%v): %v", csrName, err)
-			} else if r.Status.Certificate == nil {
-				for _, c := range r.Status.Conditions {
-					if c.Type == certv1beta1.CertificateDenied {
-						log.Errorf("CertificateDenied, name: %v, uid: %v, cond-type: %v, cond: %s",
-							r.Name, r.UID, c.Type, c.String())
-						break
-					}
-				}
-			}
-			return []byte{}
-		}
-	}
-	return []byte{}
+	return append(certPEM, caCert...), caCert, nil
 }
 
 // Return signed CSR through a watcher. If no CSR is read, return nil.
-func readSignedCsr(client clientset.Interface, csrName string, watchTimeout time.Duration, readInterval time.Duration,
-	maxNumRead int, usev1 bool,
-) []byte {
-	var watcher watch.Interface
-	var err error
-	selector := fields.OneTermEqualSelector("metadata.name", csrName).String()
-	if usev1 {
-		// Setup a List+Watch, like informers do
-		// A simple Watch will fail if the cert is signed too quickly
-		l, _ := client.CertificatesV1().CertificateSigningRequests().List(context.TODO(), metav1.ListOptions{
-			FieldSelector: selector,
-		})
-		if l != nil && len(l.Items) > 0 {
-			reqSigned := l.Items[0]
-			if reqSigned.Status.Certificate != nil {
-				return reqSigned.Status.Certificate
-			}
+func readSignedCsr(client clientset.Interface, csr string, watchTimeout time.Duration) ([]byte, error) {
+	selector := fields.OneTermEqualSelector("metadata.name", csr).String()
+	// Setup a List+Watch, like informers do
+	// A simple Watch will fail if the cert is signed too quickly
+	l, _ := client.CertificatesV1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{
+		FieldSelector: selector,
+	})
+	if l != nil && len(l.Items) > 0 {
+		reqSigned := l.Items[0]
+		if reqSigned.Status.Certificate != nil {
+			return reqSigned.Status.Certificate, nil
 		}
-		var rv string
-		if l != nil {
-			rv = l.ResourceVersion
-		}
-		watcher, err = client.CertificatesV1().CertificateSigningRequests().Watch(context.TODO(), metav1.ListOptions{
-			ResourceVersion: rv,
-			FieldSelector:   selector,
-		})
-	} else {
-		l, _ := client.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), metav1.ListOptions{
-			FieldSelector: selector,
-		})
-		if l != nil && len(l.Items) > 0 {
-			reqSigned := l.Items[0]
-			if reqSigned.Status.Certificate != nil {
-				return reqSigned.Status.Certificate
-			}
-		}
-		var rv string
-		if l != nil {
-			rv = l.ResourceVersion
-		}
-		watcher, err = client.CertificatesV1beta1().CertificateSigningRequests().Watch(context.TODO(), metav1.ListOptions{
-			ResourceVersion: rv,
-			FieldSelector:   selector,
-		})
 	}
-	if err == nil {
-		timeout := false
-		// Set a timeout
-		timer := time.After(watchTimeout)
-		for {
-			select {
-			case r := <-watcher.ResultChan():
-				if usev1 {
-					reqSigned := r.Object.(*certv1.CertificateSigningRequest)
-					if reqSigned.Status.Certificate != nil {
-						return reqSigned.Status.Certificate
-					}
-				} else {
-					reqSigned := r.Object.(*certv1beta1.CertificateSigningRequest)
-					if reqSigned.Status.Certificate != nil {
-						return reqSigned.Status.Certificate
-					}
-				}
-			case <-timer:
-				log.Debugf("timeout when watching CSR %v", csrName)
-				timeout = true
-			}
-			if timeout {
-				break
-			}
-		}
+	var rv string
+	if l != nil {
+		rv = l.ResourceVersion
+	}
+	watcher, err := client.CertificatesV1().CertificateSigningRequests().Watch(context.Background(), metav1.ListOptions{
+		ResourceVersion: rv,
+		FieldSelector:   selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch CSR %v", csr)
 	}
 
-	return getSignedCsr(client, csrName, readInterval, maxNumRead, usev1)
+	// Set a timeout
+	timer := time.After(watchTimeout)
+	for {
+		select {
+		case r := <-watcher.ResultChan():
+			reqSigned := r.Object.(*cert.CertificateSigningRequest)
+			if reqSigned.Status.Certificate != nil {
+				return reqSigned.Status.Certificate, nil
+			}
+		case <-timer:
+			return nil, fmt.Errorf("timeout when watching CSR %v", csr)
+		}
+	}
 }
 
 // Clean up the CSR
-func cleanUpCertGen(client clientset.Interface, usev1 bool, csrName string) error {
-	var err error
-
-	if usev1 {
-		err = client.CertificatesV1().CertificateSigningRequests().Delete(context.TODO(), csrName, metav1.DeleteOptions{})
-	} else {
-		err = client.CertificatesV1beta1().CertificateSigningRequests().Delete(context.TODO(), csrName, metav1.DeleteOptions{})
-	}
-
+func cleanupCSR(client clientset.Interface, csr *cert.CertificateSigningRequest) error {
+	err := client.CertificatesV1().CertificateSigningRequests().Delete(context.TODO(), csr.Name, metav1.DeleteOptions{})
 	if err != nil {
-		log.Errorf("failed to delete CSR (%v): %v", csrName, err)
+		log.Errorf("failed to delete CSR (%v): %v", csr.Name, err)
 	} else {
-		log.Debugf("deleted CSR: %v", csrName)
+		log.Debugf("deleted CSR: %v", csr.Name)
 	}
 	return err
 }

--- a/security/pkg/k8s/chiron/utils_test.go
+++ b/security/pkg/k8s/chiron/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	cert "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -91,14 +92,6 @@ type mockTLSServer struct {
 func defaultReactionFunc(obj runtime.Object) kt.ReactionFunc {
 	return func(act kt.Action) (bool, runtime.Object, error) {
 		return true, obj, nil
-	}
-}
-
-func defaultListReactionFunc(obj runtime.Object) kt.ReactionFunc {
-	return func(act kt.Action) (bool, runtime.Object, error) {
-		return true, &cert.CertificateSigningRequestList{
-			Items: []cert.CertificateSigningRequest{*(obj.(*cert.CertificateSigningRequest))},
-		}, nil
 	}
 }
 
@@ -191,80 +184,6 @@ func TestIsTCPReachable(t *testing.T) {
 	}
 }
 
-func TestCheckDuplicateCSR(t *testing.T) {
-	testCases := map[string]struct {
-		gracePeriodRatio  float32
-		minGracePeriod    time.Duration
-		k8sCaCertFile     string
-		dnsNames          []string
-		secretNames       []string
-		serviceNamespaces []string
-		csrName           string
-		secretName        string
-		secretNameSpace   string
-		expectFail        bool
-		isDuplicate       bool
-	}{
-		"fetching a CSR without a duplicate should fail": {
-			gracePeriodRatio:  0.6,
-			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
-			dnsNames:          []string{"foo"},
-			secretNames:       []string{"istio.webhook.foo"},
-			serviceNamespaces: []string{"foo.ns"},
-			secretName:        "mock-secret",
-			secretNameSpace:   "mock-secret-namespace",
-			expectFail:        true,
-			csrName:           "domain-cluster.local-ns--secret-mock-secret",
-			isDuplicate:       false,
-		},
-		"fetching a CSR with a duplicate should pass": {
-			gracePeriodRatio:  0.6,
-			k8sCaCertFile:     "./test-data/example-ca-cert.pem",
-			dnsNames:          []string{"foo"},
-			secretNames:       []string{"istio.webhook.foo"},
-			serviceNamespaces: []string{"foo.ns"},
-			secretName:        "mock-secret",
-			secretNameSpace:   "mock-secret-namespace",
-			expectFail:        false,
-			csrName:           "domain-cluster.local-ns--secret-mock-secret",
-			isDuplicate:       true,
-		},
-	}
-
-	for tcName, tc := range testCases {
-		client := fake.NewSimpleClientset()
-		csr := &cert.CertificateSigningRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: tc.csrName,
-			},
-			Status: cert.CertificateSigningRequestStatus{
-				Certificate: []byte(exampleIssuedCert),
-			},
-		}
-		if tc.isDuplicate {
-			client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
-			client.PrependReactor("list", "certificatesigningrequests", defaultListReactionFunc(csr))
-		}
-		v1CsrReq, _ := checkDuplicateCsr(client, tc.csrName)
-		if tc.expectFail {
-			if v1CsrReq != nil {
-				t.Errorf("test case (%s) should have failed", tcName)
-			}
-		} else if v1CsrReq == nil {
-			t.Errorf("test case (%s) failed unexpectedly", tcName)
-		}
-
-		certData := readSignedCsr(client, tc.csrName, 1*time.Millisecond, 1*time.Millisecond, 1, true)
-		if tc.expectFail {
-			if len(certData) != 0 {
-				t.Errorf("test case (%s) should have failed", tcName)
-			}
-		} else if len(certData) == 0 {
-			t.Errorf("test case (%s) failed unexpectedly", tcName)
-		}
-	}
-}
-
 func TestSubmitCSR(t *testing.T) {
 	testCases := map[string]struct {
 		gracePeriodRatio float32
@@ -289,35 +208,32 @@ func TestSubmitCSR(t *testing.T) {
 	}
 
 	for tcName, tc := range testCases {
-		client := fake.NewSimpleClientset()
-		csr := &cert.CertificateSigningRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "domain-cluster.local-ns--secret-mock-secret",
-			},
-			Status: cert.CertificateSigningRequestStatus{
-				Certificate: []byte(exampleIssuedCert),
-			},
-		}
-		client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
-
-		numRetries := 3
-
-		usages := []cert.KeyUsage{
-			cert.UsageDigitalSignature,
-			cert.UsageKeyEncipherment,
-			cert.UsageServerAuth,
-			cert.UsageClientAuth,
-		}
-
-		_, r, _, err := submitCSR(client, []byte("test-pem"), "test-signer",
-			usages, numRetries, DefaulCertTTL)
-		if tc.expectFail {
-			if err == nil {
-				t.Errorf("test case (%s) should have failed", tcName)
+		t.Run(tcName, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			csr := &cert.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "domain-cluster.local-ns--secret-mock-secret",
+				},
+				Status: cert.CertificateSigningRequestStatus{
+					Certificate: []byte(exampleIssuedCert),
+				},
 			}
-		} else if err != nil || r == nil {
-			t.Errorf("test case (%s) failed unexpectedly: %v", tcName, err)
-		}
+			client.PrependReactor("get", "certificatesigningrequests", defaultReactionFunc(csr))
+
+			usages := []cert.KeyUsage{
+				cert.UsageDigitalSignature,
+				cert.UsageKeyEncipherment,
+				cert.UsageServerAuth,
+				cert.UsageClientAuth,
+			}
+			r, err := submitCSR(client, []byte("test-pem"), "test-signer",
+				usages, DefaulCertTTL)
+			if tc.expectFail {
+				assert.Error(t, err)
+			} else if err != nil || r == nil {
+				t.Errorf("test case (%s) failed unexpectedly: %v", tcName, err)
+			}
+		})
 	}
 }
 
@@ -381,6 +297,7 @@ func TestReadSignedCertificate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			log.FindScope("default").SetOutputLevel(log.DebugLevel)
 			client := initFakeKubeClient(t, tc.certificateData)
 
 			// 4. Read the signed certificate
@@ -458,12 +375,34 @@ func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
 			case r := <-w.ResultChan():
 				csr := r.Object.(*cert.CertificateSigningRequest).DeepCopy()
 				if csr.Status.Certificate != nil {
+					log.Debugf("test signer skip, already signed: %v", csr.Name)
 					continue
 				}
-				csr.Status.Certificate = certificate
-				client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
+				if approved(csr) {
+					// This is a pretty terrible hack, but client-go fake doesn't properly support list+watch,
+					// so any updates in between the list and watch would be missed. So give some time for the watch to start
+					time.Sleep(time.Millisecond * 25)
+					csr.Status.Certificate = certificate
+					_, err := client.Kube().CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, csr, metav1.UpdateOptions{})
+					log.Debugf("test signer sign %v: %v", csr.Name, err)
+				} else {
+					log.Debugf("test signer skip, not approved: %v", csr.Name)
+				}
 			}
 		}
 	}()
 	return client
+}
+
+func approved(csr *cert.CertificateSigningRequest) bool {
+	return GetCondition(csr.Status.Conditions, cert.CertificateApproved).Status == corev1.ConditionTrue
+}
+
+func GetCondition(conditions []cert.CertificateSigningRequestCondition, condition cert.RequestConditionType) cert.CertificateSigningRequestCondition {
+	for _, cond := range conditions {
+		if cond.Type == condition {
+			return cond
+		}
+	}
+	return cert.CertificateSigningRequestCondition{}
 }

--- a/tests/integration/security/util/secret/secret.go
+++ b/tests/integration/security/util/secret/secret.go
@@ -24,10 +24,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/test"
-	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/util"
 )
+
+// IstioDNSSecretType is the Istio DNS secret annotation type
+const IstioDNSSecretType = "istio.io/dns-key-and-cert"
 
 // ExamineDNSSecretOrFail calls ExamineDNSSecret and fails t if an error occurs.
 func ExamineDNSSecretOrFail(t test.Failer, secret *v1.Secret, expectedID string) {
@@ -41,9 +43,9 @@ func ExamineDNSSecretOrFail(t test.Failer, secret *v1.Secret, expectedID string)
 // * Secret type is correctly set;
 // * Key, certificate and CA root are correctly saved in the data section;
 func ExamineDNSSecret(secret *v1.Secret, expectedID string) error {
-	if secret.Type != chiron.IstioDNSSecretType {
+	if secret.Type != IstioDNSSecretType {
 		return fmt.Errorf(`unexpected value for the "type" annotation: expecting %v but got %v`,
-			chiron.IstioDNSSecretType, secret.Type)
+			IstioDNSSecretType, secret.Type)
 	}
 
 	for _, key := range []string{ca.CertChainFile, ca.RootCertFile, ca.PrivateKeyFile} {


### PR DESCRIPTION
This PR updates to use the v1 CSR API exclusively. This has been available since Kubernetes 1.19, and stopped supporting 1.19 a while back.

In addition, there are a few misc improvements. I will comment inline the motivation behind them