### PR TITLE
pkg: cleanup misleading usage of time.Duration

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1332,7 +1332,7 @@ func TestController_ServiceWithChangingDiscoveryNamespaces(t *testing.T) {
 		controller *FakeController,
 	) {
 		// update meshConfig
-		if err := testMeshWatcher.Update(meshConfig, 5); err != nil {
+		if err := testMeshWatcher.Update(meshConfig, time.Second*5); err != nil {
 			t.Fatalf("%v", err)
 		}
 
@@ -1531,7 +1531,7 @@ func TestControllerEnableResourceScoping(t *testing.T) {
 	) {
 		t.Helper()
 		// update meshConfig
-		if err := testMeshWatcher.Update(meshConfig, 5); err != nil {
+		if err := testMeshWatcher.Update(meshConfig, time.Second*5); err != nil {
 			t.Fatalf("%v", err)
 		}
 

--- a/pkg/config/mesh/watcher_test_utils.go
+++ b/pkg/config/mesh/watcher_test_utils.go
@@ -44,7 +44,7 @@ func (t *TestWatcher) Update(meshConfig *meshconfig.MeshConfig, timeout time.Dur
 	select {
 	case <-t.doneCh:
 		return nil
-	case <-time.After(time.Second * timeout):
+	case <-time.After(timeout):
 		return errors.New("timed out waiting for mesh.Watcher handler to trigger")
 	}
 }


### PR DESCRIPTION
Package should not accept a duration and then multiple it by seconds. Caller should do that