### PR TITLE
vm/packaging: add hostname package as a dependency

### DIFF
--- a/releasenotes/notes/45866.yaml
+++ b/releasenotes/notes/45866.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 45866
+releaseNotes:
+- |
+  **Fixed** an issue where the hostname package is not listed as a dependency for the VM packages.

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -68,6 +68,7 @@ rpm/fpm:
 		--depends iproute \
 		--depends iptables \
 		--depends sudo \
+		--depends hostname \
 		$(RPM_COMPRESSION) \
 		$(SIDECAR_FILES)
 
@@ -87,6 +88,7 @@ deb/fpm:
 		--depends iproute2 \
 		--depends iptables \
 		--depends sudo \
+		--depends hostname \
 		$(DEB_COMPRESSION) \
 		$(SIDECAR_FILES)
 


### PR DESCRIPTION
The init script (istio-start.sh) uses the hostname command which isn't always installed in certain distros (e.g. CentOS 8).

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure