### PR TITLE
Remove dependency on `model` from `pkg/version`

### DIFF
--- a/pkg/proxy/proxyinfo.go
+++ b/pkg/proxy/proxyinfo.go
@@ -50,7 +50,7 @@ func GetProxyInfo(kubeClient kube.CLIClient, istioNamespace string) (*[]istioVer
 			pi = append(pi, istioVersion.ProxyInfo{
 				ID:           ss.ProxyID,
 				IstioVersion: ss.SyncStatus.IstioVersion,
-				Type:         istioVersion.ToUserFacingNodeType(ss.ProxyType),
+				Type:         istioVersion.ToUserFacingNodeType(string(ss.ProxyType)),
 			})
 		}
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-
-	"istio.io/istio/pilot/pkg/model"
 )
 
 // The following fields are populated at build time using -ldflags -X.
@@ -56,14 +54,13 @@ type MeshInfo []ServerInfo
 // NodeType decides the responsibility of the proxy serves in the mesh
 type NodeType string
 
-func ToUserFacingNodeType(t model.NodeType) NodeType {
+func ToUserFacingNodeType(t string) NodeType {
 	switch t {
-	case model.Router:
+	case "router":
 		return "gateway"
-	case model.Ztunnel, model.Waypoint, model.SidecarProxy:
+	default:
 		return NodeType(t)
 	}
-	return ""
 }
 
 // ProxyInfo contains the version for a single data plane component


### PR DESCRIPTION
This recent change made the docker-builder bloat from ~20mb to ~80mb
