### PR TITLE
Reduce istiod dns cert usages: remove client certificate

### DIFF
--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -64,7 +64,6 @@ func GenKeyCertK8sCA(client clientset.Interface, dnsName,
 		cert.UsageDigitalSignature,
 		cert.UsageKeyEncipherment,
 		cert.UsageServerAuth,
-		cert.UsageClientAuth,
 	}
 	if signerName == "" {
 		signerName = "kubernetes.io/legacy-unknown"


### PR DESCRIPTION
Istiod DNS certificate doesn't need Client Auth Permissions