### PR TITLE
CDS cache key includes hbone status

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -41,6 +41,7 @@ type clusterCache struct {
 	locality       *core.Locality // identifies the locality the cluster is generated for
 	proxyClusterID string         // identifies the kubernetes cluster a proxy is in
 	proxySidecar   bool           // identifies if this proxy is a Sidecar
+	hbone          bool
 	proxyView      model.ProxyView
 	metadataCerts  *metadataCerts // metadata certificates of proxy
 
@@ -80,6 +81,8 @@ func (t *clusterCache) Key() any {
 	h.Write([]byte(strconv.FormatBool(t.downstreamAuto)))
 	h.Write(Separator)
 	h.Write([]byte(strconv.FormatBool(t.supportsIPv4)))
+	h.Write(Separator)
+	h.Write([]byte(strconv.FormatBool(t.hbone)))
 	h.Write(Separator)
 
 	if t.proxyView != nil {
@@ -171,6 +174,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		proxyClusterID:  cb.clusterID,
 		proxySidecar:    cb.sidecarProxy(),
 		proxyView:       cb.proxyView,
+		hbone:           cb.hbone,
 		http2:           port.Protocol.IsHTTP2(),
 		downstreamAuto:  cb.sidecarProxy() && util.IsProtocolSniffingEnabledForOutboundPort(port),
 		supportsIPv4:    cb.supportsIPv4,


### PR DESCRIPTION
AFAICT this is all that is needed to fix #46081 

* EDS disables caching by setting `needToCompute = true`
* RDS codepath doesn't seem to reference HBONE/Ambient status
* LDS doesn't use cache


If we're nervous that it's not enough, maybe we can do something like

```golang
func (c *clusterCache) Cacheable() bool {
  return !c.hbone
}
```