### PR TITLE
downloadIstioCandidate.sh supports passing env TARGET_OS

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -21,13 +21,13 @@
 # The script fetches the latest Istio release candidate and untars it.
 # You can pass variables on the command line to download a specific version
 # or to override the processor architecture. For example, to download
-# Istio 1.6.8 for the x86_64 architecture,
-# run curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -.
+# Istio 1.6.8 for the x86_64 architecture and linux OS,
+# run curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 TARGET_OS=Linux sh -.
 
 set -e
 
 # Determines the operating system.
-OS="$(uname)"
+OS="${TARGET_OS:-$(uname)}"
 if [ "${OS}" = "Darwin" ] ; then
   OSEXT="osx"
 else

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -24,7 +24,7 @@
 #
 
 # Determines the operating system.
-OS="$(uname)"
+OS="${TARGET_OS:-$(uname)}"
 if [ "${OS}" = "Darwin" ] ; then
   OSEXT="osx"
 else


### PR DESCRIPTION
**Please provide a description of this PR:**

Sometimes we may download Istio on a personal/work computer (Mac) and then transfer it to a test environment (Linux) for installation, in which case we need to specify the target OS.