### PR TITLE
Allocate memory space for slice in advance

### DIFF
--- a/istioctl/pkg/util/formatting/formatter.go
+++ b/istioctl/pkg/util/formatting/formatter.go
@@ -62,7 +62,7 @@ func Print(ms diag.Messages, format string, colorize bool) (string, error) {
 }
 
 func printLog(ms diag.Messages, colorize bool) string {
-	var logOutput []string
+	logOutput := make([]string, 0, len(ms))
 	for _, m := range ms {
 		logOutput = append(logOutput, render(m, colorize))
 	}

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -236,7 +236,7 @@ func (os K8sObjects) String() string {
 
 // Keys returns a slice with the keys of os.
 func (os K8sObjects) Keys() []string {
-	var out []string
+	out := make([]string, 0, len(os))
 	for _, oo := range os {
 		out = append(out, oo.Hash())
 	}
@@ -245,7 +245,7 @@ func (os K8sObjects) Keys() []string {
 
 // UnstructuredItems returns the list of items of unstructured.Unstructured.
 func (os K8sObjects) UnstructuredItems() []unstructured.Unstructured {
-	var usList []unstructured.Unstructured
+	usList := make([]unstructured.Unstructured, 0, len(os))
 	for _, obj := range os {
 		usList = append(usList, *obj.UnstructuredObject())
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -958,7 +958,7 @@ func TestIsServiceVisible(t *testing.T) {
 }
 
 func serviceNames(svcs []*Service) []string {
-	var s []string
+	s := make([]string, 0, len(svcs))
 	for _, ss := range svcs {
 		s = append(s, string(ss.Hostname))
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1003,7 +1003,7 @@ func (ports PortList) Equals(other PortList) bool {
 }
 
 func (ports PortList) String() string {
-	var sp []string
+	sp := make([]string, 0, len(ports))
 	for _, p := range ports {
 		sp = append(sp, p.String())
 	}

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -203,7 +203,7 @@ func ConstructSdsSecretConfig(name string) *tls.SdsSecretConfig {
 }
 
 func AppendURIPrefixToTrustDomain(trustDomainAliases []string) []string {
-	var res []string
+	res := make([]string, 0, len(trustDomainAliases))
 	for _, td := range trustDomainAliases {
 		res = append(res, spiffe.URIPrefix+td+"/")
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1732,7 +1732,7 @@ func TestInstancesByPort_WorkloadInstances(t *testing.T) {
 
 	want := []string{"2.2.2.2:8082", "2.2.2.2:8083"} // expect both WorkloadEntries even though they have the same IP
 
-	var got []string
+	got := make([]string, 0, len(instances))
 	for _, instance := range instances {
 		got = append(got, net.JoinHostPort(instance.Endpoint.Address, strconv.Itoa(int(instance.Endpoint.EndpointPort))))
 	}
@@ -1920,7 +1920,7 @@ func createEndpoints(t *testing.T, controller *FakeController, name, namespace s
 		esps = append(esps, discovery.EndpointPort{Name: &n, Port: &portNum})
 	}
 
-	var sliceEndpoint []discovery.Endpoint
+	sliceEndpoint := make([]discovery.Endpoint, 0, len(ips))
 	for i, ip := range ips {
 		sliceEndpoint = append(sliceEndpoint, discovery.Endpoint{
 			Addresses: []string{ip},
@@ -2472,7 +2472,7 @@ func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
 	// we should have the pod IP and the workload Entry's IP in the endpoints..
 	// the first endpoint should be that of the k8s pod and the second one should be the workload entry
 
-	var gotEndpointIPs []string
+	gotEndpointIPs := make([]string, 0, len(ev.Endpoints))
 	for _, ep := range ev.Endpoints {
 		gotEndpointIPs = append(gotEndpointIPs, ep.Address)
 	}

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -195,7 +195,7 @@ func (sd *ServiceDiscovery) AddInstanceNotify(service host.Name, instance *model
 	key = fmt.Sprintf("%s:%s", service, instance.ServicePort.Name)
 	instanceList = sd.instancesByPortName[key]
 	sd.instancesByPortName[key] = append(instanceList, instance)
-	var eps []*model.IstioEndpoint
+	eps := make([]*model.IstioEndpoint, 0, len(sd.instancesByPortName[key]))
 	for _, i := range sd.instancesByPortName[key] {
 		eps = append(eps, i.Endpoint)
 	}

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -977,7 +977,7 @@ func expectAmbient(strings []string, ambient bool) []string {
 	if !ambient {
 		return strings
 	}
-	var out []string
+	out := make([]string, 0, len(strings))
 	for _, s := range strings {
 		out = append(out, "connect_originate;"+s)
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

I recently did some local testing and found that allocating memory to slice in advance greatly reduced the execution time of the program. So this PR is to help optimize memory allocation and improve the execution efficiency of the program

```golang
func AppendVar() []int {
	var res []int
	for i := 0; i < 10; i++ {
		res = append(res, i)
	}
	return res
}

func AppendPreAllocate() []int {
	res := make([]int, 0, 10)
	for i := 0; i < 10; i++ {
		res = append(res, i)
	}
	return res
}

func AppendPreAllocateIndex() []int {
	res := make([]int, 10)
	for i := 0; i < 10; i++ {
		res[i] = i
	}
	return res
}

func BenchmarkAppendVar(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AppendVar()
	}
}

func BenchmarkAppendPreAllocate(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AppendPreAllocate()
	}
}

func BenchmarkAppendPreAllocateIndex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AppendPreAllocateIndex()
	}
}
```

<img width="666" alt="image" src="https://github.com/istio/istio/assets/47143494/a8608e4f-ad5c-48c3-beb9-62a633a3987e">

