### PR TITLE
virtualHost.Domains for dual stack

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1125,11 +1125,8 @@ func (s *Service) GetExtraAddressesForProxy(node *Proxy) []string {
 	if features.EnableDualStack && node.Metadata != nil {
 		if node.Metadata.ClusterID != "" {
 			addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
-			// In a k8s svc ClusterIPs contains the what we call the DefaultAddress
-			// that address is already being removed from ClusterVIPs in
-			// pilot/pkg/serviceregistry/kube/conversion.go
-			if len(addresses) > 0 {
-				return addresses
+			if len(addresses) > 1 {
+				return addresses[1:]
 			}
 		}
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1093,12 +1093,6 @@ func (s *Service) GetAddresses(node *Proxy) []string {
 // GetAddressForProxy returns a Service's address specific to the cluster where the node resides
 func (s *Service) GetAddressForProxy(node *Proxy) string {
 	if node.Metadata != nil {
-		// pilot/pkg/serviceregistry/kube/conversion.go was updated to remove
-		// DefaultAddress from ClusterVIPs. We need to handle that here in
-		// order to build virtualHost Domains correctly for dual stack
-		if s.DefaultAddress != "" && s.DefaultAddress != constants.UnspecifiedIP {
-			return s.DefaultAddress
-		}
 		if node.Metadata.ClusterID != "" {
 			addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 			if len(addresses) > 0 {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -334,16 +334,18 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 			servicesByName[svc.Hostname] = &model.Service{
 				Hostname:       svc.Hostname,
 				DefaultAddress: svc.GetAddressForProxy(node),
-				// cannot correctly build virtualHost domains for dual stack without ClusterVIPs
-				ClusterVIPs:  *svc.ClusterVIPs.DeepCopy(),
-				MeshExternal: svc.MeshExternal,
-				Resolution:   svc.Resolution,
-				Ports:        []*model.Port{svcPort},
+				MeshExternal:   svc.MeshExternal,
+				Resolution:     svc.Resolution,
+				Ports:          []*model.Port{svcPort},
 				Attributes: model.ServiceAttributes{
 					Namespace:       svc.Attributes.Namespace,
 					ServiceRegistry: svc.Attributes.ServiceRegistry,
 					Labels:          svc.Attributes.Labels,
 				},
+			}
+			if features.EnableDualStack {
+				// cannot correctly build virtualHost domains for dual stack without ClusterVIPs
+				servicesByName[svc.Hostname].ClusterVIPs = *svc.ClusterVIPs.DeepCopy()
 			}
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -24,6 +24,7 @@ import (
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/test/xdstest"
@@ -40,11 +41,12 @@ import (
 
 func TestGenerateVirtualHostDomains(t *testing.T) {
 	cases := []struct {
-		name    string
-		service *model.Service
-		port    int
-		node    *model.Proxy
-		want    []string
+		name            string
+		service         *model.Service
+		port            int
+		node            *model.Proxy
+		want            []string
+		enableDualStack bool
 	}{
 		{
 			name: "same domain",
@@ -271,6 +273,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				"1.2.3.4",
 				"[2406:3003:2064:35b8:864:a648:4b96:e37d]",
 			},
+			enableDualStack: true,
 		},
 	}
 
@@ -282,7 +285,13 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
+			if c.enableDualStack {
+				features.EnableDualStack = true
+			}
 			testFn(t, c.service, c.port, c.node, c.want)
+			if c.enableDualStack {
+				features.EnableDualStack = false
+			}
 		})
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -285,13 +285,8 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			if c.enableDualStack {
-				features.EnableDualStack = true
-			}
+			test.SetForTest[bool](t, &features.EnableDualStack, c.enableDualStack)
 			testFn(t, c.service, c.port, c.node, c.want)
-			if c.enableDualStack {
-				features.EnableDualStack = false
-			}
 		})
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -251,7 +251,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 				DefaultAddress: "1.2.3.4",
 				ClusterVIPs: model.AddressMap{
 					Addresses: map[cluster.ID][]string{
-						"cluster-1": {"2406:3003:2064:35b8:864:a648:4b96:e37d"},
+						"cluster-1": {"1.2.3.4", "2406:3003:2064:35b8:864:a648:4b96:e37d"},
 						"cluster-2": {"4.3.2.1"}, // ensure other clusters aren't being populated in domains slice
 					},
 				},

--- a/releasenotes/notes/45564-virtualHost-Domains-for-dual-stack.yaml
+++ b/releasenotes/notes/45564-virtualHost-Domains-for-dual-stack.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 45557
+releaseNotes:
+- |
+  **Fixed** an issue in dual stack meshes where virtualHost.Domains was missing the second IP address from dual stack services.


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes #45557

Adds the additional IP from services spec.clusterIPs into the virtualHost.Domains