### PR TITLE
monitoring: cleanup more direct open census usage

### DIFF
--- a/cni/pkg/monitoring/monitoring.go
+++ b/cni/pkg/monitoring/monitoring.go
@@ -19,11 +19,8 @@ import (
 	"net"
 	"net/http"
 
-	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opencensus.io/stats/view"
-
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/network"
 )
 
@@ -38,12 +35,11 @@ func SetupMonitoring(port int, path string, stop <-chan struct{}) {
 		log.Errorf("unable to listen on socket: %v", err)
 		return
 	}
-	exporter, err := ocprom.NewExporter(ocprom.Options{Registry: prometheus.DefaultRegisterer.(*prometheus.Registry)})
+	exporter, err := monitoring.RegisterPrometheusExporter(nil, nil)
 	if err != nil {
 		log.Errorf("could not set up prometheus exporter: %v", err)
 		return
 	}
-	view.RegisterExporter(exporter)
 	mux.Handle(path, exporter)
 	monitoringServer := &http.Server{
 		Handler: mux,

--- a/operator/cmd/operator/server.go
+++ b/operator/cmd/operator/server.go
@@ -20,10 +20,8 @@ import (
 	"strings"
 	"time"
 
-	ocprom "contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
-	"go.opencensus.io/stats/view"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -38,6 +36,7 @@ import (
 	"istio.io/istio/operator/pkg/metrics"
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/version"
 )
 
@@ -191,14 +190,11 @@ func run(sArgs *serverArgs) {
 	}
 
 	log.Infof("Creating operator metrics exporter available at %s", monitoringBindAddress)
-	exporter, err := ocprom.NewExporter(ocprom.Options{
-		Registry:  ctrlmetrics.Registry.(*prometheus.Registry),
-		Namespace: "istio_install_operator",
-	})
-	if err != nil {
+	registry := ctrlmetrics.Registry.(*prometheus.Registry)
+	wrapped := prometheus.WrapRegistererWithPrefix("istio_install_operator_", registry)
+
+	if _, err := monitoring.RegisterPrometheusExporter(wrapped, registry); err != nil {
 		log.Warnf("Error while building exporter: %v", err)
-	} else {
-		view.RegisterExporter(exporter)
 	}
 
 	log.Info("Registering Components.")

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -20,10 +20,6 @@ import (
 	"net/http"
 	"time"
 
-	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opencensus.io/stats/view"
-
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/version"
@@ -66,11 +62,10 @@ func init() {
 }
 
 func addMonitor(mux *http.ServeMux) error {
-	exporter, err := ocprom.NewExporter(ocprom.Options{Registry: prometheus.DefaultRegisterer.(*prometheus.Registry)})
+	exporter, err := monitoring.RegisterPrometheusExporter(nil, nil)
 	if err != nil {
 		return fmt.Errorf("could not set up prometheus exporter: %v", err)
 	}
-	view.RegisterExporter(exporter)
 	mux.Handle(metricsPath, exporter)
 
 	mux.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -20,9 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"go.opencensus.io/stats/view"
-
 	"istio.io/istio/pilot/pkg/model/test"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -423,19 +422,8 @@ func TestJwtRefreshIntervalRecoverFromFail(t *testing.T) {
 	}
 }
 
-func getCounterValue(counterName string, t *testing.T) float64 {
-	counterValue := 0.0
-	if data, err := view.RetrieveData(counterName); err == nil {
-		if len(data) != 0 {
-			counterValue = data[0].Data.(*view.SumData).Value
-		}
-	} else {
-		t.Fatalf("failed to get value for counter %s: %v", counterName, err)
-	}
-	return counterValue
-}
-
 func TestJwtPubKeyMetric(t *testing.T) {
+	mt := monitortest.New(t)
 	defaultRefreshInterval := 50 * time.Millisecond
 	refreshIntervalOnFail := 2 * time.Millisecond
 	r := NewJwksResolver(JwtPubKeyEvictionDuration, defaultRefreshInterval, refreshIntervalOnFail, 1*time.Millisecond)
@@ -446,38 +434,35 @@ func TestJwtPubKeyMetric(t *testing.T) {
 
 	ms.ReturnErrorForFirstNumHits = 1
 
-	successValueBefore := getCounterValue(networkFetchSuccessCounter.Name(), t)
-	failValueBefore := getCounterValue(networkFetchFailCounter.Name(), t)
-
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 	cases := []struct {
+		name              string
 		in                []string
 		expectedJwtPubkey string
+		metric            string
 	}{
 		{
+			name:              "fail",
 			in:                []string{"", mockCertURL},
 			expectedJwtPubkey: "",
+			metric:            networkFetchFailCounter.Name(),
 		},
 		{
+			name:              "success",
 			in:                []string{"", mockCertURL},
 			expectedJwtPubkey: test.JwtPubKey2,
+			metric:            networkFetchFailCounter.Name(),
 		},
 	}
 
+	// First attempt should fail, but retries cause subsequent ones to succeed
+	// Mock server only returns an error on the first attempt
 	for _, c := range cases {
 		retry.UntilOrFail(t, func() bool {
 			pk, _ := r.GetPublicKey(c.in[0], c.in[1])
 			return c.expectedJwtPubkey == pk
 		}, retry.Delay(time.Millisecond))
-	}
-
-	successValueAfter := getCounterValue(networkFetchSuccessCounter.Name(), t)
-	failValueAfter := getCounterValue(networkFetchFailCounter.Name(), t)
-	if successValueBefore >= successValueAfter {
-		t.Errorf("the success counter is not incremented")
-	}
-	if failValueBefore >= failValueAfter {
-		t.Errorf("the fail counter is not incremented")
+		mt.Assert(c.metric, nil, monitortest.AtLeast(1))
 	}
 }
 

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -54,10 +54,9 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/retry"
-	sutil "istio.io/istio/security/pkg/nodeagent/util"
 )
 
 const yamlSeparator = "\n---"
@@ -1040,6 +1039,7 @@ func TestRunAndServe(t *testing.T) {
 }
 
 func testSideCarInjectorMetrics(t *testing.T) {
+	mt := monitortest.New(t)
 	expected := []string{
 		"sidecar_injection_requests_total",
 		"sidecar_injection_success_total",
@@ -1047,16 +1047,7 @@ func testSideCarInjectorMetrics(t *testing.T) {
 		"sidecar_injection_failure_total",
 	}
 	for _, e := range expected {
-		retry.UntilSuccessOrFail(t, func() error {
-			got, err := sutil.GetMetricsCounterValueWithTags(e, nil)
-			if err != nil {
-				return err
-			}
-			if got <= 0 {
-				return fmt.Errorf("metric empty")
-			}
-			return nil
-		})
+		mt.Assert(e, nil, monitortest.AtLeast(1))
 	}
 }
 

--- a/pkg/monitoring/monitoring_test.go
+++ b/pkg/monitoring/monitoring_test.go
@@ -15,14 +15,11 @@
 package monitoring_test
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
 
-	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 
 	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/monitoring/monitortest"
@@ -243,30 +240,19 @@ func (r registerFail) Register() error {
 
 type testRecordHook struct{}
 
-func (r *testRecordHook) OnRecordInt64Measure(i *stats.Int64Measure, tags []tag.Mutator, value int64) {
-}
-
-func (r *testRecordHook) OnRecordFloat64Measure(f *stats.Float64Measure, tags []tag.Mutator, value float64) {
+func (r *testRecordHook) OnRecord(name string, tags monitoring.LabelSet, value float64) {
 	// Check if this is `events_total` metric.
-	if f.Name() != "events_total" {
+	if name != "events_total" {
 		return
 	}
 
-	// Get name tag of recorded testSume metric, and record the corresponding hookSum metric.
-	ctx, err := tag.New(context.Background(), tags...)
-	if err != nil {
+	nl := monitoring.MustCreateLabel("name")
+	// Get name tag of recorded testSum metric, and record the corresponding hookSum metric.
+	v, f := tags.Value(nl)
+	if !f {
 		return
 	}
-	tm := tag.FromContext(ctx)
-	tk, err := tag.NewKey("name")
-	if err != nil {
-		return
-	}
-	v, found := tm.Value(tk)
-	if !found {
-		return
-	}
-	hookSum.With(name.Value(v)).Record(value)
+	hookSum.With(nl.Value(v)).Record(value)
 }
 
 func BenchmarkCounter(b *testing.B) {

--- a/pkg/monitoring/monitortest/test.go
+++ b/pkg/monitoring/monitortest/test.go
@@ -154,6 +154,7 @@ func (m *MetricsTest) Assert(name string, tags map[string]string, val Compare, o
 		return fmt.Errorf("no matching rows found")
 	}, opt...)
 	if err != nil {
+		m.t.Logf("Metric %v not found; Dumping known metrics:", name)
 		m.Dump()
 		m.t.Fatal(err)
 	}
@@ -174,6 +175,8 @@ func toFloat(r interface{}) float64 {
 
 func (m *MetricsTest) Dump() {
 	m.t.Helper()
+	reader := metricexport.NewReader()
+	reader.ReadAndExport(m.exp)
 	m.exp.Lock()
 	defer m.exp.Unlock()
 	for name, met := range m.exp.metrics {

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -25,14 +25,12 @@ import (
 	"sync"
 	"sync/atomic"
 
-	ocprom "contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/hashicorp/go-multierror"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opencensus.io/stats/view"
 
 	"istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/server/endpoint"
 )
@@ -272,12 +270,11 @@ func (s *Instance) validate() error {
 func (s *Instance) startMetricsServer() {
 	mux := http.NewServeMux()
 
-	exporter, err := ocprom.NewExporter(ocprom.Options{Registry: prometheus.DefaultRegisterer.(*prometheus.Registry)})
+	exporter, err := monitoring.RegisterPrometheusExporter(nil, nil)
 	if err != nil {
 		log.Errorf("could not set up prometheus exporter: %v", err)
 		return
 	}
-	view.RegisterExporter(exporter)
 	mux.Handle("/metrics", LogRequests(exporter))
 	s.metricsServer = &http.Server{
 		Handler: mux,

--- a/security/pkg/monitoring/monitoring.go
+++ b/security/pkg/monitoring/monitoring.go
@@ -34,7 +34,3 @@ func init() {
 		NumOutgoingRetries,
 	)
 }
-
-func Reset() {
-	NumOutgoingRetries.Record(0)
-}

--- a/security/pkg/nodeagent/util/util.go
+++ b/security/pkg/nodeagent/util/util.go
@@ -23,8 +23,6 @@ import (
 	"path"
 	"time"
 
-	"go.opencensus.io/stats/view"
-
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/file"
 )
@@ -44,29 +42,6 @@ func ParseCertAndGetExpiryTimestamp(certByte []byte) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("failed to parse certificate: %v", err)
 	}
 	return cert.NotAfter, nil
-}
-
-// GetMetricsCounterValueWithTags returns counter value in float64. For test purpose only.
-func GetMetricsCounterValueWithTags(metricName string, tags map[string]string) (float64, error) {
-	rows, err := view.RetrieveData(metricName)
-	if err != nil {
-		return float64(0), err
-	}
-	if len(rows) == 0 {
-		return 0, nil
-	}
-	for _, row := range rows {
-		need := len(tags)
-		for _, t := range row.Tags {
-			if tags[t.Key.Name()] == t.Value {
-				need--
-			}
-		}
-		if need == 0 {
-			return rows[0].Data.(*view.SumData).Value, nil
-		}
-	}
-	return float64(0), fmt.Errorf("no metrics matched tags %s: %d", metricName, len(rows))
 }
 
 // Output the key and certificate to the given directory.


### PR DESCRIPTION
The only remaining things are the controlz stuff which is pretty tied to
opencensus currently, will deal with those at another time probably.

This cleans up all usage of opencensus outside of `pkg/monitoring`. This
is to aide in transition to Otel/Prom library usage.

There are 3 parts to this:
* Some tests not using `monitortest` yet, simply migrate them
* Move view registration into `monitoring` package
* Cleanup Hook interface to reduce exposing opencensus internals.
  Instead, only our abstraction is exposed.
