### PR TITLE
Add support for voulmes and volumeMount in the istio/gateway helm chart.

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
             name: http-envoy-prom
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -108,3 +112,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -217,6 +217,26 @@
     },
     "terminationGracePeriodSeconds": {
       "type": "number"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "mountPath": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -129,3 +129,7 @@ imagePullSecrets: []
 podDisruptionBudget: {}
 
 terminationGracePeriodSeconds: 30
+
+volumeMounts: []
+
+volumes: []

--- a/releasenotes/notes/36999.yaml
+++ b/releasenotes/notes/36999.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/36999
+
+releaseNotes:
+  - |
+    **Added** support for volumeMount and volumes values for istio/gateway Helm chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

As mentioned in #36999 the current istio/gateway chart lacks the support for directly mounting volumes which is necessary for mounting secrets or loading lua files stored in a ConfigMap that need to be mounted.

Suggested workarounds have been to mount these manually, however that does not fit well in a GitOps workflow.

Attempting to revive the proposed change from #38198 which has not had any activity for over a year and has since been closed. cc @maxhov happy to defer to you if you want to revive your PR.