### PR TITLE
tf: fix spelling typos

### DIFF
--- a/pkg/test/echo/server/forwarder/tcp.go
+++ b/pkg/test/echo/server/forwarder/tcp.go
@@ -97,7 +97,7 @@ func (c *tcpProtocol) makeRequest(ctx context.Context, cfg *Config, requestID in
 			return "", err
 		}
 		if string(readBytes) != common.ServerFirstMagicString {
-			return "", fmt.Errorf("did not receive magic sting. Want %q, got %q", common.ServerFirstMagicString, string(readBytes))
+			return "", fmt.Errorf("did not receive magic string. Want %q, got %q", common.ServerFirstMagicString, string(readBytes))
 		}
 	}
 

--- a/pkg/test/framework/components/authz/kube.go
+++ b/pkg/test/framework/components/authz/kube.go
@@ -123,7 +123,7 @@ func newKubeServer(ctx resource.Context, ns namespace.Instance) (server *serverI
 		return
 	}
 
-	// Patch MeshConfig to intall the providers.
+	// Patch MeshConfig to install the providers.
 	err = server.installProviders(ctx)
 	return
 }

--- a/pkg/test/framework/components/cluster/clusterboot/factory_test.go
+++ b/pkg/test/framework/components/cluster/clusterboot/factory_test.go
@@ -102,7 +102,7 @@ func TestBuild(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(clusters) != len(tests) {
-			t.Errorf("expcted %d clusters but built %d", len(tests), len(clusters))
+			t.Errorf("expected %d clusters but built %d", len(tests), len(clusters))
 		}
 	})
 	for _, tc := range tests {

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -111,7 +111,7 @@ type builder struct {
 	// Only the first per-cluster entry for a given config should have a non-nil ref.
 	refs map[cluster.Kind][]*echo.Instance
 	// namespaces caches namespaces by their prefix; used for converting Static namespace from configs into actual
-	// namesapces
+	// namespaces
 	namespaces map[string]namespace.Instance
 	// the set of injection templates for each cluster
 	templates map[string]sets.String

--- a/pkg/test/framework/components/echo/echotest/setup.go
+++ b/pkg/test/framework/components/echo/echotest/setup.go
@@ -75,13 +75,13 @@ func (t *T) SetupForPair(setupFn func(ctx framework.TestContext, from echo.Calle
 
 // SetupForServicePair works similarly to SetupForPair, but the setup function accepts echo.Services, which
 // contains instances for multiple services and should be used in combination with RunForN.
-// The length of dsts services will alyas be N.
+// The length of dsts services will always be N.
 func (t *T) SetupForServicePair(setupFn svcPairSetupFn) *T {
 	t.deploymentPairSetup = append(t.deploymentPairSetup, setupFn)
 	return t
 }
 
-// SetupForDestination is run each time the destination Service (but not destination cluser) changes.
+// SetupForDestination is run each time the destination Service (but not destination cluster) changes.
 func (t *T) SetupForDestination(setupFn dstSetupFn) *T {
 	t.destinationDeploymentSetup = append(t.destinationDeploymentSetup, setupFn)
 	return t

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -545,7 +545,7 @@ spec:
 			return fmt.Errorf("failed customizing cluster.env: %v", err)
 		}
 
-		// push boostrap config as a ConfigMap so we can mount it on our "vm" pods
+		// push bootstrap config as a ConfigMap so we can mount it on our "vm" pods
 		cmData := map[string][]byte{}
 		generatedFiles, err := os.ReadDir(subsetDir)
 		if err != nil {

--- a/pkg/test/framework/components/echo/kube/workload_manager.go
+++ b/pkg/test/framework/components/echo/kube/workload_manager.go
@@ -69,7 +69,7 @@ func newWorkloadManager(ctx resource.Context, cfg echo.Config, handler workloadH
 		}
 	}
 	if grpcInstancePort == 0 {
-		return nil, errors.New("unable fo find GRPC command port")
+		return nil, errors.New("unable to find GRPC command port")
 	}
 
 	m := &workloadManager{

--- a/pkg/test/framework/components/echo/staticvm/instance.go
+++ b/pkg/test/framework/components/echo/staticvm/instance.go
@@ -74,7 +74,7 @@ func newInstance(ctx resource.Context, config echo.Config) (echo.Instance, error
 
 	grpcPort, found := config.Ports.ForProtocol(protocol.GRPC)
 	if !found {
-		return nil, errors.New("unable fo find GRPC command port")
+		return nil, errors.New("unable to find GRPC command port")
 	}
 	workloads, err := newWorkloads(config.StaticAddresses, grpcPort.WorkloadPort, config.TLSSettings, config.Cluster)
 	if err != nil {

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -222,7 +222,7 @@ func parseClusterIndex(index string) (clusterIndex, error) {
 }
 
 // configsVal implements config.Value to allow setting the path as a flag or embedding the topology content
-// in the overal test framework config
+// in the overall test framework config
 type configsVal []cluster.Config
 
 func (c *configsVal) String() string {

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -54,7 +54,7 @@ func getConfigValue(path []string, val map[string]*structpb.Value) *structpb.Val
 				return getConfigValue(path[1:], thisVal.GetStructValue().Fields)
 			}
 			retVal = thisVal
-		case 3: // match somthing like aaa[100]
+		case 3: // match something like aaa[100]
 			thisVal := val[match[1]]
 			// If it is a list and looking for more down the path
 			if thisVal.GetListValue() != nil && len(path) > 1 {

--- a/pkg/test/framework/features/README.md
+++ b/pkg/test/framework/features/README.md
@@ -6,7 +6,7 @@ The features package defines values that are used to track feature coverage at e
 
 ## Labeling a Test
 
-Labeling a test with a feature and scenario allow release managers and others to understand what value this test case is adding.  To label a test, call the Feature() function on the Test Object, with a string identifying the feature and scenario you are testing.  These parameters should be formatted like featurepath.scenariopath, where both feature path and scenario path are dot delimited heirarchies, and the featurepath is a leaf node in features.yaml.  If you are testing a feature whose path does not yet exist in features,yaml, see the next section for how to define one.
+Labeling a test with a feature and scenario allow release managers and others to understand what value this test case is adding.  To label a test, call the Feature() function on the Test Object, with a string identifying the feature and scenario you are testing.  These parameters should be formatted like featurepath.scenariopath, where both feature path and scenario path are dot delimited hierarchies, and the featurepath is a leaf node in features.yaml.  If you are testing a feature whose path does not yet exist in features,yaml, see the next section for how to define one.
 
 ## Adding New Feature Constants
 
@@ -29,7 +29,7 @@ will allow you to label a test with:
 
 where "usability.observability.status" is the feature, and "exist-by-default" is the scenario in the first case, and the second case has no scenario.
 
-The heirarchical nature of feature labels allows us to aggregate data about related feature sets.  To provide for consistent reporting and aggregation, we have defined the top two layers of hierarchy, and ask that you place your feature under these headings.  For more detail on the purpose of each heading, see Top-Level Feature Headings below.  If you feel that none of the existing headings fit your feature, please check with the Test and Release Working Group before adding a new heading.
+The hierarchical nature of feature labels allows us to aggregate data about related feature sets.  To provide for consistent reporting and aggregation, we have defined the top two layers of hierarchy, and ask that you place your feature under these headings.  For more detail on the purpose of each heading, see Top-Level Feature Headings below.  If you feel that none of the existing headings fit your feature, please check with the Test and Release Working Group before adding a new heading.
 
 ## Writing a Test Stub
 

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -149,7 +149,7 @@ features:
     wasm:
       remote-load:
       image-pull-policy:
-  # features releated to the lifecycle of istio installations
+  # features related to the lifecycle of istio installations
   installation:
     operator:
       uninstall_revision:

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -57,7 +57,7 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 		s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "tproxy")
 	}
 	if s.SkipDelta {
-		// TODO we may also want to trigger this if we have an old verion
+		// TODO we may also want to trigger this if we have an old version
 		s.SkipWorkloadClasses = append(s.SkipWorkloadClasses, "delta")
 	}
 	// Allow passing a single CSV flag as well

--- a/pkg/test/loadbalancersim/loadbalancer/edf.go
+++ b/pkg/test/loadbalancersim/loadbalancer/edf.go
@@ -52,7 +52,7 @@ func (pq *priorityQueue) Push(x any) {
 	*pq = append(*pq, entry)
 }
 
-// Pop implements heap.Interface for poping an item from the heap
+// Pop implements heap.Interface for popping an item from the heap
 func (pq *priorityQueue) Pop() any {
 	old := *pq
 	n := len(old)

--- a/pkg/test/loadbalancersim/timer/queue.go
+++ b/pkg/test/loadbalancersim/timer/queue.go
@@ -91,7 +91,7 @@ func (q *Queue) stopTimer() {
 func (q *Queue) resetTimer() {
 	// Below is a separate function to limit the scope of the lock.
 	// We don't want to lock when we modify the timer in case it causes
-	// an immediate callback, which would reaquire the lock.
+	// an immediate callback, which would reacquire the lock.
 	needReset, resetDuration := func() (bool, time.Duration) {
 		q.mutex.Lock()
 		defer q.mutex.Unlock()

--- a/pkg/test/util/retry/retry_test.go
+++ b/pkg/test/util/retry/retry_test.go
@@ -45,7 +45,7 @@ func TestConverge(t *testing.T) {
 			return nil
 		}, Converge(2), Timeout(time.Second*10000), Delay(time.Millisecond))
 		if err != nil {
-			t.Fatalf("expected convergance, but test failed: %v", err)
+			t.Fatalf("expected convergence, but test failed: %v", err)
 		}
 	})
 


### PR DESCRIPTION
This PR fix typos in `pkg/test` directory.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure