### PR TITLE
solve the problem that can't do heap and cpu profiling at the startup

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -175,6 +175,14 @@ func (e *envoy) Run(abort <-chan error) error {
 
 	/* #nosec */
 	cmd := exec.Command(e.BinaryPath, args...)
+	val, exist := os.LookupEnv("HEAPPROFILE")
+	if exist {
+		cmd.Env = append(cmd.Env, "HEAPPROFILE="+val)
+	}
+	val, exist = os.LookupEnv("CPUPROFILE")
+	if exist {
+		cmd.Env = append(cmd.Env, "CPUPROFILE="+val)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if e.AgentIsRoot {


### PR DESCRIPTION
**Please provide a description of this PR:**
this PR help to improve profiling for the istio.
though istio admin can do cpu or heap profile. but sometimes it is too late.
because the envoy can consume vary large memory(4G memory) when startup when it is used as istio gateway.
without this ability, it is hard to find why envoy consume so large memory. so these env variable is necessary.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ Y] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure