### PR TITLE
Handle null values in istio-discovery template

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -47,7 +47,7 @@
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent
-          address: {{ .Values.global.tracer.datadog.address | default "$(HOST_IP):8126" }}
+          address: {{ ((.Values.global.tracer).datadog).address | default "$(HOST_IP):8126" }}
       {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
         stackdriver:
           # enables trace output to stdout.

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -51,21 +51,13 @@
       {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
         stackdriver:
           # enables trace output to stdout.
-        {{- if $.Values.global.tracer.stackdriver.debug }}
-          debug: {{ $.Values.global.tracer.stackdriver.debug }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}
+          debug: {{ (($.Values.global.tracer).stackdriver).debug | default "false" }}
           # The global default max number of attributes per span.
-          maxNumberOfAttributes: {{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes | default "200" }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}
+          maxNumberOfAttributes: {{ (($.Values.global.tracer).stackdriver).maxNumberOfAttributes | default "200" }}
           # The global default max number of annotation events per span.
-          maxNumberOfAnnotations: {{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations | default "200" }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}
+          maxNumberOfAnnotations: {{ (($.Values.global.tracer).stackdriver).maxNumberOfAnnotations | default "200" }}
           # The global default max number of message events per span.
-          maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
-        {{- end }}
+          maxNumberOfMessageEvents: {{ (($.Values.global.tracer).stackdriver).maxNumberOfMessageEvents | default "200" }}
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
       {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
 {{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -47,7 +47,7 @@
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent
-          address: {{ .Values.global.tracer.datadog.address | default "$(HOST_IP):8126" }}
+          address: {{ ((.Values.global.tracer).datadog).address | default "$(HOST_IP):8126" }}
       {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
         stackdriver:
           # enables trace output to stdout.

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -51,21 +51,13 @@
       {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
         stackdriver:
           # enables trace output to stdout.
-        {{- if $.Values.global.tracer.stackdriver.debug }}
-          debug: {{ $.Values.global.tracer.stackdriver.debug }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}
+          debug: {{ (($.Values.global.tracer).stackdriver).debug | default "false" }}
           # The global default max number of attributes per span.
-          maxNumberOfAttributes: {{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes | default "200" }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}
+          maxNumberOfAttributes: {{ (($.Values.global.tracer).stackdriver).maxNumberOfAttributes | default "200" }}
           # The global default max number of annotation events per span.
-          maxNumberOfAnnotations: {{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations | default "200" }}
-        {{- end }}
-        {{- if $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}
+          maxNumberOfAnnotations: {{ (($.Values.global.tracer).stackdriver).maxNumberOfAnnotations | default "200" }}
           # The global default max number of message events per span.
-          maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
-        {{- end }}
+          maxNumberOfMessageEvents: {{ (($.Values.global.tracer).stackdriver).maxNumberOfMessageEvents | default "200" }}
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
       {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
 {{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}

--- a/releasenotes/notes/helm_chart_istiodiscovery_defaultvalues.yaml
+++ b/releasenotes/notes/helm_chart_istiodiscovery_defaultvalues.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+issue:
+ - 45855
+
+releaseNotes:
+- |
+  **Fixed** Null traversal issue when using datadog or stackdriver with no tracing options.


### PR DESCRIPTION
Fix for #45855

I ran `helm install --dry-run -f config.yaml ...` and  `helm lint -f config.yaml ...` in every chart. I fixed the null traversal in `istio-discovery` and `make gen` fixed the one in `istiod-remote`. Is there any other way I can look for similar issues?

```yaml
# config.yaml
global:
  logAsJson: true
  proxy:
    tracer: "datadog"
```