### PR TITLE
fix time after memory leak

### DIFF
--- a/pilot/pkg/serviceregistry/util/xdsfake/updater.go
+++ b/pilot/pkg/serviceregistry/util/xdsfake/updater.go
@@ -145,6 +145,8 @@ func (fx *Updater) RemoveShard(shardKey model.ShardKey) {
 
 func (fx *Updater) WaitOrFail(t test.Failer, et string) *Event {
 	t.Helper()
+	delay := time.NewTimer(time.Second * 5)
+	defer delay.Stop()
 	for {
 		select {
 		case e := <-fx.Events:
@@ -153,7 +155,7 @@ func (fx *Updater) WaitOrFail(t test.Failer, et string) *Event {
 			}
 			log.Infof("skipping event %q want %q", e.Type, et)
 			continue
-		case <-time.After(time.Second * 5):
+		case <-delay.C:
 			t.Fatalf("timed out waiting for %v", et)
 		}
 	}
@@ -173,7 +175,8 @@ func (fx *Updater) StrictMatchOrFail(t test.Failer, events ...Event) {
 
 func (fx *Updater) matchOrFail(t test.Failer, strict bool, events ...Event) {
 	t.Helper()
-
+	delay := time.NewTimer(time.Second * 5)
+	defer delay.Stop()
 	for {
 		if len(events) == 0 {
 			return
@@ -200,7 +203,7 @@ func (fx *Updater) matchOrFail(t test.Failer, strict bool, events ...Event) {
 				}
 			}
 			continue
-		case <-time.After(time.Second * 5):
+		case <-delay.C:
 			t.Fatalf("timed out waiting for %v", events)
 		}
 	}

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -713,6 +713,9 @@ func (p *XdsProxy) tapRequest(req *discovery.DiscoveryRequest, timeout time.Dura
 	// Send to Istiod
 	connection.sendRequest(req)
 
+	delay := time.NewTimer(timeout)
+	defer delay.Stop()
+
 	// Wait for expected response or timeout
 	for {
 		select {
@@ -720,7 +723,7 @@ func (p *XdsProxy) tapRequest(req *discovery.DiscoveryRequest, timeout time.Dura
 			if res.TypeUrl == req.TypeUrl {
 				return res, nil
 			}
-		case <-time.After(timeout):
+		case <-delay.C:
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

The underlying Timer is not recovered by the garbage collector until the timer fires. We should not wait long for select using time.After, This will create many timers in memory 