### PR TITLE
Make isZtunnelPod's kubeclient error a global variable to further simplify isZtunnelPod

### DIFF
--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -42,8 +42,8 @@ func TestProxyConfig(t *testing.T) {
 		"httpbin-794b576b6c-qx6pf":    []byte("{}"),
 		"ztunnel-9v7nw":               []byte("current log level is debug"),
 	}
-	isZtunnelPod = func(podName, _ string) (bool, error) {
-		return strings.HasPrefix(podName, "ztunnel"), nil
+	isZtunnelPod = func(podName, _ string) bool {
+		return strings.HasPrefix(podName, "ztunnel")
 	}
 	cases := []execTestCase{
 		{


### PR DESCRIPTION
**Please provide a description of this PR:**
A follow-up PR to address @wulianglongrd's comment [here ](https://github.com/istio/istio/pull/45022#discussion_r1206214682) around how we store the error for a failed kube client initialization when calling `isZtunnelPod`. Making the error from a failed kube client initialization global instead of local within the `isZtunnelPod` func simplifies it a bit, bringing `isZtunnelPod` back to returning just one value as opposed to the two return values I just added in that recent PR to improve logging.

P.S. This pattern of memoizing the error is similar to what we're currently doing with `isZtunnelPodKubeClient`.