### PR TITLE
Skip the CABundle updates when there is no CABundle

### DIFF
--- a/pilot/pkg/keycertbundle/watcher.go
+++ b/pilot/pkg/keycertbundle/watcher.go
@@ -114,3 +114,8 @@ func (w *Watcher) GetKeyCertBundle() KeyCertBundle {
 	defer w.mutex.RUnlock()
 	return w.bundle
 }
+
+// HasBundle returns true if CABundle has a value.
+func (w *Watcher) HasBundle() bool {
+	return w.bundle.CABundle != nil
+}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -145,7 +145,10 @@ func (c *Controller) Reconcile(key types.NamespacedName) error {
 
 	scope.Debugf("Reconcile(enter)")
 	defer func() { scope.Debugf("Reconcile(exit)") }()
-
+	if !c.o.CABundleWatcher.HasBundle() {
+		// If there is no bundle, skip the patch for this time.
+		return nil
+	}
 	caBundle, err := util.LoadCABundle(c.o.CABundleWatcher)
 	if err != nil {
 		scope.Errorf("Failed to load CA bundle: %v", err)

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -132,6 +132,10 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(webhookConfigName string
 
 	found := false
 	updated := false
+	if !w.CABundleWatcher.HasBundle() {
+		// If there is no bundle, skip the patch for this time.
+		return nil
+	}
 	caCertPem, err := util.LoadCABundle(w.CABundleWatcher)
 	if err != nil {
 		log.Errorf("Failed to load CA bundle: %v", err)


### PR DESCRIPTION
To reduce the misleading message, if CABundle is not set in the CABundleWatcher, let's skip to update the Webhooks.

Change-Id: I343f65a8d38331e47ef3962baf69ff2354fe5b8a