### PR TITLE
Don't fire CNI installer watch events unless Istio binaries are changed.

### DIFF
--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -19,12 +19,13 @@ import (
 	"path/filepath"
 
 	"istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Copies/mirrors any files present in a single source dir to N number of target dirs
-// and returns a slice of the filenames copied.
-func copyBinaries(srcDir string, targetDirs []string) ([]string, error) {
-	var copiedFilenames []string
+// and returns a set of the filenames copied.
+func copyBinaries(srcDir string, targetDirs []string) (sets.Set[string], error) {
+	copiedFilenames := sets.Set[string]{}
 	srcFiles, err := os.ReadDir(srcDir)
 	if err != nil {
 		return copiedFilenames, err
@@ -51,7 +52,7 @@ func copyBinaries(srcDir string, targetDirs []string) ([]string, error) {
 			installLog.Infof("Copied %s to %s.", filename, targetDir)
 		}
 
-		copiedFilenames = append(copiedFilenames, filename)
+		copiedFilenames.Insert(filename)
 	}
 
 	return copiedFilenames, nil

--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -21,33 +21,38 @@ import (
 	"istio.io/istio/pkg/file"
 )
 
-func copyBinaries(srcDir string, targetDirs []string) error {
-	for _, targetDir := range targetDirs {
-		if err := file.IsDirWriteable(targetDir); err != nil {
-			installLog.Infof("Directory %s is not writable, skipping.", targetDir)
+// Copies/mirrors any files present in a single source dir to N number of target dirs
+// and returns a slice of the filenames copied.
+func copyBinaries(srcDir string, targetDirs []string) ([]string, error) {
+	var copiedFilenames []string
+	srcFiles, err := os.ReadDir(srcDir)
+	if err != nil {
+		return copiedFilenames, err
+	}
+
+	for _, f := range srcFiles {
+		if f.IsDir() {
 			continue
 		}
 
-		files, err := os.ReadDir(srcDir)
-		if err != nil {
-			return err
-		}
+		filename := f.Name()
+		srcFilepath := filepath.Join(srcDir, filename)
 
-		for _, f := range files {
-			if f.IsDir() {
+		for _, targetDir := range targetDirs {
+			if err := file.IsDirWriteable(targetDir); err != nil {
+				installLog.Infof("Directory %s is not writable, skipping.", targetDir)
 				continue
 			}
 
-			filename := f.Name()
-
-			srcFilepath := filepath.Join(srcDir, filename)
 			err := file.AtomicCopy(srcFilepath, targetDir, filename)
 			if err != nil {
-				return err
+				return copiedFilenames, err
 			}
 			installLog.Infof("Copied %s to %s.", filename, targetDir)
 		}
+
+		copiedFilenames = append(copiedFilenames, filename)
 	}
 
-	return nil
+	return copiedFilenames, nil
 }

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -54,7 +54,7 @@ func TestCopyBinaries(t *testing.T) {
 				file.WriteOrFail(t, filepath.Join(targetDir, filename), []byte(contents))
 			}
 
-			err := copyBinaries(srcDir, []string{targetDir})
+			binariesCopied, err := copyBinaries(srcDir, []string{targetDir})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -62,6 +62,14 @@ func TestCopyBinaries(t *testing.T) {
 			for filename, expectedContents := range c.expectedFiles {
 				contents := file.AsStringOrFail(t, filepath.Join(targetDir, filename))
 				assert.Equal(t, contents, expectedContents)
+
+				wasCopied := false
+				for _, bin := range binariesCopied {
+					if bin == filename {
+						wasCopied = true
+					}
+				}
+				assert.Equal(t, wasCopied, true)
 			}
 		})
 	}

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -64,7 +64,7 @@ func TestCopyBinaries(t *testing.T) {
 				assert.Equal(t, contents, expectedContents)
 
 				wasCopied := false
-				for _, bin := range binariesCopied {
+				for _, bin := range binariesCopied.UnsortedList() {
 					if bin == filename {
 						wasCopied = true
 					}

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -26,6 +26,7 @@ import (
 	testutils "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/sets"
 )
 
 func TestCheckInstall(t *testing.T) {
@@ -172,7 +173,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			}
 
 			t.Log("Expecting an invalid configuration log:")
-			if err := in.sleepCheckInstall(ctx, []string{}); err != nil {
+			if err := in.sleepCheckInstall(ctx, sets.Set[string]{}); err != nil {
 				t.Fatalf("error should be nil due to invalid config, got: %v", err)
 			}
 			assert.Equal(t, isReady.Load(), false)
@@ -209,7 +210,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			// Should detect a valid configuration and wait indefinitely for a file modification
 			errChan := make(chan error)
 			go func(ctx context.Context) {
-				errChan <- in.sleepCheckInstall(ctx, []string{})
+				errChan <- in.sleepCheckInstall(ctx, sets.Set[string]{})
 			}(ctx)
 
 			select {
@@ -249,7 +250,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 				// Run sleepCheckInstall
 				go func(ctx context.Context, in *Installer) {
-					errChan <- in.sleepCheckInstall(ctx, []string{})
+					errChan <- in.sleepCheckInstall(ctx, sets.Set[string]{})
 				}(ctx, in)
 			}
 

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -172,7 +172,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			}
 
 			t.Log("Expecting an invalid configuration log:")
-			if err := in.sleepCheckInstall(ctx); err != nil {
+			if err := in.sleepCheckInstall(ctx, []string{}); err != nil {
 				t.Fatalf("error should be nil due to invalid config, got: %v", err)
 			}
 			assert.Equal(t, isReady.Load(), false)
@@ -209,7 +209,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			// Should detect a valid configuration and wait indefinitely for a file modification
 			errChan := make(chan error)
 			go func(ctx context.Context) {
-				errChan <- in.sleepCheckInstall(ctx)
+				errChan <- in.sleepCheckInstall(ctx, []string{})
 			}(ctx)
 
 			select {
@@ -249,7 +249,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 				// Run sleepCheckInstall
 				go func(ctx context.Context, in *Installer) {
-					errChan <- in.sleepCheckInstall(ctx)
+					errChan <- in.sleepCheckInstall(ctx, []string{})
 				}(ctx, in)
 			}
 

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -49,7 +49,7 @@ func (w *Watcher) Close() {
 }
 
 // Creates a file watcher that watches for any changes to the directory
-func CreateFileWatcher(dirs ...string) (*Watcher, error) {
+func CreateFileWatcher(paths ...string) (*Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, fmt.Errorf("watcher create: %v", err)
@@ -58,12 +58,12 @@ func CreateFileWatcher(dirs ...string) (*Watcher, error) {
 	fileModified, errChan := make(chan struct{}), make(chan error)
 	go watchFiles(watcher, fileModified, errChan)
 
-	for _, dir := range dirs {
-		if !file.Exists(dir) {
-			log.Infof("skip watching non-existing dir %v", dir)
+	for _, path := range paths {
+		if !file.Exists(path) {
+			log.Infof("file watcher skipping watch on non-existent path: %v", path)
 			continue
 		}
-		if err := watcher.Add(dir); err != nil {
+		if err := watcher.Add(path); err != nil {
 			if closeErr := watcher.Close(); closeErr != nil {
 				err = fmt.Errorf("%s: %w", closeErr.Error(), err)
 			}


### PR DESCRIPTION
-------

The CNI agent copies CNI binaries to well-known paths on the node, where the CNI subsystem in use will invoke them, if configured.

It then starts a file watch on those paths, and re-copies the binaries if changes are detected, as a self-healing mechanism.

However, the current code watches the *entire* destination directory for change events, not just the Istio-owned files that are copied there - this makes the Istio CNI plugin slightly poorly behaved if other CNI plugins are in the chain, in that Istio's watcher will uselessly fire if non-Istio binaries are copied to the same spot, causing it to redeploy the binaries even if they are unchanged.

This PR changes that behavior so that the watcher only watches the binaries it _actually installs_ in the destination path, rather than _everything_ in the destination path, which is arguably bugged behavior.