### PR TITLE
Add flexibility to Istio egress labels, name and namespace for E2E tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -171,6 +171,18 @@ type Config struct {
 	// IngressGatewayIstioLabel allows overriding the selector of the ingressgateway service (defaults to istio=ingressgateway)
 	// This field should only be set when DeployIstio is false
 	IngressGatewayIstioLabel string
+
+	// EgressGatewayServiceName is the service name to use to reference the egressgateway
+	// This field should only be set when DeployIstio is false
+	EgressGatewayServiceName string
+
+	// EgressGatewayServiceNamespace allows overriding the namespace of the egressgateway service (defaults to SystemNamespace)
+	// This field should only be set when DeployIstio is false
+	EgressGatewayServiceNamespace string
+
+	// EgressGatewayIstioLabel allows overriding the selector of the egressgateway service (defaults to istio=egressgateway)
+	// This field should only be set when DeployIstio is false
+	EgressGatewayIstioLabel string
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {
@@ -342,6 +354,9 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("IngressGatewayServiceName:      %v\n", c.IngressGatewayServiceName)
 	result += fmt.Sprintf("IngressGatewayServiceNamespace: %v\n", c.IngressGatewayServiceNamespace)
 	result += fmt.Sprintf("IngressGatewayIstioLabel:     	 %v\n", c.IngressGatewayIstioLabel)
+	result += fmt.Sprintf("EgressGatewayServiceName:      %v\n", c.EgressGatewayServiceName)
+	result += fmt.Sprintf("EressGatewayServiceNamespace: %v\n", c.EgressGatewayServiceNamespace)
+	result += fmt.Sprintf("EgressGatewayIstioLabel:     	 %v\n", c.EgressGatewayIstioLabel)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -53,4 +53,16 @@ func init() {
 		settingsFromCommandline.IngressGatewayIstioLabel,
 		`Specifies the istio label of the ingressgateway to search for when running tests in a preinstalled istio installation.
 		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayServiceName, "istio.test.kube.egressGatewayServiceName",
+		settingsFromCommandline.EgressGatewayServiceName,
+		`Specifies the name of the egressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayServiceNamespace, "istio.test.kube.egressGatewayServiceNamespace",
+		settingsFromCommandline.IngressGatewayServiceNamespace,
+		`Specifies the namespace of the egressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayIstioLabel, "istio.test.kube.egressGatewayIstioLabel",
+		settingsFromCommandline.EgressGatewayIstioLabel,
+		`Specifies the istio label of the egressgateway to search for when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
 }

--- a/tests/integration/pilot/testdata/tunneling/gateway/tcp/gateway.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tcp/gateway.tmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: istio-egressgateway
+  name: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
 spec:
   selector:
-    istio: egressgateway
+    istio: {{ .EgressGatewayIstioLabel | default "egressgateway" }}
   servers:
   - port:
       number: 80

--- a/tests/integration/pilot/testdata/tunneling/gateway/tcp/virtual-service.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tcp/virtual-service.tmpl.yaml
@@ -12,7 +12,7 @@ spec:
     - port: {{ .externalSvcTcpPort }}
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         port:
           number: 80
   tls:
@@ -22,7 +22,7 @@ spec:
       - external.{{ .externalNamespace }}.svc.cluster.local
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         port:
           number: 443
 ---
@@ -34,7 +34,7 @@ spec:
   hosts:
   - external.{{ .externalNamespace }}.svc.cluster.local
   gateways:
-  - istio-egressgateway
+  - {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
   tcp:
   - match:
     - port: 80

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/gateway.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/gateway.tmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: istio-egressgateway
+  name: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
 spec:
   selector:
-    istio: egressgateway
+    istio: {{ .EgressGatewayIstioLabel | default "egressgateway" }}
   servers:
   - port:
       number: 80

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/mtls.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/mtls.tmpl.yaml
@@ -3,7 +3,7 @@ kind: DestinationRule
 metadata:
   name: originate-mtls-for-egress-gateway
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/virtual-service.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/istio-mutual/virtual-service.tmpl.yaml
@@ -12,7 +12,7 @@ spec:
     - port: {{ .externalSvcTcpPort }}
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         port:
           number: 80
   tls:
@@ -22,7 +22,7 @@ spec:
       - external.{{ .externalNamespace }}.svc.cluster.local
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         port:
           number: 443
 ---
@@ -34,7 +34,7 @@ spec:
   hosts:
   - external.{{ .externalNamespace }}.svc.cluster.local
   gateways:
-  - istio-egressgateway
+  - {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
   tcp:
   - match:
     - port: 80

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/gateway.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/gateway.tmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: istio-egressgateway
+  name: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
 spec:
   selector:
-    istio: egressgateway
+    istio: {{ .EgressGatewayIstioLabel | default "egressgateway" }} 
   servers:
   - port:
       number: 443

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/originate-tls.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/originate-tls.tmpl.yaml
@@ -3,7 +3,7 @@ kind: DestinationRule
 metadata:
   name: originate-tls-for-external-svc
 spec:
-  host: istio-egressgateway.istio-system.svc.cluster.local
+  host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
   subsets:
   - name: originate-tls-for-plain-traffic
     trafficPolicy:

--- a/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/virtual-service.tmpl.yaml
+++ b/tests/integration/pilot/testdata/tunneling/gateway/tls/passthrough/virtual-service.tmpl.yaml
@@ -12,7 +12,7 @@ spec:
     - port: {{ .externalSvcTcpPort }}
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         subset: originate-tls-for-plain-traffic
         port:
           number: 443
@@ -23,7 +23,7 @@ spec:
       - external.{{ .externalNamespace }}.svc.cluster.local
     route:
     - destination:
-        host: istio-egressgateway.istio-system.svc.cluster.local
+        host: {{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default "istio-system" }}.svc.cluster.local
         port:
           number: 443
 ---
@@ -35,11 +35,11 @@ spec:
   hosts:
   - external.{{ .externalNamespace }}.svc.cluster.local
   gateways:
-  - istio-egressgateway
+  - {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
   tls:
   - match:
     - gateways:
-      - istio-egressgateway
+      - {{ .EgressGatewayServiceName | default "istio-egressgateway" }}
       port: 443
       sniHosts:
       - external.{{ .externalNamespace }}.svc.cluster.local

--- a/tests/integration/pilot/tunneling_test.go
+++ b/tests/integration/pilot/tunneling_test.go
@@ -121,11 +121,14 @@ func TestTunnelingOutboundTraffic(t *testing.T) {
 
 			for _, proxyConfig := range forwardProxyConfigurations {
 				templateParams := map[string]any{
-					"externalNamespace":  externalNs,
-					"forwardProxyPort":   proxyConfig.Port,
-					"tlsEnabled":         proxyConfig.TLSEnabled,
-					"externalSvcTcpPort": ports.TCPForHTTP.ServicePort,
-					"externalSvcTlsPort": ports.HTTPS.ServicePort,
+					"externalNamespace":             externalNs,
+					"forwardProxyPort":              proxyConfig.Port,
+					"tlsEnabled":                    proxyConfig.TLSEnabled,
+					"externalSvcTcpPort":            ports.TCPForHTTP.ServicePort,
+					"externalSvcTlsPort":            ports.HTTPS.ServicePort,
+					"EgressGatewayIstioLabel":       i.Settings().EgressGatewayIstioLabel,
+					"EgressGatewayServiceName":      i.Settings().EgressGatewayServiceName,
+					"EgressGatewayServiceNamespace": i.Settings().EgressGatewayServiceNamespace,
 				}
 				ctx.ConfigIstio().EvalFile(externalNs, templateParams, tunnelingDestinationRuleFile).ApplyOrFail(ctx)
 

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1170,8 +1170,11 @@ func TestAuthz_EgressGateway(t *testing.T) {
 				ToMatch(toMatch).
 				Config(config.File("testdata/authz/egress-gateway.yaml.tmpl").WithParams(param.Params{
 					// The namespaces for each resource are specified in the file. Use "" as the ns to apply to.
-					param.Namespace.String(): "",
-					"Allowed":                allowed,
+					param.Namespace.String():        "",
+					"EgressGatewayIstioLabel":       i.Settings().EgressGatewayIstioLabel,
+					"EgressGatewayServiceName":      i.Settings().EgressGatewayServiceName,
+					"EgressGatewayServiceNamespace": i.Settings().EgressGatewayServiceNamespace,
+					"Allowed":                       allowed,
 				})).
 				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 					allow := allowValue(from.NamespacedName() == allowed.Config().NamespacedName())

--- a/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/egress-gateway.yaml.tmpl
@@ -13,12 +13,12 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: egressgateway
-  namespace: {{ .SystemNamespace.Name }}
+  name: {{ .EgressGatewayServiceName | default "egressgateway" }}
+  namespace: {{ .EgressGatewayServiceNamespace | default .SystemNamespace.Name }}
 spec:
   selector:
     matchLabels:
-      app: istio-egressgateway
+      app: {{ .EgressGatewayIstioLabel | default "istio-egressgateway" }}
   rules:
     - to: # only allow /allow for company.com
         - operation:
@@ -53,7 +53,7 @@ metadata:
   namespace: {{ .From.NamespaceName }}
 spec:
   selector:
-    istio: egressgateway
+    istio: {{ .EgressGatewayIstioLabel | default "egressgateway" }}
   servers:
     - port:
         number: 80
@@ -89,7 +89,7 @@ spec:
           port: 80
       route:
         - destination:
-            host: "istio-egressgateway.{{ .SystemNamespace.Name }}.svc.cluster.local"
+            host: "{{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default .SystemNamespace.Name }}.svc.cluster.local"
             port:
               number: 80
           weight: 100
@@ -128,7 +128,7 @@ spec:
           port: 80
       route:
         - destination:
-            host: "istio-egressgateway.{{ .SystemNamespace.Name }}.svc.cluster.local"
+            host: "{{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default .SystemNamespace.Name }}.svc.cluster.local"
             port:
               number: 443
           weight: 100
@@ -153,7 +153,7 @@ metadata:
   name: test-egress
   namespace: {{ .From.NamespaceName }}
 spec:
-  host: "istio-egressgateway.{{ .SystemNamespace.Name }}.svc.cluster.local"
+  host: "{{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default .SystemNamespace.Name }}.svc.cluster.local"
   trafficPolicy:
     portLevelSettings:
       - port:
@@ -168,7 +168,7 @@ metadata:
   name: test-egress
   namespace: {{ .SystemNamespace.Name }}
 spec:
-  host: "istio-egressgateway.{{ .SystemNamespace.Name }}.svc.cluster.local"
+  host: "{{ .EgressGatewayServiceName | default "istio-egressgateway" }}.{{ .EgressGatewayServiceNamespace | default .SystemNamespace.Name }}.svc.cluster.local"
   trafficPolicy:
     portLevelSettings:
       - port:


### PR DESCRIPTION
The Istio E2E tests still assume a lot about a pre-existing environment when running integration tests, specifically around the egress gateway deployments. This PR allows the test runner to change the expected service name, namespace and labels during the e2e tests

Part of: #45663 