### PR TITLE
force-disconnect proxies on WorkloadGroup deletion

### DIFF
--- a/pilot/pkg/autoregistration/connections.go
+++ b/pilot/pkg/autoregistration/connections.go
@@ -1,0 +1,141 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoregistration
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// Connection from a proxy to a control plane.
+// This interface exists to avoid circular reference to xds.Connection as well
+// as keeps the API surface scoped to what we need for auto-registration logic.
+type Connection interface {
+	ID() string
+	Proxy() *model.Proxy
+	ConnectedAt() time.Time
+	Stop()
+}
+
+// a single proxy may have multiple connections, so we track them here
+// when a WorkloadGroup is deleted, we can force disconnects
+// when OnDisconnect occurs, we only trigger cleanup when there are no more connections for that proxy
+type adsConnections struct {
+	sync.Mutex
+	byProxy map[proxyKey]connectionSet
+}
+
+func newAdsConnections() *adsConnections {
+	return &adsConnections{byProxy: map[proxyKey]connectionSet{}}
+}
+
+func (m *adsConnections) ForceDisconnectGroup(wg types.NamespacedName) {
+	// collect the proxies that should be disconnected (don't remove them, OnDisconnect will)
+	proxies := 0
+	m.Lock()
+	var conns []Connection
+	for key, connections := range m.byProxy {
+		if key.GroupName == wg.Name && key.Namespace == wg.Namespace {
+			proxies++
+			conns = append(conns, connections.Items()...)
+		}
+	}
+	m.Unlock()
+
+	for _, connection := range conns {
+		// should never happen..
+		if !connection.Proxy().WorkloadEntryAutoCreated {
+			log.Errorf("auto-registration controller incorrectly tracking connection for %s", connection.Proxy().ID)
+		}
+		connection.Stop()
+	}
+	log.Infof("WorkloadGroup deletion for %s/%s: force closed %d connections for %d proxies",
+		wg.Namespace, wg.Name, len(conns), proxies)
+}
+
+func (m *adsConnections) Connect(conn Connection) {
+	m.Lock()
+	defer m.Unlock()
+	k := makeProxyKey(conn.Proxy())
+
+	connections := m.byProxy[k]
+	if connections == nil {
+		connections = make(connectionSet)
+		m.byProxy[k] = connections
+	}
+	connections[conn.ID()] = conn
+}
+
+// Disconnect tracks disconnect events of ads clients.
+// Returns false once there are no more connections for the given proxy.
+func (m *adsConnections) Disconnect(conn Connection) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	k := makeProxyKey(conn.Proxy())
+	connections := m.byProxy[k]
+	if connections == nil {
+		return false
+	}
+
+	id := conn.ID()
+	delete(connections, id)
+	if len(connections) == 0 {
+		delete(m.byProxy, k)
+		return false
+	}
+
+	return true
+}
+
+// keys required to uniquely ID a single proxy
+type proxyKey struct {
+	Network   string
+	IP        string
+	GroupName string
+	Namespace string
+}
+
+// a single proxy may have multiple connections
+type connectionSet map[string]Connection
+
+func (cs connectionSet) Add(connection Connection) {
+	cs[connection.ID()] = connection
+}
+
+func (cs connectionSet) Remove(connection Connection) {
+	delete(cs, connection.ID())
+}
+
+func (cs connectionSet) Items() []Connection {
+	var out []Connection
+	for _, connection := range cs {
+		out = append(out, connection)
+	}
+	return out
+}
+
+func makeProxyKey(proxy *model.Proxy) proxyKey {
+	return proxyKey{
+		Network:   string(proxy.Metadata.Network),
+		IP:        proxy.IPAddresses[0],
+		GroupName: proxy.Metadata.AutoRegisterGroup,
+		Namespace: proxy.Metadata.Namespace,
+	}
+}

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -188,7 +188,7 @@ type workItem struct {
 // setupEjectOnDelete adds a handler to force disconnect proxies that use
 // auto-registration when their associated WorkloadGroup is deleted
 func (c *Controller) setupEjectOnDelete() {
-	c.disconnectQueue = controllers.NewQueue("eject_auto_registered_connections",
+	c.disconnectQueue = controllers.NewQueue("eject auto registered connections",
 		controllers.WithReconciler(func(key kubetypes.NamespacedName) error {
 			if c.store.Get(gvk.WorkloadGroup, key.Name, key.Namespace) != nil {
 				// this shouldn't happen in practice, but it could if the queue is draining really slow
@@ -423,6 +423,7 @@ func (c *Controller) OnDisconnect(conn Connection) {
 		return
 	}
 
+	// if there is still an ads connection, do not unregister.
 	if remainingConnections := c.adsConnections.Disconnect(conn); remainingConnections {
 		return
 	}

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -120,11 +119,8 @@ type Controller struct {
 	// cleanupQueue delays the cleanup of auto registered WorkloadEntries to allow for grace period
 	cleanupQueue queue.Delayed
 
-	mutex sync.Mutex
-	// record the current adsConnections number
-	// note: this is to handle reconnect to the same istiod, but in rare case the disconnect event is later than the connect event
-	// keyed by proxy network+ip
-	adsConnections map[string]uint8
+	adsConnections  *adsConnections
+	disconnectQueue controllers.Queue
 
 	// maxConnectionAge is a duration that workload entry should be cleaned up if it does not reconnects.
 	maxConnectionAge time.Duration
@@ -137,30 +133,32 @@ type HealthEvent = health.HealthEvent
 
 // NewController create a controller which manages workload lifecycle and health status.
 func NewController(store model.ConfigStoreController, instanceID string, maxConnAge time.Duration) *Controller {
-	if features.WorkloadEntryAutoRegistration || features.WorkloadEntryHealthChecks {
-		if maxConnAge != math.MaxInt64 {
-			maxConnAge += maxConnAge / 2
-			// if overflow, set it to max int64
-			if maxConnAge < 0 {
-				maxConnAge = time.Duration(math.MaxInt64)
-			}
-		}
-		c := &Controller{
-			instanceID:       instanceID,
-			store:            store,
-			cleanupLimit:     rate.NewLimiter(rate.Limit(20), 1),
-			cleanupQueue:     queue.NewDelayed(),
-			adsConnections:   map[string]uint8{},
-			maxConnectionAge: maxConnAge,
-		}
-		c.queue = controllers.NewQueue("unregister_workloadentry",
-			controllers.WithMaxAttempts(maxRetries),
-			controllers.WithGenericReconciler(c.unregisterWorkload))
-		c.stateStore = state.NewStore(store, c)
-		c.healthController = health.NewController(c.stateStore, maxRetries)
-		return c
+	if !features.WorkloadEntryAutoRegistration && !features.WorkloadEntryHealthChecks {
+		return nil
 	}
-	return nil
+
+	if maxConnAge != math.MaxInt64 {
+		maxConnAge += maxConnAge / 2
+		// if overflow, set it to max int64
+		if maxConnAge < 0 {
+			maxConnAge = time.Duration(math.MaxInt64)
+		}
+	}
+	c := &Controller{
+		instanceID:       instanceID,
+		store:            store,
+		cleanupLimit:     rate.NewLimiter(rate.Limit(20), 1),
+		cleanupQueue:     queue.NewDelayed(),
+		adsConnections:   newAdsConnections(),
+		maxConnectionAge: maxConnAge,
+	}
+	c.queue = controllers.NewQueue("unregister_workloadentry",
+		controllers.WithMaxAttempts(maxRetries),
+		controllers.WithGenericReconciler(c.unregisterWorkload))
+	c.stateStore = state.NewStore(store, c)
+	c.healthController = health.NewController(c.stateStore, maxRetries)
+	c.setupEjectOnDelete()
+	return c
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {
@@ -170,6 +168,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.store != nil && c.cleanupQueue != nil {
 		go c.periodicWorkloadEntryCleanup(stop)
 		go c.cleanupQueue.Run(stop)
+		go c.disconnectQueue.Run(stop)
 	}
 
 	go c.queue.Run(stop)
@@ -186,6 +185,28 @@ type workItem struct {
 	origConTime time.Time
 }
 
+// setupEjectOnDelete adds a handler to force disconnect proxies that use
+// auto-registration when their associated WorkloadGroup is deleted
+func (c *Controller) setupEjectOnDelete() {
+	c.disconnectQueue = controllers.NewQueue("eject_auto_registered_connections",
+		controllers.WithReconciler(func(key kubetypes.NamespacedName) error {
+			if c.store.Get(gvk.WorkloadGroup, key.Name, key.Namespace) != nil {
+				// this shouldn't happen in practice, but it could if the queue is draining really slow
+				// if we see it happens, that means the proxy will have to hit MaxConnectionAge to get
+				// the WorkloadEntry recreated (entries are cleaned up by OwnerRef)
+				log.Warnf("WorkloadGroup %s/%s still exists. NOT force disconnecting proxies", key.Name, key.Namespace)
+				return nil
+			}
+			c.adsConnections.ForceDisconnectGroup(key)
+			return nil
+		}))
+	c.store.RegisterEventHandler(gvk.WorkloadGroup, func(_ config.Config, cfg config.Config, event model.Event) {
+		if event == model.EventDelete {
+			c.disconnectQueue.Add(config.NamespacedName(cfg))
+		}
+	})
+}
+
 func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
 	if c.Annotations == nil {
 		c.Annotations = map[string]string{}
@@ -195,7 +216,7 @@ func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
 	delete(c.Annotations, DisconnectedAtAnnotation)
 }
 
-// RegisterWorkload determines whether a connecting proxy represents a non-Kubernetes
+// OnConnect determines whether a connecting proxy represents a non-Kubernetes
 // workload and, if that's the case, initiates special processing required for that type
 // of workloads, such as auto-registration, health status updates, etc.
 //
@@ -206,10 +227,11 @@ func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
 // If connecting proxy represents a workload that is not using auto-registration,
 // the WorkloadEntry resource is expected to exist beforehand. Otherwise, no special
 // processing will be initiated, e.g. health status updates will be ignored.
-func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) error {
+func (c *Controller) OnConnect(conn Connection) error {
 	if c == nil {
 		return nil
 	}
+	proxy := conn.Proxy()
 	var entryName string
 	var autoCreate bool
 	if features.WorkloadEntryAutoRegistration && proxy.Metadata.AutoRegisterGroup != "" {
@@ -233,11 +255,9 @@ func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) err
 	proxy.WorkloadEntryName = entryName
 	proxy.WorkloadEntryAutoCreated = autoCreate
 
-	c.mutex.Lock()
-	c.adsConnections[makeProxyKey(proxy)]++
-	c.mutex.Unlock()
+	c.adsConnections.Connect(conn)
 
-	err := c.onWorkloadConnect(entryName, proxy, conTime, autoCreate)
+	err := c.onWorkloadConnect(entryName, proxy, conn.ConnectedAt(), autoCreate)
 	if err != nil {
 		log.Error(err)
 	}
@@ -376,7 +396,7 @@ func (c *Controller) changeWorkloadEntryStateToDisconnected(entryName string, pr
 	return true, nil
 }
 
-// QueueUnregisterWorkload determines whether a connected proxy represents a non-Kubernetes
+// OnDisconnect determines whether a connected proxy represents a non-Kubernetes
 // workload and, if that's the case, terminates special processing required for that type
 // of workloads, such as auto-registration, health status updates, etc.
 //
@@ -389,37 +409,30 @@ func (c *Controller) changeWorkloadEntryStateToDisconnected(entryName string, pr
 //
 // If proxy represents a workload that is not using auto-registration, WorkloadEntry resource
 // will be scheduled to be marked unhealthy if the proxy does not reconnect within a grace period.
-func (c *Controller) QueueUnregisterWorkload(proxy *model.Proxy, origConnect time.Time) {
+func (c *Controller) OnDisconnect(conn Connection) {
 	if c == nil {
 		return
 	}
 	if !features.WorkloadEntryAutoRegistration && !features.WorkloadEntryHealthChecks {
 		return
 	}
+	proxy := conn.Proxy()
 	// check if the WE already exists, update the status
 	entryName := proxy.WorkloadEntryName
 	if entryName == "" {
 		return
 	}
 
-	c.mutex.Lock()
-	proxyKey := makeProxyKey(proxy)
-	num := c.adsConnections[proxyKey]
-	// if there is still ads connection, do not unregister.
-	if num > 1 {
-		c.adsConnections[proxyKey] = num - 1
-		c.mutex.Unlock()
+	if remainingConnections := c.adsConnections.Disconnect(conn); remainingConnections {
 		return
 	}
-	delete(c.adsConnections, proxyKey)
-	c.mutex.Unlock()
 
 	workload := &workItem{
 		entryName:   entryName,
-		autoCreated: proxy.WorkloadEntryAutoCreated,
-		proxy:       proxy,
+		autoCreated: conn.Proxy().WorkloadEntryAutoCreated,
+		proxy:       conn.Proxy(),
 		disConTime:  time.Now(),
-		origConTime: origConnect,
+		origConTime: conn.ConnectedAt(),
 	}
 	// queue has max retry itself
 	c.queue.Add(workload)
@@ -674,16 +687,6 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 		// TODO status fields used for garbage collection
 		Status: nil,
 	}
-}
-
-func makeProxyKey(proxy *model.Proxy) string {
-	key := strings.Join([]string{
-		string(proxy.Metadata.Network),
-		proxy.IPAddresses[0],
-		proxy.WorkloadEntryName,
-		proxy.Metadata.Namespace,
-	}, "~")
-	return key
 }
 
 func isAutoRegisteredWorkloadEntry(wle *config.Config) bool {

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,6 +47,43 @@ import (
 
 func init() {
 	features.WorkloadEntryCleanupGracePeriod = 50 * time.Millisecond
+}
+
+var _ Connection = &fakeConn{}
+
+type fakeConn struct {
+	sync.RWMutex
+	proxy    *model.Proxy
+	connTime time.Time
+	stopped  bool
+}
+
+func makeConn(proxy *model.Proxy, connTime time.Time) *fakeConn {
+	return &fakeConn{proxy: proxy, connTime: connTime}
+}
+
+func (f *fakeConn) ID() string {
+	return fmt.Sprintf("%s-%v", f.proxy.IPAddresses[0], f.connTime)
+}
+
+func (f *fakeConn) Proxy() *model.Proxy {
+	return f.proxy
+}
+
+func (f *fakeConn) ConnectedAt() time.Time {
+	return f.connTime
+}
+
+func (f *fakeConn) Stop() {
+	f.Lock()
+	defer f.Unlock()
+	f.stopped = true
+}
+
+func (f *fakeConn) Stopped() bool {
+	f.RLock()
+	defer f.RUnlock()
+	return f.stopped
 }
 
 var (
@@ -105,7 +143,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			c.RegisterWorkload(tc, time.Now())
+			c.OnConnect(makeConn(tc, time.Now()))
 			items := store.List(gvk.WorkloadEntry, model.NamespaceAll)
 			if len(items) != 0 {
 				t.Fatalf("expected 0 WorkloadEntry")
@@ -129,74 +167,79 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 	defer close(stop2)
 	go c1.Run(stop1)
 	go c2.Run(stop2)
+	go store.Run(stop2)
 
 	n := fakeNode("reg1", "zone1", "subzone1")
 
+	var p1conn1, p1conn2 *fakeConn
 	p := fakeProxy("1.2.3.4", wgA, "nw1")
 	p.XdsNode = n
 
+	var p2conn1 *fakeConn
 	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
 	p2.XdsNode = n
 
+	var p3conn1 *fakeConn
 	p3 := fakeProxy("1.2.3.5", wgA, "nw1")
 	p3.XdsNode = n
 
-	// allows associating a Register call with Unregister
-	var origConnTime time.Time
-
 	t.Run("initial registration", func(t *testing.T) {
 		// simply make sure the entry exists after connecting
-		c1.RegisterWorkload(p, time.Now())
+		p1conn1 = makeConn(p, time.Now())
+		c1.OnConnect(p1conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("multinetwork same ip", func(t *testing.T) {
 		// make sure we don't overrwrite a similar entry for a different network
-		c2.RegisterWorkload(p2, time.Now())
+		p2conn1 = makeConn(p2, time.Now())
+		c2.OnConnect(p2conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		checkEntryOrFail(t, store, wgA, p2, n, c2.instanceID)
+		c2.OnDisconnect(p2conn1) // cleanup for future tests
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
-			c1.QueueUnregisterWorkload(p, time.Now())
+			c1.OnDisconnect(p1conn1)
 			checkEntryOrFailAfter(t, store, wgA, p, n, "", features.WorkloadEntryCleanupGracePeriod/2)
 			// reconnect, ensure entry is there with the same instance id
-			origConnTime = time.Now()
-			c1.RegisterWorkload(p, origConnTime)
+			p1conn1 = makeConn(p, time.Now())
+			c1.OnConnect(p1conn1)
 			checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 		})
 		t.Run("same instance: connect before disconnect ", func(t *testing.T) {
 			// reconnect, ensure entry is there with the same instance id
-			c1.RegisterWorkload(p, origConnTime.Add(10*time.Millisecond))
+			p1conn2 = makeConn(p, p1conn1.ConnectedAt().Add(10*time.Millisecond))
+			c1.OnConnect(p1conn2)
 			// disconnect (associated with original connect, not the reconnect)
 			// make sure entry is still there with disconnect meta
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(p1conn1)
 			checkEntryOrFailAfter(t, store, wgA, p, n, c1.instanceID, features.WorkloadEntryCleanupGracePeriod/2)
 		})
 		t.Run("different instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect metadata
-			c1.QueueUnregisterWorkload(p, time.Now())
+			c1.OnDisconnect(p1conn2)
 			checkEntryOrFailAfter(t, store, wgA, p, n, "", features.WorkloadEntryCleanupGracePeriod/2)
 			// reconnect, ensure entry is there with the new instance id
-			origConnTime = time.Now()
-			c2.RegisterWorkload(p, origConnTime)
+			p1conn1 = makeConn(p, time.Now())
+			c2.OnConnect(p1conn1)
 			checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
 		})
 	})
 	t.Run("slow reconnect", func(t *testing.T) {
 		// disconnect, wait and make sure entry is gone
-		c2.QueueUnregisterWorkload(p, origConnTime)
+		c2.OnDisconnect(p1conn1)
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkNoEntry(store, wgA, p)
 		})
 		// reconnect
-		origConnTime = time.Now()
-		c1.RegisterWorkload(p, origConnTime)
+		p1conn1 = makeConn(p, time.Now())
+		c1.OnConnect(p1conn1)
 		checkEntryOrFail(t, store, wgA, p, n, c1.instanceID)
 	})
 	t.Run("garbage collected if pilot stops after disconnect", func(t *testing.T) {
 		// disconnect, kill the cleanup queue from the first controller
-		c1.QueueUnregisterWorkload(p, origConnTime)
+		c1.OnDisconnect(p1conn1)
 		// stop processing the delayed close queue in c1, forces using periodic cleanup
 		close(stop1)
 		stopped1 = true
@@ -208,14 +251,33 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 
 	t.Run("garbage collected if pilot and workload stops simultaneously before pilot can do anything", func(t *testing.T) {
 		// simulate p3 has been registered long before
-		c2.RegisterWorkload(p3, time.Now().Add(-2*maxConnAge))
+		p3conn1 = makeConn(p3, time.Now().Add(-2*maxConnAge))
+		c2.OnConnect(p3conn1)
 
-		// keep silent to simulate the scenario
+		// keep silent to simulate the scenario (don't OnDisconnect to simulate pilot being down)
 
 		// unfortunately, this retry at worst could be twice as long as the sweep interval
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkNoEntry(store, wgA, p3)
 		}, retry.Timeout(time.Until(time.Now().Add(21*features.WorkloadEntryCleanupGracePeriod))))
+
+		c2.OnDisconnect(p3conn1) // cleanup the state for future tests
+	})
+
+	t.Run("workload group removed", func(t *testing.T) {
+		p1conn1 = makeConn(p, time.Now())
+		c2.OnConnect(p1conn1)
+
+		checkEntryOrFail(t, store, wgA, p, n, c2.instanceID)
+
+		store.Delete(gvk.WorkloadGroup, wgA.Name, wgA.Namespace, nil)
+
+		retry.UntilSuccessOrFail(t, func() error {
+			if !p1conn1.Stopped() {
+				return fmt.Errorf("expected connection to be terminated")
+			}
+			return nil
+		})
 	})
 
 	// TODO test garbage collection if pilot stops before disconnect meta is set (relies on heartbeat)
@@ -228,7 +290,7 @@ func TestUpdateHealthCondition(t *testing.T) {
 	go ig2.Run(stop)
 	p := fakeProxy("1.2.3.4", wgA, "litNw")
 	p.XdsNode = fakeNode("reg1", "zone1", "subzone1")
-	ig.RegisterWorkload(p, time.Now())
+	ig.OnConnect(makeConn(p, time.Now()))
 	t.Run("auto registered healthy health", func(t *testing.T) {
 		ig.QueueWorkloadEntryHealth(p, HealthEvent{
 			Healthy: true,
@@ -326,7 +388,7 @@ func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_WorkloadEntryNotFo
 	// change proxy metadata to make it unsuitable for health checks
 	proxy.Metadata.WorkloadEntry = "non-exisiting-workload-entry"
 
-	err := c.RegisterWorkload(proxy, time.Now())
+	err := c.OnConnect(makeConn(proxy, time.Now()))
 	assert.Error(t, err)
 }
 
@@ -370,7 +432,7 @@ func TestNonAutoregisteredWorkloads_UnsuitableForHealthChecks_ShouldNotBeTreated
 
 			proxy := tc.proxy(we)
 
-			err := c.RegisterWorkload(proxy, time.Now())
+			err := c.OnConnect(makeConn(proxy, time.Now()))
 			assert.NoError(t, err)
 
 			wle := store.Get(gvk.WorkloadEntry, we.Name, we.Namespace)
@@ -403,7 +465,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldBeTreatedAsCon
 
 			now := time.Now()
 
-			err := c.RegisterWorkload(proxy, now)
+			err := c.OnConnect(makeConn(proxy, now))
 			assert.NoError(t, err)
 
 			wle := store.Get(gvk.WorkloadEntry, we.Name, we.Namespace)
@@ -437,14 +499,14 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 	t.Run("initial connect", func(t *testing.T) {
 		// connect
 		origConnTime = time.Now()
-		c1.RegisterWorkload(p, origConnTime)
+		c1.OnConnect(makeConn(p, origConnTime))
 		// ensure the entry is connected
 		checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 	})
 	t.Run("reconnect", func(t *testing.T) {
 		t.Run("same instance: disconnect then connect", func(t *testing.T) {
 			// disconnect
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// wait until WE get updated asynchronously
 			retry.UntilSuccessOrFail(t, func() error {
 				return checkEntryDisconnected(store, weB)
@@ -453,7 +515,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, "")
 			// reconnect
 			origConnTime = time.Now()
-			c1.RegisterWorkload(p, origConnTime)
+			c1.OnConnect(makeConn(p, origConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 		})
@@ -464,17 +526,17 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 				origConnTime = nextConnTime
 			}()
 			// reconnect
-			c1.RegisterWorkload(p, nextConnTime)
+			c1.OnConnect(makeConn(p, nextConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 			// disconnect (associated with original connect, not the reconnect)
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// ensure the entry is connected
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c1.instanceID)
 		})
 		t.Run("different instance: disconnect then connect", func(t *testing.T) {
 			// disconnect
-			c1.QueueUnregisterWorkload(p, origConnTime)
+			c1.OnDisconnect(makeConn(p, origConnTime))
 			// wait until WE get updated asynchronously
 			retry.UntilSuccessOrFail(t, func() error {
 				return checkEntryDisconnected(store, weB)
@@ -483,7 +545,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, "")
 			// reconnect
 			origConnTime = time.Now()
-			c2.RegisterWorkload(p, origConnTime)
+			c2.OnConnect(makeConn(p, origConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 		})
@@ -494,11 +556,11 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 				origConnTime = nextConnTime
 			}()
 			// reconnect to the new instance
-			c2.RegisterWorkload(p, nextConnTime)
+			c2.OnConnect(makeConn(p, nextConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 			// disconnect (associated with original connect, not the reconnect)
-			c2.QueueUnregisterWorkload(p, origConnTime)
+			c2.OnDisconnect(makeConn(p, origConnTime))
 			// ensure the entry is connected to the new instance
 			checkNonAutoRegisteredEntryOrFail(t, store, weB, c2.instanceID)
 		})
@@ -511,7 +573,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldSupportLifecyc
 		// ensure health condition has been updated
 		checkHealthOrFail(t, store, p, true)
 		// disconnect
-		c2.QueueUnregisterWorkload(p, origConnTime)
+		c2.OnDisconnect(makeConn(p, origConnTime))
 		// wait until WE get updated asynchronously
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkEntryDisconnected(store, weB)
@@ -536,7 +598,7 @@ func TestNonAutoregisteredWorkloads_SuitableForHealthChecks_ShouldUpdateHealthCo
 
 	p := fakeProxySuitableForHealthChecks(weB)
 
-	c1.RegisterWorkload(p, time.Now())
+	c1.OnConnect(makeConn(p, time.Now()))
 
 	t.Run("healthy", func(t *testing.T) {
 		// report workload is healthy

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -542,7 +542,7 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 	if err != nil {
 		return err
 	}
-	// Check if proxy cluster has an alias configured, if yes use that as cluster conID for this proxy.
+	// Check if proxy cluster has an alias configured, if yes use that as cluster ID for this proxy.
 	if alias, exists := s.ClusterAliases[proxy.Metadata.ClusterID]; exists {
 		proxy.Metadata.ClusterID = alias
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -108,6 +108,22 @@ type Connection struct {
 	errorChan chan error
 }
 
+func (conn *Connection) ID() string {
+	return conn.conID
+}
+
+func (conn *Connection) Proxy() *model.Proxy {
+	return conn.proxy
+}
+
+func (conn *Connection) ConnectedAt() time.Time {
+	return conn.connectedAt
+}
+
+func (conn *Connection) Stop() {
+	close(conn.stop)
+}
+
 // Event represents a config or registry event that results in a push.
 type Event struct {
 	// pushRequest PushRequest to use for the push.
@@ -526,7 +542,7 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 	if err != nil {
 		return err
 	}
-	// Check if proxy cluster has an alias configured, if yes use that as cluster ID for this proxy.
+	// Check if proxy cluster has an alias configured, if yes use that as cluster conID for this proxy.
 	if alias, exists := s.ClusterAliases[proxy.Metadata.ClusterID]; exists {
 		proxy.Metadata.ClusterID = alias
 	}
@@ -576,7 +592,7 @@ func (s *DiscoveryServer) closeConnection(con *Connection) {
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterDisconnect(con.conID, AllEventTypesList)
 	}
-	s.WorkloadEntryController.QueueUnregisterWorkload(con.proxy, con.connectedAt)
+	s.WorkloadEntryController.OnDisconnect(con)
 }
 
 func connectionID(node string) string {
@@ -639,7 +655,7 @@ func (s *DiscoveryServer) initializeProxy(con *Connection) error {
 	proxy := con.proxy
 	// this should be done before we look for service instances, but after we load metadata
 	// TODO fix check in kubecontroller treat echo VMs like there isn't a pod
-	if err := s.WorkloadEntryController.RegisterWorkload(proxy, con.connectedAt); err != nil {
+	if err := s.WorkloadEntryController.OnConnect(con); err != nil {
 		return err
 	}
 	s.computeProxyState(proxy, nil)
@@ -1006,8 +1022,4 @@ func orderWatchedResources(resources map[string]*model.WatchedResource) []*model
 		}
 	}
 	return wr
-}
-
-func (conn *Connection) Stop() {
-	close(conn.stop)
 }


### PR DESCRIPTION
https://github.com/istio/istio/pull/44709#issuecomment-1538445005

Based on this suggestion, it seems reasonable to terminate the connections of proxies that rely on a WorkloadGroup. Ideally if I delete and recreate a workload group:

1. WG deleted, proxy force disconnects
2. We handle the disconnect and trigger our own cleanup logic. The WorkloadEntry SHOULD already get cleaned up by the ownerRef to the group
3. Proxy tries to connect, gets FAILED_PRECONDITION since the group doesn't exist
4. retries until WG is created
5. Auto-registration occurs

--- 

Without this change: The user would need to manually restart their fleet's proxies or call /debug/force_disconnect for each proxy. The server's max connection age defaults to 30 minutes but can easily end up being higher.  The golang default is [infinity](https://github.com/istio/istio/blob/c65178b3e60d3540afbb4f2547b20d6755a8cbf9/pkg/keepalive/options.go#L74) for some reason. 
