### PR TITLE
Add resource settings to gateway-api deployment templates

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -55,6 +55,27 @@ spec:
       - name: istio-proxy
         image: "{{ .ProxyImage }}"
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+        resources:
+          {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+          requests:
+            {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+            cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+            {{ end }}
+            {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+            memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+            {{ end }}
+          {{ end }}
+          {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+          limits:
+            {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+            cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+            {{ end }}
+            {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+            memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
         securityContext:
         {{- if .KubeVersion122 }}
           # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -54,28 +54,11 @@ spec:
       containers:
       - name: istio-proxy
         image: "{{ .ProxyImage }}"
-        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-        {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+        {{- if .Values.global.proxy.resources }}
         resources:
-          {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-          requests:
-            {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-            cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-            {{ end }}
-            {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-            memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-            {{ end }}
-          {{ end }}
-          {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-          limits:
-            {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-            cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-            {{ end }}
-            {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-            memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
+          {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+        {{- end }}
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         securityContext:
         {{- if .KubeVersion122 }}
           # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.33.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.36.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1440,28 +1440,11 @@ templates:
           containers:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
-            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            {{- if .Values.global.proxy.resources }}
             resources:
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
-              requests:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
-                {{ end }}
-              {{ end }}
-              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
-              limits:
-                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
-                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
-                {{ end }}
-                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
-                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
+              {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+            {{- end }}
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1441,6 +1441,27 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit")  }}
+            resources:
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPU") (isset .Annotations "sidecar.istio.io/proxyMemory") }}
+              requests:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPU") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPU" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemory") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemory" | quote }}
+                {{ end }}
+              {{ end }}
+              {{ if or (isset .Annotations "sidecar.istio.io/proxyCPULimit") (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") }}
+              limits:
+                {{ if (isset .Annotations "sidecar.istio.io/proxyCPULimit") -}}
+                cpu: {{ index .Annotations "sidecar.istio.io/proxyCPULimit" | quote }}
+                {{ end }}
+                {{ if (isset .Annotations "sidecar.istio.io/proxyMemoryLimit") -}}
+                memory: {{ index .Annotations "sidecar.istio.io/proxyMemoryLimit" | quote }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
             securityContext:
             {{- if .KubeVersion122 }}
               # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326


### PR DESCRIPTION
This PR extends the gateway-api deployment template with cpu and memory resource settings. The approach used is very similar to the one used in `manifests/charts/istio-control/istio-discovery/files/injection-template.yaml`, i.e. annotations like `sidecar.istio.io/proxyCPU` are used to specify resource requests and limits. The annotation names are already in use (https://istio.io/latest/docs/reference/config/annotations), however, one could consider if the `sidecar.istio.io` name is appropriate for gateway-api deployment resources where its really not a sidecar a such.

Setting cpu requests are important for HPA scaling, e.g. the procedure described here: https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#resource-attachment-and-scaling




This adds another annotation that gateway-api resources respond to, i.e. the documentation here should be updated if this PR is considered "the preferred approach to solve the problem" : https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment