### PR TITLE
Fix health probe port overwrite

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -709,6 +709,7 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Forward incoming headers to the application.
+	appReq.Host = prober.HTTPGet.Host
 	for name, values := range req.Header {
 		appReq.Header[name] = slices.Clone(values)
 		if len(values) > 0 && (strings.EqualFold(name, "Host") || name == ":authority") {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -709,10 +709,10 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Forward incoming headers to the application.
-	appReq.Host = req.Host
 	for name, values := range req.Header {
 		appReq.Header[name] = slices.Clone(values)
 		if len(values) > 0 && (strings.EqualFold(name, "Host") || name == ":authority") {
+			// Probe has specific host header override; honor it
 			appReq.Host = values[0]
 		}
 	}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -709,7 +709,9 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Forward incoming headers to the application.
-	appReq.Host = prober.HTTPGet.Host
+	if prober.HTTPGet.Host != "" {
+		appReq.Host = prober.HTTPGet.Host
+	}
 	for name, values := range req.Header {
 		appReq.Header[name] = slices.Clone(values)
 		if len(values) > 0 && (strings.EqualFold(name, "Host") || name == ":authority") {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -886,9 +886,6 @@ func TestAppProbe(t *testing.T) {
 		}
 		if c := tc.config["/"+tc.probePath]; c != nil {
 			if hc := c.HTTPGet; hc != nil {
-				if hc.Host != "" {
-					req.Host = hc.Host
-				}
 				for _, h := range hc.HTTPHeaders {
 					req.Header[h.Name] = append(req.Header[h.Name], h.Value)
 				}


### PR DESCRIPTION
**Please provide a description of this PR:**

Resolves #45482.

This change removes the overwrite of the host of the application request created by the istio-agent status server. Previously, the host was overwritten to the host of the original request from Kubelet to the istio-agent status server. Unless a host header was specified, the host would always be set to the status port, 15020, rather than the application port used for health checks.

Testing:
- Modified unit tests to remove explicit port override. Without the override in the unit tests, the existing workflow fails as expected. The unit test override did not reflect the actual workflow and values of a health check request.