### PR TITLE
Gamma: fix consumer overrides

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -214,6 +214,20 @@ func buildSidecarVirtualHostsForVirtualService(
 
 	hosts, servicesInVirtualService := separateVSHostsAndServices(virtualService, serviceRegistry)
 
+	// Gateway allows only routes from the namespace of the proxy, or namespace of the destination.
+	if model.UseGatewaySemantics(virtualService) {
+		res := make([]*model.Service, 0, len(servicesInVirtualService))
+		for _, s := range servicesInVirtualService {
+			if s.Attributes.Namespace != virtualService.Namespace && node.ConfigNamespace != virtualService.Namespace {
+				continue
+			}
+			res = append(res, s)
+		}
+		if len(res) == 0 {
+			return nil
+		}
+	}
+
 	// Now group these Services by port so that we can infer the destination.port if the user
 	// doesn't specify any port for a multiport service. We need to know the destination port in
 	// order to build the cluster name (outbound|<port>|<subset>|<serviceFQDN>)

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1626,6 +1626,9 @@ func (args vsArgs) Config(t *testing.T, variant string) string {
 				if len(spl) != 5 {
 					t.Skipf("unsupported match: %v", spl)
 				}
+				if spl[0] == "*" {
+					t.Skipf("unsupported match: %v", spl)
+				}
 				args.GwMatches = append(args.GwMatches, types.NamespacedName{
 					Namespace: spl[1],
 					Name:      spl[0],
@@ -1802,6 +1805,9 @@ spec:
 			expected: map[string][]string{
 				"foo.default.svc.cluster.local": {"outbound|80||foo.default.svc.cluster.local"},
 			},
+			expectedGateway: map[string][]string{
+				"foo.default.svc.cluster.local": nil,
+			},
 		},
 		{
 			name: "unknown port 8080",
@@ -1917,6 +1923,9 @@ spec:
 			expected: map[string][]string{
 				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
 			},
+			expectedGateway: map[string][]string{
+				"known.default.svc.cluster.local": {"outbound|80||known.default.svc.cluster.local"},
+			},
 		},
 		{
 			name: "arbitrary rule port 8080",
@@ -1930,8 +1939,8 @@ spec:
 			expected: map[string][]string{
 				"known.default.svc.cluster.local": {"outbound|8080||alt-known.default.svc.cluster.local"},
 			},
-			expectedGateway: map[string][]string{ // No implicit port matching for gateway
-				"known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+			expectedGateway: map[string][]string{
+				"known.default.svc.cluster.local": {"outbound|8080||known.default.svc.cluster.local"},
 			},
 		},
 		{
@@ -1963,8 +1972,7 @@ spec:
 				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
-				// TODO: consumer namespace wins
-				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||not-default.example.com"},
 			},
 		},
 		{
@@ -1996,8 +2004,7 @@ spec:
 				"known.default.svc.cluster.local": {"outbound|8080||arbitrary.example.com"},
 			},
 			expectedGateway: map[string][]string{
-				// TODO: Consumer gateway wins. No implicit destination port for Gateway
-				"known.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
+				"known.default.svc.cluster.local": {"outbound|80||not-default.example.com"},
 			},
 		},
 		{
@@ -2332,7 +2339,8 @@ spec:
 				// even though there is an *.svc.cluster.local, since we do not import it we should create a wildcard matcher
 				"*.default.svc.cluster.local": {"outbound|80||arbitrary.example.com"},
 				// We did not import this, shouldn't show up
-				"explicit.default.svc.cluster.local": nil,
+				"explicit.default.svc.cluster.local":        nil,
+				"not-default.not-default.svc.cluster.local": {"outbound|80||not-default.not-default.svc.cluster.local"},
 			},
 		},
 		{
@@ -2380,8 +2388,8 @@ spec:
 				"known.default.svc.cluster.local": {"outbound|80||producer.example.com"},
 			},
 			expectedGateway: map[string][]string{
-				// TODO: consumer namespace wins
-				"known.default.svc.cluster.local": {"outbound|80||producer.example.com"},
+				// consumer wins
+				"known.default.svc.cluster.local": {"outbound|80||consumer.example.com"},
 			},
 		},
 		{
@@ -2431,7 +2439,6 @@ spec:
 			},
 		},
 	}
-	// TODO test httproute when support for arbitrary hostnames is added in the GEP
 	for _, variant := range []string{"httproute", "virtualservice"} {
 		t.Run(variant, func(t *testing.T) {
 			for _, tt := range cases {


### PR DESCRIPTION
~Builds on https://github.com/istio/istio/pull/45058~

Fixes https://github.com/istio/istio/issues/45057

In VirtualService oldest one wins - even if its in a random namespace. That is, Namespace A -> Namespace B can be impacted by Namespace C's VirtualService.

In gamma, it is more strict. Consumer Namespace > Producer Namespace > Nothing (no fallback to arbitrary namespace).

This PR implements this precedence and updates our tests to match the new behavior (previously they were 'TODO's). There are no e2e tests since that is part of conformance which has an open PR; will pull it in soon.