### PR TITLE
Check ztunnel namespace

### DIFF
--- a/cni/pkg/ambient/podutil.go
+++ b/cni/pkg/ambient/podutil.go
@@ -65,7 +65,11 @@ func podHasSidecar(pod *corev1.Pod) bool {
 }
 
 func ztunnelPod(pod *corev1.Pod) bool {
-	return pod.GetLabels()["app"] == "ztunnel"
+	// Short term fix - we may make it customisable later
+	if pod.Namespace == "istio-system" || pod.Namespace == "kube-system" {
+		return pod.GetLabels()["app"] == "ztunnel"
+	}
+	return false
 }
 
 func AnnotateEnrolledPod(client kubernetes.Interface, pod *corev1.Pod) error {


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a quick fix for part of https://github.com/istio/istio/issues/46032 - we may add more customization 
or rules later. 

It prevents use of ztunnel in other namespace - but also avoid the problem of a (malicious or accidental) pod 
having the app=ztunnel label taking over ztunnel.