### PR TITLE
refactor mergeMaps to avoid effect params

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -265,10 +265,14 @@ func mergeMaps(base, override map[string]string) map[string]string {
 	if override == nil {
 		return base
 	}
-	for k, v := range override {
-		base[k] = v
+	merged := make(map[string]string, len(base)+len(override))
+	for k, v := range base {
+		merged[k] = v
 	}
-	return base
+	for k, v := range override {
+		merged[k] = v
+	}
+	return merged
 }
 
 // generateMutatingWebhook renders a mutating webhook configuration from the given tagWebhookConfig.


### PR DESCRIPTION
**Please provide a description of this PR:**

This way of writing is easy to be misunderstood as generating a new map from two maps and easy to overlook that this method will change the input parameters
```
func mergeMaps(base, override map[string]string) map[string]string{}
```
Using this kind of no return can make it clear that it will change the input parameters

```
func mergeMaps(base, override map[string]string)
```
Or return a new map as in this pr, without changing the input parameters

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
