### PR TITLE
fix string point without check nil

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1207,11 +1207,9 @@ func createRewriteFilter(filter *k8s.HTTPURLRewriteFilter) *istio.HTTPRewrite {
 	if filter.Path != nil {
 		switch filter.Path.Type {
 		case k8sbeta.PrefixMatchHTTPPathModifier:
-			url := ""
 			if filter.Path.ReplacePrefixMatch != nil {
-				url = *filter.Path.ReplacePrefixMatch
+				rewrite.Uri = *filter.Path.ReplacePrefixMatch
 			}
-			rewrite.Uri = url
 		case k8sbeta.FullPathHTTPPathModifier:
 			replaceFullPath := "/"
 			if filter.Path.ReplaceFullPath != nil {

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1207,11 +1207,19 @@ func createRewriteFilter(filter *k8s.HTTPURLRewriteFilter) *istio.HTTPRewrite {
 	if filter.Path != nil {
 		switch filter.Path.Type {
 		case k8sbeta.PrefixMatchHTTPPathModifier:
-			rewrite.Uri = *filter.Path.ReplacePrefixMatch
+			url := ""
+			if filter.Path.ReplacePrefixMatch != nil {
+				url = *filter.Path.ReplacePrefixMatch
+			}
+			rewrite.Uri = url
 		case k8sbeta.FullPathHTTPPathModifier:
+			replaceFullPath := "/"
+			if filter.Path.ReplaceFullPath != nil {
+				replaceFullPath = *filter.Path.ReplaceFullPath
+			}
 			rewrite.UriRegexRewrite = &istio.RegexRewrite{
 				Match:   "/.*",
-				Rewrite: *filter.Path.ReplaceFullPath,
+				Rewrite: replaceFullPath,
 			}
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
The ReplacePrefixMatch and ReplaceFullPath  are omitempty, So if they are not be set,Nil will Assign to istio.RegexRewrite.Rewrite or rewrite.Uri and then panic.
```
// HTTPPathModifier defines configuration for path modifiers.
type HTTPPathModifier struct {
	// Type defines the type of path modifier. Additional types may be
	// added in a future release of the API.
	//
	// Note that values may be added to this enum, implementations
	// must ensure that unknown values will not cause a crash.
	//
	// Unknown values here must result in the implementation setting the
	// Accepted Condition for the Route to `status: False`, with a
	// Reason of `UnsupportedValue`.
	//
	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
	Type HTTPPathModifierType `json:"type"`

	// ReplaceFullPath specifies the value with which to replace the full path
	// of a request during a rewrite or redirect.
	//
	// +kubebuilder:validation:MaxLength=1024
	// +optional
	ReplaceFullPath *string `json:"replaceFullPath,omitempty"`

	// ReplacePrefixMatch specifies the value with which to replace the prefix
	// match of a request during a rewrite or redirect. For example, a request
	// to "/foo/bar" with a prefix match of "/foo" would be modified to "/bar".
	//
	// Note that this matches the behavior of the PathPrefix match type. This
	// matches full path elements. A path element refers to the list of labels
	// in the path split by the `/` separator. When specified, a trailing `/` is
	// ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
	// match the prefix `/abc`, but the path `/abcd` would not.
	//
	// +kubebuilder:validation:MaxLength=1024
	// +optional
	ReplacePrefixMatch *string `json:"replacePrefixMatch,omitempty"`
}

```