### PR TITLE
Refactor ambient controller to avoid race conditions

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -61,7 +61,6 @@ func TestAmbientIndex(t *testing.T) {
 	pc := clienttest.Wrap(t, controller.podsClient)
 	sc := clienttest.Wrap(t, controller.services)
 	cfg.RegisterEventHandler(gvk.AuthorizationPolicy, controller.AuthorizationPolicyHandler)
-	cfg.RegisterEventHandler(gvk.WorkloadEntry, controller.WorkloadEntryHandler)
 	cfg.RegisterEventHandler(gvk.PeerAuthentication, controller.PeerAuthenticationHandler)
 	go cfg.Run(test.NewStop(t))
 
@@ -183,7 +182,7 @@ func TestAmbientIndex(t *testing.T) {
 	assertAddresses(t, controller, "", "name1", "name2", "name3")
 	assertAddresses(t, controller, "testnetwork/10.0.0.1")
 	assertEvent(t, fx, "cluster0//Pod/ns1/name2", "ns1/svc1.ns1.svc.company.com")
-	assert.Equal(t, len(controller.ambientIndex.byService), 0)
+	assert.Equal(t, len(controller.ambientIndex.(*AmbientIndexImpl).byService), 0)
 
 	// Add a waypoint proxy pod for namespace
 	addPods("127.0.0.200", "waypoint-ns-pod", "namespace-wide",

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -55,7 +55,6 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	pc := clienttest.Wrap(t, controller.podsClient)
 	sc := clienttest.Wrap(t, controller.services)
 	cfg.RegisterEventHandler(gvk.AuthorizationPolicy, controller.AuthorizationPolicyHandler)
-	cfg.RegisterEventHandler(gvk.WorkloadEntry, controller.WorkloadEntryHandler)
 	go cfg.Run(test.NewStop(t))
 	assertWorkloads := func(lookup string, state workloadapi.WorkloadStatus, names ...string) {
 		t.Helper()
@@ -221,7 +220,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	assertWorkloads("", workloadapi.WorkloadStatus_HEALTHY, "name1", "name2", "name3")
 	assertWorkloads("/10.0.0.1", workloadapi.WorkloadStatus_HEALTHY)
 	assertEvent(t, fx, "cluster0/networking.istio.io/WorkloadEntry/ns1/name2", "ns1/svc1.ns1.svc.company.com")
-	assert.Equal(t, len(controller.ambientIndex.byService), 0)
+	assert.Equal(t, len(controller.ambientIndex.(*AmbientIndexImpl).byService), 0)
 
 	// Add a waypoint proxy pod for namespace
 	addPods("127.0.0.200", "waypoint-ns-pod", "namespace-wide",

--- a/pilot/pkg/serviceregistry/kube/controller/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/authorization.go
@@ -407,7 +407,7 @@ func (c *Controller) PeerAuthenticationHandler(old config.Config, obj config.Con
 		}
 	}
 
-	updates := c.calculateUpdatedWorkloads(pods)
+	updates := c.ambientIndex.CalculateUpdatedWorkloads(pods, nil, c)
 
 	if len(updates) > 0 {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
@@ -417,19 +417,39 @@ func (c *Controller) PeerAuthenticationHandler(old config.Config, obj config.Con
 	}
 }
 
-func (c *Controller) calculateUpdatedWorkloads(pods map[string]*v1.Pod) map[model.ConfigKey]struct{} {
+// CalculateUpdatedWorkloads returns the set of updated config keys for the given
+// pods and workload entries.
+//
+// NOTE: As an interface method of AmbientIndex, this locks the index.
+func (a *AmbientIndexImpl) CalculateUpdatedWorkloads(pods map[string]*v1.Pod,
+	workloadEntries map[networkAddress]*apiv1alpha3.WorkloadEntry, c *Controller,
+) map[model.ConfigKey]struct{} {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	updates := map[model.ConfigKey]struct{}{}
 	for _, pod := range pods {
-		newWl := c.extractWorkload(pod)
+		newWl := a.extractWorkload(pod, c)
 		if newWl != nil {
 			// Update the pod, since it now has new VIP info
 			networkAddrs := networkAddressFromWorkload(newWl)
-			c.ambientIndex.mu.Lock()
 			for _, networkAddr := range networkAddrs {
-				c.ambientIndex.byPod[networkAddr] = newWl
+				a.byPod[networkAddr] = newWl
 			}
-			c.ambientIndex.byUID[c.generatePodUID(pod)] = newWl
-			c.ambientIndex.mu.Unlock()
+			a.byUID[c.generatePodUID(pod)] = newWl
+			updates[model.ConfigKey{Kind: kind.Address, Name: newWl.ResourceName()}] = struct{}{}
+		}
+	}
+
+	for _, w := range workloadEntries {
+		newWl := a.extractWorkloadEntry(w, c)
+		if newWl != nil {
+			// Update the WorkloadEntry, since it now has new VIP info
+			networkAddrs := networkAddressFromWorkload(newWl)
+			for _, networkAddr := range networkAddrs {
+				a.byWorkloadEntry[networkAddr] = newWl
+			}
+			a.byUID[c.generateWorkloadEntryUID(w.GetNamespace(), w.GetName())] = newWl
 			updates[model.ConfigKey{Kind: kind.Address, Name: newWl.ResourceName()}] = struct{}{}
 		}
 	}
@@ -473,8 +493,6 @@ func (c *Controller) AuthorizationPolicyHandler(old config.Config, obj config.Co
 		}
 	}
 
-	updates := c.calculateUpdatedWorkloads(pods)
-
 	workloadEntries := map[networkAddress]*apiv1alpha3.WorkloadEntry{}
 	for _, w := range c.getWorkloadEntriesInPolicy(obj.Namespace, sel) {
 		network := c.Network(w.Spec.Address, w.Spec.Labels).String()
@@ -499,20 +517,7 @@ func (c *Controller) AuthorizationPolicyHandler(old config.Config, obj config.Co
 		}
 	}
 
-	for _, w := range workloadEntries {
-		newWl := c.extractWorkloadEntry(w)
-		if newWl != nil {
-			// Update the WorkloadEntry, since it now has new VIP info
-			networkAddrs := networkAddressFromWorkload(newWl)
-			c.ambientIndex.mu.Lock()
-			for _, networkAddr := range networkAddrs {
-				c.ambientIndex.byWorkloadEntry[networkAddr] = newWl
-			}
-			c.ambientIndex.byUID[c.generateWorkloadEntryUID(w.GetNamespace(), w.GetName())] = newWl
-			c.ambientIndex.mu.Unlock()
-			updates[model.ConfigKey{Kind: kind.Address, Name: newWl.ResourceName()}] = struct{}{}
-		}
-	}
+	updates := c.ambientIndex.CalculateUpdatedWorkloads(pods, workloadEntries, c)
 
 	if len(updates) > 0 {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -229,7 +229,7 @@ type Controller struct {
 
 	podsClient kclient.Client[*v1.Pod]
 
-	ambientIndex     *AmbientIndex
+	ambientIndex     AmbientIndex
 	configController model.ConfigStoreController
 	configCluster    bool
 }

--- a/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
@@ -16,12 +16,14 @@ package controller
 
 import (
 	"github.com/hashicorp/go-multierror"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/mesh"
 	filter "istio.io/istio/pkg/kube/namespace"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // initialize handlers for discovery selection scoping
@@ -75,6 +77,35 @@ func (c *Controller) initMeshWatcherHandler(meshWatcher mesh.Watcher, discoveryN
 	})
 }
 
+// HandleSelectedNamespace processes pods and workload entries for the selected namespace
+// and sends an XDS update as needed.
+//
+// NOTE: As an interface method of AmbientIndex, this locks the index.
+func (a *AmbientIndexImpl) HandleSelectedNamespace(ns string, pods []*corev1.Pod, c *Controller) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	updates := sets.New[model.ConfigKey]()
+
+	// Handle Pods.
+	for _, p := range pods {
+		updates = updates.Merge(a.handlePod(nil, p, false, c))
+	}
+
+	// Handle WorkloadEntries.
+	allWorkloadEntries := c.getControllerWorkloadEntries(ns)
+	for _, w := range allWorkloadEntries {
+		updates = updates.Merge(a.handleWorkloadEntry(nil, w, false, c))
+	}
+
+	if len(updates) > 0 {
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
+			ConfigsUpdated: updates,
+			Reason:         []model.TriggerReason{model.AmbientUpdate},
+		})
+	}
+}
+
 // issue create events for all services, pods, and endpoints in the newly labeled namespace
 func (c *Controller) handleSelectedNamespace(ns string) {
 	var errs *multierror.Error
@@ -90,10 +121,7 @@ func (c *Controller) handleSelectedNamespace(ns string) {
 	}
 
 	if c.ambientIndex != nil {
-		c.ambientIndex.handlePods(pods, c)
-		allWorkloadEntries := c.getControllerWorkloadEntries(ns)
-		c.ambientIndex.handleWorkloadEntries(allWorkloadEntries, c)
-
+		c.ambientIndex.HandleSelectedNamespace(ns, pods, c)
 	}
 
 	errs = multierror.Append(errs, c.endpoints.sync("", ns, model.EventAdd, false))

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -78,7 +78,6 @@ func setupTest(t *testing.T) (
 		},
 	)
 	configController := memory.NewController(memory.Make(collections.Pilot))
-	configController.RegisterEventHandler(gvk.WorkloadEntry, kc.WorkloadEntryHandler)
 
 	stop := istiotest.NewStop(t)
 	go configController.Run(stop)


### PR DESCRIPTION
The ambient controller currently accesses fields in `AmbientIndex` directly, which has already led to at least one data race.

This establishes a new interface `AmbientIndex` that is used by the controller. The implementation correctly handles locking as needed.

Fixes #45816