### PR TITLE
fix incorrect stat increments in webhook patching

### DIFF
--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -99,7 +99,6 @@ func (w *WebhookCertPatcher) HasSynced() bool {
 
 // webhookPatchTask takes the result of patchMutatingWebhookConfig and modifies the result for use in task queue
 func (w *WebhookCertPatcher) webhookPatchTask(o types.NamespacedName) error {
-	reportWebhookPatchAttempts(o.Name)
 	err := w.patchMutatingWebhookConfig(o.Name)
 
 	// do not want to retry the task if these errors occur, they indicate that
@@ -125,7 +124,11 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(webhookConfigName string
 	}
 	// prevents a race condition between multiple istiods when the revision is changed or modified
 	v, ok := config.Labels[label.IoIstioRev.Name]
-	if v != w.revision || !ok {
+	if !ok {
+		log.Debugf("webhook config %q does not have revision label. It is not a Istio webhook. Skipping patching", webhookConfigName)
+		return nil
+	}
+	if v != w.revision {
 		reportWebhookPatchFailure(webhookConfigName, reasonWrongRevision)
 		return errWrongRevision
 	}
@@ -153,6 +156,7 @@ func (w *WebhookCertPatcher) patchMutatingWebhookConfig(webhookConfigName string
 	}
 
 	if updated {
+		reportWebhookPatchAttempts(w.webhookName)
 		_, err := w.webhooks.Update(config)
 		if err != nil {
 			reportWebhookPatchFailure(webhookConfigName, reasonWebhookUpdateFailure)

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -163,8 +163,8 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			testRevision,
 			"config1",
 			"webhook1",
-			caBundle0,
-			errWrongRevision.Error(),
+			[]byte{},
+			"",
 		},
 		{
 			"WrongRevisionWebhookNotUpdated",


### PR DESCRIPTION
This https://github.com/istio/istio/pull/44066 moved from watching istio only mutating webhooks to all webhooks with client side filtering. But with this, it incorrectly increments patching attempt metric for non istio webhooks which is confusing.
This PR corrects those stat increments
- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure