### PR TITLE
reduced shortDuration from 1 sec to 10 millis

### DIFF
--- a/pilot/pkg/server/instance_test.go
+++ b/pilot/pkg/server/instance_test.go
@@ -54,7 +54,7 @@ func TestStartWithNoError(t *testing.T) {
 
 func TestRunComponentsAfterStart(t *testing.T) {
 	longDuration := 10 * time.Second
-	shortDuration := 1 * time.Second
+	shortDuration := 10 * time.Millisecond
 	cases := []struct {
 		name  string
 		c     *fakeComponent


### PR DESCRIPTION
**Please provide a description of this PR:**
this PR proposes to change `shortDuration` from 1 second to 10 millis, reducing the execution time from ~1s to 0.02s

contributes to #37555 