### PR TITLE
gateway-api: proper gateway class lookup

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -110,14 +110,27 @@ type classInfo struct {
 
 var classInfos = getClassInfos()
 
-func getClassInfos() map[string]classInfo {
-	m := map[string]classInfo{
-		defaultClassName: {
+var builtinClasses = getBuiltinClasses()
+
+func getBuiltinClasses() map[gateway.ObjectName]gateway.GatewayController {
+	res := map[gateway.ObjectName]gateway.GatewayController{
+		defaultClassName:                 constants.ManagedGatewayController,
+		constants.RemoteGatewayClassName: constants.UnmanagedGatewayController,
+	}
+	if features.EnableAmbientControllers {
+		res[constants.WaypointGatewayClassName] = constants.ManagedGatewayMeshController
+	}
+	return res
+}
+
+func getClassInfos() map[gateway.GatewayController]classInfo {
+	m := map[gateway.GatewayController]classInfo{
+		constants.ManagedGatewayController: {
 			controller:  constants.ManagedGatewayController,
 			description: "The default Istio GatewayClass",
 			templates:   "kube-gateway",
 		},
-		constants.RemoteGatewayClassName: {
+		constants.UnmanagedGatewayController: {
 			// This represents a gateway that our control plane cannot discover directly via the API server.
 			// We shouldn't generate Istio resources for it. We aren't programming this gateway.
 			controller:  constants.UnmanagedGatewayController,
@@ -125,7 +138,7 @@ func getClassInfos() map[string]classInfo {
 		},
 	}
 	if features.EnableAmbientControllers {
-		m[constants.WaypointGatewayClassName] = classInfo{
+		m[constants.ManagedGatewayMeshController] = classInfo{
 			controller:               constants.ManagedGatewayMeshController,
 			description:              "The default Istio waypoint GatewayClass",
 			templates:                "waypoint",
@@ -134,14 +147,6 @@ func getClassInfos() map[string]classInfo {
 	}
 	return m
 }
-
-var knownControllers = func() sets.String {
-	res := sets.New[string]()
-	for _, v := range classInfos {
-		res.Insert(v.controller)
-	}
-	return res
-}()
 
 // NewDeploymentController constructs a DeploymentController and registers required informers.
 // The controller will not start until Run() is called.
@@ -249,17 +254,18 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 		return nil
 	}
 
-	gc := d.gatewayClasses.Get(string(gw.Spec.GatewayClassName), "")
-	if gc != nil {
-		// We found the gateway class, but we do not implement it. Skip
-		if !knownControllers.Contains(string(gc.Spec.ControllerName)) {
-			return nil
-		}
+	var controller gateway.GatewayController
+	if gc := d.gatewayClasses.Get(string(gw.Spec.GatewayClassName), ""); gc != nil {
+		controller = gc.Spec.ControllerName
 	} else {
-		// Didn't find gateway class, and it wasn't an implicitly known one
-		if _, f := classInfos[string(gw.Spec.GatewayClassName)]; !f {
-			return nil
+		if builtin, f := builtinClasses[gw.Spec.GatewayClassName]; f {
+			controller = builtin
 		}
+	}
+	ci, f := classInfos[controller]
+	if !f {
+		log.Debugf("skipping unknown controller %q", controller)
+		return nil
 	}
 
 	// find the tag or revision indicated by the object
@@ -278,16 +284,12 @@ func (d *DeploymentController) Reconcile(req types.NamespacedName) error {
 	// TODO: Here we could check if the tag is set and matches no known tags, and handle that if we are default.
 
 	// Matched class, reconcile it
-	return d.configureIstioGateway(log, *gw)
+	return d.configureIstioGateway(log, *gw, ci)
 }
 
-func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway) error {
+func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gateway.Gateway, gi classInfo) error {
 	// If user explicitly sets addresses, we are assuming they are pointing to an existing deployment.
 	// We will not manage it in this case
-	gi, f := classInfos[string(gw.Spec.GatewayClassName)]
-	if !f {
-		return nil
-	}
 	if gi.templates == "" {
 		log.Debug("skip gateway class without template")
 		return nil

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
@@ -1,0 +1,212 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default-custom
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default-custom
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: default
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        istio.io/gateway-name: default
+        service.istio.io/canonical-name: default-custom
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: JWT_POLICY
+          value: <no value>
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: ISTIO_META_POD_PORTS
+          value: '[]'
+        - name: ISTIO_META_APP_CONTAINERS
+          value: ""
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: default-custom
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/default-custom
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
+        image: test/proxyv2:test
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/credential-uds
+          name: credential-socket
+        - mountPath: /var/run/secrets/workload-spiffe-credentials
+          name: workload-certs
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      serviceAccountName: default-custom
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: credential-socket
+      - emptyDir: {}
+        name: workload-certs
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir: {}
+        name: istio-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+  name: default-custom
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: default
+    uid: null
+spec:
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: default
+  type: LoadBalancer
+---


### PR DESCRIPTION
Today, we don't actually support custom GatewayClass names, violating
the spec. This makes use support them and adds tests.

Thi also improves the test to be more of a blackbox and test more parts
of the code.
