### PR TITLE
remove  gatewayclass since its already present

### DIFF
--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -252,14 +252,6 @@ func UnmanagedGatewayTest(t framework.TestContext) {
 		false, t.Clusters().Configs()...)
 
 	t.ConfigIstio().
-		YAML("", `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: istio
-spec:
-  controllerName: istio.io/gateway-controller
-`).
 		YAML("", fmt.Sprintf(`
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway


### PR DESCRIPTION
This check happens in https://github.com/istio/istio/blob/8f378324c05a945ab1cceafe714e79546c91dd85/pkg/test/framework/components/crd/gateway.go#L68 while deploying the APIs. There is also a subtest to check the status.

**Please provide a description of this PR:**