### PR TITLE
Queue metrics

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -674,8 +674,8 @@ var (
 	OptimizedConfigRebuild = env.Register("ENABLE_OPTIMIZED_CONFIG_REBUILD", true,
 		"If enabled, pilot will only rebuild config for resources that have changed").Get()
 
-	EnableControllerQueueMetrics = env.RegisterBoolVar("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
-		"If enabled, publishes metrics for queue depth, latency and processing times.")
+	EnableControllerQueueMetrics = env.Register("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
+		"If enabled, publishes metrics for queue depth, latency and processing times.").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -673,6 +673,9 @@ var (
 
 	OptimizedConfigRebuild = env.Register("ENABLE_OPTIMIZED_CONFIG_REBUILD", true,
 		"If enabled, pilot will only rebuild config for resources that have changed").Get()
+
+	EnableControllerQueueMetrics = env.RegisterBoolVar("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
+		"If enabled, publishes metrics for queue depth, latency and processing times.")
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -19,9 +19,10 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/log"
-	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // Task to be performed.

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -127,14 +127,13 @@ func (q *queueImpl) processNextItem() bool {
 	if shuttingdown {
 		return false
 	}
-	//time.Sleep(time.Millisecond * 500)
-	callback := *task
+
 	// Run the task.
-	if err := callback(); err != nil {
+	if err := (*task)(); err != nil {
 		delay := q.delay
 		log.Infof("Work item handle failed (%v), retry after delay %v", err, delay)
 		time.AfterFunc(delay, func() {
-			q.Push(callback)
+			q.Push(*task)
 		})
 	}
 	if q.enableMetrics {

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -52,10 +52,9 @@ type queueImpl struct {
 	closed    chan struct{}
 	closeOnce *sync.Once
 	// initialSync indicates the queue has initially "synced".
-	initialSync   *atomic.Bool
-	id            string
-	metrics       *queueMetrics
-	enableMetrics bool
+	initialSync *atomic.Bool
+	id          string
+	metrics     *queueMetrics
 }
 
 // NewQueue instantiates a queue with a processing function

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -26,24 +26,6 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
-func BenchmarkQueue(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		q := NewQueue(1 * time.Microsecond)
-		s := make(chan struct{})
-		go q.Run(s)
-		wg := sync.WaitGroup{}
-		wg.Add(1000)
-		for i := 0; i < 1000; i++ {
-			q.Push(func() error {
-				wg.Done()
-				return nil
-			})
-		}
-		wg.Wait()
-		close(s)
-	}
-}
-
 func TestOrdering(t *testing.T) {
 	numValues := 1000
 

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -14,9 +14,10 @@
 package queue
 
 import (
+	"time"
+
 	"istio.io/istio/pkg/monitoring"
 	"k8s.io/utils/clock"
-	"time"
 )
 
 var (
@@ -27,12 +28,12 @@ var (
 	latency = monitoring.NewDistribution(
 		"pilot_worker_queue_latency",
 		"Latency before the item is processed",
-		[]float64{.01, .1, 0.5, 1, 3, 5},
+		[]float64{.01, .1, .2, .5, 1, 3, 5},
 		monitoring.WithLabels(queueIdTag))
 
 	workDuration = monitoring.NewDistribution("pilot_worker_queue_duration",
 		"Time taken to process an item",
-		[]float64{.01, .1, 0.5, 1, 3, 5},
+		[]float64{.01, .1, .2, .5, 1, 3, 5},
 		monitoring.WithLabels(queueIdTag))
 )
 
@@ -87,7 +88,7 @@ func (m *queueMetrics) sinceInSeconds(start time.Time) float64 {
 	return m.clock.Since(start).Seconds()
 }
 
-func NewQueueMetrics(id string) *queueMetrics {
+func newQueueMetrics(id string) *queueMetrics {
 	return &queueMetrics{
 		id:                   id,
 		depth:                depth.With(queueIdTag.Value(id)),

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -45,7 +45,6 @@ type queueMetrics struct {
 	workDuration monitoring.Metric
 	id           string
 	clock        clock.WithTicker
-	queueDepth   int64
 }
 
 // Gets the time since the specified start in seconds.

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -16,8 +16,9 @@ package queue
 import (
 	"time"
 
-	"istio.io/istio/pkg/monitoring"
 	"k8s.io/utils/clock"
+
+	"istio.io/istio/pkg/monitoring"
 )
 
 var (

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -55,7 +55,6 @@ func (m *queueMetrics) add(item *Task) {
 		return
 	}
 	m.queueDepth++
-	//log.Infof("the current length is %d", m.queueDepth)
 	m.adds.With(queueIdTag.Value(m.id)).Increment()
 	m.depth.With(queueIdTag.Value(m.id)).RecordInt(m.queueDepth)
 	if _, exists := m.addTimes[item]; !exists {

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -19,6 +19,7 @@ import (
 
 	"k8s.io/utils/clock"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/monitoring"
 )
 
@@ -63,5 +64,10 @@ func newQueueMetrics(id string) *queueMetrics {
 }
 
 func init() {
-	monitoring.MustRegister(depth, latency, workDuration)
+	enableQueueMetrics := func() bool {
+		return features.EnableControllerQueueMetrics
+	}
+	monitoring.RegisterIf(depth, enableQueueMetrics)
+	monitoring.RegisterIf(latency, enableQueueMetrics)
+	monitoring.RegisterIf(workDuration, enableQueueMetrics)
 }

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -1,0 +1,110 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package queue
+
+import (
+	"istio.io/istio/pkg/monitoring"
+	"k8s.io/utils/clock"
+	"time"
+)
+
+var (
+	queueIdTag = monitoring.MustCreateLabel("queueId")
+
+	depth = monitoring.NewGauge("pilot_worker_queue_depth", "Depth of the controller queues", monitoring.WithLabels(queueIdTag))
+
+	adds = monitoring.NewSum("pilot_worker_queue_adds", "Adds to the controller queues", monitoring.WithLabels(queueIdTag))
+
+	latency = monitoring.NewDistribution(
+		"pilot_worker_queue_latency",
+		"Latency before the item is processed",
+		[]float64{.01, .1, 0.5, 1, 3, 5},
+		monitoring.WithLabels(queueIdTag))
+
+	workDuration = monitoring.NewDistribution("pilot_worker_queue_duration",
+		"Time taken to process an item",
+		[]float64{.01, .1, 0.5, 1, 3, 5},
+		monitoring.WithLabels(queueIdTag))
+)
+
+type queueMetrics struct {
+	depth                monitoring.Metric
+	adds                 monitoring.Metric
+	latency              monitoring.Metric
+	workDuration         monitoring.Metric
+	id                   string
+	addTimes             map[*Task]time.Time
+	processingStartTimes map[*Task]time.Time
+	clock                clock.WithTicker
+	queueDepth           int64
+}
+
+func (m *queueMetrics) add(item *Task) {
+	if m == nil {
+		return
+	}
+	m.queueDepth++
+	//log.Infof("the current length is %d", m.queueDepth)
+	m.adds.With(queueIdTag.Value(m.id)).Increment()
+	m.depth.With(queueIdTag.Value(m.id)).RecordInt(m.queueDepth)
+	if _, exists := m.addTimes[item]; !exists {
+		m.addTimes[item] = m.clock.Now()
+	}
+}
+
+func (m *queueMetrics) get(item *Task) {
+	if m == nil {
+		return
+	}
+	m.queueDepth--
+	m.depth.With(queueIdTag.Value(m.id)).RecordInt(m.queueDepth)
+	m.processingStartTimes[item] = m.clock.Now()
+	if startTime, exists := m.addTimes[item]; exists {
+		m.latency.With(queueIdTag.Value(m.id)).Record(m.sinceInSeconds(startTime))
+		delete(m.addTimes, item)
+	}
+}
+
+func (m *queueMetrics) done(item *Task) {
+	if m == nil {
+		return
+	}
+
+	if startTime, exists := m.processingStartTimes[item]; exists {
+		m.workDuration.With(queueIdTag.Value(m.id)).Record(m.sinceInSeconds(startTime))
+		delete(m.processingStartTimes, item)
+	}
+}
+
+// Gets the time since the specified start in seconds.
+func (m *queueMetrics) sinceInSeconds(start time.Time) float64 {
+	return m.clock.Since(start).Seconds()
+}
+
+func NewQueueMetrics(id string) *queueMetrics {
+	return &queueMetrics{
+		id:                   id,
+		depth:                depth,
+		workDuration:         workDuration,
+		latency:              latency,
+		adds:                 adds,
+		clock:                clock.RealClock{},
+		addTimes:             map[*Task]time.Time{},
+		processingStartTimes: map[*Task]time.Time{},
+	}
+}
+
+func init() {
+	monitoring.MustRegister(adds, depth, latency, workDuration)
+}

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package queue
 
 import (
@@ -39,49 +40,12 @@ var (
 )
 
 type queueMetrics struct {
-	depth                monitoring.Metric
-	latency              monitoring.Metric
-	workDuration         monitoring.Metric
-	id                   string
-	addTimes             map[*Task]time.Time
-	processingStartTimes map[*Task]time.Time
-	clock                clock.WithTicker
-	queueDepth           int64
-}
-
-func (m *queueMetrics) add(item *Task) {
-	if m == nil {
-		return
-	}
-	m.queueDepth++
-	m.depth.RecordInt(m.queueDepth)
-	if _, exists := m.addTimes[item]; !exists {
-		m.addTimes[item] = m.clock.Now()
-	}
-}
-
-func (m *queueMetrics) get(item *Task) {
-	if m == nil {
-		return
-	}
-	m.queueDepth--
-	m.processingStartTimes[item] = m.clock.Now()
-	m.depth.RecordInt(m.queueDepth)
-	if startTime, exists := m.addTimes[item]; exists {
-		m.latency.Record(m.sinceInSeconds(startTime))
-		delete(m.addTimes, item)
-	}
-}
-
-func (m *queueMetrics) done(item *Task) {
-	if m == nil {
-		return
-	}
-
-	if startTime, exists := m.processingStartTimes[item]; exists {
-		m.workDuration.Record(m.sinceInSeconds(startTime))
-		delete(m.processingStartTimes, item)
-	}
+	depth        monitoring.Metric
+	latency      monitoring.Metric
+	workDuration monitoring.Metric
+	id           string
+	clock        clock.WithTicker
+	queueDepth   int64
 }
 
 // Gets the time since the specified start in seconds.
@@ -91,13 +55,11 @@ func (m *queueMetrics) sinceInSeconds(start time.Time) float64 {
 
 func newQueueMetrics(id string) *queueMetrics {
 	return &queueMetrics{
-		id:                   id,
-		depth:                depth.With(queueIDTag.Value(id)),
-		workDuration:         workDuration.With(queueIDTag.Value(id)),
-		latency:              latency.With(queueIDTag.Value(id)),
-		clock:                clock.RealClock{},
-		addTimes:             map[*Task]time.Time{},
-		processingStartTimes: map[*Task]time.Time{},
+		id:           id,
+		depth:        depth.With(queueIDTag.Value(id)),
+		workDuration: workDuration.With(queueIDTag.Value(id)),
+		latency:      latency.With(queueIDTag.Value(id)),
+		clock:        clock.RealClock{},
 	}
 }
 

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -21,20 +21,20 @@ import (
 )
 
 var (
-	queueIdTag = monitoring.MustCreateLabel("queueId")
+	queueIDTag = monitoring.MustCreateLabel("queueID")
 
-	depth = monitoring.NewGauge("pilot_worker_queue_depth", "Depth of the controller queues", monitoring.WithLabels(queueIdTag))
+	depth = monitoring.NewGauge("pilot_worker_queue_depth", "Depth of the controller queues", monitoring.WithLabels(queueIDTag))
 
 	latency = monitoring.NewDistribution(
 		"pilot_worker_queue_latency",
 		"Latency before the item is processed",
 		[]float64{.01, .1, .2, .5, 1, 3, 5},
-		monitoring.WithLabels(queueIdTag))
+		monitoring.WithLabels(queueIDTag))
 
 	workDuration = monitoring.NewDistribution("pilot_worker_queue_duration",
 		"Time taken to process an item",
 		[]float64{.01, .1, .2, .5, 1, 3, 5},
-		monitoring.WithLabels(queueIdTag))
+		monitoring.WithLabels(queueIDTag))
 )
 
 type queueMetrics struct {
@@ -91,9 +91,9 @@ func (m *queueMetrics) sinceInSeconds(start time.Time) float64 {
 func newQueueMetrics(id string) *queueMetrics {
 	return &queueMetrics{
 		id:                   id,
-		depth:                depth.With(queueIdTag.Value(id)),
-		workDuration:         workDuration.With(queueIdTag.Value(id)),
-		latency:              latency.With(queueIdTag.Value(id)),
+		depth:                depth.With(queueIDTag.Value(id)),
+		workDuration:         workDuration.With(queueIDTag.Value(id)),
+		latency:              latency.With(queueIDTag.Value(id)),
 		clock:                clock.RealClock{},
 		addTimes:             map[*Task]time.Time{},
 		processingStartTimes: map[*Task]time.Time{},

--- a/pkg/queue/metrics_test.go
+++ b/pkg/queue/metrics_test.go
@@ -14,10 +14,11 @@
 package queue
 
 import (
-	"istio.io/istio/pilot/pkg/features"
 	"sync"
 	"testing"
 	"time"
+
+	"istio.io/istio/pilot/pkg/features"
 )
 
 func BenchmarkMetricsQueue(b *testing.B) {

--- a/pkg/queue/metrics_test.go
+++ b/pkg/queue/metrics_test.go
@@ -1,0 +1,124 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package queue
+
+import (
+	"istio.io/istio/pilot/pkg/features"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkMetricsQueue(b *testing.B) {
+	features.EnableControllerQueueMetrics = true
+	q := NewQueue(1 * time.Microsecond)
+	s := make(chan struct{})
+	go q.Run(s)
+	for n := 0; n < b.N; n++ {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		q.Push(func() error {
+			wg.Done()
+			return nil
+		})
+		wg.Wait()
+
+	}
+	close(s)
+}
+
+func BenchmarkMetricsQueueDisabled(b *testing.B) {
+	features.EnableControllerQueueMetrics = false
+	q := NewQueue(1 * time.Microsecond)
+	s := make(chan struct{})
+	go q.Run(s)
+	for n := 0; n < b.N; n++ {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		q.Push(func() error {
+			wg.Done()
+			return nil
+		})
+		wg.Wait()
+	}
+	close(s)
+}
+
+func BenchmarkMetricsQueueAdd(b *testing.B) {
+	q := newQueueMetrics("test")
+	var task Task
+	task = func() error {
+		return nil
+	}
+	for n := 0; n < b.N; n++ {
+		q.add(&task)
+	}
+}
+
+func BenchmarkMetricsQueueInc(b *testing.B) {
+	q := newQueueMetrics("test")
+	for n := 0; n < b.N; n++ {
+		q.depth.Increment()
+	}
+}
+
+func BenchmarkMetricsQueueRec(b *testing.B) {
+	q := newQueueMetrics("test")
+	for n := 0; n < b.N; n++ {
+		q.depth.Record(100)
+	}
+}
+
+func BenchmarkMetricsQueueSinceInSeconds(b *testing.B) {
+	q := newQueueMetrics("test")
+	dt := time.Now()
+	for n := 0; n < b.N; n++ {
+		q.sinceInSeconds(dt)
+	}
+}
+
+func BenchmarkMetricsQueueGet(b *testing.B) {
+	mq := newQueueMetrics("test")
+	var task Task
+	task = func() error {
+		return nil
+	}
+	for n := 0; n < b.N; n++ {
+		mq.add(&task)
+		mq.get(&task)
+	}
+}
+
+func Test_queueMetrics_add(t *testing.T) {
+	q := newQueueMetrics("test")
+	type args struct {
+		item *Task
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "item",
+			args: args{
+				item: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q.add(tt.args.item)
+		})
+	}
+}

--- a/pkg/queue/metrics_test.go
+++ b/pkg/queue/metrics_test.go
@@ -55,17 +55,6 @@ func BenchmarkMetricsQueueDisabled(b *testing.B) {
 	close(s)
 }
 
-func BenchmarkMetricsQueueAdd(b *testing.B) {
-	q := newQueueMetrics("test")
-	var task Task
-	task = func() error {
-		return nil
-	}
-	for n := 0; n < b.N; n++ {
-		q.add(&task)
-	}
-}
-
 func BenchmarkMetricsQueueInc(b *testing.B) {
 	q := newQueueMetrics("test")
 	for n := 0; n < b.N; n++ {
@@ -85,40 +74,5 @@ func BenchmarkMetricsQueueSinceInSeconds(b *testing.B) {
 	dt := time.Now()
 	for n := 0; n < b.N; n++ {
 		q.sinceInSeconds(dt)
-	}
-}
-
-func BenchmarkMetricsQueueGet(b *testing.B) {
-	mq := newQueueMetrics("test")
-	var task Task
-	task = func() error {
-		return nil
-	}
-	for n := 0; n < b.N; n++ {
-		mq.add(&task)
-		mq.get(&task)
-	}
-}
-
-func Test_queueMetrics_add(t *testing.T) {
-	q := newQueueMetrics("test")
-	type args struct {
-		item *Task
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "item",
-			args: args{
-				item: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			q.add(tt.args.item)
-		})
 	}
 }

--- a/releasenotes/notes/45734.yaml
+++ b/releasenotes/notes/45734.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+issue:
+  - 44985
+
+releaseNotes:
+  - |
+    **Added** support for K8s controller queue metrics, enabled by setting env variable `ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS` as `true`.


### PR DESCRIPTION
**Please provide a description of this PR:**
The PR adds metrics to the K8s worker queue. The metrics really helped to discover a lock contention issue mentioned in https://github.com/istio/istio/issues/44985.

The metrics are kept behind the flag, so that they can be enabled explicitly as adding them does result in impacted benchmarks.