### PR TITLE
serviceentry: Fix stable IP allocation with duplicate host in same namespace

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -946,23 +946,22 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	hnMap := make(map[string]octetPair)
 	allocated := 0
 	for _, svc := range hashedServices {
-		if svc == nil {
-			// There is no service in the slot. Just increment x and move forward.
+		// Regardless of wether a slot is used, if we have IP re-use or allocate a new IP, we want to preserve
+		// a relation between the index in hashedServices and the allocated IP
+		x++
+		if x%255 == 0 {
 			x++
-			if x%255 == 0 {
-				x++
-			}
+		}
+
+		if svc == nil {
 			continue
 		}
+
 		n := makeServiceKey(svc)
 		if v, ok := hnMap[n]; ok {
 			log.Debugf("Reuse IP for domain %s", n)
 			setAutoAllocatedIPs(svc, v)
 		} else {
-			x++
-			if x%255 == 0 {
-				x++
-			}
 			if allocated >= maxIPs {
 				log.Errorf("out of IPs to allocate for service entries. x:= %d, maxips:= %d", x, maxIPs)
 				return services


### PR DESCRIPTION
When an IP was reused (the same host name used in two service entries

This caused a change in all subsequent IP allocations, regardless of
namespace, and intermittent BlackHoleCluster for all services with
higher IPs.

This change removes this problem condition, and adds a regression test.

There are a few cases where IPs still can change:

* Adding a duplicate service entry in a namespace, if the conflict
  resolution hash is lower than the first hash. This could probably be
  fixed by relocating the IP reuse logic to the first loop.

* Deleting the oldest service entry of an host with the same hash value
  as another service entry

But none of these has the large cascading effect as this issue.

For clusters with IP auto allocation and duplicate hostnames in a single
namespace, this change will change auto allocated IPs.