### PR TITLE
Use StringMatch instead deprecated matcher types

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -51,14 +51,17 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: method
                     name: :method
+                    stringMatch:
+                      exact: method
                 - header:
                     name: :method
-                    prefixMatch: method-prefix-
+                    stringMatch:
+                      prefix: method-prefix-
                 - header:
                     name: :method
-                    suffixMatch: -suffix-method
+                    stringMatch:
+                      suffix: -suffix-method
                 - header:
                     name: :method
                     presentMatch: true
@@ -66,14 +69,17 @@ typedConfig:
                 orRules:
                   rules:
                   - header:
-                      exactMatch: not-method
                       name: :method
+                      stringMatch:
+                        exact: not-method
                   - header:
                       name: :method
-                      prefixMatch: not-method-prefix-
+                      stringMatch:
+                        prefix: not-method-prefix-
                   - header:
                       name: :method
-                      suffixMatch: -not-suffix-method
+                      stringMatch:
+                        suffix: -not-suffix-method
                   - header:
                       name: :method
                       presentMatch: true
@@ -418,14 +424,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -433,14 +442,17 @@ typedConfig:
                 orIds:
                   ids:
                   - header:
-                      exactMatch: not-header
                       name: X-header
+                      stringMatch:
+                        exact: not-header
                   - header:
                       name: X-header
-                      prefixMatch: not-header-prefix-
+                      stringMatch:
+                        prefix: not-header-prefix-
                   - header:
                       name: X-header
-                      suffixMatch: -not-suffix-header
+                      stringMatch:
+                        suffix: -not-suffix-header
                   - header:
                       name: X-header
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -10,11 +10,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: GET
                     name: :method
+                    stringMatch:
+                      exact: GET
                 - header:
-                    exactMatch: POST
                     name: :method
+                    stringMatch:
+                      exact: POST
         principals:
         - andIds:
             ids:
@@ -156,9 +158,11 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: abc1
                     name: X-abc
+                    stringMatch:
+                      exact: abc1
                 - header:
-                    exactMatch: abc2
                     name: X-abc
+                    stringMatch:
+                      exact: abc2
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/simple-policy-td-aliases-out.yaml
@@ -10,8 +10,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[0]
         principals:
         - andIds:
             ids:
@@ -59,8 +60,9 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[0]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[0]
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -22,11 +22,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -64,11 +66,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[0]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[0]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[0]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -146,14 +150,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -224,14 +231,17 @@ typedConfig:
             - orIds:
                 ids:
                 - header:
-                    exactMatch: header
                     name: X-header
+                    stringMatch:
+                      exact: header
                 - header:
                     name: X-header
-                    prefixMatch: header-prefix-
+                    stringMatch:
+                      prefix: header-prefix-
                 - header:
                     name: X-header
-                    suffixMatch: -suffix-header
+                    stringMatch:
+                      suffix: -suffix-header
                 - header:
                     name: X-header
                     presentMatch: true
@@ -262,11 +272,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[0]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[0]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[0]-method[2]
             - orRules:
                 rules:
                 - urlPath:
@@ -296,11 +308,13 @@ typedConfig:
             - orRules:
                 rules:
                 - header:
-                    exactMatch: rule[1]-to[1]-method[1]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[1]
                 - header:
-                    exactMatch: rule[1]-to[1]-method[2]
                     name: :method
+                    stringMatch:
+                      exact: rule[1]-to[1]-method[2]
             - orRules:
                 rules:
                 - urlPath:

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -33,25 +33,11 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 				PresentMatch: true,
 			},
 		}
-	} else if strings.HasPrefix(v, "*") {
-		return &routepb.HeaderMatcher{
-			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-				SuffixMatch: v[1:],
-			},
-		}
-	} else if strings.HasSuffix(v, "*") {
-		return &routepb.HeaderMatcher{
-			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
-				PrefixMatch: v[:len(v)-1],
-			},
-		}
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-			ExactMatch: v,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: StringMatcher(v),
 		},
 	}
 }
@@ -75,10 +61,8 @@ func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
 	}
 	return &routepb.HeaderMatcher{
 		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: &matcher.RegexMatcher{
-				Regex: `(?i)` + regex,
-			},
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+			StringMatch: StringMatcherRegex(`(?i)` + regex),
 		},
 	}
 }
@@ -94,40 +78,13 @@ func HostMatcher(k, v string) *routepb.HeaderMatcher {
 				PresentMatch: true,
 			},
 		}
-	} else if strings.HasPrefix(v, "*") {
-		return &routepb.HeaderMatcher{
-			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-				StringMatch: &matcher.StringMatcher{
-					IgnoreCase: true,
-					MatchPattern: &matcher.StringMatcher_Suffix{
-						Suffix: v[1:],
-					},
-				},
-			},
-		}
-	} else if strings.HasSuffix(v, "*") {
-		return &routepb.HeaderMatcher{
-			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-				StringMatch: &matcher.StringMatcher{
-					IgnoreCase: true,
-					MatchPattern: &matcher.StringMatcher_Prefix{
-						Prefix: v[:len(v)-1],
-					},
-				},
-			},
-		}
 	}
+	m := StringMatcher(v)
+	m.IgnoreCase = true
 	return &routepb.HeaderMatcher{
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-			StringMatch: &matcher.StringMatcher{
-				IgnoreCase: true,
-				MatchPattern: &matcher.StringMatcher_Exact{
-					Exact: v,
-				},
-			},
+			StringMatch: m,
 		},
 	}
 }

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -20,6 +20,7 @@ import (
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	v32 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -37,30 +38,42 @@ func TestHeaderMatcher(t *testing.T) {
 			V:    "/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_ExactMatch{
-					ExactMatch: "/productpage",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &v32.StringMatcher{
+						MatchPattern: &v32.StringMatcher_Exact{
+							Exact: "/productpage",
+						},
+					},
 				},
 			},
 		},
 		{
 			Name: "suffix match",
 			K:    ":path",
-			V:    "*/productpage*",
+			V:    "/productpage*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SuffixMatch{
-					SuffixMatch: "/productpage*",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &v32.StringMatcher{
+						MatchPattern: &v32.StringMatcher_Prefix{
+							Prefix: "/productpage",
+						},
+					},
 				},
 			},
 		},
 		{
 			Name: "prefix match",
 			K:    ":path",
-			V:    "/productpage*",
+			V:    "*/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_PrefixMatch{
-					PrefixMatch: "/productpage",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &v32.StringMatcher{
+						MatchPattern: &v32.StringMatcher_Suffix{
+							Suffix: "/productpage",
+						},
+					},
 				},
 			},
 		},
@@ -78,10 +91,12 @@ func TestHeaderMatcher(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := HeaderMatcher(tc.K, tc.V)
-		if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
-			t.Errorf("expecting %v, but got %v", tc.Expect, actual)
-		}
+		t.Run(tc.Name, func(t *testing.T) {
+			actual := HeaderMatcher(tc.K, tc.V)
+			if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+				t.Errorf("expecting %v, but got %v", tc.Expect, actual)
+			}
+		})
 	}
 }
 
@@ -107,9 +122,13 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "*.example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcher.RegexMatcher{
-						Regex: `(?i).*\.example\.com`,
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_SafeRegex{
+							SafeRegex: &matcher.RegexMatcher{
+								Regex: `(?i).*\.example\.com`,
+							},
+						},
 					},
 				},
 			},
@@ -120,9 +139,13 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.*",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcher.RegexMatcher{
-						Regex: `(?i)example\..*`,
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_SafeRegex{
+							SafeRegex: &matcher.RegexMatcher{
+								Regex: `(?i)example\..*`,
+							},
+						},
 					},
 				},
 			},
@@ -133,9 +156,13 @@ func TestHostMatcherWithRegex(t *testing.T) {
 			V:    "example.com",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
-					SafeRegexMatch: &matcher.RegexMatcher{
-						Regex: `(?i)example\.com`,
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_SafeRegex{
+							SafeRegex: &matcher.RegexMatcher{
+								Regex: `(?i)example\.com`,
+							},
+						},
 					},
 				},
 			},

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -20,7 +20,6 @@ import (
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	v32 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -39,8 +38,8 @@ func TestHeaderMatcher(t *testing.T) {
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: &v32.StringMatcher{
-						MatchPattern: &v32.StringMatcher_Exact{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_Exact{
 							Exact: "/productpage",
 						},
 					},
@@ -54,8 +53,8 @@ func TestHeaderMatcher(t *testing.T) {
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: &v32.StringMatcher{
-						MatchPattern: &v32.StringMatcher_Prefix{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_Prefix{
 							Prefix: "/productpage",
 						},
 					},
@@ -69,8 +68,8 @@ func TestHeaderMatcher(t *testing.T) {
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: &v32.StringMatcher{
-						MatchPattern: &v32.StringMatcher_Suffix{
+					StringMatch: &matcher.StringMatcher{
+						MatchPattern: &matcher.StringMatcher_Suffix{
 							Suffix: "/productpage",
 						},
 					},

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -207,7 +207,8 @@ func TestGenerator(t *testing.T) {
 			value: "foo",
 			want: yamlPrincipal(t, `
          header:
-          exactMatch: foo
+          stringMatch: 
+           exact: foo
           name: x-foo`),
 		},
 		{
@@ -271,7 +272,8 @@ func TestGenerator(t *testing.T) {
 			value: "GET",
 			want: yamlPermission(t, `
          header:
-          exactMatch: GET
+          stringMatch:
+           exact: GET
           name: :method`),
 		},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

`HeaderMatcher_PrefixMatch` and etc are deprecated.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
