### PR TITLE
Remove experiemental message of proxy-config secret

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -1356,7 +1356,6 @@ func secretConfigCmd(ctx cli.Context) *cobra.Command {
 	secretConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
 	secretConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
-	secretConfigCmd.Long += "\n\n" + istioctlutil.ExperimentalMsg
 	return secretConfigCmd
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Secret dump has been used for a while, and it has been improved for years. I think we can remove the experimental message now.