### PR TITLE
Fix proxy-status diff for ztunnel pod

### DIFF
--- a/istioctl/pkg/proxystatus/proxystatus.go
+++ b/istioctl/pkg/proxystatus/proxystatus.go
@@ -22,11 +22,11 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/spf13/cobra"
-	"istio.io/istio/istioctl/pkg/util/ambient"
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/multixds"
+	"istio.io/istio/istioctl/pkg/util/ambient"
 	"istio.io/istio/istioctl/pkg/writer/compare"
 	"istio.io/istio/istioctl/pkg/writer/pilot"
 	pilotxds "istio.io/istio/pilot/pkg/xds"
@@ -78,8 +78,8 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 					return err
 				}
 				if ambient.IsZtunnelPod(kubeClient, podName, ns) {
-					_, _ = fmt.Fprintln(c.OutOrStdout(),
-						fmt.Sprintf("Sync diff is not available for ztunnel pod %s.%s", podName, ns))
+					_, _ = fmt.Fprintf(c.OutOrStdout(),
+						"Sync diff is not available for ztunnel pod %s.%s\n", podName, ns)
 					return nil
 				}
 				var envoyDump []byte
@@ -190,8 +190,8 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 					return err
 				}
 				if ambient.IsZtunnelPod(kubeClient, podName, ns) {
-					_, _ = fmt.Fprintln(c.OutOrStdout(),
-						fmt.Sprintf("Sync diff is not available for ztunnel pod %s.%s", podName, ns))
+					_, _ = fmt.Fprintf(c.OutOrStdout(),
+						"Sync diff is not available for ztunnel pod %s.%s\n", podName, ns)
 					return nil
 				}
 				var envoyDump []byte

--- a/istioctl/pkg/proxystatus/proxystatus.go
+++ b/istioctl/pkg/proxystatus/proxystatus.go
@@ -22,6 +22,7 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/spf13/cobra"
+	"istio.io/istio/istioctl/pkg/util/ambient"
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
@@ -75,6 +76,11 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				podName, ns, err := ctx.InferPodInfoFromTypedResource(args[0], ctx.Namespace())
 				if err != nil {
 					return err
+				}
+				if ambient.IsZtunnelPod(kubeClient, podName, ns) {
+					_, _ = fmt.Fprintln(c.OutOrStdout(),
+						fmt.Sprintf("Sync diff is not available for ztunnel pod %s.%s", podName, ns))
+					return nil
 				}
 				var envoyDump []byte
 				if configDumpFile != "" {
@@ -182,6 +188,11 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				podName, ns, err := ctx.InferPodInfoFromTypedResource(args[0], ctx.Namespace())
 				if err != nil {
 					return err
+				}
+				if ambient.IsZtunnelPod(kubeClient, podName, ns) {
+					_, _ = fmt.Fprintln(c.OutOrStdout(),
+						fmt.Sprintf("Sync diff is not available for ztunnel pod %s.%s", podName, ns))
+					return nil
 				}
 				var envoyDump []byte
 				if configDumpFile != "" {

--- a/releasenotes/notes/45641.yaml
+++ b/releasenotes/notes/45641.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where Ztunnel pods could be compared to Envoy configs in `istioctl proxy-status` and `istioctl x proxy-status`. They are now excluded from the comparison.


### PR DESCRIPTION
**Please provide a description of this PR:**
Ztunnel pods are displayed in `proxy-status`, however envoy xDS configs are not available for them, and they should not be included for sync diff. Currently there are also some errors when we do 
```
istioctl ps ztunnel-dt9pp.istio-system
```
because of the missing config.