### PR TITLE
Support namespace filtering for proxy status

### DIFF
--- a/istioctl/pkg/proxystatus/proxystatus.go
+++ b/istioctl/pkg/proxystatus/proxystatus.go
@@ -98,7 +98,11 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				}
 				return c.Diff()
 			}
-			statuses, err := kubeClient.AllDiscoveryDo(context.TODO(), ctx.IstioNamespace(), "debug/syncz")
+			queryStr := "debug/syncz"
+			if ctx.Namespace() != "" {
+				queryStr += "?namespace=" + ctx.Namespace()
+			}
+			statuses, err := kubeClient.AllDiscoveryDo(context.TODO(), ctx.IstioNamespace(), queryStr)
 			if err != nil {
 				return err
 			}

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -271,7 +271,7 @@ func (s *DiscoveryServer) Syncz(w http.ResponseWriter, req *http.Request) {
 	syncz := make([]SyncStatus, 0)
 	for _, con := range s.Clients() {
 		node := con.proxy
-		if node != nil && (namespace == "" || node.Metadata.Namespace == namespace) {
+		if node != nil && (namespace == "" || node.Metadata != nil && node.Metadata.Namespace == namespace) {
 			syncz = append(syncz, SyncStatus{
 				ProxyID:              node.ID,
 				ProxyType:            node.Type,

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -266,10 +266,12 @@ func isRequestFromLocalhost(r *http.Request) bool {
 
 // Syncz dumps the synchronization status of all Envoys connected to this Pilot instance
 func (s *DiscoveryServer) Syncz(w http.ResponseWriter, req *http.Request) {
+	namespace := req.URL.Query().Get("namespace")
+
 	syncz := make([]SyncStatus, 0)
 	for _, con := range s.Clients() {
 		node := con.proxy
-		if node != nil {
+		if node != nil && (namespace == "" || node.Metadata.Namespace == namespace) {
 			syncz = append(syncz, SyncStatus{
 				ProxyID:              node.ID,
 				ProxyType:            node.Type,

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -271,7 +271,7 @@ func (s *DiscoveryServer) Syncz(w http.ResponseWriter, req *http.Request) {
 	syncz := make([]SyncStatus, 0)
 	for _, con := range s.Clients() {
 		node := con.proxy
-		if node != nil && (namespace == "" || (node.Metadata != nil && node.Metadata.Namespace == namespace)) {
+		if node != nil && (namespace == "" || node.Metadata.Namespace == namespace) {
 			syncz = append(syncz, SyncStatus{
 				ProxyID:              node.ID,
 				ProxyType:            node.Type,

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -271,7 +271,7 @@ func (s *DiscoveryServer) Syncz(w http.ResponseWriter, req *http.Request) {
 	syncz := make([]SyncStatus, 0)
 	for _, con := range s.Clients() {
 		node := con.proxy
-		if node != nil && (namespace == "" || node.Metadata != nil && node.Metadata.Namespace == namespace) {
+		if node != nil && (namespace == "" || (node.Metadata != nil && node.Metadata.Namespace == namespace)) {
 			syncz = append(syncz, SyncStatus{
 				ProxyID:              node.ID,
 				ProxyType:            node.Type,

--- a/releasenotes/notes/45919.yaml
+++ b/releasenotes/notes/45919.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for namespace filtering for proxy statuses. Note: please ensure that both istioctl and istiod are upgraded for this feature to work.

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -352,6 +352,13 @@ func TestProxyStatus(t *testing.T) {
 				}
 				return expectSubstrings(output, "Clusters Match", "Listeners Match", "Routes Match")
 			})
+
+			// test namespace filtering
+			retry.UntilSuccessOrFail(t, func() error {
+				args = []string{"proxy-status", "-n", apps.Namespace.Name()}
+				output, _ = istioCtl.InvokeOrFail(t, args)
+				return expectSubstrings(output, fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()))
+			})
 		})
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
The current debugging interface for proxy status may display too much information. This PR enables filtering of proxy status by namespace using the `?namespace=` query. This also allows `istioctl proxy-status -n` to function correctly.