### PR TITLE
Fix uninstall not removing revision when missing webhook

### DIFF
--- a/releasenotes/notes/45278.yaml
+++ b/releasenotes/notes/45278.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where components are not uninstalled correctly when the webhook is missing.

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -59,6 +59,13 @@ func TestUninstallByRevision(t *testing.T) {
 		NewTest(t).
 		Features("installation.istioctl.uninstall_revision").
 		Run(func(t framework.TestContext) {
+			// Revision is deleted by IOP CR. Missing resources won't affect the test.
+			cluster := t.Clusters().Default().Kube()
+			revisionWh := fmt.Sprintf("istio-sidecar-injector-%s", stableRevision)
+			if err := cluster.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(),
+				revisionWh, metav1.DeleteOptions{}); err != nil {
+				return fmt.Errorf("could not delete mutating webhook config %s: %v", revisionWh, err)
+			}
 			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
 				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 				uninstallCmd := []string{

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -64,7 +64,7 @@ func TestUninstallByRevision(t *testing.T) {
 			revisionWh := fmt.Sprintf("istio-sidecar-injector-%s", stableRevision)
 			if err := cluster.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(),
 				revisionWh, metav1.DeleteOptions{}); err != nil {
-				return fmt.Errorf("could not delete mutating webhook config %s: %v", revisionWh, err)
+				scopes.Framework.Errorf("could not delete mutating webhook config %s: %v", revisionWh, err)
 			}
 			t.NewSubTest("uninstall_revision").Run(func(t framework.TestContext) {
 				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})


### PR DESCRIPTION
**Please provide a description of this PR:**
This is found when I was doing the test, the webhook is missing, and the revision can never be uninstalled only if using `uninstall --purge`.

The old logic list the webhook and check if there's a match, and I revised to use the installed CRs to perform the check.