### PR TITLE
move cache to environment

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -55,9 +55,16 @@ import (
 var _ mesh.Holder = &Environment{}
 
 func NewEnvironment() *Environment {
+	var cache XdsCache
+	if features.EnableXDSCaching {
+		cache = NewXdsCache()
+	} else {
+		cache = DisabledCache{}
+	}
 	return &Environment{
 		pushContext:   NewPushContext(),
-		EndpointIndex: NewEndpointIndex(),
+		Cache:         cache,
+		EndpointIndex: NewEndpointIndex(cache),
 	}
 }
 
@@ -108,6 +115,9 @@ type Environment struct {
 	// EndpointShards for a service. This is a global (per-server) list, built from
 	// incremental updates. This is keyed by service and namespace
 	EndpointIndex *EndpointIndex
+
+	// Cache for XDS resources.
+	Cache XdsCache
 }
 
 func (e *Environment) Mesh() *meshconfig.MeshConfig {

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -116,16 +116,11 @@ type EndpointIndex struct {
 	cache XdsCache
 }
 
-func NewEndpointIndex() *EndpointIndex {
+func NewEndpointIndex(cache XdsCache) *EndpointIndex {
 	return &EndpointIndex{
 		shardsBySvc: make(map[string]map[string]*EndpointShards),
+		cache:       cache,
 	}
-}
-
-func (e *EndpointIndex) SetCache(cache XdsCache) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.cache = cache
 }
 
 // must be called with lock

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -125,9 +125,6 @@ func NewEndpointIndex(cache XdsCache) *EndpointIndex {
 
 // must be called with lock
 func (e *EndpointIndex) clearCacheForService(svc, ns string) {
-	if e.cache == nil {
-		return
-	}
 	e.cache.Clear(sets.Set[ConfigKey]{{
 		Kind:      kind.ServiceEntry,
 		Name:      svc,

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -167,7 +167,7 @@ func NewDiscoveryServer(env *model.Environment, instanceID string, clusterID clu
 			debounceMax:       features.DebounceMax,
 			enableEDSDebounce: features.EnableEDSDebounce,
 		},
-		Cache:              model.DisabledCache{},
+		Cache:              env.Cache,
 		instanceID:         instanceID,
 		clusterID:          clusterID,
 		discoveryStartTime: processStartTime,
@@ -179,14 +179,7 @@ func NewDiscoveryServer(env *model.Environment, instanceID string, clusterID clu
 	}
 
 	out.initJwksResolver()
-
-	if features.EnableXDSCaching {
-		out.Cache = model.NewXdsCache()
-		// clear the cache as endpoint shards are modified to avoid cache write race
-		out.Env.EndpointIndex.SetCache(out.Cache)
-	}
-
-	out.ConfigGenerator = core.NewConfigGenerator(out.Cache)
+	out.ConfigGenerator = core.NewConfigGenerator(env.Cache)
 
 	return out
 }

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -475,9 +475,10 @@ func (f *FakeDiscoveryServer) EnsureSynced(t test.Failer) {
 // out of sync fields typically are bugs.
 func (f *FakeDiscoveryServer) AssertEndpointConsistency() error {
 	f.t.Helper()
+	cache := model.DisabledCache{}
 	mock := &DiscoveryServer{
-		Env:   &model.Environment{EndpointIndex: model.NewEndpointIndex()},
-		Cache: model.DisabledCache{},
+		Env:   &model.Environment{EndpointIndex: model.NewEndpointIndex(cache)},
+		Cache: cache,
 	}
 	ag := f.Discovery.Env.ServiceDiscovery.(*aggregate.Controller)
 

--- a/tests/fuzz/pilot_model_fuzzer.go
+++ b/tests/fuzz/pilot_model_fuzzer.go
@@ -198,7 +198,7 @@ func FuzzInitContext(data []byte) int {
 	env.ServiceDiscovery = sd
 
 	env.Watcher = mesh.NewFixedWatcher(m)
-	env.EndpointIndex = model.NewEndpointIndex()
+	env.EndpointIndex = model.NewEndpointIndex(model.DisabledCache{})
 	env.Init()
 	pc := model.NewPushContext()
 	_ = pc.InitContext(env, nil, nil)


### PR DESCRIPTION
Move cache to env so that we build it once and use it every where. Otherwise we have to keep checking `cache != nil` many places. 
Ref https://github.com/istio/istio/pull/45800#discussion_r1252506861
- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure