### PR TITLE
Fix ztunnel is not being pruned during uninstall if installed with `manifest generate`

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -4,7 +4,10 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- .Values.labels | toYaml | nindent 4}}
+    {{ with .Values.labels -}}{{ toYaml . | indent 4 }}{{ end }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Ztunnel"
+    istio.io/rev: {{ .Values.revision | default "default" }}
   annotations:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -10,7 +10,10 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- .Values.labels | toYaml | nindent 4}}
+    {{ with .Values.labels -}}{{ toYaml . | indent 4 }}{{ end }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Ztunnel"
+    istio.io/rev: {{ .Values.revision | default "default" }}
   annotations:
     {{- .Values.annotations | toYaml | nindent 4 }}
 ---

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -59,3 +59,9 @@ redirectMode: "iptables"
 # 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
 # Default K8S value is 30 seconds
 terminationGracePeriodSeconds: 30
+
+# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
+revision: ""
+
+# For Helm compatibility.
+ownerName: ""

--- a/releasenotes/notes/46204.yaml
+++ b/releasenotes/notes/46204.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where Ztunnel component was not being pruned during the uninstallation process, when the Istio
+  is applied using the `istioctl manifest generate` command.


### PR DESCRIPTION
**Please provide a description of this PR:**
This is inconsistent with other components.

This copy&paste the logic from istio-cni.