### PR TITLE
fix: istioctl remove all revisions of istio operator when not specify revision

### DIFF
--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -15,6 +15,7 @@
 package mesh
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -63,7 +64,15 @@ func operatorRemoveCmd(ctx cli.Context, rootArgs *RootArgs, orArgs *operatorRemo
 		Use:   "remove",
 		Short: "Removes the Istio operator controller from the cluster.",
 		Long:  "The remove subcommand removes the Istio operator controller from the cluster.",
-		Args:  cobra.ExactArgs(0),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if orArgs.revision == "" && !orArgs.purge {
+				return fmt.Errorf("at least one of the --revision or --purge flags must be set")
+			}
+			if len(args) > 0 {
+				return fmt.Errorf("istioctl operator remove does not take arguments")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := ctx.CLIClient()
 			if err != nil {
@@ -85,16 +94,20 @@ func operatorRemove(cmd *cobra.Command, cliClient kube.CLIClient, args *RootArgs
 		l.LogAndFatal(err)
 	}
 
-	// If the user is performing purge but also specified a revision, an error message
-	// should be displayed and do nothing
+	// If the user is performing purge but also specified a revision, we should warn
+	// that the purge will still remove all resources
 	if orArgs.purge && orArgs.revision != "" {
 		orArgs.revision = ""
-		l.LogAndFatal("At most one of the --revision or --purge flags could be set\n")
-	} else if orArgs.revision == "default" {
-		orArgs.revision = ""
+		l.LogAndPrint("Purge remove will remove all Istio operator controller, ignoring the specified revision\n")
 	}
 
-	installed, err := isControllerInstalled(kubeClient.Kube(), orArgs.operatorNamespace, orArgs.revision)
+	var installed bool
+	if orArgs.revision == "default" {
+		installed, err = isControllerInstalled(kubeClient.Kube(), orArgs.operatorNamespace, "")
+	} else {
+		installed, err = isControllerInstalled(kubeClient.Kube(), orArgs.operatorNamespace, orArgs.revision)
+	}
+
 	if installed && err != nil {
 		l.LogAndFatal(err)
 	}

--- a/releasenotes/notes/45243.yaml
+++ b/releasenotes/notes/45243.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 45242
+releaseNotes:
+  - |
+    **Fixed** `istioctl operator remove` will remove all revisions of operator controller when the revision is "default" or not specified.

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -116,6 +116,18 @@ func TestController(t *testing.T) {
 			// install second operator deployment with different revision
 			istioCtl.InvokeOrFail(t, initCmd)
 			t.TrackResource(&operatorDumper{rev: "v2"})
+
+			initCmd = []string{
+				"operator", "init",
+				"--hub=" + s.Image.Hub,
+				"--tag=" + s.Image.Tag,
+				"--manifests=" + ManifestPath,
+				"--revision=" + "v3",
+			}
+			// install third operator deployment with different revision
+			istioCtl.InvokeOrFail(t, initCmd)
+			t.TrackResource(&operatorDumper{rev: "v3"})
+
 			installWithCRFile(t, t, cs, istioCtl, "default", "v2")
 			installWithCRFile(t, t, cs, istioCtl, "default", "")
 
@@ -123,8 +135,38 @@ func TestController(t *testing.T) {
 			cleanupInClusterCRs(t, cs)
 
 			// test operator remove command
-			scopes.Framework.Infof("checking operator remove command")
+			scopes.Framework.Infof("checking operator remove command for default revision")
 			removeCmd := []string{
+				"operator", "remove",
+				"--skip-confirmation",
+				"--revision", "default",
+			}
+			istioCtl.InvokeOrFail(t, removeCmd)
+
+			retry.UntilSuccessOrFail(t, func() error {
+				// check the revision of operator which should to be removed
+				if svc, _ := cs.Kube().CoreV1().Services(OperatorNamespace).Get(context.TODO(), "istio-operator", metav1.GetOptions{}); svc.Name != "" {
+					return fmt.Errorf("got operator service: %s from cluster, expected to be removed", svc.Name)
+				}
+				if dp, _ := cs.Kube().AppsV1().Deployments(OperatorNamespace).Get(context.TODO(), "istio-operator", metav1.GetOptions{}); dp.Name != "" {
+					return fmt.Errorf("got operator deployment %s from cluster, expected to be removed", dp.Name)
+				}
+
+				// check the revision of operator which should not to be removed
+				for _, n := range []string{"istio-operator-v2", "istio-operator-v3"} {
+					if svc, _ := cs.Kube().CoreV1().Services(OperatorNamespace).Get(context.TODO(), n, metav1.GetOptions{}); svc.Name == "" {
+						return fmt.Errorf("don't got operator service: %s from cluster, expected not to be removed", svc.Name)
+					}
+					if dp, _ := cs.Kube().AppsV1().Deployments(OperatorNamespace).Get(context.TODO(), n, metav1.GetOptions{}); dp.Name == "" {
+						return fmt.Errorf("don't got operator deployment %s from cluster, expected not to be removed", dp.Name)
+					}
+				}
+				return nil
+			}, retry.Timeout(retryTimeOut), retry.Delay(retryDelay))
+
+			// test operator remove command by purge
+			scopes.Framework.Infof("checking operator remove command")
+			removeCmd = []string{
 				"operator", "remove",
 				"--skip-confirmation",
 				"--purge",
@@ -132,7 +174,7 @@ func TestController(t *testing.T) {
 			istioCtl.InvokeOrFail(t, removeCmd)
 
 			retry.UntilSuccessOrFail(t, func() error {
-				for _, n := range []string{"istio-operator", "istio-operator-v2"} {
+				for _, n := range []string{"istio-operator-v2", "istio-operator-v3"} {
 					if svc, _ := cs.Kube().CoreV1().Services(OperatorNamespace).Get(context.TODO(), n, metav1.GetOptions{}); svc.Name != "" {
 						return fmt.Errorf("got operator service: %s from cluster, expected to be removed", svc.Name)
 					}


### PR DESCRIPTION
*Please provide a description of this PR:**

Fix  istioctl operator remove and istioctl operator remove -r default will remove all revision of operator.

Fix https://github.com/istio/istio/issues/45242