### PR TITLE
use file.AtomicWrite to chmod auth

### DIFF
--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -29,6 +29,7 @@ import (
 
 	"istio.io/istio/cni/pkg/ambient/constants"
 	ebpf "istio.io/istio/cni/pkg/ebpf/server"
+	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
@@ -279,15 +280,7 @@ func (c *AmbientConfigFile) write() error {
 
 	log.Infof("Writing ambient config: %s", data)
 
-	return atomicWrite(configFile, data)
-}
-
-func atomicWrite(filename string, data []byte) error {
-	tmpFile := filename + ".tmp"
-	if err := os.WriteFile(tmpFile, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmpFile, filename)
+	return file.AtomicWrite(configFile, data, os.FileMode(0o644))
 }
 
 func ReadAmbientConfig() (*AmbientConfigFile, error) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #45304

I am not sure this pr can fix it totally, But it is useful for the error :
```
error ambient Failed to write config file: open /etc/ambient-config/config.json.tmp: permission denied
```
file.AtomicWrite try to chmod tmp file ,but atomicWrite not


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
