### PR TITLE
exp: add ztunnel service for socks5

### DIFF
--- a/manifests/charts/ztunnel/templates/service.yaml
+++ b/manifests/charts/ztunnel/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ztunnel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- .Values.labels | toYaml | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+spec:
+  internalTrafficPolicy: Local
+  ports:
+  - name: tcp-socks5
+    port: 15080
+  selector:
+    app: ztunnel


### PR DESCRIPTION
With this and a small tweak to ztunnel, we can use ztunnel as a client without interception:

```
$curl -x socks5://ztunnel.istio-system:15080 http://echo
```

Note you cannot act as a server, though.

Not sure we should do this, just opening up for reference

**Please provide a description of this PR:**