### PR TITLE
Optimize labels.String()

### DIFF
--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -144,8 +144,8 @@ func (i Instance) String() string {
 	keys := slices.Sort(maps.Keys(i))
 
 	var buffer strings.Builder
-	// Assume each kv pair is roughly 10 characters. We could be under or over, this is just a guess to optimize
-	buffer.Grow(len(keys) * 10)
+	// Assume each kv pair is roughly 25 characters. We could be under or over, this is just a guess to optimize
+	buffer.Grow(len(keys) * 25)
 	first := true
 	for _, k := range keys {
 		v := i[k]

--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -15,14 +15,14 @@
 package labels
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
-	"sort"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
 )
 
 const (
@@ -140,25 +140,25 @@ func validateTagKey(k string) error {
 }
 
 func (i Instance) String() string {
-	labels := make([]string, 0, len(i))
-	for k, v := range i {
-		if len(v) > 0 {
-			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
-		} else {
-			labels = append(labels, k)
-		}
-	}
-	sort.Strings(labels)
+	// Ensure stable ordering
+	keys := slices.Sort(maps.Keys(i))
 
-	var buffer bytes.Buffer
+	var buffer strings.Builder
+	// Assume each kv pair is roughly 10 characters. We could be under or over, this is just a guess to optimize
+	buffer.Grow(len(keys) * 10)
 	first := true
-	for _, label := range labels {
+	for _, k := range keys {
+		v := i[k]
 		if !first {
 			buffer.WriteString(",")
 		} else {
 			first = false
 		}
-		buffer.WriteString(label)
+		if len(v) > 0 {
+			buffer.WriteString(k + "=" + v)
+		} else {
+			buffer.WriteString(k)
+		}
 	}
 	return buffer.String()
 }

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -15,7 +15,6 @@
 package labels_test
 
 import (
-	"fmt"
 	"testing"
 
 	"istio.io/istio/pkg/config/labels"
@@ -203,7 +202,7 @@ func TestInstanceValidate(t *testing.T) {
 func BenchmarkLabelString(b *testing.B) {
 	big := labels.Instance{}
 	for i := 0; i < 50; i++ {
-		big[fmt.Sprint(i)] = "some value"
+		big["topology.kubernetes.io/region"] = "some value"
 	}
 	small := labels.Instance{
 		"app": "foo",

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -15,9 +15,11 @@
 package labels_test
 
 import (
+	"fmt"
 	"testing"
 
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestInstance(t *testing.T) {
@@ -84,6 +86,43 @@ func TestInstance(t *testing.T) {
 		if got != c.expected {
 			t.Errorf("%v.SubsetOf(%v) got %v, expected %v", c.left, c.right, got, c.expected)
 		}
+	}
+}
+
+func TestString(t *testing.T) {
+	cases := []struct {
+		input    labels.Instance
+		expected string
+	}{
+		{
+			input:    nil,
+			expected: "",
+		},
+		{
+			input:    labels.Instance{},
+			expected: "",
+		},
+		{
+			input:    labels.Instance{"app": "a"},
+			expected: "app=a",
+		},
+		{
+			input:    labels.Instance{"app": "a", "prod": "env"},
+			expected: "app=a,prod=env",
+		},
+		{
+			input:    labels.Instance{"foo": ""},
+			expected: "foo",
+		},
+		{
+			input:    labels.Instance{"app": "a", "foo": ""},
+			expected: "app=a,foo",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.input.String(), tt.expected)
+		})
 	}
 }
 
@@ -158,5 +197,30 @@ func TestInstanceValidate(t *testing.T) {
 		if got := c.tags.Validate(); (got == nil) != c.valid {
 			t.Errorf("%s failed: got valid=%v but wanted valid=%v: %v", c.name, got == nil, c.valid, got)
 		}
+	}
+}
+
+func BenchmarkLabelString(b *testing.B) {
+	big := labels.Instance{}
+	for i := 0; i < 50; i++ {
+		big[fmt.Sprint(i)] = "some value"
+	}
+	small := labels.Instance{
+		"app": "foo",
+		"baz": "bar",
+	}
+	cases := []struct {
+		name  string
+		label labels.Instance
+	}{
+		{"small", small},
+		{"big", big},
+	}
+	for _, tt := range cases {
+		b.Run(tt.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_ = tt.label.String()
+			}
+		})
 	}
 }


### PR DESCRIPTION
```
name                 old time/op    new time/op    delta
LabelString/small-8     481ns ± 4%     169ns ± 1%  -64.96%  (p=0.008 n=5+5)
LabelString/big-8      12.2µs ± 3%     4.9µs ± 3%  -59.29%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
LabelString/small-8      216B ± 0%       56B ± 0%  -74.07%  (p=0.008 n=5+5)
LabelString/big-8      6.01kB ± 0%    2.30kB ± 0%  -61.67%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
LabelString/small-8      10.0 ± 0%       2.0 ± 0%  -80.00%  (p=0.008 n=5+5)
LabelString/big-8         158 ± 0%         3 ± 0%  -98.10%  (p=0.008 n=5+5)
```

This is shown to be a hot path in some scenarios (https://github.com/istio/istio/issues/44985)