### PR TITLE
Fix iop merge patch logic

### DIFF
--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	yaml2 "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 
 	v1alpha13 "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -238,10 +238,10 @@ func OverlayIOP(base, overlay string) (string, error) {
 	var bj map[string]interface{}
 	var oj map[string]interface{}
 
-	if err := yaml2.Unmarshal([]byte(base), &bj); err != nil {
+	if err := yaml.Unmarshal([]byte(base), &bj); err != nil {
 		return "", err
 	}
-	if err := yaml2.Unmarshal([]byte(overlay), &oj); err != nil {
+	if err := yaml.Unmarshal([]byte(overlay), &oj); err != nil {
 		return "", err
 	}
 
@@ -249,7 +249,7 @@ func OverlayIOP(base, overlay string) (string, error) {
 		return "", err
 	}
 
-	my, err := yaml2.Marshal(bj)
+	my, err := yaml.Marshal(bj)
 	if err != nil {
 		return "", err
 	}

--- a/releasenotes/notes/45840.yaml
+++ b/releasenotes/notes/45840.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where merging custom IstioOperator resources during installation would fail if some default values were not set.


### PR DESCRIPTION
**Please provide a description of this PR:**
I'm not sure if it's a bug or expected behavior, what I've encountered is:

When doing the istiooperator file merge during installation using `-f`, there's an error which indicates that I need to have the key present.

For example, to reproduce:
```
istioctl install -f manifests/examples/user-gateway/ingress-gateway-only.yaml
Error: generate config: could not overlay user config over base: json merge error (map: map[enabled:true namespace:my-namespace] does not contain declared merge key: name) for base object: 
...
```

The strategic merge patch needs to have the key present to perform the merge, which doesn't seem to make sense for merging overlay custom resources before the installation.