### PR TITLE
Add cipher suites support in meshConfig for mesh to mesh traffic

### DIFF
--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -39,7 +39,8 @@ var SupportedCiphers = []string{
 // BuildInboundTLS returns the TLS context corresponding to the mTLS mode.
 func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 	protocol networking.ListenerProtocol, trustDomainAliases []string, minTLSVersion tls.TlsParameters_TlsProtocol,
-        mc *meshconfig.MeshConfig) *tls.DownstreamTlsContext {
+	mc *meshconfig.MeshConfig,
+) *tls.DownstreamTlsContext {
 	if mTLSMode == model.MTLSDisable || mTLSMode == model.MTLSUnknown {
 		return nil
 	}
@@ -64,7 +65,7 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		// protocol, e.g. HTTP/2.
 		ctx.CommonTlsContext.AlpnProtocols = util.ALPNHttp
 	}
-        if mc.MeshMTLS.CipherSuites != nil {
+	if mc.MeshMTLS.CipherSuites != nil {
 		SupportedCiphers = mc.MeshMTLS.CipherSuites
 	}
 	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -65,7 +65,7 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		// protocol, e.g. HTTP/2.
 		ctx.CommonTlsContext.AlpnProtocols = util.ALPNHttp
 	}
-	if mc.MeshMTLS.CipherSuites != nil {
+	if mc != nil && mc.MeshMTLS != nil && mc.MeshMTLS.CipherSuites != nil {
 		SupportedCiphers = mc.MeshMTLS.CipherSuites
 	}
 	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -39,7 +39,7 @@ var SupportedCiphers = []string{
 // BuildInboundTLS returns the TLS context corresponding to the mTLS mode.
 func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 	protocol networking.ListenerProtocol, trustDomainAliases []string, minTLSVersion tls.TlsParameters_TlsProtocol,
-) *tls.DownstreamTlsContext {
+        mc *meshconfig.MeshConfig) *tls.DownstreamTlsContext {
 	if mTLSMode == model.MTLSDisable || mTLSMode == model.MTLSUnknown {
 		return nil
 	}
@@ -64,7 +64,9 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		// protocol, e.g. HTTP/2.
 		ctx.CommonTlsContext.AlpnProtocols = util.ALPNHttp
 	}
-
+        if mc.MeshMTLS.CipherSuites != nil {
+		SupportedCiphers = mc.MeshMTLS.CipherSuites
+	}
 	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
 	ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
 		CipherSuites:              SupportedCiphers,

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -65,12 +65,13 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		// protocol, e.g. HTTP/2.
 		ctx.CommonTlsContext.AlpnProtocols = util.ALPNHttp
 	}
+	ciphers := SupportedCiphers
 	if mc != nil && mc.MeshMTLS != nil && mc.MeshMTLS.CipherSuites != nil {
-		SupportedCiphers = mc.MeshMTLS.CipherSuites
+		ciphers = mc.MeshMTLS.CipherSuites
 	}
 	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.
 	ctx.CommonTlsContext.TlsParams = &tls.TlsParameters{
-		CipherSuites:              SupportedCiphers,
+		CipherSuites:              ciphers,
 		TlsMinimumProtocolVersion: minTLSVersion,
 		TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
 	}

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -83,8 +83,8 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 			expectedMTLSCipherSuites: []string{"ECDHE-RSA-AES256-GCM-SHA384"},
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			testNode := &model.Proxy{
 				Labels: map[string]string{

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -18,9 +18,23 @@ import (
 	"testing"
 
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	model "istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking"
 )
+
+// SupportedCiphers for server side TLS configuration.
+var DefaultSupportedCiphers = []string{
+	"ECDHE-ECDSA-AES256-GCM-SHA384",
+	"ECDHE-RSA-AES256-GCM-SHA384",
+	"ECDHE-ECDSA-AES128-GCM-SHA256",
+	"ECDHE-RSA-AES128-GCM-SHA256",
+	"AES256-GCM-SHA384",
+	"AES128-GCM-SHA256",
+}
 
 func TestGetMinTLSVersion(t *testing.T) {
 	tests := []struct {
@@ -54,6 +68,43 @@ func TestGetMinTLSVersion(t *testing.T) {
 			if minVersion != tt.expectedMinTLSVer {
 				t.Errorf("unexpected result: expected min ver %v got %v",
 					tt.expectedMinTLSVer, minVersion)
+			}
+		})
+	}
+}
+
+func TestGetMTLSCipherSuites(t *testing.T) {
+	tests := []struct {
+		name                     string
+		mesh                     meshconfig.MeshConfig
+		expectedMTLSCipherSuites []string
+	}{
+		{
+			name:                     "Default MTLS supported Ciphers",
+			expectedMTLSCipherSuites: DefaultSupportedCiphers,
+		},
+		{
+			name: "Configure 1 MTLS cipher suite",
+			mesh: meshconfig.MeshConfig{
+				MeshMTLS: &meshconfig.MeshConfig_TLSConfig{
+					CipherSuites: []string{"ECDHE-RSA-AES256-GCM-SHA384"},
+				},
+			},
+			expectedMTLSCipherSuites: []string{"ECDHE-RSA-AES256-GCM-SHA384"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testNode := &model.Proxy{
+				Labels: map[string]string{
+					"app": "foo",
+				},
+				Metadata: &model.NodeMetadata{},
+			}
+
+			got := BuildInboundTLS(model.MTLSStrict, testNode, networking.ListenerProtocolTCP, []string{}, tls.TlsParameters_TLSv1_2, &tt.mesh)
+			if diff := cmp.Diff(tt.expectedMTLSCipherSuites, got.CommonTlsContext.TlsParams.CipherSuites, protocmp.Transform()); diff != "" {
+				t.Errorf("unexpected cipher suites: %v", diff)
 			}
 		})
 	}

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -26,16 +26,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking"
 )
 
-// SupportedCiphers for server side TLS configuration.
-var DefaultSupportedCiphers = []string{
-	"ECDHE-ECDSA-AES256-GCM-SHA384",
-	"ECDHE-RSA-AES256-GCM-SHA384",
-	"ECDHE-ECDSA-AES128-GCM-SHA256",
-	"ECDHE-RSA-AES128-GCM-SHA256",
-	"AES256-GCM-SHA384",
-	"AES128-GCM-SHA256",
-}
-
 func TestGetMinTLSVersion(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -81,7 +71,7 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 	}{
 		{
 			name:                     "Default MTLS supported Ciphers",
-			expectedMTLSCipherSuites: DefaultSupportedCiphers,
+			expectedMTLSCipherSuites: SupportedCiphers,
 		},
 		{
 			name: "Configure 1 MTLS cipher suite",
@@ -94,6 +84,7 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testNode := &model.Proxy{
 				Labels: map[string]string{

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -193,9 +193,9 @@ func (a v1beta1PolicyApplier) InboundMTLSSettings(
 		Port: endpointPort,
 		Mode: effectiveMTLSMode,
 		TCP: authn_utils.BuildInboundTLS(effectiveMTLSMode, node, networking.ListenerProtocolTCP,
-			trustDomainAliases, minTLSVersion),
+			trustDomainAliases, minTLSVersion, mc),
 		HTTP: authn_utils.BuildInboundTLS(effectiveMTLSMode, node, networking.ListenerProtocolHTTP,
-			trustDomainAliases, minTLSVersion),
+			trustDomainAliases, minTLSVersion, mc),
 	}
 }
 

--- a/releasenotes/notes/cipher_suites_mesh_to_mesh.yaml
+++ b/releasenotes/notes/cipher_suites_mesh_to_mesh.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - https://github.com/istio/istio/issues/28996
+releaseNotes:
+  - |
+    **Added** cipher_suites support for mesh to mesh traffic through MeshConfig API.


### PR DESCRIPTION
Added code changes to support meshconfig to configure cipher suites on sidecars for mesh to mesh traffic. 



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [x ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure


Testing :

meshConfig.Yaml 

```yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  name: istiocontrolplane-default
  namespace: istio-system
spec:
  meshConfig:
    meshMTLS:
      ecdhCurves:
        - P-256
      cipherSuites:
        - ECDHE-RSA-AES128-GCM-SHA256
```

With above mesh config, verified cipher suites used in the tls negotiation between sidecars. And tls negotiation failed if we used any cipher suites other than configured cipher suites. 