### PR TITLE
allow unresolved gateway addresses

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -81,6 +81,8 @@ type NetworkManager struct {
 	NameCache  *networkGatewayNameCache
 	xdsUpdater XDSUpdater
 
+	// just to ensure NetworkGateways and Unresolved are updated together
+	mu sync.Mutex
 	// embedded NetworkGateways only includes gateways with IPs
 	// hostnames are resolved in control plane (or filtered out if feature is disabled)
 	*NetworkGateways
@@ -154,6 +156,8 @@ func (mgr *NetworkManager) reload() bool {
 	gatewaySet.InsertAll(mgr.env.NetworkGateways()...)
 	resolvedGatewaySet := mgr.resolveHostnameGateways(gatewaySet)
 
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
 	return mgr.NetworkGateways.update(resolvedGatewaySet) || mgr.Unresolved.update(gatewaySet)
 }
 

--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -66,6 +66,14 @@ func (ngh *NetworkGatewaysHandler) NotifyGatewayHandlers() {
 	}
 }
 
+type NetworkGateways struct {
+	mu sync.RWMutex
+	// least common multiple of gateway number of {per network, per cluster}
+	lcm                 uint32
+	byNetwork           map[network.ID][]NetworkGateway
+	byNetworkAndCluster map[networkAndCluster][]NetworkGateway
+}
+
 // NetworkManager provides gateway details for accessing remote networks.
 type NetworkManager struct {
 	env *Environment
@@ -73,12 +81,11 @@ type NetworkManager struct {
 	NameCache  *networkGatewayNameCache
 	xdsUpdater XDSUpdater
 
-	// least common multiple of gateway number of {per network, per cluster}
-	mu                  sync.RWMutex
-	lcm                 uint32
-	byNetwork           map[network.ID][]NetworkGateway
-	byNetworkAndCluster map[networkAndCluster][]NetworkGateway
-	multiNetworkEnabled bool
+	// embedded NetworkGateways only includes gateways with IPs
+	// hostnames are resolved in control plane (or filtered out if feature is disabled)
+	*NetworkGateways
+	// includes all gateways with no DNS resolution or filtering, regardless of feature flags
+	Unresolved *NetworkGateways
 }
 
 // NewNetworkManager creates a new NetworkManager from the Environment by merging
@@ -88,7 +95,13 @@ func NewNetworkManager(env *Environment, xdsUpdater XDSUpdater) (*NetworkManager
 	if err != nil {
 		return nil, err
 	}
-	mgr := &NetworkManager{env: env, NameCache: nameCache, xdsUpdater: xdsUpdater}
+	mgr := &NetworkManager{
+		env:             env,
+		NameCache:       nameCache,
+		xdsUpdater:      xdsUpdater,
+		NetworkGateways: &NetworkGateways{},
+		Unresolved:      &NetworkGateways{},
+	}
 	env.AddNetworksHandler(mgr.reloadGateways)
 	// register to per registry, will be called when gateway service changed
 	env.AppendNetworkGatewayHandler(mgr.reloadGateways)
@@ -99,10 +112,7 @@ func NewNetworkManager(env *Environment, xdsUpdater XDSUpdater) (*NetworkManager
 
 // reloadGateways reloads NetworkGateways and triggers a push if they change.
 func (mgr *NetworkManager) reloadGateways() {
-	mgr.mu.Lock()
-	oldGateways := sets.New(mgr.allGateways()...)
-	changed := !mgr.reload().Equals(oldGateways)
-	mgr.mu.Unlock()
+	changed := mgr.reload()
 
 	if changed && mgr.xdsUpdater != nil {
 		log.Infof("gateways changed, triggering push")
@@ -110,7 +120,7 @@ func (mgr *NetworkManager) reloadGateways() {
 	}
 }
 
-func (mgr *NetworkManager) reload() NetworkGatewaySet {
+func (mgr *NetworkManager) reload() bool {
 	log.Infof("reloading network gateways")
 
 	// Generate a snapshot of the state of gateways by merging the contents of
@@ -142,11 +152,19 @@ func (mgr *NetworkManager) reload() NetworkGatewaySet {
 	// - the internal map of label gateways - these get deleted if the service is deleted, updated if the ip changes etc.
 	// - the computed map from meshNetworks (triggered by reloadNetworkLookup, the ported logic from getGatewayAddresses)
 	gatewaySet.InsertAll(mgr.env.NetworkGateways()...)
-	mgr.multiNetworkEnabled = len(gatewaySet) > 0
+	resolvedGatewaySet := mgr.resolveHostnameGateways(gatewaySet)
 
-	mgr.resolveHostnameGateways(gatewaySet)
+	return mgr.NetworkGateways.update(resolvedGatewaySet) || mgr.Unresolved.update(gatewaySet)
+}
 
-	// Now populate the maps by network and by network+cluster.
+func (gws *NetworkGateways) update(gatewaySet NetworkGatewaySet) bool {
+	gws.mu.Lock()
+	defer gws.mu.Unlock()
+	if gatewaySet.Equals(sets.New(gws.allGateways()...)) {
+		return false
+	}
+
+	// index by network or network+cluster for quick lookup
 	byNetwork := make(map[network.ID][]NetworkGateway)
 	byNetworkAndCluster := make(map[networkAndCluster][]NetworkGateway)
 	for gw := range gatewaySet {
@@ -175,22 +193,24 @@ func (mgr *NetworkManager) reload() NetworkGatewaySet {
 		lcmVal = lcm(lcmVal, num)
 	}
 
-	mgr.lcm = uint32(lcmVal)
-	mgr.byNetwork = byNetwork
-	mgr.byNetworkAndCluster = byNetworkAndCluster
+	gws.lcm = uint32(lcmVal)
+	gws.byNetwork = byNetwork
+	gws.byNetworkAndCluster = byNetworkAndCluster
 
-	return gatewaySet
+	return true
 }
 
-func (mgr *NetworkManager) resolveHostnameGateways(gatewaySet NetworkGatewaySet) {
+// resolveHostnameGateway either resolves or removes gateways that use a non-IP Address
+func (mgr *NetworkManager) resolveHostnameGateways(gatewaySet NetworkGatewaySet) NetworkGatewaySet {
+	resolvedGatewaySet := make(NetworkGatewaySet, len(gatewaySet))
 	// filter the list of gateways to resolve
 	hostnameGateways := map[string][]NetworkGateway{}
 	names := sets.New[string]()
 	for gw := range gatewaySet {
 		if netutil.IsValidIPAddress(gw.Addr) {
+			resolvedGatewaySet.Insert(gw)
 			continue
 		}
-		gatewaySet.Delete(gw)
 		if !features.ResolveHostnameGateways {
 			log.Warnf("Failed parsing gateway address %s from Service Registry. "+
 				"Set RESOLVE_HOSTNAME_GATEWAYS on istiod to enable resolving hostnames in the control plane.",
@@ -202,7 +222,7 @@ func (mgr *NetworkManager) resolveHostnameGateways(gatewaySet NetworkGatewaySet)
 	}
 
 	if !features.ResolveHostnameGateways {
-		return
+		return resolvedGatewaySet
 	}
 	// resolve each hostname
 	for host, addrs := range mgr.NameCache.Resolve(names) {
@@ -216,61 +236,62 @@ func (mgr *NetworkManager) resolveHostnameGateways(gatewaySet NetworkGatewaySet)
 				// copy the base gateway to preserve the port/network, but update with the resolved IP
 				resolvedGw := gw
 				resolvedGw.Addr = resolved
-				gatewaySet.Insert(resolvedGw)
+				resolvedGatewaySet.Insert(resolvedGw)
 			}
 		}
 	}
+	return resolvedGatewaySet
 }
 
-func (mgr *NetworkManager) IsMultiNetworkEnabled() bool {
-	if mgr == nil {
+func (gws *NetworkGateways) IsMultiNetworkEnabled() bool {
+	if gws == nil {
 		return false
 	}
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
-	return mgr.multiNetworkEnabled
+	gws.mu.RLock()
+	defer gws.mu.RUnlock()
+	return len(gws.byNetwork) > 0
 }
 
 // GetLBWeightScaleFactor returns the least common multiple of the number of gateways per network.
-func (mgr *NetworkManager) GetLBWeightScaleFactor() uint32 {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
-	return mgr.lcm
+func (gws *NetworkGateways) GetLBWeightScaleFactor() uint32 {
+	gws.mu.RLock()
+	defer gws.mu.RUnlock()
+	return gws.lcm
 }
 
-func (mgr *NetworkManager) AllGateways() []NetworkGateway {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
-	return mgr.allGateways()
+func (gws *NetworkGateways) AllGateways() []NetworkGateway {
+	gws.mu.RLock()
+	defer gws.mu.RUnlock()
+	return gws.allGateways()
 }
 
-func (mgr *NetworkManager) allGateways() []NetworkGateway {
-	if mgr.byNetwork == nil {
+func (gws *NetworkGateways) allGateways() []NetworkGateway {
+	if gws.byNetwork == nil {
 		return nil
 	}
 	out := make([]NetworkGateway, 0)
-	for _, gateways := range mgr.byNetwork {
+	for _, gateways := range gws.byNetwork {
 		out = append(out, gateways...)
 	}
 	return SortGateways(out)
 }
 
-func (mgr *NetworkManager) GatewaysForNetwork(nw network.ID) []NetworkGateway {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
-	if mgr.byNetwork == nil {
+func (gws *NetworkGateways) GatewaysForNetwork(nw network.ID) []NetworkGateway {
+	gws.mu.RLock()
+	defer gws.mu.RUnlock()
+	if gws.byNetwork == nil {
 		return nil
 	}
-	return mgr.byNetwork[nw]
+	return gws.byNetwork[nw]
 }
 
-func (mgr *NetworkManager) GatewaysForNetworkAndCluster(nw network.ID, c cluster.ID) []NetworkGateway {
-	mgr.mu.RLock()
-	defer mgr.mu.RUnlock()
-	if mgr.byNetwork == nil {
+func (gws *NetworkGateways) GatewaysForNetworkAndCluster(nw network.ID, c cluster.ID) []NetworkGateway {
+	gws.mu.RLock()
+	defer gws.mu.RUnlock()
+	if gws.byNetwork == nil {
 		return nil
 	}
-	return mgr.byNetworkAndCluster[networkAndClusterFor(nw, c)]
+	return gws.byNetworkAndCluster[networkAndClusterFor(nw, c)]
 }
 
 type networkAndCluster struct {

--- a/pilot/pkg/model/network_test.go
+++ b/pilot/pkg/model/network_test.go
@@ -123,8 +123,8 @@ func TestGatewayHostnames(t *testing.T) {
 				return len(env.NetworkManager.AllGateways()) == 0
 			}, retry.Timeout(2*time.Duration(ttl)*time.Second))
 			xdsUpdater.WaitOrFail(t, "xds full")
-			if !env.NetworkManager.IsMultiNetworkEnabled() {
-				t.Fatalf("multi network is not enabled")
+			if env.NetworkManager.IsMultiNetworkEnabled() {
+				t.Fatalf("multi network should not be enabled when there are no gateways")
 			}
 		})
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -920,6 +920,7 @@ func (s *DiscoveryServer) pushStatusHandler(w http.ResponseWriter, req *http.Req
 type PushContextDebug struct {
 	AuthorizationPolicies *model.AuthorizationPolicies
 	NetworkGateways       []model.NetworkGateway
+	UnresolvedGateways    []model.NetworkGateway
 }
 
 // pushContextHandler dumps the current PushContext
@@ -932,6 +933,7 @@ func (s *DiscoveryServer) pushContextHandler(w http.ResponseWriter, req *http.Re
 	push.AuthorizationPolicies = pc.AuthzPolicies
 	if pc.NetworkManager() != nil {
 		push.NetworkGateways = pc.NetworkManager().AllGateways()
+		push.UnresolvedGateways = pc.NetworkManager().Unresolved.AllGateways()
 	}
 
 	writeJSON(w, push, req)

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -379,6 +379,17 @@ func (b *EndpointBuilder) createClusterLoadAssignment(llbOpts []*LocalityEndpoin
 	}
 }
 
+func (b *EndpointBuilder) IsDNSCluster() bool {
+	return b.service != nil && (b.service.Resolution == model.DNSLB || b.service.Resolution == model.DNSRoundRobinLB)
+}
+
+func (b *EndpointBuilder) gateways() *model.NetworkGateways {
+	if b.IsDNSCluster() {
+		return b.push.NetworkManager().Unresolved
+	}
+	return b.push.NetworkManager().NetworkGateways
+}
+
 // buildEnvoyLbEndpoint packs the endpoint based on istio info.
 func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnabled bool) *endpoint.LbEndpoint {
 	addr := util.BuildAddress(e.Address, e.EndpointPort)

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -37,7 +37,7 @@ import (
 // (if gateway exists and its IP is an IP and not a dns name).
 // Information for the mesh networks is provided as a MeshNetwork config map.
 func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoints) []*LocalityEndpoints {
-	if !b.push.NetworkManager().IsMultiNetworkEnabled() {
+	if !b.gateways().IsMultiNetworkEnabled() {
 		// Multi-network is not configured (this is the case by default). Just access all endpoints directly.
 		return endpoints
 	}
@@ -49,7 +49,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 	// Scale all weights by the lcm of gateways per network and gateways per cluster.
 	// This will allow us to more easily spread traffic to the endpoint across multiple
 	// network gateways, increasing reliability of the endpoint.
-	scaleFactor := b.push.NetworkManager().GetLBWeightScaleFactor()
+	scaleFactor := b.gateways().GetLBWeightScaleFactor()
 
 	// Go through all cluster endpoints and add those with the same network as the sidecar
 	// to the result. Also count the number of endpoints per each remote network while
@@ -178,10 +178,10 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 //     where the exported endpoints reside, we ensure that we only send traffic to exported endpoints.
 func (b *EndpointBuilder) selectNetworkGateways(nw network.ID, c cluster.ID) []model.NetworkGateway {
 	// Get the gateways for this network+cluster combination.
-	gws := b.push.NetworkManager().GatewaysForNetworkAndCluster(nw, c)
+	gws := b.gateways().GatewaysForNetworkAndCluster(nw, c)
 	if len(gws) == 0 {
 		// No match for network+cluster, just match the network.
-		gws = b.push.NetworkManager().GatewaysForNetwork(nw)
+		gws = b.gateways().GatewaysForNetwork(nw)
 	}
 	return gws
 }

--- a/releasenotes/notes/46088.yaml
+++ b/releasenotes/notes/46088.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Updated** When using a ServiceEntry with DNS resolution, DNS for multi-network gateways 
+    will be resolved at the proxy instead of in the control plane. 


### PR DESCRIPTION
When the cluster uses DNS resolution, we can just send the hostname rather than doing in-control plane resolution.
I could see an argument that this should only occur when ResolveHostnameGateways is off, but I think it should also be possible to use that for EDS, and this for CDS(DNS)

solves #45506 along with #45733 

