### PR TITLE
Mark validate referential flag as hidden because of no usage

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -422,7 +422,7 @@ func NewValidateCommand(ctx cli.Context) *cobra.Command {
 	flags := c.PersistentFlags()
 	flags.StringSliceVarP(&filenames, "filename", "f", nil, "Inputs of files to validate")
 	flags.BoolVarP(&referential, "referential", "x", true, "Enable structural validation for policy and telemetry")
-	flags.MarkHidden("referential")
+	_ = flags.MarkHidden("referential")
 	return c
 }
 

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -422,7 +422,7 @@ func NewValidateCommand(ctx cli.Context) *cobra.Command {
 	flags := c.PersistentFlags()
 	flags.StringSliceVarP(&filenames, "filename", "f", nil, "Inputs of files to validate")
 	flags.BoolVarP(&referential, "referential", "x", true, "Enable structural validation for policy and telemetry")
-
+	flags.MarkHidden("referential")
 	return c
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
The flag is not being used anywhere in the project, and I guess it's been related to the mixer migration.