### PR TITLE
Fix readiness probe when sidecar injector is disabled

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -319,6 +319,7 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error initializing sidecar injector: %v", err)
 		}
+		s.readinessFlags.sidecarInjectorReady.Store(true)
 		s.webhookInfo.mu.Lock()
 		s.webhookInfo.wh = wh
 		s.webhookInfo.mu.Unlock()


### PR DESCRIPTION
Make sure the readiness probe returns ready when the sidecar injector is not used, or not configured.

Fix #45990

**Please provide a description of this PR:**
Resolves the bug reported in #45990 by making sure the readiness probe for the sidecar injector is true when the injector is not used.  This prevents istiod from getting stuck in the non-ready state.