### PR TITLE
configurable to switch between minAva maxUnav pdb

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
@@ -16,7 +16,12 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "IngressGateways"
 spec:
-  minAvailable: 1
+  {{- if .Values.minAvailable }}
+  minAvailable: {{ .Values.minAvailable }}
+  {{- end }}
+  {{- if .Values.maxUnavailable }}
+  maxUnavailable: {{ .Values.maxUnavailable }}
+  {{- end }}
   selector:
     matchLabels:
 {{ $gateway.labels | toYaml | trim | indent 6 }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -107,6 +107,9 @@ gateways:
 
     # The injection template to use for the gateway. If not set, no injection will be performed.
     injectionTemplate: ""
+    
+    #podDisruptionBudget configuration
+    minAvailable: 1
 
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""


### PR DESCRIPTION
**Please provide a description of this PR:**
Allows users to configure between setting minAvailable and maxUnavailable for podDisruptionBudget. This has been necessary as with the previous minAvailable setting, we are seeing most ingress pods being wiped bar one which has seen to cause blips of outages. This can be mitigated with the option to set maxUnavailable as the pods follow a rolling restart like nature where pods are recycled 1 by 1 when maxUnavailable is set to 1 for example.