### PR TITLE
use defer to unlock

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -191,6 +191,7 @@ func (e *envoy) Run(abort <-chan error) error {
 		log.Warnf("Aborting proxy")
 		if errKill := cmd.Process.Kill(); errKill != nil {
 			log.Warnf("killing proxy caused an error %v", errKill)
+			return errKill
 		}
 		return err
 	case err := <-done:

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -191,7 +191,6 @@ func (e *envoy) Run(abort <-chan error) error {
 		log.Warnf("Aborting proxy")
 		if errKill := cmd.Process.Kill(); errKill != nil {
 			log.Warnf("killing proxy caused an error %v", errKill)
-			return errKill
 		}
 		return err
 	case err := <-done:

--- a/releasenotes/notes/45331.yaml
+++ b/releasenotes/notes/45331.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+    **Fixed** use defer to unlock mutex

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -255,6 +255,7 @@ func (sc *SecretManagerClient) GenerateSecret(resourceName string) (secret *secu
 		// possible by keeping the output in a directory with clever use of symlinks in the future,
 		// if needed.
 		sc.outputMutex.Lock()
+		defer sc.outputMutex.Unlock()
 		if resourceName == security.RootCertReqResourceName || resourceName == security.WorkloadKeyCertResourceName {
 			if err := nodeagentutil.OutputKeyCertToDir(sc.configOptions.OutputKeyCertToDir, secret.PrivateKey,
 				secret.CertificateChain, secret.RootCert); err != nil {
@@ -263,7 +264,6 @@ func (sc *SecretManagerClient) GenerateSecret(resourceName string) (secret *secu
 				resourceLog(resourceName).Debugf("output the resource to %v", sc.configOptions.OutputKeyCertToDir)
 			}
 		}
-		sc.outputMutex.Unlock()
 	}()
 
 	// First try to generate secret from file.


### PR DESCRIPTION
**Please provide a description of this PR:**
- Correctly return the exception information caused by the cmd kill error when envoy stops, and print the correct log to facilitate troubleshooting
- Use defer to release the lock, so we will never forget unlock it