### PR TITLE
helm: ztunnel chart should template XDS endpoint and resource prefix, not hardcode them

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: ztunnel
+  name: {{ .Values.appName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- .Values.labels | toYaml | nindent 4}}
@@ -14,12 +14,12 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: ztunnel
+      app: {{ .Values.appName }}
   template:
     metadata:
       labels:
         sidecar.istio.io/inject: "false"
-        app: ztunnel
+        app: {{ .Values.appName }}
 {{ with .Values.podLabels -}}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
         cni.projectcalico.org/allowedSourcePrefixes: "[\"0.0.0.0/0\"]"
@@ -27,7 +27,7 @@ spec:
         sidecar.istio.io/inject: "false"
 {{ with .Values.podAnnotations -}}{{ toYaml . | indent 8 }}{{ end }}
     spec:
-      serviceAccountName: ztunnel
+      serviceAccountName: {{ .Values.appName }}
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -44,7 +44,7 @@ spec:
 {{- end }}
         ports:
         - containerPort: 15020
-          name: ztunnel-stats
+          name: {{ .Values.appName }}-stats
           protocol: TCP
         resources:
 {{- if .Values.resources }}
@@ -91,6 +91,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        {{- if .Values.xdsHost }}
+        - name: XDS_ADDRESS
+          value: https://{{ .Values.xdsHost }}
+        - name: CA_ADDRESS
+          value: https://{{ .Values.xdsHost }}
+        {{- end }}
         - name: SERVICE_ACCOUNT
           valueFrom:
             fieldRef:

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -7,7 +7,7 @@ imagePullSecrets:
   {{- end }}
   {{- end }}
 metadata:
-  name: ztunnel
+  name: {{ .Values.appName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- .Values.labels | toYaml | nindent 4}}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -5,6 +5,9 @@ tag: latest
 # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.
 variant: ""
 
+# Name/prefix to use when creating named k8s resources for this chart.
+appName: "ztunnel"
+
 # Image name to pull from. Image will be `Hub/Image:Tag-Variant`
 # If Image contains a "/", it will replace the entire `image` in the pod.
 image: ztunnel
@@ -51,11 +54,11 @@ meshConfig:
   defaultConfig:
     proxyMetadata: {}
 
-# Ambient redirection mode: "iptables" or "ebpf"
-redirectMode: "iptables"
-
 # This value defines:
 # 1. how many seconds kube waits for ztunnel pod to gracefully exit before forcibly terminating it (this value)
 # 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
 # Default K8S value is 30 seconds
 terminationGracePeriodSeconds: 30
+
+# Which XDS endpoint ztunnel should be configured to contact
+xdsHost: "istiod.istio-system.svc:15012"

--- a/releasenotes/notes/ztunnel-chart-xdscfg.yaml
+++ b/releasenotes/notes/ztunnel-chart-xdscfg.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Added** Add xdsHost property to ztunnel Helm chart.
+    **Added** Add appName property to ztunnel Helm chart.


### PR DESCRIPTION
- Allow Helm templating of the XDS endpoint(s) used by ztunnel chart (previously hardcoded/obscured - ztunnel internally autodefaults to `istiod.istio-system.svc:15012` if nothing is defined so default behavior is unchanged here)
- Template `ztunnel` as the appname so it's treated as the global constant it effectively already is.