### PR TITLE
Move uninstall out of experimental commands

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -203,7 +203,6 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(metrics.Cmd(ctx))
 	experimentalCmd.AddCommand(describe.Cmd(ctx))
 	experimentalCmd.AddCommand(wait.Cmd(ctx))
-	experimentalCmd.AddCommand(softGraduatedCmd(mesh.UninstallCmd(root.LoggingOptions)))
 	experimentalCmd.AddCommand(config.Cmd())
 	experimentalCmd.AddCommand(workload.Cmd(ctx))
 	experimentalCmd.AddCommand(revision.Cmd(ctx))
@@ -311,19 +310,20 @@ func configureLogging(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
+// softGraduatedCmd is kept for future use when commands are softly graduated.
 // softGraduatedCmd is used for commands that have graduated, but we still want the old invocation to work.
-func softGraduatedCmd(cmd *cobra.Command) *cobra.Command {
-	msg := fmt.Sprintf("(%s has graduated. Use `istioctl %s`)", cmd.Name(), cmd.Name())
-
-	newCmd := *cmd
-	newCmd.Short = fmt.Sprintf("%s %s", cmd.Short, msg)
-	newCmd.RunE = func(c *cobra.Command, args []string) error {
-		fmt.Fprintln(cmd.ErrOrStderr(), msg)
-		return cmd.RunE(c, args)
-	}
-
-	return &newCmd
-}
+//func softGraduatedCmd(cmd *cobra.Command) *cobra.Command {
+//	msg := fmt.Sprintf("(%s has graduated. Use `istioctl %s`)", cmd.Name(), cmd.Name())
+//
+//	newCmd := *cmd
+//	newCmd.Short = fmt.Sprintf("%s %s", cmd.Short, msg)
+//	newCmd.RunE = func(c *cobra.Command, args []string) error {
+//		fmt.Fprintln(cmd.ErrOrStderr(), msg)
+//		return cmd.RunE(c, args)
+//	}
+//
+//	return &newCmd
+//}
 
 // seeExperimentalCmd is used for commands that have been around for a release but not graduated from
 // Other alternative

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -310,21 +310,6 @@ func configureLogging(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// softGraduatedCmd is kept for future use when commands are softly graduated.
-// softGraduatedCmd is used for commands that have graduated, but we still want the old invocation to work.
-//func softGraduatedCmd(cmd *cobra.Command) *cobra.Command {
-//	msg := fmt.Sprintf("(%s has graduated. Use `istioctl %s`)", cmd.Name(), cmd.Name())
-//
-//	newCmd := *cmd
-//	newCmd.Short = fmt.Sprintf("%s %s", cmd.Short, msg)
-//	newCmd.RunE = func(c *cobra.Command, args []string) error {
-//		fmt.Fprintln(cmd.ErrOrStderr(), msg)
-//		return cmd.RunE(c, args)
-//	}
-//
-//	return &newCmd
-//}
-
 // seeExperimentalCmd is used for commands that have been around for a release but not graduated from
 // Other alternative
 // for graduatedCmd see https://github.com/istio/istio/pull/26408

--- a/releasenotes/notes/45640.yaml
+++ b/releasenotes/notes/45640.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Removed** `uninstall` command from `istioctl experimental`, use `istioctl uninstall` instead.


### PR DESCRIPTION
**Please provide a description of this PR:**
Uninstall has been graduated almost a year ago. I think we can remove it from experimental commands for the next release.