### PR TITLE
Share an initialized kubeclient instead of re-initializing it everytime kubeclient is needed

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/istioctl/pkg/authz"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/istioctl/pkg/util/handlers"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 )
 
@@ -65,7 +64,7 @@ The command also supports reading from a standalone config dump file with flag -
 				return fmt.Errorf("failed to get config dump from file %s: %s", configDumpFile, err)
 			}
 		} else if len(args) == 1 {
-			kubeClient, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %w", err)
 			}
@@ -115,7 +114,7 @@ func getConfigDumpFromFile(filename string) (*configdump.Wrapper, error) {
 }
 
 func getConfigDumpFromPod(podName, podNamespace string) (*configdump.Wrapper, error) {
-	kubeClient, err := kube.NewCLIClient(kube.BuildClientCmd(kubeconfig, configContext), "")
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -64,7 +64,7 @@ The command also supports reading from a standalone config dump file with flag -
 				return fmt.Errorf("failed to get config dump from file %s: %s", configDumpFile, err)
 			}
 		} else if len(args) == 1 {
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %w", err)
 			}
@@ -114,7 +114,7 @@ func getConfigDumpFromFile(filename string) (*configdump.Wrapper, error) {
 }
 
 func getConfigDumpFromPod(podName, podNamespace string) (*configdump.Wrapper, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/checkinject.go
+++ b/istioctl/cmd/checkinject.go
@@ -63,7 +63,7 @@ Checks associated resources of the given resource, and running webhooks to exami
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/checkinject.go
+++ b/istioctl/cmd/checkinject.go
@@ -63,7 +63,7 @@ Checks associated resources of the given resource, and running webhooks to exami
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return err
 			}
@@ -72,15 +72,15 @@ Checks associated resources of the given resource, and running webhooks to exami
 			if len(args) == 1 {
 				podName, podNs, err = handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(namespace, defaultNamespace),
-					MakeKubeFactory(client))
+					MakeKubeFactory(kubeClient))
 				if err != nil {
 					return err
 				}
-				pod, err := client.Kube().CoreV1().Pods(podNs).Get(context.TODO(), podName, metav1.GetOptions{})
+				pod, err := kubeClient.Kube().CoreV1().Pods(podNs).Get(context.TODO(), podName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				ns, err := client.Kube().CoreV1().Namespaces().Get(context.TODO(), podNs, metav1.GetOptions{})
+				ns, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.TODO(), podNs, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -90,7 +90,7 @@ Checks associated resources of the given resource, and running webhooks to exami
 				if namespace == "" {
 					namespace = defaultNamespace
 				}
-				ns, err := client.Kube().CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+				ns, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -101,7 +101,7 @@ Checks associated resources of the given resource, and running webhooks to exami
 				podLabels = ls.MatchLabels
 				nsLabels = ns.GetLabels()
 			}
-			whs, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{})
+			whs, err := kubeClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/clusters.go
+++ b/istioctl/cmd/clusters.go
@@ -34,7 +34,7 @@ func clustersCommand() *cobra.Command {
 		Use:   "remote-clusters",
 		Short: "Lists the remote clusters each istiod instance is connected to.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/completion.go
+++ b/istioctl/cmd/completion.go
@@ -25,7 +25,7 @@ import (
 )
 
 func getPodsNameInDefaultNamespace(toComplete string) ([]string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func validPodsNameArgs(cmd *cobra.Command, args []string, toComplete string) ([]
 }
 
 func getServicesName(toComplete string) ([]string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func validServiceArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 }
 
 func getNamespacesName(toComplete string) ([]string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/completion.go
+++ b/istioctl/cmd/completion.go
@@ -25,7 +25,7 @@ import (
 )
 
 func getPodsNameInDefaultNamespace(toComplete string) ([]string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func validPodsNameArgs(cmd *cobra.Command, args []string, toComplete string) ([]
 }
 
 func getServicesName(toComplete string) ([]string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func validServiceArgs(cmd *cobra.Command, args []string, toComplete string) ([]s
 }
 
 func getNamespacesName(toComplete string) ([]string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -77,7 +77,7 @@ func promDashCmd() *cobra.Command {
   istioctl dash prometheus
   istioctl d prometheus`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -113,7 +113,7 @@ func grafanaDashCmd() *cobra.Command {
   istioctl dash grafana
   istioctl d grafana`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -149,7 +149,7 @@ func kialiDashCmd() *cobra.Command {
   istioctl dash kiali
   istioctl d kiali`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -185,7 +185,7 @@ func jaegerDashCmd() *cobra.Command {
   istioctl dash jaeger
   istioctl d jaeger`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -221,7 +221,7 @@ func zipkinDashCmd() *cobra.Command {
   istioctl dash zipkin
   istioctl d zipkin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -271,7 +271,7 @@ func envoyDashCmd() *cobra.Command {
 				return fmt.Errorf("name cannot be provided when a selector is specified")
 			}
 
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -342,7 +342,7 @@ func controlZDashCmd() *cobra.Command {
 				return fmt.Errorf("name cannot be provided when a selector is specified")
 			}
 
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -395,7 +395,7 @@ func skywalkingDashCmd() *cobra.Command {
   istioctl dash skywalking
   istioctl d skywalking`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -271,14 +271,14 @@ func envoyDashCmd() *cobra.Command {
 				return fmt.Errorf("name cannot be provided when a selector is specified")
 			}
 
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
 			var podName, ns string
 			if labelSelector != "" {
-				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(envoyDashNs, defaultNamespace), labelSelector)
+				pl, err := kubeClient.PodsForSelector(context.TODO(), handlers.HandleNamespace(envoyDashNs, defaultNamespace), labelSelector)
 				if err != nil {
 					return fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 				}
@@ -297,14 +297,14 @@ func envoyDashCmd() *cobra.Command {
 			} else {
 				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
 					handlers.HandleNamespace(envoyDashNs, defaultNamespace),
-					MakeKubeFactory(client))
+					MakeKubeFactory(kubeClient))
 				if err != nil {
 					return err
 				}
 			}
 
 			return portForward(podName, ns, fmt.Sprintf("Envoy sidecar %s", podName),
-				"http://%s", bindAddress, proxyAdminPort, client, c.OutOrStdout(), browser)
+				"http://%s", bindAddress, proxyAdminPort, kubeClient, c.OutOrStdout(), browser)
 		},
 	}
 

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDashboard(t *testing.T) {
 	kubeClientWithRevision = mockExecClientDashboard
-	initKubeClient = mockEnvoyClientDashboard
+	getKubeClient = mockEnvoyClientDashboard
 
 	cases := []testCase{
 		{ // case 0
@@ -125,13 +125,13 @@ func TestDashboard(t *testing.T) {
 	}
 }
 
-func mockExecClientDashboard(_, _, _ string) (kube.CLIClient, error) {
+func mockExecClientDashboard(_ string) (kube.CLIClient, error) {
 	return MockClient{
 		CLIClient: kube.NewFakeClient(),
 	}, nil
 }
 
-func mockEnvoyClientDashboard(_, _ string) error {
+func mockEnvoyClientDashboard() error {
 	kubeClient = MockClient{
 		CLIClient: kube.NewFakeClient(),
 	}

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDashboard(t *testing.T) {
 	kubeClientWithRevision = mockExecClientDashboard
-	kubeClient = mockEnvoyClientDashboard
+	initKubeClient = mockEnvoyClientDashboard
 
 	cases := []testCase{
 		{ // case 0
@@ -131,8 +131,9 @@ func mockExecClientDashboard(_, _, _ string) (kube.CLIClient, error) {
 	}, nil
 }
 
-func mockEnvoyClientDashboard(_, _ string) (kube.CLIClient, error) {
-	return MockClient{
+func mockEnvoyClientDashboard(_, _ string) error {
+	kubeClient = MockClient{
 		CLIClient: kube.NewFakeClient(),
-	}, nil
+	}
+	return nil
 }

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -137,7 +137,7 @@ the configuration objects that affect that pod.`,
 			}
 			// TODO look for port collisions between services targeting this pod
 
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}
@@ -1097,7 +1097,7 @@ the configuration objects that affect that service.`,
 				return nil
 			}
 
-			kubeClient, err := newCLIClient(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := newCLIClient(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/injector-list.go
+++ b/istioctl/cmd/injector-list.go
@@ -80,7 +80,7 @@ func injectorListCommand() *cobra.Command {
 		Long:    `List sidecar injector and sidecar versions`,
 		Example: `  istioctl experimental injector list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}

--- a/istioctl/cmd/internal-debug.go
+++ b/istioctl/cmd/internal-debug.go
@@ -112,7 +112,7 @@ By default it will use the default serviceAccount from (istio-system) namespace 
   istioctl x internal-debug syncz --xds-label istio.io/rev=default
 `,
 		RunE: func(c *cobra.Command, args []string) error {
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -414,7 +414,7 @@ func istiodLogCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(logCmd *cobra.Command, args []string) error {
-			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			client, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}

--- a/istioctl/cmd/metrics.go
+++ b/istioctl/cmd/metrics.go
@@ -98,7 +98,7 @@ type workloadMetrics struct {
 func run(c *cobra.Command, args []string) error {
 	log.Debugf("metrics command invoked for workload(s): %v", args)
 
-	client, err := kubeClientWithRevision(kubeconfig, configContext, metricsOpts.Revision)
+	client, err := kubeClientWithRevision(metricsOpts.Revision)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %v", err)
 	}

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -36,7 +36,7 @@ type mockPromAPI struct {
 	cannedResponse map[string]prometheus_model.Value
 }
 
-func mockExecClientAuthNoPilot(_, _, _ string) (kube.CLIClient, error) {
+func mockExecClientAuthNoPilot(_ string) (kube.CLIClient, error) {
 	return MockClient{
 		CLIClient: kube.NewFakeClient(),
 	}, nil
@@ -83,7 +83,7 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func mockPortForwardClientAuthPrometheus(_, _, _ string) (kube.CLIClient, error) {
+func mockPortForwardClientAuthPrometheus(_ string) (kube.CLIClient, error) {
 	return MockClient{
 		CLIClient: kube.NewFakeClient(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -125,7 +125,7 @@ var (
 var isZtunnelPod = func(podName, podNamespace string) (bool, error) {
 	var err error
 	once.Do(func() {
-		err = initKubeClient(kubeconfig, configContext)
+		err = getKubeClient()
 	})
 	if err != nil {
 		return false, err
@@ -145,7 +145,7 @@ func ztunnelLogLevel(level string) string {
 }
 
 func extractConfigDump(podName, podNamespace string, eds bool) ([]byte, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -161,7 +161,7 @@ func extractConfigDump(podName, podNamespace string, eds bool) ([]byte, error) {
 }
 
 func extractZtunnelConfigDump(podName, podNamespace string) ([]byte, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -241,7 +241,7 @@ func setupConfigdumpEnvoyConfigWriter(debug []byte, out io.Writer) (*configdump.
 }
 
 func setupEnvoyClusterStatsConfig(podName, podNamespace string, outputFormat string) (string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -258,7 +258,7 @@ func setupEnvoyClusterStatsConfig(podName, podNamespace string, outputFormat str
 }
 
 func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat string) (string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -291,7 +291,7 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 }
 
 func setupEnvoyLogConfig(param, podName, podNamespace string) (string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -327,7 +327,7 @@ func getLogLevelFromConfigMap() (string, error) {
 }
 
 func setupPodClustersWriter(podName, podNamespace string, out io.Writer) (*clusters.ConfigWriter, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -1451,7 +1451,7 @@ func proxyConfig() *cobra.Command {
 }
 
 func getPodNames(podflag string) ([]string, string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return []string{}, "", fmt.Errorf("failed to create k8s client: %w", err)
 	}
@@ -1470,7 +1470,7 @@ func getPodName(podflag string) (string, string, error) {
 }
 
 func getPodNameWithNamespace(podflag, ns string) (string, string, error) {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create k8s client: %w", err)
 	}
@@ -1494,7 +1494,7 @@ func getPodNameBySelector(labelSelector string) ([]string, string, error) {
 		podNames []string
 		ns       string
 	)
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create k8s client: %w", err)
 	}

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -39,7 +39,6 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 )
 
@@ -118,21 +117,20 @@ var stringToLevel = map[string]Level{
 }
 
 var (
-	loggerLevelString      = ""
-	reset                  = false
-	once                   sync.Once
-	isZtunnelPodKubeClient kube.CLIClient
+	loggerLevelString = ""
+	reset             = false
+	once              sync.Once
 )
 
 var isZtunnelPod = func(podName, podNamespace string) (bool, error) {
 	var err error
 	once.Do(func() {
-		isZtunnelPodKubeClient, err = kubeClient(kubeconfig, configContext)
+		err = initKubeClient(kubeconfig, configContext)
 	})
 	if err != nil {
 		return false, err
 	}
-	return ambientutil.IsZtunnelPod(isZtunnelPodKubeClient, podName, podNamespace), nil
+	return ambientutil.IsZtunnelPod(kubeClient, podName, podNamespace), nil
 }
 
 func ztunnelLogLevel(level string) string {
@@ -147,7 +145,7 @@ func ztunnelLogLevel(level string) string {
 }
 
 func extractConfigDump(podName, podNamespace string, eds bool) ([]byte, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -163,7 +161,7 @@ func extractConfigDump(podName, podNamespace string, eds bool) ([]byte, error) {
 }
 
 func extractZtunnelConfigDump(podName, podNamespace string) ([]byte, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -243,7 +241,7 @@ func setupConfigdumpEnvoyConfigWriter(debug []byte, out io.Writer) (*configdump.
 }
 
 func setupEnvoyClusterStatsConfig(podName, podNamespace string, outputFormat string) (string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -260,7 +258,7 @@ func setupEnvoyClusterStatsConfig(podName, podNamespace string, outputFormat str
 }
 
 func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat string) (string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -293,7 +291,7 @@ func setupEnvoyServerStatsConfig(podName, podNamespace string, outputFormat stri
 }
 
 func setupEnvoyLogConfig(param, podName, podNamespace string) (string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -329,7 +327,7 @@ func getLogLevelFromConfigMap() (string, error) {
 }
 
 func setupPodClustersWriter(podName, podNamespace string, out io.Writer) (*clusters.ConfigWriter, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -1453,7 +1451,7 @@ func proxyConfig() *cobra.Command {
 }
 
 func getPodNames(podflag string) ([]string, string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return []string{}, "", fmt.Errorf("failed to create k8s client: %w", err)
 	}
@@ -1472,7 +1470,7 @@ func getPodName(podflag string) (string, string, error) {
 }
 
 func getPodNameWithNamespace(podflag, ns string) (string, string, error) {
-	kubeClient, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create k8s client: %w", err)
 	}
@@ -1496,11 +1494,11 @@ func getPodNameBySelector(labelSelector string) ([]string, string, error) {
 		podNames []string
 		ns       string
 	)
-	client, err := kubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create k8s client: %w", err)
 	}
-	pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(namespace, defaultNamespace), labelSelector)
+	pl, err := kubeClient.PodsForSelector(context.TODO(), handlers.HandleNamespace(namespace, defaultNamespace), labelSelector)
 	if err != nil {
 		return nil, "", fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 	}

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -195,7 +195,7 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 
 	// Override the exec client factory used by proxyconfig.go and proxystatus.go
 	kubeClientWithRevision = mockClientExecFactoryGenerator(c.execClientConfig)
-	initKubeClient = mockEnvoyClientFactoryGenerator(c.execClientConfig)
+	getKubeClient = mockEnvoyClientFactoryGenerator(c.execClientConfig)
 
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(c.args)
@@ -232,8 +232,8 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 // mockClientExecFactoryGenerator generates a function with the same signature as
 // kubernetes.NewExecClient() that returns a mock client.
 // nolint: lll
-func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string, _ string) (kube.CLIClient, error) {
-	outFactory := func(_, _ string, _ string) (kube.CLIClient, error) {
+func mockClientExecFactoryGenerator(testResults map[string][]byte) func(_ string) (kube.CLIClient, error) {
+	outFactory := func(_ string) (kube.CLIClient, error) {
 		return MockClient{
 			CLIClient: kube.NewFakeClient(),
 			Results:   testResults,
@@ -243,8 +243,8 @@ func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconf
 	return outFactory
 }
 
-func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) error {
-	outFactory := func(_, _ string) error {
+func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func() error {
+	outFactory := func() error {
 		kubeClient = MockClient{
 			CLIClient: kube.NewFakeClient(),
 			Results:   testResults,

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -195,7 +195,7 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 
 	// Override the exec client factory used by proxyconfig.go and proxystatus.go
 	kubeClientWithRevision = mockClientExecFactoryGenerator(c.execClientConfig)
-	kubeClient = mockEnvoyClientFactoryGenerator(c.execClientConfig)
+	initKubeClient = mockEnvoyClientFactoryGenerator(c.execClientConfig)
 
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(c.args)
@@ -243,12 +243,13 @@ func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconf
 	return outFactory
 }
 
-func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kube.CLIClient, error) {
-	outFactory := func(_, _ string) (kube.CLIClient, error) {
-		return MockClient{
+func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) error {
+	outFactory := func(_, _ string) error {
+		kubeClient = MockClient{
 			CLIClient: kube.NewFakeClient(),
 			Results:   testResults,
-		}, nil
+		}
+		return nil
 	}
 
 	return outFactory

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -67,7 +67,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}
@@ -137,7 +137,7 @@ func readConfigFile(filename string) ([]byte, error) {
 	return data, nil
 }
 
-func newKubeClientWithRevision(kubeconfig, configContext string, revision string) (kube.CLIClient, error) {
+func newKubeClientWithRevision(revision string) (kube.CLIClient, error) {
 	rc, err := kube.DefaultRestConfig(kubeconfig, configContext, func(config *rest.Config) {
 		// We are running a one-off command locally, so we don't need to worry too much about rate limiting
 		// Bumping this up greatly decreases install time
@@ -150,10 +150,10 @@ func newKubeClientWithRevision(kubeconfig, configContext string, revision string
 	return kube.NewCLIClient(kube.NewClientConfigForRestConfig(rc), revision)
 }
 
-func newKubeClient(kubeconfig, configContext string) error {
+func initKubeClient() error {
 	var err error
 	once.Do(func() {
-		kubeClient, err = newKubeClientWithRevision(kubeconfig, configContext, "")
+		kubeClient, err = newKubeClientWithRevision("")
 	})
 	return err
 }
@@ -195,7 +195,7 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 `,
 		Aliases: []string{"ps"},
 		RunE: func(c *cobra.Command, args []string) error {
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -150,8 +150,12 @@ func newKubeClientWithRevision(kubeconfig, configContext string, revision string
 	return kube.NewCLIClient(kube.NewClientConfigForRestConfig(rc), revision)
 }
 
-func newKubeClient(kubeconfig, configContext string) (kube.CLIClient, error) {
-	return newKubeClientWithRevision(kubeconfig, configContext, "")
+func newKubeClient(kubeconfig, configContext string) error {
+	var err error
+	once.Do(func() {
+		kubeClient, err = newKubeClientWithRevision(kubeconfig, configContext, "")
+	})
+	return err
 }
 
 func xdsStatusCommand() *cobra.Command {

--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -183,20 +183,20 @@ func revisionListCommand() *cobra.Command {
 }
 
 func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) error {
-	client, err := newKubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v",
 			kubeconfig, configContext, err)
 	}
 
-	revisions, err := tag.ListRevisionDescriptions(client)
+	revisions, err := tag.ListRevisionDescriptions(kubeClient)
 	if err != nil {
 		return fmt.Errorf("cannot list revisions for kubeconfig=%s, context=%s: %v",
 			kubeconfig, configContext, err)
 	}
 
 	// Get a list of all CRs which are installed in this cluster
-	iopcrs, err := getAllMergedIstioOperatorCRs(client, logger)
+	iopcrs, err := getAllMergedIstioOperatorCRs(kubeClient, logger)
 	if err != nil {
 		return fmt.Errorf("error while listing IstioOperator CRs: %v", err)
 	}
@@ -557,13 +557,13 @@ func revisionExists(revDescription *tag.RevisionDescription) bool {
 }
 
 func annotateWithNamespaceAndPodInfo(revDescription *tag.RevisionDescription, revisionAliases []string) error {
-	client, err := newKubeClient(kubeconfig, configContext)
+	err := initKubeClient(kubeconfig, configContext)
 	if err != nil {
 		return fmt.Errorf("failed to create kubeclient: %v", err)
 	}
 	nsMap := make(map[string]*tag.NsInfo)
 	for _, ra := range revisionAliases {
-		pods, err := getPodsWithSelector(client, "", &metav1.LabelSelector{
+		pods, err := getPodsWithSelector(kubeClient, "", &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				label.IoIstioRev.Name: ra,
 			},

--- a/istioctl/cmd/revision.go
+++ b/istioctl/cmd/revision.go
@@ -183,16 +183,14 @@ func revisionListCommand() *cobra.Command {
 }
 
 func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) error {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
-		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v",
-			kubeconfig, configContext, err)
+		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v", kubeconfig, configContext, err)
 	}
 
 	revisions, err := tag.ListRevisionDescriptions(kubeClient)
 	if err != nil {
-		return fmt.Errorf("cannot list revisions for kubeconfig=%s, context=%s: %v",
-			kubeconfig, configContext, err)
+		return fmt.Errorf("cannot list revisions for kubeconfig=%s, context=%s: %v", kubeconfig, configContext, err)
 	}
 
 	// Get a list of all CRs which are installed in this cluster
@@ -229,7 +227,7 @@ func revisionList(writer io.Writer, args *revisionArgs, logger clog.Logger) erro
 
 	if args.verbose {
 		for rev, desc := range revisions {
-			revClient, err := newKubeClientWithRevision(kubeconfig, configContext, rev)
+			revClient, err := newKubeClientWithRevision(rev)
 			if err != nil {
 				return fmt.Errorf("failed to get revision based kubeclient for revision: %s", rev)
 			}
@@ -497,10 +495,9 @@ func getAllMergedIstioOperatorCRs(client kube.CLIClient, logger clog.Logger) ([]
 
 func printRevisionDescription(w io.Writer, args *revisionArgs, logger clog.Logger) error {
 	revision := args.name
-	client, err := newKubeClientWithRevision(kubeconfig, configContext, revision)
+	client, err := newKubeClientWithRevision(revision)
 	if err != nil {
-		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v",
-			kubeconfig, configContext, err)
+		return fmt.Errorf("cannot create kubeclient for kubeconfig=%s, context=%s: %v", kubeconfig, configContext, err)
 	}
 	allIops, err := getAllMergedIstioOperatorCRs(client, logger)
 	if err != nil {
@@ -557,7 +554,7 @@ func revisionExists(revDescription *tag.RevisionDescription) bool {
 }
 
 func annotateWithNamespaceAndPodInfo(revDescription *tag.RevisionDescription, revisionAliases []string) error {
-	err := initKubeClient(kubeconfig, configContext)
+	err := getKubeClient()
 	if err != nil {
 		return fmt.Errorf("failed to create kubeclient: %v", err)
 	}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/bug-report/pkg/bugreport"
 )
@@ -75,8 +76,12 @@ var (
 	// Create a kubernetes client (or mockClient) for talking to control plane components
 	kubeClientWithRevision = newKubeClientWithRevision
 
+	// The kubeClient used throughout the cmd package. After kubeClient is initialized for the first
+	// time the client is not initialized again and is shared between callers.
+	kubeClient kube.CLIClient
+
 	// Create a kubernetes.ExecClient (or mock) for talking to data plane components
-	kubeClient = newKubeClient
+	initKubeClient = newKubeClient
 
 	loggingOptions = defaultLogOptions()
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -81,7 +81,7 @@ var (
 	kubeClient kube.CLIClient
 
 	// Create a kubernetes.ExecClient (or mock) for talking to data plane components
-	initKubeClient = newKubeClient
+	getKubeClient = initKubeClient
 
 	loggingOptions = defaultLogOptions()
 

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -136,7 +136,7 @@ injection labels.`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKubeClient(kubeconfig, configContext)
+			err := initKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -184,7 +184,7 @@ injection labels.`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKubeClient(kubeconfig, configContext)
+			err := initKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -217,7 +217,7 @@ func tagListCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKubeClient(kubeconfig, configContext)
+			err := initKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -252,7 +252,7 @@ revision tag before removing using the "istioctl tag list" command.
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKubeClient(kubeconfig, configContext)
+			err := initKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}

--- a/istioctl/cmd/tag.go
+++ b/istioctl/cmd/tag.go
@@ -136,12 +136,12 @@ injection labels.`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
 
-			return setTag(context.Background(), client, args[0], revision, istioNamespace, false, cmd.OutOrStdout(), cmd.OutOrStderr())
+			return setTag(context.Background(), kubeClient, args[0], revision, istioNamespace, false, cmd.OutOrStdout(), cmd.OutOrStderr())
 		},
 	}
 
@@ -184,12 +184,12 @@ injection labels.`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
 
-			return setTag(context.Background(), client, args[0], revision, istioNamespace, true, cmd.OutOrStdout(), cmd.OutOrStderr())
+			return setTag(context.Background(), kubeClient, args[0], revision, istioNamespace, true, cmd.OutOrStdout(), cmd.OutOrStderr())
 		},
 	}
 
@@ -217,11 +217,11 @@ func tagListCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
-			return listTags(context.Background(), client.Kube(), cmd.OutOrStdout())
+			return listTags(context.Background(), kubeClient.Kube(), cmd.OutOrStdout())
 		},
 	}
 
@@ -252,12 +252,12 @@ revision tag before removing using the "istioctl tag list" command.
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
 
-			return removeTag(context.Background(), client.Kube(), args[0], skipConfirmation, cmd.OutOrStdout())
+			return removeTag(context.Background(), kubeClient.Kube(), args[0], skipConfirmation, cmd.OutOrStdout())
 		},
 	}
 

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -63,7 +63,7 @@ func newVersionCommand() *cobra.Command {
 }
 
 func getRemoteInfo(opts clioptions.ControlPlaneOptions) (*istioVersion.MeshInfo, error) {
-	kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+	kubeClient, err := kubeClientWithRevision(opts.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func xdsRemoteVersionWrapper(opts *clioptions.ControlPlaneOptions, centralOpts *
 		xdsRequest := discovery.DiscoveryRequest{
 			TypeUrl: "istio.io/connections",
 		}
-		kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+		kubeClient, err := kubeClientWithRevision(opts.Revision)
 		if err != nil {
 			return nil, err
 		}

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -184,7 +184,7 @@ func poll(cmd *cobra.Command,
 	targetResource string,
 	opts clioptions.ControlPlaneOptions,
 ) (present, notpresent, sdcnum int, err error) {
-	kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+	kubeClient, err := kubeClientWithRevision(opts.Revision)
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/istioctl/cmd/waypoint.go
+++ b/istioctl/cmd/waypoint.go
@@ -110,7 +110,7 @@ func waypointCmd() *cobra.Command {
   istioctl x waypoint apply --service-account something --namespace default`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gw := makeGateway(true)
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -149,7 +149,7 @@ func waypointCmd() *cobra.Command {
 			if len(args) > 1 {
 				return fmt.Errorf("too many arguments, expected 0 or 1")
 			}
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -191,7 +191,7 @@ func waypointCmd() *cobra.Command {
   istioctl x waypoint list -A`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := cmd.OutOrStdout()
-			err := initKubeClient(kubeconfig, configContext)
+			err := getKubeClient()
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}

--- a/istioctl/cmd/waypoint.go
+++ b/istioctl/cmd/waypoint.go
@@ -110,11 +110,11 @@ func waypointCmd() *cobra.Command {
   istioctl x waypoint apply --service-account something --namespace default`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gw := makeGateway(true)
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
-			gwc := client.GatewayAPI().GatewayV1beta1().Gateways(handlers.HandleNamespace(namespace, defaultNamespace))
+			gwc := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(handlers.HandleNamespace(namespace, defaultNamespace))
 			b, err := yaml.Marshal(gw)
 			if err != nil {
 				return err
@@ -149,14 +149,14 @@ func waypointCmd() *cobra.Command {
 			if len(args) > 1 {
 				return fmt.Errorf("too many arguments, expected 0 or 1")
 			}
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
 			if len(args) == 1 {
 				name := args[0]
 				ns := handlers.HandleNamespace(namespace, defaultNamespace)
-				gw, err := client.GatewayAPI().GatewayV1beta1().Gateways(ns).Get(context.Background(), name, metav1.GetOptions{})
+				gw, err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(ns).Get(context.Background(), name, metav1.GetOptions{})
 				if err != nil {
 					if errors.IsNotFound(err) {
 						fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v not found\n", ns, name)
@@ -164,7 +164,7 @@ func waypointCmd() *cobra.Command {
 					}
 					return err
 				}
-				if err := client.GatewayAPI().GatewayV1beta1().Gateways(ns).
+				if err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(ns).
 					Delete(context.Background(), gw.Name, metav1.DeleteOptions{}); err != nil {
 					return err
 				}
@@ -172,7 +172,7 @@ func waypointCmd() *cobra.Command {
 				return nil
 			}
 			gw := makeGateway(true)
-			if err = client.GatewayAPI().GatewayV1beta1().Gateways(gw.Namespace).
+			if err = kubeClient.GatewayAPI().GatewayV1beta1().Gateways(gw.Namespace).
 				Delete(context.Background(), gw.Name, metav1.DeleteOptions{}); err != nil {
 				return err
 			}
@@ -191,7 +191,7 @@ func waypointCmd() *cobra.Command {
   istioctl x waypoint list -A`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := cmd.OutOrStdout()
-			client, err := kubeClient(kubeconfig, configContext)
+			err := initKubeClient(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
@@ -201,7 +201,7 @@ func waypointCmd() *cobra.Command {
 			} else if namespace != "" {
 				ns = namespace
 			}
-			gws, err := client.GatewayAPI().GatewayV1beta1().Gateways(ns).
+			gws, err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(ns).
 				List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return err

--- a/istioctl/cmd/waypoint_test.go
+++ b/istioctl/cmd/waypoint_test.go
@@ -79,7 +79,7 @@ func TestWaypointList(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeClient = kube.NewFakeClient()
-			initKubeClient = func(kubeconfig, configContext string) error {
+			getKubeClient = func() error {
 				return nil
 			}
 			for _, gw := range tt.gateways {

--- a/istioctl/cmd/waypoint_test.go
+++ b/istioctl/cmd/waypoint_test.go
@@ -78,12 +78,12 @@ func TestWaypointList(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			client := kube.NewFakeClient()
-			kubeClient = func(kubeconfig, configContext string) (kube.CLIClient, error) {
-				return client, nil
+			kubeClient = kube.NewFakeClient()
+			initKubeClient = func(kubeconfig, configContext string) error {
+				return nil
 			}
 			for _, gw := range tt.gateways {
-				_, _ = client.GatewayAPI().GatewayV1beta1().Gateways(gw.Namespace).Create(context.Background(), gw, metav1.CreateOptions{})
+				_, _ = kubeClient.GatewayAPI().GatewayV1beta1().Gateways(gw.Namespace).Create(context.Background(), gw, metav1.CreateOptions{})
 			}
 			defaultFile, err := os.ReadFile(fmt.Sprintf("testdata/waypoint/%s", tt.expectedOutFile))
 			if err != nil {

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -205,7 +205,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			kubeClient, err := kubeClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/workload_test.go
+++ b/istioctl/cmd/workload_test.go
@@ -208,7 +208,7 @@ func TestWorkloadEntryConfigure(t *testing.T) {
 		}
 		t.Run(dir.Name(), func(t *testing.T) {
 			testdir := path.Join("testdata/vmconfig", dir.Name())
-			kubeClientWithRevision = func(_, _, _ string) (kube.CLIClient, error) {
+			kubeClientWithRevision = func(_ string) (kube.CLIClient, error) {
 				return kube.SetRevisionForTest(kube.NewFakeClient(
 					&v1.ServiceAccount{
 						ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "vm-serviceaccount"},
@@ -299,7 +299,7 @@ func TestWorkloadEntryConfigureNilProxyMetadata(t *testing.T) {
 	testdir := "testdata/vmconfig-nil-proxy-metadata"
 	noClusterID := "failed to automatically determine the --clusterID"
 
-	kubeClientWithRevision = func(_, _, _ string) (kube.CLIClient, error) {
+	kubeClientWithRevision = func(_ string) (kube.CLIClient, error) {
 		return kube.NewFakeClient(
 			&v1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "vm-serviceaccount"},


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR is a follow up to a comment thread from another PR: https://github.com/istio/istio/pull/45022#discussion_r1204898447

The goal of this PR is to remove the re-initialization of the kubeclient if it's already been initialized using the root command [defined values for `kubeconfig` and `configContext`](https://github.com/istio/istio/blob/e4afd9a7b1c642930e1460e3a1d388768824339a/istioctl/cmd/root.go#L152-L156) . It's relied upon so often and since these values are the only ones being used (there are a few exceptions where kubeClient is made by passing in revisions, so those aren't in scope for this PR) it makes sense to only initialize kubeclient the first time it's called and share that initialized client across the package.