### PR TITLE
monitoring: set otel logger

### DIFF
--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -32,8 +32,16 @@ import (
 	"istio.io/istio/pkg/slices"
 )
 
-var meter = func() api.Meter {
-	return otel.GetMeterProvider().Meter("istio")
+var (
+	meter = func() api.Meter {
+		return otel.GetMeterProvider().Meter("istio")
+	}
+
+	monitoringLogger = log.RegisterScope("monitoring", "metrics monitoring")
+)
+
+func init() {
+	otel.SetLogger(log.NewLogrAdapter(monitoringLogger))
 }
 
 // RegisterPrometheusExporter sets the global metrics handler to the provided Prometheus registerer and gatherer.


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes: https://github.com/istio/istio/issues/46142

cc @howardjohn 

after:

```
2023-07-27T15:49:37.987712Z	error	monitoring	aggregation: explicit bucket histogram: non-monotonic boundaries: [0.005 0.001 0.01 0.1 1 5]: not using aggregation with view	criteria={dns_upstream_request_duration_seconds  0  {  } []} mask={   {[0.005 0.001 0.01 0.1 1 5] false} <nil>}
```