### PR TITLE
Fix log format for non sidecar type in CNI

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -284,7 +284,7 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 	}
 
 	if pi.ProxyType != "" && pi.ProxyType != "sidecar" {
-		log.Infof("excluded %s/%s because it has proxy type %s", podNamespace, podName, pi.ProxyType)
+		log.Infof("excluded %s/%s pod because it has proxy type %s", podNamespace, podName, pi.ProxyType)
 		return nil
 	}
 

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -284,7 +284,7 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 	}
 
 	if pi.ProxyType != "" && pi.ProxyType != "sidecar" {
-		log.Infof("excluded because it has proxy type %v", podNamespace, podName, pi.ProxyType)
+		log.Infof("excluded %s/%s because it has proxy type %s", podNamespace, podName, pi.ProxyType)
 		return nil
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Current istio-cni prints the following log message:

```
$ kubectl logs -n istio-system istio-cni-node-95f24
   ...
2023-07-27T03:08:35.936079Z	info	cni	excluded because it has proxy type istio-system%!(EXTRA string=ztunnel-9fgjp, string=ztunnel)
```

It is obviously contains wrong log format. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Networking