### PR TITLE
remove extractNames and ListContains

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -504,7 +504,7 @@ func dedupeDomains(domains []string, vhdomains sets.String, expandedHosts []stri
 		// the real "foo.com"
 		// This works by providing a list of domains that were added as expanding the DNS domain as part of expandedHosts,
 		// and a list of known unexpanded FQDNs to compare against
-		if util.ListContains(expandedHosts, d) && knownFQDNs.Contains(d) { // O(n) search, but n is at most 10
+		if slices.Contains(expandedHosts, d) && knownFQDNs.Contains(d) { // O(n) search, but n is at most 10
 			continue
 		}
 		temp = append(temp, d)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -119,15 +119,6 @@ var ALPNHttp3OverQUIC = []string{"h3"}
 // ALPNDownstreamWithMxc advertises that Proxy is going to talk either tcp(for metadata exchange), http2 or http 1.1.
 var ALPNDownstreamWithMxc = []string{"istio-peer-exchange", "h2", "http/1.1"}
 
-func ListContains(haystack []string, needle string) bool {
-	for _, n := range haystack {
-		if needle == n {
-			return true
-		}
-	}
-	return false
-}
-
 // ConvertAddressToCidr converts from string to CIDR proto
 func ConvertAddressToCidr(addr string) *core.CidrRange {
 	cidr, err := AddrStrToCidrRange(addr)

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -487,7 +488,9 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 		Nonce:             nonce(req.Push.LedgerVersion),
 		Resources:         res,
 	}
-	currentResources := extractNames(res)
+	currentResources := slices.Map(res, func(r *discovery.Resource) string {
+		return r.Name
+	})
 	if usedDelta {
 		resp.RemovedResources = deletedRes
 	} else if req.Full {
@@ -612,12 +615,4 @@ func deltaWatchedResources(existing []string, request *discovery.DeltaDiscoveryR
 		wildcard = true
 	}
 	return sets.SortedList(res), wildcard
-}
-
-func extractNames(res []*discovery.Resource) []string {
-	names := []string{}
-	for _, r := range res {
-		names = append(names, r.Name)
-	}
-	return names
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

`extractNames` and `ListContains` can be replaced and I think we can clean them up.