### PR TITLE
revert common/config/.golangci

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -237,24 +237,6 @@ linters-settings:
       - github.com/golang/protobuf/jsonpb: "don't use the jsonpb package directly; use util/protomarshal instead"
       - google.golang.org/protobuf/encoding/protojson: "don't use the protojson package directly; use util/protomarshal instead"
       - gomodules.xyz/jsonpatch/v3: "don't use v3; v2 is orders of magnitude higher performance"
-    additional-guards:
-      - list-type: denylist
-        packages-with-error-message:
-          - istio.io/istio/operator: "operator should not be imported"
-          - istio.io/istio/istioctl: "istioctl should not be imported"
-        # Specify rules by which the linter ignores certain files for consideration.
-        ignore-file-rules:
-          # Tests can do anything
-          - "**/*_test.go"
-          - "**/istio/tests/**"
-          - "**/istio/pkg/test/**"
-          # Main code should only be used by appropriate binaries
-          - "**/istio/operator/**"
-          - "**/istio/istioctl/**"
-          - "**/istio/tools/bug-report/**"
-          # This should only really import operator API, but that is hard to express without a larger refactoring
-          - "**/pkg/kube/**"
-          - "**/pkg/url/**"
   gosec:
     includes:
       - G401


### PR DESCRIPTION
**Please provide a description of this PR:**

This change was introduced https://github.com/istio/istio/commit/927780f61e51bd831e0e1cec213296d93d1c9ab9 but does not exist in common-files. This causes local runs of `make precommit` and `make lint` to fail:

Fixes https://github.com/istio/istio/issues/45054

Wasn't sure if reverting was the best way, as another change from common-files will also adjust this. I'm not sure how it's not failing in Prow, but it fails all runs locally.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
