### PR TITLE
Add validation of workload entry identity (#117)

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -206,6 +206,9 @@ func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) err
 				"however WorkloadEntry %s/%s is not found", proxy.Metadata.Namespace, proxy.Metadata.WorkloadEntry)
 		}
 		if health.IsEligibleForHealthStatusUpdates(wle) {
+			if err := ensureProxyCanControlEntry(proxy, wle); err != nil {
+				return err
+			}
 			entryName = wle.Name
 		}
 	}
@@ -224,6 +227,25 @@ func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) err
 		log.Error(err)
 	}
 	return err
+}
+
+// ensureProxyCanControlEntry ensures the connected proxy's identity matches that of the WorkloadEntry it is associating with.
+func ensureProxyCanControlEntry(proxy *model.Proxy, wle *config.Config) error {
+	if !features.ValidateWorkloadEntryIdentity {
+		// Validation disabled, skip
+		return nil
+	}
+	if proxy.VerifiedIdentity == nil {
+		return fmt.Errorf("registration of WorkloadEntry requires a verified identity")
+	}
+	if proxy.VerifiedIdentity.Namespace != wle.Namespace {
+		return fmt.Errorf("registration of WorkloadEntry namespace mismatch: %q vs %q", proxy.VerifiedIdentity.Namespace, wle.Namespace)
+	}
+	spec := wle.Spec.(*v1alpha3.WorkloadEntry)
+	if spec.ServiceAccount != "" && proxy.VerifiedIdentity.ServiceAccount != spec.ServiceAccount {
+		return fmt.Errorf("registration of WorkloadEntry service account mismatch: %q vs %q", proxy.VerifiedIdentity.ServiceAccount, spec.ServiceAccount)
+	}
+	return nil
 }
 
 // onWorkloadConnect creates/updates WorkloadEntry of the connecting workload.
@@ -257,6 +279,9 @@ func (c *Controller) becomeControllerOf(entryName string, proxy *model.Proxy, co
 func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, conTime time.Time) error {
 	wle := c.store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
 	if wle != nil {
+		if err := ensureProxyCanControlEntry(proxy, wle); err != nil {
+			return err
+		}
 		changed, err := c.changeWorkloadEntryStateToConnected(entryName, proxy, conTime)
 		if err != nil {
 			autoRegistrationErrors.Increment()
@@ -278,6 +303,9 @@ func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, conT
 			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
 	}
 	entry := workloadEntryFromGroup(entryName, proxy, groupCfg)
+	if err := ensureProxyCanControlEntry(proxy, entry); err != nil {
+		return err
+	}
 	setConnectMeta(entry, c.instanceID, conTime)
 	_, err := c.store.Create(*entry)
 	if err != nil {

--- a/pilot/pkg/autoregistration/controller_test.go
+++ b/pilot/pkg/autoregistration/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
@@ -70,6 +71,39 @@ var (
 			},
 		},
 		Spec:   tmplA,
+		Status: nil,
+	}
+	wgAWrongNs = config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadGroup,
+			Namespace:        "wrong",
+			Name:             "wg-a",
+			Labels: map[string]string{
+				"grouplabel": "notonentry",
+			},
+		},
+		Spec:   tmplA,
+		Status: nil,
+	}
+	wgWithoutSA = config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadGroup,
+			Namespace:        "a",
+			Name:             "wg-b",
+			Labels: map[string]string{
+				"grouplabel": "notonentry",
+			},
+		},
+		Spec: &v1alpha3.WorkloadGroup{
+			Template: &v1alpha3.WorkloadEntry{
+				Ports:          map[string]uint32{"http": 80},
+				Labels:         map[string]string{"app": "a"},
+				Network:        "nw0",
+				Locality:       "reg0/zone0/subzone0",
+				Weight:         1,
+				ServiceAccount: "",
+			},
+		},
 		Status: nil,
 	}
 	weB = config.Config{
@@ -133,13 +167,13 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 
 	n := fakeNode("reg1", "zone1", "subzone1")
 
-	p := fakeProxy("1.2.3.4", wgA, "nw1")
+	p := fakeProxy("1.2.3.4", wgA, "nw1", "sa-a")
 	p.Locality = n.Locality
 
-	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
+	p2 := fakeProxy("1.2.3.4", wgA, "nw2", "sa-a")
 	p2.Locality = n.Locality
 
-	p3 := fakeProxy("1.2.3.5", wgA, "nw1")
+	p3 := fakeProxy("1.2.3.5", wgA, "nw1", "sa-a")
 	p3.Locality = n.Locality
 
 	// allows associating a Register call with Unregister
@@ -218,7 +252,37 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 			return checkNoEntry(store, wgA, p3)
 		}, retry.Timeout(time.Until(time.Now().Add(21*features.WorkloadEntryCleanupGracePeriod))))
 	})
+	t.Run("unverified client", func(t *testing.T) {
+		p := fakeProxy("1.2.3.6", wgA, "nw1", "")
 
+		// Should fail
+		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		checkNoEntryOrFail(t, store, wgA, p)
+	})
+	t.Run("wrong SA client", func(t *testing.T) {
+		p := fakeProxy("1.2.3.6", wgA, "nw1", "wrong")
+
+		// Should fail
+		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		checkNoEntryOrFail(t, store, wgA, p)
+	})
+	t.Run("wrong NS client", func(t *testing.T) {
+		p := fakeProxy("1.2.3.6", wgA, "nw1", "sa-a")
+		p.Metadata.Namespace = "wrong"
+
+		// Should fail
+		assert.Error(t, c1.RegisterWorkload(p, time.Now()))
+		checkNoEntryOrFail(t, store, wgA, p)
+	})
+	t.Run("no SA WG", func(t *testing.T) {
+		p := fakeProxy("1.2.3.6", wgWithoutSA, "nw1", "sa-a")
+		n := fakeNode("reg0", "zone0", "subzone0")
+		p.Locality = n.Locality
+
+		// Should fail
+		assert.NoError(t, c1.RegisterWorkload(p, time.Now()))
+		checkEntryOrFail(t, store, wgWithoutSA, p, n, c1.instanceID)
+	})
 	// TODO test garbage collection if pilot stops before disconnect meta is set (relies on heartbeat)
 }
 
@@ -227,7 +291,7 @@ func TestUpdateHealthCondition(t *testing.T) {
 	ig, ig2, store := setup(t)
 	go ig.Run(stop)
 	go ig2.Run(stop)
-	p := fakeProxy("1.2.3.4", wgA, "litNw")
+	p := fakeProxy("1.2.3.4", wgA, "litNw", "sa-a")
 	ig.RegisterWorkload(p, time.Now())
 	t.Run("auto registered healthy health", func(t *testing.T) {
 		ig.QueueWorkloadEntryHealth(p, HealthEvent{
@@ -269,7 +333,7 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 			},
 		},
 	}
-	proxy := fakeProxy("10.0.0.1", group, "nw1")
+	proxy := fakeProxy("10.0.0.1", group, "nw1", "sa")
 	proxy.Labels[model.LocalityLabel] = "rgn2/zone2/subzone2"
 	proxy.XdsNode = fakeNode("rgn2", "zone2", "subzone2")
 	proxy.Locality = proxy.XdsNode.Locality
@@ -564,6 +628,8 @@ func setup(t *testing.T) (*Controller, *Controller, model.ConfigStoreController)
 	c1 := NewController(store, "pilot-1", time.Duration(math.MaxInt64))
 	c2 := NewController(store, "pilot-2", time.Duration(math.MaxInt64))
 	createOrFail(t, store, wgA)
+	createOrFail(t, store, wgAWrongNs)
+	createOrFail(t, store, wgWithoutSA)
 	return c1, c2, store
 }
 
@@ -685,6 +751,23 @@ func checkEntryOrFailAfter(
 	checkEntryOrFail(t, store, wg, proxy, node, connectedTo)
 }
 
+func checkNoEntryOrFail(
+	t test.Failer,
+	store model.ConfigStoreController,
+	wg config.Config,
+	proxy *model.Proxy,
+) {
+	name := wg.Name + "-" + proxy.IPAddresses[0]
+	if proxy.Metadata.Network != "" {
+		name += "-" + string(proxy.Metadata.Network)
+	}
+
+	cfg := store.Get(gvk.WorkloadEntry, name, wg.Namespace)
+	if cfg != nil {
+		t.Fatalf("workload entry found when it was not expected")
+	}
+}
+
 func checkNoEntryHealth(store model.ConfigStoreController, proxy *model.Proxy) error {
 	name := proxy.WorkloadEntryName
 	cfg := store.Get(gvk.WorkloadEntry, name, proxy.Metadata.Namespace)
@@ -773,10 +856,15 @@ func checkNonAutoRegisteredEntryOrFail(t test.Failer, store model.ConfigStoreCon
 	}
 }
 
-func fakeProxy(ip string, wg config.Config, nw network.ID) *model.Proxy {
+func fakeProxy(ip string, wg config.Config, nw network.ID, sa string) *model.Proxy {
+	var id *spiffe.Identity
+	if wg.Namespace != "" && sa != "" {
+		id = &spiffe.Identity{Namespace: wg.Namespace, ServiceAccount: sa}
+	}
 	return &model.Proxy{
-		IPAddresses: []string{ip},
-		Labels:      map[string]string{"merge": "me"},
+		IPAddresses:      []string{ip},
+		Labels:           map[string]string{"merge": "me"},
+		VerifiedIdentity: id,
 		Metadata: &model.NodeMetadata{
 			AutoRegisterGroup: wg.Name,
 			Namespace:         wg.Namespace,
@@ -789,8 +877,9 @@ func fakeProxy(ip string, wg config.Config, nw network.ID) *model.Proxy {
 func fakeProxySuitableForHealthChecks(wle config.Config) *model.Proxy {
 	wleSpec := wle.Spec.(*v1alpha3.WorkloadEntry)
 	return &model.Proxy{
-		ID:          wle.Name + "." + wle.Namespace,
-		IPAddresses: []string{wleSpec.Address},
+		ID:               wle.Name + "." + wle.Namespace,
+		IPAddresses:      []string{wleSpec.Address},
+		VerifiedIdentity: &spiffe.Identity{Namespace: wle.Namespace, ServiceAccount: "my-sa"},
 		Metadata: &model.NodeMetadata{
 			Namespace: wle.Namespace,
 			Network:   network.ID(wleSpec.Network),

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -659,6 +659,11 @@ var (
 	EnableControllerQueueMetrics = env.Register("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
 		"If enabled, publishes metrics for queue depth, latency and processing times.").Get()
 
+	ValidateWorkloadEntryIdentity = env.Register("ISTIO_WORKLOAD_ENTRY_VALIDATE_IDENTITY", true,
+		"If enabled, will validate the identity of a workload matches the identity of the "+
+			"WorkloadEntry it is associating with for health checks and auto registration. "+
+			"This flag is added for backwards compatibility only and will be removed in future releases").Get()
+
 	JwksResolverInsecureSkipVerify = env.Register("JWKS_RESOLVER_INSECURE_SKIP_VERIFY", false,
 		"If enabled, istiod will skip verifying the certificate of the JWKS server.").Get()
 )

--- a/pilot/pkg/xds/vm_test.go
+++ b/pilot/pkg/xds/vm_test.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -30,6 +32,8 @@ import (
 // TestRegistration is an e2e test for registration. Most tests are in autoregister package, but this
 // exercises the full XDS flow.
 func TestRegistration(t *testing.T) {
+	// TODO: allow fake XDS to be "authenticated"
+	test.SetForTest(t, &features.ValidateWorkloadEntryIdentity, false)
 	ds := NewFakeDiscoveryServer(t, FakeOptions{})
 	ds.Store().Create(config.Config{
 		Meta: config.Meta{

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -483,15 +483,17 @@ func (a *ADSC) reconnect() {
 	a.mutex.RUnlock()
 
 	err := a.Run()
-	if err == nil {
-		a.cfg.BackoffPolicy.Reset()
-	} else {
+	if err != nil {
 		// TODO: fix reconnect
 		time.AfterFunc(a.cfg.BackoffPolicy.NextBackOff(), a.reconnect)
 	}
 }
 
 func (a *ADSC) handleRecv() {
+	// We connected, so reset the backoff
+	if a.cfg.BackoffPolicy != nil {
+		a.cfg.BackoffPolicy.Reset()
+	}
 	for {
 		var err error
 		msg, err := a.stream.Recv()

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/status"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -99,6 +100,8 @@ func TestXdsProxyBasicFlow(t *testing.T) {
 
 // Validates the proxy health checking updates
 func TestXdsProxyHealthCheck(t *testing.T) {
+	// TODO: allow fake XDS to be "authenticated"
+	test.SetForTest(t, &features.ValidateWorkloadEntryIdentity, false)
 	healthy := &discovery.DiscoveryRequest{TypeUrl: v3.HealthInfoType}
 	unhealthy := &discovery.DiscoveryRequest{
 		TypeUrl: v3.HealthInfoType,


### PR DESCRIPTION
(cherry picked from commit b6eefaf3045227431b60384002e5b0c57740288d) (cherry picked from commit 0183f2886bc078e8df4d6bbd21fa452a3a23481d)
This is a cherrypick from a CVE release. This is its first time on master. Feel free to suggest changes, but not this is already merged + shipped on all release branches so its a bit atypical