### PR TITLE
revert timeout in secretvalid context

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -419,9 +419,7 @@ func (sc *SecretManagerClient) generateKeyCertFromExistingFiles(certChainPath, k
 		_, err := tls.LoadX509KeyPair(certChainPath, keyPath)
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
-	defer cancel()
-	if err := b.RetryWithContext(ctx, secretValid); err != nil {
+	if err := b.RetryWithContext(context.TODO(), secretValid); err != nil {
 		return nil, err
 	}
 	return sc.keyCertSecretItem(certChainPath, keyPath, resourceName)


### PR DESCRIPTION
Reverts timeout logic set in https://github.com/istio/istio/pull/44993/. Now this is not needed, because we handle NextBackoff correctly

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure