### PR TITLE
add support for extension with matcher in wasm conversion

### DIFF
--- a/pkg/config/xds/filters.go
+++ b/pkg/config/xds/filters.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	WasmHTTPFilterType = resource.APITypePrefix + wellknown.HTTPWasm
-	RBACHTTPFilterType = resource.APITypePrefix + "envoy.extensions.filters.http.rbac.v3.RBAC"
-	TypedStructType    = resource.APITypePrefix + "udpa.type.v1.TypedStruct"
+	WasmHTTPFilterType   = resource.APITypePrefix + wellknown.HTTPWasm
+	RBACHTTPFilterType   = resource.APITypePrefix + "envoy.extensions.filters.http.rbac.v3.RBAC"
+	TypedStructType      = resource.APITypePrefix + "udpa.type.v1.TypedStruct"
+	ExtensionWithMatcher = resource.APITypePrefix + "envoy.extensions.common.matching.v3.ExtensionWithMatcher"
 
 	StatsFilterName       = "istio.stats"
 	StackdriverFilterName = "istio.stackdriver"

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -23,6 +23,7 @@ import (
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/extensions/common/matching/v3"
 	rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
@@ -209,6 +210,16 @@ func TestWasmConvert(t *testing.T) {
 			name: "remote load success",
 			input: []*core.TypedExtensionConfig{
 				extensionConfigMap["remote-load-success"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success-local-file"],
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote load success with extension matcher",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-success-extension-matcher"],
 			},
 			wantOutput: []*core.TypedExtensionConfig{
 				extensionConfigMap["remote-load-success-local-file"],
@@ -417,6 +428,23 @@ var extensionConfigMap = map[string]*core.TypedExtensionConfig{
 				},
 			},
 		},
+	}),
+	"remote-load-success-extension-matcher": buildAnyExtensionConfig("remote-load-success", &matcher.ExtensionWithMatcher{
+		ExtensionConfig: buildAnyExtensionConfig("remote-load-success", &wasm.Wasm{
+			Config: &v3.PluginConfig{
+				Vm: &v3.PluginConfig_VmConfig{
+					VmConfig: &v3.VmConfig{
+						Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Remote{
+							Remote: &core.RemoteDataSource{
+								HttpUri: &core.HttpUri{
+									Uri: "http://test?module=test.wasm",
+								},
+							},
+						}},
+					},
+				},
+			},
+		}),
 	}),
 	"remote-load-success-local-file": buildAnyExtensionConfig("remote-load-success", &wasm.Wasm{
 		Config: &v3.PluginConfig{


### PR DESCRIPTION
Currently we only support WASM directly under extension config. This PR adds support for `ExtensionWithMatcher` so that we can use conditional WASM using Envoy filters.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure