### PR TITLE
Fix proxy-config root-compare ztunnel component parse error

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -1378,16 +1378,17 @@ func rootCACompareConfigCmd(ctx cli.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			var configWriter1, configWriter2 *configdump.ConfigWriter
 			kubeClient, err := ctx.CLIClient()
 			if err != nil {
 				return err
 			}
+
+			var rootCA1, rootCA2 string
 			if len(args) == 2 {
 				if podName1, podNamespace1, err = getPodName(ctx, args[0]); err != nil {
 					return err
 				}
-				configWriter1, err = setupPodConfigdumpWriter(kubeClient, podName1, podNamespace1, false, c.OutOrStdout())
+				rootCA1, err = extractRootCA(kubeClient, podName1, podNamespace1, c.OutOrStdout())
 				if err != nil {
 					return err
 				}
@@ -1395,22 +1396,13 @@ func rootCACompareConfigCmd(ctx cli.Context) *cobra.Command {
 				if podName2, podNamespace2, err = getPodName(ctx, args[1]); err != nil {
 					return err
 				}
-				configWriter2, err = setupPodConfigdumpWriter(kubeClient, podName2, podNamespace2, false, c.OutOrStdout())
+				rootCA2, err = extractRootCA(kubeClient, podName2, podNamespace2, c.OutOrStdout())
 				if err != nil {
 					return err
 				}
 			} else {
 				c.Println(c.UsageString())
 				return fmt.Errorf("rootca-compare requires 2 pods as an argument")
-			}
-
-			rootCA1, err1 := configWriter1.PrintPodRootCAFromDynamicSecretDump()
-			if err1 != nil {
-				return fmt.Errorf("error when retrieving ROOTCA of [%s]: %v", args[0], err1)
-			}
-			rootCA2, err2 := configWriter2.PrintPodRootCAFromDynamicSecretDump()
-			if err2 != nil {
-				return fmt.Errorf("error when retrieving ROOTCA of [%s]: %v", args[1], err2)
 			}
 
 			var returnErr error
@@ -1433,6 +1425,22 @@ func rootCACompareConfigCmd(ctx cli.Context) *cobra.Command {
 
 	rootCACompareConfigCmd.Long += "\n\n" + istioctlutil.ExperimentalMsg
 	return rootCACompareConfigCmd
+}
+
+func extractRootCA(client kube.CLIClient, podName, podNamespace string, out io.Writer) (string, error) {
+	ztunnelPod := ambientutil.IsZtunnelPod(client, podName, podNamespace)
+	if ztunnelPod {
+		configWriter, err := setupZtunnelConfigDumpWriter(client, podName, podNamespace, out)
+		if err != nil {
+			return "", err
+		}
+		return configWriter.PrintPodRootCAFromDynamicSecretDump()
+	}
+	configWriter, err := setupPodConfigdumpWriter(client, podName, podNamespace, false, out)
+	if err != nil {
+		return "", err
+	}
+	return configWriter.PrintPodRootCAFromDynamicSecretDump()
 }
 
 func ProxyConfig(ctx cli.Context) *cobra.Command {

--- a/releasenotes/notes/45643.yaml
+++ b/releasenotes/notes/45643.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where there was a parse error when performing rootCA comparison for Ztunnel pods.


### PR DESCRIPTION
**Please provide a description of this PR:**
Ztunnel component cannot be parsed since it's different config. This fix is similar to other proxy-config config parts.

Tests:
```bash
 istio git:(master) ✗ istioctl pc rootca-compare ztunnel-dt9pp.istio-system ztunnel-hzfbf.istio-system                               
Both [ztunnel-dt9pp.istio-system] and [ztunnel-hzfbf.istio-system] have the identical ROOTCA, theoretically the connectivity between them is available
➜  istio git:(master) ✗ istioctl pc rootca-compare reviews-v2-56c97865cc-vwqgk.bookinfo reviews-v3-5cc6876f4f-n247b.bookinfo
Both [reviews-v2-56c97865cc-vwqgk.bookinfo] and [reviews-v3-5cc6876f4f-n247b.bookinfo] have the identical ROOTCA, theoretically the connectivity between them is available
```