### PR TITLE
Dedup virtualservice rule match validations

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -536,6 +536,10 @@ var testGrid = []testCase{
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService overlapping-in-single-match"},
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService overlapping-in-two-matches"},
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService overlapping-mathes-with-different-methods"},
+
+			{msg.VirtualServiceUnreachableRule, "VirtualService default/many-dups-case"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService default/many-dups-case"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService default/many-dups-case"},
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/schema/validation.go
+++ b/pkg/config/analysis/analyzers/schema/validation.go
@@ -100,9 +100,9 @@ func morePreciseMessage(r *resource.Instance, err error, isError bool) diag.Mess
 	if aae, ok := err.(*validation.AnalysisAwareError); ok {
 		switch aae.Type {
 		case "VirtualServiceUnreachableRule":
-			return msg.NewVirtualServiceUnreachableRule(r, aae.Parameters[0].(string), aae.Parameters[1].(string))
+			return msg.NewVirtualServiceUnreachableRule(r, aae.Parameters[0].([]string), aae.Parameters[1].(string))
 		case "VirtualServiceIneffectiveMatch":
-			return msg.NewVirtualServiceIneffectiveMatch(r, aae.Parameters[0].(string), aae.Parameters[1].(string), aae.Parameters[2].(string))
+			return msg.NewVirtualServiceIneffectiveMatch(r, aae.Parameters[0].(string), aae.Parameters[1].(string))
 		}
 	}
 	if !isError {

--- a/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
+++ b/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
@@ -204,3 +204,157 @@ spec:
     route:
     - destination:
         host: api1.facebook.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: many-dups-case
+  namespace: default
+spec:
+  exportTo:
+  - istio-system
+  hosts:
+  - '*'
+  gateways:
+  - istio-system/ingressgateway
+  http:
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/prefix
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host2
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/prefix
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host2
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/prefix
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host2
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/prefix
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host2
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/prefix
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host2
+        port:
+          number: 7681
+  - match:
+    - uri:
+        prefix: /api/fake-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: fake.host
+        port:
+          number: 7681

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -110,12 +110,12 @@ var (
 	NoServerCertificateVerificationPortLevel = diag.NewMessageType(diag.Warning, "IST0129", "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s at port %s")
 
 	// VirtualServiceUnreachableRule defines a diag.MessageType for message "VirtualServiceUnreachableRule".
-	// Description: A VirtualService rule will never be used because a previous rule uses the same match.
-	VirtualServiceUnreachableRule = diag.NewMessageType(diag.Warning, "IST0130", "VirtualService rule %v not used (%s).")
+	// Description: VirtualService rules will never be used because a previous rule uses the same match.
+	VirtualServiceUnreachableRule = diag.NewMessageType(diag.Warning, "IST0130", "VirtualService rules %v not used (%s).")
 
 	// VirtualServiceIneffectiveMatch defines a diag.MessageType for message "VirtualServiceIneffectiveMatch".
-	// Description: A VirtualService rule match duplicates a match in a previous rule.
-	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %v match %v is not used (duplicate/overlapping match in rule %v).")
+	// Description: VirtualService rule matches duplicates a match in a previous rule.
+	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule matches [%v] not used (duplicate/overlapping match in rule %v).")
 
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
 	// Description: Host defined in VirtualService not found in Gateway.
@@ -558,23 +558,22 @@ func NewNoServerCertificateVerificationPortLevel(r *resource.Instance, destinati
 }
 
 // NewVirtualServiceUnreachableRule returns a new diag.Message based on VirtualServiceUnreachableRule.
-func NewVirtualServiceUnreachableRule(r *resource.Instance, ruleno string, reason string) diag.Message {
+func NewVirtualServiceUnreachableRule(r *resource.Instance, rulenos []string, reason string) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceUnreachableRule,
 		r,
-		ruleno,
+		rulenos,
 		reason,
 	)
 }
 
 // NewVirtualServiceIneffectiveMatch returns a new diag.Message based on VirtualServiceIneffectiveMatch.
-func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno string, matchno string, dupno string) diag.Message {
+func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleMatches string, dupNo string) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceIneffectiveMatch,
 		r,
-		ruleno,
-		matchno,
-		dupno,
+		ruleMatches,
+		dupNo,
 	)
 }
 

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -298,26 +298,24 @@ messages:
   - name: "VirtualServiceUnreachableRule"
     code: IST0130
     level: Warning
-    description: "A VirtualService rule will never be used because a previous rule uses the same match."
-    template: "VirtualService rule %v not used (%s)."
+    description: "VirtualService rules will never be used because a previous rule uses the same match."
+    template: "VirtualService rules %v not used (%s)."
     args:
-      - name: ruleno
-        type: string
+      - name: rulenos
+        type: "[]string"
       - name: reason
         type: "string"
 
   - name: "VirtualServiceIneffectiveMatch"
     code: IST0131
     level: Info
-    description: "A VirtualService rule match duplicates a match in a previous rule."
-    template: "VirtualService rule %v match %v is not used (duplicate/overlapping match in rule %v)."
+    description: "VirtualService rule matches duplicates a match in a previous rule."
+    template: "VirtualService rule matches [%v] not used (duplicate/overlapping match in rule %v)."
     args:
-      - name: ruleno
-        type: string
-      - name: matchno
-        type: string
-      - name: dupno
-        type: string
+      - name: ruleMatches
+        type: "string"
+      - name: dupNo
+        type: "string"
 
   - name: "VirtualServiceHostNotFoundInGateway"
     code: IST0132

--- a/releasenotes/notes/45804.yaml
+++ b/releasenotes/notes/45804.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Improved** a situation where validation and analyzers will report noisy IST0130 and IST0131 messages. Now the messages are deduplicated and only reported once for similar errors.


### PR DESCRIPTION
**Please provide a description of this PR:**
When applying a resource with multiple rules, it has noisy warnings in validation, and nosiy warnings/infos in analyze,

examples:
```
Warning: virtualService rule #1 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #1 not used (all matches used by prior rules)
Warning: virtualService rule #2 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #2 not used (all matches used by prior rules)
Warning: virtualService rule #3 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #3 not used (all matches used by prior rules)
Warning: virtualService rule #5 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #5 not used (all matches used by prior rules)
Warning: virtualService rule #6 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #6 not used (all matches used by prior rules)
Warning: virtualService rule #7 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #7 not used (all matches used by prior rules)
Warning: virtualService rule #8 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #8 not used (all matches used by prior rules)
Warning: virtualService rule #9 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #9 not used (all matches used by prior rules)
Warning: virtualService rule #10 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #10 not used (all matches used by prior rules)
Warning: virtualService rule #11 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #11 not used (all matches used by prior rules)
Warning: virtualService rule #12 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #12 not used (all matches used by prior rules)
Warning: virtualService rule #13 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #13 not used (all matches used by prior rules)
Warning: virtualService rule #14 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #14 not used (all matches used by prior rules)
Warning: virtualService rule #15 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #15 not used (all matches used by prior rules)
Warning: virtualService rule #16 match #0 is not used (duplicate/overlapping match in rule #4)
Warning: virtualService rule #16 not used (all matches used by prior rules)
Warning: virtualService rule #17 match #0 is not used (duplicate/overlapping match in rule #0)
Warning: virtualService rule #17 not used (all matches used by prior rules)
Warning: virtualService rule #18 match #0 is not used (duplicate/overlapping match in rule #4)
...
```

This PR aims to dedup the messages.

Now for `VirtualServiceUnreachableRule` message, a list of rules will be reported instead of the single one.
For `VirtualServiceIneffectiveMatch`, a list of rule-matches will be reported for each dup rule instead of reporting a message for every rule-match.

examples:
```
Warning [IST0130] (VirtualService default/many-dups-case pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:208) VirtualService rules [#1 #2 #3 #5 #6 #7 #8 #9 #10 #11 #12 #13] not used (all matches used by prior rules).
Info [IST0131] (VirtualService default/many-dups-case pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:208) VirtualService rule matches [rule #1 match #0,rule #2 match #0,rule #3 match #0,rule #5 match #0,rule #7 match #0,rule #9 match #0,rule #11 match #0,rule #13 match #0] not used (duplicate/overlapping match in rule #0).
Info [IST0131] (VirtualService default/many-dups-case pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:208) VirtualService rule matches [rule #6 match #0,rule #8 match #0,rule #10 match #0,rule #12 match #0] not used (duplicate/overlapping match in rule #4).
```