### PR TITLE
Implement support for Regex Rewrite for URI's

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -512,6 +512,13 @@ func applyHTTPRouteDestination(
 				},
 				Substitution: fullURI,
 			}
+		} else if regexRewrite := in.Rewrite.GetUriRegexRewrite(); regexRewrite != nil {
+			action.RegexRewrite = &matcher.RegexMatchAndSubstitute{
+				Pattern: &matcher.RegexMatcher{
+					Regex: regexRewrite.Match,
+				},
+				Substitution: regexRewrite.Rewrite,
+			}
 		} else {
 			action.PrefixRewrite = uri
 		}

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -997,6 +997,27 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}))
 	})
 
+	t.Run("for path regex match with regex rewrite", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
+			virtualServiceWithPathRegexMatchRegexRewrite,
+			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(len(routes)).To(gomega.Equal(1))
+
+		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
+		g.Expect(ok).NotTo(gomega.BeFalse())
+		g.Expect(routeAction.Route.RegexRewrite).To(gomega.Equal(&matcher.RegexMatchAndSubstitute{
+			Pattern: &matcher.RegexMatcher{
+				Regex: "^/service/([^/]+)(/.*)$",
+			},
+			Substitution: "\\2/instance/\\1",
+		}))
+	})
+
 	t.Run("for redirect uri prefix '%PREFIX()%' that is without gateway semantics", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
@@ -1802,6 +1823,48 @@ var virtualServiceWithRewriteFullPathAndHost = config.Config{
 				Rewrite: &networking.HTTPRewrite{
 					Uri:       "%FULLREPLACE()%/replace-full",
 					Authority: "bar.example.org",
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "foo.example.org",
+						},
+						Weight: 100,
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithPathRegexMatchRegexRewrite = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+		Annotations: map[string]string{
+			"internal.istio.io/route-semantics": "gateway",
+		},
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "full-path-and-host-rewrite",
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Regex{
+								Regex: "^/service/[^/]+/.*$",
+							},
+						},
+					},
+				},
+				Rewrite: &networking.HTTPRewrite{
+					UriRegexRewrite: &networking.RegexRewrite{
+						Match:   "^/service/([^/]+)(/.*)$",
+						Rewrite: "\\2/instance/\\1",
+					},
 				},
 				Route: []*networking.HTTPRouteDestination{
 					{

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3171,8 +3171,14 @@ func validateHTTPDirectResponse(directResponse *networking.HTTPDirectResponse) (
 }
 
 func validateHTTPRewrite(rewrite *networking.HTTPRewrite) error {
-	if rewrite != nil && rewrite.Uri == "" && rewrite.Authority == "" {
-		return errors.New("rewrite must specify URI, authority, or both")
+	if rewrite == nil {
+		return nil
+	}
+	if rewrite.Uri != "" && rewrite.UriRegexRewrite != nil {
+		return errors.New("rewrite may only contain one of URI or uriRegexRewrite")
+	}
+	if rewrite.Uri == "" && rewrite.UriRegexRewrite == nil && rewrite.Authority == "" {
+		return errors.New("rewrite must specify at least one of URI, uriRegexRewrite, or authority. Only one of URI or uriRegexRewrite may be specified")
 	}
 	return nil
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3175,10 +3175,10 @@ func validateHTTPRewrite(rewrite *networking.HTTPRewrite) error {
 		return nil
 	}
 	if rewrite.Uri != "" && rewrite.UriRegexRewrite != nil {
-		return errors.New("rewrite may only contain one of URI or uriRegexRewrite")
+		return errors.New("rewrite may only contain one of URI or UriRegexRewrite")
 	}
 	if rewrite.Uri == "" && rewrite.UriRegexRewrite == nil && rewrite.Authority == "" {
-		return errors.New("rewrite must specify at least one of URI, uriRegexRewrite, or authority. Only one of URI or uriRegexRewrite may be specified")
+		return errors.New("rewrite must specify at least one of URI, UriRegexRewrite, or authority. Only one of URI or UriRegexRewrite may be specified")
 	}
 	return nil
 }

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2079,7 +2079,39 @@ func TestValidateHTTPRewrite(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:  "no uri or authority",
+			name: "uriRegexRewrite",
+			in: &networking.HTTPRewrite{
+				UriRegexRewrite: &networking.RegexRewrite{
+					Match:   "^/service/([^/]+)(/.*)$",
+					Rewrite: "\\2/instance/\\1",
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "uriRegexRewrite and authority",
+			in: &networking.HTTPRewrite{
+				Authority: "foobar.org",
+				UriRegexRewrite: &networking.RegexRewrite{
+					Match:   "^/service/([^/]+)(/.*)$",
+					Rewrite: "\\2/instance/\\1",
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "uriRegexRewrite and uri",
+			in: &networking.HTTPRewrite{
+				Uri: "/path/to/resource",
+				UriRegexRewrite: &networking.RegexRewrite{
+					Match:   "^/service/([^/]+)(/.*)$",
+					Rewrite: "\\2/instance/\\1",
+				},
+			},
+			valid: false,
+		},
+		{
+			name:  "no uri, uriRegexRewrite, or authority",
 			in:    &networking.HTTPRewrite{},
 			valid: false,
 		},

--- a/releasenotes/notes/httpregexrewrite.yaml
+++ b/releasenotes/notes/httpregexrewrite.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 22290
+releaseNotes:
+- |
+  **Added** support for Regex Rewrite in VirtualService HTTPRewrite


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR implements the API change here https://github.com/istio/api/pull/2753. Regarding issue: https://github.com/istio/istio/issues/22290
- Adds support for `uriRegexRewrite` under HTTPRewrite in Virtual Service. 
- Update validation webhook to understand the new field. URI rewrite and uriRegexRewrite cannot be used together