### PR TITLE
ambient: dynamically determine dstport for geneve link

### DIFF
--- a/cni/pkg/ambient/constants/constants.go
+++ b/cni/pkg/ambient/constants/constants.go
@@ -38,6 +38,9 @@ const (
 	InboundTun  = "istioin"
 	OutboundTun = "istioout"
 
+	InboundTunVNI  = uint32(1000)
+	OutboundTunVNI = uint32(1001)
+
 	InboundTunIP         = "192.168.126.1"
 	ZTunnelInboundTunIP  = "192.168.126.2"
 	OutboundTunIP        = "192.168.127.1"

--- a/releasenotes/notes/45831.yaml
+++ b/releasenotes/notes/45831.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** creating `istioin` and `istioout` geneve links on nodes which already have configured
+    an external geneve link or another geneve link for the same VNI and remote IP. To avoid getting errors
+    in these cases, istio-cni dynamically determines available destination ports for created geneve links.


### PR DESCRIPTION
**Please provide a description of this PR:**

This small change fixes one of the issues of ambient on OpenShift with ovn-kubernetes CNI.

By default, ovn-kubernetes creates an external geneve link named "ovn_sys_6081", and therefore istio-cni fails to create links for geneve tunnels `istioin` and `istioout`, because "**There already exists an externally controlled device on this destination port**" - this is the error message from `ip link add` command. The port conflict occurs, because istio-cni does not specify destination ports for created links and therefore it uses the same port - 6081.

I also noticed that similar error may occur when a node has a geneve link with the same VNI and remote IP as `istioin` and `istioout`. This is probably unlikely to happen, but it's at least theoretically possible.

I added a function to find first available destination port if there is a conflict.