### PR TITLE
update jaeger vulnerability

### DIFF
--- a/samples/addons/jaeger.yaml
+++ b/samples/addons/jaeger.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: "docker.io/jaegertracing/all-in-one:1.35"
+          image: "docker.io/jaegertracing/all-in-one:1.46"
           env:
             - name: BADGER_EPHEMERAL
               value: "false"


### PR DESCRIPTION
**Please provide a description of this PR:**
Istio use jaegertracing: 1.35 in addon directory.  And for security purposes, We scan these images and find 11 vulnerabilities。Details as below:
Total: 11 (UNKNOWN: 0, LOW: 0, MEDIUM: 8, HIGH: 2, CRITICAL: 1)
CVE-2022-37434  CRITICAL!!!!
CVE-2023-0286- libcrypto1.1  HIGH!!!
CVE-2023-0286-libssl1.1 HIGH !!! 
...

In the jaegertracing version of 1.46,   we fix these vulnerabilities and do some bugfix for other features. 
The scan result is safe, as below:
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
And it works well.