### PR TITLE
Always enable listener.ContinueOnListenerFiltersTimeout

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1674,7 +1674,6 @@ func removeListenerFilterTimeout(listeners []*listener.Listener) {
 
 		if !hasHTTPInspector && l.TrafficDirection == core.TrafficDirection_OUTBOUND {
 			l.ListenerFiltersTimeout = durationpb.New(0)
-
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1304,7 +1304,7 @@ func buildListener(opts buildListenerOpts, trafficDirection core.TrafficDirectio
 			res.ListenerFiltersTimeout = opts.push.Mesh.ProtocolDetectionTimeout
 			// if timeout is not disabled, set ContinueOnListenerFiltersTimeout
 			// if timeout = nil, a default 15s will be applied.
-			if !(res.ListenerFiltersTimeout.GetNanos() == 0 && res.ListenerFiltersTimeout.GetSeconds() == 0) {
+			if res.ListenerFiltersTimeout == nil || !(res.ListenerFiltersTimeout.GetNanos() == 0 && res.ListenerFiltersTimeout.GetSeconds() == 0) {
 				res.ContinueOnListenerFiltersTimeout = true
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -164,9 +164,10 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 	// Now we have top level listener... but we must have an internal listener for each standard filter chain
 	// 1 listener per port; that listener will do protocol detection.
 	l := &listener.Listener{
-		Name:              MainInternalName,
-		ListenerSpecifier: &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
-		TrafficDirection:  core.TrafficDirection_INBOUND,
+		Name:                             MainInternalName,
+		ListenerSpecifier:                &listener.Listener_InternalListener{InternalListener: &listener.Listener_InternalListenerConfig{}},
+		TrafficDirection:                 core.TrafficDirection_INBOUND,
+		ContinueOnListenerFiltersTimeout: true,
 	}
 
 	inboundChainConfigs := lb.buildInboundChainConfigs()
@@ -271,9 +272,10 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 	}
 	address := util.BuildAddress(addresses[0], tPort)
 	l := &listener.Listener{
-		Name:             name,
-		Address:          address,
-		TrafficDirection: core.TrafficDirection_INBOUND,
+		Name:                             name,
+		Address:                          address,
+		TrafficDirection:                 core.TrafficDirection_INBOUND,
+		ContinueOnListenerFiltersTimeout: true,
 	}
 	if features.EnableDualStack && len(addresses) > 1 {
 		// add extra addresses for the listener
@@ -294,7 +296,6 @@ func (lb *ListenerBuilder) buildInboundListener(name string, addresses []string,
 	l.FilterChains = chains
 	l.ListenerFilters = populateListenerFilters(lb.node, l, bindToPort)
 	l.ListenerFiltersTimeout = lb.push.Mesh.GetProtocolDetectionTimeout()
-	l.ContinueOnListenerFiltersTimeout = true
 	return l
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1454,14 +1454,15 @@ func testOutboundListenerFilterTimeout(t *testing.T, services ...*model.Service)
 			t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
 		}
 
-		if listeners[0].ContinueOnListenerFiltersTimeout {
+		if listeners[0].ListenerFiltersTimeout == nil ||
+			(listeners[0].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[0].ListenerFiltersTimeout.GetNanos() != 0) {
 			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
-				listeners[0].ContinueOnListenerFiltersTimeout, listeners[0].ListenerFiltersTimeout)
+				listeners[0].ContinueOnListenerFiltersTimeout,
+				listeners[0].ListenerFiltersTimeout)
 		}
-
-		if !listeners[1].ContinueOnListenerFiltersTimeout &&
-			(listeners[1].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[1].ListenerFiltersTimeout.GetNanos() != 0) {
-			t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+		if listeners[1].ListenerFiltersTimeout == nil ||
+			(listeners[0].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[0].ListenerFiltersTimeout.GetNanos() != 0) {
+			t.Fatalf("expected timeout disabled , found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 				listeners[1].ContinueOnListenerFiltersTimeout,
 				listeners[1].ListenerFiltersTimeout)
 		}
@@ -1499,9 +1500,8 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
-			if listeners[0].ContinueOnListenerFiltersTimeout {
-				t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
-					listeners[0].ContinueOnListenerFiltersTimeout,
+			if listeners[0].ListenerFiltersTimeout.GetSeconds() != 5 {
+				t.Fatalf("expected timeout 5s, found  ListenerFiltersTimeout %v",
 					listeners[0].ListenerFiltersTimeout)
 			}
 
@@ -1526,7 +1526,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyHTTPFilterChainMatch(t, http)
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
-			if !listeners[0].ContinueOnListenerFiltersTimeout && listeners[0].ListenerFiltersTimeout == nil {
+			if listeners[0].ListenerFiltersTimeout == nil {
 				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 					listeners[0].ContinueOnListenerFiltersTimeout,
 					listeners[0].ListenerFiltersTimeout)
@@ -2736,9 +2736,12 @@ func buildOutboundListeners(t *testing.T, proxy *model.Proxy, sidecarConfig *con
 	virtualService *config.Config, services ...*model.Service,
 ) []*listener.Listener {
 	t.Helper()
+	m := mesh.DefaultMeshConfig()
+	m.ProtocolDetectionTimeout = durationpb.New(5 * time.Second)
 	cg := NewConfigGenTest(t, TestOptions{
 		Services:       services,
 		ConfigPointers: []*config.Config{sidecarConfig, virtualService},
+		MeshConfig:     m,
 	})
 	listeners := NewListenerBuilder(proxy, cg.env.PushContext()).buildSidecarOutboundListeners(cg.SetupProxy(proxy), cg.env.PushContext())
 	xdstest.ValidateListeners(t, listeners)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1459,7 +1459,8 @@ func testOutboundListenerFilterTimeout(t *testing.T, services ...*model.Service)
 				listeners[0].ContinueOnListenerFiltersTimeout, listeners[0].ListenerFiltersTimeout)
 		}
 
-		if !listeners[1].ContinueOnListenerFiltersTimeout && (listeners[1].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[1].ListenerFiltersTimeout.GetNanos() != 0) {
+		if !listeners[1].ContinueOnListenerFiltersTimeout &&
+			(listeners[1].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[1].ListenerFiltersTimeout.GetNanos() != 0) {
 			t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 				listeners[1].ContinueOnListenerFiltersTimeout,
 				listeners[1].ListenerFiltersTimeout)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1455,12 +1455,12 @@ func testOutboundListenerFilterTimeout(t *testing.T, services ...*model.Service)
 		}
 
 		if listeners[0].ContinueOnListenerFiltersTimeout {
-			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v",
-				listeners[0].ContinueOnListenerFiltersTimeout)
+			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+				listeners[0].ContinueOnListenerFiltersTimeout, listeners[0].ListenerFiltersTimeout)
 		}
 
-		if !listeners[1].ContinueOnListenerFiltersTimeout || listeners[1].ListenerFiltersTimeout == nil {
-			t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+		if !listeners[1].ContinueOnListenerFiltersTimeout && (listeners[1].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[1].ListenerFiltersTimeout.GetNanos() != 0) {
+			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 				listeners[1].ContinueOnListenerFiltersTimeout,
 				listeners[1].ListenerFiltersTimeout)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1460,7 +1460,7 @@ func testOutboundListenerFilterTimeout(t *testing.T, services ...*model.Service)
 		}
 
 		if !listeners[1].ContinueOnListenerFiltersTimeout && (listeners[1].ListenerFiltersTimeout.GetSeconds() != 0 && listeners[1].ListenerFiltersTimeout.GetNanos() != 0) {
-			t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+			t.Fatalf("expected timeout enabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 				listeners[1].ContinueOnListenerFiltersTimeout,
 				listeners[1].ListenerFiltersTimeout)
 		}
@@ -1498,8 +1498,8 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
-			if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
-				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
+			if listeners[0].ContinueOnListenerFiltersTimeout {
+				t.Fatalf("expected timeout disabled, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 					listeners[0].ContinueOnListenerFiltersTimeout,
 					listeners[0].ListenerFiltersTimeout)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1525,7 +1525,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			verifyHTTPFilterChainMatch(t, http)
 			verifyListenerFilters(t, listeners[0].ListenerFilters)
 
-			if !listeners[0].ContinueOnListenerFiltersTimeout || listeners[0].ListenerFiltersTimeout == nil {
+			if !listeners[0].ContinueOnListenerFiltersTimeout && listeners[0].ListenerFiltersTimeout == nil {
 				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
 					listeners[0].ContinueOnListenerFiltersTimeout,
 					listeners[0].ListenerFiltersTimeout)
@@ -2548,6 +2548,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 					MaxPathTagLength: tc.in.MaxPathTagLength,
 					Sampling:         tc.in.Sampling,
 				},
+				DiscoveryAddress: "istiod.istio-system.svc:15012",
 			}
 			listeners := buildListeners(t, TestOptions{MeshConfig: m}, nil)
 			httpProxy := xdstest.ExtractListener("127.0.0.1_15007", listeners)


### PR DESCRIPTION
**Please provide a description of this PR:**

Always enable continue_on_listener_filter timeout, so that we do not need to distinguish Listener filter timeout nil with 0.

Actually, this field only take effect when timeout set.