### PR TITLE
Fix gateway server port in bookinfo sample

### DIFF
--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -9,7 +9,7 @@ spec:
     istio: ingressgateway # use istio default controller
   servers:
   - port:
-      number: 80
+      number: 8080
       name: http
       protocol: HTTP
     hosts:


### PR DESCRIPTION
**Please provide a description of this PR:**
This lead to the test failure mentioned in https://github.com/istio/istio/pull/45726#issuecomment-1629790045.

After https://github.com/istio/istio/pull/45726 corrected the port selection, running `istioctl analyze` from the steps on the Getting Started page produces a new warning. This PR addresses this by replacing the gateway's port from 80 to 8080. This fixes the warning message and doesn't change the actual Envoy listener port.

/cc @ericvn 