### PR TITLE
Check the disabled status when adding a log provider

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -525,7 +525,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		cfg := telemetryFilterConfig{
 			Provider:      p,
 			metricsConfig: mertricCfg,
-			AccessLogging: logging,
+			AccessLogging: logging && !tml[k].Disabled,
 			Metrics:       metrics,
 			LogsFilter:    tml[p.Name].Filter,
 			NodeType:      proxy.Type,

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -516,7 +516,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		if p == nil {
 			continue
 		}
-		_, logging := tml[k]
+		loggingCfg, logging := tml[k]
 		mertricCfg, metrics := tmm[k]
 
 		mertricCfg.RotationInterval = rotationInterval
@@ -525,7 +525,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		cfg := telemetryFilterConfig{
 			Provider:      p,
 			metricsConfig: mertricCfg,
-			AccessLogging: logging && !tml[k].Disabled,
+			AccessLogging: logging && !loggingCfg.Disabled,
 			Metrics:       metrics,
 			LogsFilter:    tml[p.Name].Filter,
 			NodeType:      proxy.Type,

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -682,6 +682,20 @@ func TestTelemetryFilters(t *testing.T) {
 			},
 		},
 	}
+	stackdriverDisabled := &tpb.Telemetry{
+		AccessLogging: []*tpb.AccessLogging{
+			{
+				Providers: []*tpb.ProviderRef{
+					{
+						Name: "stackdriver",
+					},
+				},
+				Disabled: &wrappers.BoolValue{
+					Value: true,
+				},
+			},
+		},
+	}
 
 	cfg := `{"metrics":[{"dimensions":{"add":"bar"},"name":"requests_total","tags_to_remove":["remove"]}]}`
 
@@ -931,6 +945,20 @@ func TestTelemetryFilters(t *testing.T) {
 			},
 			map[string]string{
 				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL","metric_expiry_duration":"3600s"}`,
+			},
+		},
+		{
+			"disable stackdriver",
+			[]config.Config{newTelemetry("istio-system", stackdriverDisabled)},
+			sidecar,
+			networking.ListenerClassSidecarInbound,
+			networking.ListenerProtocolHTTP,
+			&meshconfig.MeshConfig_DefaultProviders{
+				Metrics:       []string{"stackdriver"},
+				AccessLogging: []string{"stackdriver"},
+			},
+			map[string]string{
+				"istio.stackdriver": `{"disable_server_access_logging":true,"disable_host_header_fallback":true,"metric_expiry_duration":"3600s"}`,
 			},
 		},
 	}

--- a/releasenotes/notes/check-disabled-status.yaml
+++ b/releasenotes/notes/check-disabled-status.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+  - |
+    **Fixed** an issue where disabling a log provider through Istio telemetry API would not work.


### PR DESCRIPTION
**Please provide a description of this PR:**

By checking the disabled status when adding a log provider, this PR fixes an issue where disabling a log provider through Istio telemetry API would not work. Otherwise, a disabled log provider may still be added to the log configuration and cause the disabling to not work as expected. The test case in this PR verifies that with the fix this PR, a disabled log provider will not be added to the log configuration.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure