### PR TITLE
slices: Ensure GC on Delete(), per upstream recommendation

### DIFF
--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -67,6 +67,10 @@ func Clone[S ~[]E, E any](s S) S {
 
 // Delete removes the element i from s, returning the modified slice.
 func Delete[S ~[]E, E any](s S, i int) S {
+	// "If those elements contain pointers you might consider zeroing those elements
+	// so that objects they reference can be garbage collected."
+	var empty E
+	s[i] = empty
 	return slices.Delete(s, i, i+1)
 }
 

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -17,7 +17,28 @@ package slices
 import (
 	"reflect"
 	"testing"
+
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/tests/util/leak"
 )
+
+func TestDelete(t *testing.T) {
+	type s struct {
+		Junk string
+	}
+	var input []*s
+	var output []*s
+	t.Run("inner", func(t *testing.T) {
+		a := &s{"a"}
+		b := &s{"b"}
+		// Check that we can garbage collect elements when we delete them.
+		leak.MustGarbageCollect(t, b)
+		input = []*s{a, b}
+		output = Delete(input, 1)
+	})
+	assert.Equal(t, output, []*s{{"a"}})
+	assert.Equal(t, input, []*s{{"a"}, nil})
+}
 
 func TestFindFunc(t *testing.T) {
 	emptyElement := []string{}


### PR DESCRIPTION
Was going to use this in another PR. Ultimately decided no need for Delete, but still a good improvement for when/where we do use it.