### PR TITLE
logging: cleanup errdict usage

### DIFF
--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -777,7 +777,7 @@ func (s *Server) CreateRulesOnNode(ztunnelVeth, ztunnelIP string, captureDNS boo
 	for _, route := range routes {
 		err = execute(route.Cmd, route.Args...)
 		if err != nil {
-			log.Errorf(fmt.Errorf("failed to add route (%+v): %v", route, err))
+			log.Errorf("failed to add route (%+v): %v", route, err)
 		}
 	}
 

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -178,12 +178,12 @@ var (
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldIOP, ok := e.ObjectOld.(*iopv1alpha1.IstioOperator)
 			if !ok {
-				scope.Errorf(errdict.OperatorFailedToGetObjectInCallback, "failed to get old IstioOperator")
+				errdict.OperatorFailedToGetObjectInCallback.Log(scope).Errorf("failed to get old IstioOperator")
 				return false
 			}
 			newIOP, ok := e.ObjectNew.(*iopv1alpha1.IstioOperator)
 			if !ok {
-				scope.Errorf(errdict.OperatorFailedToGetObjectInCallback, "failed to get new IstioOperator")
+				errdict.OperatorFailedToGetObjectInCallback.Log(scope).Errorf("failed to get new IstioOperator")
 				return false
 			}
 
@@ -261,7 +261,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		scope.Warnf(errdict.OperatorFailedToGetObjectFromAPIServer, "error getting IstioOperator %s: %s", iopName, err)
+		errdict.OperatorFailedToGetObjectFromAPIServer.Log(scope).Warnf("error getting IstioOperator %s: %s", iopName, err)
 		metrics.CountCRFetchFail(errors.ReasonForError(err))
 		return reconcile.Result{}, err
 	}
@@ -286,7 +286,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	// get the merged values in iop on top of the defaults for the profile given by iop.profile
 	iopMerged.Spec, err = mergeIOPSWithProfile(iopMerged)
 	if err != nil {
-		scope.Errorf(errdict.OperatorFailedToMergeUserIOP, "failed to merge base profile with user IstioOperator CR %s, %s", iopName, err)
+		errdict.OperatorFailedToMergeUserIOP.Log(scope).Errorf("failed to merge base profile with user IstioOperator CR %s, %s", iopName, err)
 		return reconcile.Result{}, err
 	}
 
@@ -329,7 +329,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 				scope.Infof("Could not remove finalizer from %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
 				return reconcile.Result{}, nil
 			}
-			scope.Errorf(errdict.OperatorFailedToRemoveFinalizer, "error removing finalizer: %s", finalizerError)
+			errdict.OperatorFailedToRemoveFinalizer.Log(scope).Errorf("error removing finalizer: %s", finalizerError)
 			return reconcile.Result{}, finalizerError
 		}
 		return reconcile.Result{}, nil
@@ -346,7 +346,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 			} else if errors.IsConflict(err) {
 				scope.Infof("Could not add finalizer to %s due to conflict. Operation will be retried in next reconcile attempt.", iopName)
 			}
-			scope.Errorf(errdict.OperatorFailedToAddFinalizer, "Failed to add finalizer to IstioOperator CR %s: %s", iopName, err)
+			errdict.OperatorFailedToAddFinalizer.Log(scope).Errorf("Failed to add finalizer to IstioOperator CR %s: %s", iopName, err)
 			return reconcile.Result{}, err
 		}
 	}
@@ -372,7 +372,7 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	}
 	err = util.ValidateIOPCAConfig(r.kubeClient, iopMerged)
 	if err != nil {
-		scope.Errorf(errdict.OperatorFailedToConfigure, "failed to apply IstioOperator resources. Error %s", err)
+		errdict.OperatorFailedToConfigure.Log(scope).Errorf("failed to apply IstioOperator resources. Error %s", err)
 		return reconcile.Result{}, err
 	}
 	helmReconcilerOptions := &helmreconciler.Options{

--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -23,13 +23,13 @@ func registerDefaultScope() *Scope {
 var defaultScope = registerDefaultScope()
 
 // Fatal outputs a message at fatal level.
-func Fatal(fields ...any) {
-	defaultScope.Fatal(fields...)
+func Fatal(fields any) {
+	defaultScope.Fatal(fields)
 }
 
 // Fatalf uses fmt.Sprintf to construct and log a message at fatal level.
-func Fatalf(args ...any) {
-	defaultScope.Fatalf(args...)
+func Fatalf(format string, args ...any) {
+	defaultScope.Fatalf(format, args...)
 }
 
 // FatalEnabled returns whether output of messages using this scope is currently enabled for fatal-level output.
@@ -43,8 +43,8 @@ func Error(fields any) {
 }
 
 // Errorf uses fmt.Sprintf to construct and log a message at error level.
-func Errorf(args ...any) {
-	defaultScope.Errorf(args...)
+func Errorf(format string, args ...any) {
+	defaultScope.Errorf(format, args...)
 }
 
 // ErrorEnabled returns whether output of messages using this scope is currently enabled for error-level output.
@@ -58,8 +58,8 @@ func Warn(fields any) {
 }
 
 // Warnf uses fmt.Sprintf to construct and log a message at warn level.
-func Warnf(args ...any) {
-	defaultScope.Warnf(args...)
+func Warnf(format string, args ...any) {
+	defaultScope.Warnf(format, args...)
 }
 
 // WarnEnabled returns whether output of messages using this scope is currently enabled for warn-level output.
@@ -73,8 +73,8 @@ func Info(fields any) {
 }
 
 // Infof uses fmt.Sprintf to construct and log a message at info level.
-func Infof(args ...any) {
-	defaultScope.Infof(args...)
+func Infof(format string, args ...any) {
+	defaultScope.Infof(format, args...)
 }
 
 // InfoEnabled returns whether output of messages using this scope is currently enabled for info-level output.
@@ -88,8 +88,8 @@ func Debug(fields any) {
 }
 
 // Debugf uses fmt.Sprintf to construct and log a message at debug level.
-func Debugf(args ...any) {
-	defaultScope.Debugf(args...)
+func Debugf(format string, args ...any) {
+	defaultScope.Debugf(format, args...)
 }
 
 // DebugEnabled returns whether output of messages using this scope is currently enabled for debug-level output.

--- a/pkg/log/default_test.go
+++ b/pkg/log/default_test.go
@@ -18,8 +18,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-
-	"istio.io/istio/pkg/structured"
 )
 
 func testOptions() *Options {
@@ -192,31 +190,6 @@ func TestDefault(t *testing.T) {
 				t.Errorf("Got '%v', expected a match with '%v'", lines[0], c.pat)
 			}
 		})
-	}
-}
-
-func TestErrorDictionary(t *testing.T) {
-	ie := &structured.Error{
-		MoreInfo:    "MoreInfo",
-		Impact:      "Impact",
-		Action:      "Action",
-		LikelyCause: "LikelyCause",
-	}
-	lines, err := captureStdout(func() {
-		if err := Configure(DefaultOptions()); err != nil {
-			t.Errorf("Got err '%v', expecting success", err)
-		}
-
-		Infof(ie, "Hello")
-		_ = Sync()
-	})
-	if err != nil {
-		t.Errorf("Got error '%v', expected success", err)
-	}
-
-	expected := "Hello	moreInfo=MoreInfo impact=Impact action=Action likelyCause=LikelyCause"
-	if match, _ := regexp.MatchString(expected, lines[0]); !match {
-		t.Errorf("Got '%v', expected a match with '%v'", lines[0], expected)
 	}
 }
 

--- a/pkg/log/zapcore_handler.go
+++ b/pkg/log/zapcore_handler.go
@@ -15,111 +15,20 @@
 package log
 
 import (
-	"fmt"
-	"runtime"
-	"strings"
-	"time"
-
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"istio.io/istio/pkg/structured"
 )
 
-var (
-	toLevel = map[zapcore.Level]Level{
-		zapcore.FatalLevel: FatalLevel,
-		zapcore.ErrorLevel: ErrorLevel,
-		zapcore.WarnLevel:  WarnLevel,
-		zapcore.InfoLevel:  InfoLevel,
-		zapcore.DebugLevel: DebugLevel,
-	}
-	toZapLevel = map[Level]zapcore.Level{
-		FatalLevel: zapcore.FatalLevel,
-		ErrorLevel: zapcore.ErrorLevel,
-		WarnLevel:  zapcore.WarnLevel,
-		InfoLevel:  zapcore.InfoLevel,
-		DebugLevel: zapcore.DebugLevel,
-	}
-)
-
-func init() {
-	registerDefaultHandler(ZapLogHandlerCallbackFunc)
-}
-
-// ZapLogHandlerCallbackFunc is the handler function that emulates the previous Istio logging output and adds
-// support for errdict package and labels logging.
-func ZapLogHandlerCallbackFunc(
-	level Level,
-	scope *Scope,
-	ie *structured.Error,
-	msg string,
-) {
-	var fields []zapcore.Field
-	if useJSON.Load().(bool) {
-		if ie != nil {
-			fields = appendNotEmptyField(fields, "message", msg)
-			// Unlike zap, don't leave the message in CLI format.
-			msg = ""
-			fields = appendNotEmptyField(fields, "moreInfo", ie.MoreInfo)
-			fields = appendNotEmptyField(fields, "impact", ie.Impact)
-			fields = appendNotEmptyField(fields, "action", ie.Action)
-			fields = appendNotEmptyField(fields, "likelyCause", ie.LikelyCause)
-			fields = appendNotEmptyField(fields, "err", toErrString(ie.Err))
-		}
-		for _, k := range scope.labelKeys {
-			v := scope.labels[k]
-			fields = append(fields, zap.Field{
-				Key:       k,
-				Type:      zapcore.ReflectType,
-				Interface: v,
-			})
-		}
-	} else {
-		sb := &strings.Builder{}
-		sb.WriteString(msg)
-		if ie != nil || len(scope.labelKeys) > 0 {
-			sb.WriteString("\t")
-		}
-		if ie != nil {
-			appendNotEmptyString(sb, "moreInfo", ie.MoreInfo)
-			appendNotEmptyString(sb, "impact", ie.Impact)
-			appendNotEmptyString(sb, "action", ie.Action)
-			appendNotEmptyString(sb, "likelyCause", ie.LikelyCause)
-			appendNotEmptyString(sb, "err", toErrString(ie.Err))
-		}
-		space := false
-		for _, k := range scope.labelKeys {
-			if space {
-				sb.WriteString(" ")
-			}
-			sb.WriteString(fmt.Sprintf("%s=%v", k, scope.labels[k]))
-			space = true
-		}
-		msg = sb.String()
-	}
-	emit(scope, toZapLevel[level], msg, fields)
-}
-
-// appendNotEmptyField appends a field with key:value to fields. If value is empty, it does nothing.
-func appendNotEmptyField(fields []zapcore.Field, key, value string) []zapcore.Field {
-	if key == "" || value == "" {
-		return fields
-	}
-	return append(fields, zap.String(key, value))
-}
-
-// appendNotEmptyString appends a key=value string to sb. If value is empty, it does nothing.
-func appendNotEmptyString(sb *strings.Builder, key, value string) {
-	if key == "" || value == "" {
-		return
-	}
-	sb.WriteString(fmt.Sprintf("%s=%v ", key, value))
+var toLevel = map[zapcore.Level]Level{
+	zapcore.FatalLevel: FatalLevel,
+	zapcore.ErrorLevel: ErrorLevel,
+	zapcore.WarnLevel:  WarnLevel,
+	zapcore.InfoLevel:  InfoLevel,
+	zapcore.DebugLevel: DebugLevel,
 }
 
 // callerSkipOffset is how many callers to pop off the stack to determine the caller function locality, used for
 // adding file/line number to log output.
-const callerSkipOffset = 4
+const callerSkipOffset = 2
 
 func dumpStack(level zapcore.Level, scope *Scope) bool {
 	thresh := toLevel[level]
@@ -131,37 +40,4 @@ func dumpStack(level zapcore.Level, scope *Scope) bool {
 		}
 	}
 	return scope.GetStackTraceLevel() >= thresh
-}
-
-func emit(scope *Scope, level zapcore.Level, msg string, fields []zapcore.Field) {
-	e := zapcore.Entry{
-		Message:    msg,
-		Level:      level,
-		Time:       time.Now(),
-		LoggerName: scope.nameToEmit,
-	}
-
-	if scope.GetLogCallers() {
-		e.Caller = zapcore.NewEntryCaller(runtime.Caller(scope.callerSkip + callerSkipOffset))
-	}
-
-	if dumpStack(level, scope) {
-		e.Stack = zap.Stack("").String
-	}
-
-	pt := funcs.Load().(patchTable)
-	if pt.write != nil {
-		if err := pt.write(e, fields); err != nil {
-			_, _ = fmt.Fprintf(pt.errorSink, "%v log write error: %v\n", time.Now(), err)
-			_ = pt.errorSink.Sync()
-		}
-	}
-}
-
-// toErrString returns the string representation of err, handling the nil case.
-func toErrString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
 }

--- a/pkg/structured/structured.go
+++ b/pkg/structured/structured.go
@@ -16,6 +16,8 @@ package structured
 
 import (
 	"fmt"
+
+	"istio.io/istio/pkg/log"
 )
 
 // Error represents structured error information, for optional use in scope.X or log.X calls.
@@ -35,7 +37,27 @@ type Error struct {
 	Err error
 }
 
-// Error implements the error#Error interface.
+// Log appends relevant labels to the log scope.
+func (e *Error) Log(s *log.Scope) *log.Scope {
+	lbls := make([]any, 0, 10)
+	if e.MoreInfo != "" {
+		lbls = append(lbls, "moreInfo", e.MoreInfo)
+	}
+	if e.Impact != "" {
+		lbls = append(lbls, "impact", e.Impact)
+	}
+	if e.Action != "" {
+		lbls = append(lbls, "action", e.Action)
+	}
+	if e.LikelyCause != "" {
+		lbls = append(lbls, "likelyCause", e.LikelyCause)
+	}
+	if e.Err != nil {
+		lbls = append(lbls, "err", e.Err.Error())
+	}
+	return s.WithLabels(lbls...)
+}
+
 func (e *Error) Error() string {
 	if e == nil {
 		return ""

--- a/pkg/test/failer.go
+++ b/pkg/test/failer.go
@@ -135,9 +135,7 @@ func (e *errorWrapper) Log(args ...any) {
 }
 
 func (e *errorWrapper) Logf(format string, args ...any) {
-	ag := []any{format}
-	ag = append(ag, args...)
-	log.Infof(ag...)
+	log.Infof(format, args...)
 }
 
 func (e *errorWrapper) TempDir() string {

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -244,7 +244,7 @@ func (t *testAnalyzer) Label(labels ...label.Instance) Test {
 
 func (t *testAnalyzer) Features(feats ...features.Feature) Test {
 	if err := addFeatureLabels(t.featureLabels, feats...); err != nil {
-		log.Errorf(err)
+		log.Error(err)
 		t.goTest.FailNow()
 	}
 	return t

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -152,7 +152,7 @@ func (t *testImpl) Label(labels ...label.Instance) Test {
 func (t *testImpl) Features(feats ...features.Feature) Test {
 	if err := addFeatureLabels(t.featureLabels, feats...); err != nil {
 		// test runs shouldn't fail
-		log.Errorf(err)
+		log.Error(err)
 	}
 	return t
 }

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -569,6 +569,6 @@ func configLogs(opt *log.Options) error {
 	return log.Configure(&opt2)
 }
 
-func logRuntime(start time.Time, args ...any) {
-	log.WithLabels("runtime", time.Since(start)).Infof(args...)
+func logRuntime(start time.Time, format string, args ...any) {
+	log.WithLabels("runtime", time.Since(start)).Infof(format, args...)
 }

--- a/tools/docker-builder/builder/crane.go
+++ b/tools/docker-builder/builder/crane.go
@@ -137,8 +137,8 @@ func ByteCount(b int64) string {
 func Build(b BuildSpec) error {
 	t0 := time.Now()
 	lt := t0
-	trace := func(d ...any) {
-		log.WithLabels("image", b.Name, "total", time.Since(t0), "step", time.Since(lt)).Infof(d...)
+	trace := func(format string, d ...any) {
+		log.WithLabels("image", b.Name, "total", time.Since(t0), "step", time.Since(lt)).Infof(format, d...)
 		lt = time.Now()
 	}
 	if len(b.Dests) == 0 {


### PR DESCRIPTION
For https://github.com/istio/istio/issues/44683

Partially reverts https://github.com/istio/pkg/pull/192

We current have an `errdict` mechanism, which is basically just a struct
of k/v pairs to insert into logs. We made this builtin to our logging
system. This adds a lot of complexity, and I don't think its needed.

Instead, just add a helper to the errdict to make it add labels to the
logger we want, and strip out all of the first-class support in
`pkg/log`.

This change moves us closer to being able to just swap `slog` in (waiting for Go 1.21)
