### PR TITLE
Set route MaxStreamDuraration so grpc-timeout header can be used

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -776,9 +776,12 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 			ClusterSpecifier: &route.RouteAction_Cluster{Cluster: egressCluster},
 			// Disable timeout instead of assuming some defaults.
 			Timeout: notimeout,
-			// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
-			// nolint: staticcheck
-			MaxGrpcTimeout: notimeout,
+			MaxStreamDuration: &route.RouteAction_MaxStreamDuration{
+				MaxStreamDuration: notimeout,
+				// If not configured at all, the grpc-timeout header is not used and
+				// gRPC requests time out like any other requests using timeout or its default.
+				GrpcTimeoutHeaderMax: notimeout,
+			},
 		}
 
 		return &route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -539,15 +539,7 @@ func (lb *ListenerBuilder) routeDestination(out *route.Route, in *networking.HTT
 		Cors:        istio_route.TranslateCORSPolicy(in.CorsPolicy),
 		RetryPolicy: retry.ConvertPolicy(policy),
 	}
-
-	// Configure timeouts specified by Virtual Service if they are provided, otherwise set it to defaults.
-	action.Timeout = istio_route.Notimeout
-	if in.Timeout != nil {
-		action.Timeout = in.Timeout
-	}
-	// Use deprecated value for now as the replacement MaxStreamDuration has some regressions.
-	// nolint: staticcheck
-	action.MaxGrpcTimeout = action.Timeout
+	istio_route.SetRouteTimeout(action, in.Timeout)
 
 	out.Action = &route.Route_Route{Route: action}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -433,7 +433,7 @@ func translateRoute(
 	} else if in.DirectResponse != nil {
 		ApplyDirectResponse(out, in.DirectResponse)
 	} else {
-		applyHTTPRouteDestination(out, node, virtualService, in, opts.Mesh, authority, serviceRegistry, listenPort, hashByDestination)
+		applyHTTPRouteDestination(out, virtualService, in, opts.Mesh, authority, serviceRegistry, listenPort, hashByDestination)
 	}
 
 	out.Decorator = &route.Decorator{
@@ -457,7 +457,6 @@ func translateRoute(
 
 func applyHTTPRouteDestination(
 	out *route.Route,
-	node *model.Proxy,
 	vs config.Config,
 	in *networking.HTTPRoute,
 	mesh *meshconfig.MeshConfig,

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -77,8 +77,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetGrpcTimeoutHeaderMax()).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration().GetSeconds()).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetGrpcTimeoutHeaderMax().GetSeconds()).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with HTTP/3 discovery enabled", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(10)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration().GetSeconds()).To(gomega.Equal(int64(10)))
 	})
 
 	t.Run("for virtual service with disabled timeout", func(t *testing.T) {
@@ -126,7 +126,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration().GetSeconds()).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -77,8 +77,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetGrpcTimeoutHeaderMax()).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with HTTP/3 discovery enabled", func(t *testing.T) {
@@ -112,8 +112,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(10)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(10)))
 	})
 
 	t.Run("for virtual service with disabled timeout", func(t *testing.T) {
@@ -127,8 +126,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
-		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxStreamDuration.GetMaxStreamDuration()).To(gomega.Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix https://github.com/istio/istio/issues/45141


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
