### PR TITLE
Change retry interval in jwtkeyresolver to 10 millis for testing

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1237,7 +1237,7 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 	push := &model.PushContext{}
 	push.JwtKeyResolver = model.NewJwksResolver(
 		model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval,
-		model.JwtPubKeyRefreshIntervalOnFailure, model.JwtPubKeyRetryInterval)
+		model.JwtPubKeyRefreshIntervalOnFailure, 50*time.Millisecond)
 	defer push.JwtKeyResolver.Close()
 
 	for _, c := range cases {

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -918,7 +918,7 @@ func TestJwtFilter(t *testing.T) {
 	push := model.NewPushContext()
 	push.JwtKeyResolver = model.NewJwksResolver(
 		model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval,
-		model.JwtPubKeyRefreshIntervalOnFailure, model.JwtPubKeyRetryInterval)
+		model.JwtPubKeyRefreshIntervalOnFailure, 10*time.Millisecond)
 	defer push.JwtKeyResolver.Close()
 
 	push.ServiceIndex.HostnameAndNamespace[host.Name("jwt-token-issuer.mesh")] = map[string]*model.Service{}
@@ -1237,7 +1237,7 @@ func TestConvertToEnvoyJwtConfig(t *testing.T) {
 	push := &model.PushContext{}
 	push.JwtKeyResolver = model.NewJwksResolver(
 		model.JwtPubKeyEvictionDuration, model.JwtPubKeyRefreshInterval,
-		model.JwtPubKeyRefreshIntervalOnFailure, 50*time.Millisecond)
+		model.JwtPubKeyRefreshIntervalOnFailure, 10*time.Millisecond)
 	defer push.JwtKeyResolver.Close()
 
 	for _, c := range cases {


### PR DESCRIPTION
**Please provide a description of this PR:**
Contributes to #37555 .

This PR shortens the retryInterval to 10 millis for jwtresolver, bringing down the testing time from 7s to ~.40s

However, I found that the duration of the test fluctuates, depending on a "race condition" (probably an inaccurate expression) between `closeChan` and `jwksuriChannel` receiving values:

https://github.com/cebernardi/istio/blob/91c957436b75554ba4ad514ec00e182ff7040b0b/pilot/pkg/model/jwks_resolver.go#L402-L408

If `jwksuriChannel` receives a value before `closeChan`, the `Close` function waits for 8 attempts to be made to resolve the jwk uri before returning (thus, the test takes longer).

Is it something that should be addressed? If yes, would it be in this PR, or in another PR?