### PR TITLE
remove temp file after use

### DIFF
--- a/istioctl/pkg/multicluster/env_test.go
+++ b/istioctl/pkg/multicluster/env_test.go
@@ -130,6 +130,7 @@ func (f *fakeEnvironment) CreateClient(_ string) (kube.CLIClient, error) {
 func TestNewEnvironment(t *testing.T) {
 	context := "" // empty, use current-Context
 	kubeconfig, wantConfig := createFakeKubeconfigFileOrDie(t)
+	defer os.Remove(kubeconfig)
 
 	wantEnv := &KubeEnvironment{
 		config:     wantConfig,


### PR DESCRIPTION
**Please provide a description of this PR:**

The func createFakeKubeconfigFileOrDie create a temp file by os.CreateTemp. But does not remove it.

https://github.com/istio/istio/blob/d8b21e02e754b6e93bf259ff7e226fafaa9c16d3/istioctl/pkg/multicluster/env_test.go#L53