### PR TITLE
Change to use Node instead of RawMetadata in LoadStatsConfigJSONStr

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -172,7 +172,7 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 	opts = append(opts, proxyOpts...)
 
 	// Append LRS related options.
-	opts = append(opts, option.LoadStatsConfigJSONStr(cfg.RawMetadata))
+	opts = append(opts, option.LoadStatsConfigJSONStr(cfg.Node))
 
 	// TODO: allow reading a file with additional metadata (for example if created with
 	// 'envref'. This will allow Istio to generate the right config even if the pod info

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -253,9 +253,9 @@ func MetadataDiscovery(value bool) Instance {
 	return newOption("metadata_discovery", value)
 }
 
-func LoadStatsConfigJSONStr(rawMeta map[string]any) Instance {
+func LoadStatsConfigJSONStr(node *model.Node) Instance {
 	// JSON string for configuring Load Reporting Service.
-	if json, ok := rawMeta["LOAD_STATS_CONFIG_JSON"].(string); ok {
+	if json, ok := node.RawMetadata["LOAD_STATS_CONFIG_JSON"].(string); ok {
 		return newOption("load_stats_config_json_str", json)
 	}
 	return skipOption("load_stats_config_json_str")


### PR DESCRIPTION
To give more extensibility to the function `LoadStatsConfigJSONStr`, the entire Node is given instead of "RawMetadata".
Based on this, platform specific codes may be able to fill `load_stats_config_json_str` with more flexibility.

Change-Id: I21117025bb99b62c18484d2f1598a001751faaa4