### PR TITLE
feat(charts): add volumes/volumemounts to istio gateway chart

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       {{- with .Values.volumes }}
       volumes:
-        {{ toYaml . | nindet 8 }}
+        {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: istio-proxy

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
       {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{ toYaml . | nindet 8 }}
+      {{- end }}
       containers:
         - name: istio-proxy
           # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
@@ -91,6 +95,10 @@ spec:
             name: http-envoy-prom
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -217,6 +217,18 @@
     },
     "terminationGracePeriodSeconds": {
       "type": "number"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
     }
   }
 }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -129,3 +129,11 @@ imagePullSecrets: []
 podDisruptionBudget: {}
 
 terminationGracePeriodSeconds: 30
+
+# A list of `Volumes` added into the Gateway Pods. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumes: []
+
+# A list of `VolumeMounts` added into the Gateway Pods. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumeMounts: []

--- a/releasenotes/notes/45894.yaml
+++ b/releasenotes/notes/45894.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** volumes and volumeMounts to the gateways chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes https://github.com/istio/istio/issues/45878 by enabling the end-user to supply custom `volumes` and `volumeMounts` parameters to each gateway.