### PR TITLE
Add deprecated note to operator cmd

### DIFF
--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/istio/pkg/url"
 )
 
-var depNote = "Note: Operator is deprecated, " +
+var depNote = "Note: Operator has been deprecated, " +
 	"and this command will be removed in the future. See " + url.DocsURL + "setup/install/operator/ for more details."
 
 // OperatorCmd is a group of commands related to installation and management of the operator controller.

--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -22,8 +22,8 @@ import (
 	"istio.io/istio/pkg/url"
 )
 
-var depNote = "Note: Operator has been deprecated, " +
-	"and this command will be removed in the future. See " + url.DocsURL + "setup/install/operator/ for more details."
+var depNote = "Note: This command has been deprecated, and will be removed in the future. " +
+	"See " + url.DocsURL + "setup/install/operator/ for more details on why the use of the Operator is not recommended."
 
 // OperatorCmd is a group of commands related to installation and management of the operator controller.
 func OperatorCmd() *cobra.Command {

--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -15,15 +15,22 @@
 package mesh
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"istio.io/istio/pkg/url"
 )
+
+var depNote = "Note: Operator is deprecated, " +
+	"and this command will be removed in the future. See " + url.DocsURL + "setup/install/operator/ for more details."
 
 // OperatorCmd is a group of commands related to installation and management of the operator controller.
 func OperatorCmd() *cobra.Command {
 	oc := &cobra.Command{
 		Use:   "operator",
-		Short: "Commands related to Istio operator controller.",
-		Long:  "The operator command installs, dumps, removes and shows the status of the operator controller.",
+		Short: "Commands related to Istio operator controller." + fmt.Sprintf(" (%s)", depNote),
+		Long:  "The operator command installs, dumps, removes and shows the status of the operator controller.\n\n" + depNote,
 	}
 
 	odArgs := &operatorDumpArgs{}


### PR DESCRIPTION
**Please provide a description of this PR:**
I think users somehow need to be notified that the command is not recommended for use, and this is better than directly hiding it in the future.

Any ideas? @zirain @howardjohn 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
