### PR TITLE
fix(sec): upgrade tornado to 6.3.2

### DIFF
--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -25,7 +25,7 @@ simplejson==3.16.0
 six==1.12.0
 threadloop==1.0.2
 thrift==0.11.0
-tornado==5.1
+tornado==6.3.2
 urllib3==1.26.5
 visitor==0.1.3
 Werkzeug==2.2.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tornado 5.1
- [CVE-2023-28370](https://www.oscs1024.com/hd/CVE-2023-28370)


### What did I do？
Upgrade tornado from 5.1 to 6.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS