### PR TITLE
Fix tracing in postsubmit tests

### DIFF
--- a/common/scripts/tracing.sh
+++ b/common/scripts/tracing.sh
@@ -35,7 +35,7 @@ function tracing::extract_prow_trace() {
 
 function _genattrs() {
   # No upstream standard, so copy from https://github.com/jenkinsci/opentelemetry-plugin/blob/master/docs/job-traces.md
-  if [[ -n "${PULL_NUMBER}" ]]
+  if [[ -n "${PULL_NUMBER:-}" ]]
   then
     url="https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID},"
   else

--- a/common/scripts/tracing.sh
+++ b/common/scripts/tracing.sh
@@ -35,7 +35,7 @@ function tracing::extract_prow_trace() {
 
 function _genattrs() {
   # No upstream standard, so copy from https://github.com/jenkinsci/opentelemetry-plugin/blob/master/docs/job-traces.md
-  if [[ -n "${PULL_NUMBER:-}" ]]
+  if [[ -n "${PULL_NUMBER:=}" ]]
   then
     url="https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID},"
   else
@@ -48,7 +48,7 @@ function _genattrs() {
     "ci.pipeline.run.id=${PROW_JOB_ID},"\
     "ci.pipeline.run.repo=${REPO_OWNER}/${REPO_NAME},"\
     "ci.pipeline.run.base=${PULL_BASE_REF},"\
-    "ci.pipeline.run.pull_number=${PULL_NUMBER:-none},"\
+    "ci.pipeline.run.pull_number=${PULL_NUMBER},"\
     "ci.pipeline.run.pull_sha=${PULL_PULL_SHA:-${PULL_BASE_SHA:-none}}"
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Should be the last pass of this.

I tested with the following script (key was setting nonuser to get the failure we are seeing before the fix):
```
#!/bin/bash
set -o nounset

  if [[ -n "${PULL_NUMBER:-}" ]]
   then
    set +o nounset
    url="https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID},"
  else
    set +o nounset
    url="https://prow.istio.io/view/gs/istio-prow/pr-logs/${JOB_NAME}/${BUILD_ID},"
  fi
set -o nounset
echo ${url}

  echo "ci.pipeline.run.pull_number=${PULL_NUMBER:-none},"
```