### PR TITLE
Remove skips on ambient tests related to #43238

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -133,13 +133,6 @@ func TestServices(t *testing.T) {
 			opt.Check = tcpValidator
 		}
 
-		if src.Config().IsUncaptured() && dst.Config().HasWaypointProxy() {
-			// For this case, it is broken if the src and dst are on the same node.
-			// Because client request is not captured to perform the hairpin
-			// TODO(https://github.com/istio/istio/issues/43238): fix this and remove this skip
-			opt.Check = check.OK()
-		}
-
 		if !dst.Config().HasWaypointProxy() &&
 			!src.Config().HasWaypointProxy() &&
 			(src.Config().Service != dst.Config().Service) &&
@@ -263,10 +256,6 @@ func TestServerRouting(t *testing.T) {
 		if !dst.Config().HasWaypointProxy() {
 			return
 		}
-		if src.Config().IsUncaptured() {
-			// TODO: fix this and remove this skip
-			t.Skip("https://github.com/istio/istio/issues/43238")
-		}
 		t.NewSubTest("set header").Run(func(t framework.TestContext) {
 			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 				"Destination": dst.Config().Service,
@@ -346,10 +335,6 @@ func TestWaypointEnvoyFilter(t *testing.T) {
 		if !dst.Config().HasWaypointProxy() {
 			return
 		}
-		if src.Config().IsUncaptured() {
-			// TODO: fix this and remove this skip
-			t.Skip("https://github.com/istio/istio/issues/43238")
-		}
 		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 			"Destination": dst.Config().Service,
 		}, `apiVersion: networking.istio.io/v1alpha3
@@ -419,10 +404,6 @@ func TestTrafficSplit(t *testing.T) {
 		}
 		if !dst.Config().HasWaypointProxy() {
 			return
-		}
-		if src.Config().IsUncaptured() {
-			// TODO: fix this and remove this skip
-			t.Skip("https://github.com/istio/istio/issues/43238")
 		}
 		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 			"Destination": dst.Config().Service,
@@ -610,11 +591,6 @@ spec:
 			// Ensure we don't get stuck on old connections with old RBAC rules. This causes 45s test times
 			// due to draining.
 			opt.NewConnectionPerRequest = true
-			if src.Config().IsUncaptured() {
-				// For this case, it is broken if the src and dst are on the same node.
-				// TODO: fix this and remove this skip
-				t.Skip("https://github.com/istio/istio/issues/43238")
-			}
 
 			t.NewSubTest("permissive").Run(func(t framework.TestContext) {
 				t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
@@ -679,11 +655,6 @@ spec:
 			// Ensure we don't get stuck on old connections with old RBAC rules. This causes 45s test times
 			// due to draining.
 			opt.NewConnectionPerRequest = true
-			if src.Config().IsUncaptured() {
-				// For this case, it is broken if the src and dst are on the same node.
-				// TODO: fix this and remove this skip
-				t.Skip("https://github.com/istio/istio/issues/43238")
-			}
 
 			overrideCheck := func(opt *echo.CallOptions) {
 				switch {
@@ -954,10 +925,6 @@ spec:
 			// Ensure we don't get stuck on old connections with old RBAC rules. This causes 45s test times
 			// due to draining.
 			opt.NewConnectionPerRequest = true
-			if src.Config().IsUncaptured() {
-				// TODO: fix this and remove this skip
-				t.Skip("https://github.com/istio/istio/issues/43238")
-			}
 			policySpec := `
   rules:
   - to:


### PR DESCRIPTION
**Please provide a description of this PR:**

#43238 has been resolved so tests no longer need to be skipped when src is uncaptured and dst has a waypoint.

**Note**: Tried testing this locally using prow `./prow/integ-suite-kind.sh --kind-config ./prow/config/ambient-sc.yaml test.integration.ambient.kube` and ran into the following image pull error with resources in the echo namespace:

 ```
Failed to pull image "auto": rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/library/auto:latest": failed to resolve reference "docker.io/library/auto:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

Related issue: https://github.com/istio/istio/issues/35789