### PR TITLE
tf: cleanup spammy injection log

### DIFF
--- a/pkg/test/framework/components/istio/configmap.go
+++ b/pkg/test/framework/components/istio/configmap.go
@@ -149,7 +149,7 @@ func (ic *injectConfig) UpdateInjectionConfig(t resource.Context, update func(*i
 			if err := ic.updateConfigMap(c, cfgMap); err != nil {
 				return err
 			}
-			scopes.Framework.Infof("patched %s injection configmap:\n%s", c.Name(), cfgMap.Data["config"])
+			scopes.Framework.Debugf("patched %s injection configmap:\n%s", c.Name(), cfgMap.Data["config"])
 			return nil
 		})
 	}
@@ -177,7 +177,7 @@ func (ic *injectConfig) UpdateInjectionConfig(t resource.Context, update func(*i
 				if err := ic.updateConfigMap(c, cfgMap); err != nil {
 					return err
 				}
-				scopes.Framework.Infof("cleanup patched %s meshconfig:\n%s", c.Name(), cfgMap.Data["config"])
+				scopes.Framework.Debugf("cleanup patched %s injection configmap:\n%s", c.Name(), cfgMap.Data["config"])
 				return nil
 			})
 		}


### PR DESCRIPTION
This logs ~2.5k lines of config, not needed.
