### PR TITLE
feat(gateway): add settings to stabilize gateways for high traffic

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -107,7 +107,10 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
   replicas: {{ . }}
   {{- end }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       securityContext:
       {{- if .Values.securityContext }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -57,6 +57,9 @@
     "terminationGracePeriodSeconds": {
       "type": [ "null", "integer" ]
     },
+    "readinessProbe": {
+      "type": [ "null", "object" ]
+    },
     "labels": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -48,6 +48,9 @@
     "env": {
       "type": "object"
     },
+    "strategy": {
+      "type": "object"
+    },
     "labels": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -51,6 +51,9 @@
     "strategy": {
       "type": "object"
     },
+    "minReadySeconds": {
+      "type": [ "null", "integer" ]
+    },
     "labels": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -54,6 +54,9 @@
     "minReadySeconds": {
       "type": [ "null", "integer" ]
     },
+    "terminationGracePeriodSeconds": {
+      "type": [ "null", "integer" ]
+    },
     "labels": {
       "type": "object"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -78,6 +78,12 @@ env: {}
 # Deployment Update strategy
 strategy: {}
 
+# Sets the Deployment minReadySeconds value
+minReadySeconds:
+
+# Sets the per-pod terminationGracePeriodSeconds setting.
+terminationGracePeriodSeconds:
+
 # Labels to apply to all resources
 labels: {}
 

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -84,17 +84,10 @@ minReadySeconds:
 # Sets the per-pod terminationGracePeriodSeconds setting.
 terminationGracePeriodSeconds:
 
-# Configures the Pod ReadinessProbe
-readinessProbe:
-  failureThreshold: 30
-  httpGet:
-    path: /healthz/ready
-    port: 15021
-    scheme: HTTP
-  initialDelaySeconds: 1
-  periodSeconds: 2
-  successThreshold: 1
-  timeoutSeconds: 1
+# Optionally configure a custom readinessProbe. By default the control plane
+# automatically injects the readinessProbe. If you wish to override that
+# behavior, you may define your own readinessProbe here.
+readinessProbe: {}
 
 # Labels to apply to all resources
 labels: {}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -84,6 +84,18 @@ minReadySeconds:
 # Sets the per-pod terminationGracePeriodSeconds setting.
 terminationGracePeriodSeconds:
 
+# Configures the Pod ReadinessProbe
+readinessProbe:
+  failureThreshold: 30
+  httpGet:
+    path: /healthz/ready
+    port: 15021
+    scheme: HTTP
+  initialDelaySeconds: 1
+  periodSeconds: 2
+  successThreshold: 1
+  timeoutSeconds: 1
+
 # Labels to apply to all resources
 labels: {}
 

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -75,6 +75,9 @@ autoscaling:
 # Pod environment variables
 env: {}
 
+# Deployment Update strategy
+strategy: {}
+
 # Labels to apply to all resources
 labels: {}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

We operate our IngressGateways at fairly high traffic volumes - frequently exceeding 50,000 QPS of inbound traffic with a _wide_ range of traffic shapes. We've found that in order to safely replace pods at this scale, we need to make tweaks to the Deployment rollout process. These three settings (`spec.strategy`, `spec.minReadySeconds` and `spec.template.spec.terminationGracePeriodSeconds`) are critical to tuning the rollout process to be stable and smooth no matter the traffic load.