### PR TITLE
Remove the need of anyuid permission on OpenShift

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -65,8 +65,8 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
+            runAsUser: {{ .ProxyUID | default "1337" }}
+            runAsGroup: {{ .ProxyGID | default "1337" }}
             runAsNonRoot: true
           {{- else }}
             capabilities:

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -53,10 +53,11 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
+{{- if not (eq .Values.global.platform "openshift") }}
         runAsUser: 1337
         runAsGroup: 1337
+{{- end }}
         runAsNonRoot: true
-        fsGroup: 1337
 {{- end }}
       serviceAccountName: {{ $gateway.name }}-service-account
 {{- if .Values.global.priorityClassName }}

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -57,10 +57,9 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
-        runAsUser: 1337
-        runAsGroup: 1337
+        runAsUser: {{ .ProxyUID | default "1337" }}
+        runAsGroup: {{ .ProxyGID | default "1337" }}
         runAsNonRoot: true
-        fsGroup: 1337
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-egressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -53,10 +53,11 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
+{{- if not (eq .Values.global.platform "openshift") }}
         runAsUser: 1337
         runAsGroup: 1337
+{{- end }}
         runAsNonRoot: true
-        fsGroup: 1337
 {{- end }}
       serviceAccountName: {{ $gateway.name }}-service-account
 {{- if .Values.global.priorityClassName }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -57,10 +57,9 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
-        runAsUser: 1337
-        runAsGroup: 1337
+        runAsUser: {{ .ProxyUID | default "1337" }}
+        runAsGroup: {{ .ProxyGID | default "1337" }}
         runAsNonRoot: true
-        fsGroup: 1337
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -85,7 +85,7 @@ spec:
     - "-z"
     - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
     - "-u"
-    - "1337"
+    - {{ .ProxyUID | default "1337" | quote }}
     - "-m"
     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
     - "-i"
@@ -152,8 +152,8 @@ spec:
       runAsUser: 0
     {{- else }}
       readOnlyRootFilesystem: true
-      runAsGroup: 1337
-      runAsUser: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
+      runAsUser: {{ .ProxyUID | default "1337" }}
       runAsNonRoot: true
     {{- end }}
   {{ end -}}
@@ -359,7 +359,7 @@ spec:
         - ALL
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-      runAsGroup: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -378,13 +378,13 @@ spec:
         - ALL
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-      runAsGroup: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0
       {{- else -}}
       runAsNonRoot: true
-      runAsUser: 1337
+      runAsUser: {{ .ProxyUID | default "1337" }}
       {{- end }}
       {{- end }}
     resources:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -68,8 +68,10 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
+{{- if not (eq .Values.global.platform "openshift") }}
           runAsUser: 1337
           runAsGroup: 1337
+{{- end }}
           runAsNonRoot: true
         {{- else }}
           capabilities:

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -78,8 +78,6 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
-      securityContext:
-        fsGroup: 1337
       containers:
         - name: discovery
 {{- if contains "/" .Values.pilot.image }}
@@ -188,8 +186,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
             runAsNonRoot: true
             capabilities:
               drop:

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsUser: 1337
             runAsNonRoot: true
 {{- if .Values.operator.seccompProfile }}
             seccompProfile:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -85,7 +85,7 @@ spec:
     - "-z"
     - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
     - "-u"
-    - "1337"
+    - {{ .ProxyUID | default "1337" | quote }}
     - "-m"
     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
     - "-i"
@@ -152,8 +152,8 @@ spec:
       runAsUser: 0
     {{- else }}
       readOnlyRootFilesystem: true
-      runAsGroup: 1337
-      runAsUser: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
+      runAsUser: {{ .ProxyUID | default "1337" }}
       runAsNonRoot: true
     {{- end }}
   {{ end -}}
@@ -359,7 +359,7 @@ spec:
         - ALL
       privileged: true
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-      runAsGroup: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
       runAsNonRoot: false
       runAsUser: 0
       {{- else }}
@@ -378,13 +378,13 @@ spec:
         - ALL
       privileged: {{ .Values.global.proxy.privileged }}
       readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-      runAsGroup: 1337
+      runAsGroup: {{ .ProxyGID | default "1337" }}
       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
       runAsNonRoot: false
       runAsUser: 0
       {{- else -}}
       runAsNonRoot: true
-      runAsUser: 1337
+      runAsUser: {{ .ProxyUID | default "1337" }}
       {{- end }}
       {{- end }}
     resources:

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -836,6 +836,9 @@ func (s *Server) cachesSynced() bool {
 	if !s.configController.HasSynced() {
 		return false
 	}
+	if s.webhookInfo.wh != nil && !s.webhookInfo.wh.HasSynced() {
+		return false
+	}
 	return true
 }
 

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -76,10 +76,11 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	log.Info("initializing sidecar injector")
 
 	parameters := inject.WebhookParameters{
-		Watcher:  watcher,
-		Env:      s.environment,
-		Mux:      s.httpsMux,
-		Revision: args.Revision,
+		Watcher:    watcher,
+		Env:        s.environment,
+		Mux:        s.httpsMux,
+		Revision:   args.Revision,
+		KubeClient: s.kubeClient,
 	}
 
 	wh, err := inject.NewWebhook(parameters)

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -320,6 +320,12 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("reconciling")
 
+	var ns *corev1.Namespace
+	if d.namespaces != nil {
+		ns = d.namespaces.Get(gw.Namespace, "")
+	}
+	proxyUID, proxyGID := inject.GetProxyIDs(ns)
+
 	defaultName := getDefaultName(gw.Name, &gw.Spec)
 
 	serviceType := gi.defaultServiceType
@@ -336,6 +342,8 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		KubeVersion122: kube.IsAtLeastVersion(d.client, 22),
 		Revision:       d.revision,
 		ServiceType:    serviceType,
+		ProxyUID:       proxyUID,
+		ProxyGID:       proxyGID,
 	}
 
 	if overwriteControllerVersion {
@@ -530,6 +538,8 @@ type TemplateInput struct {
 	ClusterID      string
 	KubeVersion122 bool
 	Revision       string
+	ProxyUID       int64
+	ProxyGID       int64
 }
 
 func extractServicePorts(gw gateway.Gateway) []corev1.ServicePort {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -418,7 +418,6 @@ func newClientInternal(clientFactory *clientFactory, revision string, cluster cl
 		}
 	}
 	c.version = lazy.NewWithRetry(clientWithTimeout.Discovery().ServerVersion)
-
 	return &c, nil
 }
 

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 // InjectionPolicy determines the policy for injecting the
@@ -104,6 +105,8 @@ type SidecarTemplateData struct {
 	Values         map[string]any
 	Revision       string
 	ProxyImage     string
+	ProxyUID       int64
+	ProxyGID       int64
 }
 
 type (
@@ -394,6 +397,8 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		return nil, nil, err
 	}
 
+	proxyUID, proxyGID := GetProxyIDs(params.namespace)
+
 	data := SidecarTemplateData{
 		TypeMeta:       params.typeMeta,
 		DeploymentMeta: params.deployMeta,
@@ -404,6 +409,8 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		Values:         params.valuesConfig.asMap,
 		Revision:       params.revision,
 		ProxyImage:     ProxyImage(params.valuesConfig.asStruct, params.proxyConfig.Image, strippedPod.Annotations),
+		ProxyUID:       proxyUID,
+		ProxyGID:       proxyGID,
 	}
 
 	mergedPod = params.pod
@@ -857,4 +864,25 @@ func updateClusterEnvs(container *corev1.Container, newKVs map[string]string) {
 		envVars = append(envVars, corev1.EnvVar{Name: key, Value: val, ValueFrom: nil})
 	}
 	container.Env = envVars
+}
+
+// GetProxyIDs returns the UID and GID to be used in the RunAsUser and RunAsGroup fields in the template
+// Inspects the namespace metadata for hints and fallbacks to the usual value of 1337.
+func GetProxyIDs(namespace *corev1.Namespace) (uid int64, gid int64) {
+	uid = constants.DefaultProxyUIDInt
+	gid = constants.DefaultProxyUIDInt
+
+	if namespace == nil {
+		return
+	}
+
+	// Check for OpenShift specifics and returns the max number in the range specified in the namespace annotation
+	if _, uidMax, err := getPreallocatedUIDRange(namespace); err == nil {
+		uid = *uidMax
+	}
+	if groups, err := getPreallocatedSupplementalGroups(namespace); err == nil && len(groups) > 0 {
+		gid = groups[0].Max
+	}
+
+	return
 }

--- a/pkg/kube/inject/openshift.go
+++ b/pkg/kube/inject/openshift.go
@@ -1,0 +1,163 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Functions below were copied from
+// https://github.com/openshift/apiserver-library-go/blob/c22aa58bb57416b9f9f190957d07c9e7669c26df/pkg/securitycontextconstraints/sccmatching/matcher.go
+// These functions are not exported, and, if they were, when imported bring k8s.io/kubernetes as dependency, which is problematic
+// License is Apache 2.0: https://github.com/openshift/apiserver-library-go/blob/c22aa58bb57416b9f9f190957d07c9e7669c26df/LICENSE
+
+package inject
+
+import (
+	"fmt"
+	"strings"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"istio.io/istio/pkg/log"
+)
+
+// getPreallocatedUIDRange retrieves the annotated value from the namespace, splits it to make
+// the min/max and formats the data into the necessary types for the strategy options.
+func getPreallocatedUIDRange(ns *corev1.Namespace) (*int64, *int64, error) {
+	annotationVal, ok := ns.Annotations[securityv1.UIDRangeAnnotation]
+	if !ok {
+		return nil, nil, fmt.Errorf("unable to find annotation %s", securityv1.UIDRangeAnnotation)
+	}
+	if len(annotationVal) == 0 {
+		return nil, nil, fmt.Errorf("found annotation %s but it was empty", securityv1.UIDRangeAnnotation)
+	}
+	uidBlock, err := ParseBlock(annotationVal)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	min := int64(uidBlock.Start)
+	max := int64(uidBlock.End)
+	log.Debugf("got preallocated values for min: %d, max: %d for uid range in namespace %s", min, max, ns.Name)
+	return &min, &max, nil
+}
+
+// getPreallocatedSupplementalGroups gets the annotated value from the namespace.
+func getPreallocatedSupplementalGroups(ns *corev1.Namespace) ([]securityv1.IDRange, error) {
+	groups, err := getSupplementalGroupsAnnotation(ns)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("got preallocated value for groups: %s in namespace %s", groups, ns.Name)
+
+	blocks, err := parseSupplementalGroupAnnotation(groups)
+	if err != nil {
+		return nil, err
+	}
+
+	idRanges := []securityv1.IDRange{}
+	for _, block := range blocks {
+		rng := securityv1.IDRange{
+			Min: int64(block.Start),
+			Max: int64(block.End),
+		}
+		idRanges = append(idRanges, rng)
+	}
+	return idRanges, nil
+}
+
+// getSupplementalGroupsAnnotation provides a backwards compatible way to get supplemental groups
+// annotations from a namespace by looking for SupplementalGroupsAnnotation and falling back to
+// UIDRangeAnnotation if it is not found.
+func getSupplementalGroupsAnnotation(ns *corev1.Namespace) (string, error) {
+	groups, ok := ns.Annotations[securityv1.SupplementalGroupsAnnotation]
+	if !ok {
+		log.Debugf("unable to find supplemental group annotation %s falling back to %s", securityv1.SupplementalGroupsAnnotation, securityv1.UIDRangeAnnotation)
+
+		groups, ok = ns.Annotations[securityv1.UIDRangeAnnotation]
+		if !ok {
+			return "", fmt.Errorf("unable to find supplemental group or uid annotation for namespace %s", ns.Name)
+		}
+	}
+
+	if len(groups) == 0 {
+		return "", fmt.Errorf("unable to find groups using %s and %s annotations", securityv1.SupplementalGroupsAnnotation, securityv1.UIDRangeAnnotation)
+	}
+	return groups, nil
+}
+
+// parseSupplementalGroupAnnotation parses the group annotation into blocks.
+func parseSupplementalGroupAnnotation(groups string) ([]Block, error) {
+	blocks := []Block{}
+	segments := strings.Split(groups, ",")
+	for _, segment := range segments {
+		block, err := ParseBlock(segment)
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, block)
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("no blocks parsed from annotation %s", groups)
+	}
+	return blocks, nil
+}
+
+// Functions below were copied from
+// https://github.com/openshift/library-go/blob/561433066966536ac17f3c9852d7d85f7b7e1e36/pkg/security/uid/uid.go
+// Copied here to avoid bringing tons of dependencies
+// License is Apache 2.0: https://github.com/openshift/library-go/blob/561433066966536ac17f3c9852d7d85f7b7e1e36/LICENSE
+
+type Block struct {
+	Start uint32
+	End   uint32
+}
+
+var (
+	ErrBlockSlashBadFormat = fmt.Errorf("block not in the format \"<start>/<size>\"")
+	ErrBlockDashBadFormat  = fmt.Errorf("block not in the format \"<start>-<end>\"")
+)
+
+func ParseBlock(in string) (Block, error) {
+	if strings.Contains(in, "/") {
+		var start, size uint32
+		n, err := fmt.Sscanf(in, "%d/%d", &start, &size)
+		if err != nil {
+			return Block{}, err
+		}
+		if n != 2 {
+			return Block{}, ErrBlockSlashBadFormat
+		}
+		return Block{Start: start, End: start + size - 1}, nil
+	}
+
+	var start, end uint32
+	n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
+	if err != nil {
+		return Block{}, err
+	}
+	if n != 2 {
+		return Block{}, ErrBlockDashBadFormat
+	}
+	return Block{Start: start, End: end}, nil
+}
+
+func (b Block) String() string {
+	return fmt.Sprintf("%d/%d", b.Start, b.Size())
+}
+
+func (b Block) RangeString() string {
+	return fmt.Sprintf("%d-%d", b.Start, b.End)
+}
+
+func (b Block) Size() uint32 {
+	return b.End - b.Start + 1
+}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -96,7 +96,7 @@ templates:
         - "-z"
         - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
         - "-u"
-        - "1337"
+        - {{ .ProxyUID | default "1337" | quote }}
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -163,8 +163,8 @@ templates:
           runAsUser: 0
         {{- else }}
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- end }}
       {{ end -}}
@@ -370,7 +370,7 @@ templates:
             - ALL
           privileged: true
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: false
           runAsUser: 0
           {{- else }}
@@ -389,13 +389,13 @@ templates:
             - ALL
           privileged: {{ .Values.global.proxy.privileged }}
           readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
-          runAsGroup: 1337
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
           runAsNonRoot: false
           runAsUser: 0
           {{- else -}}
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: {{ .ProxyUID | default "1337" }}
           {{- end }}
           {{- end }}
         resources:
@@ -1490,8 +1490,10 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
+    {{- if not (eq .Values.global.platform "openshift") }}
               runAsUser: 1337
               runAsGroup: 1337
+    {{- end }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/releasenotes/notes/remove-anyuid-openshift.yaml
+++ b/releasenotes/notes/remove-anyuid-openshift.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+docs:
+- 'https://istio.io/latest/docs/setup/platform-setup/openshift/'
+releaseNotes:
+- |
+    **Improved** Usage on OpenShift clusters is simplified by removing the need of granting the `anyuid` SCC privilege to Istio and applications.

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -134,7 +134,8 @@ Only applies when traffic from all groups (i.e. "*") is being redirected to Envo
 )
 
 const (
-	DefaultProxyUID = "1337"
+	DefaultProxyUID    = "1337"
+	DefaultProxyUIDInt = int64(1337)
 )
 
 // Constants used in environment variables


### PR DESCRIPTION
- Remove the hard-coded usages of `runAsUser` and `runAsGroup` in charts
- Where necessary, replace them with a helm field `.ProxyUID` and `.ProxyGID`.
- When running in OpenShift, these fields will be set at runtime based on annotations present on the pod's namespace.
- When not on OpenShift (strictly speaking, when such annotations are not present), these values fallback to the current, defauls value of 1337.

With this change we can remove the extra steps related to `anyuid` in the [OpenShift setup page](https://istio.io/v1.17/docs/setup/platform-setup/openshift/).
