### PR TITLE
wasmplugin allows 'nil' value sha256

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3972,7 +3972,7 @@ func validateWasmPluginURL(pluginURL string) error {
 }
 
 func validateWasmPluginSHA(plugin *extensions.WasmPlugin) error {
-	if plugin.Sha256 == "" {
+	if plugin.Sha256 == "" || plugin.Sha256 == "nil" {
 		return nil
 	}
 	if len(plugin.Sha256) != 64 {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -8367,6 +8367,14 @@ func TestValidateWasmPlugin(t *testing.T) {
 			"", "",
 		},
 		{
+			"valid http w/ nil sha",
+			&extensions.WasmPlugin{
+				Url:    "http://test.com/test",
+				Sha256: "nil",
+			},
+			"", "",
+		},
+		{
 			"short sha",
 			&extensions.WasmPlugin{
 				Url:    "http://test.com/test",


### PR DESCRIPTION
**Please provide a description of this PR:**

We used to allow the `Sha256` field to be optional, in fact istio sets `"nil"` to the null sha256 value to bypass the xDS API checksum and reverts this special value to `""` in the pilot-agent, see https://github.com/istio/istio/blob/ d14105866e811a925414e901b6386b3fbad4f800/pkg/wasm/convert.go#L217 .

We later changed the field to required in [Update WasmPlugin code to work with non-optional sha256 #35608](https://github.com/istio/istio/pull/35608), but kept the pilot-agent but kept the compatible logic in the pilot-agent.

I think it makes sense to allow not setting valid sha256 values in scenarios like testing, so I submitted this PR: The special value was released in the istio validation logic