### PR TITLE
Add output format option to precheck

### DIFF
--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -58,6 +58,7 @@ import (
 func Cmd(ctx cli.Context) *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	var skipControlPlane bool
+	var msgOutputFormat string
 	// cmd represents the upgradeCheck command
 	cmd := &cobra.Command{
 		Use:   "precheck",
@@ -88,7 +89,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			msgs.Add(nsmsgs...)
 			// Print all the messages to stdout in the specified format
 			msgs = msgs.SortedDedupedCopy()
-			output, err := formatting.Print(msgs, formatting.LogFormat, false)
+			output, err := formatting.Print(msgs, msgOutputFormat, false)
 			if err != nil {
 				return err
 			}
@@ -109,6 +110,8 @@ See %s for more information about causes and resolutions.`, url.ConfigAnalysis)
 		},
 	}
 	cmd.PersistentFlags().BoolVar(&skipControlPlane, "skip-controlplane", false, "skip checking the control plane")
+	cmd.PersistentFlags().StringVarP(&msgOutputFormat, "output", "o", formatting.LogFormat,
+		fmt.Sprintf("Output format: one of %v", formatting.MsgOutputFormatKeys))
 	opts.AttachControlPlaneFlags(cmd)
 	return cmd
 }

--- a/releasenotes/notes/46072.yaml
+++ b/releasenotes/notes/46072.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** output format option for `istioctl experimental pre-check` command. Valid options are `log`, `json` or `yaml`.


### PR DESCRIPTION
**Please provide a description of this PR:**
Since precheck is using analyze messages, it can be specified with format option like json,yaml as well to gather more information from the output instead of only logs.