### PR TITLE
Fix precheck newclient usage

### DIFF
--- a/istioctl/cmd/precheck.go
+++ b/istioctl/cmd/precheck.go
@@ -136,18 +136,10 @@ func checkControlPlane(cli kube.CLIClient) (diag.Messages, error) {
 		resource.Namespace(istioNamespace),
 		nil,
 	)
-	// Set up the kube client
-	config := kube.BuildClientCmd(kubeconfig, configContext)
-	restConfig, err := config.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
-
-	k, err := kube.NewClient(kube.NewClientConfigForRestConfig(restConfig), "")
-	if err != nil {
-		return nil, err
-	}
-	sa.AddRunningKubeSource(k)
+	sa.AddRunningKubeSource(cli)
 	cancel := make(chan struct{})
 	result, err := sa.Analyze(cancel)
 	if err != nil {


### PR DESCRIPTION
**Please provide a description of this PR:**
There's no need to setup a new client for the kubesource, should just use CLIClient