### PR TITLE
skip empty ocsp staple configuration

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -407,26 +407,29 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 			},
 		})
 	default:
+		tlsCertificate := &envoytls.TlsCertificate{
+			CertificateChain: &core.DataSource{
+				Specifier: &core.DataSource_InlineBytes{
+					InlineBytes: certInfo.Cert,
+				},
+			},
+			PrivateKey: &core.DataSource{
+				Specifier: &core.DataSource_InlineBytes{
+					InlineBytes: certInfo.Key,
+				},
+			},
+		}
+		if certInfo.Staple != nil {
+			tlsCertificate.OcspStaple = &core.DataSource{
+				Specifier: &core.DataSource_InlineBytes{
+					InlineBytes: certInfo.Staple,
+				},
+			}
+		}
 		res = protoconv.MessageToAny(&envoytls.Secret{
 			Name: name,
 			Type: &envoytls.Secret_TlsCertificate{
-				TlsCertificate: &envoytls.TlsCertificate{
-					CertificateChain: &core.DataSource{
-						Specifier: &core.DataSource_InlineBytes{
-							InlineBytes: certInfo.Cert,
-						},
-					},
-					PrivateKey: &core.DataSource{
-						Specifier: &core.DataSource_InlineBytes{
-							InlineBytes: certInfo.Key,
-						},
-					},
-					OcspStaple: &core.DataSource{
-						Specifier: &core.DataSource_InlineBytes{
-							InlineBytes: certInfo.Staple,
-						},
-					},
-				},
+				TlsCertificate: tlsCertificate,
 			},
 		})
 	}


### PR DESCRIPTION
I think this was introduced due to https://github.com/istio/istio/pull/45104/files#diff-304c91dfb9b2487f0bb78e849baf67e7255bcea0bbd0e1b632a17b74b85bf9eaL237 