### PR TITLE
[release-1.18] telemetry: enable experimental mertic expiry

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -761,6 +761,12 @@ var (
 	// This is a feature flag, can be removed if protobuf proves universally better.
 	KubernetesClientContentType = env.Register("ISTIO_KUBE_CLIENT_CONTENT_TYPE", "protobuf",
 		"The content type to use for Kubernetes clients. Defaults to protobuf. Valid options: [protobuf, json]").Get()
+
+	// This is an experimental feature flag, can be removed once it became stable, and should introduced to Telemetry API.
+	MetricRotationInterval = env.Register("METRIC_ROTATION_INTERVAL", 0*time.Second,
+		"Metric scope rotation interval, set to 0 to disable the metric scope rotation").Get()
+	MetricGracefulDeletionInterval = env.Register("METRIC_GRACEFUL_DELETION_INTERVAL", 5*time.Minute,
+		"Metric expiry graceful deletion interval. No-op if METRIC_ROTATION_INTERVAL is disabled.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/api/envoy/extensions/stats"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/labels"
@@ -129,9 +130,11 @@ func getTelemetries(env *Environment) *Telemetries {
 }
 
 type metricsConfig struct {
-	ClientMetrics     metricConfig
-	ServerMetrics     metricConfig
-	ReportingInterval *durationpb.Duration
+	ClientMetrics            metricConfig
+	ServerMetrics            metricConfig
+	ReportingInterval        *durationpb.Duration
+	RotationInterval         *durationpb.Duration
+	GracefulDeletionInterval *durationpb.Duration
 }
 
 type metricConfig struct {
@@ -503,6 +506,9 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		allKeys.Insert(k)
 	}
 
+	rotationInterval := getInterval(features.MetricRotationInterval, defaultMetricRotationInterval)
+	gracefulDeletionInterval := getInterval(features.MetricGracefulDeletionInterval, defaultMetricGracefulDeletionInterval)
+
 	m := make([]telemetryFilterConfig, 0, allKeys.Len())
 	for _, k := range sets.SortedList(allKeys) {
 		p := t.fetchProvider(k)
@@ -510,11 +516,14 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 			continue
 		}
 		_, logging := tml[k]
-		_, metrics := tmm[k]
+		mertricCfg, metrics := tmm[k]
+
+		mertricCfg.RotationInterval = rotationInterval
+		mertricCfg.GracefulDeletionInterval = gracefulDeletionInterval
 
 		cfg := telemetryFilterConfig{
 			Provider:      p,
-			metricsConfig: tmm[k],
+			metricsConfig: mertricCfg,
 			AccessLogging: logging,
 			Metrics:       metrics,
 			LogsFilter:    tml[p.Name].Filter,
@@ -535,6 +544,22 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 	// Update cache
 	t.computedMetricsFilters[key] = res
 	return res
+}
+
+// defaul value for metric rotation interval and graceful deletion interval,
+// more details can be found in here: https://github.com/istio/proxy/blob/master/source/extensions/filters/http/istio_stats/config.proto#L116
+var (
+	defaultMetricRotationInterval         = 0 * time.Second
+	defaultMetricGracefulDeletionInterval = 5 * time.Minute
+)
+
+// getInterval return nil to reduce the size of the config, when equal to the default.
+func getInterval(input, defaultValue time.Duration) *durationpb.Duration {
+	if input == defaultValue {
+		return nil
+	}
+
+	return durationpb.New(input)
 }
 
 // mergeLogs returns the set of providers for the given logging configuration.
@@ -1101,6 +1126,8 @@ func generateStatsConfig(class networking.ListenerClass, filterConfig telemetryF
 	cfg := stats.PluginConfig{
 		DisableHostHeaderFallback: disableHostHeaderFallback(class),
 		TcpReportingDuration:      filterConfig.ReportingInterval,
+		RotationInterval:          filterConfig.RotationInterval,
+		GracefulDeletionInterval:  filterConfig.GracefulDeletionInterval,
 	}
 
 	for _, override := range listenerCfg.Overrides {

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -978,3 +978,31 @@ func TestTelemetryFilters(t *testing.T) {
 		})
 	}
 }
+
+func TestGetInterval(t *testing.T) {
+	cases := []struct {
+		name              string
+		input, defaultVal time.Duration
+		expected          *durationpb.Duration
+	}{
+		{
+			name:       "return nil",
+			input:      0,
+			defaultVal: 0,
+			expected:   nil,
+		},
+		{
+			name:       "return input",
+			input:      1 * time.Second,
+			defaultVal: 0,
+			expected:   durationpb.New(1 * time.Second),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getInterval(tc.input, tc.defaultVal)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/releasenotes/notes/44605.yaml
+++ b/releasenotes/notes/44605.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Added** metric expiry support, when env flags `METRIC_ROTATION_INTERVAL` and
+    `METRIC_GRACEFUL_DELETION_INTERVAL` are enabled.


### PR DESCRIPTION
This is a cherry-pick of #44605

fixes: #44995