### PR TITLE
Disable distribution initialization

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -314,30 +314,32 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 		UpdateInterval: features.StatusUpdateInterval,
 		PodName:        args.PodName,
 	}
-	s.addStartFunc("status reporter init", func(stop <-chan struct{}) error {
-		s.statusReporter.Init(s.environment.GetLedger(), stop)
-		return nil
-	})
-	s.addTerminatingStartFunc("status reporter", func(stop <-chan struct{}) error {
-		if writeStatus {
-			s.statusReporter.Start(s.kubeClient.Kube(), args.Namespace, args.PodName, stop)
-		}
-		return nil
-	})
-	s.XDSServer.StatusReporter = s.statusReporter
-	if writeStatus {
-		s.addTerminatingStartFunc("status distribution", func(stop <-chan struct{}) error {
-			leaderelection.
-				NewLeaderElection(args.Namespace, args.PodName, leaderelection.StatusController, args.Revision, s.kubeClient).
-				AddRunFunction(func(leaderStop <-chan struct{}) {
-					// Controller should be created for calling the run function every time, so it can
-					// avoid concurrently calling of informer Run() for controller in controller.Start
-					controller := distribution.NewController(s.kubeClient.RESTConfig(), args.Namespace, s.RWConfigStore, s.statusManager)
-					s.statusReporter.SetController(controller)
-					controller.Start(leaderStop)
-				}).Run(stop)
+	if features.EnableDistributionTracking {
+		s.addStartFunc("status reporter init", func(stop <-chan struct{}) error {
+			s.statusReporter.Init(s.environment.GetLedger(), stop)
 			return nil
 		})
+		s.addTerminatingStartFunc("status reporter", func(stop <-chan struct{}) error {
+			if writeStatus {
+				s.statusReporter.Start(s.kubeClient.Kube(), args.Namespace, args.PodName, stop)
+			}
+			return nil
+		})
+		s.XDSServer.StatusReporter = s.statusReporter
+		if writeStatus {
+			s.addTerminatingStartFunc("status distribution", func(stop <-chan struct{}) error {
+				leaderelection.
+					NewLeaderElection(args.Namespace, args.PodName, leaderelection.StatusController, args.Revision, s.kubeClient).
+					AddRunFunction(func(leaderStop <-chan struct{}) {
+						// Controller should be created for calling the run function every time, so it can
+						// avoid concurrently calling of informer Run() for controller in controller.Start
+						controller := distribution.NewController(s.kubeClient.RESTConfig(), args.Namespace, s.RWConfigStore, s.statusManager)
+						s.statusReporter.SetController(controller)
+						controller.Start(leaderStop)
+					}).Run(stop)
+				return nil
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Aside from just simplifying things a bit by disabling unused codepaths,
this also frees up about 33% of Istiod's resting heap usage dfue to
avoiding the massive channel used in the distribution queue
