### PR TITLE
Cleanup listener generation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -531,7 +531,7 @@ func (configgen *ConfigGeneratorImpl) buildClustersFromServiceInstances(cb *Clus
 				},
 			}
 		})
-		localCluster := cb.buildInboundClusterForPortOrUDS(epPort, bind, proxy, services[0], services)
+		localCluster := cb.buildInboundCluster(epPort, bind, proxy, services[0], services)
 		// If inbound cluster match has service, we should see if it matches with any host name across all instances.
 		hosts := make([]host.Name, 0, len(instances))
 		for _, si := range instances {
@@ -638,7 +638,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, p
 				TargetPort:  uint32(port),
 			},
 		}
-		localCluster := cb.buildInboundClusterForPortOrUDS(int(ingressListener.Port.Number), endpointAddress, proxy, endpoint, nil)
+		localCluster := cb.buildInboundCluster(int(ingressListener.Port.Number), endpointAddress, proxy, endpoint, nil)
 		clusters = cp.conditionallyAppend(clusters, []host.Name{endpoint.Service.Hostname}, localCluster.build())
 	}
 	return clusters

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -442,14 +442,14 @@ type ServiceTarget struct {
 	Port    ServiceInstancePort
 }
 
-// buildInboundClusterForPortOrUDS constructs a single inbound cluster. The cluster will be bound to
+// buildInboundCluster constructs a single inbound cluster. The cluster will be bound to
 // `inbound|clusterPort||`, and send traffic to <bind>:<instance.Endpoint.EndpointPort>. A workload
 // will have a single inbound cluster per port. In general this works properly, with the exception of
 // the Service-oriented DestinationRule, and upstream protocol selection. Our documentation currently
 // requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
 // Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however,
 // Sidecar.Ingress allows these to be different.
-func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind string,
+func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 	proxy *model.Proxy, instance ServiceTarget, inboundServices []ServiceTarget,
 ) *clusterWrapper {
 	clusterName := model.BuildInboundSubsetKey(clusterPort)

--- a/pilot/pkg/networking/core/v1alpha3/filterchain_options.go
+++ b/pilot/pkg/networking/core/v1alpha3/filterchain_options.go
@@ -15,7 +15,6 @@
 package v1alpha3
 
 import (
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -172,8 +171,6 @@ var (
 			TransportProtocol: xdsfilters.RawBufferTransportProtocol,
 		},
 	}
-
-	emptyFilterChainMatch = &listener.FilterChainMatch{}
 )
 
 // getTLSFilterChainMatchOptions returns the FilterChainMatchOptions that should be used based on mTLS mode and protocol

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -517,9 +517,10 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 }
 
 func finalizeOutboundListeners(lb *ListenerBuilder, listenerMap map[string]*outboundListenerEntry) []*listener.Listener {
-	fallthroughNetworkFilters := buildOutboundCatchAllNetworkFiltersOnly(lb.push, lb.node)
 	listeners := make([]*listener.Listener, 0, len(listenerMap))
 	for _, le := range listenerMap {
+		// TODO: this could be outside the loop, but we would get object sharing in EnvoyFilter patches.
+		fallthroughNetworkFilters := buildOutboundCatchAllNetworkFiltersOnly(lb.push, lb.node)
 		l := buildListenerFromEntry(lb, le, fallthroughNetworkFilters)
 		listeners = append(listeners, l)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -28,7 +28,6 @@ import (
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/durationpb"
-	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -50,6 +49,7 @@ import (
 	secconst "istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/slices"
 	netutil "istio.io/istio/pkg/util/net"
+	"istio.io/istio/pkg/util/sets"
 )
 
 const (
@@ -67,11 +67,6 @@ const (
 	// AutoOverTCP represents incoming AUTO existing TCP
 	AutoOverTCP
 )
-
-// MutableListener represents a listener that is being built.
-type MutableListener struct {
-	istionetworking.MutableObjects
-}
 
 // A set of pre-allocated variables related to protocol sniffing logic for
 // propagating the ALPN to upstreams
@@ -242,13 +237,38 @@ func enableHTTP10(enableFlag string) bool {
 	return enableFlag == "1"
 }
 
+type listenerBinding struct {
+	// binds contains a list of all addresses this listener should bind to. The first one in the list is considered the primary
+	binds []string
+	// bindToPort determines whether this binds to a real port. If so, it becomes a real linux-level listener. Otherwise,
+	// it is just a synthetic listener for matching with original_dst
+	bindToPort bool
+}
+
+// Primary returns the primary bind, or empty if there is none
+func (l listenerBinding) Primary() string {
+	if len(l.binds) == 0 {
+		return ""
+	}
+	return l.binds[0]
+}
+
+// Extra returns any additional bindings. This is always empty if dual stack is disabled
+func (l listenerBinding) Extra() []string {
+	if !features.EnableDualStack || len(l.binds) == 1 {
+		return nil
+	}
+	return l.binds[1:]
+}
+
 type outboundListenerEntry struct {
-	services    []*model.Service
 	servicePort *model.Port
-	bind        string
-	listener    *listener.Listener
-	locked      bool
-	protocol    protocol.Instance
+
+	bind listenerBinding
+
+	locked   bool
+	chains   []*filterChainOpts
+	protocol protocol.Instance
 }
 
 func protocolName(p protocol.Instance) string {
@@ -267,28 +287,19 @@ type outboundListenerConflict struct {
 	node            *model.Proxy
 	listenerName    string
 	currentProtocol protocol.Instance
-	currentServices []*model.Service
 	newHostname     host.Name
 	newProtocol     protocol.Instance
 }
 
 func (c outboundListenerConflict) addMetric(metrics model.Metrics) {
-	currentHostnames := make([]string, len(c.currentServices))
-	for i, s := range c.currentServices {
-		currentHostnames[i] = string(s.Hostname)
-	}
-	concatHostnames := strings.Join(currentHostnames, ",")
 	metrics.AddMetric(c.metric,
 		c.listenerName,
 		c.node.ID,
-		fmt.Sprintf("Listener=%s Accepted%s=%s Rejected%s=%s %sServices=%d",
+		fmt.Sprintf("Listener=%s Accepted=%s Rejected=%s (%s)",
 			c.listenerName,
 			protocolName(c.currentProtocol),
-			concatHostnames,
 			protocolName(c.newProtocol),
-			c.newHostname,
-			protocolName(c.currentProtocol),
-			len(c.currentServices)))
+			c.newHostname))
 }
 
 // buildSidecarOutboundListeners generates http and tcp listeners for
@@ -300,7 +311,6 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 
 	actualWildcards, actualLocalHosts := getWildcardsAndLocalHost(node.GetIPMode())
 
-	var tcpListeners, httpListeners []*listener.Listener
 	// For conflict resolution
 	listenerMap := make(map[string]*outboundListenerEntry)
 
@@ -322,11 +332,11 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 		services := egressListener.Services()
 		virtualServices := egressListener.VirtualServices()
 
+		bind := listenerBinding{}
 		// determine the bindToPort setting for listeners
-		bindToPort := false
 		if noneMode {
 			// do not care what the listener's capture mode setting is. The proxy does not use iptables
-			bindToPort = true
+			bind.bindToPort = true
 		} else if egressListener.IstioListener != nil {
 			if egressListener.IstioListener.CaptureMode == networking.CaptureMode_NONE {
 				// proxy uses iptables redirect or tproxy. IF mode is not set
@@ -334,12 +344,12 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 				// listener's capture mode specifies NONE, then the proxy wants
 				// this listener alone to be on a physical port. If the
 				// listener's capture mode is default, then its same as
-				// iptables i.e. bindToPort is false.
-				bindToPort = true
+				// iptables i.e. BindToPort is false.
+				bind.bindToPort = true
 			} else if strings.HasPrefix(egressListener.IstioListener.Bind, model.UnixAddressPrefix) {
 				// If the bind is a Unix domain socket, set bindtoPort to true as it makes no
 				// sense to have ORIG_DST listener for unix domain socket listeners.
-				bindToPort = true
+				bind.bindToPort = true
 			}
 		}
 
@@ -358,11 +368,10 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 		// If captureMode is not NONE, i.e., bindToPort is false, then
 		// we will bind to user specified IP (if any) or to the VIPs of services in
 		// this egress listener.
-		var bind string
 		if egressListener.IstioListener != nil && egressListener.IstioListener.Bind != "" {
-			bind = egressListener.IstioListener.Bind
-		} else if bindToPort {
-			bind = actualLocalHosts[0]
+			bind.binds = []string{egressListener.IstioListener.Bind}
+		} else if bind.bindToPort {
+			bind.binds = actualLocalHosts
 		}
 
 		if egressListener.IstioListener != nil &&
@@ -375,7 +384,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 			// that will route to a proper Service.
 
 			// Skip ports we cannot bind to
-			if !node.CanBindToPort(bindToPort, egressListener.IstioListener.Port.Number) {
+			if !node.CanBindToPort(bind.bindToPort, egressListener.IstioListener.Port.Number) {
 				log.Warnf("buildSidecarOutboundListeners: skipping privileged sidecar port %d for node %s as it is an unprivileged proxy",
 					egressListener.IstioListener.Port.Number, node.ID)
 				continue
@@ -387,43 +396,24 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 				Name:     egressListener.IstioListener.Port.Name,
 			}
 
-			if conflictWithStaticListener(node, bind, listenPort.Port, listenPort.Protocol) {
+			if conflictWithStaticListener(node, bind.Primary(), listenPort.Port, listenPort.Protocol) {
 				log.Warnf("buildSidecarOutboundListeners: skipping sidecar port %d for node %s as it conflicts with static listener",
 					egressListener.IstioListener.Port.Number, node.ID)
 				continue
 			}
 
-			var extraBind []string
-			if egressListener.IstioListener.Bind == "" {
-				if bindToPort {
-					// the first local host would be the binding address and
-					// the rest would be the additional addresses
-					if len(actualLocalHosts) > 1 {
-						extraBind = actualLocalHosts[1:]
-					}
-				} else {
-					// the first wildcard address would be the binding address and
-					// the rest would be the additional addresses
-					if len(actualWildcards) > 1 {
-						extraBind = actualWildcards[1:]
-					}
-				}
-			}
-
-			// Build ListenerOpts and PluginParams once and reuse across all Services to avoid unnecessary allocations.
-			listenerOpts := buildListenerOpts{
-				push:       push,
-				proxy:      node,
-				bind:       bind,
-				port:       listenPort,
-				bindToPort: bindToPort,
-				extraBind:  extraBind,
-			}
+			// TODO: dualstack wildcards
 
 			for _, service := range services {
-				listenerOpts.service = service
+				listenerOpts := outboundListenerOpts{
+					push:    push,
+					proxy:   node,
+					bind:    bind,
+					port:    listenPort,
+					service: service,
+				}
 				// Set service specific attributes here.
-				lb.buildSidecarOutboundListenerForPortOrUDS(listenerOpts, listenerMap, virtualServices, actualWildcards[0])
+				lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 			}
 		} else {
 			// This is a catch all egress listener with no port. This
@@ -443,26 +433,18 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 			// To ensure that we do not add anything to listeners we have
 			// already generated, run through the outboundListenerEntry map and set
 			// the locked bit to true.
-			// buildSidecarOutboundListenerForPortOrUDS will not add/merge
+			// buildSidecarOutboundListener will not add/merge
 			// any HTTP/TCP listener if there is already a outboundListenerEntry
 			// with locked bit set to true
 			for _, e := range listenerMap {
 				e.locked = true
 			}
 
-			// Build ListenerOpts and PluginParams once and reuse across all Services to avoid unnecessary allocations.
-			listenerOpts := buildListenerOpts{
-				push:       push,
-				proxy:      node,
-				bindToPort: bindToPort,
-			}
-
 			for _, service := range services {
 				saddress := service.GetAddressForProxy(node)
-				sExtrAddresses := service.GetExtraAddressesForProxy(node)
 				for _, servicePort := range service.Ports {
 					// Skip ports we cannot bind to
-					if !node.CanBindToPort(bindToPort, uint32(servicePort.Port)) {
+					if !node.CanBindToPort(bind.bindToPort, uint32(servicePort.Port)) {
 						// here, we log at DEBUG level instead of WARN to avoid noise
 						// when the catch all egress listener hits ports 80 and 443
 						log.Debugf("buildSidecarOutboundListeners: skipping privileged service port %s:%d for node %s as it is an unprivileged proxy",
@@ -470,32 +452,25 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 						continue
 					}
 
-					if conflictWithStaticListener(node, bind, servicePort.Port, servicePort.Protocol) {
+					if conflictWithStaticListener(node, bind.Primary(), servicePort.Port, servicePort.Protocol) {
 						log.Debugf("buildSidecarOutboundListeners: skipping service port %s:%d for node %s as it conflicts with static listener",
 							service.Hostname, servicePort.Port, node.ID)
 						continue
 					}
 
-					// bind might have been modified by below code, so reset it for every Service.
-					listenerOpts.bind = bind
-					// listenerOpts.extraBind should be specified at the same time for dual stack env
-					if len(actualLocalHosts) > 1 {
-						if bind == actualLocalHosts[0] {
-							listenerOpts.extraBind = actualLocalHosts[1:]
-						} else if len(sExtrAddresses) > 0 {
-							listenerOpts.extraBind = sExtrAddresses
-						}
+					listenerOpts := outboundListenerOpts{
+						push:    push,
+						proxy:   node,
+						bind:    bind,
+						port:    servicePort,
+						service: service,
 					}
-
-					// port depends on servicePort.
-					listenerOpts.port = servicePort
-					listenerOpts.service = service
 
 					// Support statefulsets/headless services with TCP ports, and empty service address field.
 					// Instead of generating a single 0.0.0.0:Port listener, generate a listener
 					// for each instance. HTTP services can happily reside on 0.0.0.0:PORT and use the
 					// wildcard route match to get to the appropriate IP through original dst clusters.
-					if features.EnableHeadlessService && bind == "" && service.Resolution == model.Passthrough &&
+					if features.EnableHeadlessService && bind.Primary() == "" && service.Resolution == model.Passthrough &&
 						saddress == constants.UnspecifiedIP && (servicePort.Protocol.IsTCP() || servicePort.Protocol.IsUnsupported()) {
 						instances := push.ServiceInstancesByPort(service, servicePort.Port, nil)
 						if service.Attributes.ServiceRegistry != provider.Kubernetes && len(instances) == 0 && service.Attributes.LabelSelectors == nil {
@@ -507,7 +482,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 							// selected or scaled down, so we skip these as well. This leaves us with
 							// only a plain ServiceEntry with resolution NONE. In this case, we will
 							// fallback to a wildcard listener.
-							lb.buildSidecarOutboundListenerForPortOrUDS(listenerOpts, listenerMap, virtualServices, actualWildcards[0])
+							lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 							continue
 						}
 						for _, instance := range instances {
@@ -523,12 +498,12 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 							if instance.Endpoint.Address == node.IPAddresses[0] {
 								continue
 							}
-							listenerOpts.bind = instance.Endpoint.Address
-							lb.buildSidecarOutboundListenerForPortOrUDS(listenerOpts, listenerMap, virtualServices, actualWildcards[0])
+							listenerOpts.bind.binds = []string{instance.Endpoint.Address}
+							lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 						}
 					} else {
 						// Standard logic for headless and non headless services
-						lb.buildSidecarOutboundListenerForPortOrUDS(listenerOpts, listenerMap, virtualServices, actualWildcards[0])
+						lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 					}
 				}
 			}
@@ -538,20 +513,120 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 	// Now validate all the listeners. Collate the tcp listeners first and then the HTTP listeners
 	// TODO: This is going to be bad for caching as the order of listeners in tcpListeners or httpListeners is not
 	// guaranteed.
-	for _, l := range listenerMap {
-		if l.servicePort.Protocol.IsTCP() {
-			tcpListeners = append(tcpListeners, l.listener)
-		} else {
-			httpListeners = append(httpListeners, l.listener)
+	return finalizeOutboundListeners(lb, listenerMap)
+}
+
+func finalizeOutboundListeners(lb *ListenerBuilder, listenerMap map[string]*outboundListenerEntry) []*listener.Listener {
+	fallthroughNetworkFilters := buildOutboundCatchAllNetworkFiltersOnly(lb.push, lb.node)
+	listeners := make([]*listener.Listener, 0, len(listenerMap))
+	for _, le := range listenerMap {
+		l := buildListenerFromEntry(lb, le, fallthroughNetworkFilters)
+		listeners = append(listeners, l)
+	}
+	return listeners
+}
+
+func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry, fallthroughNetworkFilters []*listener.Filter) *listener.Listener {
+	l := &listener.Listener{
+		// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy doesn't like
+		Name:                             getListenerName(le.bind.Primary(), le.servicePort.Port, istionetworking.TransportProtocolTCP),
+		Address:                          util.BuildAddress(le.bind.Primary(), uint32(le.servicePort.Port)),
+		AdditionalAddresses:              util.BuildAdditionalAddresses(le.bind.Extra(), uint32(le.servicePort.Port)),
+		TrafficDirection:                 core.TrafficDirection_OUTBOUND,
+		ContinueOnListenerFiltersTimeout: true,
+	}
+	if builder.node.Metadata.OutboundListenerExactBalance {
+		l.ConnectionBalanceConfig = &listener.Listener_ConnectionBalanceConfig{
+			BalanceType: &listener.Listener_ConnectionBalanceConfig_ExactBalance_{
+				ExactBalance: &listener.Listener_ConnectionBalanceConfig_ExactBalance{},
+			},
 		}
 	}
-	tcpListeners = append(tcpListeners, httpListeners...)
-	// Build pass through filter chains now that all the non-passthrough filter chains are ready.
-	for _, l := range tcpListeners {
-		appendListenerFallthroughRouteForCompleteListener(l, node, push)
+	if !le.bind.bindToPort {
+		l.BindToPort = proto.BoolFalse
 	}
-	removeListenerFilterTimeout(tcpListeners)
-	return tcpListeners
+
+	// add a TLS inspector if we need to detect ServerName or ALPN
+	// (this is not applicable for QUIC listeners)
+	needTLSInspector := false
+	needHTTPInspector := false
+	for _, chain := range le.chains {
+		needsALPN := chain.tlsContext != nil && chain.tlsContext.CommonTlsContext != nil && len(chain.tlsContext.CommonTlsContext.AlpnProtocols) > 0
+		if len(chain.sniHosts) > 0 || needsALPN {
+			needTLSInspector = true
+		}
+		needHTTP := len(chain.applicationProtocols) > 0
+		if needHTTP {
+			needHTTPInspector = true
+		}
+	}
+
+	// We add a TLS inspector when http inspector is needed for outbound only. This
+	// is because if we ever set ALPN in the match without
+	// transport_protocol=raw_buffer, Envoy will automatically inject a tls
+	// inspector: https://github.com/envoyproxy/envoy/issues/13601. This leads to
+	// excessive logging and loss of control over the config. For inbound this is not
+	// needed, since we are explicitly setting transport protocol in every single
+	// match. We can do this for outbound as well, at which point this could be
+	// removed, but have not yet
+	if needTLSInspector || needHTTPInspector {
+		l.ListenerFilters = append(l.ListenerFilters, xdsfilters.TLSInspector)
+	}
+
+	if needHTTPInspector {
+		l.ListenerFilters = append(l.ListenerFilters, xdsfilters.HTTPInspector)
+		// Enable timeout only if they configure it and we have an HTTP inspector.
+		// This is really unsafe, so hopefully not used...
+		l.ListenerFiltersTimeout = builder.push.Mesh.ProtocolDetectionTimeout
+	} else {
+		// Otherwise, do not have a timeout at all
+		l.ListenerFiltersTimeout = durationpb.New(0)
+	}
+
+	for _, opt := range le.chains {
+		chain := &listener.FilterChain{
+			Metadata:        opt.metadata,
+			TransportSocket: buildDownstreamTLSTransportSocket(opt.tlsContext),
+		}
+		if opt.httpOpts == nil {
+			// we are building a network filter chain (no http connection manager) for this filter chain
+			chain.Filters = opt.networkFilters
+		} else {
+			opt.httpOpts.statPrefix = strings.ToLower(l.TrafficDirection.String()) + "_" + l.Name
+			opt.httpOpts.port = le.servicePort.Port
+			hcm := builder.buildHTTPConnectionManager(opt.httpOpts)
+			filter := &listener.Filter{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(hcm)},
+			}
+			chain.Filters = append(chain.Filters, filter)
+		}
+
+		// Set a default filter chain. This allows us to avoid issues where
+		// traffic starts to match a filter chain but then doesn't match latter criteria, leading to
+		// dropped requests. See https://github.com/istio/istio/issues/26079 for details.
+		// If there are multiple filter chains and a match all chain, move it to DefaultFilterChain
+		// This ensures it will always be used as the fallback.
+		if opt.isMatchAll() {
+			l.DefaultFilterChain = chain
+		} else {
+			chain.FilterChainMatch = opt.toFilterChainMatch()
+			l.FilterChains = append(l.FilterChains, chain)
+		}
+	}
+	// If there is only one filter chain, no need to use DefaultFilterChain
+	// This is probably not necessary, but for consistency with older code we keep the same logic.
+	if l.DefaultFilterChain != nil && len(l.FilterChains) == 0 {
+		l.FilterChains = []*listener.FilterChain{l.DefaultFilterChain}
+		l.DefaultFilterChain = nil
+	} else if l.DefaultFilterChain == nil {
+		l.DefaultFilterChain = &listener.FilterChain{
+			FilterChainMatch: &listener.FilterChainMatch{},
+			Name:             util.PassthroughFilterChain,
+			Filters:          fallthroughNetworkFilters,
+		}
+	}
+	return l
 }
 
 func (lb *ListenerBuilder) buildHTTPProxy(node *model.Proxy,
@@ -578,62 +653,149 @@ func (lb *ListenerBuilder) buildHTTPProxy(node *model.Proxy,
 		httpOpts.AcceptHttp_10 = true
 	}
 
-	opts := buildListenerOpts{
-		push:  push,
-		proxy: node,
-		bind:  actualLocalHosts[0],
-		port:  &model.Port{Port: int(httpProxyPort)},
-		filterChainOpts: []*filterChainOpts{{
-			httpOpts: &httpListenerOpts{
-				rds:              model.RDSHttpProxy,
-				useRemoteAddress: false,
-				connectionManager: &hcm.HttpConnectionManager{
-					HttpProtocolOptions: httpOpts,
-				},
-				protocol: protocol.HTTP_PROXY,
-				class:    istionetworking.ListenerClassSidecarOutbound,
+	fcs := []*filterChainOpts{{
+		httpOpts: &httpListenerOpts{
+			rds:              model.RDSHttpProxy,
+			useRemoteAddress: false,
+			connectionManager: &hcm.HttpConnectionManager{
+				HttpProtocolOptions: httpOpts,
 			},
-		}},
-		bindToPort:      true,
-		skipUserFilters: true,
-	}
-
-	if len(actualLocalHosts) > 1 {
-		opts.extraBind = actualLocalHosts[1:]
-	}
-	l := buildListener(opts, core.TrafficDirection_OUTBOUND)
-
-	// TODO: plugins for HTTP_PROXY mode, envoyfilter needs another listener match for SIDECAR_HTTP_PROXY
-	mutable := &MutableListener{
-		MutableObjects: istionetworking.MutableObjects{
-			Listener:     l,
-			FilterChains: []istionetworking.FilterChain{{}},
+			protocol: protocol.HTTP_PROXY,
+			class:    istionetworking.ListenerClassSidecarOutbound,
 		},
-	}
-	if err := mutable.build(lb, opts); err != nil {
-		log.Warnf("buildHTTPProxy filter chain: %v", err)
-		return nil
-	}
-	return l
+	}}
+
+	return buildListenerFromEntry(lb, &outboundListenerEntry{
+		chains: fcs,
+		bind: listenerBinding{
+			binds:      actualLocalHosts,
+			bindToPort: true,
+		},
+		servicePort: &model.Port{Port: int(httpProxyPort)},
+	}, nil)
 }
 
-func buildSidecarOutboundHTTPListenerOptsForPortOrUDS(listenerMapKey *string,
-	currentListenerEntry **outboundListenerEntry, listenerOpts *buildListenerOpts,
-	listenerMap map[string]*outboundListenerEntry, actualWildcard string,
+func buildSidecarOutboundHTTPListenerOpts(
+	opts outboundListenerOpts,
+	actualWildcard string,
 	listenerProtocol istionetworking.ListenerProtocol,
-) (bool, []*filterChainOpts) {
-	// first identify the bind if its not set. Then construct the key
-	// used to lookup the listener in the conflict map.
-	if len(listenerOpts.bind) == 0 { // no user specified bind. Use 0.0.0.0:Port or [::]:Port
-		actualWildcards, _ := getWildcardsAndLocalHost(listenerOpts.proxy.GetIPMode())
-		listenerOpts.bind = actualWildcards[0]
-		if len(actualWildcards) > 0 {
-			listenerOpts.extraBind = actualWildcards[1:]
+) []*filterChainOpts {
+	var rdsName string
+	if opts.port.Port == 0 {
+		rdsName = opts.bind.Primary() // use the UDS as a rds name
+	} else {
+		if listenerProtocol == istionetworking.ListenerProtocolAuto && opts.bind.Primary() != actualWildcard && opts.service != nil {
+			// For sniffed services, we have a unique listener and route just for that service
+			rdsName = string(opts.service.Hostname) + ":" + strconv.Itoa(opts.port.Port)
+		} else {
+			// Otherwise we have a shared one per-port
+			rdsName = strconv.Itoa(opts.port.Port)
 		}
 	}
-	*listenerMapKey = listenerOpts.bind + ":" + strconv.Itoa(listenerOpts.port.Port)
+	httpOpts := &httpListenerOpts{
+		// Set useRemoteAddress to true for sidecar outbound listeners so that it picks up the localhost address of the sender,
+		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
+		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
+		useRemoteAddress: features.UseRemoteAddress,
+		rds:              rdsName,
 
-	var exists bool
+		protocol: opts.port.Protocol,
+		class:    istionetworking.ListenerClassSidecarOutbound,
+	}
+
+	if features.HTTP10 || enableHTTP10(opts.proxy.Metadata.HTTP10) {
+		httpOpts.connectionManager = &hcm.HttpConnectionManager{
+			HttpProtocolOptions: &core.Http1ProtocolOptions{
+				AcceptHttp_10: true,
+			},
+		}
+	}
+
+	return []*filterChainOpts{{
+		httpOpts: httpOpts,
+	}}
+}
+
+func buildSidecarOutboundTCPListenerOpts(opts outboundListenerOpts, virtualServices []config.Config) []*filterChainOpts {
+	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
+	out := make([]*filterChainOpts, 0)
+	var svcConfigs []config.Config
+	if opts.service != nil {
+		// Do not filter namespace for now.
+		// TODO(https://github.com/istio/istio/issues/46146) we may need to, or something more sophisticated
+		svcConfigs = getConfigsForHost("", opts.service.Hostname, virtualServices)
+	} else {
+		svcConfigs = virtualServices
+	}
+
+	out = append(out, buildSidecarOutboundTLSFilterChainOpts(opts.proxy, opts.push, opts.cidr, opts.service,
+		opts.bind.Primary(), opts.port, meshGateway, svcConfigs)...)
+	out = append(out, buildSidecarOutboundTCPFilterChainOpts(opts.proxy, opts.push, opts.cidr, opts.service,
+		opts.port, meshGateway, svcConfigs)...)
+	return out
+}
+
+// buildSidecarOutboundListener builds a single listener and
+// adds it to the listenerMap provided by the caller.  Listeners are added
+// if one doesn't already exist. HTTP listeners on same port are ignored
+// (as vhosts are shipped through RDS).  TCP listeners on same port are
+// allowed only if they have different CIDR matches.
+func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundListenerOpts,
+	listenerMap map[string]*outboundListenerEntry, virtualServices []config.Config, actualWildcards []string,
+) {
+	// TODO: remove actualWildcard
+	var currentListenerEntry *outboundListenerEntry
+
+	conflictType := NoConflict
+
+	listenerPortProtocol := listenerOpts.port.Protocol
+	listenerProtocol := istionetworking.ModelProtocolToListenerProtocol(listenerOpts.port.Protocol)
+
+	var listenerMapKey string
+	switch listenerProtocol {
+	case istionetworking.ListenerProtocolTCP, istionetworking.ListenerProtocolAuto:
+		// Determine the listener address if bind is empty
+		// we listen on the service VIP if and only
+		// if the address is an IP address. If its a CIDR, we listen on
+		// 0.0.0.0, and setup a filter chain match for the CIDR range.
+		// As a small optimization, CIDRs with /32 prefix will be converted
+		// into listener address so that there is a dedicated listener for this
+		// ip:port. This will reduce the impact of a listener reload
+		if listenerOpts.bind.Primary() == "" { // TODO: make this better
+			svcListenAddress := listenerOpts.service.GetAddressForProxy(listenerOpts.proxy)
+			svcExtraListenAddresses := listenerOpts.service.GetExtraAddressesForProxy(listenerOpts.proxy)
+			// Override the svcListenAddress, using the proxy ipFamily, for cases where the ipFamily cannot be detected easily.
+			// For example: due to the possibility of using hostnames instead of ips in ServiceEntry,
+			// it is hard to detect ipFamily for such services.
+			if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsIPv6() &&
+				svcListenAddress == constants.UnspecifiedIP {
+				svcListenAddress = constants.UnspecifiedIPv6
+			}
+			// We should never get an empty address.
+			// This is a safety guard, in case some platform adapter isn't doing things
+			// properly
+			if len(svcListenAddress) > 0 {
+				if !strings.Contains(svcListenAddress, "/") {
+					listenerOpts.bind.binds = append([]string{svcListenAddress}, svcExtraListenAddresses...)
+				} else {
+					// Address is a CIDR. Fall back to 0.0.0.0 and
+					// filter chain match
+					// TODO: this probably needs to handle dual stack better
+					listenerOpts.bind.binds = actualWildcards
+					listenerOpts.cidr = svcListenAddress
+				}
+			}
+		}
+		listenerMapKey = listenerKey(listenerOpts.bind.Primary(), listenerOpts.port.Port)
+
+	case istionetworking.ListenerProtocolHTTP:
+		// first identify the bind if its not set. Then construct the key
+		// used to lookup the listener in the conflict map.
+		if len(listenerOpts.bind.Primary()) == 0 { // no user specified bind. Use 0.0.0.0:Port or [::]:Port
+			listenerOpts.bind.binds = actualWildcards
+		}
+		listenerMapKey = listenerKey(listenerOpts.bind.Primary(), listenerOpts.port.Port)
+	}
 
 	// Have we already generated a listener for this Port based on user
 	// specified listener ports? if so, we should not add any more HTTP
@@ -651,212 +813,58 @@ func buildSidecarOutboundHTTPListenerOptsForPortOrUDS(listenerMapKey *string,
 	// resolution type, since we collapse all HTTP listeners into a
 	// single 0.0.0.0:port listener and use vhosts to distinguish
 	// individual http services in that port
-	if *currentListenerEntry, exists = listenerMap[*listenerMapKey]; exists {
+	if cur, exists := listenerMap[listenerMapKey]; exists {
+		currentListenerEntry = cur
 		// NOTE: This is not a conflict. This is simply filtering the
 		// services for a given listener explicitly.
 		// When the user declares their own ports in Sidecar.egress
 		// with some specific services on those ports, we should not
 		// generate any more listeners on that port as the user does
 		// not want those listeners. Protocol sniffing is not needed.
-		if (*currentListenerEntry).locked {
-			return false, nil
-		}
-	}
-
-	// No conflicts. Add a http filter chain option to the listenerOpts
-	var rdsName string
-	if listenerOpts.port.Port == 0 {
-		rdsName = listenerOpts.bind // use the UDS as a rds name
-	} else {
-		if listenerProtocol == istionetworking.ListenerProtocolAuto && listenerOpts.bind != actualWildcard && listenerOpts.service != nil {
-			rdsName = string(listenerOpts.service.Hostname) + ":" + strconv.Itoa(listenerOpts.port.Port)
-		} else {
-			rdsName = strconv.Itoa(listenerOpts.port.Port)
-		}
-	}
-	httpOpts := &httpListenerOpts{
-		// Set useRemoteAddress to true for sidecar outbound listeners so that it picks up the localhost address of the sender,
-		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
-		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
-		useRemoteAddress: features.UseRemoteAddress,
-		rds:              rdsName,
-
-		protocol: listenerOpts.port.Protocol,
-		class:    istionetworking.ListenerClassSidecarOutbound,
-	}
-
-	if features.HTTP10 || enableHTTP10(listenerOpts.proxy.Metadata.HTTP10) {
-		httpOpts.connectionManager = &hcm.HttpConnectionManager{
-			HttpProtocolOptions: &core.Http1ProtocolOptions{
-				AcceptHttp_10: true,
-			},
-		}
-	}
-
-	return true, []*filterChainOpts{{
-		httpOpts: httpOpts,
-	}}
-}
-
-func buildSidecarOutboundTCPListenerOptsForPortOrUDS(listenerMapKey *string,
-	currentListenerEntry **outboundListenerEntry, listenerOpts *buildListenerOpts, listenerMap map[string]*outboundListenerEntry,
-	virtualServices []config.Config, actualWildcard string,
-) (bool, []*filterChainOpts) {
-	// first identify the bind if its not set. Then construct the key
-	// used to lookup the listener in the conflict map.
-
-	// Determine the listener address if bind is empty
-	// we listen on the service VIP if and only
-	// if the address is an IP address. If its a CIDR, we listen on
-	// 0.0.0.0, and setup a filter chain match for the CIDR range.
-	// As a small optimization, CIDRs with /32 prefix will be converted
-	// into listener address so that there is a dedicated listener for this
-	// ip:port. This will reduce the impact of a listener reload
-	var destinationCIDR string
-	if len(listenerOpts.bind) == 0 {
-		svcListenAddress := listenerOpts.service.GetAddressForProxy(listenerOpts.proxy)
-		svcExtraListenAddresses := listenerOpts.service.GetExtraAddressesForProxy(listenerOpts.proxy)
-		// Override the svcListenAddress, using the proxy ipFamily, for cases where the ipFamily cannot be detected easily.
-		// For example: due to the possibility of using hostnames instead of ips in ServiceEntry,
-		// it is hard to detect ipFamily for such services.
-		if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsIPv6() &&
-			svcListenAddress == constants.UnspecifiedIP {
-			svcListenAddress = constants.UnspecifiedIPv6
-		}
-		// We should never get an empty address.
-		// This is a safety guard, in case some platform adapter isn't doing things
-		// properly
-		if len(svcListenAddress) > 0 {
-			if !strings.Contains(svcListenAddress, "/") {
-				listenerOpts.bind = svcListenAddress
-			} else {
-				// Address is a CIDR. Fall back to 0.0.0.0 and
-				// filter chain match
-				destinationCIDR = svcListenAddress
-				listenerOpts.bind = actualWildcard
-			}
-			if len(svcExtraListenAddresses) > 0 {
-				listenerOpts.extraBind = svcExtraListenAddresses
-			}
-		}
-	}
-
-	// could be a unix domain socket or an IP bind
-	*listenerMapKey = listenerKey(listenerOpts.bind, listenerOpts.port.Port)
-
-	var exists bool
-
-	// Have we already generated a listener for this Port based on user
-	// specified listener ports? if so, we should not add any more
-	// services to the port. The user could have specified a sidecar
-	// resource with one or more explicit ports and then added a catch
-	// all listener, implying add all other ports as usual. When we are
-	// iterating through the services for a catchAll egress listener,
-	// the caller would have set the locked bit for each listener Entry
-	// in the map.
-	//
-	// Check if this TCP listener conflicts with an existing HTTP listener
-	if *currentListenerEntry, exists = listenerMap[*listenerMapKey]; exists {
-		// NOTE: This is not a conflict. This is simply filtering the
-		// services for a given listener explicitly.
-		// When the user declares their own ports in Sidecar.egress
-		// with some specific services on those ports, we should not
-		// generate any more listeners on that port as the user does
-		// not want those listeners. Protocol sniffing is not needed.
-		if (*currentListenerEntry).locked {
-			return false, nil
-		}
-	}
-
-	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
-	return true, buildSidecarOutboundTCPTLSFilterChainOpts(listenerOpts.proxy,
-		listenerOpts.push, virtualServices,
-		destinationCIDR, listenerOpts.service,
-		listenerOpts.bind, listenerOpts.port, meshGateway)
-}
-
-// buildSidecarOutboundListenerForPortOrUDS builds a single listener and
-// adds it to the listenerMap provided by the caller.  Listeners are added
-// if one doesn't already exist. HTTP listeners on same port are ignored
-// (as vhosts are shipped through RDS).  TCP listeners on same port are
-// allowed only if they have different CIDR matches.
-func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts buildListenerOpts,
-	listenerMap map[string]*outboundListenerEntry, virtualServices []config.Config, actualWildcard string,
-) {
-	var listenerMapKey string
-	var currentListenerEntry *outboundListenerEntry
-	var ret bool
-	var opts []*filterChainOpts
-
-	listenerOpts.class = istionetworking.ListenerClassSidecarOutbound
-
-	conflictType := NoConflict
-
-	listenerPortProtocol := listenerOpts.port.Protocol
-	listenerProtocol := istionetworking.ModelProtocolToListenerProtocol(listenerOpts.port.Protocol)
-
-	// For HTTP_PROXY protocol defined by sidecars, just create the HTTP listener right away.
-	if listenerPortProtocol == protocol.HTTP_PROXY {
-		if ret, opts = buildSidecarOutboundHTTPListenerOptsForPortOrUDS(&listenerMapKey, &currentListenerEntry,
-			&listenerOpts, listenerMap, actualWildcard, listenerProtocol); !ret {
+		if cur.locked {
 			return
 		}
-		listenerOpts.filterChainOpts = opts
+	}
+
+	var opts []*filterChainOpts
+	// For HTTP_PROXY protocol defined by sidecars, just create the HTTP listener right away.
+	if listenerPortProtocol == protocol.HTTP_PROXY {
+		opts = buildSidecarOutboundHTTPListenerOpts(listenerOpts, actualWildcards[0], listenerProtocol)
 	} else {
 		switch listenerProtocol {
 		case istionetworking.ListenerProtocolHTTP:
-			if ret, opts = buildSidecarOutboundHTTPListenerOptsForPortOrUDS(&listenerMapKey,
-				&currentListenerEntry, &listenerOpts, listenerMap, actualWildcard, listenerProtocol); !ret {
-				return
-			}
-
 			// Check if conflict happens
 			if currentListenerEntry != nil {
 				// Build HTTP listener. If current listener entry is using HTTP or protocol sniffing,
 				// append the service. Otherwise (TCP), change current listener to use protocol sniffing.
-				if currentListenerEntry.protocol.IsHTTP() {
-					// conflictType is HTTPOverHTTP
-					// In these cases, we just add the services and exit early rather than recreate an identical listener
-					currentListenerEntry.services = append(currentListenerEntry.services, listenerOpts.service)
-					return
-				} else if currentListenerEntry.protocol.IsTCP() {
+				if currentListenerEntry.protocol.IsTCP() {
 					conflictType = HTTPOverTCP
 				} else {
-					// conflictType is HTTPOverAuto
-					// In these cases, we just add the services and exit early rather than recreate an identical listener
-					currentListenerEntry.services = append(currentListenerEntry.services, listenerOpts.service)
+					// Exit early, listener already exists
 					return
 				}
 			}
+			opts = buildSidecarOutboundHTTPListenerOpts(listenerOpts, actualWildcards[0], listenerProtocol)
+
 			// Add application protocol filter chain match to the http filter chain. The application protocol will be set by http inspector
 			// Since application protocol filter chain match has been added to the http filter chain, a fall through filter chain will be
 			// appended to the listener later to allow arbitrary egress TCP traffic pass through when its port is conflicted with existing
 			// HTTP services, which can happen when a pod accesses a non registry service.
-			if listenerOpts.bind == actualWildcard {
+			if listenerOpts.bind.Primary() == actualWildcards[0] {
 				for _, opt := range opts {
-					if opt.match == nil {
-						opt.match = &listener.FilterChainMatch{}
-					}
-
 					// Support HTTP/1.0, HTTP/1.1 and HTTP/2
-					opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, plaintextHTTPALPNs...)
-					opt.match.TransportProtocol = xdsfilters.RawBufferTransportProtocol
+					opt.applicationProtocols = append(opt.applicationProtocols, plaintextHTTPALPNs...)
+					opt.transportProtocol = xdsfilters.RawBufferTransportProtocol
 				}
-
-				listenerOpts.needHTTPInspector = true
 
 				// if we have a tcp fallthrough filter chain, this is no longer an HTTP listener - it
 				// is instead "unsupported" (auto detected), as we have a TCP and HTTP filter chain with
 				// inspection to route between them
 				listenerPortProtocol = protocol.Unsupported
 			}
-			listenerOpts.filterChainOpts = opts
 
 		case istionetworking.ListenerProtocolTCP:
-			if ret, opts = buildSidecarOutboundTCPListenerOptsForPortOrUDS(&listenerMapKey, &currentListenerEntry,
-				&listenerOpts, listenerMap, virtualServices, actualWildcard); !ret {
-				return
-			}
+			opts = buildSidecarOutboundTCPListenerOpts(listenerOpts, virtualServices)
 
 			// Check if conflict happens
 			if currentListenerEntry != nil {
@@ -871,70 +879,35 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 				}
 			}
 
-			listenerOpts.filterChainOpts = opts
-
 		case istionetworking.ListenerProtocolAuto:
-			// Add tcp filter chain, build TCP filter chain first.
-			if ret, opts = buildSidecarOutboundTCPListenerOptsForPortOrUDS(&listenerMapKey, &currentListenerEntry,
-				&listenerOpts, listenerMap, virtualServices, actualWildcard); !ret {
-				return
-			}
-			listenerOpts.filterChainOpts = append(listenerOpts.filterChainOpts, opts...)
-
-			// Add http filter chain and tcp filter chain to the listener opts
-			if ret, opts = buildSidecarOutboundHTTPListenerOptsForPortOrUDS(&listenerMapKey, &currentListenerEntry,
-				&listenerOpts, listenerMap, actualWildcard, listenerProtocol); !ret {
-				return
-			}
-
-			// Add application protocol filter chain match to the http filter chain. The application protocol will be set by http inspector
-			for _, opt := range opts {
-				if opt.match == nil {
-					opt.match = &listener.FilterChainMatch{}
-				}
-
-				// Support HTTP/1.0, HTTP/1.1 and HTTP/2
-				opt.match.ApplicationProtocols = append(opt.match.ApplicationProtocols, plaintextHTTPALPNs...)
-				opt.match.TransportProtocol = xdsfilters.RawBufferTransportProtocol
-			}
-
-			listenerOpts.filterChainOpts = append(listenerOpts.filterChainOpts, opts...)
-			listenerOpts.needHTTPInspector = true
-
 			if currentListenerEntry != nil {
 				if currentListenerEntry.protocol.IsHTTP() {
 					conflictType = AutoOverHTTP
 				} else if currentListenerEntry.protocol.IsTCP() {
 					conflictType = AutoOverTCP
 				} else {
-					// conflictType is AutoOverAuto
-					// In these cases, we just add the services and exit early rather than recreate an identical listener
-					currentListenerEntry.services = append(currentListenerEntry.services, listenerOpts.service)
+					// Exit early, listener already exists
 					return
 				}
 			}
+			// Add tcp filter chain, build TCP filter chain first.
+			tcpOpts := buildSidecarOutboundTCPListenerOpts(listenerOpts, virtualServices)
+
+			// Add http filter chain and tcp filter chain to the listener opts
+			httpOpts := buildSidecarOutboundHTTPListenerOpts(listenerOpts, actualWildcards[0], listenerProtocol)
+			// Add application protocol filter chain match to the http filter chain. The application protocol will be set by http inspector
+			for _, opt := range httpOpts {
+				// Support HTTP/1.0, HTTP/1.1 and HTTP/2
+				opt.applicationProtocols = append(opt.applicationProtocols, plaintextHTTPALPNs...)
+				opt.transportProtocol = xdsfilters.RawBufferTransportProtocol
+			}
+
+			opts = append(tcpOpts, httpOpts...)
 
 		default:
 			// UDP or other protocols: no need to log, it's too noisy
 			return
 		}
-	}
-
-	// Lets build the new listener with the filter chains. In the end, we will
-	// merge the filter chains with any existing listener on the same port/bind point
-	l := buildListener(listenerOpts, core.TrafficDirection_OUTBOUND)
-
-	mutable := &MutableListener{
-		MutableObjects: istionetworking.MutableObjects{
-			Listener:     l,
-			FilterChains: getPluginFilterChain(listenerOpts),
-		},
-	}
-
-	// Filters are serialized one time into an opaque struct once we have the complete list.
-	if err := mutable.build(lb, listenerOpts); err != nil {
-		log.Warnf("buildSidecarOutboundListeners: %v", err)
-		return
 	}
 
 	// If there is a TCP listener on well known port, cannot add any http filter chain
@@ -948,94 +921,32 @@ func (lb *ListenerBuilder) buildSidecarOutboundListenerForPortOrUDS(listenerOpts
 		return
 	}
 
-	// There are 9 types conflicts
-	//    Incoming Existing
-	//  1. HTTP -> HTTP
-	//  2. HTTP -> TCP
-	//  3. HTTP -> unknown
-	//  4. TCP  -> HTTP
-	//  5. TCP  -> TCP
-	//  6. TCP  -> unknown
-	//  7. unknown -> HTTP
-	//  8. unknown -> TCP
-	//  9. unknown -> unknown
-	//  Type 1 can be resolved by appending service to existing services
-	//  Type 2 can be resolved by merging TCP filter chain with HTTP filter chain
-	//  Type 3 can be resolved by appending service to existing services
-	//  Type 4 can be resolved by merging HTTP filter chain with TCP filter chain
-	//  Type 5 can be resolved by merging TCP filter chains
-	//  Type 6 can be resolved by merging TCP filter chains
-	//  Type 7 can be resolved by appending service to existing services
-	//  Type 8 can be resolved by merging TCP filter chains
-	//  Type 9 can be resolved by merging TCP and HTTP filter chains
-	if currentListenerEntry != nil {
-		// Listener filters enable inspecting TLS or HTTP. If either filter chain depends on it, our final listener
-		// must also have the inspector.
-		currentListenerEntry.listener.ListenerFilters = mergeListenerFilters(currentListenerEntry.listener.ListenerFilters, mutable.Listener.ListenerFilters)
-	}
+	// In general, for handling conflicts we:
+	// * Turn on sniffing if its HTTP and TCP mixed
+	// * Merge filter chains
 	switch conflictType {
-	case NoConflict:
-		if currentListenerEntry != nil {
-			currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains,
-				listenerOpts, listenerMapKey, listenerMap)
-		} else {
-			listenerMap[listenerMapKey] = &outboundListenerEntry{
-				services:    []*model.Service{listenerOpts.service},
-				servicePort: listenerOpts.port,
-				bind:        listenerOpts.bind,
-				listener:    mutable.Listener,
-				protocol:    listenerPortProtocol,
-			}
-		}
-	case HTTPOverTCP:
-		// Merge HTTP filter chain to TCP filter chain
-		currentListenerEntry.listener.FilterChains = mergeFilterChains(mutable.Listener.FilterChains, currentListenerEntry.listener.FilterChains)
-		currentListenerEntry.protocol = protocol.Unsupported
-		currentListenerEntry.services = append(currentListenerEntry.services, listenerOpts.service)
-
-	case TCPOverHTTP:
-		// Merge TCP filter chain to HTTP filter chain
-		currentListenerEntry.listener.FilterChains = mergeFilterChains(currentListenerEntry.listener.FilterChains, mutable.Listener.FilterChains)
-		currentListenerEntry.protocol = protocol.Unsupported
-	case TCPOverTCP:
-		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
-		// HTTP filter chain is different from TCP filter chain's.
-		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
-	case TCPOverAuto:
-		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
-		// HTTP filter chain is different from TCP filter chain's.
-		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains, listenerOpts, listenerMapKey, listenerMap)
-
-	case AutoOverHTTP:
+	case NoConflict, AutoOverHTTP:
+		// This is a new entry (NoConflict), or completely overriding (AutoOverHTTP); add it to the map
 		listenerMap[listenerMapKey] = &outboundListenerEntry{
-			services:    append(currentListenerEntry.services, listenerOpts.service),
 			servicePort: listenerOpts.port,
 			bind:        listenerOpts.bind,
-			listener:    mutable.Listener,
-			protocol:    protocol.Unsupported,
+			chains:      opts,
+			protocol:    listenerPortProtocol,
 		}
 
-	case AutoOverTCP:
-		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
-		// HTTP filter chain is different from TCP filter chain's.
-		currentListenerEntry.listener.FilterChains = mergeTCPFilterChains(mutable.Listener.FilterChains,
-			listenerOpts, listenerMapKey, listenerMap)
+	case HTTPOverTCP, TCPOverHTTP, AutoOverTCP:
+		// Merge the two and "upgrade" to sniffed
+		mergeTCPFilterChains(currentListenerEntry, opts, listenerOpts)
 		currentListenerEntry.protocol = protocol.Unsupported
 
+	case TCPOverTCP, TCPOverAuto:
+		// Merge two TCP filter chains. HTTP filter chain will not conflict with TCP filter chain because HTTP filter chain match for
+		// HTTP filter chain is different from TCP filter chain's.
+		mergeTCPFilterChains(currentListenerEntry, opts, listenerOpts)
+
 	default:
-		// Covered previously - in this case we return early to prevent creating listeners that we end up throwing away
 		// This should never happen
 		log.Errorf("Got unexpected conflict type %v. This should never happen", conflictType)
-	}
-
-	if log.DebugEnabled() && len(mutable.Listener.FilterChains) > 1 || currentListenerEntry != nil {
-		var numChains int
-		if currentListenerEntry != nil {
-			numChains = len(currentListenerEntry.listener.FilterChains)
-		} else {
-			numChains = len(mutable.Listener.FilterChains)
-		}
-		log.Debugf("buildSidecarOutboundListeners: multiple filter chain listener %s with %d chains", mutable.Listener.Name, numChains)
 	}
 }
 
@@ -1065,42 +976,55 @@ type httpListenerOpts struct {
 
 // filterChainOpts describes a filter chain: a set of filters with the same TLS context
 type filterChainOpts struct {
-	filterChainName  string
-	sniHosts         []string
-	destinationCIDRs []string
-	metadata         *core.Metadata
-	tlsContext       *auth.DownstreamTlsContext
-	httpOpts         *httpListenerOpts
-	match            *listener.FilterChainMatch
-	listenerFilters  []*listener.ListenerFilter
-	networkFilters   []*listener.Filter
-	filterChain      istionetworking.FilterChain
+	// Matching criteria. Will eventually turn into FilterChainMatch
+	sniHosts             []string
+	destinationCIDRs     []string
+	applicationProtocols []string
+	transportProtocol    string
+
+	// Arbitrary metadata to attach to the filter
+	metadata *core.Metadata
+
+	// TLS configuration for the filter
+	tlsContext *auth.DownstreamTlsContext
+
+	// Set if this is for HTTP. Cannot be set with networkFilters
+	httpOpts *httpListenerOpts
+	// Set if this is for TCP chain. Cannot be set with httpOpts
+	networkFilters []*listener.Filter
 }
 
-// buildListenerOpts are the options required to build a Listener
-type buildListenerOpts struct {
-	// nolint: maligned
-	push              *model.PushContext
-	proxy             *model.Proxy
-	bind              string
-	extraBind         []string
+// gatewayListenerOpts are the options required to build a gateway Listener
+type gatewayListenerOpts struct {
+	push  *model.PushContext
+	proxy *model.Proxy
+
+	bindToPort bool
+	bind       string
+	extraBind  []string
+
 	port              *model.Port
 	filterChainOpts   []*filterChainOpts
-	bindToPort        bool
-	skipUserFilters   bool
-	needHTTPInspector bool
 	needPROXYProtocol bool
-	class             istionetworking.ListenerClass
-	service           *model.Service
-	transport         istionetworking.TransportProtocol
 }
 
-// buildListener builds and initializes a Listener proto based on the provided opts. It does not set any filters.
+// outboundListenerOpts are the options to build an outbound listener
+type outboundListenerOpts struct {
+	push  *model.PushContext
+	proxy *model.Proxy
+
+	bind listenerBinding
+	cidr string
+
+	port    *model.Port
+	service *model.Service
+}
+
+// buildGatewayListener builds and initializes a Listener proto based on the provided opts. It does not set any filters.
 // Optionally for HTTP filters with TLS enabled, HTTP/3 can be supported by generating QUIC Mirror filters for the
 // same port (it is fine as QUIC uses UDP)
-func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirection) *listener.Listener {
+func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.TransportProtocol) *listener.Listener {
 	filterChains := make([]*listener.FilterChain, 0, len(opts.filterChainOpts))
-	listenerFiltersMap := make(map[string]bool)
 	var listenerFilters []*listener.ListenerFilter
 
 	// Strip PROXY header first for non-QUIC traffic if requested.
@@ -1110,87 +1034,20 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 
 	// add a TLS inspector if we need to detect ServerName or ALPN
 	// (this is not applicable for QUIC listeners)
-	needTLSInspector := false
-	if opts.transport == istionetworking.TransportProtocolTCP {
+	if transport == istionetworking.TransportProtocolTCP {
 		for _, chain := range opts.filterChainOpts {
 			needsALPN := chain.tlsContext != nil && chain.tlsContext.CommonTlsContext != nil && len(chain.tlsContext.CommonTlsContext.AlpnProtocols) > 0
 			if len(chain.sniHosts) > 0 || needsALPN {
-				needTLSInspector = true
+				listenerFilters = append(listenerFilters, xdsfilters.TLSInspector)
 				break
 			}
 		}
 	}
 
-	if opts.proxy.GetInterceptionMode() == model.InterceptionTproxy && trafficDirection == core.TrafficDirection_INBOUND {
-		listenerFiltersMap[wellknown.OriginalSource] = true
-		listenerFilters = append(listenerFilters, xdsfilters.OriginalSrc)
-	}
-
-	// We add a TLS inspector when http inspector is needed for outbound only. This
-	// is because if we ever set ALPN in the match without
-	// transport_protocol=raw_buffer, Envoy will automatically inject a tls
-	// inspector: https://github.com/envoyproxy/envoy/issues/13601. This leads to
-	// excessive logging and loss of control over the config For inbound this is not
-	// needed, since we are explicitly setting transport protocol in every single
-	// match. We can do this for outbound as well, at which point this could be
-	// removed, but have not yet
-	if opts.transport == istionetworking.TransportProtocolTCP &&
-		(needTLSInspector || (opts.class == istionetworking.ListenerClassSidecarOutbound && opts.needHTTPInspector)) {
-		listenerFiltersMap[wellknown.TlsInspector] = true
-		listenerFilters = append(listenerFilters, xdsfilters.TLSInspector)
-	}
-
-	// TODO: For now we assume that only HTTP/3 is used over QUIC. Revisit this in the future
-	if opts.needHTTPInspector && opts.transport == istionetworking.TransportProtocolTCP {
-		listenerFiltersMap[wellknown.HttpInspector] = true
-		listenerFilters = append(listenerFilters, xdsfilters.HTTPInspector)
-	}
-
 	for _, chain := range opts.filterChainOpts {
-		for _, filter := range chain.listenerFilters {
-			if _, exist := listenerFiltersMap[filter.Name]; !exist {
-				listenerFiltersMap[filter.Name] = true
-				listenerFilters = append(listenerFilters, filter)
-			}
-		}
-		match := &listener.FilterChainMatch{}
-		needMatch := false
-		if chain.match != nil {
-			needMatch = true
-			match = chain.match
-		}
-		if len(chain.sniHosts) > 0 {
-			fullWildcardFound := false
-			for _, h := range chain.sniHosts {
-				if h == "*" {
-					fullWildcardFound = true
-					// If we have a host with *, it effectively means match anything, i.e.
-					// no SNI based matching for this host.
-					break
-				}
-			}
-			if !fullWildcardFound {
-				chain.sniHosts = append([]string{}, chain.sniHosts...)
-				sort.Stable(sort.StringSlice(chain.sniHosts))
-				match.ServerNames = chain.sniHosts
-			}
-		}
-		if len(chain.destinationCIDRs) > 0 {
-			chain.destinationCIDRs = append([]string{}, chain.destinationCIDRs...)
-			sort.Stable(sort.StringSlice(chain.destinationCIDRs))
-			for _, d := range chain.destinationCIDRs {
-				cidr := util.ConvertAddressToCidr(d)
-				if cidr != nil && cidr.AddressPrefix != constants.UnspecifiedIP {
-					match.PrefixRanges = append(match.PrefixRanges, cidr)
-				}
-			}
-		}
-
-		if !needMatch && filterChainMatchEmpty(match) {
-			match = nil
-		}
+		match := chain.toFilterChainMatch()
 		var transportSocket *core.TransportSocket
-		switch opts.transport {
+		switch transport {
 		case istionetworking.TransportProtocolTCP:
 			transportSocket = buildDownstreamTLSTransportSocket(chain.tlsContext)
 		case istionetworking.TransportProtocolQUIC:
@@ -1203,16 +1060,12 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 	}
 
 	var res *listener.Listener
-	switch opts.transport {
+	switch transport {
 	case istionetworking.TransportProtocolTCP:
-		var bindToPort *wrappers.BoolValue
 		var connectionBalance *listener.Listener_ConnectionBalanceConfig
-		if !opts.bindToPort {
-			bindToPort = proto.BoolFalse
-		}
 		// only use to exact_balance for tcp outbound listeners; virtualOutbound listener should
 		// not have this set per Envoy docs for redirected listeners
-		if opts.proxy.Metadata.OutboundListenerExactBalance && trafficDirection == core.TrafficDirection_OUTBOUND {
+		if opts.proxy.Metadata.OutboundListenerExactBalance {
 			connectionBalance = &listener.Listener_ConnectionBalanceConfig{
 				BalanceType: &listener.Listener_ConnectionBalanceConfig_ExactBalance_{
 					ExactBalance: &listener.Listener_ConnectionBalanceConfig_ExactBalance{},
@@ -1224,16 +1077,15 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 			// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy doesn't like
 			Name:                             getListenerName(opts.bind, opts.port.Port, istionetworking.TransportProtocolTCP),
 			Address:                          util.BuildAddress(opts.bind, uint32(opts.port.Port)),
-			TrafficDirection:                 trafficDirection,
+			TrafficDirection:                 core.TrafficDirection_OUTBOUND,
 			ListenerFilters:                  listenerFilters,
 			FilterChains:                     filterChains,
-			BindToPort:                       bindToPort,
 			ConnectionBalanceConfig:          connectionBalance,
 			ContinueOnListenerFiltersTimeout: true,
 		}
 		// add extra addresses for the listener
 		if features.EnableDualStack && len(opts.extraBind) > 0 {
-			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port.Port), opts.proxy)
+			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port.Port))
 		}
 
 		if opts.proxy.Type != model.Router {
@@ -1244,11 +1096,11 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 		//       mature, refactor some of these to an interface so that they kick off the process
 		//       of building listener, filter chains, serializing etc based on transport protocol
 		listenerName := getListenerName(opts.bind, opts.port.Port, istionetworking.TransportProtocolQUIC)
-		log.Debugf("buildListener: building UDP/QUIC listener %s", listenerName)
+		log.Debugf("buildGatewayListener: building UDP/QUIC listener %s", listenerName)
 		res = &listener.Listener{
 			Name:             listenerName,
 			Address:          util.BuildNetworkAddress(opts.bind, uint32(opts.port.Port), istionetworking.TransportProtocolQUIC),
-			TrafficDirection: trafficDirection,
+			TrafficDirection: core.TrafficDirection_OUTBOUND,
 			FilterChains:     filterChains,
 			UdpListenerConfig: &listener.UdpListenerConfig{
 				// TODO: Maybe we should add options in MeshConfig to
@@ -1261,121 +1113,118 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 		}
 		// add extra addresses for the listener
 		if features.EnableDualStack && len(opts.extraBind) > 0 {
-			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port.Port), opts.proxy)
+			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port.Port))
 		}
 	}
 
-	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, opts.class)
+	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, istionetworking.ListenerClassGateway)
 
 	return res
 }
 
-func getMatchAllFilterChain(l *listener.Listener) (int, *listener.FilterChain) {
-	for i, fc := range l.FilterChains {
-		if isMatchAllFilterChain(fc) {
-			return i, fc
+// isMatchAll returns true if this chain will match everything
+// This closely matches toFilterChainMatch
+func (chain *filterChainOpts) isMatchAll() bool {
+	return (len(chain.sniHosts) == 0 || slices.Contains(chain.sniHosts, "*")) &&
+		len(chain.applicationProtocols) == 0 &&
+		len(chain.transportProtocol) == 0 &&
+		len(chain.destinationCIDRs) == 0
+}
+
+func (chain *filterChainOpts) conflictsWith(other *filterChainOpts) bool {
+	a, b := chain, other
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.transportProtocol != b.transportProtocol {
+		return false
+	}
+	if !slices.Equal(a.applicationProtocols, b.applicationProtocols) {
+		return false
+	}
+	// SNI order does not matter, and we ignore * entries
+	sniSet := func(sni []string) sets.String {
+		if len(sni) == 0 {
+			return nil
+		}
+		res := sets.NewWithLength[string](len(sni))
+		for _, s := range sni {
+			if s == "*" {
+				continue
+			}
+			res.Insert(s)
+		}
+		return res
+	}
+	if !sniSet(a.sniHosts).Equals(sniSet(b.sniHosts)) {
+		return false
+	}
+
+	// Order doesn't matter. Make sure we properly handle overlapping prefixes though
+	// eg: 1.2.3.4/8 is the same as 1.5.6.7/8.
+	cidrSet := func(cidrs []string) sets.String {
+		if len(cidrs) == 0 {
+			return nil
+		}
+		res := sets.NewWithLength[string](len(cidrs))
+		for _, s := range cidrs {
+			prefix, err := util.AddrStrToPrefix(s)
+			if err != nil {
+				continue
+			}
+			if prefix.Addr().String() == constants.UnspecifiedIP {
+				continue
+			}
+
+			if s == "*" {
+				continue
+			}
+			res.Insert(prefix.Masked().String())
+		}
+		return res
+	}
+	return cidrSet(a.destinationCIDRs).Equals(cidrSet(b.destinationCIDRs))
+}
+
+func (chain *filterChainOpts) toFilterChainMatch() *listener.FilterChainMatch {
+	if chain.isMatchAll() {
+		return nil
+	}
+	match := &listener.FilterChainMatch{
+		ApplicationProtocols: chain.applicationProtocols,
+		TransportProtocol:    chain.transportProtocol,
+	}
+	if len(chain.sniHosts) > 0 {
+		fullWildcardFound := false
+		for _, h := range chain.sniHosts {
+			if h == "*" {
+				fullWildcardFound = true
+				// If we have a host with *, it effectively means match anything, i.e.
+				// no SNI based matching for this host.
+				break
+			}
+		}
+		if !fullWildcardFound {
+			chain.sniHosts = append([]string{}, chain.sniHosts...)
+			sort.Stable(sort.StringSlice(chain.sniHosts))
+			match.ServerNames = chain.sniHosts
 		}
 	}
-	return 0, nil
-}
-
-// Create pass through filter chain for the listener assuming all the other filter chains are ready.
-// The match member of pass through filter chain depends on the existing non-passthrough filter chain.
-// TODO(lambdai): Calculate the filter chain match to replace the wildcard and replace appendListenerFallthroughRoute.
-func appendListenerFallthroughRouteForCompleteListener(l *listener.Listener, node *model.Proxy, push *model.PushContext) {
-	matchIndex, matchAll := getMatchAllFilterChain(l)
-
-	fallthroughNetworkFilters := buildOutboundCatchAllNetworkFiltersOnly(push, node)
-
-	outboundPassThroughFilterChain := &listener.FilterChain{
-		FilterChainMatch: &listener.FilterChainMatch{},
-		Name:             util.PassthroughFilterChain,
-		Filters:          fallthroughNetworkFilters,
-	}
-
-	// Set a default filter chain. This allows us to avoid issues where
-	// traffic starts to match a filter chain but then doesn't match latter criteria, leading to
-	// dropped requests. See https://github.com/istio/istio/issues/26079 for details.
-	// If there are multiple filter chains and a match all chain, move it to DefaultFilterChain
-	// This ensures it will always be used as the fallback.
-	if matchAll != nil && len(l.FilterChains) > 1 {
-		copy(l.FilterChains[matchIndex:], l.FilterChains[matchIndex+1:]) // Shift l.FilterChains[i+1:] left one index.
-		l.FilterChains[len(l.FilterChains)-1] = nil                      // Erase last element (write zero value).
-		l.FilterChains = l.FilterChains[:len(l.FilterChains)-1]          // Truncate slice.
-		l.DefaultFilterChain = matchAll
-	} else if matchAll == nil {
-		// Otherwise, if there is no match all already, set a passthrough match all
-		l.DefaultFilterChain = outboundPassThroughFilterChain
-	}
-}
-
-// build adds the provided TCP and HTTP filters to the provided Listener and serializes them.
-// TODO: given how tightly tied listener.FilterChains, opts.filterChainOpts, and mutable.FilterChains
-// are to each other we should encapsulate them some way to ensure they remain consistent (mainly that
-// in each an index refers to the same chain).
-func (ml *MutableListener) build(builder *ListenerBuilder, opts buildListenerOpts) error {
-	if len(opts.filterChainOpts) == 0 {
-		return fmt.Errorf("must have more than 0 chains in listener %q", ml.Listener.Name)
-	}
-	httpConnectionManagers := make([]*hcm.HttpConnectionManager, len(ml.FilterChains))
-	for i := range ml.FilterChains {
-		chain := ml.FilterChains[i]
-		opt := opts.filterChainOpts[i]
-		ml.Listener.FilterChains[i].Metadata = opt.metadata
-		ml.Listener.FilterChains[i].Name = opt.filterChainName
-		if opt.httpOpts == nil {
-			// we are building a network filter chain (no http connection manager) for this filter chain
-			// In HTTP, we need to have RBAC, etc. upfront so that they can enforce policies immediately
-			// For network filters such as mysql, mongo, etc., we need the filter codec upfront. Data from this
-			// codec is used by RBAC later.
-			//
-			// Currently, when transport is QUIC we assume HTTP3. So it should not come here.
-			// When other protocols are used over QUIC, we have to revisit this assumption.
-
-			if len(opt.networkFilters) > 0 {
-				// this is the terminating filter
-				lastNetworkFilter := opt.networkFilters[len(opt.networkFilters)-1]
-
-				for n := 0; n < len(opt.networkFilters)-1; n++ {
-					ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, opt.networkFilters[n])
-				}
-				ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, chain.TCP...)
-				ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, lastNetworkFilter)
-			} else {
-				ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, chain.TCP...)
+	if len(chain.destinationCIDRs) > 0 {
+		chain.destinationCIDRs = append([]string{}, chain.destinationCIDRs...)
+		sort.Stable(sort.StringSlice(chain.destinationCIDRs))
+		for _, d := range chain.destinationCIDRs {
+			cidr := util.ConvertAddressToCidr(d)
+			if cidr != nil && cidr.AddressPrefix != constants.UnspecifiedIP {
+				match.PrefixRanges = append(match.PrefixRanges, cidr)
 			}
-			log.Debugf("attached %d network filters to listener %q filter chain %d", len(chain.TCP)+len(opt.networkFilters), ml.Listener.Name, i)
-		} else {
-			// Add the TCP filters first.. and then the HTTP connection manager.
-			// Skip adding this if transport is not TCP (could be QUIC)
-			if chain.TransportProtocol == istionetworking.TransportProtocolTCP {
-				ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, chain.TCP...)
-			}
-
-			// If statPrefix has been set before calling this method, respect that.
-			if len(opt.httpOpts.statPrefix) == 0 {
-				opt.httpOpts.statPrefix = strings.ToLower(ml.Listener.TrafficDirection.String()) + "_" + ml.Listener.Name
-			}
-			if opts.port != nil {
-				opt.httpOpts.port = opts.port.Port
-			}
-			httpConnectionManagers[i] = builder.buildHTTPConnectionManager(opt.httpOpts)
-			filter := &listener.Filter{
-				Name:       wellknown.HTTPConnectionManager,
-				ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(httpConnectionManagers[i])},
-			}
-			ml.Listener.FilterChains[i].Filters = append(ml.Listener.FilterChains[i].Filters, filter)
-			log.Debugf("attached HTTP filter with %d http_filter options to listener %q filter chain %d",
-				len(httpConnectionManagers[i].HttpFilters), ml.Listener.Name, i)
 		}
 	}
 
-	return nil
+	return match
 }
 
-func mergeTCPFilterChains(incoming []*listener.FilterChain, listenerOpts buildListenerOpts, listenerMapKey string,
-	listenerMap map[string]*outboundListenerEntry,
-) []*listener.FilterChain {
+func mergeTCPFilterChains(current *outboundListenerEntry, incoming []*filterChainOpts, opts outboundListenerOpts) {
 	// TODO(rshriram) merge multiple identical filter chains with just a single destination CIDR based
 	// filter chain match, into a single filter chain and array of destinationcidr matches
 
@@ -1385,16 +1234,15 @@ func mergeTCPFilterChains(incoming []*listener.FilterChain, listenerOpts buildLi
 	// Extract the current filter chain matches, for every new filter chain match being added, check if there is a matching
 	// one in previous filter chains, if so, skip adding this filter chain with a warning.
 
-	currentListenerEntry := listenerMap[listenerMapKey]
-	mergedFilterChains := make([]*listener.FilterChain, 0, len(currentListenerEntry.listener.FilterChains)+len(incoming))
+	merged := make([]*filterChainOpts, 0, len(current.chains)+len(incoming))
 	// Start with the current listener's filter chains.
-	mergedFilterChains = append(mergedFilterChains, currentListenerEntry.listener.FilterChains...)
+	merged = append(merged, current.chains...)
 
-	for _, incomingFilterChain := range incoming {
+	for _, incoming := range incoming {
 		conflict := false
 
-		for _, existingFilterChain := range mergedFilterChains {
-			conflict = isConflict(existingFilterChain, incomingFilterChain)
+		for _, existing := range merged {
+			conflict = existing.conflictsWith(incoming)
 
 			if conflict {
 				// NOTE: While pluginParams.Service can be nil,
@@ -1403,8 +1251,8 @@ func mergeTCPFilterChains(incoming []*listener.FilterChain, listenerOpts buildLi
 				// the wildcard egress listener. the check for the "locked" bit will eliminate the collision.
 				// User is also not allowed to add duplicate ports in the egress listener
 				var newHostname host.Name
-				if listenerOpts.service != nil {
-					newHostname = listenerOpts.service.Hostname
+				if opts.service != nil {
+					newHostname = opts.service.Hostname
 				} else {
 					// user defined outbound listener via sidecar API
 					newHostname = "sidecar-config-egress-tcp-listener"
@@ -1412,114 +1260,23 @@ func mergeTCPFilterChains(incoming []*listener.FilterChain, listenerOpts buildLi
 
 				outboundListenerConflict{
 					metric:          model.ProxyStatusConflictOutboundListenerTCPOverTCP,
-					node:            listenerOpts.proxy,
-					listenerName:    listenerMapKey,
-					currentServices: currentListenerEntry.services,
-					currentProtocol: currentListenerEntry.servicePort.Protocol,
+					node:            opts.proxy,
+					listenerName:    getListenerName(opts.bind.Primary(), opts.port.Port, istionetworking.TransportProtocolTCP),
+					currentProtocol: current.servicePort.Protocol,
 					newHostname:     newHostname,
-					newProtocol:     listenerOpts.port.Protocol,
-				}.addMetric(listenerOpts.push)
+					newProtocol:     opts.port.Protocol,
+				}.addMetric(opts.push)
 				break
 			}
-
 		}
+
 		if !conflict {
 			// There is no conflict with any filter chain in the existing listener.
 			// So append the new filter chains to the existing listener's filter chains
-			mergedFilterChains = append(mergedFilterChains, incomingFilterChain)
-			if listenerOpts.service != nil {
-				lEntry := listenerMap[listenerMapKey]
-				lEntry.services = append(lEntry.services, listenerOpts.service)
-			}
+			merged = append(merged, incoming)
 		}
 	}
-	return mergedFilterChains
-}
-
-// isConflict determines whether the incoming filter chain has conflict with existing filter chain.
-func isConflict(existing, incoming *listener.FilterChain) bool {
-	return filterChainMatchEqual(existing.FilterChainMatch, incoming.FilterChainMatch)
-}
-
-func filterChainMatchEmpty(fcm *listener.FilterChainMatch) bool {
-	return fcm == nil || filterChainMatchEqual(fcm, emptyFilterChainMatch)
-}
-
-// filterChainMatchEqual returns true if both filter chains are equal otherwise false.
-func filterChainMatchEqual(first *listener.FilterChainMatch, second *listener.FilterChainMatch) bool {
-	if first == nil || second == nil {
-		return first == second
-	}
-	if first.TransportProtocol != second.TransportProtocol {
-		return false
-	}
-	if !slices.Equal(first.ApplicationProtocols, second.ApplicationProtocols) {
-		return false
-	}
-	if first.DestinationPort.GetValue() != second.DestinationPort.GetValue() {
-		return false
-	}
-	if !util.CidrRangeSliceEqual(first.PrefixRanges, second.PrefixRanges) {
-		return false
-	}
-	if !util.CidrRangeSliceEqual(first.SourcePrefixRanges, second.SourcePrefixRanges) {
-		return false
-	}
-	if !util.CidrRangeSliceEqual(first.DirectSourcePrefixRanges, second.DirectSourcePrefixRanges) {
-		return false
-	}
-	if first.AddressSuffix != second.AddressSuffix {
-		return false
-	}
-	if first.SuffixLen.GetValue() != second.SuffixLen.GetValue() {
-		return false
-	}
-	if first.SourceType != second.SourceType {
-		return false
-	}
-	if !slices.Equal(first.SourcePorts, second.SourcePorts) {
-		return false
-	}
-	if !slices.Equal(first.ServerNames, second.ServerNames) {
-		return false
-	}
-	return true
-}
-
-func mergeFilterChains(httpFilterChain, tcpFilterChain []*listener.FilterChain) []*listener.FilterChain {
-	var newFilterChan []*listener.FilterChain
-	for _, fc := range httpFilterChain {
-		if fc.FilterChainMatch == nil {
-			fc.FilterChainMatch = &listener.FilterChainMatch{}
-		}
-
-		var missingHTTPALPNs []string
-		for _, p := range plaintextHTTPALPNs {
-			if !slices.Contains(fc.FilterChainMatch.ApplicationProtocols, p) {
-				missingHTTPALPNs = append(missingHTTPALPNs, p)
-			}
-		}
-
-		fc.FilterChainMatch.ApplicationProtocols = append(fc.FilterChainMatch.ApplicationProtocols, missingHTTPALPNs...)
-		newFilterChan = append(newFilterChan, fc)
-	}
-	return append(tcpFilterChain, newFilterChan...)
-}
-
-func getPluginFilterChain(opts buildListenerOpts) []istionetworking.FilterChain {
-	filterChain := make([]istionetworking.FilterChain, len(opts.filterChainOpts))
-
-	for id := range filterChain {
-		if opts.filterChainOpts[id].httpOpts == nil {
-			filterChain[id].ListenerProtocol = istionetworking.ListenerProtocolTCP
-		} else {
-			filterChain[id].ListenerProtocol = istionetworking.ListenerProtocolHTTP
-		}
-		filterChain[id].TCP = opts.filterChainOpts[id].filterChain.TCP
-		filterChain[id].HTTP = opts.filterChainOpts[id].filterChain.HTTP
-	}
-
-	return filterChain
+	current.chains = merged
 }
 
 // isConflictWithWellKnownPort checks conflicts between incoming protocol and existing protocol.
@@ -1537,31 +1294,6 @@ func isConflictWithWellKnownPort(incoming, existing protocol.Instance, conflict 
 	}
 
 	return true
-}
-
-// mergeListenerFilters appends a TLS and/or HTTP inspector to `a` if `a` does not yet have it but `n` does.
-// This is used when merging filter chains - the listener filters should be the union.
-func mergeListenerFilters(a, b []*listener.ListenerFilter) []*listener.ListenerFilter {
-	alreadyHasTLSInspector := false
-	alreadyHasHTTPInspector := false
-	for _, f := range a {
-		alreadyHasTLSInspector = alreadyHasTLSInspector || f.Name == wellknown.TlsInspector
-		alreadyHasHTTPInspector = alreadyHasHTTPInspector || f.Name == wellknown.HttpInspector
-	}
-	wantTLSInspector := false
-	wantHTTPInspector := false
-	for _, f := range b {
-		wantTLSInspector = wantTLSInspector || f.Name == wellknown.TlsInspector
-		wantHTTPInspector = wantHTTPInspector || f.Name == wellknown.HttpInspector
-	}
-
-	if !alreadyHasTLSInspector && wantTLSInspector {
-		a = append(a, xdsfilters.TLSInspector)
-	}
-	if !alreadyHasHTTPInspector && wantHTTPInspector {
-		a = append(a, xdsfilters.HTTPInspector)
-	}
-	return a
 }
 
 // nolint: interfacer
@@ -1586,30 +1318,6 @@ func buildDownstreamQUICTransportSocket(tlsContext *auth.DownstreamTlsContext) *
 				DownstreamTlsContext: tlsContext,
 			}),
 		},
-	}
-}
-
-func isMatchAllFilterChain(fc *listener.FilterChain) bool {
-	// See if it is empty filter chain.
-	return filterChainMatchEmpty(fc.FilterChainMatch)
-}
-
-func removeListenerFilterTimeout(listeners []*listener.Listener) {
-	for _, l := range listeners {
-		// Remove listener filter timeout for
-		// 	1. outbound listeners AND
-		// 	2. without HTTP inspector
-		hasHTTPInspector := false
-		for _, lf := range l.ListenerFilters {
-			if lf.Name == wellknown.HttpInspector {
-				hasHTTPInspector = true
-				break
-			}
-		}
-
-		if !hasHTTPInspector && l.TrafficDirection == core.TrafficDirection_OUTBOUND {
-			l.ListenerFiltersTimeout = durationpb.New(0)
-		}
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -107,7 +107,6 @@ func (lb *ListenerBuilder) buildHTTPProxyListener() *ListenerBuilder {
 	if httpProxy == nil {
 		return lb
 	}
-	removeListenerFilterTimeout([]*listener.Listener{httpProxy})
 	lb.httpProxyListener = httpProxy
 	return lb
 }
@@ -137,7 +136,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener() *ListenerBuilder {
 	}
 	// add extra addresses for the listener
 	if features.EnableDualStack && len(actualWildcards) > 1 {
-		ipTablesListener.AdditionalAddresses = util.BuildAdditionalAddresses(actualWildcards[1:], uint32(lb.push.Mesh.ProxyListenPort), lb.node)
+		ipTablesListener.AdditionalAddresses = util.BuildAdditionalAddresses(actualWildcards[1:], uint32(lb.push.Mesh.ProxyListenPort))
 	}
 
 	class := model.OutboundListenerClass(lb.node.Type)
@@ -235,11 +234,9 @@ func buildOutboundCatchAllNetworkFiltersOnly(push *model.PushContext, node *mode
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       egressCluster,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: egressCluster},
+		IdleTimeout:      parseDuration(node.Metadata.IdleTimeout),
 	}
-	idleTimeoutDuration, err := time.ParseDuration(node.Metadata.IdleTimeout)
-	if err == nil {
-		tcpProxy.IdleTimeout = durationpb.New(idleTimeoutDuration)
-	}
+
 	filterStack := buildMetricsNetworkFilters(push, node, istionetworking.ListenerClassSidecarOutbound)
 	accessLogBuilder.setTCPAccessLog(push, node, tcpProxy, istionetworking.ListenerClassSidecarOutbound)
 	filterStack = append(filterStack, &listener.Filter{
@@ -248,6 +245,17 @@ func buildOutboundCatchAllNetworkFiltersOnly(push *model.PushContext, node *mode
 	})
 
 	return filterStack
+}
+
+func parseDuration(s string) *durationpb.Duration {
+	if s == "" {
+		return nil
+	}
+	t, err := time.ParseDuration(s)
+	if err != nil {
+		return nil
+	}
+	return durationpb.New(t)
 }
 
 // TODO: This code is still insufficient. Ideally we should be parsing all the virtual services
@@ -327,15 +335,13 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	websocketUpgrade := &hcm.HttpConnectionManager_UpgradeConfig{UpgradeType: "websocket"}
 	connectionManager.UpgradeConfigs = []*hcm.HttpConnectionManager_UpgradeConfig{websocketUpgrade}
 
-	idleTimeout, err := time.ParseDuration(lb.node.Metadata.IdleTimeout)
-	if err == nil {
+	if idleTimeout := parseDuration(lb.node.Metadata.IdleTimeout); idleTimeout != nil {
 		connectionManager.CommonHttpProtocolOptions = &core.HttpProtocolOptions{
-			IdleTimeout: durationpb.New(idleTimeout),
+			IdleTimeout: idleTimeout,
 		}
 	}
 
-	notimeout := durationpb.New(0 * time.Second)
-	connectionManager.StreamIdleTimeout = notimeout
+	connectionManager.StreamIdleTimeout = durationpb.New(0 * time.Second)
 
 	if httpOpts.rds != "" {
 		rds := &hcm.HttpConnectionManager_Rds{
@@ -383,6 +389,8 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	}
 
 	if httpOpts.protocol == protocol.GRPCWeb {
+		// TODO: because we share an HCM between many services, this check is broken; it will only work if the first
+		// GRPCWeb is probably only used for Gateways though, which don't have this concern.
 		filters = append(filters, xdsfilters.GrpcWeb)
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -27,7 +26,6 @@ import (
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -279,7 +277,7 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 	}
 	if features.EnableDualStack && len(addresses) > 1 {
 		// add extra addresses for the listener
-		l.AdditionalAddresses = util.BuildAdditionalAddresses(addresses[1:], tPort, lb.node)
+		l.AdditionalAddresses = util.BuildAdditionalAddresses(addresses[1:], tPort)
 	}
 	if lb.node.Metadata.InboundListenerExactBalance {
 		l.ConnectionBalanceConfig = &listener.Listener_ConnectionBalanceConfig{
@@ -828,10 +826,7 @@ func (lb *ListenerBuilder) buildInboundNetworkFilters(fcc inboundChainConfig) []
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: fcc.clusterName},
-	}
-	idleTimeout, err := time.ParseDuration(lb.node.Metadata.IdleTimeout)
-	if err == nil {
-		tcpProxy.IdleTimeout = durationpb.New(idleTimeout)
+		IdleTimeout:      parseDuration(lb.node.Metadata.IdleTimeout),
 	}
 	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, istionetworking.ListenerClassSidecarInbound)
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
@@ -43,7 +42,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/listenertest"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
@@ -51,6 +49,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
@@ -1371,17 +1370,18 @@ func testOutboundListenerFilterTimeout(t *testing.T, services ...*model.Service)
 			t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
 		}
 
-		if listeners[0].ListenerFiltersTimeout == nil ||
-			(listeners[0].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[0].ListenerFiltersTimeout.GetNanos() != 0) {
+		explicit := xdstest.ExtractListener("0.0.0.0_8080", listeners)
+		if explicit.ListenerFiltersTimeout == nil {
 			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
-				listeners[0].ContinueOnListenerFiltersTimeout,
-				listeners[0].ListenerFiltersTimeout)
+				explicit.ContinueOnListenerFiltersTimeout,
+				explicit.ListenerFiltersTimeout)
 		}
-		if listeners[1].ListenerFiltersTimeout == nil ||
-			(listeners[0].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[0].ListenerFiltersTimeout.GetNanos() != 0) {
-			t.Fatalf("expected timeout disabled , found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
-				listeners[1].ContinueOnListenerFiltersTimeout,
-				listeners[1].ListenerFiltersTimeout)
+
+		auto := xdstest.ExtractListener("0.0.0.0_9090", listeners)
+		if !auto.ContinueOnListenerFiltersTimeout || auto.ListenerFiltersTimeout == nil {
+			t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				auto.ContinueOnListenerFiltersTimeout,
+				auto.ListenerFiltersTimeout)
 		}
 	}
 }
@@ -1945,6 +1945,7 @@ func TestHttpProxyListener(t *testing.T) {
 	m.ProxyHttpPort = 15007
 	listeners := buildListeners(t, TestOptions{MeshConfig: m}, nil)
 	httpProxy := xdstest.ExtractListener("127.0.0.1_15007", listeners)
+	t.Logf(xdstest.Dump(t, httpProxy))
 	f := httpProxy.FilterChains[0].Filters[0]
 	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 
@@ -2291,7 +2292,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 }
 
 func customTracingTags() []*tracing.CustomTag {
-	return append(buildOptionalPolicyTags(),
+	return append(slices.Clone(optionalPolicyTags),
 		&tracing.CustomTag{
 			Tag: "istio.canonical_revision",
 			Type: &tracing.CustomTag_Literal_{
@@ -2575,343 +2576,6 @@ func buildServiceInstance(service *model.Service, instanceIP string) *model.Serv
 		},
 		ServicePort: service.Ports[0],
 		Service:     service,
-	}
-}
-
-func TestAppendListenerFallthroughRouteForCompleteListener(t *testing.T) {
-	tests := []struct {
-		name        string
-		node        *model.Proxy
-		hostname    string
-		idleTimeout *durationpb.Duration
-	}{
-		{
-			name: "Registry_Only",
-			node: &model.Proxy{
-				ID:       "foo.bar",
-				Metadata: &model.NodeMetadata{},
-				SidecarScope: &model.SidecarScope{
-					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
-						Mode: networking.OutboundTrafficPolicy_REGISTRY_ONLY,
-					},
-				},
-			},
-			hostname: util.BlackHoleCluster,
-		},
-		{
-			name: "Allow_Any",
-			node: &model.Proxy{
-				ID:       "foo.bar",
-				Metadata: &model.NodeMetadata{},
-				SidecarScope: &model.SidecarScope{
-					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
-						Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
-					},
-				},
-			},
-			hostname: util.PassthroughCluster,
-		},
-		{
-			name: "idle_timeout",
-			node: &model.Proxy{
-				ID: "foo.bar",
-				Metadata: &model.NodeMetadata{
-					IdleTimeout: "15s",
-				},
-				SidecarScope: &model.SidecarScope{
-					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
-						Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
-					},
-				},
-			},
-			hostname:    util.PassthroughCluster,
-			idleTimeout: durationpb.New(15 * time.Second),
-		},
-		{
-			name: "invalid_idle_timeout",
-			node: &model.Proxy{
-				ID: "foo.bar",
-				Metadata: &model.NodeMetadata{
-					IdleTimeout: "s15s",
-				},
-				SidecarScope: &model.SidecarScope{
-					OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
-						Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
-					},
-				},
-			},
-			hostname: util.PassthroughCluster,
-			// idleTimeout shouldn't be set, will use default value in envoy
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cg := NewConfigGenTest(t, TestOptions{})
-			l := &listener.Listener{}
-			appendListenerFallthroughRouteForCompleteListener(l, tt.node, cg.PushContext())
-			if len(l.FilterChains) != 0 {
-				t.Errorf("Expected exactly 0 filter chain")
-			}
-			if len(l.DefaultFilterChain.Filters) != 1 {
-				t.Errorf("Expected exactly 1 network filter in the chain")
-			}
-			filter := l.DefaultFilterChain.Filters[0]
-			var tcpProxy tcp.TcpProxy
-			cfg := filter.GetTypedConfig()
-			_ = cfg.UnmarshalTo(&tcpProxy)
-			if tcpProxy.StatPrefix != tt.hostname {
-				t.Errorf("Expected stat prefix %s but got %s\n", tt.hostname, tcpProxy.StatPrefix)
-			}
-			if tcpProxy.GetCluster() != tt.hostname {
-				t.Errorf("Expected cluster %s but got %s\n", tt.hostname, tcpProxy.GetCluster())
-			}
-			if tt.idleTimeout != nil && !reflect.DeepEqual(tcpProxy.IdleTimeout, tt.idleTimeout) {
-				t.Errorf("Expected IdleTimeout %s but got %s\n", tt.idleTimeout, tcpProxy.IdleTimeout)
-			}
-			if tt.idleTimeout == nil && tcpProxy.IdleTimeout != nil {
-				t.Errorf("Expected no IdleTimeout set, but got %s\n", tcpProxy.IdleTimeout.AsDuration())
-			}
-		})
-	}
-}
-
-func TestMergeTCPFilterChains(t *testing.T) {
-	cg := NewConfigGenTest(t, TestOptions{})
-
-	node := &model.Proxy{
-		ID:       "foo.bar",
-		Metadata: &model.NodeMetadata{},
-		SidecarScope: &model.SidecarScope{
-			OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
-				Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
-			},
-		},
-	}
-
-	tcpProxy := &tcp.TcpProxy{
-		StatPrefix:       "outbound|443||foo.com",
-		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: "outbound|443||foo.com"},
-	}
-
-	tcpProxyFilter := &listener.Filter{
-		Name:       wellknown.TCPProxy,
-		ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(tcpProxy)},
-	}
-
-	tcpProxy = &tcp.TcpProxy{
-		StatPrefix:       "outbound|443||bar.com",
-		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: "outbound|443||bar.com"},
-	}
-
-	tcpProxyFilter2 := &listener.Filter{
-		Name:       wellknown.TCPProxy,
-		ConfigType: &listener.Filter_TypedConfig{TypedConfig: protoconv.MessageToAny(tcpProxy)},
-	}
-
-	svcPort := &model.Port{
-		Name:     "https",
-		Port:     443,
-		Protocol: protocol.HTTPS,
-	}
-	var l listener.Listener
-	filterChains := []*listener.FilterChain{
-		{
-			FilterChainMatch: &listener.FilterChainMatch{
-				PrefixRanges: []*core.CidrRange{
-					{
-						AddressPrefix: "10.244.0.18",
-						PrefixLen:     &wrappers.UInt32Value{Value: 32},
-					},
-					{
-						AddressPrefix: "fe80::1c97:c3ff:fed7:5940",
-						PrefixLen:     &wrappers.UInt32Value{Value: 128},
-					},
-				},
-			},
-			Filters: nil, // This is not a valid config, just for test
-		},
-		{
-			FilterChainMatch: &listener.FilterChainMatch{
-				ServerNames: []string{"foo.com"},
-			},
-			// This is not a valid config, just for test
-			Filters: []*listener.Filter{tcpProxyFilter},
-		},
-		{
-			FilterChainMatch: &listener.FilterChainMatch{},
-			// This is not a valid config, just for test
-			Filters: buildOutboundCatchAllNetworkFiltersOnly(cg.PushContext(), node),
-		},
-	}
-	l.FilterChains = filterChains
-	listenerMap := map[string]*outboundListenerEntry{
-		"0.0.0.0_443": {
-			servicePort: svcPort,
-			services: []*model.Service{{
-				CreationTime:   tnow,
-				Hostname:       host.Name("foo.com"),
-				DefaultAddress: "192.168.1.1",
-				Ports:          []*model.Port{svcPort},
-				Resolution:     model.DNSLB,
-			}},
-			listener: &l,
-		},
-	}
-
-	incomingFilterChains := []*listener.FilterChain{
-		{
-			FilterChainMatch: &listener.FilterChainMatch{
-				ServerNames: []string{"bar.com"},
-			}, // This is not a valid config, just for test
-			Filters: []*listener.Filter{tcpProxyFilter2},
-		},
-	}
-
-	svc := model.Service{
-		Hostname: "bar.com",
-	}
-
-	opts := buildListenerOpts{
-		proxy:   node,
-		push:    cg.PushContext(),
-		service: &svc,
-	}
-
-	out := mergeTCPFilterChains(incomingFilterChains, opts, "0.0.0.0_443", listenerMap)
-
-	if len(out) != 4 {
-		t.Errorf("Got %d filter chains, expected 3", len(out))
-	}
-	if !isMatchAllFilterChain(out[2]) {
-		t.Errorf("The last filter chain  %#v is not wildcard matching", out[2])
-	}
-
-	if !reflect.DeepEqual(out[3].Filters, incomingFilterChains[0].Filters) {
-		t.Errorf("got %v\nwant %v\ndiff %v", out[2].Filters, incomingFilterChains[0].Filters, cmp.Diff(out[2].Filters, incomingFilterChains[0].Filters))
-	}
-}
-
-func TestFilterChainMatchEqual(t *testing.T) {
-	cases := []struct {
-		name   string
-		first  *listener.FilterChainMatch
-		second *listener.FilterChainMatch
-		want   bool
-	}{
-		{
-			name:   "both nil",
-			first:  nil,
-			second: nil,
-			want:   true,
-		},
-		{
-			name:   "one of them nil",
-			first:  nil,
-			second: &listener.FilterChainMatch{},
-			want:   false,
-		},
-		{
-			name:   "both empty",
-			first:  &listener.FilterChainMatch{},
-			second: &listener.FilterChainMatch{},
-			want:   true,
-		},
-		{
-			name: "with equal values",
-			first: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: mtlsHTTPALPNs,
-			},
-			second: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: mtlsHTTPALPNs,
-			},
-			want: true,
-		},
-		{
-			name: "with not equal values",
-			first: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: mtlsHTTPALPNs,
-			},
-			second: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: plaintextHTTPALPNs,
-			},
-			want: false,
-		},
-		{
-			name: "equal with all values",
-			first: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: mtlsHTTPALPNs,
-				DestinationPort:      &wrappers.UInt32Value{Value: 1999},
-				AddressSuffix:        "suffix",
-				SourceType:           listener.FilterChainMatch_ANY,
-				SuffixLen:            &wrappers.UInt32Value{Value: 3},
-				PrefixRanges: []*core.CidrRange{
-					{
-						AddressPrefix: "10.244.0.18",
-						PrefixLen:     &wrappers.UInt32Value{Value: 32},
-					},
-					{
-						AddressPrefix: "fe80::1c97:c3ff:fed7:5940",
-						PrefixLen:     &wrappers.UInt32Value{Value: 128},
-					},
-				},
-				SourcePrefixRanges: []*core.CidrRange{
-					{
-						AddressPrefix: "10.244.0.18",
-						PrefixLen:     &wrappers.UInt32Value{Value: 32},
-					},
-					{
-						AddressPrefix: "fe80::1c97:c3ff:fed7:5940",
-						PrefixLen:     &wrappers.UInt32Value{Value: 128},
-					},
-				},
-				SourcePorts: []uint32{2000},
-				ServerNames: []string{"foo"},
-			},
-			second: &listener.FilterChainMatch{
-				TransportProtocol:    "TCP",
-				ApplicationProtocols: plaintextHTTPALPNs,
-				DestinationPort:      &wrappers.UInt32Value{Value: 1999},
-				AddressSuffix:        "suffix",
-				SourceType:           listener.FilterChainMatch_ANY,
-				SuffixLen:            &wrappers.UInt32Value{Value: 3},
-				PrefixRanges: []*core.CidrRange{
-					{
-						AddressPrefix: "10.244.0.18",
-						PrefixLen:     &wrappers.UInt32Value{Value: 32},
-					},
-					{
-						AddressPrefix: "fe80::1c97:c3ff:fed7:5940",
-						PrefixLen:     &wrappers.UInt32Value{Value: 128},
-					},
-				},
-				SourcePrefixRanges: []*core.CidrRange{
-					{
-						AddressPrefix: "10.244.0.18",
-						PrefixLen:     &wrappers.UInt32Value{Value: 32},
-					},
-					{
-						AddressPrefix: "fe80::1c97:c3ff:fed7:5940",
-						PrefixLen:     &wrappers.UInt32Value{Value: 128},
-					},
-				},
-				SourcePorts: []uint32{2000},
-				ServerNames: []string{"foo"},
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := filterChainMatchEqual(tt.first, tt.second); got != tt.want {
-				t.Fatalf("Expected filter chain match to return %v, but got %v", tt.want, got)
-			}
-		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -87,11 +87,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: clusterName},
-	}
-
-	idleTimeout, err := time.ParseDuration(node.Metadata.IdleTimeout)
-	if err == nil {
-		tcpProxy.IdleTimeout = durationpb.New(idleTimeout)
+		IdleTimeout:      parseDuration(node.Metadata.IdleTimeout),
 	}
 	maxConnectionDuration := destinationRule.GetTrafficPolicy().GetConnectionPool().GetTcp().GetMaxConnectionDuration()
 	if maxConnectionDuration != nil {
@@ -124,12 +120,10 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: clusterSpecifier,
+
+		IdleTimeout: parseDuration(node.Metadata.IdleTimeout),
 	}
 
-	idleTimeout, err := time.ParseDuration(node.Metadata.IdleTimeout)
-	if err == nil {
-		tcpProxy.IdleTimeout = durationpb.New(idleTimeout)
-	}
 	maxConnectionDuration := destinationRule.GetTrafficPolicy().GetConnectionPool().GetTcp().GetMaxConnectionDuration()
 	if maxConnectionDuration != nil {
 		tcpProxy.MaxDownstreamConnectionDuration = maxConnectionDuration

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -332,28 +332,3 @@ TcpLoop:
 
 	return out
 }
-
-// This function can be called for namespaces with the auto generated sidecar, i.e. once per service and per port.
-// OR, it could be called in the context of an egress listener with specific TCP port on a sidecar config.
-// In the latter case, there is no service associated with this listen port. So we have to account for this
-// missing service throughout this file
-func buildSidecarOutboundTCPTLSFilterChainOpts(node *model.Proxy, push *model.PushContext,
-	configs []config.Config, destinationCIDR string, service *model.Service, bind string, listenPort *model.Port,
-	gateways map[string]bool,
-) []*filterChainOpts {
-	out := make([]*filterChainOpts, 0)
-	var svcConfigs []config.Config
-	if service != nil {
-		// Do not filter namespace for now.
-		// TODO(https://github.com/istio/istio/issues/46146) we may need to, or something more sophisticated
-		svcConfigs = getConfigsForHost("", service.Hostname, configs)
-	} else {
-		svcConfigs = configs
-	}
-
-	out = append(out, buildSidecarOutboundTLSFilterChainOpts(node, push, destinationCIDR, service,
-		bind, listenPort, gateways, svcConfigs)...)
-	out = append(out, buildSidecarOutboundTCPFilterChainOpts(node, push, destinationCIDR, service,
-		listenPort, gateways, svcConfigs)...)
-	return out
-}

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -464,13 +464,11 @@ func dryRunPolicyTraceTag(name, key string) *tracing.CustomTag {
 	}
 }
 
-func buildOptionalPolicyTags() []*tracing.CustomTag {
-	return []*tracing.CustomTag{
-		dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.name", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEffectivePolicyID),
-		dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.result", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEngineResult),
-		dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.name", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEffectivePolicyID),
-		dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.result", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEngineResult),
-	}
+var optionalPolicyTags = []*tracing.CustomTag{
+	dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.name", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEffectivePolicyID),
+	dryRunPolicyTraceTag("istio.authorization.dry_run.allow_policy.result", authz_model.RBACShadowRulesAllowStatPrefix+authz_model.RBACShadowEngineResult),
+	dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.name", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEffectivePolicyID),
+	dryRunPolicyTraceTag("istio.authorization.dry_run.deny_policy.result", authz_model.RBACShadowRulesDenyStatPrefix+authz_model.RBACShadowEngineResult),
 }
 
 func buildServiceTags(metadata *model.NodeMetadata, labels map[string]string) []*tracing.CustomTag {
@@ -558,8 +556,7 @@ func proxyConfigSamplingValue(config *meshconfig.ProxyConfig) float64 {
 func configureCustomTags(hcmTracing *hcm.HttpConnectionManager_Tracing,
 	providerTags map[string]*telemetrypb.Tracing_CustomTag, proxyCfg *meshconfig.ProxyConfig, node *model.Proxy,
 ) {
-	tags := buildOptionalPolicyTags()
-	tags = append(tags, buildServiceTags(node.Metadata, node.Labels)...)
+	tags := append(buildServiceTags(node.Metadata, node.Labels), optionalPolicyTags...)
 
 	if len(providerTags) == 0 {
 		tags = append(tags, buildCustomTagsFromProxyConfig(proxyCfg.GetTracing().GetCustomTags())...)

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -29,10 +29,10 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/pkg/xds/requestidextension"
+	"istio.io/istio/pkg/slices"
 )
 
 func TestConfigureTracing(t *testing.T) {
@@ -52,7 +52,7 @@ func TestConfigureTracing(t *testing.T) {
 
 	testcases := []struct {
 		name            string
-		opts            buildListenerOpts
+		opts            gatewayListenerOpts
 		inSpec          *model.TracingConfig
 		want            *hcm.HttpConnectionManager_Tracing
 		wantRfCtx       *xdsfilters.RouterFilterContext
@@ -188,7 +188,7 @@ func TestConfigureTracing(t *testing.T) {
 }
 
 func defaultTracingTags() []*tracing.CustomTag {
-	return append(buildOptionalPolicyTags(),
+	return append(slices.Clone(optionalPolicyTags),
 		&tracing.CustomTag{
 			Tag: "istio.canonical_revision",
 			Type: &tracing.CustomTag_Literal_{
@@ -223,8 +223,8 @@ func defaultTracingTags() []*tracing.CustomTag {
 		})
 }
 
-func fakeOptsNoTelemetryAPI() buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsNoTelemetryAPI() gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			EnableTracing: true,
@@ -253,8 +253,8 @@ func fakeOptsNoTelemetryAPI() buildListenerOpts {
 	return opts
 }
 
-func fakeOptsNoTelemetryAPIWithNilCustomTag() buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsNoTelemetryAPIWithNilCustomTag() gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			EnableTracing: true,
@@ -277,8 +277,8 @@ func fakeOptsNoTelemetryAPIWithNilCustomTag() buildListenerOpts {
 	return opts
 }
 
-func fakeOptsOnlyZipkinTelemetryAPI() buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsOnlyZipkinTelemetryAPI() gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
@@ -344,8 +344,8 @@ func fakeDatadog() *meshconfig.MeshConfig_ExtensionProvider {
 	}
 }
 
-func fakeOptsOnlyDatadogTelemetryAPI() buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsOnlyDatadogTelemetryAPI() gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
@@ -374,8 +374,8 @@ func fakeOptsOnlyDatadogTelemetryAPI() buildListenerOpts {
 	return opts
 }
 
-func fakeOptsMeshAndTelemetryAPI(enableTracing bool) buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsMeshAndTelemetryAPI(enableTracing bool) gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			EnableTracing: enableTracing,
@@ -428,8 +428,8 @@ func fakeSkywalking() *meshconfig.MeshConfig_ExtensionProvider {
 	}
 }
 
-func fakeOptsOnlySkywalkingTelemetryAPI() buildListenerOpts {
-	var opts buildListenerOpts
+func fakeOptsOnlySkywalkingTelemetryAPI() gatewayListenerOpts {
+	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
 			ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
@@ -454,9 +454,8 @@ func fakeOptsOnlySkywalkingTelemetryAPI() buildListenerOpts {
 	return opts
 }
 
-func fakeInboundOptsOnlySkywalkingTelemetryAPI() buildListenerOpts {
+func fakeInboundOptsOnlySkywalkingTelemetryAPI() gatewayListenerOpts {
 	opts := fakeOptsOnlySkywalkingTelemetryAPI()
-	opts.class = networking.ListenerClassSidecarInbound
 	return opts
 }
 

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -114,7 +114,7 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 		// add extra addresses for the listener
 		extrAddresses := si.Service.GetExtraAddressesForProxy(node)
 		if len(extrAddresses) > 0 {
-			ll.AdditionalAddresses = util.BuildAdditionalAddresses(extrAddresses, uint32(listenPort), node)
+			ll.AdditionalAddresses = util.BuildAdditionalAddresses(extrAddresses, uint32(listenPort))
 		}
 
 		out = append(out, &discovery.Resource{
@@ -325,7 +325,7 @@ func buildOutboundListeners(node *model.Proxy, push *model.PushContext, filter l
 				// add extra addresses for the listener
 				extrAddresses := sv.GetExtraAddressesForProxy(node)
 				if len(extrAddresses) > 0 {
-					ll.AdditionalAddresses = util.BuildAdditionalAddresses(extrAddresses, uint32(p.Port), node)
+					ll.AdditionalAddresses = util.BuildAdditionalAddresses(extrAddresses, uint32(p.Port))
 				}
 
 				out = append(out, &discovery.Resource{

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -17,8 +17,6 @@ package networking
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
 	"istio.io/istio/pkg/config/protocol"
 )
@@ -83,10 +81,6 @@ func (tp TransportProtocol) ToEnvoySocketProtocol() core.SocketAddress_Protocol 
 
 // FilterChain describes a set of filters (HTTP or TCP) with a shared TLS context.
 type FilterChain struct {
-	// FilterChainMatch is the match used to select the filter chain.
-	FilterChainMatch *listener.FilterChainMatch
-	// TLSContext is the TLS settings for this filter chains.
-	TLSContext *tls.DownstreamTlsContext
 	// ListenerProtocol indicates whether this filter chain is for HTTP or TCP
 	// Note that HTTP filter chains can also have network filters
 	ListenerProtocol ListenerProtocol
@@ -94,8 +88,6 @@ type FilterChain struct {
 	// This would be TCP by default
 	TransportProtocol TransportProtocol
 
-	// HTTP is the set of HTTP filters for this filter chain
-	HTTP []*hcm.HttpFilter
 	// TCP is the set of network (TCP) filters for this filter chain.
 	TCP []*listener.Filter
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -134,38 +134,36 @@ func ConvertAddressToCidr(addr string) *core.CidrRange {
 	return cidr
 }
 
+// AddrStrToCidrRange converts from string to CIDR prefix
+func AddrStrToPrefix(addr string) (netip.Prefix, error) {
+	if len(addr) == 0 {
+		return netip.Prefix{}, fmt.Errorf("empty address")
+	}
+
+	// Already a CIDR, just parse it.
+	if strings.Contains(addr, "/") {
+		return netip.ParsePrefix(addr)
+	}
+
+	// Otherwise it is a raw IP. Make it a /32 or /128 depending on family
+	ipa, err := netip.ParseAddr(addr)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+
+	return netip.PrefixFrom(ipa, ipa.BitLen()), nil
+}
+
 // AddrStrToCidrRange converts from string to CIDR proto
 func AddrStrToCidrRange(addr string) (*core.CidrRange, error) {
-	if len(addr) == 0 {
-		return nil, fmt.Errorf("empty address")
+	prefix, err := AddrStrToPrefix(addr)
+	if err != nil {
+		return nil, err
 	}
-
-	var (
-		ipAddr        netip.Addr
-		maxCidrPrefix int
-	)
-
-	if strings.Contains(addr, "/") {
-		ipp, err := netip.ParsePrefix(addr)
-		if err != nil {
-			return nil, err
-		}
-		ipAddr = ipp.Addr()
-		maxCidrPrefix = ipp.Bits()
-	} else {
-		ipa, err := netip.ParseAddr(addr)
-		if err != nil {
-			return nil, err
-		}
-
-		ipAddr = ipa
-		maxCidrPrefix = ipAddr.BitLen()
-	}
-
 	return &core.CidrRange{
-		AddressPrefix: ipAddr.String(),
+		AddressPrefix: prefix.Addr().String(),
 		PrefixLen: &wrapperspb.UInt32Value{
-			Value: uint32(maxCidrPrefix),
+			Value: uint32(prefix.Bits()),
 		},
 	}, nil
 }
@@ -187,7 +185,7 @@ func BuildAddress(bind string, port uint32) *core.Address {
 }
 
 // BuildAdditionalAddresses can add extra addresses to additional addresses for a listener
-func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32, node *model.Proxy) []*listener.AdditionalAddress {
+func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32) []*listener.AdditionalAddress {
 	var additionalAddresses []*listener.AdditionalAddress
 	if len(extrAddresses) > 0 {
 		for _, exbd := range extrAddresses {

--- a/pilot/pkg/xds/testdata/benchmarks/empty.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/empty.yaml
@@ -35,6 +35,8 @@ metadata:
 spec:
   hosts:
   - random-{{$i}}.host.example
+  addresses:
+    - 127.0.0.{{$i}}
   ports:
   - number: 80
     name: http


### PR DESCRIPTION
This PR does a major refactoring of outbound listener generation. My original motivation was to enable some changes to the XDS generation, which I have decided not to do.

As a result, this should be purely a refactoring that simplifies code and improves performance. **There is no intended behavior changes**.

**Overview of old code:**

For each service/explicit entry, we build a full Listener. This may conflict with another one, stored in a ListenerMap. During each conflict, we merge the listeners into a single one (if possible), or throw it out entirely.

This is extremely inefficient: we build a ton of things that we immediately throw away. For example, consider 1000 HTTP services on port 80. We build one HCM in the end, but we setup 1000 Listener objects then throw away 999 of them.

This is also really complex. We have some double pointers used which is a good sign things aren't in a great state...

We also have multiple points where, after we construct a listener, we then later go and mutate it. This is basically just tech debt - there is no good reason to do this, just that it was easiest at the time (in part, because the old code is so complex).

**Overview of changes**

We defer complete filter chain and listener building until we have processed everything. This makes conflicts cheaper.

Rework some of the calling to avoid passing pointers that are modified. This was not really needed, and can easily be avoided by DRY. This mostly enabled by https://github.com/istio/istio/pull/46217.
Improved conflict detection. If there are conflicts, take a "do nothing" code path more aggressively. Again, enable by https://github.com/istio/istio/pull/46217.

Simplify Dual Stack - instead of passing around bind, bindToPort, and extraBinds, make a single object that cleans usage up.

More efficient FCM checks by using our own IR instead of the full envoy proto.

Move out of MutableListener.build(). This is really complex/inefficient, needlessly so. 

Minor optimizations: improved IdleTimeout and tracing tag processing, each giving us a 5% boost of the benchmarks.


```
name                       old time/op        new time/op        delta
ListenerGeneration/http-8         123µs ±23%          96µs ± 8%  -22.22%  (p=0.000 n=10+10)
ListenerGeneration/tcp-8          537µs ±24%         352µs ± 4%  -34.37%  (p=0.000 n=10+10)
ListenerGeneration/tls-8          550µs ±12%         369µs ± 6%  -32.93%  (p=0.000 n=10+10)
ListenerGeneration/auto-8        1.96ms ±13%        1.65ms ± 8%  -15.80%  (p=0.000 n=10+8)

name                       old kb/msg         new kb/msg         delta
ListenerGeneration/http-8          14.6 ± 0%          14.6 ± 0%     ~     (all equal)
ListenerGeneration/tcp-8           34.0 ± 0%          34.0 ± 0%     ~     (all equal)
ListenerGeneration/tls-8           34.3 ± 0%          34.3 ± 0%     ~     (all equal)
ListenerGeneration/auto-8           257 ± 0%           257 ± 0%     ~     (all equal)

name                       old resources/msg  new resources/msg  delta
ListenerGeneration/http-8          3.00 ± 0%          3.00 ± 0%     ~     (all equal)
ListenerGeneration/tcp-8            103 ± 0%           103 ± 0%     ~     (all equal)
ListenerGeneration/tls-8            103 ± 0%           103 ± 0%     ~     (all equal)
ListenerGeneration/auto-8           103 ± 0%           103 ± 0%     ~     (all equal)

name                       old alloc/op       new alloc/op       delta
ListenerGeneration/http-8         109kB ± 0%          64kB ± 0%  -41.32%  (p=0.000 n=10+10)
ListenerGeneration/tcp-8          424kB ± 0%         277kB ± 0%  -34.64%  (p=0.000 n=10+10)
ListenerGeneration/tls-8          425kB ± 0%         278kB ± 0%  -34.46%  (p=0.000 n=10+10)
ListenerGeneration/auto-8        1.44MB ± 0%        1.05MB ± 0%  -27.14%  (p=0.000 n=8+9)

name                       old allocs/op      new allocs/op      delta
ListenerGeneration/http-8         1.20k ± 0%         0.64k ± 0%  -46.69%  (p=0.000 n=10+10)
ListenerGeneration/tcp-8          5.98k ± 0%         3.54k ± 0%  -40.80%  (p=0.000 n=9+10)
ListenerGeneration/tls-8          5.99k ± 0%         3.55k ± 0%  -40.72%  (p=0.000 n=10+10)
ListenerGeneration/auto-8         16.7k ± 0%          9.1k ± 0%  -45.37%  (p=0.002 n=8+10)

```