### PR TITLE
Allow lookup of GVK from client-go types

### DIFF
--- a/pkg/config/schema/codegen/templates/types.go.tmpl
+++ b/pkg/config/schema/codegen/templates/types.go.tmpl
@@ -10,6 +10,11 @@ import (
 {{- range .Packages}}
 	{{.ImportName}} "{{.PackageName}}"
 {{- end}}
+	apiistioioapiextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	apiistioioapinetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	apiistioioapinetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	apiistioioapisecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	apiistioioapitelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 )
 
 func GetGVK[T runtime.Object]() config.GroupVersionKind {
@@ -17,6 +22,10 @@ func GetGVK[T runtime.Object]() config.GroupVersionKind {
 {{- range .Entries }}
 	case *{{ .ClientImport }}.{{ .Resource.Kind }}:
 		return gvk.{{ .Resource.Identifier }}
+	{{- if and (not (eq .ClientImport .IstioAwareClientImport)) (not .Resource.Synthetic) }}
+	case *{{ .IstioAwareClientImport }}.{{ .Resource.Kind }}:
+		return gvk.{{ .Resource.Identifier }}
+    {{- end }}
 {{- end }}
   default:
     panic(fmt.Sprintf("Unknown type %T", ptr.Empty[T]()))

--- a/pkg/config/schema/kubetypes/resources.gen.go
+++ b/pkg/config/schema/kubetypes/resources.gen.go
@@ -23,6 +23,11 @@ import (
 	istioioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istioioapisecurityv1beta1 "istio.io/api/security/v1beta1"
 	istioioapitelemetryv1alpha1 "istio.io/api/telemetry/v1alpha1"
+	apiistioioapiextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	apiistioioapinetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	apiistioioapinetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	apiistioioapisecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+	apiistioioapitelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/ptr"
@@ -31,6 +36,8 @@ import (
 func GetGVK[T runtime.Object]() config.GroupVersionKind {
 	switch any(ptr.Empty[T]()).(type) {
 	case *istioioapisecurityv1beta1.AuthorizationPolicy:
+		return gvk.AuthorizationPolicy
+	case *apiistioioapisecurityv1beta1.AuthorizationPolicy:
 		return gvk.AuthorizationPolicy
 	case *k8sioapicertificatesv1.CertificateSigningRequest:
 		return gvk.CertificateSigningRequest
@@ -42,15 +49,21 @@ func GetGVK[T runtime.Object]() config.GroupVersionKind {
 		return gvk.Deployment
 	case *istioioapinetworkingv1alpha3.DestinationRule:
 		return gvk.DestinationRule
+	case *apiistioioapinetworkingv1alpha3.DestinationRule:
+		return gvk.DestinationRule
 	case *k8sioapidiscoveryv1.EndpointSlice:
 		return gvk.EndpointSlice
 	case *k8sioapicorev1.Endpoints:
 		return gvk.Endpoints
 	case *istioioapinetworkingv1alpha3.EnvoyFilter:
 		return gvk.EnvoyFilter
+	case *apiistioioapinetworkingv1alpha3.EnvoyFilter:
+		return gvk.EnvoyFilter
 	case *sigsk8siogatewayapiapisv1alpha2.GRPCRoute:
 		return gvk.GRPCRoute
 	case *istioioapinetworkingv1alpha3.Gateway:
+		return gvk.Gateway
+	case *apiistioioapinetworkingv1alpha3.Gateway:
 		return gvk.Gateway
 	case *sigsk8siogatewayapiapisv1beta1.GatewayClass:
 		return gvk.GatewayClass
@@ -74,13 +87,19 @@ func GetGVK[T runtime.Object]() config.GroupVersionKind {
 		return gvk.Node
 	case *istioioapisecurityv1beta1.PeerAuthentication:
 		return gvk.PeerAuthentication
+	case *apiistioioapisecurityv1beta1.PeerAuthentication:
+		return gvk.PeerAuthentication
 	case *k8sioapicorev1.Pod:
 		return gvk.Pod
 	case *istioioapinetworkingv1beta1.ProxyConfig:
 		return gvk.ProxyConfig
+	case *apiistioioapinetworkingv1beta1.ProxyConfig:
+		return gvk.ProxyConfig
 	case *sigsk8siogatewayapiapisv1beta1.ReferenceGrant:
 		return gvk.ReferenceGrant
 	case *istioioapisecurityv1beta1.RequestAuthentication:
+		return gvk.RequestAuthentication
+	case *apiistioioapisecurityv1beta1.RequestAuthentication:
 		return gvk.RequestAuthentication
 	case *k8sioapicorev1.Secret:
 		return gvk.Secret
@@ -90,7 +109,11 @@ func GetGVK[T runtime.Object]() config.GroupVersionKind {
 		return gvk.ServiceAccount
 	case *istioioapinetworkingv1alpha3.ServiceEntry:
 		return gvk.ServiceEntry
+	case *apiistioioapinetworkingv1alpha3.ServiceEntry:
+		return gvk.ServiceEntry
 	case *istioioapinetworkingv1alpha3.Sidecar:
+		return gvk.Sidecar
+	case *apiistioioapinetworkingv1alpha3.Sidecar:
 		return gvk.Sidecar
 	case *sigsk8siogatewayapiapisv1alpha2.TCPRoute:
 		return gvk.TCPRoute
@@ -98,17 +121,27 @@ func GetGVK[T runtime.Object]() config.GroupVersionKind {
 		return gvk.TLSRoute
 	case *istioioapitelemetryv1alpha1.Telemetry:
 		return gvk.Telemetry
+	case *apiistioioapitelemetryv1alpha1.Telemetry:
+		return gvk.Telemetry
 	case *sigsk8siogatewayapiapisv1alpha2.UDPRoute:
 		return gvk.UDPRoute
 	case *k8sioapiadmissionregistrationv1.ValidatingWebhookConfiguration:
 		return gvk.ValidatingWebhookConfiguration
 	case *istioioapinetworkingv1alpha3.VirtualService:
 		return gvk.VirtualService
+	case *apiistioioapinetworkingv1alpha3.VirtualService:
+		return gvk.VirtualService
 	case *istioioapiextensionsv1alpha1.WasmPlugin:
+		return gvk.WasmPlugin
+	case *apiistioioapiextensionsv1alpha1.WasmPlugin:
 		return gvk.WasmPlugin
 	case *istioioapinetworkingv1alpha3.WorkloadEntry:
 		return gvk.WorkloadEntry
+	case *apiistioioapinetworkingv1alpha3.WorkloadEntry:
+		return gvk.WorkloadEntry
 	case *istioioapinetworkingv1alpha3.WorkloadGroup:
+		return gvk.WorkloadGroup
+	case *apiistioioapinetworkingv1alpha3.WorkloadGroup:
 		return gvk.WorkloadGroup
 	default:
 		panic(fmt.Sprintf("Unknown type %T", ptr.Empty[T]()))


### PR DESCRIPTION
This is useful when constructing clients from type. WE don't do this
yet, but splitting out to avoid larger PR.
