### PR TITLE
fix istiod crash when filter gateway config is enabled with no virtual service destinations

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1566,6 +1566,9 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 				for host := range virtualServiceDestinations(rule) {
 					sets.InsertOrNew(ps.virtualServiceIndex.destinationsByGateway, gw, host)
 				}
+				if _, exists := ps.virtualServiceIndex.destinationsByGateway[gw]; !exists {
+					ps.virtualServiceIndex.destinationsByGateway[gw] = sets.Set[string]{}
+				}
 				addHostsFromMeshConfig(ps, ps.virtualServiceIndex.destinationsByGateway[gw])
 			}
 		}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -958,7 +958,7 @@ func TestIsServiceVisible(t *testing.T) {
 }
 
 func serviceNames(svcs []*Service) []string {
-	s := make([]string, 0, len(svcs))
+	var s []string
 	for _, ss := range svcs {
 		s = append(s, string(ss.Hostname))
 	}
@@ -2692,16 +2692,7 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 			Gateways: []string{gatewayName},
 			Http: []*networking.HTTPRoute{
 				{
-					Route: []*networking.HTTPRouteDestination{
-						{
-							Destination: &networking.Destination{
-								Host: "test",
-								Port: &networking.PortSelector{
-									Number: 80,
-								},
-							},
-						},
-					},
+					Route: []*networking.HTTPRouteDestination{},
 				},
 			},
 		},
@@ -2714,11 +2705,11 @@ func TestGetHostsFromMeshConfig(t *testing.T) {
 	}
 
 	env.ConfigStore = configStore
+	test.SetForTest(t, &features.FilterGatewayClusterConfig, true)
 	ps.initTelemetry(env)
 	ps.initDefaultExportMaps()
 	ps.initVirtualServices(env)
-	got := sets.String{}
-	addHostsFromMeshConfig(ps, got)
+	got := ps.virtualServiceIndex.destinationsByGateway[gatewayName]
 	assert.Equal(t, []string{"otel.foo.svc.cluster.local"}, sets.SortedList(got))
 }
 


### PR DESCRIPTION
Fixes Istiod crash when FILTER_GATEWAY_CONFIG is enabled, when virtual service has no destinations.

```
goroutine 556 [running]:
istio.io/istio/pkg/util/sets.Set[...].Insert(...)
	istio.io/istio/pkg/util/sets/set.go:40
istio.io/istio/pilot/pkg/model.addHostsFromMeshConfig(0x2c3a120?, 0xc021a7ebd0?)
	istio.io/istio/pilot/pkg/model/push_context.go:844 +0x153
istio.io/istio/pilot/pkg/model.(*PushContext).initVirtualServices(0xc000b72fc0, 0xc000e3fef0)
	istio.io/istio/pilot/pkg/model/push_context.go:1561 +0xe67
istio.io/istio/pilot/pkg/model.(*PushContext).createNewContext(0xc000b72fc0, 0xc000e3fef0)
	istio.io/istio/pilot/pkg/model/push_context.go:1211 +0xb3
istio.io/istio/pilot/pkg/model.(*PushContext).InitContext(0xc000b72fc0, 0xc000e3fef0, 0xc019578540, 0xc0067e8900)
	istio.io/istio/pilot/pkg/model/push_context.go:1187 +0x24d
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).initPushContext(0xc000ed8280, 0xc008066000?, 0x54bdea0?, {0xc008066030, 0x16})
	istio.io/istio/pilot/pkg/xds/discovery.go:524 +0xc5
istio.io/istio/pilot/pkg/xds.(*DiscoveryServer).Push(0x3231383065353939?, 0xc0067e8900)
	istio.io/istio/pilot/pkg/xds/discovery.go:301 +0x105
istio.io/istio/pilot/pkg/xds.debounce.func1(0x2020200a7d7b203a?, 0x1f75, {0x2250434d65737522?, 0x2c65736c6166203a?, 0x54bdea0?})
	istio.io/istio/pilot/pkg/xds/discovery.go:374 +0x4d
created by istio.io/istio/pilot/pkg/xds.debounce.func2
	istio.io/istio/pilot/pkg/xds/discovery.go:397 +0x4b5
```

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure