### PR TITLE
Introduce StartupBoost mode

### DIFF
--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -144,6 +144,7 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 	controller.DiscoveryNamespacesFilter = filter.NewDiscoveryNamespacesFilter(namespaces, meshWatcher.Mesh().GetDiscoverySelectors())
 	controller.queue = controllers.NewQueue("multicluster secret",
 		controllers.WithMaxAttempts(maxRetries),
+		controllers.WithStartupBoost(),
 		controllers.WithReconciler(controller.processItem))
 
 	secrets.AddEventHandler(controllers.ObjectHandler(controller.queue.AddObject))


### PR DESCRIPTION
This PR proposes a startup boost mode in the secret controller.

Currently, the secret controller basically uses the controller queue for processing the secrets sequentially.
The sequential processing is great for the normal state of Istiod because it would be not desired to use CPU/Memory for processing the secrets too aggressively.
But, before being synced in the startup time, it seems to be reasonable to process in parallel for the fast startup of Istiod.

Therefore, this PR extends the controller queue to have the boost mode, and it is applied to the secret controller.

If boost mode is enabled, the controller queue will process the work items in parallel only before it is synced.
After synced, the controller queue will process them sequentially as it does in the normal mode.

Change-Id: I9b7a2256044adee1cec8a9d9a208c83ff8ca0709
