### PR TITLE
istioctl: support available telemetry service name and version labels

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -33,6 +33,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/structpb"
+	"istio.io/istio/pkg/kube/labels"
+	"istio.io/istio/pkg/url"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -490,13 +492,13 @@ func printPod(writer io.Writer, pod *corev1.Pod, revision string) {
 
 	// https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
 	// says "We recommend adding an explicit app label and version label to deployments."
-	app, ok := pod.ObjectMeta.Labels["app"]
-	if !ok || app == "" {
-		fmt.Fprintf(writer, "Suggestion: add 'app' label to pod for Istio telemetry.\n")
+	if !labels.HasCanonicalServiceName(pod.Labels) {
+		fmt.Fprintf(writer, "Suggestion: add required service name label for Istio telemetry. "+
+			"See %s.\n", url.DeploymentRequirements)
 	}
-	version, ok := pod.ObjectMeta.Labels["version"]
-	if !ok || version == "" {
-		fmt.Fprintf(writer, "Suggestion: add 'version' label to pod for Istio telemetry.\n")
+	if !labels.HasCanonicalServiceRevision(pod.Labels) {
+		fmt.Fprintf(writer, "Suggestion: add required service revision label for Istio telemetry. "+
+			"See %s.\n", url.DeploymentRequirements)
 	}
 }
 

--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -33,8 +33,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/structpb"
-	"istio.io/istio/pkg/kube/labels"
-	"istio.io/istio/pkg/url"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -66,8 +64,10 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
+	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/url"
 )
 
 type myProtoValue struct {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -41,7 +41,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/config/validation"
-	labels2 "istio.io/istio/pkg/kube/labels"
+	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/url"
 )
@@ -204,14 +204,14 @@ func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructu
 	if un.GetNamespace() == handleNamespace(istioNamespace) {
 		return nil
 	}
-	labels, err := GetTemplateLabels(un)
+	objLabels, err := GetTemplateLabels(un)
 	if err != nil {
 		return err
 	}
 	url := fmt.Sprintf("See %s\n", url.DeploymentRequirements)
-	if !labels2.HasCanonicalServiceName(labels) || !labels2.HasCanonicalServiceRevision(labels) {
+	if !labels.HasCanonicalServiceName(objLabels) || !labels.HasCanonicalServiceRevision(objLabels) {
 		fmt.Fprintf(writer, "deployment %q may not provide Istio metrics and telemetry labels: %q. "+url,
-			fmt.Sprintf("%s/%s:", un.GetName(), un.GetNamespace()), labels)
+			fmt.Sprintf("%s/%s:", un.GetName(), un.GetNamespace()), objLabels)
 	}
 	return nil
 }

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
-	labels2 "istio.io/istio/pkg/kube/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,6 +41,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/config/validation"
+	labels2 "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/url"
 )

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -368,6 +368,28 @@ spec:
   ports:
     - appProtocol: fake
       port: 9080`
+	validK8sRecommendedLabels = `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: helloworld-v1
+  labels:
+    app.kubernetes.io/name: helloworld
+    app.kubernetes.io/version: v1
+spec:
+  replicas: 1
+`
+	validIstioCanonical = `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: helloworld-v1
+  labels:
+    service.istio.io/canonical-name: helloworld
+    service.istio.io/canonical-revision: v1
+spec:
+  replicas: 1
+`
 )
 
 func fromYAML(in string) *unstructured.Unstructured {
@@ -485,6 +507,16 @@ func TestValidateResource(t *testing.T) {
 			name:  "appProtocol=fake",
 			in:    inValidPortNamingSvcWithAppProtocol,
 			valid: false,
+		},
+		{
+			name:  "metric labels k8s recommended",
+			in:    validK8sRecommendedLabels,
+			valid: true,
+		},
+		{
+			name:  "metric labels istio canonical",
+			in:    validIstioCanonical,
+			valid: true,
 		},
 	}
 

--- a/releasenotes/notes/45749.yaml
+++ b/releasenotes/notes/45749.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for checking telemetry labels, which now includes Istio canonical labels and K8S recommended labels.


### PR DESCRIPTION
**Please provide a description of this PR:**
istioctl commands are still doing the only `app` and `version` check for pod labels, which is inaccurate and should be updated