### PR TITLE
Stop using deprecated Envoy runtimes flags

### DIFF
--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -85,7 +85,7 @@ func NodeMetadata(meta *model.BootstrapNodeMetadata, rawMeta map[string]any) Ins
 	return newOptionOrSkipIfZero("meta_json_str", meta).withConvert(nodeMetadataConverter(meta, rawMeta))
 }
 
-func RuntimeFlags(flags map[string]string) Instance {
+func RuntimeFlags(flags map[string]any) Instance {
 	return newOptionOrSkipIfZero("runtime_flags", flags).withConvert(jsonConverter(flags))
 }
 

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -15,7 +15,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -15,7 +15,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -10,7 +10,7 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":"true","envoy.reloadable_features.http_reject_path_with_fragment":"false","overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/45462

I think this is the best we can do without Envoy reverting
