### PR TITLE
Changed provider.Config type from any to FileWatcherCertProviderConfig in test echo server.

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -73,7 +73,7 @@ func newConfigGenTest(t *testing.T, discoveryOpts xds.FakeOptions, servers ...ec
 
 	cgt := &configGenTest{T: t}
 	wg := sync.WaitGroup{}
-	cfgs := []config.Config{}
+	var cfgs []config.Config
 
 	discoveryOpts.ListenerBuilder = func() (net.Listener, error) {
 		return net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/test/echo/server/endpoint/grpcbootstrap.go
+++ b/pkg/test/echo/server/endpoint/grpcbootstrap.go
@@ -34,11 +34,7 @@ func (b *Bootstrap) FileWatcherProvider() *FileWatcherCertProviderConfig {
 	}
 	for _, provider := range b.CertProviders {
 		if provider.PluginName == FileWatcherCertProviderName {
-			cfg, ok := provider.Config.(FileWatcherCertProviderConfig)
-			if !ok {
-				return nil
-			}
-			return &cfg
+			return &provider.Config
 		}
 	}
 	return nil
@@ -49,6 +45,6 @@ type Bootstrap struct {
 }
 
 type CertificateProvider struct {
-	PluginName string `json:"plugin_name,omitempty"`
-	Config     any    `json:"config,omitempty"`
+	PluginName string                        `json:"plugin_name,omitempty"`
+	Config     FileWatcherCertProviderConfig `json:"config,omitempty"`
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR contributes to #37555 speeding up tests from this file: https://github.com/istio/istio/blob/275a82bb40143426116dafcd711e9953e6e46abc/pilot/pkg/networking/grpcgen/grpcecho_test.go

It proposes to change provider.Config type from `any` to `FileWatcherCertProviderConfig` in the echo server, so to avoid a cast failure [here](https://github.com/istio/istio/blob/master/pkg/test/echo/server/endpoint/grpcbootstrap.go#L37).

The cast failure is the root of 10seconds delay during the execution of the test, as it fails the retrieval of the certificates from the bootstrap configuration ([here](https://github.com/istio/istio/blob/master/pkg/test/echo/server/endpoint/grpc.go#L160)) and  the server startup [waits for the readiness probe to be ready](https://github.com/istio/istio/blob/master/pkg/test/echo/server/endpoint/grpc.go#L181) with a timeout of 10 seconds.

With the 10seconds timeout gone, the tests execution takes ~30ms.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
