### PR TITLE
Dualstack: fixing to not ignore link local addresses in proxy detection

### DIFF
--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -365,7 +365,7 @@ func applyExcludeInterfaces(ifaces []string) []string {
 				continue
 			}
 			unwrapAddr := ipAddr.Unmap()
-			if !unwrapAddr.IsValid() || unwrapAddr.IsLoopback() || unwrapAddr.IsLinkLocalUnicast() || unwrapAddr.IsLinkLocalMulticast() || unwrapAddr.IsUnspecified() {
+			if !unwrapAddr.IsValid() || unwrapAddr.IsLoopback() || unwrapAddr.IsLinkLocalMulticast() || unwrapAddr.IsUnspecified() {
 				continue
 			}
 

--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -365,9 +365,6 @@ func applyExcludeInterfaces(ifaces []string) []string {
 				continue
 			}
 			unwrapAddr := ipAddr.Unmap()
-			if !unwrapAddr.IsValid() || unwrapAddr.IsLoopback() || unwrapAddr.IsLinkLocalMulticast() || unwrapAddr.IsUnspecified() {
-				continue
-			}
 
 			// Add to map
 			exclusionMap.Insert(unwrapAddr.String())

--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -102,7 +102,7 @@ func getPrivateIPsIfAvailable() ([]string, bool) {
 			}
 			// unwrap the IPv4-mapped IPv6 address
 			unwrapAddr := ipAddr.Unmap()
-			if !unwrapAddr.IsValid() || unwrapAddr.IsLoopback() || unwrapAddr.IsLinkLocalUnicast() || unwrapAddr.IsLinkLocalMulticast() {
+			if !unwrapAddr.IsValid() || unwrapAddr.IsLoopback() || unwrapAddr.IsLinkLocalMulticast() {
 				continue
 			}
 			if unwrapAddr.IsUnspecified() {

--- a/releasenotes/notes/46016.yaml
+++ b/releasenotes/notes/46016.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 45335
+releaseNotes:
+  - |
+    **Fixed** an issue preventing dualstack support for EKS IPv6 clusters with secondary IPv4 link-local address.
+
+upgradeNotes:
+  - title: Use the excluded interface option for Ignoring IPv4 in an IPv6 cluster.
+    content: |
+      If you don't wish to use Istio dualstack feature, you will need to add v4if0 to excluded interface list. e.g. traffic.sidecar.istio.io/excludeInterfaces: v4if0
+

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -213,7 +213,7 @@ func getLocalIP() (netip.Addr, bool, error) {
 			}
 			// unwrap the IPv4-mapped IPv6 address
 			unwrapAddr := ipAddr.Unmap()
-			if !unwrapAddr.IsLoopback() && !unwrapAddr.IsLinkLocalUnicast() && !unwrapAddr.IsLinkLocalMulticast() {
+			if !unwrapAddr.IsLoopback() && !unwrapAddr.IsLinkLocalMulticast() {
 				isIPv6 = unwrapAddr.Is6()
 				ipAddrs = append(ipAddrs, unwrapAddr)
 				if !DualStack {


### PR DESCRIPTION
This will fix issue #45335. This issues happens only if there are secondary interfaces in the POD.

We are ignoring linklocal addresses for proxy mode detection (Singlestack or dual). There was a previous fixed done in PR#37164 that hardcoded ignoring IPv4 linklocal address for EKS and on top of that users have to exlude 0.0.0.0 so the init consider don't redirect IPv4 traffic to the proxy. This PR will streamline both proxymode and excluding the specific interface from iptables and there will be no need to specify 0.0.0.0 via range.

Recently we have another fixed which is more flexible and cleaner by ignoring the excluded interface. E.g. If primary interface is IPv6 and secondary interface is IPv4, user can decide below.
- Install istio in singlestack mode and exclude IPv4 interface
- Install istio in dualstack mode and don't exclude any interface

Since this is specific to multiple interfaces, its not easy to test on Kind. But if someone wants to try, I have a kind setup with multus [here](https://github.com/abasitt/kube6/tree/main/istio/dualstack-withkind), i will be happy to clarify any questions.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure