### PR TITLE
Use google/safetext for yaml templating

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"text/template"
+	template "github.com/google/safetext/yamltemplate"
 	"time"
 
 	"github.com/prometheus/prometheus/util/strutil"


### PR DESCRIPTION
Switching to safetext/yamltemplate to automatically prevent YAML injection vulnerabilities.