### PR TITLE
Add missing outputformat usage for istioctl envoy-stats

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -804,7 +804,7 @@ func statsConfigCmd() *cobra.Command {
 		},
 		ValidArgsFunction: validPodsNameArgs,
 	}
-	statsConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|prom")
+	statsConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|prom|prom-merged")
 	statsConfigCmd.PersistentFlags().StringVarP(&statsType, "type", "t", "server", "Where to grab the stats: one of server|clusters")
 
 	return statsConfigCmd


### PR DESCRIPTION
**Please provide a description of this PR:**
`istioctl x envoy-stats` support `prom-merged` format output, but not reflect in usage.

