### PR TITLE
monitoring: drop raw usage of OC library

### DIFF
--- a/cni/pkg/repair/repair_test.go
+++ b/cni/pkg/repair/repair_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opencensus.io/tag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -320,7 +319,7 @@ func TestDeletePods(t *testing.T) {
 		wantErr   bool
 		wantPods  []*corev1.Pod
 		wantCount float64
-		wantTags  []tag.Tag
+		wantTags   map[string]string
 	}{
 		{
 			name:   "No broken pods",
@@ -345,11 +344,12 @@ func TestDeletePods(t *testing.T) {
 			wantPods:  []*corev1.Pod{workingPod, workingPodDiedPreviously},
 			wantErr:   false,
 			wantCount: 1,
-			wantTags:  []tag.Tag{{Key: tag.Key(resultLabel), Value: resultSuccess}, {Key: tag.Key(typeLabel), Value: deleteType}},
+			wantTags:   map[string]string{"result": resultSuccess, "type": deleteType},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mt := monitortest.New(t)
 			tt.config.DeletePods = true
 			c, err := NewRepairController(tt.client, tt.config)
 			assert.NoError(t, err)
@@ -368,6 +368,9 @@ func TestDeletePods(t *testing.T) {
 				})
 				return havePods
 			}, tt.wantPods)
+			if tt.wantCount > 0 {
+				mt.Assert(podsRepaired.Name(), tt.wantTags, monitortest.Exactly(tt.wantCount))
+			}
 		})
 	}
 }

--- a/cni/pkg/repair/repair_test.go
+++ b/cni/pkg/repair/repair_test.go
@@ -319,7 +319,7 @@ func TestDeletePods(t *testing.T) {
 		wantErr   bool
 		wantPods  []*corev1.Pod
 		wantCount float64
-		wantTags   map[string]string
+		wantTags  map[string]string
 	}{
 		{
 			name:   "No broken pods",
@@ -344,7 +344,7 @@ func TestDeletePods(t *testing.T) {
 			wantPods:  []*corev1.Pod{workingPod, workingPodDiedPreviously},
 			wantErr:   false,
 			wantCount: 1,
-			wantTags:   map[string]string{"result": resultSuccess, "type": deleteType},
+			wantTags:  map[string]string{"result": resultSuccess, "type": deleteType},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/version/version_linux_test.go
+++ b/pkg/version/version_linux_test.go
@@ -15,8 +15,9 @@
 package version
 
 import (
-	"istio.io/istio/pkg/monitoring/monitortest"
 	"testing"
+
+	"istio.io/istio/pkg/monitoring/monitortest"
 )
 
 func TestRecordComponentBuildTag(t *testing.T) {

--- a/pkg/version/version_linux_test.go
+++ b/pkg/version/version_linux_test.go
@@ -15,12 +15,8 @@
 package version
 
 import (
-	"context"
-	"errors"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"testing"
-
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 func TestRecordComponentBuildTag(t *testing.T) {
@@ -44,81 +40,9 @@ func TestRecordComponentBuildTag(t *testing.T) {
 
 	for _, v := range cases {
 		t.Run(v.name, func(tt *testing.T) {
+			mt := monitortest.New(t)
 			v.in.RecordComponentBuildTag("test")
-
-			d1, _ := view.RetrieveData("istio/build")
-			gauge := d1[0].Data.(*view.LastValueData)
-			if got, want := gauge.Value, 1.0; got != want {
-				tt.Errorf("bad value for build tag gauge: got %f, want %f", got, want)
-			}
-
-			for _, tag := range d1[0].Tags {
-				if tag.Key == gitTagKey && tag.Value == v.wantTag {
-					return
-				}
-			}
-
-			tt.Errorf("build tag not found for metric: %#v", d1)
-		})
-	}
-}
-
-func TestRecordComponentBuildTagError(t *testing.T) {
-	bi := BuildInfo{
-		Version:       "VER",
-		GitRevision:   "GITREV",
-		GolangVersion: "GOLANGVER",
-		BuildStatus:   "STATUS",
-		GitTag:        "TAG",
-	}
-
-	bi.recordBuildTag("failure", func(context.Context, ...tag.Mutator) (context.Context, error) {
-		return context.Background(), errors.New("error")
-	})
-
-	d1, _ := view.RetrieveData("istio/build")
-	for _, data := range d1 {
-		for _, tag := range data.Tags {
-			if tag.Key.Name() == "component" && tag.Value == "failure" {
-				t.Errorf("a value was recorded for the failure component unexpectedly")
-			}
-		}
-	}
-}
-
-func TestRegisterStatsPanics(t *testing.T) {
-	cases := []struct {
-		name        string
-		newTagKeyFn func(string) (tag.Key, error)
-	}{
-		{
-			"tag", func(n string) (tag.Key, error) {
-				if n == "tag" {
-					return tag.Key{}, errors.New("failure")
-				}
-				return tag.NewKey(n)
-			},
-		},
-		{
-			"component", func(n string) (tag.Key, error) {
-				if n == "component" {
-					return tag.Key{}, errors.New("failure")
-				}
-				return tag.NewKey(n)
-			},
-		},
-		{"duplicate registration", tag.NewKey},
-	}
-
-	for _, v := range cases {
-		t.Run(v.name, func(tt *testing.T) {
-			defer func() {
-				if r := recover(); r == nil {
-					tt.Fatalf("expected panic!")
-				}
-			}()
-
-			registerStats(v.newTagKeyFn)
+			mt.Assert("istio_build", map[string]string{"tag": v.wantTag}, monitortest.Exactly(1))
 		})
 	}
 }


### PR DESCRIPTION
This removes most of the direct usage of OC to use `monitoring`. The only remaining usage is the `view.RegisterExporter(exporter)` which is pretty minimal and would be a tedious to change.

This should help enable us to move libraries if needed