### PR TITLE
Avoid memory allocation within address map

### DIFF
--- a/pilot/pkg/model/addressmap.go
+++ b/pilot/pkg/model/addressmap.go
@@ -41,6 +41,16 @@ func (m *AddressMap) IsEmpty() bool {
 	return len(m.Addresses) == 0
 }
 
+func (m *AddressMap) Len() int {
+	if m == nil {
+		return 0
+	}
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return len(m.Addresses)
+}
+
 func (m *AddressMap) DeepCopy() *AddressMap {
 	if m == nil {
 		return nil

--- a/pilot/pkg/model/addressmap_test.go
+++ b/pilot/pkg/model/addressmap_test.go
@@ -109,6 +109,47 @@ func TestAddressMapIsEmpty(t *testing.T) {
 	}
 }
 
+func TestAddressMapLen(t *testing.T) {
+	cases := []struct {
+		name     string
+		newMap   func() *model.AddressMap
+		expected int
+	}{
+		{
+			name: "nil addresses map",
+			newMap: func() *model.AddressMap {
+				return nil
+			},
+			expected: 0,
+		},
+		{
+			name: "empty addresses map",
+			newMap: func() *model.AddressMap {
+				m := model.AddressMap{}
+				m.AddAddressesFor(c1ID, make([]string, 0))
+				return &m
+			},
+			expected: 0,
+		},
+		{
+			name: "non-empty addresses map",
+			newMap: func() *model.AddressMap {
+				m := model.AddressMap{}
+				m.AddAddressesFor(c1ID, c1Addresses)
+				return &m
+			},
+			expected: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(c.newMap().Len()).To(Equal(c.expected))
+		})
+	}
+}
+
 func TestAddressMapGetAddressesFor(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -722,7 +722,7 @@ func (s *ServiceAttributes) Equals(other *ServiceAttributes) bool {
 		return false
 	}
 
-	if len(s.ClusterExternalAddresses.GetAddresses()) != len(other.ClusterExternalAddresses.GetAddresses()) {
+	if s.ClusterExternalAddresses.Len() != other.ClusterExternalAddresses.Len() {
 		return false
 	}
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -254,7 +254,7 @@ func (c *Controller) Services() []*model.Service {
 				} else {
 					// We must deepcopy before merge, and after merging, the ClusterVips length will be >= 2.
 					// This is an optimization to prevent deepcopy multi-times
-					if len(services[previous].ClusterVIPs.GetAddresses()) < 2 {
+					if services[previous].ClusterVIPs.Len() < 2 {
 						// Deep copy before merging, otherwise there is a case
 						// a service in remote cluster can be deleted, but the ClusterIP left.
 						services[previous] = services[previous].DeepCopy()


### PR DESCRIPTION
This is kind of improvement. No additional memory allocation is necessary when determining the size of the address map.