### PR TITLE
remove resource version from service

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -110,9 +110,6 @@ type Service struct {
 	// MeshExternal (if true) indicates that the service is external to the mesh.
 	// These services are defined using Istio's ServiceEntry spec.
 	MeshExternal bool
-
-	// ResourceVersion represents the internal version of this object.
-	ResourceVersion string
 }
 
 func (s *Service) Key() string {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -117,7 +117,6 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 		MeshExternal:    len(externalName) > 0,
 		Resolution:      resolution,
 		CreationTime:    svc.CreationTimestamp.Time,
-		ResourceVersion: svc.ResourceVersion,
 		Attributes: model.ServiceAttributes{
 			ServiceRegistry: provider.Kubernetes,
 			Name:            svc.Name,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -130,7 +130,6 @@ func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Confi
 			Name:              "synthetic-" + svc.Attributes.Name,
 			Namespace:         svc.Attributes.Namespace,
 			CreationTimestamp: svc.CreationTime,
-			ResourceVersion:   svc.ResourceVersion,
 		},
 		Spec: se,
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

it is useless, current we do not convert k8s service.rv to it