### PR TITLE
istioctl: remove `create-remote-secret` and `remote-clusters` in experimental

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -253,8 +253,6 @@ debug and diagnose their Istio mesh.
 	// leave the multicluster commands in x for backwards compat
 	rootCmd.AddCommand(remoteSecretCmd)
 	rootCmd.AddCommand(remoteClustersCmd)
-	experimentalCmd.AddCommand(remoteSecretCmd)
-	experimentalCmd.AddCommand(remoteClustersCmd)
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
 		Title:   "Istio Control",

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -248,11 +248,9 @@ debug and diagnose their Istio mesh.
 	hideInheritedFlags(tag.TagCommand(ctx), cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(tagCmd)
 
-	remoteSecretCmd := multicluster.NewCreateRemoteSecretCommand()
-	remoteClustersCmd := proxyconfig.ClustersCommand(ctx)
 	// leave the multicluster commands in x for backwards compat
-	rootCmd.AddCommand(remoteSecretCmd)
-	rootCmd.AddCommand(remoteClustersCmd)
+	rootCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand())
+	rootCmd.AddCommand(proxyconfig.ClustersCommand(ctx))
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
 		Title:   "Istio Control",

--- a/releasenotes/notes/46051.yaml
+++ b/releasenotes/notes/46051.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Removed** the following experimental `istioctl` commands: `create-remote-secret` and `remote-clusters`.
+  They have been moved to the top level `istioctl` command.


### PR DESCRIPTION
**Please provide a description of this PR:**
They have been moved to `istioctl` almost two years ago, and I just submitted https://github.com/istio/istio.io/pull/13589 to update the doc instructions.