### PR TITLE
Use UriRegexRewrite to implement full path rewrite in Gateway API

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1209,7 +1209,10 @@ func createRewriteFilter(filter *k8s.HTTPURLRewriteFilter) *istio.HTTPRewrite {
 		case k8sbeta.PrefixMatchHTTPPathModifier:
 			rewrite.Uri = *filter.Path.ReplacePrefixMatch
 		case k8sbeta.FullPathHTTPPathModifier:
-			rewrite.Uri = fmt.Sprintf("%%FULLREPLACE()%%%s", *filter.Path.ReplaceFullPath)
+			rewrite.UriRegexRewrite = &istio.RegexRewrite{
+				Match:   "/.*",
+				Rewrite: *filter.Path.ReplaceFullPath,
+			}
 		}
 	}
 	if filter.Hostname != nil {

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1219,7 +1219,7 @@ func createRewriteFilter(filter *k8s.HTTPURLRewriteFilter) *istio.HTTPRewrite {
 		rewrite.Authority = string(*filter.Hostname)
 	}
 	// Nothing done
-	if rewrite.Uri == "" && rewrite.Authority == "" {
+	if rewrite.Uri == "" && rewrite.UriRegexRewrite == nil && rewrite.Authority == "" {
 		return nil
 	}
 	return rewrite

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml
@@ -166,7 +166,7 @@ spec:
       urlRewrite:
         hostname: "new.example.com"
         path:
-          type: ReplaceFullPath # Not currently supported
+          type: ReplaceFullPath
           replaceFullPath: "/replacement"
     backendRefs:
     - name: httpbin

--- a/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/http.yaml.golden
@@ -161,7 +161,9 @@ spec:
     name: default.rewrite.1
     rewrite:
       authority: new.example.com
-      uri: '%FULLREPLACE()%/replacement'
+      uriRegexRewrite:
+        match: /.*
+        rewrite: /replacement
     route:
     - destination:
         host: httpbin.default.svc.domain.suffix

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -504,22 +504,15 @@ func applyHTTPRouteDestination(
 		action.ClusterSpecifier = &route.RouteAction_Cluster{
 			Cluster: in.Name,
 		}
-		uri := in.Rewrite.GetUri()
-		if fullURI, isFullPathRewrite := cutPrefix(uri, "%FULLREPLACE()%"); isFullPathRewrite && model.UseGatewaySemantics(vs) {
-			action.RegexRewrite = &matcher.RegexMatchAndSubstitute{
-				Pattern: &matcher.RegexMatcher{
-					Regex: "/.*",
-				},
-				Substitution: fullURI,
-			}
-		} else if regexRewrite := in.Rewrite.GetUriRegexRewrite(); regexRewrite != nil {
+
+		if regexRewrite := in.Rewrite.GetUriRegexRewrite(); regexRewrite != nil {
 			action.RegexRewrite = &matcher.RegexMatchAndSubstitute{
 				Pattern: &matcher.RegexMatcher{
 					Regex: regexRewrite.Match,
 				},
 				Substitution: regexRewrite.Rewrite,
 			}
-		} else {
+		} else if uri := in.Rewrite.GetUri(); uri != "" {
 			action.PrefixRewrite = uri
 		}
 		if in.Rewrite.GetAuthority() != "" {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -1787,7 +1787,10 @@ var virtualServiceWithRewriteFullPath = config.Config{
 					},
 				},
 				Rewrite: &networking.HTTPRewrite{
-					Uri: "%FULLREPLACE()%/replace-full",
+					UriRegexRewrite: &networking.RegexRewrite{
+						Match:   "/.*",
+						Rewrite: "/replace-full",
+					},
 				},
 				Route: []*networking.HTTPRouteDestination{
 					{
@@ -1821,7 +1824,10 @@ var virtualServiceWithRewriteFullPathAndHost = config.Config{
 					},
 				},
 				Rewrite: &networking.HTTPRewrite{
-					Uri:       "%FULLREPLACE()%/replace-full",
+					UriRegexRewrite: &networking.RegexRewrite{
+						Match:   "/.*",
+						Rewrite: "/replace-full",
+					},
 					Authority: "bar.example.org",
 				},
 				Route: []*networking.HTTPRouteDestination{


### PR DESCRIPTION
**Please provide a description of this PR:**
Now that UriRegexRewrite is supported in HTTPRewrite https://github.com/istio/istio/pull/45398, the previous hack https://github.com/istio/istio/pull/42605 used to support full path rewrite from Gateway API is no longer needed.