### PR TITLE
Better error handling on ambient CNI

### DIFF
--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -238,10 +238,16 @@ func GetHostIP(kubeClient kubernetes.Interface) (string, error) {
 func (s *Server) AddPodToMesh(pod *corev1.Pod) {
 	switch s.redirectMode {
 	case IptablesMode:
-		_ = AddPodToMesh(s.kubeClient.Kube(), pod, "")
+		// This is used for pods already running - we can't block, but we
+		// should not annotate.
+		err := AddPodToMesh(s.kubeClient.Kube(), pod, "")
+		if err != nil {
+			return
+		}
 	case EbpfMode:
 		if err := s.updatePodEbpfOnNode(pod); err != nil {
 			log.Errorf("failed to update POD ebpf: %v", err)
+			return
 		}
 	}
 	if err := AnnotateEnrolledPod(s.kubeClient.Kube(), pod); err != nil {

--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -50,17 +50,29 @@ func RouteExists(rte []string) bool {
 	return output == "1"
 }
 
-func AddPodToMesh(client kubernetes.Interface, pod *corev1.Pod, ip string) {
-	addPodToMeshWithIptables(pod, ip)
+// AddPodToMesh will actually add a pod IP to the mesh - and will be called once for each IP.
+// In the normal case ( CNI chain ) the IPs are based on the IPAM allocations of CNI plugins before Istio.
+// Normally Istio should be the last in the chain - but not clear we can guarantee this. The Pod may add
+// additional interfaces and IPs outside of the CNI framework - those will not be handled.
+//
+// When called from the controller ( which has various startup corner cases and should mainly be used for
+// unsafe migrations since it'll break existing connections and cause traffic loss) the ip is empty and the
+// pod IP from status is used. And only one IP is added to the mesh in current implementation.
+//
+// In practice this method is adding a pod IP to the host networking capture.
+func AddPodToMesh(client kubernetes.Interface, pod *corev1.Pod, ip string) error {
+	return addPodToMeshWithIptables(pod, ip)
 }
 
-func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
+func addPodToMeshWithIptables(pod *corev1.Pod, ip string) error {
 	if ip == "" {
 		ip = pod.Status.PodIP
 	}
+	// TODO: bug, pod may have multiple IPs in PodIPs
 	if ip == "" {
 		log.Debugf("skip adding pod %s/%s, IP not yet allocated", pod.Name, pod.Namespace)
-		return
+		// TODO: is this an error ? Only a case for the post-start controller.
+		return nil
 	}
 
 	if !IsPodInIpset(pod) {
@@ -68,6 +80,7 @@ func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
 		err := Ipset.AddIP(net.ParseIP(ip).To4(), string(pod.UID))
 		if err != nil {
 			log.Errorf("Failed to add pod %s to ipset list: %v", pod.Name, err)
+			return err
 		}
 	} else {
 		log.Infof("Pod '%s/%s' (%s) is in ipset", pod.Name, pod.Namespace, string(pod.UID))
@@ -76,6 +89,7 @@ func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
 	rte, err := buildRouteForPod(ip)
 	if err != nil {
 		log.Errorf("Failed to build route for pod %s: %v", pod.Name, err)
+		return err
 	}
 
 	if !RouteExists(rte) {
@@ -88,6 +102,7 @@ func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
 		err = execute("ip", append([]string{"route", "add"}, rte...)...)
 		if err != nil {
 			log.Warnf("Failed to add route (%s) for pod %s: %v", rte, pod.Name, err)
+			return err
 		}
 	} else {
 		log.Infof("Route already exists for %s/%s: %+v", pod.Name, pod.Namespace, rte)
@@ -96,13 +111,16 @@ func addPodToMeshWithIptables(pod *corev1.Pod, ip string) {
 	dev, err := getDeviceWithDestinationOf(ip)
 	if err != nil {
 		log.Warnf("Failed to get device for destination %s", ip)
-		return
+		return err
 	}
 
 	err = disableRPFiltersForLink(dev)
 	if err != nil {
 		log.Warnf("failed to disable procfs rp_filter for device %s: %v", dev, err)
+		// I believe this is not a fatal error ?
 	}
+
+	return nil
 }
 
 func delPodFromMeshWithIptables(pod *corev1.Pod) {
@@ -220,7 +238,7 @@ func GetHostIP(kubeClient kubernetes.Interface) (string, error) {
 func (s *Server) AddPodToMesh(pod *corev1.Pod) {
 	switch s.redirectMode {
 	case IptablesMode:
-		AddPodToMesh(s.kubeClient.Kube(), pod, "")
+		_ = AddPodToMesh(s.kubeClient.Kube(), pod, "")
 	case EbpfMode:
 		if err := s.updatePodEbpfOnNode(pod); err != nil {
 			log.Errorf("failed to update POD ebpf: %v", err)

--- a/cni/pkg/plugin/ambient.go
+++ b/cni/pkg/plugin/ambient.go
@@ -74,7 +74,11 @@ func checkAmbient(
 			_ = ambient.SetProc("/proc/sys/net/ipv4/conf/"+podIfname+"/rp_filter", "0")
 
 			for _, ip := range podIPs {
-				ambient.AddPodToMesh(client, pod, ip.IP.String())
+				err = ambient.AddPodToMesh(client, pod, ip.IP.String())
+				if err != nil {
+					log.WithLabels("err", err, "pod", pod.Name, "ip", ip.IP.String()).Error("Failed to add pod to host network")
+					return false, err
+				}
 			}
 			return true, nil
 		}

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -241,6 +241,7 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 		added, err = checkAmbient(client, *ambientConf, podName, podNamespace, args.IfName, args.Netns, podIPs)
 		if err != nil {
 			log.Errorf("istio-cni cmdAdd failed to check ambient: %s", err)
+			return err
 		}
 
 		if added {


### PR DESCRIPTION
Pod should not start if it can't be added

Note this is not handling the errors loading the Namespace and Pod to identify the annotation - it can
be addressed in a separate PR, it is more complicated than just failing, we may want to use the 
cached info in the daemon so if API server is down kubelet can still restart the pod. 
The eventual goal is to have ambient enabled by default - in which case there is no need to check with K8S,
that error path is mainly for migration. 

**Please provide a description of this PR:**