### PR TITLE
fix gateway server port analysis result of GatewayPortNotOnWorkload is incorrect

### DIFF
--- a/pkg/config/analysis/analyzers/gateway/gateway.go
+++ b/pkg/config/analysis/analyzers/gateway/gateway.go
@@ -84,7 +84,11 @@ func (*IngressGatewayPortAnalyzer) analyzeGateway(r *resource.Instance, c analys
 				if svcSelector.Matches(podLabels) {
 					for _, port := range service.Ports {
 						if port.Protocol == "TCP" {
-							servicePorts[uint32(port.Port)] = true
+							if tp := port.TargetPort.IntValue(); tp != 0 {
+								servicePorts[uint32(tp)] = true
+							} else {
+								servicePorts[uint32(port.Port)] = true
+							}
 						}
 					}
 				}

--- a/pkg/config/analysis/analyzers/gateway/gateway.go
+++ b/pkg/config/analysis/analyzers/gateway/gateway.go
@@ -84,6 +84,8 @@ func (*IngressGatewayPortAnalyzer) analyzeGateway(r *resource.Instance, c analys
 				if svcSelector.Matches(podLabels) {
 					for _, port := range service.Ports {
 						if port.Protocol == "TCP" {
+							// Because the Gateway's server port is the port on which the proxy should listen for incoming connections,
+							// the actual port associated with the service is the `TargetPort` that reaches the sidecar *workload instances*.
 							if tp := port.TargetPort.IntValue(); tp != 0 {
 								servicePorts[uint32(tp)] = true
 							} else {

--- a/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-badport.yaml
+++ b/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-badport.yaml
@@ -34,8 +34,8 @@ spec:
   ports:
   - name: http2
     nodePort: 31380
-    port: 8003
+    port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8003
   selector:
     myapp: private-ingressgateway

--- a/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway.yaml
+++ b/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway.yaml
@@ -34,8 +34,8 @@ spec:
   ports:
   - name: http2
     nodePort: 31380
-    port: 8003
+    port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8003
   selector:
     myapp: private-ingressgateway

--- a/releasenotes/notes/fix-analysis-gatewayport.yaml
+++ b/releasenotes/notes/fix-analysis-gatewayport.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** Analyzer produces incorrect results for `GatewayPortNotOnWorkload` due to incorrect association of `Gateway.Spec.Servers[].Port.Number` with Service's `Port` instead of `TargetPort`.


### PR DESCRIPTION
**Please provide a description of this PR:**

The Analyzer for GatewayPortNotOnWorkload was producing incorrect results due to associating the gateway.servers[].port (the port for ingress listeners) with the `Port` of the Service.

The correct association should be with the `TargetPort` of the Service. 