### PR TITLE
>fix missing revision flag in precheck

### DIFF
--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -55,8 +55,6 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-var revision string
-
 func Cmd(ctx cli.Context) *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	var skipControlPlane bool
@@ -71,7 +69,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
   # Check only a single namespace
   istioctl x precheck --namespace default`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			cli, err := ctx.CLIClientWithRevision(revision)
+			cli, err := ctx.CLIClientWithRevision(opts.Revision)
 			if err != nil {
 				return err
 			}

--- a/releasenotes/notes/fix-istioctl-x-precheck-missing-revision.yaml
+++ b/releasenotes/notes/fix-istioctl-x-precheck-missing-revision.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** `revision` flag missing in `istioctl x precheck`.


### PR DESCRIPTION
**Please provide a description of this PR:**

`revision` flag missing in `istioctl x precheck`