### PR TITLE
Update min k8sversion to 1.25

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 24
+	MinK8SVersion               = 25
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.\n"
@@ -55,7 +55,7 @@ func extractKubernetesVersion(versionInfo *version.Info) (int, error) {
 }
 
 // IsK8VersionSupported checks minimum supported Kubernetes version for Istio.
-// If the K8s version is not atleast the `MinK8SVersion`, it logs a message warning the user that they
+// If the K8s version is not at least the `MinK8SVersion`, it logs a message warning the user that they
 // may experience problems if they proceed with the install.
 func IsK8VersionSupported(c kube.Client, l clog.Logger) error {
 	serverVersion, err := c.GetKubernetesVersion()

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -69,6 +69,11 @@ var (
 		Minor:      "24",
 		GitVersion: "v1.24",
 	}
+	version1_25 = &version.Info{
+		Major:      "1",
+		Minor:      "25",
+		GitVersion: "v1.25",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -224,6 +229,10 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_24,
+			isValid: false,
+		},
+		{
+			version: version1_25,
 			isValid: true,
 		},
 	}

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -229,6 +229,7 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_24,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_24.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
 			isValid: false,
 		},
 		{


### PR DESCRIPTION
**Please provide a description of this PR:**
Based on https://github.com/istio/istio.io/commit/ab9c5afdc7770986b41b32fa017b21c1372b782b for istioctl to generate warnings for 1.19 release, similar to what we've done in the past.

~I'll try to do a follow-up that set up a script to automatically update it from the doc site.~
I think sometimes the supported version was updated for the release at the last minute, which result in it not being updated on time. It might be better to just update it manually.