### PR TITLE
ambient: refactor controller implementation a bit

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -95,15 +95,28 @@ func ConfigNamesOfKind(configs sets.Set[ConfigKey], kind kind.Kind) sets.String 
 }
 
 // ConfigNamespacedNameOfKind extracts config names of the specified kind.
-func ConfigNamespacedNameOfKind(configs map[ConfigKey]struct{}, kind kind.Kind) map[types.NamespacedName]struct{} {
-	ret := map[types.NamespacedName]struct{}{}
+func ConfigNamespacedNameOfKind(configs map[ConfigKey]struct{}, kind kind.Kind) sets.Set[types.NamespacedName] {
+	ret := sets.New[types.NamespacedName]()
 
 	for conf := range configs {
 		if conf.Kind == kind {
-			ret[types.NamespacedName{
+			ret.Insert(types.NamespacedName{
 				Namespace: conf.Namespace,
 				Name:      conf.Name,
-			}] = struct{}{}
+			})
+		}
+	}
+
+	return ret
+}
+
+// ConfigNameOfKind extracts config names of the specified kind.
+func ConfigNameOfKind(configs map[ConfigKey]struct{}, kind kind.Kind) sets.String {
+	ret := sets.New[string]()
+
+	for conf := range configs {
+		if conf.Kind == kind {
+			ret.Insert(conf.Name)
 		}
 	}
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2174,7 +2174,11 @@ func (ps *PushContext) ServiceAccounts(hostname host.Name, namespace string, por
 	}]
 }
 
+// SupportsTunnel checks if a given IP address supports tunneling.
+// This currently only accepts workload IPs as arguments; services will always return "false".
 func (ps *PushContext) SupportsTunnel(n network.ID, ip string) bool {
+	// There should be a 1:1 relationship between IP and Workload but the interface doesn't allow this lookup.
+	// We should get 0 or 1 workloads, so just return the first.
 	infos, _ := ps.ambientIndex.AddressInformation(sets.New(n.String() + "/" + ip))
 	for _, wl := range ExtractWorkloadsFromAddresses(infos) {
 		if wl.TunnelProtocol == workloadapi.TunnelProtocol_HBONE {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -18,8 +18,6 @@ import (
 	"net/netip"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -78,11 +76,11 @@ func (c *Controller) WorkloadsForWaypoint(scope model.WaypointScope) []*model.Wo
 	return res
 }
 
-func (c *Controller) AdditionalPodSubscriptions(proxy *model.Proxy, addr, cur sets.Set[types.NamespacedName]) sets.Set[types.NamespacedName] {
+func (c *Controller) AdditionalPodSubscriptions(proxy *model.Proxy, addr, cur sets.String) sets.String {
 	if !features.EnableAmbientControllers {
 		return nil
 	}
-	res := sets.New[types.NamespacedName]()
+	res := sets.New[string]()
 	for _, p := range c.GetRegistries() {
 		res = res.Merge(p.AdditionalPodSubscriptions(proxy, addr, cur))
 	}
@@ -100,7 +98,7 @@ func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []*security.A
 	return res
 }
 
-func (c *Controller) AddressInformation(addresses sets.Set[types.NamespacedName]) ([]*model.AddressInfo, []string) {
+func (c *Controller) AddressInformation(addresses sets.String) ([]*model.AddressInfo, []string) {
 	i := []*model.AddressInfo{}
 	removed := sets.New[string]()
 	if !features.EnableAmbientControllers {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -16,33 +16,26 @@ package controller
 
 import (
 	"net/netip"
-	"strconv"
 	"strings"
 	"sync"
 
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
-	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 	kubeutil "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
 	kubelabels "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/workloadapi"
-	"istio.io/istio/pkg/workloadapi/security"
 )
 
 // AmbientIndex maintains an index of ambient WorkloadInfo objects by various keys.
@@ -63,9 +56,6 @@ type AmbientIndex struct {
 
 	// Map of Scope -> address
 	waypoints map[model.WaypointScope]*workloadapi.GatewayAddress
-
-	// serviceVipIndex maintains an index of VIP -> Service
-	serviceVipIndex *kclient.Index[string, *v1.Service]
 }
 
 func workloadToAddressInfo(w *workloadapi.Workload) *model.AddressInfo {
@@ -284,334 +274,6 @@ func (a *AmbientIndex) matchesScope(scope model.WaypointScope, w *model.Workload
 	return true
 }
 
-func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []*security.Authorization {
-	if !c.configCluster {
-		return nil
-	}
-	cfgs := c.configController.List(gvk.AuthorizationPolicy, metav1.NamespaceAll)
-	l := len(cfgs)
-	if len(requested) > 0 {
-		l = len(requested)
-	}
-	res := make([]*security.Authorization, 0, l)
-	for _, cfg := range cfgs {
-		k := model.ConfigKey{
-			Kind:      kind.AuthorizationPolicy,
-			Name:      cfg.Name,
-			Namespace: cfg.Namespace,
-		}
-		if len(requested) > 0 && !requested.Contains(k) {
-			continue
-		}
-		pol := convertAuthorizationPolicy(c.meshWatcher.Mesh().GetRootNamespace(), cfg)
-		if pol == nil {
-			continue
-		}
-		res = append(res, pol)
-	}
-	return res
-}
-
-func (c *Controller) selectorAuthorizationPolicies(ns string, lbls map[string]string) []string {
-	global := c.configController.List(gvk.AuthorizationPolicy, c.meshWatcher.Mesh().GetRootNamespace())
-	local := c.configController.List(gvk.AuthorizationPolicy, ns)
-	res := sets.New[string]()
-	matches := func(c config.Config) bool {
-		sel := c.Spec.(*v1beta1.AuthorizationPolicy).Selector
-		if sel == nil {
-			return false
-		}
-		return labels.Instance(sel.MatchLabels).SubsetOf(lbls)
-	}
-
-	for _, pl := range [][]config.Config{global, local} {
-		for _, p := range pl {
-			if matches(p) {
-				res.Insert(p.Namespace + "/" + p.Name)
-			}
-		}
-	}
-	return sets.SortedList(res)
-}
-
-func (c *Controller) AuthorizationPolicyHandler(old config.Config, obj config.Config, ev model.Event) {
-	getSelector := func(c config.Config) map[string]string {
-		if c.Spec == nil {
-			return nil
-		}
-		pol := c.Spec.(*v1beta1.AuthorizationPolicy)
-		return pol.Selector.GetMatchLabels()
-	}
-	// Normal flow for AuthorizationPolicy will trigger XDS push, so we don't need to push those. But we do need
-	// to update any relevant workloads and push them.
-	sel := getSelector(obj)
-	oldSel := getSelector(old)
-
-	switch ev {
-	case model.EventUpdate:
-		if maps.Equal(sel, oldSel) {
-			// Update event, but selector didn't change. No workloads to push.
-			return
-		}
-	default:
-		if sel == nil {
-			// We only care about selector policies
-			return
-		}
-	}
-
-	pods := map[string]*v1.Pod{}
-	for _, p := range c.getPodsInPolicy(obj.Namespace, sel) {
-		pods[p.Status.PodIP] = p
-	}
-	if oldSel != nil {
-		for _, p := range c.getPodsInPolicy(obj.Namespace, oldSel) {
-			pods[p.Status.PodIP] = p
-		}
-	}
-
-	updates := map[model.ConfigKey]struct{}{}
-	for _, pod := range pods {
-		newWl := c.extractWorkload(pod)
-		if newWl != nil {
-			// Update the pod, since it now has new VIP info
-			networkAddrs := networkAddressFromWorkload(newWl)
-			c.ambientIndex.mu.Lock()
-			for _, networkAddr := range networkAddrs {
-				c.ambientIndex.byPod[networkAddr] = newWl
-			}
-			c.ambientIndex.byUID[c.generatePodUID(pod)] = newWl
-			c.ambientIndex.mu.Unlock()
-			updates[model.ConfigKey{Kind: kind.Address, Name: newWl.ResourceName()}] = struct{}{}
-		}
-	}
-
-	if len(updates) > 0 {
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
-			ConfigsUpdated: updates,
-			Reason:         []model.TriggerReason{model.AmbientUpdate},
-		})
-	}
-}
-
-func (c *Controller) getPodsInPolicy(ns string, sel map[string]string) []*v1.Pod {
-	if ns == c.meshWatcher.Mesh().GetRootNamespace() {
-		ns = metav1.NamespaceAll
-	}
-	return c.podsClient.List(ns, klabels.ValidatedSetSelector(sel))
-}
-
-func convertAuthorizationPolicy(rootns string, obj config.Config) *security.Authorization {
-	pol := obj.Spec.(*v1beta1.AuthorizationPolicy)
-
-	scope := security.Scope_WORKLOAD_SELECTOR
-	if pol.Selector == nil {
-		scope = security.Scope_NAMESPACE
-		// TODO: TDA
-		if rootns == obj.Namespace {
-			scope = security.Scope_GLOBAL // TODO: global workload?
-		}
-	}
-	action := security.Action_ALLOW
-	switch pol.Action {
-	case v1beta1.AuthorizationPolicy_ALLOW:
-	case v1beta1.AuthorizationPolicy_DENY:
-		action = security.Action_DENY
-	default:
-		return nil
-	}
-	opol := &security.Authorization{
-		Name:      obj.Name,
-		Namespace: obj.Namespace,
-		Scope:     scope,
-		Action:    action,
-		Groups:    nil,
-	}
-
-	for _, rule := range pol.Rules {
-		rules := handleRule(action, rule)
-		if rules != nil {
-			rg := &security.Group{
-				Rules: rules,
-			}
-			opol.Groups = append(opol.Groups, rg)
-		}
-	}
-
-	return opol
-}
-
-func anyNonEmpty[T any](arr ...[]T) bool {
-	for _, a := range arr {
-		if len(a) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func handleRule(action security.Action, rule *v1beta1.Rule) []*security.Rules {
-	toMatches := []*security.Match{}
-	for _, to := range rule.To {
-		op := to.Operation
-		if action == security.Action_ALLOW && anyNonEmpty(op.Hosts, op.NotHosts, op.Methods, op.NotMethods, op.Paths, op.NotPaths) {
-			// L7 policies never match for ALLOW
-			// For DENY they will always match, so it is more restrictive
-			return nil
-		}
-		match := &security.Match{
-			DestinationPorts:    stringToPort(op.Ports),
-			NotDestinationPorts: stringToPort(op.NotPorts),
-		}
-		// if !emptyRuleMatch(match) {
-		toMatches = append(toMatches, match)
-		//}
-	}
-	fromMatches := []*security.Match{}
-	for _, from := range rule.From {
-		op := from.Source
-		if action == security.Action_ALLOW && anyNonEmpty(op.RemoteIpBlocks, op.NotRemoteIpBlocks, op.RequestPrincipals, op.NotRequestPrincipals) {
-			// L7 policies never match for ALLOW
-			// For DENY they will always match, so it is more restrictive
-			return nil
-		}
-		match := &security.Match{
-			SourceIps:     stringToIP(op.IpBlocks),
-			NotSourceIps:  stringToIP(op.NotIpBlocks),
-			Namespaces:    stringToMatch(op.Namespaces),
-			NotNamespaces: stringToMatch(op.NotNamespaces),
-			Principals:    stringToMatch(op.Principals),
-			NotPrincipals: stringToMatch(op.NotPrincipals),
-		}
-		// if !emptyRuleMatch(match) {
-		fromMatches = append(fromMatches, match)
-		//}
-	}
-
-	rules := []*security.Rules{}
-	if len(toMatches) > 0 {
-		rules = append(rules, &security.Rules{Matches: toMatches})
-	}
-	if len(fromMatches) > 0 {
-		rules = append(rules, &security.Rules{Matches: fromMatches})
-	}
-	for _, when := range rule.When {
-		l4 := l4WhenAttributes.Contains(when.Key)
-		if action == security.Action_ALLOW && !l4 {
-			// L7 policies never match for ALLOW
-			// For DENY they will always match, so it is more restrictive
-			return nil
-		}
-		positiveMatch := &security.Match{
-			Namespaces:       whenMatch("source.namespace", when, false, stringToMatch),
-			Principals:       whenMatch("source.principal", when, false, stringToMatch),
-			SourceIps:        whenMatch("source.ip", when, false, stringToIP),
-			DestinationPorts: whenMatch("destination.port", when, false, stringToPort),
-			DestinationIps:   whenMatch("destination.ip", when, false, stringToIP),
-
-			NotNamespaces:       whenMatch("source.namespace", when, true, stringToMatch),
-			NotPrincipals:       whenMatch("source.principal", when, true, stringToMatch),
-			NotSourceIps:        whenMatch("source.ip", when, true, stringToIP),
-			NotDestinationPorts: whenMatch("destination.port", when, true, stringToPort),
-			NotDestinationIps:   whenMatch("destination.ip", when, true, stringToIP),
-		}
-		rules = append(rules, &security.Rules{Matches: []*security.Match{positiveMatch}})
-	}
-	return rules
-}
-
-var l4WhenAttributes = sets.New(
-	"source.ip",
-	"source.namespace",
-	"source.principal",
-	"destination.ip",
-	"destination.port",
-)
-
-func whenMatch[T any](s string, when *v1beta1.Condition, invert bool, f func(v []string) []T) []T {
-	if when.Key != s {
-		return nil
-	}
-	if invert {
-		return f(when.NotValues)
-	}
-	return f(when.Values)
-}
-
-func stringToMatch(rules []string) []*security.StringMatch {
-	res := make([]*security.StringMatch, 0, len(rules))
-	for _, v := range rules {
-		var sm *security.StringMatch
-		switch {
-		case v == "*":
-			sm = &security.StringMatch{MatchType: &security.StringMatch_Presence{}}
-		case strings.HasPrefix(v, "*"):
-			sm = &security.StringMatch{MatchType: &security.StringMatch_Suffix{
-				Suffix: strings.TrimPrefix(v, "*"),
-			}}
-		case strings.HasSuffix(v, "*"):
-			sm = &security.StringMatch{MatchType: &security.StringMatch_Prefix{
-				Prefix: strings.TrimSuffix(v, "*"),
-			}}
-		default:
-			sm = &security.StringMatch{MatchType: &security.StringMatch_Exact{
-				Exact: v,
-			}}
-		}
-		res = append(res, sm)
-	}
-	return res
-}
-
-func stringToPort(rules []string) []uint32 {
-	res := make([]uint32, 0, len(rules))
-	for _, m := range rules {
-		p, err := strconv.ParseUint(m, 10, 32)
-		if err != nil || p > 65535 {
-			continue
-		}
-		res = append(res, uint32(p))
-	}
-	return res
-}
-
-func stringToIP(rules []string) []*security.Address {
-	res := make([]*security.Address, 0, len(rules))
-	for _, m := range rules {
-		if len(m) == 0 {
-			continue
-		}
-
-		var (
-			ipAddr        netip.Addr
-			maxCidrPrefix uint32
-		)
-
-		if strings.Contains(m, "/") {
-			ipp, err := netip.ParsePrefix(m)
-			if err != nil {
-				continue
-			}
-			ipAddr = ipp.Addr()
-			maxCidrPrefix = uint32(ipp.Bits())
-		} else {
-			ipa, err := netip.ParseAddr(m)
-			if err != nil {
-				continue
-			}
-
-			ipAddr = ipa
-			maxCidrPrefix = uint32(ipAddr.BitLen())
-		}
-
-		res = append(res, &security.Address{
-			Address: ipAddr.AsSlice(),
-			Length:  maxCidrPrefix,
-		})
-	}
-	return res
-}
-
 func (c *Controller) constructService(svc *v1.Service) *model.ServiceInfo {
 	ports := make([]*workloadapi.Port, 0, len(svc.Spec.Ports))
 	for _, p := range svc.Spec.Ports {
@@ -654,7 +316,6 @@ func (c *Controller) extractWorkload(p *v1.Pod) *model.WorkloadInfo {
 		// Waypoints do not have waypoints
 	} else {
 		// First check for a waypoint for our SA explicit
-		// TODO: this is not robust against temporary waypoint downtime. We also need the users intent (Gateway).
 		found := false
 		if waypoint, found = c.ambientIndex.waypoints[model.WaypointScope{Namespace: p.Namespace, ServiceAccount: p.Spec.ServiceAccountName}]; !found {
 			// if there are none, check namespace wide waypoints
@@ -759,7 +420,6 @@ func (c *Controller) setupIndex() *AmbientIndex {
 		},
 	}
 	c.services.AddEventHandler(serviceHandler)
-	idx.serviceVipIndex = kclient.CreateIndex[string, *v1.Service](c.services, getVIPs)
 	return &idx
 }
 
@@ -966,24 +626,17 @@ func (c *Controller) getPodsInService(svc *v1.Service) []*v1.Pod {
 
 // AddressInformation returns all AddressInfo's in the cluster.
 // This may be scoped to specific subsets by specifying a non-empty addresses field
-func (c *Controller) AddressInformation(addresses sets.Set[types.NamespacedName]) ([]*model.AddressInfo, []string) {
+func (c *Controller) AddressInformation(addresses sets.String) ([]*model.AddressInfo, []string) {
 	if len(addresses) == 0 {
 		// Full update
 		return c.ambientIndex.All(), nil
 	}
 	var wls []*model.AddressInfo
 	var removed []string
-	for p := range addresses {
-		wname := p.Name
-		// GenerateDeltas has the formatted wname from the xds request, but not sure if other callers
-		// have the format enforced
-		if _, _, found := strings.Cut(p.Name, "/"); !found {
-			cNetwork := c.Network(p.Name, make(labels.Instance, 0)).String()
-			wname = cNetwork + "/" + p.Name
-		}
-		wl := c.ambientIndex.Lookup(wname)
+	for addr := range addresses {
+		wl := c.ambientIndex.Lookup(addr)
 		if len(wl) == 0 {
-			removed = append(removed, p.Name)
+			removed = append(removed, addr)
 		} else {
 			wls = append(wls, wl...)
 		}
@@ -1035,6 +688,7 @@ func (c *Controller) constructWorkload(pod *v1.Pod, waypoint *workloadapi.Gatewa
 		AuthorizationPolicies: policies,
 		Status:                workloadapi.WorkloadStatus_HEALTHY,
 		ClusterId:             c.Cluster().String(),
+		Waypoint:              waypoint,
 	}
 	if !IsPodReady(pod) {
 		wl.Status = workloadapi.WorkloadStatus_UNHEALTHY
@@ -1045,10 +699,6 @@ func (c *Controller) constructWorkload(pod *v1.Pod, waypoint *workloadapi.Gatewa
 
 	wl.WorkloadName, wl.WorkloadType = workloadNameAndType(pod)
 	wl.CanonicalName, wl.CanonicalRevision = kubelabels.CanonicalService(pod.Labels, wl.WorkloadName)
-	// If we have a remote proxy, configure it
-	if waypoint != nil {
-		wl.Waypoint = waypoint
-	}
 
 	if pod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled {
 		// Configured for override
@@ -1093,50 +743,37 @@ func getVIPs(svc *v1.Service) []string {
 
 func (c *Controller) AdditionalPodSubscriptions(
 	proxy *model.Proxy,
-	allAddresses sets.Set[types.NamespacedName],
-	currentSubs sets.Set[types.NamespacedName],
-) sets.Set[types.NamespacedName] {
-	shouldSubscribe := sets.New[types.NamespacedName]()
+	allAddresses sets.String,
+	currentSubs sets.String,
+) sets.String {
+	shouldSubscribe := sets.New[string]()
 
 	// First, we want to handle VIP subscriptions. Example:
 	// Client subscribes to VIP1. Pod1, part of VIP1, is sent.
 	// The client wouldn't be explicitly subscribed to Pod1, so it would normally ignore it.
 	// Since it is a part of VIP1 which we are subscribe to, add it to the subscriptions
-	for s := range allAddresses {
-		cNetwork := c.Network(s.Name, make(labels.Instance, 0)).String()
-		for _, wl := range c.ambientIndex.Lookup(cNetwork + "/" + s.Name) {
+	for addr := range allAddresses {
+		for _, wl := range model.ExtractWorkloadsFromAddresses(c.ambientIndex.Lookup(addr)) {
 			// We may have gotten an update for Pod, but are subscribe to a Service.
 			// We need to force a subscription on the Pod as well
-			switch addr := wl.Address.Type.(type) {
-			case *workloadapi.Address_Workload:
-				for vip := range addr.Workload.VirtualIps {
-					t := types.NamespacedName{Name: vip}
-					if currentSubs.Contains(t) {
-						shouldSubscribe.Insert(types.NamespacedName{Name: wl.ResourceName()})
-						break
-					}
+			for vip := range wl.VirtualIps {
+				if currentSubs.Contains(vip) {
+					shouldSubscribe.Insert(wl.ResourceName())
+					break
 				}
-			case *workloadapi.Address_Service:
-				// ignore, results in duplicate entries pushed to proxies
 			}
 		}
 	}
 
 	// Next, as an optimization, we will send all node-local endpoints
 	if nodeName := proxy.Metadata.NodeName; nodeName != "" {
-		for _, wl := range c.ambientIndex.All() {
-			switch addr := wl.Address.Type.(type) {
-			case *workloadapi.Address_Workload:
-				if addr.Workload.Node == nodeName {
-					n := types.NamespacedName{Name: wl.ResourceName()}
-					if currentSubs.Contains(n) {
-						continue
-					}
-					shouldSubscribe.Insert(n)
+		for _, wl := range model.ExtractWorkloadsFromAddresses(c.ambientIndex.All()) {
+			if wl.Node == nodeName {
+				n := wl.ResourceName()
+				if currentSubs.Contains(n) {
+					continue
 				}
-			case *workloadapi.Address_Service:
-				// Services are not constrained to a particular node
-				continue
+				shouldSubscribe.Insert(n)
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/authorization.go
@@ -1,0 +1,359 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"net/netip"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+
+	"istio.io/api/security/v1beta1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi/security"
+)
+
+func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []*security.Authorization {
+	if !c.configCluster {
+		return nil
+	}
+	cfgs := c.configController.List(gvk.AuthorizationPolicy, metav1.NamespaceAll)
+	l := len(cfgs)
+	if len(requested) > 0 {
+		l = len(requested)
+	}
+	res := make([]*security.Authorization, 0, l)
+	for _, cfg := range cfgs {
+		k := model.ConfigKey{
+			Kind:      kind.AuthorizationPolicy,
+			Name:      cfg.Name,
+			Namespace: cfg.Namespace,
+		}
+		if len(requested) > 0 && !requested.Contains(k) {
+			continue
+		}
+		pol := convertAuthorizationPolicy(c.meshWatcher.Mesh().GetRootNamespace(), cfg)
+		if pol == nil {
+			continue
+		}
+		res = append(res, pol)
+	}
+	return res
+}
+
+func (c *Controller) selectorAuthorizationPolicies(ns string, lbls map[string]string) []string {
+	global := c.configController.List(gvk.AuthorizationPolicy, c.meshWatcher.Mesh().GetRootNamespace())
+	local := c.configController.List(gvk.AuthorizationPolicy, ns)
+	res := sets.New[string]()
+	matches := func(c config.Config) bool {
+		sel := c.Spec.(*v1beta1.AuthorizationPolicy).Selector
+		if sel == nil {
+			return false
+		}
+		return labels.Instance(sel.MatchLabels).SubsetOf(lbls)
+	}
+
+	for _, pl := range [][]config.Config{global, local} {
+		for _, p := range pl {
+			if matches(p) {
+				res.Insert(p.Namespace + "/" + p.Name)
+			}
+		}
+	}
+	return sets.SortedList(res)
+}
+
+func (c *Controller) AuthorizationPolicyHandler(old config.Config, obj config.Config, ev model.Event) {
+	getSelector := func(c config.Config) map[string]string {
+		if c.Spec == nil {
+			return nil
+		}
+		pol := c.Spec.(*v1beta1.AuthorizationPolicy)
+		return pol.Selector.GetMatchLabels()
+	}
+	// Normal flow for AuthorizationPolicy will trigger XDS push, so we don't need to push those. But we do need
+	// to update any relevant workloads and push them.
+	sel := getSelector(obj)
+	oldSel := getSelector(old)
+
+	switch ev {
+	case model.EventUpdate:
+		if maps.Equal(sel, oldSel) {
+			// Update event, but selector didn't change. No workloads to push.
+			return
+		}
+	default:
+		if sel == nil {
+			// We only care about selector policies
+			return
+		}
+	}
+
+	pods := map[string]*v1.Pod{}
+	for _, p := range c.getPodsInPolicy(obj.Namespace, sel) {
+		pods[p.Status.PodIP] = p
+	}
+	if oldSel != nil {
+		for _, p := range c.getPodsInPolicy(obj.Namespace, oldSel) {
+			pods[p.Status.PodIP] = p
+		}
+	}
+
+	updates := map[model.ConfigKey]struct{}{}
+	for _, pod := range pods {
+		newWl := c.extractWorkload(pod)
+		if newWl != nil {
+			// Update the pod, since it now has new VIP info
+			networkAddrs := networkAddressFromWorkload(newWl)
+			c.ambientIndex.mu.Lock()
+			for _, networkAddr := range networkAddrs {
+				c.ambientIndex.byPod[networkAddr] = newWl
+			}
+			c.ambientIndex.byUID[c.generatePodUID(pod)] = newWl
+			c.ambientIndex.mu.Unlock()
+			updates[model.ConfigKey{Kind: kind.Address, Name: newWl.ResourceName()}] = struct{}{}
+		}
+	}
+
+	if len(updates) > 0 {
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
+			ConfigsUpdated: updates,
+			Reason:         []model.TriggerReason{model.AmbientUpdate},
+		})
+	}
+}
+
+func (c *Controller) getPodsInPolicy(ns string, sel map[string]string) []*v1.Pod {
+	if ns == c.meshWatcher.Mesh().GetRootNamespace() {
+		ns = metav1.NamespaceAll
+	}
+	return c.podsClient.List(ns, klabels.ValidatedSetSelector(sel))
+}
+
+func convertAuthorizationPolicy(rootns string, obj config.Config) *security.Authorization {
+	pol := obj.Spec.(*v1beta1.AuthorizationPolicy)
+
+	scope := security.Scope_WORKLOAD_SELECTOR
+	if pol.Selector == nil {
+		scope = security.Scope_NAMESPACE
+		// TODO: TDA
+		if rootns == obj.Namespace {
+			scope = security.Scope_GLOBAL // TODO: global workload?
+		}
+	}
+	action := security.Action_ALLOW
+	switch pol.Action {
+	case v1beta1.AuthorizationPolicy_ALLOW:
+	case v1beta1.AuthorizationPolicy_DENY:
+		action = security.Action_DENY
+	default:
+		return nil
+	}
+	opol := &security.Authorization{
+		Name:      obj.Name,
+		Namespace: obj.Namespace,
+		Scope:     scope,
+		Action:    action,
+		Groups:    nil,
+	}
+
+	for _, rule := range pol.Rules {
+		rules := handleRule(action, rule)
+		if rules != nil {
+			rg := &security.Group{
+				Rules: rules,
+			}
+			opol.Groups = append(opol.Groups, rg)
+		}
+	}
+
+	return opol
+}
+
+func anyNonEmpty[T any](arr ...[]T) bool {
+	for _, a := range arr {
+		if len(a) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func handleRule(action security.Action, rule *v1beta1.Rule) []*security.Rules {
+	toMatches := []*security.Match{}
+	for _, to := range rule.To {
+		op := to.Operation
+		if action == security.Action_ALLOW && anyNonEmpty(op.Hosts, op.NotHosts, op.Methods, op.NotMethods, op.Paths, op.NotPaths) {
+			// L7 policies never match for ALLOW
+			// For DENY they will always match, so it is more restrictive
+			return nil
+		}
+		match := &security.Match{
+			DestinationPorts:    stringToPort(op.Ports),
+			NotDestinationPorts: stringToPort(op.NotPorts),
+		}
+		toMatches = append(toMatches, match)
+	}
+	fromMatches := []*security.Match{}
+	for _, from := range rule.From {
+		op := from.Source
+		if action == security.Action_ALLOW && anyNonEmpty(op.RemoteIpBlocks, op.NotRemoteIpBlocks, op.RequestPrincipals, op.NotRequestPrincipals) {
+			// L7 policies never match for ALLOW
+			// For DENY they will always match, so it is more restrictive
+			return nil
+		}
+		match := &security.Match{
+			SourceIps:     stringToIP(op.IpBlocks),
+			NotSourceIps:  stringToIP(op.NotIpBlocks),
+			Namespaces:    stringToMatch(op.Namespaces),
+			NotNamespaces: stringToMatch(op.NotNamespaces),
+			Principals:    stringToMatch(op.Principals),
+			NotPrincipals: stringToMatch(op.NotPrincipals),
+		}
+		fromMatches = append(fromMatches, match)
+	}
+
+	rules := []*security.Rules{}
+	if len(toMatches) > 0 {
+		rules = append(rules, &security.Rules{Matches: toMatches})
+	}
+	if len(fromMatches) > 0 {
+		rules = append(rules, &security.Rules{Matches: fromMatches})
+	}
+	for _, when := range rule.When {
+		l4 := l4WhenAttributes.Contains(when.Key)
+		if action == security.Action_ALLOW && !l4 {
+			// L7 policies never match for ALLOW
+			// For DENY they will always match, so it is more restrictive
+			return nil
+		}
+		positiveMatch := &security.Match{
+			Namespaces:       whenMatch("source.namespace", when, false, stringToMatch),
+			Principals:       whenMatch("source.principal", when, false, stringToMatch),
+			SourceIps:        whenMatch("source.ip", when, false, stringToIP),
+			DestinationPorts: whenMatch("destination.port", when, false, stringToPort),
+			DestinationIps:   whenMatch("destination.ip", when, false, stringToIP),
+
+			NotNamespaces:       whenMatch("source.namespace", when, true, stringToMatch),
+			NotPrincipals:       whenMatch("source.principal", when, true, stringToMatch),
+			NotSourceIps:        whenMatch("source.ip", when, true, stringToIP),
+			NotDestinationPorts: whenMatch("destination.port", when, true, stringToPort),
+			NotDestinationIps:   whenMatch("destination.ip", when, true, stringToIP),
+		}
+		rules = append(rules, &security.Rules{Matches: []*security.Match{positiveMatch}})
+	}
+	return rules
+}
+
+var l4WhenAttributes = sets.New(
+	"source.ip",
+	"source.namespace",
+	"source.principal",
+	"destination.ip",
+	"destination.port",
+)
+
+func whenMatch[T any](s string, when *v1beta1.Condition, invert bool, f func(v []string) []T) []T {
+	if when.Key != s {
+		return nil
+	}
+	if invert {
+		return f(when.NotValues)
+	}
+	return f(when.Values)
+}
+
+func stringToMatch(rules []string) []*security.StringMatch {
+	res := make([]*security.StringMatch, 0, len(rules))
+	for _, v := range rules {
+		var sm *security.StringMatch
+		switch {
+		case v == "*":
+			sm = &security.StringMatch{MatchType: &security.StringMatch_Presence{}}
+		case strings.HasPrefix(v, "*"):
+			sm = &security.StringMatch{MatchType: &security.StringMatch_Suffix{
+				Suffix: strings.TrimPrefix(v, "*"),
+			}}
+		case strings.HasSuffix(v, "*"):
+			sm = &security.StringMatch{MatchType: &security.StringMatch_Prefix{
+				Prefix: strings.TrimSuffix(v, "*"),
+			}}
+		default:
+			sm = &security.StringMatch{MatchType: &security.StringMatch_Exact{
+				Exact: v,
+			}}
+		}
+		res = append(res, sm)
+	}
+	return res
+}
+
+func stringToPort(rules []string) []uint32 {
+	res := make([]uint32, 0, len(rules))
+	for _, m := range rules {
+		p, err := strconv.ParseUint(m, 10, 32)
+		if err != nil || p > 65535 {
+			continue
+		}
+		res = append(res, uint32(p))
+	}
+	return res
+}
+
+func stringToIP(rules []string) []*security.Address {
+	res := make([]*security.Address, 0, len(rules))
+	for _, m := range rules {
+		if len(m) == 0 {
+			continue
+		}
+
+		var (
+			ipAddr        netip.Addr
+			maxCidrPrefix uint32
+		)
+
+		if strings.Contains(m, "/") {
+			ipp, err := netip.ParsePrefix(m)
+			if err != nil {
+				continue
+			}
+			ipAddr = ipp.Addr()
+			maxCidrPrefix = uint32(ipp.Bits())
+		} else {
+			ipa, err := netip.ParseAddr(m)
+			if err != nil {
+				continue
+			}
+
+			ipAddr = ipa
+			maxCidrPrefix = uint32(ipAddr.BitLen())
+		}
+
+		res = append(res, &security.Address{
+			Address: ipAddr.AsSlice(),
+			Length:  maxCidrPrefix,
+		})
+	}
+	return res
+}

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -413,7 +413,7 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 	}
 
 	// Otherwise has ambient enabled. Note: this is a synthetic label, not existing in the real Pod.
-	if b.push.SupportsTunnel(e.Address) {
+	if b.push.SupportsTunnel(e.Network, e.Address) {
 		supportsTunnel = true
 	}
 	// Otherwise supports tunnel

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -111,6 +111,17 @@ func Map[E any, O any](s []E, f func(E) O) []O {
 	return n
 }
 
+// MapFilter runs f() over all elements in s and returns any non-nil results
+func MapFilter[E any, O any](s []E, f func(E) *O) []O {
+	n := make([]O, 0, len(s))
+	for _, e := range s {
+		if res := f(e); res != nil {
+			n = append(n, *res)
+		}
+	}
+	return n
+}
+
 // Reference takes a pointer to all elements in the slice
 func Reference[E any](s []E) []*E {
 	res := make([]*E, 0, len(s))


### PR DESCRIPTION
* Consistently use resource key as `network/foo`. Use string instead of
  NamespaceName and remove logic that assumes other key formats
* Add a helper to avoid so many type switches
* Move out authz rules to its own file; no changes, just moving
* A few other nit fixes as followup from PR
