### PR TITLE
Run TestSidecarRoutes in parallel

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2441,7 +2441,7 @@ spec:
 	}
 	for _, variant := range []string{"httproute", "virtualservice"} {
 		t.Run(variant, func(t *testing.T) {
-			for i, _ := range cases {
+			for i := range cases {
 				tt := cases[i]
 				t.Run(tt.name, func(t *testing.T) {
 					t.Parallel()

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2441,8 +2441,11 @@ spec:
 	}
 	for _, variant := range []string{"httproute", "virtualservice"} {
 		t.Run(variant, func(t *testing.T) {
-			for _, tt := range cases {
+			for i, _ := range cases {
+				tt := cases[i]
+				//pr := *tt.proxy
 				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
 					cfg := knownServices
 					for _, tc := range tt.cfg {
 						cfg = cfg + "\n---\n" + tc.Config(t, variant)
@@ -2472,9 +2475,10 @@ spec:
 						t.Fatalf("route %q not found, have %v", tt.routeName, xdstest.MapKeys(r))
 					}
 					gotHosts := xdstest.ExtractVirtualHosts(vh)
-
+					fmt.Println("exp", exp)
 					for wk, wv := range exp {
 						got := gotHosts[wk]
+						fmt.Println("had", xdstest.MapKeys(gotHosts))
 						if !reflect.DeepEqual(wv, got) {
 							t.Errorf("%q: wanted %v, got %v (had %v)", wk, wv, got, xdstest.MapKeys(gotHosts))
 						}

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2441,8 +2441,8 @@ spec:
 	}
 	for _, variant := range []string{"httproute", "virtualservice"} {
 		t.Run(variant, func(t *testing.T) {
-			for i := range cases {
-				tt := cases[i]
+			for _, tt := range cases {
+				tt := tt
 				t.Run(tt.name, func(t *testing.T) {
 					t.Parallel()
 					cfg := knownServices

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -2443,7 +2443,6 @@ spec:
 		t.Run(variant, func(t *testing.T) {
 			for i, _ := range cases {
 				tt := cases[i]
-				//pr := *tt.proxy
 				t.Run(tt.name, func(t *testing.T) {
 					t.Parallel()
 					cfg := knownServices
@@ -2475,10 +2474,8 @@ spec:
 						t.Fatalf("route %q not found, have %v", tt.routeName, xdstest.MapKeys(r))
 					}
 					gotHosts := xdstest.ExtractVirtualHosts(vh)
-					fmt.Println("exp", exp)
 					for wk, wv := range exp {
 						got := gotHosts[wk]
-						fmt.Println("had", xdstest.MapKeys(gotHosts))
 						if !reflect.DeepEqual(wv, got) {
 							t.Errorf("%q: wanted %v, got %v (had %v)", wk, wv, got, xdstest.MapKeys(gotHosts))
 						}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -143,6 +143,8 @@ type DiscoveryServer struct {
 
 	// pushVersion stores the numeric push version. This should be accessed via NextVersion()
 	pushVersion atomic.Uint64
+
+	processStartTime time.Time
 }
 
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures
@@ -164,9 +166,10 @@ func NewDiscoveryServer(env *model.Environment, instanceID string, clusterID clu
 			debounceMax:       features.DebounceMax,
 			enableEDSDebounce: features.EnableEDSDebounce,
 		},
-		Cache:      model.DisabledCache{},
-		instanceID: instanceID,
-		clusterID:  clusterID,
+		Cache:            model.DisabledCache{},
+		instanceID:       instanceID,
+		clusterID:        clusterID,
+		processStartTime: time.Now(),
 	}
 
 	out.ClusterAliases = make(map[cluster.ID]cluster.ID)
@@ -216,11 +219,9 @@ func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
 }
 
-var processStartTime = time.Now()
-
 // CachesSynced is called when caches have been synced so that server can accept connections.
 func (s *DiscoveryServer) CachesSynced() {
-	log.Infof("All caches have been synced up in %v, marking server ready", time.Since(processStartTime))
+	log.Infof("All caches have been synced up in %v, marking server ready", time.Since(s.processStartTime))
 	s.serverReady.Store(true)
 }
 

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -143,8 +143,6 @@ type DiscoveryServer struct {
 
 	// pushVersion stores the numeric push version. This should be accessed via NextVersion()
 	pushVersion atomic.Uint64
-
-	processStartTime time.Time
 }
 
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures
@@ -166,10 +164,9 @@ func NewDiscoveryServer(env *model.Environment, instanceID string, clusterID clu
 			debounceMax:       features.DebounceMax,
 			enableEDSDebounce: features.EnableEDSDebounce,
 		},
-		Cache:            model.DisabledCache{},
-		instanceID:       instanceID,
-		clusterID:        clusterID,
-		processStartTime: time.Now(),
+		Cache:      model.DisabledCache{},
+		instanceID: instanceID,
+		clusterID:  clusterID,
 	}
 
 	out.ClusterAliases = make(map[cluster.ID]cluster.ID)
@@ -219,9 +216,11 @@ func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
 }
 
+var processStartTime = time.Now()
+
 // CachesSynced is called when caches have been synced so that server can accept connections.
 func (s *DiscoveryServer) CachesSynced() {
-	log.Infof("All caches have been synced up in %v, marking server ready", time.Since(s.processStartTime))
+	log.Infof("All caches have been synced up in %v, marking server ready", time.Since(processStartTime))
 	s.serverReady.Store(true)
 }
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -330,7 +330,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// initialized.
 	s.ConfigUpdate(&model.PushRequest{Full: true})
 
-	processStartTime = time.Now()
+	s.processStartTime = time.Now()
 
 	// Wait until initial updates are committed
 	c := s.InboundUpdates.Load()

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -330,8 +330,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// initialized.
 	s.ConfigUpdate(&model.PushRequest{Full: true})
 
-	s.processStartTime = time.Now()
-
 	// Wait until initial updates are committed
 	c := s.InboundUpdates.Load()
 	retry.UntilOrFail(t, func() bool {


### PR DESCRIPTION
**Please provide a description of this PR:**
Contributes to #37555 

This PR proposes to run TestSidecarRoutes (~5.8s) in parallel, reducing the execution time to less than a second.

Running the tests in parallel exposed a data race, so I moved `processStartTime` into the scope of `DiscoveryService`.

I tried to exclude, at the best of my knowledge, that there are side effects to this change, but we need the opinion of someone with a deeper understanding of the code. 

My understanding is that the condition created by running the test in parallel is sort of artificial, and normally we wouldn't have multiple instances of `DiscoveryService`, so no data race on `processStartTime`. 
On the other hand, it doesn't seem to hurt moving it from a package scope to a structure scope.

thoughts?