### PR TITLE
feat(charts/gateway): add podLabels property

### DIFF
--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -30,7 +30,7 @@ app.kubernetes.io/name: {{ include "gateway.name" . }}
 
 {{- define "gateway.podLabels" -}}
 {{ include "gateway.selectorLabels" . }}
-{{- range $key, $val := .Values.labels }}
+{{- range $key, $val := merge .Values.podLabels .Values.labels }}
 {{- if not (or (eq $key "app") (eq $key "istio")) }}
 {{ $key | quote }}: {{ $val | quote }}
 {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -74,6 +74,9 @@
         }
       }
     },
+    "podLabels": {
+      "type": "object"
+    },
     "replicaCount": {
       "type": [ "integer", "null" ]
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -30,6 +30,10 @@ podAnnotations:
   inject.istio.io/templates: "gateway"
   sidecar.istio.io/inject: "true"
 
+# Labels to apply to only the pods created by the deployment.
+# Values defined here will override values set in `labels`.
+podLabels: {}
+
 # Define the security context for the pod.
 # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
 # On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.


### PR DESCRIPTION
This PR adds a new property `podLabels` to the gateway chart. This will enable a user to apply labels only to the deployment created pods.