### PR TITLE
deps: stop importing operator in istiod

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -237,6 +237,24 @@ linters-settings:
       - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
       - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
       - gomodules.xyz/jsonpatch/v3: "don't use v3; v2 is orders of magnitude higher performance"
+    additional-guards:
+      - list-type: denylist
+        packages-with-error-message:
+          - istio.io/istio/operator: "operator should not be imported"
+          - istio.io/istio/istioctl: "istioctl should not be imported"
+        # Specify rules by which the linter ignores certain files for consideration.
+        ignore-file-rules:
+          # Tests can do anything
+          - "**/*_test.go"
+          - "**/istio/tests/**"
+          - "**/istio/pkg/test/**"
+          # Main code should only be used by appropriate binaries
+          - "**/istio/operator/**"
+          - "**/istio/istioctl/**"
+          - "**/istio/tools/bug-report/**"
+          # This should only really import operator API, but that is hard to express without a larger refactoring
+          - "**/pkg/kube/**"
+          - "**/pkg/url/**"
   gosec:
     includes:
       - G401

--- a/pkg/config/analysis/diag/messages.go
+++ b/pkg/config/analysis/diag/messages.go
@@ -16,8 +16,6 @@ package diag
 
 import (
 	"sort"
-
-	"istio.io/istio/operator/pkg/object"
 )
 
 // Messages is a slice of Message items.
@@ -81,19 +79,6 @@ func (ms *Messages) FilterOutLowerThan(outputLevel Level) Messages {
 	for _, m := range *ms {
 		if m.Type.Level().IsWorseThanOrEqualTo(outputLevel) {
 			outputMessages = append(outputMessages, m)
-		}
-	}
-	return outputMessages
-}
-
-func (ms *Messages) FilterOutBasedOnResources(resources object.K8sObjects) Messages {
-	outputMessages := Messages{}
-	for _, m := range *ms {
-		for _, rs := range resources {
-			if rs.Name == m.Resource.Metadata.FullName.Name.String() {
-				outputMessages = append(outputMessages, m)
-				break
-			}
 		}
 	}
 	return outputMessages

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/label"
-	"istio.io/istio/istioctl/pkg/tag"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
@@ -91,7 +90,7 @@ func (p *tagWatcher) HasSynced() bool {
 func (p *tagWatcher) GetMyTags() sets.String {
 	res := sets.New(p.revision)
 	for _, wh := range p.index.Lookup(p.revision) {
-		res.Insert(wh.GetLabels()[tag.IstioTagLabel])
+		res.Insert(wh.GetLabels()[IstioTagLabel])
 	}
 	return res
 }
@@ -109,6 +108,8 @@ func isTagWebhook(uobj any) bool {
 	if !ok {
 		return false
 	}
-	_, ok = obj.GetLabels()[tag.IstioTagLabel]
+	_, ok = obj.GetLabels()[IstioTagLabel]
 	return ok
 }
+
+const IstioTagLabel = "istio.io/tag"

--- a/tools/golangci-override.yaml
+++ b/tools/golangci-override.yaml
@@ -5,3 +5,21 @@ linters-settings:
     - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
     - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
     - gomodules.xyz/jsonpatch/v3: "don't use v3; v2 is orders of magnitude higher performance"
+    additional-guards:
+      - list-type: denylist
+        packages-with-error-message:
+          - istio.io/istio/operator: "operator should not be imported"
+          - istio.io/istio/istioctl: "istioctl should not be imported"
+        # Specify rules by which the linter ignores certain files for consideration.
+        ignore-file-rules:
+          # Tests can do anything
+          - "**/*_test.go"
+          - "**/istio/tests/**"
+          - "**/istio/pkg/test/**"
+          # Main code should only be used by appropriate binaries
+          - "**/istio/operator/**"
+          - "**/istio/istioctl/**"
+          - "**/istio/tools/bug-report/**"
+          # This should only really import operator API, but that is hard to express without a larger refactoring
+          - "**/pkg/kube/**"
+          - "**/pkg/url/**"


### PR DESCRIPTION
This cleans up some imports to avoid importing all of operator. Trims a lot of deps and about 1mb of binary size. Add a linter to prevent regressions.

**Please provide a description of this PR:**