### PR TITLE
optimize convertIstioListenerToWrapper performance

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -32,22 +32,29 @@ import (
 
 // SelectVirtualServices selects the virtual services by matching given services' host names.
 // This function is used by sidecar converter.
-func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, hosts map[string][]host.Name) []config.Config {
+func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, hostsByNamespace map[string]hostClassification) []config.Config {
 	importedVirtualServices := make([]config.Config, 0)
 
 	vsset := sets.New[string]()
-	addVirtualService := func(vs config.Config, hosts host.Names) {
+	addVirtualService := func(vs config.Config, hosts hostClassification) {
 		vsname := vs.Name + "/" + vs.Namespace
 		rule := vs.Spec.(*networking.VirtualService)
-		for _, ih := range hosts {
-			// Check if the virtual service is already processed.
+
+		for _, vh := range rule.Hosts {
 			if vsset.Contains(vsname) {
 				break
 			}
-			for _, h := range rule.Hosts {
-				// VirtualServices can have many hosts, so we need to avoid appending
-				// duplicated virtualservices to slice importedVirtualServices
-				if vsHostMatches(h, ih, vs) {
+
+			// first, check exactHosts
+			if hosts.exactHosts.Contains(host.Name(vh)) {
+				importedVirtualServices = append(importedVirtualServices, vs)
+				vsset.Insert(vsname)
+				break
+			}
+
+			// exactHosts not found, fallback to loop allHosts
+			for _, ah := range hosts.allHosts {
+				if ah.Matches(host.Name(vh)) {
 					importedVirtualServices = append(importedVirtualServices, vs)
 					vsset.Insert(vsname)
 					break
@@ -65,12 +72,12 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 			// and break out of the loop.
 
 			// Check if there is an explicit import of form ns/* or ns/host
-			if importedHosts, nsFound := hosts[configNamespace]; nsFound {
+			if importedHosts, nsFound := hostsByNamespace[configNamespace]; nsFound {
 				addVirtualService(c, importedHosts)
 			}
 
 			// Check if there is an import of form */host or */*
-			if importedHosts, wnsFound := hosts[wildcardNamespace]; wnsFound {
+			if importedHosts, wnsFound := hostsByNamespace[wildcardNamespace]; wnsFound {
 				addVirtualService(c, importedHosts)
 			}
 		}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -54,7 +54,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 
 			// exactHosts not found, fallback to loop allHosts
 			for _, ah := range hosts.allHosts {
-				if ah.Matches(host.Name(vh)) {
+				if vsHostMatches(vh, ah, vs) {
 					importedVirtualServices = append(importedVirtualServices, vs)
 					vsset.Insert(vsname)
 					break


### PR DESCRIPTION
update on 8.25:

Save the exact hosts(Sidecar CR Egress.Hosts) separately in Set (internal implementation is map), so that in the following process can be matched using map search instead of loop.

- When hosts are all exact hosts: performance will be improved. In our production environment, the average time-consuming for[ this indicator](https://github.com/istio/istio/blob/master/pilot/pkg/xds/monitoring.go#L105) has dropped by 50%+ (off-topic: I think the indicator bounds are set too narrowly, there is a [discussion here](https://github.com/istio/istio/pull/45924)). From the benchmarks below, the performance improvement is not obvious, which may be caused by inappropriate benchmark test case data.

- When hosts are all wildcard hosts: performance may drop, but not much (<5%).


The memory will be slightly increased (<10%), but it seems to be acceptable, because too much cpu consumption is the current problem.


**benchmark result(update on 8.25)**:
```shell
$ go test -run="none" -bench="BenchmarkConvertIstioListenerToWrapper" -test.benchmem -count=5 . > old.txt
$ go test -run="none" -bench="BenchmarkConvertIstioListenerToWrapper" -test.benchmem -count=5 . > new.txt
$ benchstat old.txt new.txt
name                                               old time/op    new time/op    delta
ConvertIstioListenerToWrapper/small-exact-12         3.79µs ± 4%    3.86µs ± 7%     ~     (p=0.841 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12      2.23µs ± 1%    2.30µs ± 2%   +3.22%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12     6.38µs ±16%    6.41µs ± 2%     ~     (p=0.310 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12        52.3µs ±23%    37.6µs ± 0%  -28.13%  (p=0.016 n=5+4)
ConvertIstioListenerToWrapper/middle-wildcard-12     40.7µs ± 7%    36.7µs ± 1%   -9.78%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12    55.7µs ± 5%    54.3µs ± 3%     ~     (p=0.421 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12            183µs ± 1%     147µs ±10%  -20.09%  (p=0.016 n=4+5)
ConvertIstioListenerToWrapper/big-wildcard-12         168µs ±30%     140µs ± 2%  -16.62%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-match-all-12        216µs ±49%     177µs ± 3%     ~     (p=0.310 n=5+5)

name                                               old alloc/op   new alloc/op   delta
ConvertIstioListenerToWrapper/small-exact-12         2.45kB ± 0%    2.64kB ± 0%   +7.84%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12        592B ± 0%      640B ± 0%   +8.11%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12     9.69kB ± 0%    9.74kB ± 0%   +0.50%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12        13.4kB ± 0%    13.9kB ± 0%   +3.60%  (p=0.016 n=5+4)
ConvertIstioListenerToWrapper/middle-wildcard-12     4.18kB ± 0%    4.22kB ± 0%   +1.15%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12    88.1kB ± 0%    88.2kB ± 0%   +0.05%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12           22.0kB ± 0%    23.1kB ± 0%   +4.98%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-wildcard-12        10.9kB ± 0%    11.0kB ± 0%   +0.44%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-match-all-12        350kB ± 0%     350kB ± 0%   +0.01%  (p=0.008 n=5+5)

name                                               old allocs/op  new allocs/op  delta
ConvertIstioListenerToWrapper/small-exact-12           27.0 ± 0%      29.0 ± 0%   +7.41%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-wildcard-12        18.0 ± 0%      19.0 ± 0%   +5.56%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/small-match-all-12       31.0 ± 0%      32.0 ± 0%   +3.23%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-exact-12           134 ± 0%       137 ± 0%   +2.24%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-wildcard-12        117 ± 0%       118 ± 0%   +0.85%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/middle-match-all-12       145 ± 0%       146 ± 0%   +0.69%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-exact-12              341 ± 0%       345 ± 0%   +1.17%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-wildcard-12           322 ± 0%       323 ± 0%   +0.31%  (p=0.008 n=5+5)
ConvertIstioListenerToWrapper/big-match-all-12          363 ± 0%       363 ± 0%     ~     (p=0.159 n=5+5)