### PR TITLE
PushRequest.Reason change to map to optimize mem/merge cost

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -159,7 +159,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					// Trigger a push so we can recompute status
 					s.XDSServer.ConfigUpdate(&model.PushRequest{
 						Full:   true,
-						Reason: []model.TriggerReason{model.GlobalUpdate},
+						Reason: model.NewReasonStats(model.GlobalUpdate),
 					})
 					<-leaderStop
 					log.Infof("Stopping gateway status writer")

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -495,7 +495,7 @@ func (s *Server) initSDSServer() {
 				Full:           false,
 				ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.Secret, Name: name, Namespace: namespace}),
 
-				Reason: []model.TriggerReason{model.SecretTrigger},
+				Reason: model.NewReasonStats(model.SecretTrigger),
 			})
 		})
 		s.multiclusterController.AddHandler(creds)
@@ -851,7 +851,7 @@ func (s *Server) initRegistryEventHandlers() {
 			pushReq := &model.PushRequest{
 				Full:           true,
 				ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: string(curr.Hostname), Namespace: curr.Attributes.Namespace}),
-				Reason:         []model.TriggerReason{model.ServiceUpdate},
+				Reason:         model.NewReasonStats(model.ServiceUpdate),
 			}
 			s.XDSServer.ConfigUpdate(pushReq)
 		}
@@ -876,7 +876,7 @@ func (s *Server) initRegistryEventHandlers() {
 			pushReq := &model.PushRequest{
 				Full:           true,
 				ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.MustFromGVK(curr.GroupVersionKind), Name: curr.Name, Namespace: curr.Namespace}),
-				Reason:         []model.TriggerReason{model.ConfigUpdate},
+				Reason:         model.NewReasonStats(model.ConfigUpdate),
 			}
 			s.XDSServer.ConfigUpdate(pushReq)
 		}
@@ -902,7 +902,7 @@ func (s *Server) initRegistryEventHandlers() {
 			s.environment.GatewayAPIController.RegisterEventHandler(gvk.Namespace, func(config.Config, config.Config, model.Event) {
 				s.XDSServer.ConfigUpdate(&model.PushRequest{
 					Full:   true,
-					Reason: []model.TriggerReason{model.NamespaceUpdate},
+					Reason: model.NewReasonStats(model.NamespaceUpdate),
 				})
 			})
 			s.environment.GatewayAPIController.RegisterEventHandler(gvk.Secret, func(_ config.Config, gw config.Config, _ model.Event) {
@@ -915,7 +915,7 @@ func (s *Server) initRegistryEventHandlers() {
 							Namespace: gw.Namespace,
 						}: {},
 					},
-					Reason: []model.TriggerReason{model.SecretTrigger},
+					Reason: model.NewReasonStats(model.SecretTrigger),
 				})
 			})
 		}
@@ -1208,7 +1208,7 @@ func (s *Server) initMeshHandlers() {
 		s.XDSServer.ConfigGenerator.MeshConfigChanged(s.environment.Mesh())
 		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
-			Reason: []model.TriggerReason{model.GlobalUpdate},
+			Reason: model.NewReasonStats(model.GlobalUpdate),
 		})
 	})
 }
@@ -1241,7 +1241,7 @@ func (s *Server) initWorkloadTrustBundle(args *PilotArgs) error {
 	s.workloadTrustBundle.UpdateCb(func() {
 		pushReq := &model.PushRequest{
 			Full:   true,
-			Reason: []model.TriggerReason{model.GlobalUpdate},
+			Reason: model.NewReasonStats(model.GlobalUpdate),
 		}
 		s.XDSServer.ConfigUpdate(pushReq)
 	})

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -147,7 +147,7 @@ func TestNamespaceEvent(t *testing.T) {
 	c.RegisterEventHandler(gvk.Namespace, func(_, cfg config.Config, _ model.Event) {
 		s.ConfigUpdate(&model.PushRequest{
 			Full:   true,
-			Reason: []model.TriggerReason{model.NamespaceUpdate},
+			Reason: model.NewReasonStats(model.NamespaceUpdate),
 		})
 	})
 

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -106,7 +106,7 @@ func (mgr *NetworkManager) reloadGateways() {
 
 	if changed && mgr.xdsUpdater != nil {
 		log.Infof("gateways changed, triggering push")
-		mgr.xdsUpdater.ConfigUpdate(&PushRequest{Full: true, Reason: []TriggerReason{NetworksTrigger}})
+		mgr.xdsUpdater.ConfigUpdate(&PushRequest{Full: true, Reason: NewReasonStats(NetworksTrigger)})
 	}
 }
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -367,7 +367,7 @@ type PushRequest struct {
 	// to avoid unbounded cardinality in metrics. If this is not set, it may be automatically filled in later.
 	// There should only be multiple reasons if the push request is the result of two distinct triggers, rather than
 	// classifying a single trigger as having multiple reasons.
-	Reason []TriggerReason
+	Reason ReasonStats
 
 	// Delta defines the resources that were added or removed as part of this push request.
 	// This is set only on requests from the client which change the set of resources they (un)subscribe from.
@@ -384,6 +384,53 @@ type ResourceDelta struct {
 
 func (rd ResourceDelta) IsEmpty() bool {
 	return len(rd.Subscribed) == 0 && len(rd.Unsubscribed) == 0
+}
+
+type ReasonStats map[TriggerReason]int
+
+func NewReasonStats(reasons ...TriggerReason) ReasonStats {
+	ret := make(ReasonStats)
+	for _, reason := range reasons {
+		ret.Add(reason)
+	}
+	return ret
+}
+
+func (r ReasonStats) Add(reason TriggerReason) {
+	r[reason]++
+}
+
+func (r ReasonStats) Merge(other ReasonStats) {
+	for reason, count := range other {
+		r[reason] += count
+	}
+}
+
+func (r ReasonStats) CopyMerge(other ReasonStats) ReasonStats {
+	if len(r) == 0 {
+		return other
+	}
+	if len(other) == 0 {
+		return r
+	}
+
+	merged := make(ReasonStats, len(r)+len(other))
+	merged.Merge(r)
+	merged.Merge(other)
+
+	return merged
+}
+
+func (r ReasonStats) Count() int {
+	var ret int
+	for _, count := range r {
+		ret += count
+	}
+	return ret
+}
+
+func (r ReasonStats) Has(reason TriggerReason) bool {
+	return r[reason] > 0
 }
 
 type TriggerReason string
@@ -435,7 +482,12 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 	// Keep the first (older) start time
 
 	// Merge the two reasons. Note that we shouldn't deduplicate here, or we would under count
-	pr.Reason = append(pr.Reason, other.Reason...)
+	if len(other.Reason) > 0 {
+		if pr.Reason == nil {
+			pr.Reason = make(map[TriggerReason]int)
+		}
+		pr.Reason.Merge(other.Reason)
+	}
 
 	// If either is full we need a full push
 	pr.Full = pr.Full || other.Full
@@ -468,11 +520,11 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 		return pr
 	}
 
-	var reason []TriggerReason
+	var reason ReasonStats
 	if len(pr.Reason)+len(other.Reason) > 0 {
-		reason = make([]TriggerReason, 0, len(pr.Reason)+len(other.Reason))
-		reason = append(reason, pr.Reason...)
-		reason = append(reason, other.Reason...)
+		reason = make(ReasonStats)
+		reason.Merge(pr.Reason)
+		reason.Merge(other.Reason)
 	}
 	merged := &PushRequest{
 		// Keep the first (older) start time
@@ -499,16 +551,11 @@ func (pr *PushRequest) CopyMerge(other *PushRequest) *PushRequest {
 }
 
 func (pr *PushRequest) IsRequest() bool {
-	return len(pr.Reason) == 1 && pr.Reason[0] == ProxyRequest
+	return len(pr.Reason) == 1 && pr.Reason.Has(ProxyRequest)
 }
 
 func (pr *PushRequest) IsProxyUpdate() bool {
-	for _, r := range pr.Reason {
-		if r == ProxyUpdate {
-			return true
-		}
-	}
-	return false
+	return pr.Reason.Has(ProxyUpdate)
 }
 
 func (pr *PushRequest) PushReason() string {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -88,7 +88,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 				ConfigsUpdated: sets.Set[ConfigKey]{
 					{Kind: kind.Kind(1), Namespace: "ns1"}: {},
 				},
-				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate},
+				Reason: NewReasonStats(ServiceUpdate, ServiceUpdate),
 			},
 			&PushRequest{
 				Full:  false,
@@ -97,7 +97,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 				ConfigsUpdated: sets.Set[ConfigKey]{
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},
 				},
-				Reason: []TriggerReason{EndpointUpdate},
+				Reason: NewReasonStats(EndpointUpdate),
 			},
 			PushRequest{
 				Full:  true,
@@ -107,7 +107,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 					{Kind: kind.Kind(1), Namespace: "ns1"}: {},
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},
 				},
-				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate, EndpointUpdate},
+				Reason: NewReasonStats(ServiceUpdate, ServiceUpdate, EndpointUpdate),
 			},
 		},
 		{
@@ -135,17 +135,17 @@ func TestMergeUpdateRequest(t *testing.T) {
 }
 
 func TestConcurrentMerge(t *testing.T) {
-	reqA := &PushRequest{Reason: make([]TriggerReason, 0, 100)}
-	reqB := &PushRequest{Reason: []TriggerReason{ServiceUpdate, ProxyUpdate}}
+	reqA := &PushRequest{Reason: make(ReasonStats)}
+	reqB := &PushRequest{Reason: NewReasonStats(ServiceUpdate, ProxyUpdate)}
 	for i := 0; i < 50; i++ {
 		go func() {
 			reqA.CopyMerge(reqB)
 		}()
 	}
-	if len(reqA.Reason) != 0 {
+	if reqA.Reason.Count() != 0 {
 		t.Fatalf("reqA modified: %v", reqA.Reason)
 	}
-	if len(reqB.Reason) != 2 {
+	if reqB.Reason.Count() != 2 {
 		t.Fatalf("reqB modified: %v", reqB.Reason)
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -375,7 +375,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},
@@ -386,7 +386,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},
@@ -397,7 +397,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},
@@ -434,7 +434,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 				Full:           false,
 				ConfigsUpdated: updates,
-				Reason:         []model.TriggerReason{model.AmbientUpdate},
+				Reason:         model.NewReasonStats(model.AmbientUpdate),
 			})
 		}
 	})
@@ -457,7 +457,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 				Full:           false,
 				ConfigsUpdated: updates,
-				Reason:         []model.TriggerReason{model.AmbientUpdate},
+				Reason:         model.NewReasonStats(model.AmbientUpdate),
 			})
 		}
 	})
@@ -470,7 +470,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},
@@ -490,7 +490,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},
@@ -501,7 +501,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			if len(updates) > 0 {
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
-					Reason:         []model.TriggerReason{model.AmbientUpdate},
+					Reason:         model.NewReasonStats(model.AmbientUpdate),
 				})
 			}
 		},

--- a/pilot/pkg/serviceregistry/kube/controller/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/authorization.go
@@ -412,7 +412,7 @@ func (c *Controller) PeerAuthenticationHandler(old config.Config, obj config.Con
 	if len(updates) > 0 {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			ConfigsUpdated: updates,
-			Reason:         []model.TriggerReason{model.AmbientUpdate},
+			Reason:         model.NewReasonStats(model.AmbientUpdate),
 		})
 	}
 }
@@ -522,7 +522,7 @@ func (c *Controller) AuthorizationPolicyHandler(old config.Config, obj config.Co
 	if len(updates) > 0 {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			ConfigsUpdated: updates,
-			Reason:         []model.TriggerReason{model.AmbientUpdate},
+			Reason:         model.NewReasonStats(model.AmbientUpdate),
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -424,7 +424,7 @@ func (c *Controller) deleteService(svc *model.Service) {
 		c.NotifyGatewayHandlers()
 		// TODO trigger push via handler
 		// networks are different, we need to update all eds endpoints
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
 	}
 
 	shard := model.ShardKeyFromRegistry(c)
@@ -466,7 +466,7 @@ func (c *Controller) addOrUpdateService(curr *v1.Service, currConv *model.Servic
 	// as that full push is only triggered for the specific service.
 	if needsFullPush {
 		// networks are different, we need to update all eds endpoints
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
 	}
 
 	shard := model.ShardKeyFromRegistry(c)
@@ -528,7 +528,7 @@ func (c *Controller) onNodeEvent(_, node *v1.Node, event model.Event) error {
 	if updatedNeeded && c.updateServiceNodePortAddresses() {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			Full:   true,
-			Reason: []model.TriggerReason{model.ServiceUpdate},
+			Reason: model.NewReasonStats(model.ServiceUpdate),
 		})
 	}
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/discoverycontrollers.go
@@ -46,7 +46,7 @@ func (c *Controller) initDiscoveryNamespaceHandlers(discoveryNamespacesFilter fi
 				if features.EnableEnhancedResourceScoping {
 					c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 						Full:   true,
-						Reason: []model.TriggerReason{model.NamespaceUpdate},
+						Reason: model.NewReasonStats(model.NamespaceUpdate),
 					})
 				}
 				return nil
@@ -59,7 +59,7 @@ func (c *Controller) initDiscoveryNamespaceHandlers(discoveryNamespacesFilter fi
 				if features.EnableEnhancedResourceScoping {
 					c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 						Full:   true,
-						Reason: []model.TriggerReason{model.NamespaceUpdate},
+						Reason: model.NewReasonStats(model.NamespaceUpdate),
 					})
 				}
 				return nil
@@ -101,7 +101,7 @@ func (a *AmbientIndexImpl) HandleSelectedNamespace(ns string, pods []*corev1.Pod
 	if len(updates) > 0 {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			ConfigsUpdated: updates,
-			Reason:         []model.TriggerReason{model.AmbientUpdate},
+			Reason:         model.NewReasonStats(model.AmbientUpdate),
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -372,7 +372,7 @@ func (esc *endpointSliceController) processEndpointEvent(name string, namespace 
 					// TODO: extend and set service instance type, so no need to re-init push context
 					ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: modelSvc.Hostname.String(), Namespace: svc.Namespace}),
 
-					Reason: []model.TriggerReason{model.HeadlessEndpointUpdate},
+					Reason: model.NewReasonStats(model.HeadlessEndpointUpdate),
 				})
 				return nil
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -187,7 +187,7 @@ func (m *Multicluster) ClusterDeleted(clusterID cluster.ID) error {
 	m.deleteCluster(clusterID)
 	m.m.Unlock()
 	if m.XDSUpdater != nil {
-		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.ClusterUpdate}})
+		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate)})
 	}
 	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -239,7 +239,7 @@ func (c *Controller) reloadNetworkGateways() {
 	if gwsChanged {
 		c.NotifyGatewayHandlers()
 		// TODO ConfigUpdate via gateway handler
-		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
+		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache.go
@@ -215,7 +215,7 @@ func (ic *serviceImportCacheImpl) doFullPush(mcsHost host.Name, ns string) {
 		Full:           true,
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: mcsHost.String(), Namespace: ns}),
 
-		Reason: []model.TriggerReason{model.ServiceUpdate},
+		Reason: model.NewReasonStats(model.ServiceUpdate),
 	}
 	ic.opts.XDSUpdater.ConfigUpdate(pushReq)
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -141,7 +141,7 @@ func (sd *ServiceDiscovery) AddServiceNotify(svc *model.Service) {
 		Full:           true,
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: string(svc.Hostname), Namespace: svc.Attributes.Namespace}),
 
-		Reason: []model.TriggerReason{model.ServiceUpdate},
+		Reason: model.NewReasonStats(model.ServiceUpdate),
 	}
 	sd.XdsUpdater.ConfigUpdate(pushReq)
 }

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -338,7 +338,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 	pushReq := &model.PushRequest{
 		Full:           true,
 		ConfigsUpdated: configsUpdated,
-		Reason:         []model.TriggerReason{model.EndpointUpdate},
+		Reason:         model.NewReasonStats(model.EndpointUpdate),
 	}
 	// trigger a full push
 	s.XdsUpdater.ConfigUpdate(pushReq)
@@ -473,7 +473,7 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	pushReq := &model.PushRequest{
 		Full:           true,
 		ConfigsUpdated: configsUpdated,
-		Reason:         []model.TriggerReason{model.ServiceUpdate},
+		Reason:         model.NewReasonStats(model.ServiceUpdate),
 	}
 	s.XdsUpdater.ConfigUpdate(pushReq)
 }
@@ -615,7 +615,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 		pushReq := &model.PushRequest{
 			Full:           true,
 			ConfigsUpdated: configsUpdated,
-			Reason:         []model.TriggerReason{model.EndpointUpdate},
+			Reason:         model.NewReasonStats(model.EndpointUpdate),
 		}
 		s.XdsUpdater.ConfigUpdate(pushReq)
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -213,7 +213,7 @@ func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *C
 	request := &model.PushRequest{
 		Full:   true,
 		Push:   con.proxy.LastPushContext,
-		Reason: []model.TriggerReason{model.ProxyRequest},
+		Reason: model.NewReasonStats(model.ProxyRequest),
 
 		// The usage of LastPushTime (rather than time.Now()), is critical here for correctness; This time
 		// is used by the XDS cache to determine if a entry is stale. If we use Now() with an old push context,
@@ -822,7 +822,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID cluster.ID, ip string) {
 		Full:   true,
 		Push:   s.globalPushContext(),
 		Start:  time.Now(),
-		Reason: []model.TriggerReason{model.ProxyUpdate},
+		Reason: model.NewReasonStats(model.ProxyUpdate),
 	})
 }
 
@@ -832,7 +832,7 @@ func AdsPushAll(s *DiscoveryServer) {
 	s.AdsPushAll(&model.PushRequest{
 		Full:   true,
 		Push:   s.globalPushContext(),
-		Reason: []model.TriggerReason{model.DebugTrigger},
+		Reason: model.NewReasonStats(model.DebugTrigger),
 	})
 }
 

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -607,7 +607,7 @@ func BenchmarkPushRequest(b *testing.B) {
 			trigger := allTriggers[i%len(allTriggers)]
 			nreq := &model.PushRequest{
 				ConfigsUpdated: sets.New[model.ConfigKey](),
-				Reason:         []model.TriggerReason{trigger},
+				Reason:         model.NewReasonStats(trigger),
 			}
 			for c := 0; c < configs; c++ {
 				nreq.ConfigsUpdated.Insert(model.ConfigKey{Kind: kind.ServiceEntry, Name: fmt.Sprintf("%d", c), Namespace: "default"})
@@ -615,7 +615,7 @@ func BenchmarkPushRequest(b *testing.B) {
 			req = req.Merge(nreq)
 		}
 		for p := 0; p < proxies; p++ {
-			recordPushTriggers(req.Reason...)
+			recordPushTriggers(req.Reason)
 		}
 	}
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -293,7 +293,7 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 	request := &model.PushRequest{
 		Full:   true,
 		Push:   con.proxy.LastPushContext,
-		Reason: []model.TriggerReason{model.ProxyRequest},
+		Reason: model.NewReasonStats(model.ProxyRequest),
 
 		// The usage of LastPushTime (rather than time.Now()), is critical here for correctness; This time
 		// is used by the XDS cache to determine if a entry is stale. If we use Now() with an old push context,

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -73,7 +73,7 @@ func (s *DiscoveryServer) EDSUpdate(shard model.ShardKey, serviceName string, na
 		s.ConfigUpdate(&model.PushRequest{
 			Full:           pushType == FullPush,
 			ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: serviceName, Namespace: namespace}),
-			Reason:         []model.TriggerReason{model.EndpointUpdate},
+			Reason:         model.NewReasonStats(model.EndpointUpdate),
 		})
 	}
 }

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -1155,7 +1155,7 @@ func addUdsEndpoint(s *xds.DiscoveryServer, m *memory.ServiceDiscovery) {
 
 	pushReq := &model.PushRequest{
 		Full:   true,
-		Reason: []model.TriggerReason{model.ConfigUpdate},
+		Reason: model.NewReasonStats(model.ConfigUpdate),
 	}
 	s.ConfigUpdate(pushReq)
 }

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -145,7 +145,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		pushReq := &model.PushRequest{
 			Full:           true,
 			ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: string(curr.Hostname), Namespace: curr.Attributes.Namespace}),
-			Reason:         []model.TriggerReason{model.ServiceUpdate},
+			Reason:         model.NewReasonStats(model.ServiceUpdate),
 		}
 		s.ConfigUpdate(pushReq)
 	}
@@ -161,7 +161,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		opts.NetworksWatcher.AddNetworksHandler(func() {
 			s.ConfigUpdate(&model.PushRequest{
 				Full:   true,
-				Reason: []model.TriggerReason{model.NetworksTrigger},
+				Reason: model.NewReasonStats(model.NetworksTrigger),
 			})
 		})
 	}
@@ -260,7 +260,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		pushReq := &model.PushRequest{
 			Full:           true,
 			ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.MustFromGVK(curr.GroupVersionKind), Name: curr.Name, Namespace: curr.Namespace}),
-			Reason:         []model.TriggerReason{model.ConfigUpdate},
+			Reason:         model.NewReasonStats(model.ConfigUpdate),
 		}
 		s.ConfigUpdate(pushReq)
 	}

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -207,11 +207,11 @@ var triggerMetric = map[model.TriggerReason]monitoring.Metric{
 	model.ClusterUpdate:   pushTriggers.With(typeTag.Value(string(model.ClusterUpdate))),
 }
 
-func recordPushTriggers(reasons ...model.TriggerReason) {
-	for _, r := range reasons {
+func recordPushTriggers(reasons model.ReasonStats) {
+	for r, cnt := range reasons {
 		t, f := triggerMetric[r]
 		if f {
-			t.Increment()
+			t.RecordInt(int64(cnt))
 		} else {
 			pushTriggers.With(typeTag.Value(string(r))).Increment()
 		}

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -74,12 +74,7 @@ func ndsNeedsPush(req *model.PushRequest) bool {
 }
 
 func headlessEndpointsUpdated(req *model.PushRequest) bool {
-	for _, reason := range req.Reason {
-		if reason == model.HeadlessEndpointUpdate {
-			return true
-		}
-	}
-	return false
+	return req.Reason.Has(model.HeadlessEndpointUpdate)
 }
 
 func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req *model.PushRequest) (model.Resources, model.XdsLogDetails, error) {

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -120,7 +120,7 @@ func TestGenerate(t *testing.T) {
 		{
 			name:      "partial push with headless endpoint update",
 			proxy:     &model.Proxy{Type: model.SidecarProxy},
-			request:   &model.PushRequest{Reason: []model.TriggerReason{model.HeadlessEndpointUpdate}},
+			request:   &model.PushRequest{Reason: model.NewReasonStats(model.HeadlessEndpointUpdate)},
 			nameTable: emptyNameTable,
 		},
 		{

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -59,7 +59,7 @@ func (s *Server) OnSecretUpdate(resourceName string) {
 	s.workloadSds.XdsServer.Push(&model.PushRequest{
 		Full:           false,
 		ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.Secret, Name: resourceName}),
-		Reason:         []model.TriggerReason{model.SecretTrigger},
+		Reason:         model.NewReasonStats(model.SecretTrigger),
 	})
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Previously, Reason []TriggerReason was used in the PushRequest to record the reasons for triggering the push. However, we have a debounce mechanism to aggregate a large number of changes that occur within a short period of time. This aggregation operation also aggregates Reason, but only concatenates the arrays, which leads to a lot of array resizing when a large number of changes occur in a short period of time. For example: EndpointUpdate -> EndpointUpdate,ConfigUpdate -> EndpointUpdate,ConfigUpdate,ConfigUpdate -> EndpointUpdate,ConfigUpdate,ConfigUpdate,ConfigUpdate -> … This can lead to a lot of memory allocation.

In our actual scenario, when the amount of configuration is large, the above aggregation operation for Reason will bring significant memory overhead and memory usage increase to Istio. Although the duration may not be long, there is still a risk of OOM when memory resources are not abundant.

Therefore, for the purpose of performance optimization, this field has been changed to a map type. Considering that the actual TriggerReason is enumerable, the memory overhead in the aggregation operation can be reduced to a negligible level.