### PR TITLE
populate crl only when the key is present in secret

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -320,21 +320,24 @@ func atMostNJoin(data []string, limit int) string {
 }
 
 func toEnvoyCaSecret(name string, certInfo *credscontroller.CertInfo) *discovery.Resource {
+	validationContext := &envoytls.CertificateValidationContext{
+		TrustedCa: &core.DataSource{
+			Specifier: &core.DataSource_InlineBytes{
+				InlineBytes: certInfo.Cert,
+			},
+		},
+	}
+	if certInfo.CRL != nil {
+		validationContext.Crl = &core.DataSource{
+			Specifier: &core.DataSource_InlineBytes{
+				InlineBytes: certInfo.CRL,
+			},
+		}
+	}
 	res := protoconv.MessageToAny(&envoytls.Secret{
 		Name: name,
 		Type: &envoytls.Secret_ValidationContext{
-			ValidationContext: &envoytls.CertificateValidationContext{
-				TrustedCa: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: certInfo.Cert,
-					},
-				},
-				Crl: &core.DataSource{
-					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: certInfo.CRL,
-					},
-				},
-			},
+			ValidationContext: validationContext,
 		},
 	})
 	return &discovery.Resource{


### PR DESCRIPTION

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
