### PR TITLE
CRL: integration tests sidecar egress tls origination

### DIFF
--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -18,6 +18,7 @@
 package security
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 	"strings"
@@ -35,16 +36,18 @@ import (
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
-// TestMutualTlsOrigination test MUTUAL TLS mode with TLS origination happening at Sidecar
-// It uses CredentialName set in DestinationRule API to fetch secrets from k8s API server
+// TestSidecarMutualTlsOrigination test MUTUAL TLS mode with TLS origination happening at the sidecar.
+// It uses CredentialName set in DestinationRule API to fetch secrets from k8s API server.
 func TestSidecarMutualTlsOrigination(t *testing.T) {
 	// nolint: staticcheck
 	framework.NewTest(t).
 		Features("security.egress.mtls.sds").
 		Run(func(t framework.TestContext) {
 			var (
-				credNameGeneric = "mtls-credential-generic"
-				fakeCredName    = "fake-mtls-credential"
+				credNameGeneric  = "mtls-credential-generic"
+				fakeCredName     = "fake-mtls-credential"
+				credWithCRL      = "mtls-credential-generic-valid-crl"
+				credWithDummyCRL = "mtls-credential-generic-dummy-crl"
 			)
 
 			// Create a valid kubernetes secret to provision key/cert for sidecar.
@@ -54,11 +57,6 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 				CaCert:      file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/root-cert.pem")),
 			}, true, apps.Ns1.Namespace.Name())
 
-			// Authorize only one of the sidecars in the namespace with secret listing permissions.
-			serviceAccount := apps.Ns1.A.Config().ServiceAccountName()
-			serviceAccountName := serviceAccount[strings.LastIndex(serviceAccount, "/")+1:]
-			authorizeSidecar(t, apps.Ns1.Namespace, serviceAccountName)
-
 			// Create a kubernetes secret with an invalid ClientCert
 			ingressutil.CreateIngressKubeSecretInNamespace(t, fakeCredName, ingressutil.Mtls, ingressutil.IngressCredential{
 				Certificate: file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/fake-cert-chain.pem")),
@@ -66,54 +64,112 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 				CaCert:      file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/root-cert.pem")),
 			}, false, apps.Ns1.Namespace.Name())
 
+			// Create a valid kubernetes secret to provision key/cert for sidecar, configured with valid CRL
+			ingressutil.CreateIngressKubeSecretInNamespace(t, credWithCRL, ingressutil.Mtls, ingressutil.IngressCredential{
+				Certificate: file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/cert-chain.pem")),
+				PrivateKey:  file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/key.pem")),
+				CaCert:      file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/root-cert.pem")),
+				Crl:         file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/ca.crl")),
+			}, false, apps.Ns2.Namespace.Name())
+
+			// Create a valid kubernetes secret to provision key/cert for sidecar, configured with dummy CRL
+			ingressutil.CreateIngressKubeSecretInNamespace(t, credWithDummyCRL, ingressutil.Mtls, ingressutil.IngressCredential{
+				Certificate: file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/cert-chain.pem")),
+				PrivateKey:  file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/key.pem")),
+				CaCert:      file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dns/root-cert.pem")),
+				Crl:         file.AsStringOrFail(t, path.Join(env.IstioSrc, "tests/testdata/certs/dummy.crl")),
+			}, false, apps.Ns2.Namespace.Name())
+
 			// Set up Host Namespace
 			host := apps.External.All.Config().ClusterLocalFQDN()
 
 			testCases := []struct {
-				name            string
-				statusCode      int
-				credentialToUse string
-				from            echo.Instances
-				drSelector      string
+				name             string
+				credentialToUse  string
+				from             echo.Instances
+				authorizeSidecar bool
+				drSelector       string
+				expectedResponse ingressutil.ExpectedResponse
 			}{
 				// Mutual TLS origination from an authorized sidecar to https endpoint
 				{
-					name:            "authorized sidecar",
-					statusCode:      http.StatusOK,
-					credentialToUse: credNameGeneric,
-					from:            apps.Ns1.A,
-					drSelector:      "a",
+					name:             "authorized sidecar",
+					credentialToUse:  credNameGeneric,
+					from:             apps.Ns1.A,
+					drSelector:       "a",
+					authorizeSidecar: true,
+					expectedResponse: ingressutil.ExpectedResponse{
+						StatusCode: http.StatusOK,
+					},
 				},
 				// Mutual TLS origination from an unauthorized sidecar to https endpoint
-				// This will result in `ERROR Secret is not supplied by SDS`
+				// This will result in `TLS ERROR Secret is not supplied by SDS`
 				{
 					name:            "unauthorized sidecar",
-					statusCode:      http.StatusBadRequest,
 					credentialToUse: credNameGeneric,
 					from:            apps.Ns1.B,
 					drSelector:      "b",
+					expectedResponse: ingressutil.ExpectedResponse{
+						StatusCode:   http.StatusServiceUnavailable,
+						ErrorMessage: "Secret is not supplied by SDS",
+					},
 				},
 				// Mutual TLS origination using an invalid client certificate
-				// This will result in `400 BadRequest`
+				// This will result in `TLS ERROR: Secret is not supplied by SDS`
 				{
-					name:            "invalid client cert",
-					statusCode:      http.StatusBadRequest,
-					credentialToUse: fakeCredName,
-					from:            apps.Ns1.C,
-					drSelector:      "c",
+					name:             "invalid client cert",
+					credentialToUse:  fakeCredName,
+					from:             apps.Ns1.C,
+					drSelector:       "c",
+					authorizeSidecar: true,
+					expectedResponse: ingressutil.ExpectedResponse{
+						StatusCode:   http.StatusServiceUnavailable,
+						ErrorMessage: "Secret is not supplied by SDS",
+					},
+				},
+				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL specifying the server certificate as revoked.
+				// This will result in `certificate verify failed`
+				{
+					name:             "valid crl",
+					credentialToUse:  credWithCRL,
+					from:             apps.Ns2.A,
+					drSelector:       "a",
+					authorizeSidecar: true,
+					expectedResponse: ingressutil.ExpectedResponse{
+						StatusCode:   http.StatusServiceUnavailable,
+						ErrorMessage: "CERTIFICATE_VERIFY_FAILED",
+					},
+				},
+				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL with a dummy revoked certificate.
+				// Since the certificate in action is not revoked, the communication should not be impacted.
+				{
+					name:             "dummy crl",
+					credentialToUse:  credWithDummyCRL,
+					from:             apps.Ns2.B,
+					drSelector:       "b",
+					authorizeSidecar: true,
+					expectedResponse: ingressutil.ExpectedResponse{
+						StatusCode: http.StatusOK,
+					},
 				},
 			}
 			for _, tc := range testCases {
 				t.NewSubTest(tc.name).Run(func(t framework.TestContext) {
+					if tc.authorizeSidecar {
+						serviceAccount := tc.from.Config().ServiceAccountName()
+						serviceAccountName := serviceAccount[strings.LastIndex(serviceAccount, "/")+1:]
+						authorizeSidecar(t, tc.from.Config().Namespace, serviceAccountName)
+					}
 					newTLSSidecarDestinationRule(t, apps.External.All, "MUTUAL", tc.drSelector, tc.credentialToUse,
-						apps.Ns1.Namespace)
-					callOpt := newTLSSidecarCallOpts(apps.External.All[0], host, tc.statusCode)
+						tc.from.Config().Namespace)
+					callOpt := newTLSSidecarCallOpts(apps.External.All[0], host, tc.expectedResponse)
 					tc.from[0].CallOrFail(t, callOpt)
 				})
 			}
 		})
 }
 
+// Authorize only specific sidecars in the namespace with secret listing permissions.
 func authorizeSidecar(t framework.TestContext, clientNamespace namespace.Instance, serviceAccountName string) {
 	args := map[string]any{
 		"ServiceAccount": serviceAccountName,
@@ -160,7 +216,24 @@ func newTLSSidecarDestinationRule(t framework.TestContext, to echo.Instances, de
 		"CredentialName":   credentialName,
 		"WorkloadSelector": workloadSelector,
 	}
-
+	se := `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: originate-mtls-for-nginx
+spec:
+  hosts:
+  - "{{ .to.Config.ClusterLocalFQDN }}"
+  ports:
+  - number: 80
+    name: http-port
+    protocol: HTTP
+    targetPort: 443
+  - number: 443
+    name: https-port
+    protocol: HTTPS
+  resolution: DNS
+`
 	dr := `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -176,27 +249,39 @@ spec:
   trafficPolicy:
     portLevelSettings:
       - port:
-          number: 443
+          number: 80
         tls:
           mode: {{.Mode}}
           credentialName: {{.CredentialName}}
           sni: {{ .to.Config.ClusterLocalFQDN }}
 `
-	t.ConfigIstio().Eval(clientNamespace.Name(), args, dr).ApplyOrFail(t, apply.NoCleanup)
+	t.ConfigIstio().Eval(clientNamespace.Name(), args, se, dr).ApplyOrFail(t, apply.NoCleanup)
 }
 
-func newTLSSidecarCallOpts(to echo.Target, host string, statusCode int) echo.CallOptions {
+func newTLSSidecarCallOpts(to echo.Target, host string, exRsp ingressutil.ExpectedResponse) echo.CallOptions {
 	return echo.CallOptions{
 		To: to,
 		Port: echo.Port{
-			Protocol:    protocol.HTTP,
-			ServicePort: 443,
+			Protocol: protocol.HTTP,
 		},
 		HTTP: echo.HTTP{
 			Headers: headers.New().WithHost(host).Build(),
 		},
-		Check: check.And(
-			check.NoErrorAndStatus(statusCode),
-		),
+		Check: func(result echo.CallResult, err error) error {
+			// Check that the error message is expected.
+			if err != nil {
+				// If expected error message is empty, but we got some error
+				// message then it should be treated as error.
+				if len(exRsp.ErrorMessage) == 0 {
+					return fmt.Errorf("unexpected error: %w", err)
+				}
+				if !strings.Contains(err.Error(), exRsp.ErrorMessage) {
+					return fmt.Errorf("expected response error message %s but got %w and the response code is %+v",
+						exRsp.ErrorMessage, err, result.Responses)
+				}
+				return nil
+			}
+			return check.And(check.NoErrorAndStatus(exRsp.StatusCode), check.BodyContains(exRsp.ErrorMessage)).Check(result, nil)
+		},
 	}
 }


### PR DESCRIPTION
- Sidecar Egress TLS Origination Integration Tests for CRL Support.
- Enhanced existing tests to properly verify the error messages along with response code

Implementation PR: https://github.com/istio/istio/pull/45104
API PR: https://github.com/istio/api/pull/2796
Ingress Integration tests PR: https://github.com/istio/istio/pull/45237

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
