### PR TITLE
clean and fix string split

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1091,11 +1091,7 @@ func GetProxyConfigNamespace(proxy *Proxy) string {
 	// if not found, for backward compatibility, extract the namespace from
 	// the proxy domain. this is a k8s specific hack and should be enabled
 	parts := strings.Split(proxy.DNSDomain, ".")
-	if len(parts) > 1 { // k8s will have namespace.<domain>
-		return parts[0]
-	}
-
-	return ""
+	return parts[0]
 }
 
 const (

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -601,6 +601,10 @@ func VirtualServiceDependencies(vs config.Config) []ConfigKey {
 			// shouldn't happen
 			continue
 		}
+		if len(knn) < 2 {
+			log.Errorf("invalid InternalParentName parts: %s", knn)
+			continue
+		}
 		nn := strings.Split(knn[1], ".")
 		out = append(out, ConfigKey{
 			Kind:      k,


### PR DESCRIPTION
**Please provide a description of this PR:**
if strings.Split have not substring. it will return [""],so it is unnecessary use 
```
if len(parts) > 1 {
		return parts[0]
	}

	return ""
```

in addition, add len(knn) to avoid panic