### PR TITLE
Fix test flake TestFuzzMergeHttpRoute

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -322,6 +322,9 @@ func mergeHTTPRoute(root *networking.HTTPRoute, delegate *networking.HTTPRoute) 
 	if delegate.CorsPolicy == nil {
 		delegate.CorsPolicy = root.CorsPolicy
 	}
+	if delegate.Mirrors == nil {
+		delegate.Mirrors = root.Mirrors
+	}
 	if delegate.Headers == nil {
 		delegate.Headers = root.Headers
 	}

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -1809,6 +1809,7 @@ func TestFuzzMergeHttpRoute(t *testing.T) {
 			r.Route = nil
 			r.Redirect = nil
 			r.Delegate = nil
+			r.Mirrors = []*networking.HTTPMirrorPolicy{{}}
 		},
 		func(r *networking.HTTPMatchRequest, c fuzz.Continue) {
 			*r = networking.HTTPMatchRequest{}
@@ -1853,6 +1854,9 @@ func TestFuzzMergeHttpRoute(t *testing.T) {
 		},
 		func(r *networking.Headers, c fuzz.Continue) {
 			*r = networking.Headers{}
+		},
+		func(r *networking.HTTPMirrorPolicy, c fuzz.Continue) {
+			*r = networking.HTTPMirrorPolicy{}
 		})
 
 	root := &networking.HTTPRoute{}


### PR DESCRIPTION
**Please provide a description of this PR:**
There's a new field `mirrors` after the client-go is merged, which results in the test flake.

See https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/46241/unit-tests_istio/1686266642125819904