### PR TITLE
Fix analyze waypoint hbone portname warning

### DIFF
--- a/pkg/config/analysis/analyzers/service/portname.go
+++ b/pkg/config/analysis/analyzers/service/portname.go
@@ -17,14 +17,14 @@ package service
 import (
 	"fmt"
 
-	"istio.io/istio/pkg/config/analysis/msg"
-	"istio.io/istio/pkg/config/constants"
-	configKube "istio.io/istio/pkg/config/kube"
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
 	"istio.io/istio/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/constants"
+	configKube "istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/gvk"
 )

--- a/pkg/config/analysis/analyzers/service/portname.go
+++ b/pkg/config/analysis/analyzers/service/portname.go
@@ -17,13 +17,14 @@ package service
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/constants"
+	configKube "istio.io/istio/pkg/config/kube"
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
 	"istio.io/istio/pkg/config/analysis/analyzers/util"
-	"istio.io/istio/pkg/config/analysis/msg"
-	configKube "istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
@@ -66,11 +67,13 @@ func (s *PortNameAnalyzer) Analyze(c analysis.Context) {
 
 func (s *PortNameAnalyzer) analyzeService(r *resource.Instance, c analysis.Context) {
 	svc := r.Message.(*v1.ServiceSpec)
+	// Skip gateway managed services, which are not created by users
+	if v, ok := r.Metadata.Labels[constants.ManagedGatewayLabel]; ok &&
+		v == constants.ManagedGatewayControllerLabel ||
+		v == constants.ManagedGatewayMeshControllerLabel {
+		return
+	}
 	for i, port := range svc.Ports {
-		// Skip internal ports, which are not created by users
-		if port.AppProtocol != nil && *port.AppProtocol == "hbone" {
-			continue
-		}
 		instance := configKube.ConvertProtocol(port.Port, port.Name, port.Protocol, port.AppProtocol)
 		if instance.IsUnsupported() || port.Name == "tcp" && svc.Type == "ExternalName" {
 

--- a/pkg/config/analysis/analyzers/service/portname.go
+++ b/pkg/config/analysis/analyzers/service/portname.go
@@ -67,6 +67,10 @@ func (s *PortNameAnalyzer) Analyze(c analysis.Context) {
 func (s *PortNameAnalyzer) analyzeService(r *resource.Instance, c analysis.Context) {
 	svc := r.Message.(*v1.ServiceSpec)
 	for i, port := range svc.Ports {
+		// Skip internal ports, which are not created by users
+		if port.AppProtocol != nil && *port.AppProtocol == "hbone" {
+			continue
+		}
 		instance := configKube.ConvertProtocol(port.Port, port.Name, port.Protocol, port.AppProtocol)
 		if instance.IsUnsupported() || port.Name == "tcp" && svc.Type == "ExternalName" {
 

--- a/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
+++ b/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
@@ -12,3 +12,30 @@ spec:
       protocol: TCP
       port: 8080
       targetPort: 8080
+---
+# internal waypoint, should not generate warning
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    istio.io/for-service-account: reviews
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+  name: reviews-istio-waypoint
+  namespace: ambient
+spec:
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - appProtocol: hbone
+    name: mesh
+    port: 15008
+    protocol: TCP
+    targetPort: 15008
+  selector:
+    istio.io/gateway-name: reviews
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
+++ b/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
@@ -8,10 +8,10 @@ spec:
   selector:
     app: my-service
   ports:
-    - name: tcp-foo
-      protocol: TCP
-      port: 8080
-      targetPort: 8080
+  - name: tcp-foo
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
 ---
 # internal waypoint, should not generate warning
 apiVersion: v1
@@ -39,3 +39,31 @@ spec:
     istio.io/gateway-name: reviews
   sessionAffinity: None
   type: ClusterIP
+---
+# managed gateway, should not generate warning
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    test: test
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: gateway-istio
+  namespace: istio-ingress
+spec:
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    nodePort: 32481
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - appProtocol: http
+    name: default
+    nodePort: 30686
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    istio.io/gateway-name: gateway
+  type: LoadBalancer

--- a/pkg/config/kube/conversion.go
+++ b/pkg/config/kube/conversion.go
@@ -60,9 +60,6 @@ func ConvertProtocol(port int32, portName string, proto corev1.Protocol, appProt
 		// "http2 over cleartext", which is also what our HTTP2 port is
 		case "kubernetes.io/h2c":
 			return protocol.HTTP2
-		// hbone is a protocol used internally
-		case "hbone":
-			return protocol.HBONE
 		}
 	}
 

--- a/pkg/config/kube/conversion.go
+++ b/pkg/config/kube/conversion.go
@@ -60,6 +60,9 @@ func ConvertProtocol(port int32, portName string, proto corev1.Protocol, appProt
 		// "http2 over cleartext", which is also what our HTTP2 port is
 		case "kubernetes.io/h2c":
 			return protocol.HTTP2
+		// hbone is a protocol used internally
+		case "hbone":
+			return protocol.HBONE
 		}
 	}
 

--- a/releasenotes/notes/45644.yaml
+++ b/releasenotes/notes/45644.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where analyzers were reporting messages for the gateway-managed waypoint service.

--- a/releasenotes/notes/45644.yaml
+++ b/releasenotes/notes/45644.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
 - |
-  **Fixed** an issue where analyzers were reporting messages for the gateway-managed waypoint service.
+  **Fixed** an issue where analyzers were reporting messages for the gateway-managed services.


### PR DESCRIPTION
**Please provide a description of this PR:**
Analyze has the message for port name of waypoint:
```
Info [IST0118] (Service ambient/httpbin-istio-waypoint) Port name mesh (port: 15008, targetPort: 15008) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service ambient/productpage-istio-waypoint) Port name mesh (port: 15008, targetPort: 15008) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service ambient/ratings-istio-waypoint) Port name mesh (port: 15008, targetPort: 15008) doesn't follow the naming convention of Istio port.
```

Since this is implemented internally, I think we can avoid reporting these messages.