### PR TITLE
helloworld sample update

### DIFF
--- a/samples/helloworld/helloworld-dual-stack.yaml
+++ b/samples/helloworld/helloworld-dual-stack.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    app: helloworld
+    service: helloworld
+spec:
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+  - IPv6
+  - IPv4
+  ports:
+  - port: 5000
+    name: http
+  selector:
+    app: helloworld
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld-v1
+  labels:
+    app: helloworld
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helloworld
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: helloworld
+        version: v1
+    spec:
+      containers:
+      - name: helloworld
+        image: docker.io/istio/examples-helloworld-v1
+        resources:
+          requests:
+            cpu: "100m"
+        imagePullPolicy: IfNotPresent #Always
+        ports:
+        - containerPort: 5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloworld-v2
+  labels:
+    app: helloworld
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helloworld
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: helloworld
+        version: v2
+    spec:
+      containers:
+      - name: helloworld
+        image: docker.io/istio/examples-helloworld-v2
+        resources:
+          requests:
+            cpu: "100m"
+        imagePullPolicy: IfNotPresent #Always
+        ports:
+        - containerPort: 5000

--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -22,7 +22,9 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # old image had curl and could be used as a sample client if desired
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update \
+  && apt-get install curl --no-install-recommends -y \
+  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000
 

--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -26,4 +26,6 @@ EXPOSE 5000
 ARG service_version
 ENV SERVICE_VERSION ${service_version:-v1}
 
-CMD ["python", "app.py"]
+# image will bind on TCP6 by default. In k8s pod spec (in a deployment pod template most likely) override for explicit IPv4 if needed with the command shown below:
+# ["gunicorn", "-b", "[0.0.0.0]:5000", "app:app", "-k", "gevent"]
+CMD ["gunicorn", "-b", "[::]:5000", "app:app", "-k", "gevent"]

--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -21,6 +21,9 @@ COPY requirements.txt ./
 # install the dependencies and packages in the requirements file
 RUN pip install --no-cache-dir -r requirements.txt
 
+# old image had curl and could be used as a sample client if desired
+RUN apt-get update && apt-get install -y curl
+
 EXPOSE 5000
 
 ARG service_version

--- a/samples/helloworld/src/app.py
+++ b/samples/helloworld/src/app.py
@@ -38,4 +38,4 @@ def health():
 
 
 if __name__ == "__main__":
-    app.run(host='::', threaded=True)
+    app.run(host='127.0.0.1', threaded=True) # listen on IPv4; gunicorn will accept IPv6 from outside the pod

--- a/samples/helloworld/src/app.py
+++ b/samples/helloworld/src/app.py
@@ -38,4 +38,4 @@ def health():
 
 
 if __name__ == "__main__":
-    app.run(host='127.0.0.1', threaded=True) # listen on IPv4; gunicorn will accept IPv6 from outside the pod
+    app.run(host='127.0.0.1', threaded=True)  # listen on IPv4; gunicorn will accept IPv6 from outside the pod

--- a/samples/helloworld/src/requirements.txt
+++ b/samples/helloworld/src/requirements.txt
@@ -5,3 +5,4 @@ flask_bootstrap
 json2html
 simplejson
 gevent
+gunicorn


### PR DESCRIPTION
**Please provide a description of this PR:**

- update helloworld to use gunicorn
    - gunicorn is standard practice for deploying flask apps
- bind TCP6 by default but offer a fallback option if necessary
    - at this stage most any systems in use will probably handle translation of IPv4 to applications which are listening IPv6 in Kubernetes but I included instructions in the Dockerfile to fall back to IPv4 explicitly
    - went ahead an moved the app itself to listening on localhost (IPv4) since gunicorn is handling IPv6 traffic coming from outside the container. This is to simplify overriding runtime config to use (only) IPv4 if for some reason it's required.
- introduce a dual stack manifest for helloworld on k8s