### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Configures Depdendabot to PR go security updates only
+
+version: 2
+updates:
+  # Go configuration for master branch
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Limit number of open PRs to 0 so that we only get security updates
+    # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
+  # Go configuration for release-1.18 branch
+  - package-ecosystem: "gomod"
+    target-branch: "release-1.18"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Limit number of open PRs to 0 so that we only get security updates
+    # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
+    open-pull-requests-limit: 0
+   


### PR DESCRIPTION
**Please provide a description of this PR:**
As discussed on 21/6/23 WG call, we would like to get automatic security updates on our release branches as well as our default branch to solve the problem where they get merged and not cherry picked to the releases.  We didn't have an explicit dependabot configuration declared previously, so this PR seeks to replicate our existing behaviour on the master branch and apply it to release-1.18 too. I've tested this by enabling dependabot in my fork of 1.18 and I see PRs raised that match those that already exist in istio/istio:master, so I think this works.  Once we are sure, I will raise another PR to add this to 1.17 and 1.16 branches as discussed.