### PR TITLE
Implement InsecureSkipVerify from DestinationRule.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1105,7 +1105,11 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			tls = tls.DeepCopy()
 			tls.SubjectAltNames = opts.serviceAccounts
 		}
-		if tls.CredentialName != "" {
+		if tls.InsecureSkipVerify.Value == true || tls.CredentialName != "" {
+			tlsContext = &auth.UpstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{},
+				Sni:              tls.Sni,
+			}
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
 			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1105,12 +1105,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			tls = tls.DeepCopy()
 			tls.SubjectAltNames = opts.serviceAccounts
 		}
-
 		if tls.CredentialName != "" {
-			tlsContext = &auth.UpstreamTlsContext{
-				CommonTlsContext: &auth.CommonTlsContext{},
-				Sni:              tls.Sni,
-			}
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
 			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
@@ -1121,7 +1116,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			}
 			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
 			// don't set up SdsSecretConfig
-			if !res.IsRootCertificate() || util.InsecureSkipVerify(tls) {
+			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
@@ -1154,7 +1149,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			tls.SubjectAltNames = opts.serviceAccounts
 		}
 		if tls.CredentialName != "" {
-			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
+			// If credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
 			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
 		} else {
@@ -1177,7 +1172,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 
 			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
 			// don't set up SdsSecretConfig
-			if !res.IsRootCertificate() || util.InsecureSkipVerify(tls) {
+			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
 			} else {
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
@@ -1224,7 +1219,7 @@ func (cb *ClusterBuilder) setAutoSniAndAutoSanValidation(mc *MutableCluster, tls
 	if len(tls.Sni) == 0 {
 		setAutoSni = true
 	}
-	if features.VerifyCertAtClient && len(tls.SubjectAltNames) == 0 && !util.InsecureSkipVerify(tls) {
+	if features.VerifyCertAtClient && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
 		setAutoSanValidation = true
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1105,7 +1105,7 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			tls = tls.DeepCopy()
 			tls.SubjectAltNames = opts.serviceAccounts
 		}
-		if tls.InsecureSkipVerify.Value {
+		if tls.InsecureSkipVerify != nil && tls.InsecureSkipVerify.Value {
 			tls.CaCertificates = ""
 			tls.SubjectAltNames = []string{}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1105,7 +1105,15 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 			tls = tls.DeepCopy()
 			tls.SubjectAltNames = opts.serviceAccounts
 		}
-		if tls.InsecureSkipVerify.Value == true || tls.CredentialName != "" {
+		if tls.InsecureSkipVerify.Value {
+			tls.CaCertificates = ""
+			tls.SubjectAltNames = []string{}
+
+			tlsContext = &auth.UpstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{},
+				Sni:              tls.Sni,
+			}
+		} else if tls.CredentialName != "" {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -4032,7 +4032,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					Tls: &networking.ClientTLSSettings{
 						CaCertificates:     constants.RootCertFilename,
 						Mode:               networking.ClientTLSSettings_SIMPLE,
-						InsecureSkipVerify: &types.BoolValue{Value: false},
+						InsecureSkipVerify: &wrapperspb.BoolValue{Value: false},
 						Sni:                "foo.default.svc.cluster.local",
 						SubjectAltNames:    []string{"foo.default.svc.cluster.local"},
 					},
@@ -4061,7 +4061,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					Tls: &networking.ClientTLSSettings{
 						CaCertificates:     constants.RootCertFilename,
 						Mode:               networking.ClientTLSSettings_SIMPLE,
-						InsecureSkipVerify: &types.BoolValue{Value: false},
+						InsecureSkipVerify: &wrappers.BoolValue{Value: false},
 						Sni:                "foo.default.svc.cluster.local",
 					},
 				},
@@ -4090,7 +4090,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					Tls: &networking.ClientTLSSettings{
 						CaCertificates:     constants.RootCertFilename,
 						Mode:               networking.ClientTLSSettings_SIMPLE,
-						InsecureSkipVerify: &types.BoolValue{Value: true},
+						InsecureSkipVerify: &wrappers.BoolValue{Value: true},
 						Sni:                "foo.default.svc.cluster.local",
 						SubjectAltNames:    []string{"foo.default.svc.cluster.local"},
 					},
@@ -4119,7 +4119,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					Tls: &networking.ClientTLSSettings{
 						CaCertificates:     constants.RootCertFilename,
 						Mode:               networking.ClientTLSSettings_SIMPLE,
-						InsecureSkipVerify: &types.BoolValue{Value: true},
+						InsecureSkipVerify: &wrappers.BoolValue{Value: true},
 						Sni:                "foo.default.svc.cluster.local",
 					},
 				},

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -3988,11 +3988,9 @@ func TestInsecureSkipVerify(t *testing.T) {
 			Protocol: protocol.Unsupported,
 		},
 	}
+
 	service := &model.Service{
-		ClusterLocal: model.HostVIPs{
-			Hostname: host.Name("foo.default.svc.cluster.local"),
-		},
-		Address:    "1.1.1.1",
+		Hostname:   host.Name("foo.default.svc.cluster.local"),
 		Ports:      servicePort,
 		Resolution: model.ClientSideLB,
 		Attributes: model.ServiceAttributes{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -4015,7 +4015,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 	}{
 		{
 			name:        "With tls mode simple, InsecureSkipVerify is not specified and ca cert is supplied",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4071,7 +4071,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode simple, InsecureSkipVerify is set false and ca cert is supplied",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4128,7 +4128,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode simple, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4160,7 +4160,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode simple, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true and AUTO_SNI is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4190,7 +4190,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode simple and CredentialName, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4223,7 +4223,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode mutual, InsecureSkipVerify is not specified and ca cert is supplied",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4303,7 +4303,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode mutual, InsecureSkipVerify is set false and ca cert is supplied",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4384,7 +4384,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode mutual, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4440,7 +4440,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode mutual, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true and AUTO_SNI is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4494,7 +4494,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode mutual and CredentialName, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4538,7 +4538,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 		},
 		{
 			name:        "With tls mode istio mutual, InsecureSkipVerify is set true",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}, CommonLbConfig: &cluster.Cluster_CommonLbConfig{}},
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
@@ -4661,6 +4661,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			proxy := cg.SetupProxy(nil)
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 			ec := NewMutableCluster(tc.cluster)
+			tc.cluster.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
 			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tc.service.Hostname).GetRule()
 			_ = cb.applyDestinationRule(ec, tc.clusterMode, tc.service, tc.port, tc.proxyView, destRule, tc.serviceAcct)
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -755,3 +755,8 @@ func MaybeBuildStatefulSessionFilterConfig(svc *model.Service) *statefulsession.
 	}
 	return nil
 }
+
+// InsecureSkipVerify will return true when the field InsecureSkipVerify is explicitly set as true.
+func InsecureSkipVerify(tls *networking.ClientTLSSettings) bool {
+	return tls != nil && tls.InsecureSkipVerify != nil && tls.InsecureSkipVerify.Value
+}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -755,8 +755,3 @@ func MaybeBuildStatefulSessionFilterConfig(svc *model.Service) *statefulsession.
 	}
 	return nil
 }
-
-// InsecureSkipVerify will return true when the field InsecureSkipVerify is explicitly set as true.
-func InsecureSkipVerify(tls *networking.ClientTLSSettings) bool {
-	return tls != nil && tls.InsecureSkipVerify != nil && tls.InsecureSkipVerify.Value
-}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -256,7 +256,7 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
 		}
 	}
 
-	if util.InsecureSkipVerify(tlsOpts) {
+	if tlsOpts.GetInsecureSkipVerify().GetValue() {
 		return
 	}
 

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -255,6 +255,11 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
 			ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName, credentialSocketExist),
 		}
 	}
+
+	if util.InsecureSkipVerify(tlsOpts) {
+		return
+	}
+
 	// create SDS config for gateway to fetch certificate validation context
 	// at gateway agent.
 	defaultValidationContext := &tls.CertificateValidationContext{

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -256,6 +256,7 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext,
 		}
 	}
 
+	// If the InsecureSkipVerify is true, there is no need to configure CA Cert and SAN.
 	if tlsOpts.GetInsecureSkipVerify().GetValue() {
 		return
 	}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1499,6 +1499,23 @@ func validateTLS(settings *networking.ClientTLSSettings) (errs error) {
 		return
 	}
 
+	if settings.GetInsecureSkipVerify().GetValue() {
+		if settings.Mode == networking.ClientTLSSettings_SIMPLE {
+			// In tls simple mode, we can specify ca cert by CaCertificates or CredentialName.
+			if settings.CaCertificates != "" || settings.CredentialName != "" || settings.SubjectAltNames != nil {
+				errs = appendErrors(errs, fmt.Errorf("cannot specify CaCertificates or CredentialName or SubjectAltNames when InsecureSkipVerify is set true"))
+			}
+		}
+
+		if settings.Mode == networking.ClientTLSSettings_MUTUAL {
+			// In tls mutual mode, we can specify both client cert and ca cert by CredentialName.
+			// However, here we can not distinguish whether user specify ca cert by CredentialName or not.
+			if settings.CaCertificates != "" || settings.SubjectAltNames != nil {
+				errs = appendErrors(errs, fmt.Errorf("cannot specify CaCertificates or SubjectAltNames when InsecureSkipVerify is set true"))
+			}
+		}
+	}
+
 	if (settings.Mode == networking.ClientTLSSettings_SIMPLE || settings.Mode == networking.ClientTLSSettings_MUTUAL) &&
 		settings.CredentialName != "" {
 		if settings.ClientCertificate != "" || settings.CaCertificates != "" || settings.PrivateKey != "" {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3758,23 +3758,225 @@ func TestValidateDestinationRule(t *testing.T) {
 				{Name: "v2", Labels: map[string]string{"version": "v2"}},
 			},
 		}, valid: true},
+
+		{name: "InsecureSkipVerify is not specified with tls mode simple, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_SIMPLE,
+					CaCertificates:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is not specified with tls mode simple, and the ca cert is specified by CredentialName", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_SIMPLE,
+					CredentialName:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set false with tls mode simple, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_SIMPLE,
+					CaCertificates:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: false,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set false with tls mode simple, and the ca cert is specified by CredentialName", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_SIMPLE,
+					CredentialName:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: false,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set true with tls mode simple, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:           networking.ClientTLSSettings_SIMPLE,
+					CredentialName: "test",
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: false},
+
+		{name: "InsecureSkipVerify is set true with tls mode simple, and the ca cert is specified by CredentialName", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:           networking.ClientTLSSettings_SIMPLE,
+					CaCertificates: "test",
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: false},
+
+		{name: "InsecureSkipVerify is set true with tls mode simple, and the san is specified", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_SIMPLE,
+					SubjectAltNames: []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: false},
+
+		{name: "InsecureSkipVerify is not specified with tls mode mutual, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:              networking.ClientTLSSettings_MUTUAL,
+					CaCertificates:    "test",
+					PrivateKey:        "key",
+					ClientCertificate: "cert",
+					SubjectAltNames:   []string{"reviews.default.svc"},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is not specified with tls mode mutual, and the ca cert is specified by CredentialName", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_MUTUAL,
+					CredentialName:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set false with tls mode mutual, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:              networking.ClientTLSSettings_MUTUAL,
+					CaCertificates:    "test",
+					PrivateKey:        "key",
+					ClientCertificate: "cert",
+					SubjectAltNames:   []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: false,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set false with tls mode mutual, and the ca cert is specified by CredentialName", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:            networking.ClientTLSSettings_MUTUAL,
+					CredentialName:  "test",
+					SubjectAltNames: []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: false,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set true with tls mode mutual, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:              networking.ClientTLSSettings_MUTUAL,
+					CaCertificates:    "test",
+					PrivateKey:        "key",
+					ClientCertificate: "cert",
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: false},
+
+		{name: "InsecureSkipVerify is set true with tls mode mutual, and the ca cert is specified by CaCertificates", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:           networking.ClientTLSSettings_MUTUAL,
+					CredentialName: "test",
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set true with tls mode mutual, and the ca cert is not specified", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:              networking.ClientTLSSettings_MUTUAL,
+					PrivateKey:        "key",
+					ClientCertificate: "cert",
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: true},
+
+		{name: "InsecureSkipVerify is set true with tls mode mutual, and the san is specified", in: &networking.DestinationRule{
+			Host: "reviews",
+			TrafficPolicy: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:              networking.ClientTLSSettings_MUTUAL,
+					PrivateKey:        "key",
+					ClientCertificate: "cert",
+					SubjectAltNames:   []string{"reviews.default.svc"},
+					InsecureSkipVerify: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+			},
+		}, valid: false},
 	}
 	for _, c := range cases {
-		warn, got := ValidateDestinationRule(config.Config{
-			Meta: config.Meta{
-				Name:      someName,
-				Namespace: someNamespace,
-			},
-			Spec: c.in,
+		t.Run(c.name, func(t *testing.T) {
+			warn, got := ValidateDestinationRule(config.Config{
+				Meta: config.Meta{
+					Name:      someName,
+					Namespace: someNamespace,
+				},
+				Spec: c.in,
+			})
+			if (got == nil) != c.valid {
+				t.Errorf("ValidateDestinationRule failed on %v: got valid=%v but wanted valid=%v: %v",
+					c.name, got == nil, c.valid, got)
+			}
+			if (warn == nil) == c.warning {
+				t.Errorf("ValidateDestinationRule failed on %v: got warn=%v but wanted warn=%v: %v",
+					c.name, warn == nil, c.warning, warn)
+			}
 		})
-		if (got == nil) != c.valid {
-			t.Errorf("ValidateDestinationRule failed on %v: got valid=%v but wanted valid=%v: %v",
-				c.name, got == nil, c.valid, got)
-		}
-		if (warn == nil) == c.warning {
-			t.Errorf("ValidateDestinationRule failed on %v: got warn=%v but wanted warn=%v: %v",
-				c.name, warn == nil, c.warning, warn)
-		}
 	}
 }
 

--- a/releasenotes/notes/35357.yaml
+++ b/releasenotes/notes/35357.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 33472
+releaseNotes:
+  - |
+    **Added** `insecureSkipVerify` implementation from DestinationRule. Setting `insecureSkipVerify` to `true` will disable CA certificate and Subject Alternative Names verification for the host.


### PR DESCRIPTION
The original pr is https://github.com/istio/istio/pull/35357.
The relative issuse is https://github.com/istio/istio/issues/45611.

The InsecureSkipVerify only works on the case that the tls mode is simple or mutual. When the InsecureSkipVerify is enabled true, the below behaviors are expected.
1. If the env `VERIFY_CERTIFICATE_AT_CLIENT` is enabled true and tls mode of service A is simple，envoy will not check server cert signature (system ca when ca cert is not supplied) and SAN. Even if env `ENABLE_AUTO_SNI` is enabled true, envoy will not use the automic SAN mode.
2. If the env `VERIFY_CERTIFICATE_AT_CLIENT` is enabled true and tls mode of service A is mutual，envoy will only use the client key and cert to do mutual tls but not check server cert signature (system ca when ca cert is not supplied) and SAN. Even if env `ENABLE_AUTO_SNI` is enabled true, envoy will not use the automic SAN mode.
3. If tls mode of service A is istio mutual, this setting do nothing.

Follow up: Since this setting works depends on whether the environment variables `VERIFY_CERTIFICATE_AT_CLIENT` are turned on，should we enable the env `VERIFY_CERTIFICATE_AT_CLIENT` by default from now? 

cc @hzxuzhonghu @howardjohn @kfaseela 