### PR TITLE
Fix getGatewayClasses has waypoint after Ambient is disabled

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1378,7 +1378,8 @@ func getGatewayClasses(r GatewayResources) map[string]k8s.GatewayController {
 	for _, obj := range r.GatewayClass {
 		gwc := obj.Spec.(*k8s.GatewayClassSpec)
 		allFound.Insert(obj.Name)
-		if gwc.ControllerName == constants.ManagedGatewayController || gwc.ControllerName == constants.ManagedGatewayMeshController {
+		if gwc.ControllerName == constants.ManagedGatewayController ||
+			features.EnableAmbientControllers && gwc.ControllerName == constants.ManagedGatewayMeshController {
 			res[obj.Name] = gwc.ControllerName
 
 			// Set status. If we created it, it may already be there. If not, set it again


### PR DESCRIPTION
**Please provide a description of this PR:**
A situation when Ambient was enabled, and the GatewayClass functioned well. 
However, after reinstallation with a minimal profile, Ambient was disabled. Despite this, the GatewayClass remains included since its status has not changed, which results in waypoint GatewayClass being unnecessarily included.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
