### PR TITLE
feat(charts): use .Release.Namespace if .Values.global.istioNamespace is missing

### DIFF
--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -127,7 +127,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/base/templates/clusterrolebinding.yaml
+++ b/manifests/charts/base/templates/clusterrolebinding.yaml
@@ -6,32 +6,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ default .Release.Namespace .Values.global.istioNamespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 ---

--- a/manifests/charts/base/templates/default.yaml
+++ b/manifests/charts/base/templates/default.yaml
@@ -20,7 +20,7 @@ webhooks:
         {{- else }}
         name: istiod-{{ .Values.defaultRevision }}
         {{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
     rules:

--- a/manifests/charts/base/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/base/templates/reader-serviceaccount.yaml
@@ -10,7 +10,7 @@ imagePullSecrets:
     {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/base/templates/role.yaml
+++ b/manifests/charts/base/templates/role.yaml
@@ -6,8 +6,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/base/templates/rolebinding.yaml
+++ b/manifests/charts/base/templates/rolebinding.yaml
@@ -6,16 +6,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ default .Release.Namespace .Values.global.istioNamespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}

--- a/manifests/charts/base/templates/serviceaccount.yaml
+++ b/manifests/charts/base/templates/serviceaccount.yaml
@@ -13,7 +13,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istiod-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -18,7 +18,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
     rules:

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -156,7 +156,7 @@ spec:
           {{- if .Values.global.caAddress }}
             value: {{ .Values.global.caAddress }}
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -156,7 +156,7 @@ spec:
           {{- if .Values.global.caAddress }}
             value: {{ .Values.global.caAddress }}
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -50,7 +50,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-agent.yaml
@@ -93,7 +93,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/grpc-simple.yaml
@@ -23,7 +23,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_NAMESPACE
           value: |
-             {{ .Values.global.istioNamespace }}
+             {{ default .Release.Namespace .Values.global.istioNamespace }}
       command:
         - sh
         - "-c"

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -233,7 +233,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -120,7 +120,7 @@ spec:
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -93,7 +93,7 @@ spec:
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:

--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrolebinding.yaml
@@ -12,7 +12,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 ---
 {{- if not (eq (toString .Values.pilot.env.PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER) "false") }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,5 +29,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -7,7 +7,7 @@
     # When processing a leaf namespace Istio will search for declarations in that namespace first
     # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
     # is processed as if it were declared in the leaf namespace.
-    rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
+    rootNamespace: {{ default .Release.Namespace (default .Values.global.istioNamespace .Values.meshConfig.rootNamespace) }}
 
   {{ $prom := include "prometheus" . | eq "true" }}
   {{ $sdMetrics := include "sd-metrics" . | eq "true" }}
@@ -43,7 +43,7 @@
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." (default .Release.Namespace .Values.global.istioNamespace) ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -13,4 +13,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}
+  name: istio-validator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -19,7 +19,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
     rules:

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -50,7 +50,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -233,7 +233,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ default .Release.Namespace .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/charts/istiod-remote/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 ---
 {{- if not (eq (toString .Values.pilot.env.PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER) "false") }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,6 +30,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -7,7 +7,7 @@
     # When processing a leaf namespace Istio will search for declarations in that namespace first
     # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
     # is processed as if it were declared in the leaf namespace.
-    rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
+    rootNamespace: {{ default .Release.Namespace (default .Values.global.istioNamespace .Values.meshConfig.rootNamespace) }}
 
   {{ $prom := include "prometheus" . | eq "true" }}
   {{ $sdMetrics := include "sd-metrics" . | eq "true" }}
@@ -43,7 +43,7 @@
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          address: {{ ((.Values.global.tracer).zipkin).address | default (print "zipkin." default .Release.Namespace .Values.global.istioNamespace ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent

--- a/manifests/charts/istiod-remote/templates/default.yaml
+++ b/manifests/charts/istiod-remote/templates/default.yaml
@@ -21,7 +21,7 @@ webhooks:
         {{- else }}
         name: istiod-{{ .Values.defaultRevision }}
         {{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
     rules:

--- a/manifests/charts/istiod-remote/templates/reader-clusterrolebinding.yaml
+++ b/manifests/charts/istiod-remote/templates/reader-clusterrolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}

--- a/manifests/charts/istiod-remote/templates/reader-serviceaccount.yaml
+++ b/manifests/charts/istiod-remote/templates/reader-serviceaccount.yaml
@@ -10,7 +10,7 @@ imagePullSecrets:
     {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/charts/istiod-remote/templates/role.yaml
+++ b/manifests/charts/istiod-remote/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istiod-remote/templates/rolebinding.yaml
+++ b/manifests/charts/istiod-remote/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istiod{{- if not (eq .Values.revision "")}}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -14,5 +14,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/serviceaccount.yaml
+++ b/manifests/charts/istiod-remote/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
@@ -3,7 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}
+  name: istio-validator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ default .Release.Namespace .Values.global.istioNamespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -20,7 +20,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ default .Release.Namespace .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}
     rules:


### PR DESCRIPTION
**Please provide a description of this PR:**

The motivation behind this PR is to allow the various charts to be tested using the [ct](https://github.com/helm/chart-testing) tool. Today the CT tool [is missing the ability](https://github.com/helm/chart-testing/pull/380) to explicitly define a testing namespace for a specific chart within a repo.

The scenario where this matters is if you have a repository with multiple Helm charts and you use the `ct` tool to test them. The  `ct` tool is responsible for figuring out which charts to test ... and when it does, it dynamically generates a namespace for each and every test. The Istio charts though do not work like this because they have this hard-coded value to a single namespace.

This PR updates every location that used `.Values.global.istioNamespace` to fall-back to `.Release.Namespace` if necessary. This should allow users of the helm charts to pass in a `~` to override the chart default for the istio-namespace:

```yaml
# values.yaml
global:
  istioNamespace: ~
```