### PR TITLE
refactor wasm extension rewrite logic

### DIFF
--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -64,7 +64,7 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 				return
 			}
 
-			err := rewritetWasmExtensions(extConfig, cache)
+			err := rewriteWasmExtensions(extConfig, cache)
 			if err != nil {
 				wasmConfigConversionCount.
 					With(resultTag.Value(unmarshalFailure)).
@@ -85,10 +85,10 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 	return err
 }
 
-// rewritetWasmExtensions updates the extension config to use local file instead of remote fetch for all wasm filters.
+// rewriteWasmExtensions updates the extension config to use local file instead of remote fetch for all wasm filters.
 // It does an in-place update of WASM config.
 // Currently we only support a WASM filter per extension config.
-func rewritetWasmExtensions(ec *core.TypedExtensionConfig, cache Cache) error {
+func rewriteWasmExtensions(ec *core.TypedExtensionConfig, cache Cache) error {
 	wasmHTTPFilterConfig := &wasm.Wasm{}
 
 	// Wasm filter can be configured using typed struct and Wasm filter type

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -310,9 +310,6 @@ func TestWasmConvert(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if c.name != "remote load fail open" {
-			continue
-		}
 		t.Run(c.name, func(t *testing.T) {
 			resources := make([]*anypb.Any, 0, len(c.input))
 			for _, i := range c.input {

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -310,6 +310,9 @@ func TestWasmConvert(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		if c.name != "remote load fail open" {
+			continue
+		}
 		t.Run(c.name, func(t *testing.T) {
 			resources := make([]*anypb.Any, 0, len(c.input))
 			for _, i := range c.input {


### PR DESCRIPTION
This PR rewrites the wasm extension inline (i.e. replace in the existing extension config) instead of creating new extension config.

I refactored it like this to support Composite Filter with WASM extensions (there can be many WASM extensions in the composite filter for each action so we need to replace inline). But after discussion with @kyessenov , he suggested it would be simpler to add ECDS support for Composite filter. But I thought this refactor would be useful in general. If folks think, it is not needed, I can close this

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure