### PR TITLE
Fix status writer potential nil panic

### DIFF
--- a/pilot/pkg/status/resource.go
+++ b/pilot/pkg/status/resource.go
@@ -103,7 +103,7 @@ func GetTypedStatus(in any) (out *v1alpha1.IstioStatus, err error) {
 }
 
 func GetOGProvider(in any) (out GenerationProvider, err error) {
-	if ret, ok := in.(*v1alpha1.IstioStatus); ok {
+	if ret, ok := in.(*v1alpha1.IstioStatus); ok && ret != nil {
 		return &IstioGenerationProvider{ret}, nil
 	}
 	return nil, fmt.Errorf("cannot cast %T: %v to GenerationProvider", in, in)


### PR DESCRIPTION
**Please provide a description of this PR:**
Found this when somehow in the test, a struct with a nil value was inputted, and the type assertion passed. However, later on, its self function `SetObservedGeneration` panicked because of this passed nil value.