### PR TITLE
Don't hardcode versions in upgrade test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/alecthomas/participle v0.4.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"istio.io/istio/pkg/log"
 )
@@ -149,4 +150,15 @@ func ReadProxySHA() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("PROXY_REPO_SHA not found")
+}
+
+// ReadVersion returns the contents of the $ROOTDIR/VERSION file
+func ReadVersion() (string, error) {
+	f := filepath.Join(IstioSrc, "VERSION")
+	v, err := os.ReadFile(f)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(string(v), "\n"), nil
 }

--- a/pkg/util/image/registry.go
+++ b/pkg/util/image/registry.go
@@ -1,0 +1,41 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Exists returns true if the image in the argument exists in a container registry.
+// The argument must be a complete image name, e.g. "gcr.io/istio-release/pilot:1.19.0".
+// If the image does not exist, it returns false and an optional error message, for debug purposes.
+func Exists(image string) (bool, error) {
+	c := exec.Command("crane", "manifest", image)
+	b := &bytes.Buffer{}
+	c.Stderr = b
+	err := c.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	if strings.Contains(b.String(), "MANIFEST_UNKNOWN") {
+		return false, fmt.Errorf(b.String())
+	}
+
+	return false, fmt.Errorf("failed to check image existence: %v, %v", err, b.String())
+}

--- a/tests/integration/helm/upgrade/helm_upgrade_test.go
+++ b/tests/integration/helm/upgrade/helm_upgrade_test.go
@@ -20,13 +20,53 @@ package helmupgrade
 import (
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
+
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/util/image"
 )
 
-const (
-	previousSupportedVersion = "1.16.0"
-	nMinusTwoVersion         = "1.15.0"
+var (
+	previousSupportedVersion string
+	nMinusTwoVersion         string
 )
+
+const imageToCheck = "gcr.io/istio-release/pilot"
+
+func initVersions(ctx resource.Context) error {
+	versionFromFile, err := env.ReadVersion()
+	if err != nil {
+		return err
+	}
+
+	v, err := semver.NewVersion(versionFromFile)
+	if err != nil {
+		return err
+	}
+
+	previousVersion := semver.New(v.Major(), v.Minor()-1, v.Patch(), v.Prerelease(), v.Metadata())
+
+	// If the previous version is not published yet, use the latest one
+	if exists, _ := image.Exists(imageToCheck + ":" + previousVersion.String()); !exists {
+		previousVersion = semver.New(v.Major(), v.Minor()-2, v.Patch(), v.Prerelease(), v.Metadata())
+	}
+
+	previousSupportedVersion = previousVersion.String()
+	nMinusTwoVersion = semver.New(previousVersion.Major(), previousVersion.Minor()-1, previousVersion.Patch(),
+		previousVersion.Prerelease(), previousVersion.Metadata()).String()
+
+	// Workaround publish issues
+	if previousSupportedVersion == "1.17.0" {
+		previousSupportedVersion = "1.17.1"
+	}
+	if nMinusTwoVersion == "1.17.0" {
+		nMinusTwoVersion = "1.17.1"
+	}
+
+	return nil
+}
 
 // TestDefaultInPlaceUpgradeFromPreviousMinorRelease tests Istio upgrade using Helm with default options for Istio 1.(n-1)
 func TestDefaultInPlaceUpgradeFromPreviousMinorRelease(t *testing.T) {

--- a/tests/integration/helm/upgrade/main_test.go
+++ b/tests/integration/helm/upgrade/main_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	// nolint: staticcheck
 	framework.
 		NewSuite(m).
+		Setup(initVersions).
 		RequireSingleCluster().
 		Run()
 }

--- a/tools/docker-builder/docker.go
+++ b/tools/docker-builder/docker.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
 	testenv "istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/util/image"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -291,7 +292,14 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 			}
 			i := i
 			e.Go(func() error {
-				return assertImageNonExisting(i)
+				exists, err := image.Exists(i)
+				if exists {
+					return fmt.Errorf("image %q already exists", i)
+				}
+				if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+					return nil
+				}
+				return fmt.Errorf("failed to check image existence: %v", err)
 			})
 		}
 		if err := e.Wait(); err != nil {
@@ -300,20 +308,6 @@ func ConstructBakeFile(a Args) (map[string]string, error) {
 	}
 
 	return tarFiles, os.WriteFile(out, j, 0o644)
-}
-
-func assertImageNonExisting(i string) error {
-	c := exec.Command("crane", "manifest", i)
-	b := &bytes.Buffer{}
-	c.Stderr = b
-	err := c.Run()
-	if err != nil {
-		if strings.Contains(b.String(), "MANIFEST_UNKNOWN") {
-			return nil
-		}
-		return fmt.Errorf("failed to check image existence: %v, %v", err, b.String())
-	}
-	return fmt.Errorf("image %q already exists", i)
 }
 
 func Copy(srcFile, dstFile string) error {


### PR DESCRIPTION
Instead, rely on the contents of the VERSIOn file
