### PR TITLE
Remove duplicate link

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -10,7 +10,6 @@ Next steps:
     * https://istio.io/latest/docs/tasks/traffic-management
     * https://istio.io/latest/docs/tasks/security/
     * https://istio.io/latest/docs/tasks/policy-enforcement/
-    * https://istio.io/latest/docs/tasks/policy-enforcement/
   * Review the list of actively supported releases, CVE publications and our hardening guide:
     * https://istio.io/latest/docs/releases/supported-releases/
     * https://istio.io/latest/news/security/


### PR DESCRIPTION
**Please provide a description of this PR:**
Just removes a duplicate link in the text that prints to stdout on installation of the Helm chart.