### PR TITLE
Add cipher suites support in meshConfig for mesh-wide cipher

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1203,7 +1203,6 @@ func applyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconf
 	if len(tlsDefaults.CipherSuites) > 0 {
 		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsDefaults.CipherSuites
 	}
-
 }
 
 // Set auto_sni if EnableAutoSni feature flag is enabled and if sni field is not explicitly set in DR.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1200,6 +1200,10 @@ func applyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconf
 	if len(tlsDefaults.EcdhCurves) > 0 {
 		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsDefaults.EcdhCurves
 	}
+	if len(tlsDefaults.CipherSuites) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsDefaults.CipherSuites
+	}
+
 }
 
 // Set auto_sni if EnableAutoSni feature flag is enabled and if sni field is not explicitly set in DR.

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -681,7 +681,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "ecdh curves specified in mesh config with tls SIMPLE",
+			name: "ecdh curves and cipher suites specified in mesh config with tls SIMPLE",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
 				Port: &networking.Port{
@@ -695,14 +695,16 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 			mesh: &meshconfig.MeshConfig{
 				TlsDefaults: &meshconfig.MeshConfig_TLSConfig{
-					EcdhCurves: []string{"P-256"},
+					EcdhCurves:   []string{"P-256"},
+					CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA"},
 				},
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
 					TlsParams: &auth.TlsParameters{
-						EcdhCurves: []string{"P-256"},
+						EcdhCurves:   []string{"P-256"},
+						CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA"},
 					},
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
@@ -731,7 +733,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "ecdh curves specified in mesh config with, tls mode ISTIO_MUTUAL",
+			name: "ecdh curves and cipher suites specified in mesh config with, tls mode ISTIO_MUTUAL",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com"},
 				Port: &networking.Port{
@@ -743,7 +745,8 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 			mesh: &meshconfig.MeshConfig{
 				TlsDefaults: &meshconfig.MeshConfig_TLSConfig{
-					EcdhCurves: []string{"P-256"},
+					EcdhCurves:   []string{"P-256"},
+					CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES256-GCM-SHA384"},
 				},
 			},
 			result: &auth.DownstreamTlsContext{
@@ -803,7 +806,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "ecdh curves specified in mesh config with tls MUTUAL",
+			name: "ecdh curves and cipher suites specified in mesh config with tls MUTUAL",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com", "bookinfo.example.com"},
 				Port: &networking.Port{
@@ -819,13 +822,15 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 			mesh: &meshconfig.MeshConfig{
 				TlsDefaults: &meshconfig.MeshConfig_TLSConfig{
-					EcdhCurves: []string{"P-256", "P-384"},
+					EcdhCurves:   []string{"P-256", "P-384"},
+					CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES256-GCM-SHA384"},
 				},
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: &auth.TlsParameters{
-						EcdhCurves: []string{"P-256", "P-384"},
+						EcdhCurves:   []string{"P-256", "P-384"},
+						CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES256-GCM-SHA384"},
 					},
 					AlpnProtocols: util.ALPNHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -186,6 +186,9 @@ func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ct
 	if len(tlsDefaults.EcdhCurves) > 0 {
 		tlsParamsOrNew(ctx).EcdhCurves = tlsDefaults.EcdhCurves
 	}
+	if len(tlsDefaults.CipherSuites) > 0 {
+		tlsParamsOrNew(ctx).CipherSuites = tlsDefaults.CipherSuites
+	}
 	if tlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
 		tlsParamsOrNew(ctx).TlsMinimumProtocolVersion = auth.TlsParameters_TlsProtocol(tlsDefaults.MinProtocolVersion)
 	}

--- a/releasenotes/notes/cipher_suites.yaml
+++ b/releasenotes/notes/cipher_suites.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/28996
+releaseNotes:
+  - |
+    **Added** cipher_suites support for mesh-internal traffic through MeshConfig API.

--- a/releasenotes/notes/cipher_suites.yaml
+++ b/releasenotes/notes/cipher_suites.yaml
@@ -5,4 +5,4 @@ issue:
   - https://github.com/istio/istio/issues/28996
 releaseNotes:
   - |
-    **Added** cipher_suites support for mesh-internal traffic through MeshConfig API.
+    **Added** cipher_suites support for non ISTIO_MUTUAL traffic through MeshConfig API.


### PR DESCRIPTION
Allow users to specify the ciphers they want sidecars to use within their sidecars.