### PR TITLE
Fix AccesslogsMode server testcase

### DIFF
--- a/tests/integration/telemetry/api/accesslogs_test.go
+++ b/tests/integration/telemetry/api/accesslogs_test.go
@@ -67,7 +67,6 @@ func TestAccessLogsFilter(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.logging.filter").
 		Run(func(t framework.TestContext) {
-			applyTelemetryResource(t, false)
 			runAccessLogFilterTests(t, false)
 			t.ConfigIstio().File(common.GetAppNamespace().Name(), "./testdata/accesslog/filter.yaml").ApplyOrFail(t)
 			runAccessLogFilterTests(t, true)
@@ -98,7 +97,6 @@ func TestAccessLogsDefaultProvider(t *testing.T) {
 		Features("observability.telemetry.logging.defaultprovider").
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("disabled").Run(func(t framework.TestContext) {
-				applyTelemetryResource(t, false)
 				runAccessLogsTests(t, false)
 			})
 			t.NewSubTest("enabled").Run(func(t framework.TestContext) {

--- a/tests/integration/telemetry/api/accesslogs_test.go
+++ b/tests/integration/telemetry/api/accesslogs_test.go
@@ -67,6 +67,7 @@ func TestAccessLogsFilter(t *testing.T) {
 	framework.NewTest(t).
 		Features("observability.telemetry.logging.filter").
 		Run(func(t framework.TestContext) {
+			applyTelemetryResource(t, false)
 			runAccessLogFilterTests(t, false)
 			t.ConfigIstio().File(common.GetAppNamespace().Name(), "./testdata/accesslog/filter.yaml").ApplyOrFail(t)
 			runAccessLogFilterTests(t, true)
@@ -83,7 +84,7 @@ func TestAccessLogsMode(t *testing.T) {
 			})
 			t.NewSubTest("server").Run(func(t framework.TestContext) {
 				t.ConfigIstio().File(common.GetAppNamespace().Name(), "./testdata/accesslog/mode-server.yaml").ApplyOrFail(t)
-				runAccessLogModeTests(t, false, false)
+				runAccessLogModeTests(t, false, true)
 			})
 			t.NewSubTest("client-and-server").Run(func(t framework.TestContext) {
 				t.ConfigIstio().File(common.GetAppNamespace().Name(), "./testdata/accesslog/mode-clientserver.yaml").ApplyOrFail(t)
@@ -97,6 +98,7 @@ func TestAccessLogsDefaultProvider(t *testing.T) {
 		Features("observability.telemetry.logging.defaultprovider").
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("disabled").Run(func(t framework.TestContext) {
+				applyTelemetryResource(t, false)
 				runAccessLogsTests(t, false)
 			})
 			t.NewSubTest("enabled").Run(func(t framework.TestContext) {


### PR DESCRIPTION
Existing testcase for TestAccessLogsMode/server was set to expect no logs from server and client even though the setting applied had a MATCH set to server.

Fix: TestAccessLogsMode/server case, is fixed to expect server logs.



