### PR TITLE
Trust domain logic

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -318,9 +318,9 @@ func ValidateTrustDomain(domain string) error {
 		if i == len(parts)-1 && label == "" {
 			return nil
 		}
-		if !labels.IsDNS1123Label(label) {
-			return fmt.Errorf("trust domain name %q invalid", domain)
-		}
+		//if !labels.IsDNS1123Label(label) {
+		//	return fmt.Errorf("trust domain name %q invalid", domain)
+		//}
 	}
 	return nil
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -318,9 +318,22 @@ func ValidateTrustDomain(domain string) error {
 		if i == len(parts)-1 && label == "" {
 			return nil
 		}
-		//if !labels.IsDNS1123Label(label) {
-		//	return fmt.Errorf("trust domain name %q invalid", domain)
-		//}
+
+		if strings.Contains(label, "/") {
+			split := strings.Split(label, "/")
+			for _, l := range split {
+				if !labels.IsDNS1123Label(l) {
+					return fmt.Errorf("trust domain name %q invalid", domain)
+				}
+				if strings.Contains(l, "/ns/") || strings.Contains(l, "/sa/") {
+					return fmt.Errorf("trust domain name %q invalid", domain)
+				}
+			}
+		} else {
+			if !labels.IsDNS1123Label(label) {
+				return fmt.Errorf("trust domain name %q invalid", domain)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -145,8 +145,8 @@ func TestValidateTrustDomain(t *testing.T) {
 		{"trailing dot", "foo.bar.com.", ""},
 		{"prefix dash", "-foo.bar.com", "invalid"},
 		{"forward slash separated", "foo/bar/com", ""},
-		{"forward slash separated ns", "foo/ns/com", ""},
-		{"forward slash separated sa", "foo/sa/com", ""},
+		{"forward slash separated ns", "foo/ns/com", "invalid"},
+		{"forward slash separated sa", "foo/sa/com", "invalid"},
 		{"colon separated", "foo:bar:com", "invalid"},
 	}
 	for _, tt := range tests {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -144,7 +144,9 @@ func TestValidateTrustDomain(t *testing.T) {
 		{"middle dash", "f-oo.bar.com", ""},
 		{"trailing dot", "foo.bar.com.", ""},
 		{"prefix dash", "-foo.bar.com", "invalid"},
-		{"forward slash separated", "foo/bar/com", "invalid"},
+		{"forward slash separated", "foo/bar/com", ""},
+		{"forward slash separated ns", "foo/ns/com", ""},
+		{"forward slash separated sa", "foo/sa/com", ""},
 		{"colon separated", "foo:bar:com", "invalid"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Please provide a description of this PR:**

This would allow the trust domain to contain forward slashes to expand the options the end user has for configuring their spiffe Ids.  