### PR TITLE
Don't set InformerWatchNamespace for cluster scoped resources

### DIFF
--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -64,8 +64,6 @@ type colEntry struct {
 	IstioAwareClientImport string
 	// ClientGroupPath represents the group in the client. Example: NetworkingV1alpha3.
 	ClientGroupPath string
-	// InformerGroup represents the group in the client. Example: Networking().V1alpha3().
-	InformerGroup string
 	// ClientGetter returns the path to get the client from a kube.Client. Example: Istio.
 	ClientGetter string
 	// ClientTypePath returns the kind name. Basically upper cased "plural". Example: Gateways
@@ -105,7 +103,6 @@ func buildInputs() (inputs, error) {
 			StatusImport:           toImport(r.StatusProtoPackage),
 			IstioAwareClientImport: toIstioAwareImport(r.ProtoPackage),
 			ClientGroupPath:        toGroup(r.ProtoPackage),
-			InformerGroup:          toInformerGroup(r.ProtoPackage),
 			ClientGetter:           toGetter(r.ProtoPackage),
 			ClientTypePath:         toTypePath(r),
 			SpecType:               tname,
@@ -185,17 +182,6 @@ func toGroup(protoPackage string) string {
 	}
 	// rest have two levels of nesting
 	return strcase.UpperCamelCase(p[e-1]) + strcase.UpperCamelCase(p[e])
-}
-
-func toInformerGroup(protoPackage string) string {
-	p := strings.Split(protoPackage, "/")
-	e := len(p) - 1
-	if strings.Contains(protoPackage, "sigs.k8s.io/gateway-api") {
-		// Gateway has one level of nesting with custom name
-		return "Gateway()." + strcase.UpperCamelCase(p[e]) + "()"
-	}
-	// rest have two levels of nesting
-	return strcase.UpperCamelCase(p[e-1]) + "()." + strcase.UpperCamelCase(p[e]) + "()"
 }
 
 type packageImport struct {

--- a/pkg/config/schema/codegen/common.go
+++ b/pkg/config/schema/codegen/common.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/template"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/schema/ast"
 	"istio.io/istio/pkg/test/env"
 )
@@ -46,13 +47,20 @@ func Run() error {
 			agentEntries = append(agentEntries, e)
 		}
 	}
+
+	// add MCS types
+	gvrEntries := append([]colEntry{
+		{Resource: &ast.Resource{Identifier: "ServiceExport", Plural: "serviceexports", Version: features.MCSAPIVersion, Group: features.MCSAPIGroup}},
+		{Resource: &ast.Resource{Identifier: "ServiceImport", Plural: "serviceimports", Version: features.MCSAPIVersion, Group: features.MCSAPIGroup}},
+	}, inp.Entries...)
+
 	return errors.Join(
 		writeTemplate("pkg/config/schema/gvk/resources.gen.go", gvkTemplate, map[string]any{
 			"Entries":     inp.Entries,
 			"PackageName": "gvk",
 		}),
 		writeTemplate("pkg/config/schema/gvr/resources.gen.go", gvrTemplate, map[string]any{
-			"Entries":     inp.Entries,
+			"Entries":     gvrEntries,
 			"PackageName": "gvr",
 		}),
 		writeTemplate("pilot/pkg/config/kube/crdclient/types.gen.go", crdclientTemplate, map[string]any{

--- a/pkg/config/schema/codegen/templates/gvr.go.tmpl
+++ b/pkg/config/schema/codegen/templates/gvr.go.tmpl
@@ -11,3 +11,16 @@ var (
 	{{.Resource.Identifier}} = schema.GroupVersionResource{Group: "{{.Resource.Group}}", Version: "{{.Resource.Version}}", Resource: "{{.Resource.Plural}}"}
 {{- end }}
 )
+
+func IsClusterScoped(g schema.GroupVersionResource) bool {
+	switch g {
+{{- range .Entries }}
+    {{- if not .Resource.Synthetic }}
+    case gvr.{{.Resource.Identifier}}:
+        return {{.Resource.ClusterScoped}}
+    {{- end }}
+{{- end }}
+	}
+    // shouldn't happen
+	return false
+}

--- a/pkg/config/schema/codegen/templates/gvr.go.tmpl
+++ b/pkg/config/schema/codegen/templates/gvr.go.tmpl
@@ -16,7 +16,7 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 	switch g {
 {{- range .Entries }}
 	{{- if not .Resource.Synthetic }}
-	case gvr.{{.Resource.Identifier}}:
+	case {{.Resource.Identifier}}:
 		return {{.Resource.ClusterScoped}}
 	{{- end }}
 {{- end }}

--- a/pkg/config/schema/codegen/templates/gvr.go.tmpl
+++ b/pkg/config/schema/codegen/templates/gvr.go.tmpl
@@ -15,12 +15,12 @@ var (
 func IsClusterScoped(g schema.GroupVersionResource) bool {
 	switch g {
 {{- range .Entries }}
-    {{- if not .Resource.Synthetic }}
-    case gvr.{{.Resource.Identifier}}:
-        return {{.Resource.ClusterScoped}}
-    {{- end }}
+	{{- if not .Resource.Synthetic }}
+	case gvr.{{.Resource.Identifier}}:
+		return {{.Resource.ClusterScoped}}
+	{{- end }}
 {{- end }}
 	}
-    // shouldn't happen
+	// shouldn't happen
 	return false
 }

--- a/pkg/config/schema/gvr/resources.gen.go
+++ b/pkg/config/schema/gvr/resources.gen.go
@@ -6,6 +6,8 @@ package gvr
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 var (
+	ServiceExport                  = schema.GroupVersionResource{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceexports"}
+	ServiceImport                  = schema.GroupVersionResource{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceimports"}
 	AuthorizationPolicy            = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1beta1", Resource: "authorizationpolicies"}
 	CertificateSigningRequest      = schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
 	ConfigMap                      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
@@ -47,3 +49,90 @@ var (
 	WorkloadEntry                  = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "workloadentries"}
 	WorkloadGroup                  = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "workloadgroups"}
 )
+
+func IsClusterScoped(g schema.GroupVersionResource) bool {
+	switch g {
+	case ServiceExport:
+		return false
+	case ServiceImport:
+		return false
+	case AuthorizationPolicy:
+		return false
+	case CertificateSigningRequest:
+		return true
+	case ConfigMap:
+		return false
+	case CustomResourceDefinition:
+		return true
+	case Deployment:
+		return false
+	case DestinationRule:
+		return false
+	case EndpointSlice:
+		return false
+	case Endpoints:
+		return false
+	case EnvoyFilter:
+		return false
+	case GRPCRoute:
+		return false
+	case Gateway:
+		return false
+	case GatewayClass:
+		return true
+	case HTTPRoute:
+		return false
+	case Ingress:
+		return false
+	case IngressClass:
+		return true
+	case KubernetesGateway:
+		return false
+	case MutatingWebhookConfiguration:
+		return true
+	case Namespace:
+		return true
+	case Node:
+		return true
+	case PeerAuthentication:
+		return false
+	case Pod:
+		return false
+	case ProxyConfig:
+		return false
+	case ReferenceGrant:
+		return false
+	case RequestAuthentication:
+		return false
+	case Secret:
+		return false
+	case Service:
+		return false
+	case ServiceAccount:
+		return false
+	case ServiceEntry:
+		return false
+	case Sidecar:
+		return false
+	case TCPRoute:
+		return false
+	case TLSRoute:
+		return false
+	case Telemetry:
+		return false
+	case UDPRoute:
+		return false
+	case ValidatingWebhookConfiguration:
+		return true
+	case VirtualService:
+		return false
+	case WasmPlugin:
+		return false
+	case WorkloadEntry:
+		return false
+	case WorkloadGroup:
+		return false
+	}
+	// shouldn't happen
+	return false
+}

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	istiogvr "istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kubeclient"
 	types "istio.io/istio/pkg/config/schema/kubetypes"
 	"istio.io/istio/pkg/kube"
@@ -300,13 +300,8 @@ func keyFunc(name, namespace string) string {
 }
 
 func ToOpts(c kube.Client, gvr schema.GroupVersionResource, filter Filter) kubetypes.InformerOptions {
-	s, ok := collections.All.FindByGroupVersionResource(gvr)
-	if !ok {
-		// shouldn't happen
-		log.Fatalf("unrecognized type %v", gvr)
-	}
 	ns := filter.Namespace
-	if !s.IsClusterScoped() && ns == "" {
+	if !istiogvr.IsClusterScoped(gvr) && ns == "" {
 		ns = features.InformerWatchNamespace
 	}
 	return kubetypes.InformerOptions{

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -26,7 +26,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kubeclient"
+	types "istio.io/istio/pkg/config/schema/kubetypes"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/informerfactory"
@@ -189,7 +192,8 @@ func New[T controllers.ComparableObject](c kube.Client) Client[T] {
 // This means there must only be one filter configuration for a given type using the same kube.Client.
 // Use with caution.
 func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) Client[T] {
-	inf := kubeclient.GetInformerFiltered[T](c, toOpts(c, filter))
+	gvr := gvk.MustToGVR(types.GetGVK[T]())
+	inf := kubeclient.GetInformerFiltered[T](c, ToOpts(c, gvr, filter))
 	return &fullClient[T]{
 		writeClient: writeClient[T]{client: c},
 		Informer:    newInformerClient[T](inf, filter),
@@ -209,7 +213,7 @@ func NewDelayedInformer(c kube.Client, gvr schema.GroupVersionResource, informer
 	}
 	delay := newDelayedFilter(gvr, watcher)
 	inf := func() informerfactory.StartableInformer {
-		opts := toOpts(c, filter)
+		opts := ToOpts(c, gvr, filter)
 		opts.InformerType = informerType
 		return kubeclient.GetInformerFilteredFromGVR(c, opts, gvr)
 	}
@@ -218,13 +222,13 @@ func NewDelayedInformer(c kube.Client, gvr schema.GroupVersionResource, informer
 
 // NewUntypedInformer returns an untyped client for a given GVR. This is read-only.
 func NewUntypedInformer(c kube.Client, gvr schema.GroupVersionResource, filter Filter) Untyped {
-	inf := kubeclient.GetInformerFilteredFromGVR(c, toOpts(c, filter), gvr)
+	inf := kubeclient.GetInformerFilteredFromGVR(c, ToOpts(c, gvr, filter), gvr)
 	return newInformerClient[controllers.Object](inf, filter)
 }
 
 // NewDynamic returns a dynamic client for a given GVR. This is read-only.
 func NewDynamic(c kube.Client, gvr schema.GroupVersionResource, filter Filter) Untyped {
-	opts := toOpts(c, filter)
+	opts := ToOpts(c, gvr, filter)
 	opts.InformerType = kubetypes.DynamicInformer
 	inf := kubeclient.GetInformerFilteredFromGVR(c, opts, gvr)
 	return newInformerClient[controllers.Object](inf, filter)
@@ -232,7 +236,7 @@ func NewDynamic(c kube.Client, gvr schema.GroupVersionResource, filter Filter) U
 
 // NewMetadata returns a metadata client for a given GVR. This is read-only.
 func NewMetadata(c kube.Client, gvr schema.GroupVersionResource, filter Filter) Informer[*metav1.PartialObjectMetadata] {
-	opts := toOpts(c, filter)
+	opts := ToOpts(c, gvr, filter)
 	opts.InformerType = kubetypes.MetadataInformer
 	inf := kubeclient.GetInformerFilteredFromGVR(c, opts, gvr)
 	return newInformerClient[*metav1.PartialObjectMetadata](inf, filter)
@@ -295,9 +299,14 @@ func keyFunc(name, namespace string) string {
 	return namespace + "/" + name
 }
 
-func toOpts(c kube.Client, filter Filter) kubetypes.InformerOptions {
+func ToOpts(c kube.Client, gvr schema.GroupVersionResource, filter Filter) kubetypes.InformerOptions {
+	s, ok := collections.All.FindByGroupVersionResource(gvr)
+	if !ok {
+		// shouldn't happen
+		log.Fatalf("unrecognized type %v", gvr)
+	}
 	ns := filter.Namespace
-	if ns == "" {
+	if !s.IsClusterScoped() && ns == "" {
 		ns = features.InformerWatchNamespace
 	}
 	return kubetypes.InformerOptions{

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -16,6 +16,7 @@ package kclient_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -24,10 +25,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	istioclient "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
@@ -267,4 +270,51 @@ func TestErrorHandler(t *testing.T) {
 	deployments := kclient.New[*appsv1.Deployment](c)
 	deployments.Start(test.NewStop(t))
 	mt.Assert("controller_sync_errors_total", map[string]string{"cluster": "fake"}, monitortest.AtLeast(1))
+}
+
+func TestToOpts(t *testing.T) {
+	test.SetForTest(t, &features.InformerWatchNamespace, "istio-system")
+	c := kube.NewFakeClient()
+	cases := []struct {
+		name   string
+		gvr    schema.GroupVersionResource
+		filter kclient.Filter
+		want   kubetypes.InformerOptions
+	}{
+		{
+			name: "watch pods in the foo namespace",
+			gvr:  gvr.Pod,
+			filter: kclient.Filter{
+				Namespace: "foo",
+			},
+			want: kubetypes.InformerOptions{
+				Namespace: "foo",
+				Cluster:   c.ClusterID(),
+			},
+		},
+		{
+			name: "watch pods in the InformerWatchNamespace",
+			gvr:  gvr.Pod,
+			want: kubetypes.InformerOptions{
+				Namespace: features.InformerWatchNamespace,
+				Cluster:   c.ClusterID(),
+			},
+		},
+		{
+			name: "watch namespaces",
+			gvr:  gvr.Namespace,
+			want: kubetypes.InformerOptions{
+				Namespace: "",
+				Cluster:   c.ClusterID(),
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kclient.ToOpts(c, tt.gvr, tt.filter)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToOpts: got %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
When using `ISTIO_WATCH_NAMESPACE`, I got: 
```
k8s.io/client-go@v0.27.0/tools/cache/reflector.go:231: 
failed to list *v1.PartialObjectMetadata: the server could not find the requested resource
```
We should not set watch namespace for cluster scoped resources
Maybe related to https://github.com/istio/istio/issues/45512