### PR TITLE
pilot: refactor version to avoid globals

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -833,7 +833,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID cluster.ID, ip string) {
 // AdsPushAll will send updates to all nodes, with a full push.
 // Mainly used in Debug interface.
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(versionInfo(), &model.PushRequest{
+	s.AdsPushAll(s.PushVersion.CurrentVersion(), &model.PushRequest{
 		Full:   true,
 		Push:   s.globalPushContext(),
 		Reason: []model.TriggerReason{model.DebugTrigger},

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -833,7 +833,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID cluster.ID, ip string) {
 // AdsPushAll will send updates to all nodes, with a full push.
 // Mainly used in Debug interface.
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(s.PushVersion.CurrentVersion(), &model.PushRequest{
+	s.AdsPushAll(&model.PushRequest{
 		Full:   true,
 		Push:   s.globalPushContext(),
 		Reason: []model.TriggerReason{model.DebugTrigger},
@@ -841,14 +841,14 @@ func AdsPushAll(s *DiscoveryServer) {
 }
 
 // AdsPushAll will send updates to all nodes, for a full config or incremental EDS.
-func (s *DiscoveryServer) AdsPushAll(version string, req *model.PushRequest) {
+func (s *DiscoveryServer) AdsPushAll(req *model.PushRequest) {
 	if !req.Full {
-		log.Infof("XDS: Incremental Pushing:%s ConnectedEndpoints:%d Version:%s",
-			version, s.adsClientCount(), req.Push.PushVersion)
+		log.Infof("XDS: Incremental Pushing ConnectedEndpoints:%d Version:%s",
+			s.adsClientCount(), req.Push.PushVersion)
 	} else {
 		totalService := len(req.Push.GetAllServices())
-		log.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d Version:%s",
-			version, totalService, s.adsClientCount(), req.Push.PushVersion)
+		log.Infof("XDS: Pushing Services:%d ConnectedEndpoints:%d Version:%s",
+			totalService, s.adsClientCount(), req.Push.PushVersion)
 		monServices.Record(float64(totalService))
 
 		// Make sure the ConfigsUpdated map exists

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -178,6 +178,20 @@ func TestAdsBadId(t *testing.T) {
 	ads.ExpectNoResponse(t)
 }
 
+func TestVersionNonce(t *testing.T) {
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	ads := s.ConnectADS().WithType(v3.ClusterType)
+	resp1 := ads.RequestResponseAck(t, nil)
+	fullPush(s)
+	resp2 := ads.ExpectResponse(t)
+	if !(resp1.VersionInfo < resp2.VersionInfo) {
+		t.Fatalf("version should be incrementing: %v -> %v", resp1.VersionInfo, resp2.VersionInfo)
+	}
+	if resp1.Nonce == resp2.Nonce {
+		t.Fatalf("nonce should change %v -> %v", resp1.Nonce, resp2.Nonce)
+	}
+}
+
 func TestAdsClusterUpdate(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	ads := s.ConnectADS().WithType(v3.EndpointType)

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -288,7 +288,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 					l := s.Discovery.generateEndpoints(NewEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
 					loadAssignments = append(loadAssignments, protoconv.MessageToAny(l))
 				}
-				response = endpointDiscoveryResponse(loadAssignments, version, push.LedgerVersion)
+				response = endpointDiscoveryResponse(loadAssignments, s.Discovery.PushVersion.CurrentVersion(), push.LedgerVersion)
 			}
 			logDebug(b, model.AnyToUnnamedResources(response.GetResources()))
 		})

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -288,7 +288,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 					l := s.Discovery.generateEndpoints(NewEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
 					loadAssignments = append(loadAssignments, protoconv.MessageToAny(l))
 				}
-				response = endpointDiscoveryResponse(loadAssignments, s.Discovery.PushVersion.CurrentVersion(), push.LedgerVersion)
+				response = endpointDiscoveryResponse(loadAssignments, push.PushVersion, push.LedgerVersion)
 			}
 			logDebug(b, model.AnyToUnnamedResources(response.GetResources()))
 		})

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1079,7 +1078,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 	for j := 0; j < nPushes; j++ {
 		if inc {
 			// This will be throttled - we want to trigger a single push
-			s.Discovery.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
+			s.Discovery.AdsPushAll(&model.PushRequest{
 				Full: false,
 				ConfigsUpdated: sets.New(model.ConfigKey{
 					Kind: kind.ServiceEntry,


### PR DESCRIPTION
Minor refactoring, no need to use globals here. Also clean up to use
atomics instead of mutex for simplicity
