### PR TITLE
feat: Support for LBExternalAddresses annotation in service conversion

### DIFF
--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -42,6 +42,13 @@ const (
 	// It is used for multi-cluster scenario, and with nodePort type gateway service.
 	// TODO: move to API
 	NodeSelectorAnnotation = "traffic.istio.io/nodeSelector"
+
+	// LBExternalAddressesAnnotation overrides the external address value with a LoadBalancer type service.
+	// This can be used when you want to resolve services using a customized address instead of
+	// the default address set by the load balancer controller, etc.
+	// Multiple external addresses are supported, separated by commas.
+	// e.g. traffic.istio.io/lbExternalAddresses: "google.com,127.68.16.1"
+	LBExternalAddressesAnnotation = "traffic.istio.io/lbExternalAddresses"
 )
 
 func convertPort(port corev1.ServicePort) *model.Port {
@@ -167,6 +174,9 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 			istioService.Attributes.ClusterExternalAddresses = &model.AddressMap{}
 		}
 		istioService.Attributes.ClusterExternalAddresses.AddAddressesFor(clusterID, svc.Spec.ExternalIPs)
+	}
+	if addrs := svc.Annotations[LBExternalAddressesAnnotation]; addrs != "" {
+		istioService.Attributes.ClusterExternalAddresses.SetAddressesFor(clusterID, strings.Split(addrs, ","))
 	}
 
 	return istioService

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -43,7 +43,7 @@ const (
 	// TODO: move to API
 	NodeSelectorAnnotation = "traffic.istio.io/nodeSelector"
 
-	// LBExternalAddressesAnnotation overrides the external address value with a LoadBalancer type service.
+	// This annotation *overrides* (not appends) the external address value with a LoadBalancer type service.
 	// This can be used when you want to resolve services using a customized address instead of
 	// the default address set by the load balancer controller, etc.
 	// Multiple external addresses are supported, separated by commas.

--- a/releasenotes/notes/lb-external-addresses-annotation.yaml
+++ b/releasenotes/notes/lb-external-addresses-annotation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 43656
+releaseNotes:
+  - |
+    **Added** `traffic.istio.io/lbExternalAddresses` annotation to the service to allow overriding the external address of the load balancer.


### PR DESCRIPTION
This PR adds the ability to override the external address from the annotation when converting a load balancer type service to an istio service.

In the current implementation, load balancer type services resolve external addresses using only the addresses set in `.status.loadBalancer.ingress` by the load balancer controller, etc.
By adding this feature, istio users will be able to override the external address of the load balancer with a customized ip address or dns record, if necessary.

Adding this feature can support cases where for some reason you want to connect to a service's load balancer using customized DNS records, etc.
For example, the DNS records automatically generated by the load balancer controller are set to a private zone and cannot be resolved directly from other networks.

- Fixed #43656

This is my first commit to this repository, so please let me know if I am doing something wrong!

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
