### PR TITLE
wip: test TestGatewayHostnames

### DIFF
--- a/pilot/pkg/model/network_test.go
+++ b/pilot/pkg/model/network_test.go
@@ -113,7 +113,7 @@ func TestGatewayHostnames(t *testing.T) {
 			// addresses should be updated
 			retry.UntilOrFail(t, func() bool {
 				return !reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
+			}, retry.Timeout(2*model.MinGatewayTTL))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 
@@ -133,7 +133,7 @@ func TestGatewayHostnames(t *testing.T) {
 			retry.UntilOrFail(t, func() bool {
 				return len(env.NetworkManager.AllGateways()) != 0 &&
 					!reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
+			}, retry.Timeout(2*model.MinGatewayTTL))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 	}

--- a/pilot/pkg/model/network_test.go
+++ b/pilot/pkg/model/network_test.go
@@ -113,13 +113,14 @@ func TestGatewayHostnames(t *testing.T) {
 			// addresses should be updated
 			retry.UntilOrFail(t, func() bool {
 				return !reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL))
+			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 
 		workingDNSServer.setHosts(make(sets.Set[string]))
 		t.Run("no answer", func(t *testing.T) {
 			retry.UntilOrFail(t, func() bool {
+				fmt.Println(env.NetworkManager.AllGateways())
 				return len(env.NetworkManager.AllGateways()) == 0
 			}, retry.Timeout(2*time.Duration(ttl)*time.Second))
 			xdsUpdater.WaitOrFail(t, "xds full")
@@ -131,9 +132,10 @@ func TestGatewayHostnames(t *testing.T) {
 		workingDNSServer.setHosts(sets.New(gwHost))
 		t.Run("new answer", func(t *testing.T) {
 			retry.UntilOrFail(t, func() bool {
+				fmt.Println(env.NetworkManager.AllGateways())
 				return len(env.NetworkManager.AllGateways()) != 0 &&
 					!reflect.DeepEqual(env.NetworkManager.AllGateways(), gateways)
-			}, retry.Timeout(2*model.MinGatewayTTL))
+			}, retry.Timeout(2*model.MinGatewayTTL), retry.Delay(time.Millisecond*10))
 			xdsUpdater.WaitOrFail(t, "xds full")
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes(#45488)

The **retry.Delay** set delay and delayMax
```
// Delay sets the delay between successive retry attempts.
func Delay(delay time.Duration) Option {
	return func(cfg *config) {
		cfg.delay = delay
		cfg.delayMax = delay
	}
}
```

It set  delay and delayMax to time.Millisecond*10. But it default is time.Millisecond * 10, and delayMax is DefaultDelay(time.Millisecond * 10) * 16.
I think delayMax is 16 * DefaultDelay(time.Millisecond * 10) may hold the retry time of test