### PR TITLE
Call `initMeshHandlers` before `initMeshConfiguration`

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -257,11 +257,11 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 		return nil, fmt.Errorf("error initializing kube client: %v", err)
 	}
 
+	s.initMeshHandlers()
 	s.initMeshConfiguration(args, s.fileWatcher)
 	spiffe.SetTrustDomain(s.environment.Mesh().GetTrustDomain())
 
 	s.initMeshNetworks(args, s.fileWatcher)
-	s.initMeshHandlers()
 	s.environment.Init()
 	if err := s.environment.InitNetworksManager(s.XDSServer); err != nil {
 		return nil, err


### PR DESCRIPTION
There's a small window where the MeshConfig could be modified after `initMeshConfiguration` is called but before `initMeshHandlers` is called. This PR prevents that data race by making sure initMeshHandlers is called first.

If anyone has tips on how to test this, let me know
 
Fixes #45739

