### PR TITLE
pilot: reduce lock contention in EDS

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1061,6 +1061,7 @@ func TestInitPushContext(t *testing.T) {
 			ClusterLocalHosts{}),
 		// These are not feasible/worth comparing
 		cmpopts.IgnoreTypes(sync.RWMutex{}, localServiceDiscovery{}, FakeStore{}, atomic.Bool{}, sync.Mutex{}),
+		cmpopts.IgnoreUnexported(IstioEndpoint{}),
 		cmpopts.IgnoreInterfaces(struct{ mesh.Holder }{}),
 		protocmp.Transform(),
 	)

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -159,7 +159,6 @@ func TestWorkloadInstanceEqual(t *testing.T) {
 			Labels:          labels.Instance{"app": "prod-app"},
 			Address:         "an-address",
 			ServicePortName: "service-port-name",
-			EnvoyEndpoint:   nil,
 			ServiceAccount:  "service-account",
 			Network:         "Network",
 			Locality: Locality{

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -21,27 +21,22 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 )
 
-var (
-	endpoint1 = IstioEndpoint{
-		Address:      "192.168.1.1",
-		EndpointPort: 10001,
-	}
-
-	service1 = &Service{
-		Hostname:       "one.service.com",
-		DefaultAddress: "192.168.3.1", // VIP
-		Ports: PortList{
-			&Port{Name: "http", Port: 81, Protocol: protocol.HTTP},
-			&Port{Name: "http-alt", Port: 8081, Protocol: protocol.HTTP},
-		},
-	}
-)
+var service1 = &Service{
+	Hostname:       "one.service.com",
+	DefaultAddress: "192.168.3.1", // VIP
+	Ports: PortList{
+		&Port{Name: "http", Port: 81, Protocol: protocol.HTTP},
+		&Port{Name: "http-alt", Port: 8081, Protocol: protocol.HTTP},
+	},
+}
 
 func TestServiceInstanceValidate(t *testing.T) {
 	endpointWithLabels := func(lbls labels.Instance) *IstioEndpoint {
-		cpy := endpoint1
-		cpy.Labels = lbls
-		return &cpy
+		return &IstioEndpoint{
+			Address:      "192.168.1.1",
+			EndpointPort: 10001,
+			Labels:       lbls,
+		}
 	}
 
 	cases := []struct {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -767,7 +767,7 @@ func serviceInstanceFromWorkloadInstance(svc *model.Service, servicePort *model.
 	targetPort serviceTargetPort, wi *model.WorkloadInstance,
 ) *model.ServiceInstance {
 	// create an instance with endpoint whose service port name matches
-	istioEndpoint := *wi.Endpoint
+	istioEndpoint := wi.Endpoint.ShallowCopy()
 
 	// by default, use the numbered targetPort
 	istioEndpoint.EndpointPort = uint32(targetPort.num)
@@ -787,7 +787,7 @@ func serviceInstanceFromWorkloadInstance(svc *model.Service, servicePort *model.
 	return &model.ServiceInstance{
 		Service:     svc,
 		ServicePort: servicePort,
-		Endpoint:    &istioEndpoint,
+		Endpoint:    istioEndpoint,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1070,7 +1071,7 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 				if diff := cmp.Diff(tc.want[i].Service.Hostname, got[i].Service.Hostname); diff != "" {
 					t.Fatalf("GetProxyServiceInstances() returned unexpected value [%d].Service.Hostname (--want/++got): %v", i, diff)
 				}
-				if diff := cmp.Diff(tc.want[i].Endpoint, got[i].Endpoint); diff != "" {
+				if diff := cmp.Diff(tc.want[i].Endpoint, got[i].Endpoint, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 					t.Fatalf("GetProxyServiceInstances() returned unexpected value [%d].Endpoint (--want/++got): %v", i, diff)
 				}
 			}
@@ -2510,7 +2511,7 @@ func TestWorkloadInstanceHandler_WorkloadInstanceIndex(t *testing.T) {
 	verifyGetByIP := func(address string, want []*model.WorkloadInstance) {
 		got := ctl.workloadInstancesIndex.GetByIP(address)
 
-		if diff := cmp.Diff(want, got); diff != "" {
+		if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 			t.Fatalf("workload index is not valid (--want/++got): %v", diff)
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -391,12 +391,12 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			} else {
 				targetPort = serviceEntryPort.Number
 			}
-			ep := *workloadInstance.Endpoint
+			ep := workloadInstance.Endpoint.ShallowCopy()
 			ep.ServicePortName = serviceEntryPort.Name
 			ep.EndpointPort = targetPort
-			ep.EnvoyEndpoint = nil
+			ep.ComputeEnvoyEndpoint(nil)
 			out = append(out, &model.ServiceInstance{
-				Endpoint:    &ep,
+				Endpoint:    ep,
 				Service:     service,
 				ServicePort: convertPort(serviceEntryPort),
 			})

--- a/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
+++ b/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -96,12 +97,12 @@ func TestIndex(t *testing.T) {
 	verifyGetByIP := func(ip string, expected []*model.WorkloadInstance) {
 		actual := index.GetByIP(ip)
 
-		if diff := cmp.Diff(len(expected), len(actual)); diff != "" {
+		if diff := cmp.Diff(len(expected), len(actual), cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 			t.Errorf("GetByIP() returned unexpected number of workload instances (--want/++got): %v", diff)
 		}
 
 		for i := range expected {
-			if diff := cmp.Diff(expected[i], actual[i]); diff != "" {
+			if diff := cmp.Diff(expected[i], actual[i], cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 				t.Errorf("GetByIP() returned unexpected workload instance %d (--want/++got): %v", i, diff)
 			}
 		}
@@ -114,7 +115,7 @@ func TestIndex(t *testing.T) {
 	// Delete should return previously inserted value
 
 	deleted := index.Delete(wi1)
-	if diff := cmp.Diff(wi1, deleted); diff != "" {
+	if diff := cmp.Diff(wi1, deleted, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 		t.Errorf("1st Delete() returned unexpected value (--want/++got): %v", diff)
 	}
 
@@ -194,7 +195,7 @@ func TestIndex_FindAll(t *testing.T) {
 	}
 
 	for _, expected := range want {
-		if diff := cmp.Diff(expected, got[expected.Name]); diff != "" {
+		if diff := cmp.Diff(expected, got[expected.Name], cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
 			t.Fatalf("FindAllInIndex() returned unexpected workload instance %q (--want/++got): %v", expected.Name, diff)
 		}
 	}

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -256,7 +256,9 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 	// and should, therefore, not be accessed from outside the cluster.
 	isClusterLocal := b.clusterLocal
 
-	shards.Lock()
+	// To avoid lock contention, grab endpoints list before we process anything
+	eps := []*model.IstioEndpoint{}
+	shards.RLock()
 	// Extract shard keys so we can iterate in order. This ensures a stable EDS output.
 	keys := shards.Keys()
 	// The shards are updated independently, now need to filter and merge for this cluster
@@ -294,42 +296,45 @@ func (b *EndpointBuilder) buildLocalityLbEndpointsFromShards(
 					continue
 				}
 			}
-
-			mtlsEnabled := b.mtlsChecker.checkMtlsEnabled(ep)
-			// Determine if we need to build the endpoint. We try to cache it for performance reasons
-			needToCompute := ep.EnvoyEndpoint == nil
-			if features.EnableHBONE {
-				// Currently the HBONE implementation leads to different endpoint generation depending on if the
-				// client proxy supports HBONE or not. This breaks the cache.
-				// For now, just disable caching if the global HBONE flag is enabled.
-				needToCompute = true
-			}
-			if ep.EnvoyEndpoint != nil && mtlsEnabled != isMtlsEnabled(ep.EnvoyEndpoint) {
-				// The mTLS settings may have changed, invalidating the cache endpoint. Rebuild it
-				needToCompute = true
-			}
-			if needToCompute {
-				eep := buildEnvoyLbEndpoint(b, ep, mtlsEnabled)
-				if eep == nil {
-					continue
-				}
-				ep.EnvoyEndpoint = eep
-			}
-
-			locLbEps, found := localityEpMap[ep.Locality.Label]
-			if !found {
-				locLbEps = &LocalityEndpoints{
-					llbEndpoints: endpoint.LocalityLbEndpoints{
-						Locality:    util.ConvertLocality(ep.Locality.Label),
-						LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(endpoints)),
-					},
-				}
-				localityEpMap[ep.Locality.Label] = locLbEps
-			}
-			locLbEps.append(ep, ep.EnvoyEndpoint)
+			eps = append(eps, ep)
 		}
 	}
-	shards.Unlock()
+	shards.RUnlock()
+
+	for _, ep := range eps {
+		eep := ep.EnvoyEndpoint()
+		mtlsEnabled := b.mtlsChecker.checkMtlsEnabled(ep)
+		// Determine if we need to build the endpoint. We try to cache it for performance reasons
+		needToCompute := eep == nil
+		if features.EnableHBONE {
+			// Currently the HBONE implementation leads to different endpoint generation depending on if the
+			// client proxy supports HBONE or not. This breaks the cache.
+			// For now, just disable caching if the global HBONE flag is enabled.
+			needToCompute = true
+		}
+		if eep != nil && mtlsEnabled != isMtlsEnabled(eep) {
+			// The mTLS settings may have changed, invalidating the cache endpoint. Rebuild it
+			needToCompute = true
+		}
+		if needToCompute {
+			eep = buildEnvoyLbEndpoint(b, ep, mtlsEnabled)
+			if eep == nil {
+				continue
+			}
+			ep.ComputeEnvoyEndpoint(eep)
+		}
+		locLbEps, found := localityEpMap[ep.Locality.Label]
+		if !found {
+			locLbEps = &LocalityEndpoints{
+				llbEndpoints: endpoint.LocalityLbEndpoints{
+					Locality:    util.ConvertLocality(ep.Locality.Label),
+					LbEndpoints: make([]*endpoint.LbEndpoint, 0, len(eps)),
+				},
+			}
+			localityEpMap[ep.Locality.Label] = locLbEps
+		}
+		locLbEps.append(ep, eep)
+	}
 
 	locEps := make([]*LocalityEndpoints, 0, len(localityEpMap))
 	locs := make([]string, 0, len(localityEpMap))

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -16,11 +16,13 @@ package xds
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"testing"
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
@@ -626,8 +628,8 @@ func runNetworkFilterTest(t *testing.T, ds *FakeDiscoveryServer, tests []network
 			b2 := NewEndpointBuilder(cn, proxy, ds.PushContext())
 			testEndpoints2 := b2.buildLocalityLbEndpointsFromShards(testShards(), &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP})
 			filtered2 := b2.EndpointsByNetworkFilter(testEndpoints2)
-			if !reflect.DeepEqual(filtered2, filtered) {
-				t.Fatalf("output of EndpointsByNetworkFilter is non-deterministic")
+			if diff := cmp.Diff(filtered2, filtered, protocmp.Transform(), cmpopts.IgnoreUnexported(LocalityEndpoints{})); diff != "" {
+				t.Fatalf("output of EndpointsByNetworkFilter is non-deterministic: %v", diff)
 			}
 		})
 	}
@@ -731,8 +733,8 @@ func runMTLSFilterTest(t *testing.T, ds *FakeDiscoveryServer, tests []networkFil
 			testEndpoints2 := b2.buildLocalityLbEndpointsFromShards(testShards(), &model.Port{Name: "http", Port: 80, Protocol: protocol.HTTP})
 			filtered2 := b2.EndpointsByNetworkFilter(testEndpoints2)
 			filtered2 = b2.EndpointsWithMTLSFilter(filtered2)
-			if !reflect.DeepEqual(filtered2, filtered) {
-				t.Fatalf("output of EndpointsWithMTLSFilter is non-deterministic")
+			if diff := cmp.Diff(filtered2, filtered, protocmp.Transform(), cmpopts.IgnoreUnexported(LocalityEndpoints{})); diff != "" {
+				t.Fatalf("output of EndpointsByNetworkFilter is non-deterministic: %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This PR reduces lock contention in EDS. Primarily discovered/discussed/tested in https://github.com/istio/istio/issues/44985. I was also able to reproduce the same

We see very little impact on the raw microbenchmarks:
```
name                          old time/op        new time/op        delta
EndpointGeneration/1/100-48          642µs ± 2%         653µs ± 2%  +1.78%  (p=0.002 n=9+10)
EndpointGeneration/10/10-48          300µs ± 1%         306µs ± 2%  +2.11%  (p=0.000 n=10+10)
EndpointGeneration/100/10-48        2.68ms ± 1%        2.69ms ± 1%    ~     (p=0.218 n=10+10)
EndpointGeneration/1000/1-48        2.66ms ± 1%        2.70ms ± 3%  +1.57%  (p=0.017 n=9+10)

name                          old kb/msg         new kb/msg         delta
EndpointGeneration/1/100-48           10.1 ± 0%          10.1 ± 0%    ~     (all equal)
EndpointGeneration/10/10-48           7.13 ± 0%          7.13 ± 0%    ~     (all equal)
EndpointGeneration/100/10-48          69.2 ± 0%          69.2 ± 0%    ~     (all equal)
EndpointGeneration/1000/1-48          69.6 ± 0%          69.6 ± 0%    ~     (all equal)

name                          old resources/msg  new resources/msg  delta
EndpointGeneration/1/100-48            100 ± 0%           100 ± 0%    ~     (all equal)
EndpointGeneration/10/10-48           10.0 ± 0%          10.0 ± 0%    ~     (all equal)
EndpointGeneration/100/10-48          10.0 ± 0%          10.0 ± 0%    ~     (all equal)
EndpointGeneration/1000/1-48          1.00 ± 0%          1.00 ± 0%    ~     (all equal)

name                          old alloc/op       new alloc/op       delta
EndpointGeneration/1/100-48          219kB ± 0%         220kB ± 0%  +0.37%  (p=0.000 n=10+10)
EndpointGeneration/10/10-48         79.9kB ± 0%        82.4kB ± 0%  +3.11%  (p=0.000 n=9+9)
EndpointGeneration/100/10-48         672kB ± 0%         693kB ± 0%  +3.03%  (p=0.000 n=10+9)
EndpointGeneration/1000/1-48         696kB ± 0%         722kB ± 0%  +3.63%  (p=0.000 n=10+10)

name                          old allocs/op      new allocs/op      delta
EndpointGeneration/1/100-48          4.41k ± 0%         4.51k ± 0%  +2.27%  (p=0.000 n=10+10)
EndpointGeneration/10/10-48          1.66k ± 0%         1.71k ± 0%  +3.02%  (p=0.000 n=10+10)
EndpointGeneration/100/10-48         12.7k ± 0%         12.8k ± 0%  +0.65%  (p=0.000 n=10+10)
EndpointGeneration/1000/1-48         12.1k ± 0%         12.2k ± 0%  +0.12%  (p=0.000 n=10+10)
```

The very slight regression is just due to computing a slice of the endpoints inside the lock so we can access them outside the lock, which we did not have before. 

The benchmark is an isolated test, so it doesn't exercise lock contention in any way, hence why it looks strictly worse there. In my real world testing, this completely removed lock contention