### PR TITLE
Update proxy and slightly increase allowed binary size

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "92507715b2ddde73cf45d9a382ecd80271fd16c3"
+    "lastStableSHA": "1aae93a2ad83f7164e9967c3fe9b35cede4759f5"
   },
   {
     "_comment": "",

--- a/tests/binary/binaries_test.go
+++ b/tests/binary/binaries_test.go
@@ -113,7 +113,7 @@ func TestBinarySizes(t *testing.T) {
 		"bug-report":      {60, 85},
 		"client":          {20, 30},
 		"server":          {20, 30},
-		"envoy":           {60, 110},
+		"envoy":           {60, 115},
 		"ztunnel":         {15, 25},
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

The `TestBinarySizes/envoy` test is failing with the latest proxy (see https://github.com/istio/istio/pull/46028). The binary size has increased beyond the 110 limit. This PR updates the limit to 115.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
