### PR TITLE
Fix incorrect verify-install deployment count

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -306,13 +306,13 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 				v.reportFailure(kind, name, namespace, err)
 				return err
 			}
+			if namespace == v.istioNamespace && strings.HasPrefix(name, "istio") {
+				istioDeploymentCount++
+			}
 			if err = verifyDeploymentStatus(deployment); err != nil {
 				ivf := istioVerificationFailureError(filename, err)
 				v.reportFailure(kind, name, namespace, ivf)
 				return ivf
-			}
-			if namespace == v.istioNamespace && strings.HasPrefix(name, "istio") {
-				istioDeploymentCount++
 			}
 		case "Job":
 			job := &v1batch.Job{}

--- a/releasenotes/notes/46104.yaml
+++ b/releasenotes/notes/46104.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where `verify-install` has incorrect results when installed deployments are not healthy.


### PR DESCRIPTION
**Please provide a description of this PR:**
When using verify-install and Istiod is not ready, the output results are incorrect:
```
 istioctl verify-install                                         
1 Istio control planes detected, checking --revision "default" only
✔ ClusterRole: istiod-istio-system.istio-system checked successfully
...
✘ Deployment: istiod.istio-system: Istio installation failed, incomplete or does not match "generated from in cluster operator installed-state": waiting for deployment "istiod" rollout to finish: 0 of 1 updated replicas are available
✔ ConfigMap: istio-sidecar-injector.istio-system checked successfully
✔ MutatingWebhookConfiguration: istio-sidecar-injector.istio-system checked successfully
...
Checked 15 custom resource definitions
Checked 0 Istio Deployments  # this should be 1 since it's already been checked.
! No Istio installation found: 1 error occurred: # there is an installation, not no installation
```
```
 ki get po
NAME                     READY   STATUS    RESTARTS   AGE
istiod-84456795b-zh4s9   0/1     Running   0          20h
```

The deployment count should be before reporting errors unless it will be skipped if there are errors.