### PR TITLE
istioctl: add yaml output support for istioctl x revison list

### DIFF
--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -410,8 +410,8 @@ func listTags(ctx context.Context, kubeClient kubernetes.Interface, writer io.Wr
 	}
 
 	switch revArgs.output {
-	case jsonFormat:
-		return printJSON(writer, tags)
+	case jsonFormat, yamlFormat:
+		return printJSONYAML(writer, tags, revArgs.output)
 	case tableFormat:
 	default:
 		return fmt.Errorf("unknown format: %s", revArgs.output)

--- a/releasenotes/notes/45015.yaml
+++ b/releasenotes/notes/45015.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** yaml format output support for `istioctl x revison list` and `istioctl x revison tag list`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Add yaml output support for `istioctl x revison list` and `istioctl x revison tag list` 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.



The test result:
<img width="1180" alt="image" src="https://github.com/istio/istio/assets/76980726/ea8b0dd9-ad5c-4abb-986d-ac59dbd3b10e">

<img width="808" alt="image" src="https://github.com/istio/istio/assets/76980726/c2988333-f639-4624-9dca-6d13ad1018c8">


