### PR TITLE
Add release note for #45632

### DIFF
--- a/releasenotes/notes/fix-healthcheck-host-override.yaml
+++ b/releasenotes/notes/fix-healthcheck-host-override.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 45632
+
+releaseNotes:
+- |
+  **Fixed** Regression in HTTPGet healthcheck probe translation.


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds a release note for the fix related to the regression of the HTTP GET health check probe host override.

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
