### PR TITLE
pilot: make endpoint index safer

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -119,20 +119,17 @@ type EndpointIndex struct {
 func NewEndpointIndex() *EndpointIndex {
 	return &EndpointIndex{
 		shardsBySvc: make(map[string]map[string]*EndpointShards),
+		// May be overridden later by SetCache
+		cache: DisabledCache{},
 	}
 }
 
 func (e *EndpointIndex) SetCache(cache XdsCache) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	e.cache = cache
 }
 
 // must be called with lock
 func (e *EndpointIndex) clearCacheForService(svc, ns string) {
-	if e.cache == nil {
-		return
-	}
 	e.cache.Clear(sets.Set[ConfigKey]{{
 		Kind:      kind.ServiceEntry,
 		Name:      svc,
@@ -203,9 +200,6 @@ func (e *EndpointIndex) DeleteShard(shardKey ShardKey) {
 		for ns := range shardsByNamespace {
 			e.deleteServiceInner(shardKey, svc, ns, false)
 		}
-	}
-	if e.cache == nil {
-		return
 	}
 	e.cache.ClearAll()
 }

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -183,8 +183,8 @@ func NewDiscoveryServer(env *model.Environment, instanceID string, clusterID clu
 	if features.EnableXDSCaching {
 		out.Cache = model.NewXdsCache()
 		// clear the cache as endpoint shards are modified to avoid cache write race
-		out.Env.EndpointIndex.SetCache(out.Cache)
 	}
+	out.Env.EndpointIndex.SetCache(out.Cache)
 
 	out.ConfigGenerator = core.NewConfigGenerator(out.Cache)
 


### PR DESCRIPTION
Always initialize a cache to avoid any posible nil
