### PR TITLE
bind helloworld flask app on IPv6

### DIFF
--- a/samples/helloworld/src/app.py
+++ b/samples/helloworld/src/app.py
@@ -38,4 +38,4 @@ def health():
 
 
 if __name__ == "__main__":
-    app.run(host='127.0.0.1', threaded=True)  # listen on IPv4; gunicorn will accept IPv6 from outside the pod
+    app.run(host='::', threaded=True)


### PR DESCRIPTION
**Please provide a description of this PR:**

I was informed that some users are testing using the sample's source outside of the image and wish for the flask server to continue to bind on [::] in support of those uses. Switching back to [::] for flask.