### PR TITLE
Fix ambient `WorkloadEntry` update xds events

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -247,9 +247,10 @@ func (a *AmbientIndexImpl) extractWorkloadEntrySpec(w *v1alpha3.WorkloadEntry, n
 // NOTE: Mutex is locked prior to being called.
 func (a *AmbientIndexImpl) handleWorkloadEntry(oldWorkloadEntry, w *apiv1alpha3.WorkloadEntry, isDelete bool, c *Controller) sets.Set[model.ConfigKey] {
 	if oldWorkloadEntry != nil {
-		// compare only labels and annotations, which are what we care about
-		if maps.Equal(oldWorkloadEntry.Labels, w.Labels) &&
-			maps.Equal(oldWorkloadEntry.Annotations, w.Annotations) {
+		// compare only labels, annotations, and spec; which are what we care about
+		if proto.Equal(&oldWorkloadEntry.Spec, &w.Spec) &&
+			maps.Equal(oldWorkloadEntry.Annotations, w.Annotations) &&
+			maps.Equal(oldWorkloadEntry.Labels, w.Labels) {
 			return nil
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -284,3 +284,16 @@ func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
 		len(s.lookup(s.addrXdsName(""))),
 		0) // cannot lookup these workloads by address
 }
+
+func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	s := newAmbientTestServer(t, testC, testNW)
+	s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
+	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
+
+	// update service account for existing WE and expect a new xds event
+	s.addWorkloadEntries(t, "", "emptyaddr1", "sa2", map[string]string{"app": "a"})
+	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
+}

--- a/releasenotes/notes/46267.yaml
+++ b/releasenotes/notes/46267.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 46267
+
+releaseNotes:
+- |
+  **Fixed** ambient WorkloadEntry xds events to fire on updates to spec. Fixes (#46267)[https://github.com/istio/istio/issues/46267).


### PR DESCRIPTION
**Please provide a description of this PR:**

Resolves https://github.com/istio/istio/issues/46267. 

If you have an existing workload entry and update the spec, ztunnel will not receive the updated WDS information. This PR fixes that.