### PR TITLE
Update a spire image from `nightly` to a pinned version

### DIFF
--- a/samples/security/spire/spire-quickstart.yaml
+++ b/samples/security/spire/spire-quickstart.yaml
@@ -338,7 +338,7 @@ spec:
               mountPath: /tmp/spire-server/private
               readOnly: false
         - name: spire-controller-manager
-          image: ghcr.io/spiffe/spire-controller-manager:nightly
+          image: ghcr.io/spiffe/spire-controller-manager:0.2.3
           imagePullPolicy: IfNotPresent
           args:
           - "--config=spire-controller-manager-config.yaml"


### PR DESCRIPTION
**Please provide a description of this PR:**

The spire sample seems to be failing at this point, but obviously worked in the past (part of istio.io testing). I notice there is a `nightly` image specified in the sample. Let's pin this to an older image.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
