### PR TITLE
Add nodeSelector to ztunnel

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -27,6 +27,8 @@ spec:
         sidecar.istio.io/inject: "false"
 {{ with .Values.podAnnotations -}}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       serviceAccountName: ztunnel
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
**Please provide a description of this PR:**
ztunnel is linux only, so we should have a linux nodeSelector like we do for istio-cni. This will prevent ztunnel from trying to install itself on e.g. Windows nodes