### PR TITLE
Support namespace filtering for experimental proxy status

### DIFF
--- a/istioctl/pkg/proxystatus/proxystatus.go
+++ b/istioctl/pkg/proxystatus/proxystatus.go
@@ -230,7 +230,10 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			if err != nil {
 				return err
 			}
-			sw := pilot.XdsStatusWriter{Writer: c.OutOrStdout()}
+			sw := pilot.XdsStatusWriter{
+				Writer:    c.OutOrStdout(),
+				Namespace: ctx.Namespace(),
+			}
 			return sw.PrintAll(xdsResponses)
 		},
 	}

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -148,6 +148,7 @@ func (sg *StatusGen) debugSyncz() model.Resources {
 					Id: con.proxy.ID,
 					Metadata: model.NodeMetadata{
 						ClusterID:    con.proxy.Metadata.ClusterID,
+						Namespace:    con.proxy.Metadata.Namespace,
 						IstioVersion: con.proxy.Metadata.IstioVersion,
 					}.ToStruct(),
 				},

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -427,6 +427,13 @@ func TestXdsProxyStatus(t *testing.T) {
 				}
 				return expectSubstrings(output, "Clusters Match", "Listeners Match", "Routes Match")
 			})
+
+			// test namespace filtering
+			retry.UntilSuccessOrFail(t, func() error {
+				args = []string{"proxy-status", "-n", apps.Namespace.Name()}
+				output, _ = istioCtl.InvokeOrFail(t, args)
+				return expectSubstrings(output, fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()))
+			})
 		})
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
This is to align `experimental proxy-status` with `proxy-status` by enabling namespace filtering. 

TBH I'm not sure why we have two commands doing similar things. Is there anyone who can clarify the intention of this command or the future of it? The logic involved here is quite different from adding a query parameter, given that typeurl does not work like a RESTful API.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
