### PR TITLE
remove ownerRef for auto-registered workloadentry

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -662,13 +662,6 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 			Namespace:        proxy.Metadata.Namespace,
 			Labels:           entry.Labels,
 			Annotations:      annotations,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: groupCfg.GroupVersionKind.GroupVersion(),
-				Kind:       groupCfg.GroupVersionKind.Kind,
-				Name:       groupCfg.Name,
-				UID:        kubetypes.UID(groupCfg.UID),
-				Controller: &workloadGroupIsController,
-			}},
 		},
 		Spec: entry,
 		// TODO status fields used for garbage collection

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -24,9 +24,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubetypes "k8s.io/apimachinery/pkg/types"
-
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -288,13 +285,6 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 				AutoRegistrationGroupAnnotation: group.Name,
 				"foo":                           "bar",
 			},
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: group.GroupVersionKind.GroupVersion(),
-				Kind:       group.GroupVersionKind.Kind,
-				Name:       group.Name,
-				UID:        kubetypes.UID(group.UID),
-				Controller: &workloadGroupIsController,
-			}},
 		},
 		Spec: &v1alpha3.WorkloadEntry{
 			Address: "10.0.0.1",

--- a/releasenotes/notes/45329.yaml
+++ b/releasenotes/notes/45329.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 45329
+releaseNotes:
+  - |
+    **Updated** Automatically registered `WorkloadEntry` resources will no longer have an `OwnerRef`
+    to their associated `WorkloadGroup`


### PR DESCRIPTION
another alternative to deal with WorkloadGroup deletion being slow to recover WorkloadEntries. This makes it so there is nothing to recover. 

To make this change backwards compatible, we'd need to make this reconcile all auto-registered WorkloadEntry and remove existing owerref. I don't think that's worth doing. 