### PR TITLE
Ztunnel logging improvements

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -116,13 +116,13 @@ var stringToLevel = map[string]Level{
 }
 
 var (
-	loggerLevelString = ""
-	reset             = false
-	client, _         = kubeClient(kubeconfig, configContext)
+	loggerLevelString         = ""
+	reset                     = false
+	isZtunnelPodKubeClient, _ = kubeClient(kubeconfig, configContext)
 )
 
 var isZtunnelPod = func(podName, podNamespace string) bool {
-	return ambientutil.IsZtunnelPod(client, podName, podNamespace)
+	return ambientutil.IsZtunnelPod(isZtunnelPodKubeClient, podName, podNamespace)
 }
 
 func ztunnelLogLevel(level string) string {

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -1310,9 +1310,9 @@ func secretConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getPodName(args[0]); err != nil {
 					return err
 				}
-				ztunnelPod, err := isZtunnelPod(podName, podNamespace)
-				if err != nil {
-					return fmt.Errorf("failed to create k8s client: %v", err)
+				ztunnelPod, kubeClientErr := isZtunnelPod(podName, podNamespace)
+				if kubeClientErr != nil {
+					return fmt.Errorf("failed to create k8s client: %v", kubeClientErr)
 				}
 				if ztunnelPod {
 					newWriter, err = setupZtunnelConfigDumpWriter(podName, podNamespace, c.OutOrStdout())

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -469,7 +469,7 @@ func allConfigCmd() *cobra.Command {
 					}
 					ztunnelPod, err := isZtunnelPod(podName, podNamespace)
 					if err != nil {
-						return fmt.Errorf("failed to create k8s client: %v", err)
+						return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", err)
 					}
 					if ztunnelPod {
 						dump, err = extractZtunnelConfigDump(podName, podNamespace)
@@ -502,7 +502,7 @@ func allConfigCmd() *cobra.Command {
 
 					ztunnelPod, err := isZtunnelPod(podName, podNamespace)
 					if err != nil {
-						return fmt.Errorf("failed to create k8s client: %v", err)
+						return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", err)
 					}
 					if ztunnelPod {
 						w, err := setupZtunnelConfigDumpWriter(podName, podNamespace, c.OutOrStdout())
@@ -624,7 +624,7 @@ func workloadConfigCmd() *cobra.Command {
 				}
 				ztunnelPod, kubeClientErr := isZtunnelPod(podName, podNamespace)
 				if kubeClientErr != nil {
-					return fmt.Errorf("failed to create k8s client: %v", kubeClientErr)
+					return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", kubeClientErr)
 				}
 				if !ztunnelPod {
 					return fmt.Errorf("workloads command is only supported by ztunnel proxies: %v", podName)
@@ -870,7 +870,7 @@ func logCmd() *cobra.Command {
 				}
 				ztunnelPod, err := isZtunnelPod(pod, podNamespace)
 				if err != nil {
-					return fmt.Errorf("failed to create k8s client: %v", err)
+					return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", err)
 				}
 				if ztunnelPod {
 					loggerNames[name] = Ztunnel
@@ -930,7 +930,7 @@ func logCmd() *cobra.Command {
 			for _, podName := range podNames {
 				ztunnelPod, err := isZtunnelPod(podName, podNamespace)
 				if err != nil {
-					return fmt.Errorf("failed to create k8s client: %v", err)
+					return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", err)
 				}
 				if ztunnelPod {
 					q := "level=" + ztunnelLogLevel(loggerLevelString)
@@ -1312,7 +1312,7 @@ func secretConfigCmd() *cobra.Command {
 				}
 				ztunnelPod, kubeClientErr := isZtunnelPod(podName, podNamespace)
 				if kubeClientErr != nil {
-					return fmt.Errorf("failed to create k8s client: %v", kubeClientErr)
+					return fmt.Errorf("failed to determine if pod is a zTunnel pod: %v", kubeClientErr)
 				}
 				if ztunnelPod {
 					newWriter, err = setupZtunnelConfigDumpWriter(podName, podNamespace, c.OutOrStdout())

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -622,9 +622,9 @@ func workloadConfigCmd() *cobra.Command {
 				if podName, podNamespace, err = getComponentPodName(args[0]); err != nil {
 					return err
 				}
-				ztunnelPod, err := isZtunnelPod(podName, podNamespace)
-				if err != nil {
-					return fmt.Errorf("failed to create k8s client: %v", err)
+				ztunnelPod, kubeClientErr := isZtunnelPod(podName, podNamespace)
+				if kubeClientErr != nil {
+					return fmt.Errorf("failed to create k8s client: %v", kubeClientErr)
 				}
 				if !ztunnelPod {
 					return fmt.Errorf("workloads command is only supported by ztunnel proxies: %v", podName)

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -879,7 +879,9 @@ func logCmd() *cobra.Command {
 							return fmt.Errorf("unrecognized logging level: %v", ol)
 						}
 					} else {
-						loggerLevel := regexp.MustCompile(`[:=]`).Split(ol, 2)
+						logParts := strings.Split(ol, "::") // account for any specified namespace
+						loggerAndLevelOnly := logParts[len(logParts)-1]
+						loggerLevel := regexp.MustCompile(`[:=]`).Split(loggerAndLevelOnly, 2)
 						for logName, typ := range loggerNames {
 							if typ == Ztunnel {
 								// TODO validate ztunnel logger name when available: https://github.com/istio/ztunnel/issues/426

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -118,10 +118,10 @@ var stringToLevel = map[string]Level{
 var (
 	loggerLevelString = ""
 	reset             = false
+	client, _         = kubeClient(kubeconfig, configContext)
 )
 
 var isZtunnelPod = func(podName, podNamespace string) bool {
-	client, _ := kubeClient(kubeconfig, configContext)
 	return ambientutil.IsZtunnelPod(client, podName, podNamespace)
 }
 

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -86,11 +86,23 @@ func TestProxyConfig(t *testing.T) {
 			expectedString:   "unrecognized logger name: xxx",
 			wantException:    true,
 		},
+		{ // logger name invalid when namespacing is used improperly
+			execClientConfig: loggingConfig,
+			args:             strings.Split("proxy-config log ztunnel-9v7nw --level ztunnel:::pool:debug", " "),
+			expectedString:   "unrecognized logging level: pool:debug",
+			wantException:    true,
+		},
 		{ // logger name valid, but logging level invalid
 			execClientConfig: loggingConfig,
 			args:             strings.Split("proxy-config log details-v1-5b7f94f9bc-wp5tb --level http:yyy", " "),
 			expectedString:   "unrecognized logging level: yyy",
 			wantException:    true,
+		},
+		{ // logger name valid and logging level valid
+			execClientConfig: loggingConfig,
+			args:             strings.Split("proxy-config log ztunnel-9v7nw --level ztunnel::pool:debug", " "),
+			expectedString:   "",
+			wantException:    false,
 		},
 		{ // both logger name and logging level invalid
 			execClientConfig: loggingConfig,

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -42,8 +42,8 @@ func TestProxyConfig(t *testing.T) {
 		"httpbin-794b576b6c-qx6pf":    []byte("{}"),
 		"ztunnel-9v7nw":               []byte("current log level is debug"),
 	}
-	isZtunnelPod = func(podName, _ string) bool {
-		return strings.HasPrefix(podName, "ztunnel")
+	isZtunnelPod = func(podName, _ string) (bool, error) {
+		return strings.HasPrefix(podName, "ztunnel"), nil
 	}
 	cases := []execTestCase{
 		{


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes Issue #44541.

- We were creating new Kube Clients every time `isZtunnelPod` was called. This PR changes that by initializing a Kube Client one time and using that for `isZtunnelPod`.
- This PR also adds a check during log parsing to ensure that we account for namespaces being added to the logger. Instead of invalidating valid logger level combinations, we now validate them properly.  **Below is a replication of the bug and an example of how it works now**:

**Note for Reviewer:** Formatting is off for the terminal output examples since it doesn't copy/paste easily to GitHub. Apologies in advance!

*Before fix*:
```
jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp --level=ztunnel::pool:debug                                                                                                                                   
Error: unrecognized logging level: :pool:debug  
```

*After fix*:
```
jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp --level=pool:debug                                              
ztunnel-8r6kp.istio-system: 
current log level is pool:debug=trace,info    
                                                                                                                          jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp --level=ztunnel::pool:debug                                    
ztunnel-8r6kp.istio-system: 
current log level is ztunnel::pool:debug=trace,pool:debug=trace,info    
                                                                                                jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp --level=test::ztunnel::pool:debug                               
ztunnel-8r6kp.istio-system:                                                        
current log level is test::ztunnel::pool:debug=trace,ztunnel::pool:debug=trace,pool:debug=trace,info         
                                                                                                                                               jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp -r                                                              2023-05-20T11:13:02.543278Z     warn    unable to get logLevel from ConfigMap istio-sidecar-injector, using default value "warning" for envoy proxies and "info" for ztunnel                                                                                ztunnel-8r6kp.istio-system:                                                         current log level is info  
                                                                                                                                             jmorris@jeremymorris:~/Dev/istio/istioctl/cmd/istioctl$ ./istioctl -n istio-system pc log ztunnel-8r6kp --level=test::ztunnel::pool:debug                               
ztunnel-8r6kp.istio-system:                                                         
current log level is test::ztunnel::pool:debug=trace,info  
```