### PR TITLE
pilot: fix typos in comments and tests

### DIFF
--- a/pilot/cmd/pilot-agent/metrics/metrics.go
+++ b/pilot/cmd/pilot-agent/metrics/metrics.go
@@ -25,7 +25,7 @@ var (
 	typeTag = monitoring.CreateLabel("type")
 
 	// StartupTime measures the time it takes for the agent to get ready Note: This
-	// is dependant on readiness probes. This means our granularity is correlated to
+	// is dependent on readiness probes. This means our granularity is correlated to
 	// the probing interval.
 	startupTime = monitoring.NewGauge(
 		"startup_duration_seconds",

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -29,7 +29,7 @@ type Probe struct {
 	LocalHostAddr       string
 	AdminPort           uint16
 	receivedFirstUpdate bool
-	// Indicates that Envoy is ready atleast once so that we can cache and reuse that probe.
+	// Indicates that Envoy is ready at least once so that we can cache and reuse that probe.
 	atleastOnceReady bool
 	Context          context.Context
 	// NoEnvoy so we only check config status

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -811,7 +811,7 @@ func fakeNode(r, z, sz string) *core.Node {
 	}
 }
 
-// createOrFail wraps config creation with convience for failing tests
+// createOrFail wraps config creation with convenience for failing tests
 func createOrFail(t test.Failer, store model.ConfigStoreController, cfg config.Config) {
 	if _, err := store.Create(cfg); err != nil {
 		t.Fatalf("failed creating %s/%s: %v", cfg.Namespace, cfg.Name, err)

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -248,7 +248,7 @@ func TestNewServerCertInit(t *testing.T) {
 			} else {
 				if len(c.expCert) != 0 {
 					if !checkCert(t, s, c.expCert, c.expKey) {
-						t.Errorf("Istiod certifiate does not match the expectation")
+						t.Errorf("Istiod certificate does not match the expectation")
 					}
 				} else {
 					if _, err := s.getIstiodCertificate(nil); err == nil {
@@ -317,7 +317,7 @@ func TestReloadIstiodCert(t *testing.T) {
 
 	// Validate that the certs are loaded.
 	if !checkCert(t, s, testcerts.ServerCert, testcerts.ServerKey) {
-		t.Errorf("Istiod certifiate does not match the expectation")
+		t.Errorf("Istiod certificate does not match the expectation")
 	}
 
 	// Update cert/key files.

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -300,7 +300,7 @@ func TestClient(t *testing.T) {
 		retry.UntilSuccessOrFail(t, func() error {
 			cfg := store.Get(r.GroupVersionKind(), name, cfgMeta.Namespace)
 			if cfg == nil {
-				return fmt.Errorf("cfg shouldnt be nil :(")
+				return fmt.Errorf("cfg shouldn't be nil :(")
 			}
 			if !reflect.DeepEqual(cfg.Meta, cfgMeta) {
 				return fmt.Errorf("something is deeply wrong....., %v", cfg.Meta)
@@ -328,7 +328,7 @@ func TestClient(t *testing.T) {
 		retry.UntilSuccessOrFail(t, func() error {
 			cfg := store.Get(r.GroupVersionKind(), name, cfgMeta.Namespace)
 			if cfg == nil {
-				return fmt.Errorf("cfg cant be nil")
+				return fmt.Errorf("cfg can't be nil")
 			}
 			if !reflect.DeepEqual(cfg.Status, stat) {
 				return fmt.Errorf("status %v does not match %v", cfg.Status, stat)

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -854,7 +854,7 @@ func TestExtractGatewayServices(t *testing.T) {
 			gatewayServices: []string{"foo-istio.default.svc.cluster.local"},
 		},
 		{
-			name: "managed gateway with name overrided",
+			name: "managed gateway with name overridden",
 			r:    GatewayResources{Domain: "cluster.local"},
 			kgw: &k8s.GatewaySpec{
 				GatewayClassName: "istio",

--- a/pilot/pkg/credentials/kube/secrets.go
+++ b/pilot/pkg/credentials/kube/secrets.go
@@ -243,7 +243,7 @@ func ExtractCertInfo(scrt *v1.Secret) (certInfo *credentials.CertInfo, err error
 		ret.CRL = scrt.Data[TLSSecretCrl]
 		return ret, nil
 	}
-	// No cert found. Try to generate a helpful error messsage
+	// No cert found. Try to generate a helpful error message
 	if hasKeys(scrt.Data, GenericScrtCert, GenericScrtKey) {
 		return nil, fmt.Errorf("found keys %q and %q, but they were empty", GenericScrtCert, GenericScrtKey)
 	}
@@ -280,7 +280,7 @@ func extractRoot(scrt *v1.Secret) (certInfo *credentials.CertInfo, err error) {
 		ret.CRL = scrt.Data[TLSSecretCrl]
 		return ret, nil
 	}
-	// No cert found. Try to generate a helpful error messsage
+	// No cert found. Try to generate a helpful error message
 	if hasKeys(scrt.Data, GenericScrtCaCert) {
 		return nil, fmt.Errorf("found key %q, but it was empty", GenericScrtCaCert)
 	}

--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
@@ -22,7 +22,7 @@ limitations under the License.
 // A client only acts on timestamps captured locally to infer the state of the
 // leader election. The client does not consider timestamps in the leader
 // election record to be accurate because these timestamps may not have been
-// produced by a local clock. The implemention does not depend on their
+// produced by a local clock. The implementation does not depend on their
 // accuracy and only uses their change to indicate that another client has
 // renewed the leader lease. Thus the implementation is tolerant to arbitrary
 // clock skew, but is not tolerant to arbitrary clock skew rate.

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -283,7 +283,7 @@ func TestLeaderElectionNoPermission(t *testing.T) {
 	// Expect to run once
 	expectInt(t, completions.Load, 1)
 
-	// drop RBAC permssions to update the configmap
+	// drop RBAC permissions to update the configmap
 	// This simulates loosing an active lease
 	allowRbac.Store(false)
 

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -322,7 +322,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantNamespaceMutualTLS: MTLSPermissive,
 		},
 		{
-			name:              "Paritial match workload labels in foo",
+			name:              "Partial match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Instance{"app": "httpbin"},
 			wantRequestAuthn: []*config.Config{
@@ -496,7 +496,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantNamespaceMutualTLS: MTLSUnknown,
 		},
 		{
-			name:              "Paritial match workload labels in foo",
+			name:              "Partial match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Instance{"app": "httpbin"},
 			wantPeerAuthn: []*config.Config{
@@ -610,7 +610,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			},
 		},
 		{
-			name:              "tripple hit",
+			name:              "triple hit",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Instance{"app": "httpbin", "version": "v1"},
 			wantRequestAuthn: []*config.Config{

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1083,7 +1083,7 @@ func ParseIstioVersion(ver string) *IstioVersion {
 	}
 
 	parts := strings.Split(ver, ".")
-	// we are guaranteed to have atleast major and minor based on the regex
+	// we are guaranteed to have at least major and minor based on the regex
 	major, _ := strconv.Atoi(parts[0])
 	minor, _ := strconv.Atoi(parts[1])
 	// Assume very large patch release if not set
@@ -1231,7 +1231,7 @@ func IsPrivilegedPort(port uint32) bool {
 }
 
 func (node *Proxy) IsVM() bool {
-	// TODO use node metadata to indicate that this is a VM intstead of the TestVMLabel
+	// TODO use node metadata to indicate that this is a VM instead of the TestVMLabel
 	return node.Metadata.Labels[constants.TestVMLabel] != ""
 }
 

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -139,7 +139,7 @@ type metricsConfig struct {
 }
 
 type metricConfig struct {
-	// if ture, do not add filter to chain
+	// if true, do not add filter to chain
 	Disabled  bool
 	Overrides []metricsOverride
 }
@@ -547,7 +547,7 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 	return res
 }
 
-// defaul value for metric rotation interval and graceful deletion interval,
+// default value for metric rotation interval and graceful deletion interval,
 // more details can be found in here: https://github.com/istio/proxy/blob/master/source/extensions/filters/http/istio_stats/config.proto#L116
 var (
 	defaultMetricRotationInterval         = 0 * time.Second

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -113,7 +113,7 @@ var (
 		TypedConfig: protoconv.MessageToAny(&reqwithoutquery.ReqWithoutQuery{}),
 	}
 
-	// metadataFormatter configures additional formatters needed for some of the format strings like "METATDATA"
+	// metadataFormatter configures additional formatters needed for some of the format strings like "METADATA"
 	// for more information, see https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/formatter/metadata/v3/metadata.proto
 	metadataFormatter = &core.TypedExtensionConfig{
 		Name:        "envoy.formatter.metadata",

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -515,7 +515,7 @@ func stringMatchConflict(root, leaf *networking.StringMatch) bool {
 			return true
 		}
 	}
-	// If delgate regex match is specified, root should not have other matches.
+	// If delegate regex match is specified, root should not have other matches.
 	if leaf.GetRegex() != "" {
 		if root.GetRegex() != "" || root.GetPrefix() != "" || root.GetExact() != "" {
 			return true

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -2166,11 +2166,11 @@ func TestSelectVirtualService(t *testing.T) {
 	configs := SelectVirtualServices(index, "some-ns", hostsByNamespace)
 	expectedVS := []string{virtualService1.Name, virtualService2.Name, virtualService4.Name, virtualService7.Name}
 	if len(expectedVS) != len(configs) {
-		t.Fatalf("Unexpected virtualService, got %d, epxected %d", len(configs), len(expectedVS))
+		t.Fatalf("Unexpected virtualService, got %d, expected %d", len(configs), len(expectedVS))
 	}
 	for i, config := range configs {
 		if config.Name != expectedVS[i] {
-			t.Fatalf("Unexpected virtualService, got %s, epxected %s", config.Name, expectedVS[i])
+			t.Fatalf("Unexpected virtualService, got %s, expected %s", config.Name, expectedVS[i])
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -830,7 +830,7 @@ func applyOutlierDetection(c *cluster.Cluster, outlier *networking.OutlierDetect
 	// FIXME: we can't distinguish between it being unset or being explicitly set to 0
 	minHealthPercent := outlier.MinHealthPercent
 	if minHealthPercent >= 0 {
-		// When we are sending unhealthy endpoints, we should disble Panic Threshold. Otherwise
+		// When we are sending unhealthy endpoints, we should disable Panic Threshold. Otherwise
 		// Envoy will send traffic to "Unready" pods when the percentage of healthy hosts fall
 		// below minimum health percentage.
 		if features.SendUnhealthyEndpoints.Load() {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -1585,11 +1585,11 @@ func TestSelectVirtualService(t *testing.T) {
 		servicesByName)
 	expectedVS := []string{virtualService1.Name, virtualService2.Name, virtualService4.Name}
 	if len(expectedVS) != len(configs) {
-		t.Fatalf("Unexpected virtualService, got %d, epxected %d", len(configs), len(expectedVS))
+		t.Fatalf("Unexpected virtualService, got %d, expected %d", len(configs), len(expectedVS))
 	}
 	for i, config := range configs {
 		if config.Name != expectedVS[i] {
-			t.Fatalf("Unexpected virtualService, got %s, epxected %s", config.Name, expectedVS[i])
+			t.Fatalf("Unexpected virtualService, got %s, expected %s", config.Name, expectedVS[i])
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1057,7 +1057,7 @@ func TestOutboundListenerConfigWithSidecarHTTPProxy(t *testing.T) {
 			t.Fatalf("expected listener on port %d, but not found", 15080)
 		}
 		if len(l.FilterChains) != 1 {
-			t.Fatalf("expectd %d filter chains, found %d", 1, len(l.FilterChains))
+			t.Fatalf("expected %d filter chains, found %d", 1, len(l.FilterChains))
 		} else {
 			if !isHTTPFilterChain(l.FilterChains[0]) {
 				t.Fatalf("expected http filter chain, found %s", l.FilterChains[1].Filters[0].Name)
@@ -1485,7 +1485,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			}
 		} else if oldestProtocol != protocol.HTTP && oldestProtocol != protocol.TCP {
 			if len(listeners[0].FilterChains) != 1 {
-				t.Fatalf("expectd %d filter chains, found %d", 1, len(listeners[0].FilterChains))
+				t.Fatalf("expected %d filter chains, found %d", 1, len(listeners[0].FilterChains))
 			}
 			if !isHTTPFilterChain(listeners[0].FilterChains[0]) {
 				t.Fatalf("expected http filter chain, found %s", listeners[0].FilterChains[0].Filters[0].Name)
@@ -1499,7 +1499,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
 			if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
-				t.Fatalf("exptected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 					listeners[0].ContinueOnListenerFiltersTimeout,
 					listeners[0].ListenerFiltersTimeout)
 			}
@@ -1513,7 +1513,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			}
 		} else {
 			if len(listeners[0].FilterChains) != 1 {
-				t.Fatalf("expectd %d filter chains, found %d", 1, len(listeners[0].FilterChains))
+				t.Fatalf("expected %d filter chains, found %d", 1, len(listeners[0].FilterChains))
 			}
 			if listeners[0].DefaultFilterChain == nil {
 				t.Fatalf("expected default filter chains, found none")
@@ -1526,7 +1526,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
 			if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
-				t.Fatalf("exptected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 					listeners[0].ContinueOnListenerFiltersTimeout,
 					listeners[0].ListenerFiltersTimeout)
 			}
@@ -1794,7 +1794,7 @@ func verifyListenerFilters(t *testing.T, lfilters []*listener.ListenerFilter) {
 func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain) {
 	t.Helper()
 	if fc.FilterChainMatch.TransportProtocol != xdsfilters.RawBufferTransportProtocol {
-		t.Fatalf("exepct %q transport protocol, found %q", xdsfilters.RawBufferTransportProtocol, fc.FilterChainMatch.TransportProtocol)
+		t.Fatalf("expect %q transport protocol, found %q", xdsfilters.RawBufferTransportProtocol, fc.FilterChainMatch.TransportProtocol)
 	}
 
 	if !reflect.DeepEqual(plaintextHTTPALPNs, fc.FilterChainMatch.ApplicationProtocols) {
@@ -1884,7 +1884,7 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 
 		l := findListenerByPort(listeners, 8080)
 		if len(l.FilterChains) != 1 {
-			t.Fatalf("expectd %d filter chains, found %d", 1, len(l.FilterChains))
+			t.Fatalf("expected %d filter chains, found %d", 1, len(l.FilterChains))
 		}
 		if !isHTTPFilterChain(l.FilterChains[0]) {
 			t.Fatalf("expected http filter chain, found %s", l.FilterChains[0].Filters[0].Name)
@@ -2619,7 +2619,7 @@ func TestOutboundListenerConfig_TCPFailThrough(t *testing.T) {
 		t.Fatalf("failed to find listener")
 	}
 	if len(l.FilterChains) != 1 {
-		t.Fatalf("expectd %d filter chains, found %d", 1, len(l.FilterChains))
+		t.Fatalf("expected %d filter chains, found %d", 1, len(l.FilterChains))
 	}
 
 	verifyHTTPFilterChainMatch(t, l.FilterChains[0])

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1084,7 +1084,7 @@ func GetRouteOperation(in *route.Route, vsName string, port int) string {
 
 	// If there is only one destination cluster in route, return host:port/uri as description of route.
 	// Otherwise there are multiple destination clusters and destination host is not clear. For that case
-	// return virtual serivce name:port/uri as substitute.
+	// return virtual service name:port/uri as substitute.
 	if c := in.GetRoute().GetCluster(); model.IsValidSubsetKey(c) {
 		// Parse host and port from cluster name.
 		_, _, h, p := model.ParseSubsetKey(c)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
@@ -107,7 +107,7 @@ func TestDependentConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "singe parent",
+			name: "single parent",
 			r: Cache{
 				VirtualServices: []config.Config{
 					{

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -429,7 +429,7 @@ func TestMirrorPercent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mp := MirrorPercent(tt.route)
 			if !reflect.DeepEqual(mp, tt.want) {
-				t.Errorf("Unexpected mirro percent want %v, got %v", tt.want, mp)
+				t.Errorf("Unexpected mirror percent want %v, got %v", tt.want, mp)
 			}
 		})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/serviceentry_simulation_test.go
@@ -72,7 +72,7 @@ spec:
 func TestServiceEntry(t *testing.T) {
 	cases := []simulationTest{
 		{
-			name:       "identical CIDR (ignoreing insignificant bits) is dropped",
+			name:       "identical CIDR (ignoring insignificant bits) is dropped",
 			config:     fmt.Sprintf(se, "1234:1f1:123:123:f816:3eff:feb8:2287/32", "1234:1f1:123:123:f816:3eff:febf:57ce/32"),
 			kubeConfig: "",
 			calls: []simulation.Expect{{

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -530,7 +530,7 @@ func testRBAC(t *testing.T, grpcServer *xdsgrpc.GRPCServer, xdsresolver resolver
 }
 
 // From xds_resolver_test
-// testClientConn is a fake implemetation of resolver.ClientConn. All is does
+// testClientConn is a fake implementation of resolver.ClientConn. All is does
 // is to store the state received from the resolver locally and signal that
 // event through a channel.
 type testClientConn struct {

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -151,7 +151,7 @@ func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *mo
 		mode = model.MTLSDisable
 	}
 	if mode == model.MTLSPermissive {
-		// TODO gRPC's filter chain match is super limted - only effective transport_protocol match is "raw_buffer"
+		// TODO gRPC's filter chain match is super limited - only effective transport_protocol match is "raw_buffer"
 		// see https://github.com/grpc/proposal/blob/master/A36-xds-for-servers.md for detail
 		// No need to warn on each push - the behavior is still consistent with auto-mtls, which is the
 		// replacement for permissive.
@@ -241,7 +241,7 @@ func buildInboundFilterChain(node *model.Proxy, push *model.PushContext, nameSuf
 
 // buildRBAC builds the RBAC config expected by gRPC.
 //
-// See: xds/interal/httpfilter/rbac
+// See: xds/internal/httpfilter/rbac
 //
 // TODO: gRPC also supports 'per route override' - not yet clear how to use it, Istio uses path expressions instead and we don't generate
 // vhosts or routes for the inbound listener.

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -464,7 +464,7 @@ func AppendLbEndpointMetadata(istioMetadata *model.EndpointMetadata, envoyMetada
 	// Add compressed telemetry metadata. Note this is a short term solution to make server workload metadata
 	// available at client sidecar, so that telemetry filter could use for metric labels. This is useful for two cases:
 	// server does not have sidecar injected, and request fails to reach server and thus metadata exchange does not happen.
-	// Due to performance concern, telemetry metadata is compressed into a semicolon separted string:
+	// Due to performance concern, telemetry metadata is compressed into a semicolon separated string:
 	// workload-name;namespace;canonical-service-name;canonical-service-revision;cluster-id.
 	if features.EndpointTelemetryLabel {
 		// allow defaulting for non-injected cases

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
@@ -55,7 +55,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 							Ports: []*workloadapi.Port{
 								{
 									ServicePort: 80,
-									TargetPort:  8081, // port is overidden by inlined WE port
+									TargetPort:  8081, // port is overridden by inlined WE port
 								},
 							},
 						},

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -111,7 +111,7 @@ type Options struct {
 	// ClusterID identifies the cluster which the controller communicate with.
 	ClusterID cluster.ID
 
-	// ClusterAliases are aliase names for cluster. When a proxy connects with a cluster ID
+	// ClusterAliases are alias names for cluster. When a proxy connects with a cluster ID
 	// and if it has a different alias we should use that a cluster ID for proxy.
 	ClusterAliases map[string]string
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -299,7 +299,7 @@ func (e *endpointSliceCache) update(hostname host.Name, slice string, endpoints 
 	// from one slice to another See
 	// https://github.com/kubernetes/website/blob/master/content/en/docs/concepts/services-networking/endpoint-slices.md#duplicate-endpoints
 	// In this case, we can always assume and update is fresh, although older slices
-	// we have not gotten updates may be stale; therefor we always take the new
+	// we have not gotten updates may be stale; therefore we always take the new
 	// update.
 	e.endpointsByServiceAndSlice[hostname][slice] = endpoints
 }

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -145,7 +145,7 @@ func (nc *NamespaceController) reconcileCACert(o types.NamespacedName) error {
 		ns = o.Name
 	}
 	if nc.DiscoveryNamespacesFilter != nil && !nc.DiscoveryNamespacesFilter.Filter(ns) {
-		// donot delete the configmap, maybe it is owned by another control plane
+		// do not delete the configmap, maybe it is owned by another control plane
 		return nil
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -553,7 +553,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 		services := s.services.getServices(seNamespacedName)
 		currInstance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 
-		// We chech if the wi is still a subset of se. This would cover Case 1 and Case 2 from above.
+		// We check if the wi is still a subset of se. This would cover Case 1 and Case 2 from above.
 		if labels.Instance(se.WorkloadSelector.Labels).Match(wi.Endpoint.Labels) {
 			// If the workload instance still matches. We take care of the possible events.
 			instances = append(instances, currInstance...)
@@ -726,7 +726,7 @@ func (s *Controller) edsUpdate(instances []*model.ServiceInstance) {
 	s.queueEdsEvent(keys, s.doEdsUpdate)
 }
 
-// edsCacheUpdate upates eds cache serially such that we can prevent allinstances
+// edsCacheUpdate updates eds cache serially such that we can prevent allinstances
 // got at t1 can accidentally override that got at t2 if multiple threads are
 // running this function. Queueing ensures latest updated wins.
 func (s *Controller) edsCacheUpdate(instances []*model.ServiceInstance) {

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -141,7 +141,7 @@ func TestServiceStore(t *testing.T) {
 
 // Tests that when multiple service entries with "DNSRounbRobinLB" resolution type
 // are created with different/same endpoints, we only consider the first service because
-// Envoy's LogicalDNS type of cluster does not allow more than one locality LB Enpoint.
+// Envoy's LogicalDNS type of cluster does not allow more than one locality LB Endpoint.
 func TestServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	store := serviceInstancesStore{
 		ip2instance:            map[string][]*model.ServiceInstance{},

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1083,7 +1083,7 @@ func TestEndpointsDeduping(t *testing.T) {
 // TestEndpointSlicingServiceUpdate is a regression test to ensure we do not end up with duplicate endpoints when a service changes.
 func TestEndpointSlicingServiceUpdate(t *testing.T) {
 	for _, version := range []string{"latest", "20"} {
-		t.Run("kuberentes 1."+version, func(t *testing.T) {
+		t.Run("kubernetes 1."+version, func(t *testing.T) {
 			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
 				KubernetesVersion:    version,
 				EnableFakeXDSUpdater: true,

--- a/pilot/pkg/status/manager.go
+++ b/pilot/pkg/status/manager.go
@@ -74,7 +74,7 @@ func (m *Manager) Start(stop <-chan struct{}) {
 // CreateGenericController provides an interface for a status update function to be
 // called in series with other controllers, minimizing the number of actual
 // api server writes sent from various status controllers.  The UpdateFunc
-// must take the target resrouce status and arbitrary context information as
+// must take the target resource status and arbitrary context information as
 // parameters, and return the updated status value.  Multiple controllers
 // will be called in series, so the input status may not have been written
 // to the API server yet, and the output status may be modified by other

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -706,7 +706,7 @@ func (s *DiscoveryServer) getConfigDumpByResourceType(conn *Connection, req *mod
 				case v3.ExtensionConfigurationType:
 					tce := &core.TypedExtensionConfig{}
 					if err := rr.GetResource().UnmarshalTo(tce); err != nil {
-						istiolog.Warnf("failed to unmarshal extenstion: %v", err)
+						istiolog.Warnf("failed to unmarshal extension: %v", err)
 						continue
 					}
 

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -121,7 +121,7 @@ func TestDeltaEDS(t *testing.T) {
 		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
 	}
 
-	// delete svc, only send eds fot this service
+	// delete svc, only send eds for this service
 	s.MemRegistry.RemoveService(edsIncSvc)
 	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: edsIncSvc, Namespace: ""})})
 

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -138,7 +138,7 @@ type DiscoveryServer struct {
 	// ListRemoteClusters collects debug information about other clusters this istiod reads from.
 	ListRemoteClusters func() []cluster.DebugInfo
 
-	// ClusterAliases are aliase names for cluster. When a proxy connects with a cluster ID
+	// ClusterAliases are alias names for cluster. When a proxy connects with a cluster ID
 	// and if it has a different alias we should use that a cluster ID for proxy.
 	ClusterAliases map[cluster.ID]cluster.ID
 
@@ -612,7 +612,7 @@ func (s *DiscoveryServer) SortedClients() []*Connection {
 	return clients
 }
 
-// AllClients returns all connected clients, per Clients, but additionally includes unintialized connections
+// AllClients returns all connected clients, per Clients, but additionally includes uninitialized connections
 // Warning: callers must take care not to rely on the con.proxy field being set
 func (s *DiscoveryServer) AllClients() []*Connection {
 	s.adsClientsMutex.RLock()

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -348,7 +348,7 @@ func TestGenerate(t *testing.T) {
 }
 
 // TestCaching ensures we don't have cross-proxy cache generation issues. This is split from TestGenerate
-// since it is order dependant.
+// since it is order dependent.
 // Regression test for https://github.com/istio/istio/issues/33368
 func TestCaching(t *testing.T) {
 	s := NewFakeDiscoveryServer(t, FakeOptions{

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -126,7 +126,7 @@ func (sg *StatusGen) debugSyncz() model.Resources {
 
 	for _, con := range sg.Server.Clients() {
 		con.proxy.RLock()
-		// Skip "nodes" without metdata (they are probably istioctl queries!)
+		// Skip "nodes" without metadata (they are probably istioctl queries!)
 		if isProxy(con) || isZtunnel(con) {
 			xdsConfigs := make([]*status.ClientConfig_GenericXdsConfig, 0)
 			for _, stype := range stypes {


### PR DESCRIPTION
This PR fixes spelling typos in comments and tests.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure