### PR TITLE
feat(gateways): don't set spec.replicas unless user supplies a real number

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  {{- with .Values.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -75,7 +75,7 @@
       }
     },
     "replicaCount": {
-      "type": "integer"
+      "type": [ "integer", "null" ]
     },
     "resources": {
       "type": "object",

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -3,7 +3,9 @@ name: ""
 # revision declares which revision this gateway is a part of
 revision: ""
 
-replicaCount: 1
+# Controls the spec.replicas setting for the Gateway deployment if set.
+# Otherwise defaults to Kubernetes Deployment default (1).
+replicaCount:
 
 kind: Deployment
 

--- a/releasenotes/notes/46121.yaml
+++ b/releasenotes/notes/46121.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** an issue preventing the gateway chart from being used with a custom HorizontalPodAutoscaler resource.
+
+upgradeNotes:
+  - title: don't set spec.replicas unless user supplies a real number
+    content: |
+      When using the gateway chart, the user had to either pick between
+      explicitly setting `spec.replicas`, or using the chart-supplied
+      `HorizontalPodAutoscaler`. Now `spec.replicas` is only set if
+      `.Values.replicaCount` is supplied by the user and is a valid number.
+      This allows for custom `HorizontalPodAutoscalers` to be used.


### PR DESCRIPTION
**Please provide a description of this PR:**

Many users will need to manage their own `HorizontalPodAutoscaler` configurations for the Gateways to control scale-up and scale-down behaviors. To do this, users have to set `.Values.autoscaling.enabled: false`.

In the current chart setting `.Values.autoscaling.enabled: false` implicitly means setting `spec.replicas: 1` in the Deployment. For most users though who use something like ArgoCD to do deployments, this causes conflicts because their `HorizontalPodAutoscaler` will make changes to the `.spec.replicas` setting ... causing ArgoCD to report a delta between the desired and actual configs.

Given that the default behavior in Kubernetes Deplouyments is that `spec.replicas` defaults to `1` if not supplied ... it seems reasonable to simply not set this default at all unless the user actually specifies a hard-coded `.Values.replicaCount` setting.