### PR TITLE
tf: fix mismatch in debian version

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -72,7 +72,7 @@ type VMDistro = string
 const (
 	UbuntuXenial VMDistro = "UbuntuXenial"
 	UbuntuJammy  VMDistro = "UbuntuJammy"
-	Debian11     VMDistro = "Debian9"
+	Debian11     VMDistro = "Debian11"
 	Centos7      VMDistro = "Centos7"
 	Rockylinux8  VMDistro = "Centos8"
 


### PR DESCRIPTION
This is cosmetic issue only, I think -- we are correctly testing debian
11 before still... I think.
