### PR TITLE
RetryWithContext should use the new NextBackOff()

### DIFF
--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -95,7 +95,7 @@ func (b ExponentialBackOff) RetryWithContext(ctx context.Context, operation func
 		if err == nil {
 			return nil
 		}
-		next := b.exponentialBackOff.NextBackOff()
+		next := b.NextBackOff()
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%v with last error: %v", context.DeadlineExceeded, err)


### PR DESCRIPTION
**Please provide a description of this PR:**

With https://github.com/istio/istio/pull/44993/ the NextBackOff() wrapper was modified to handle certain negative scenarios where the NextBackOff() provided by cenkalti/backoff/v4 was returning -1. RetryWithContext() should also use the wrapped NextBackoff in order to prevent issue when -1 is raised.

**Before this PR:** RetryWithContext uses proper backoff until MaxElapsedTime is reached (15 min). After MaxElapsedTime has passed, RetryWithContext retries with a -1 backoff duration (no waiting time) negatively impacting performance. 

**After this PR**: if MaxElapsedTime has been reached in RetryWithContext, it will continue retrying with MaxInterval duration as waiting time.
