### PR TITLE
Fix HTTP Probe Host propagation

### DIFF
--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -748,8 +748,8 @@ func TestAppProbe(t *testing.T) {
 					HTTPGet: &apimirror.HTTPGetAction{
 						Port: intstr.IntOrString{IntVal: int32(appPort)},
 						Path: "/header",
-						Host: testHostValue,
 						HTTPHeaders: []apimirror.HTTPHeader{
+							{Name: "Host", Value: testHostValue},
 							{Name: testHeader, Value: testHeaderValue},
 						},
 					},

--- a/releasenotes/notes/app-probe-host.yaml
+++ b/releasenotes/notes/app-probe-host.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 46087
+releaseNotes:
+  - |
+    **Fixed** an issue where the `Host` header cannot be set in application probes. This behavior has changed multiple times in recent releases
+    A probe can be optionally configured to have an explicit `Host` set.
+
+    *In Kubernetes without Istio, and the new behavior with Istio*: If host is set, it is used. If not, `POD_IP:PORT`.
+    
+    *In 1.18.0 and prior*: If host is set, it is used. If not, `POD_IP:15020` (the wrong port is set)
+
+    *In 1.18.1 until now*: If host is set, it is ignored (incorrectly). If not, `POD_IP:PORT`.


### PR DESCRIPTION
This PR attempts to finally correctly handle headers in our prober.

This is an alternative to https://github.com/istio/istio/pull/46130/files

Previous attempts (there are many!!!):
* https://github.com/istio/istio/pull/45632
* https://github.com/istio/istio/pull/44297
* https://github.com/istio/istio/pull/31866
* https://github.com/istio/istio/pull/28537
* https://github.com/istio/istio/pull/20371

Fixes https://github.com/istio/istio/issues/46087

Why I think this PR is correct:

Our goal is to give identical behavior as Kubernetes does.
There are 3 cases really

Case 1: no host header explicit set
```yaml
        readinessProbe:
          httpGet:
            path: /healthz
            port: 80
```
Case 2: host header explicit set
```yaml
        readinessProbe:
          httpGet:
            httpHeaders:
            - name: Host
              value: foo
            path: /healthz
            port: 80
```
Case 3: host header explicit set multiple times
```yaml
        readinessProbe:
          httpGet:
            httpHeaders:
            - name: Host
              value: foo
            - name: host
              value: bar
            path: /healthz
            port: 80
```

How different versions behave:

**Kubernetes plain**
Case 1: IP:80
Case 2/3: foo

**This PR**
Case 1: IP:80
Case 2/3: foo

**PR 46130**
Case 1: IP (missing port)
Case 2: foo

**1.18.0**
Case 1: IP:15020 (wrong port)
Case 2: foo

**1.18.1**
Case 1: IP:80 (wrong port)
Case 2: IP:80 (missing the override header)

Still working on a release notes and test, so /hold

