### PR TITLE
Remove experimental revision tag command

### DIFF
--- a/istioctl/pkg/revision/revision.go
+++ b/istioctl/pkg/revision/revision.go
@@ -112,7 +112,6 @@ func Cmd(ctx cli.Context) *cobra.Command {
 
 	revisionCmd.AddCommand(revisionListCommand(ctx))
 	revisionCmd.AddCommand(revisionDescribeCommand(ctx))
-	revisionCmd.AddCommand(tag.TagCommand(ctx))
 	return revisionCmd
 }
 

--- a/releasenotes/notes/46257.yaml
+++ b/releasenotes/notes/46257.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Removed** `istioctl experimental revision tag` command, which was graduated to `istioctl tag`.


### PR DESCRIPTION
**Please provide a description of this PR:**
The tag command has been graduated for 2 years, and we don't need this command to be in two different places.