### PR TITLE
fix parentRefs sort

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -722,7 +722,7 @@ func extractParentReferenceInfo(gateways map[parentKey][]*parentInfo, routeRefs 
 	}
 	// Ensure stable order
 	slices.SortFunc(parentRefs, func(a, b routeParentReference) bool {
-		return fmt.Sprint(a.OriginalReference) < fmt.Sprint(b.OriginalReference)
+		return parentRefString(a.OriginalReference) < parentRefString(b.OriginalReference)
 	})
 	return parentRefs
 }


### PR DESCRIPTION
fix #45565 

Using `fmt.Sprint` to convert the reference type will get the address, so the ordering is random.