### PR TITLE
Remove usage of service instances for proxy

### DIFF
--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -565,7 +565,7 @@ func Test_parseIstioVersion(t *testing.T) {
 
 func TestSetServiceInstances(t *testing.T) {
 	tnow := time.Now()
-	instances := []*model.ServiceInstance{
+	instances := []model.ServiceTarget{
 		{
 			Service: &model.Service{
 				CreationTime: tnow.Add(1 * time.Second),
@@ -587,19 +587,19 @@ func TestSetServiceInstances(t *testing.T) {
 	}
 
 	serviceDiscovery := memory.NewServiceDiscovery()
-	serviceDiscovery.WantGetProxyServiceInstances = instances
+	serviceDiscovery.WantGetProxyServiceTargets = instances
 
 	env := &model.Environment{
 		ServiceDiscovery: serviceDiscovery,
 	}
 
 	proxy := &model.Proxy{}
-	proxy.SetServiceInstances(env)
+	proxy.SetServiceTargets(env)
 
-	assert.Equal(t, len(proxy.ServiceInstances), 3)
-	assert.Equal(t, proxy.ServiceInstances[0].Service.Hostname, "test2.com")
-	assert.Equal(t, proxy.ServiceInstances[1].Service.Hostname, "test3.com")
-	assert.Equal(t, proxy.ServiceInstances[2].Service.Hostname, "test1.com")
+	assert.Equal(t, len(proxy.ServiceTargets), 3)
+	assert.Equal(t, proxy.ServiceTargets[0].Service.Hostname, "test2.com")
+	assert.Equal(t, proxy.ServiceTargets[1].Service.Hostname, "test3.com")
+	assert.Equal(t, proxy.ServiceTargets[2].Service.Hostname, "test1.com")
 }
 
 func TestGlobalUnicastIP(t *testing.T) {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -601,14 +601,14 @@ var (
 	// This can be normal - for workloads that act only as client, or are not covered by a Service.
 	// It can also be an error, for example in cases the Endpoint list of a service was not updated by the time
 	// the sidecar calls.
-	// Updated by GetProxyServiceInstances
+	// Updated by GetProxyServiceTargets
 	ProxyStatusNoService = monitoring.NewGauge(
 		"pilot_no_ip",
 		"Pods not found in the endpoint table, possibly invalid.",
 	)
 
 	// ProxyStatusEndpointNotReady represents proxies found not be ready.
-	// Updated by GetProxyServiceInstances. Normal condition when starting
+	// Updated by GetProxyServiceTargets. Normal condition when starting
 	// an app with readiness, error if it doesn't change to 0.
 	ProxyStatusEndpointNotReady = monitoring.NewGauge(
 		"pilot_endpoint_not_ready",
@@ -1997,7 +1997,7 @@ type gatewayWithInstances struct {
 	// If true, ports that are not present in any instance will be used directly (without targetPort translation)
 	// This supports the legacy behavior of selecting gateways by pod label selector
 	legacyGatewaySelector bool
-	instances             []*ServiceInstance
+	instances             []ServiceTarget
 }
 
 func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
@@ -2019,8 +2019,8 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 		if gwsvcstr, f := cfg.Annotations[InternalGatewayServiceAnnotation]; f {
 			gwsvcs := strings.Split(gwsvcstr, ",")
 			known := sets.New[string](gwsvcs...)
-			matchingInstances := make([]*ServiceInstance, 0, len(proxy.ServiceInstances))
-			for _, si := range proxy.ServiceInstances {
+			matchingInstances := make([]ServiceTarget, 0, len(proxy.ServiceTargets))
+			for _, si := range proxy.ServiceTargets {
 				if _, f := known[string(si.Service.Hostname)]; f && si.Service.Attributes.Namespace == cfg.Namespace {
 					matchingInstances = append(matchingInstances, si)
 				}
@@ -2031,11 +2031,11 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 			}
 		} else if gw.GetSelector() == nil {
 			// no selector. Applies to all workloads asking for the gateway
-			gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, true, proxy.ServiceInstances})
+			gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, true, proxy.ServiceTargets})
 		} else {
 			gatewaySelector := labels.Instance(gw.GetSelector())
 			if gatewaySelector.SubsetOf(proxy.Labels) {
-				gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, true, proxy.ServiceInstances})
+				gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, true, proxy.ServiceTargets})
 			}
 		}
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2941,7 +2941,7 @@ func (l *localServiceDiscovery) InstancesByPort(*Service, int) []*ServiceInstanc
 	return l.serviceInstances
 }
 
-func (l *localServiceDiscovery) GetProxyServiceInstances(*Proxy) []*ServiceInstance {
+func (l *localServiceDiscovery) GetProxyServiceTargets(*Proxy) []ServiceTarget {
 	panic("implement me")
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -562,7 +562,6 @@ func TestApplyDestinationRule(t *testing.T) {
 				ConfigPointers: []*config.Config{cfg},
 				Services:       []*model.Service{tt.service},
 			})
-			cg.MemRegistry.WantGetProxyServiceInstances = instances
 			proxy := cg.SetupProxy(nil)
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
@@ -3743,21 +3742,6 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			test.SetForTest(t, &features.VerifyCertAtClient, tt.enableVerifyCertAtClient)
-			instances := []*model.ServiceInstance{
-				{
-					Service:     tt.service,
-					ServicePort: tt.port,
-					Endpoint: &model.IstioEndpoint{
-						Address:      "192.168.1.1",
-						EndpointPort: 10001,
-						Locality: model.Locality{
-							ClusterID: "",
-							Label:     "region1/zone1/subzone1",
-						},
-						TLSMode: model.IstioMutualTLSModeLabel,
-					},
-				},
-			}
 
 			var cfg *config.Config
 			if tt.destRule != nil {
@@ -3774,7 +3758,6 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 				ConfigPointers: []*config.Config{cfg},
 				Services:       []*model.Service{tt.service},
 			})
-			cg.MemRegistry.WantGetProxyServiceInstances = instances
 			proxy := cg.SetupProxy(nil)
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 
@@ -4679,18 +4662,12 @@ func TestInsecureSkipVerify(t *testing.T) {
 			test.SetForTest(t, &features.EnableAutoSni, tc.enableAutoSni)
 			test.SetForTest(t, &features.VerifyCertAtClient, tc.enableVerifyCertAtClient)
 
-			instances := []*model.ServiceInstance{
+			targets := []model.ServiceTarget{
 				{
-					Service:     tc.service,
-					ServicePort: tc.port,
-					Endpoint: &model.IstioEndpoint{
-						Address:      "192.168.1.1",
-						EndpointPort: 10001,
-						Locality: model.Locality{
-							ClusterID: "",
-							Label:     "region1/zone1/subzone1",
-						},
-						TLSMode: model.IstioMutualTLSModeLabel,
+					Service: tc.service,
+					Port: model.ServiceInstancePort{
+						ServicePort: tc.port,
+						TargetPort:  10001,
 					},
 				},
 			}
@@ -4712,7 +4689,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 				Services:       []*model.Service{tc.service},
 			})
 
-			cg.MemRegistry.WantGetProxyServiceInstances = instances
+			cg.MemRegistry.WantGetProxyServiceTargets = targets
 			proxy := cg.SetupProxy(nil)
 			cb := NewClusterBuilder(proxy, &model.PushRequest{Push: cg.PushContext()}, nil)
 			ec := newClusterWrapper(tc.cluster)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1403,18 +1403,12 @@ func TestFindServiceInstanceForIngressListener(t *testing.T) {
 		Resolution: model.ClientSideLB,
 	}
 
-	instances := []*model.ServiceInstance{
+	instances := []model.ServiceTarget{
 		{
-			Service:     service,
-			ServicePort: servicePort,
-			Endpoint: &model.IstioEndpoint{
-				Address:      "192.168.1.1",
-				EndpointPort: 7443,
-				Locality: model.Locality{
-					ClusterID: "",
-					Label:     "region1/zone1/subzone1",
-				},
-				LbWeight: 30,
+			Service: service,
+			Port: model.ServiceInstancePort{
+				ServicePort: servicePort,
+				TargetPort:  7443,
 			},
 		},
 	}
@@ -2100,7 +2094,7 @@ func TestTelemetryMetadata(t *testing.T) {
 		name      string
 		direction model.TrafficDirection
 		cluster   *cluster.Cluster
-		svcInsts  []ServiceTarget
+		svcInsts  []model.ServiceTarget
 		service   *model.Service
 		want      *core.Metadata
 	}{
@@ -2108,7 +2102,7 @@ func TestTelemetryMetadata(t *testing.T) {
 			name:      "no cluster",
 			direction: model.TrafficDirectionInbound,
 			cluster:   nil,
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2125,7 +2119,7 @@ func TestTelemetryMetadata(t *testing.T) {
 			name:      "inbound no service",
 			direction: model.TrafficDirectionInbound,
 			cluster:   &cluster.Cluster{},
-			svcInsts:  []ServiceTarget{},
+			svcInsts:  []model.ServiceTarget{},
 			want:      nil,
 		},
 		{
@@ -2142,7 +2136,7 @@ func TestTelemetryMetadata(t *testing.T) {
 					},
 				},
 			},
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2151,7 +2145,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2217,7 +2211,7 @@ func TestTelemetryMetadata(t *testing.T) {
 					},
 				},
 			},
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2226,7 +2220,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2278,7 +2272,7 @@ func TestTelemetryMetadata(t *testing.T) {
 			name:      "inbound multiple services",
 			direction: model.TrafficDirectionInbound,
 			cluster:   &cluster.Cluster{},
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2287,7 +2281,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2301,7 +2295,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "b.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2385,7 +2379,7 @@ func TestTelemetryMetadata(t *testing.T) {
 					},
 				},
 			},
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2394,7 +2388,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2496,7 +2490,7 @@ func TestTelemetryMetadata(t *testing.T) {
 			name:      "inbound duplicated metadata",
 			direction: model.TrafficDirectionInbound,
 			cluster:   &cluster.Cluster{},
-			svcInsts: []ServiceTarget{
+			svcInsts: []model.ServiceTarget{
 				{
 					Service: &model.Service{
 						Attributes: model.ServiceAttributes{
@@ -2505,7 +2499,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},
@@ -2519,7 +2513,7 @@ func TestTelemetryMetadata(t *testing.T) {
 						},
 						Hostname: "a.default",
 					},
-					Port: ServiceInstancePort{
+					Port: model.ServiceInstancePort{
 						ServicePort: &model.Port{
 							Port: 80,
 						},

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -253,7 +253,7 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 	// Initialize data structures
 	pc := f.PushContext()
 	p.SetSidecarScope(pc)
-	p.SetServiceInstances(f.env.ServiceDiscovery)
+	p.SetServiceTargets(f.env.ServiceDiscovery)
 	p.SetGatewaysForProxy(pc)
 	p.DiscoverIPMode()
 	return p

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -2343,16 +2343,16 @@ func TestBuildGatewayListeners(t *testing.T) {
 		{
 			"targetPort overrides service port",
 			&pilot_model.Proxy{
-				ServiceInstances: []*pilot_model.ServiceInstance{
+				ServiceTargets: []pilot_model.ServiceTarget{
 					{
 						Service: &pilot_model.Service{
 							Hostname: "test",
 						},
-						ServicePort: &pilot_model.Port{
-							Port: 80,
-						},
-						Endpoint: &pilot_model.IstioEndpoint{
-							EndpointPort: 8080,
+						Port: pilot_model.ServiceInstancePort{
+							ServicePort: &pilot_model.Port{
+								Port: 80,
+							},
+							TargetPort: 8080,
 						},
 					},
 				},
@@ -2983,7 +2983,7 @@ func TestBuildGatewayListeners(t *testing.T) {
 			cg := NewConfigGenTest(t, TestOptions{
 				Configs: Configs,
 			})
-			cg.MemRegistry.WantGetProxyServiceInstances = tt.node.ServiceInstances
+			cg.MemRegistry.WantGetProxyServiceTargets = tt.node.ServiceTargets
 			proxy := cg.SetupProxy(&proxyGateway)
 			if tt.node.Metadata != nil {
 				proxy.Metadata = tt.node.Metadata

--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -177,7 +177,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []*model.WorkloadInfo, svcs
 			portString := fmt.Sprintf("%d", port.Port)
 			cc := inboundChainConfig{
 				clusterName: model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "tcp", svc.Hostname, port.Port),
-				port: ServiceInstancePort{
+				port: model.ServiceInstancePort{
 					ServicePort: port,
 					TargetPort:  uint32(port.Port),
 				},
@@ -229,7 +229,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []*model.WorkloadInfo, svcs
 		// Direct pod access chain.
 		cc := inboundChainConfig{
 			clusterName: EncapClusterName,
-			port: ServiceInstancePort{
+			port: model.ServiceInstancePort{
 				ServicePort: &model.Port{
 					Name:     "unknown",
 					Protocol: protocol.TCP,

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -96,7 +96,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 			fcc := inboundChainConfig{
 				telemetryMetadata: telemetry.FilterChainMetadata{InstanceHostname: "v0.default.example.org"},
 				clusterName:       "inbound|8888||",
-				port: ServiceInstancePort{
+				port: model.ServiceInstancePort{
 					ServicePort: &model.Port{},
 				},
 			}
@@ -123,7 +123,7 @@ func TestInboundNetworkFilterOrder(t *testing.T) {
 
 		fcc := inboundChainConfig{
 			clusterName: "inbound|8888||",
-			port:        ServiceInstancePort{ServicePort: &model.Port{}},
+			port:        model.ServiceInstancePort{ServicePort: &model.Port{}},
 		}
 		push := cg.PushContext()
 		push.AuthzPolicies = getAuthorizationPolicies()
@@ -173,7 +173,7 @@ func TestInboundNetworkFilterIdleTimeout(t *testing.T) {
 			cg := NewConfigGenTest(t, TestOptions{Services: services})
 
 			fcc := inboundChainConfig{
-				port: ServiceInstancePort{ServicePort: &model.Port{}},
+				port: model.ServiceInstancePort{ServicePort: &model.Port{}},
 			}
 			node := &model.Proxy{Metadata: &model.NodeMetadata{IdleTimeout: tt.idleTimeout}}
 			listenerFilters := NewListenerBuilder(cg.SetupProxy(node), cg.PushContext()).buildInboundNetworkFilters(fcc)

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -366,7 +366,7 @@ func initPersistent(sd *memory.ServiceDiscovery) {
 func initRBACTests(sd *memory.ServiceDiscovery, store model.ConfigStore, svcname string, port int, mtls bool) {
 	ns := "test"
 	hn := svcname + "." + ns + ".svc.cluster.local"
-	// The 'memory' store GetProxyServiceInstances uses the IP address of the node and endpoints to
+	// The 'memory' store GetProxyServiceTargets uses the IP address of the node and endpoints to
 	// identify the service. In k8s store, labels are matched instead.
 	// For server configs to work, the server XDS bootstrap must match the IP.
 	sd.AddService(&model.Service{

--- a/pilot/pkg/networking/grpcgen/lds.go
+++ b/pilot/pkg/networking/grpcgen/lds.go
@@ -73,9 +73,9 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 	}
 	var out model.Resources
 	mtlsPolicy := factory.NewMtlsPolicy(push, node.Metadata.Namespace, node.Labels)
-	serviceInstancesByPort := map[uint32]*model.ServiceInstance{}
-	for _, si := range node.ServiceInstances {
-		serviceInstancesByPort[si.Endpoint.EndpointPort] = si
+	serviceInstancesByPort := map[uint32]model.ServiceTarget{}
+	for _, si := range node.ServiceTargets {
+		serviceInstancesByPort[si.Port.TargetPort] = si
 	}
 
 	for _, name := range names {
@@ -126,8 +126,8 @@ func buildInboundListeners(node *model.Proxy, push *model.PushContext, names []s
 }
 
 // nolint: unparam
-func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si *model.ServiceInstance, checker authn.MtlsPolicy) []*listener.FilterChain {
-	mode := checker.GetMutualTLSModeForPort(si.Endpoint.EndpointPort)
+func buildInboundFilterChains(node *model.Proxy, push *model.PushContext, si model.ServiceTarget, checker authn.MtlsPolicy) []*listener.FilterChain {
+	mode := checker.GetMutualTLSModeForPort(si.Port.TargetPort)
 
 	// auto-mtls label is set - clients will attempt to connect using mtls, and
 	// gRPC doesn't support permissive.

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -125,8 +125,8 @@ func needPerPortPassthroughFilterChain(port uint32, node *model.Proxy) bool {
 	}
 
 	// If there is no Sidecar, check if the port is appearing in any service.
-	for _, si := range node.ServiceInstances {
-		if port == si.Endpoint.EndpointPort {
+	for _, si := range node.ServiceTargets {
+		if port == si.Port.TargetPort {
 			return false
 		}
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -339,18 +339,18 @@ func skipSearchingRegistryForProxy(nodeClusterID cluster.ID, r serviceregistry.I
 	return !r.Cluster().Equals(nodeClusterID)
 }
 
-// GetProxyServiceInstances lists service instances co-located with a given proxy
-func (c *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
+// GetProxyServiceTargets lists service instances co-located with a given proxy
+func (c *Controller) GetProxyServiceTargets(node *model.Proxy) []model.ServiceTarget {
+	out := make([]model.ServiceTarget, 0)
 	nodeClusterID := nodeClusterID(node)
 	for _, r := range c.GetRegistries() {
 		if skipSearchingRegistryForProxy(nodeClusterID, r) {
-			log.Debugf("GetProxyServiceInstances(): not searching registry %v: proxy %v CLUSTER_ID is %v",
+			log.Debugf("GetProxyServiceTargets(): not searching registry %v: proxy %v CLUSTER_ID is %v",
 				r.Cluster(), node.ID, nodeClusterID)
 			continue
 		}
 
-		instances := r.GetProxyServiceInstances(node)
+		instances := r.GetProxyServiceTargets(node)
 		if len(instances) > 0 {
 			out = append(out, instances...)
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -224,13 +224,13 @@ func TestGetService(t *testing.T) {
 	}
 }
 
-func TestGetProxyServiceInstances(t *testing.T) {
+func TestGetProxyServiceTargets(t *testing.T) {
 	aggregateCtl := buildMockController()
 
 	// Get Instances from mockAdapter1
-	instances := aggregateCtl.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{mock.HelloInstanceV0}})
+	instances := aggregateCtl.GetProxyServiceTargets(&model.Proxy{IPAddresses: []string{mock.HelloInstanceV0}})
 	if len(instances) != 6 {
-		t.Fatalf("Returned GetProxyServiceInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetProxyServiceTargets' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.HelloService.Hostname {
@@ -239,9 +239,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 
 	// Get Instances from mockAdapter2
-	instances = aggregateCtl.GetProxyServiceInstances(&model.Proxy{IPAddresses: []string{mock.MakeIP(mock.WorldService, 1)}})
+	instances = aggregateCtl.GetProxyServiceTargets(&model.Proxy{IPAddresses: []string{mock.MakeIP(mock.WorldService, 1)}})
 	if len(instances) != 6 {
-		t.Fatalf("Returned GetProxyServiceInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetProxyServiceTargets' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.WorldService.Hostname {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -807,10 +807,10 @@ func (c *Controller) collectWorkloadInstanceEndpoints(svc *model.Service) []*mod
 	return endpoints
 }
 
-// GetProxyServiceInstances returns service instances co-located with a given proxy
+// GetProxyServiceTargets returns service instances co-located with a given proxy
 // TODO: this code does not return k8s service instances when the proxy's IP is a workload entry
 // To tackle this, we need a ip2instance map like what we have in service entry.
-func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.ServiceInstance {
+func (c *Controller) GetProxyServiceTargets(proxy *model.Proxy) []model.ServiceTarget {
 	if len(proxy.IPAddresses) > 0 {
 		proxyIP := proxy.IPAddresses[0]
 		// look up for a WorkloadEntry; if there are multiple WorkloadEntry(s)
@@ -832,14 +832,14 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 			// failover to 2
 			allServices := c.services.List(pod.Namespace, klabels.Everything())
 			if services := getPodServices(allServices, pod); len(services) > 0 {
-				out := make([]*model.ServiceInstance, 0)
+				out := make([]model.ServiceTarget, 0)
 				for _, svc := range services {
-					out = append(out, c.getProxyServiceInstancesByPod(pod, svc, proxy)...)
+					out = append(out, c.GetProxyServiceTargetsByPod(pod, svc)...)
 				}
 				return out
 			}
 			// 2. Headless service without selector
-			return c.endpoints.GetProxyServiceInstances(proxy)
+			return c.endpoints.GetProxyServiceTargets(proxy)
 		}
 
 		// 3. The pod is not present when this is called
@@ -847,9 +847,9 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		// metadata already. Because of this, we can still get most of the information we need.
 		// If we cannot accurately construct ServiceInstances from just the metadata, this will return an error and we can
 		// attempt to read the real pod.
-		out, err := c.getProxyServiceInstancesFromMetadata(proxy)
+		out, err := c.GetProxyServiceTargetsFromMetadata(proxy)
 		if err != nil {
-			log.Warnf("getProxyServiceInstancesFromMetadata for %v failed: %v", proxy.ID, err)
+			log.Warnf("GetProxyServiceTargetsFromMetadata for %v failed: %v", proxy.ID, err)
 		}
 		return out
 	}
@@ -863,8 +863,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 	return nil
 }
 
-func (c *Controller) serviceInstancesFromWorkloadInstance(si *model.WorkloadInstance) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
+func (c *Controller) serviceInstancesFromWorkloadInstance(si *model.WorkloadInstance) []model.ServiceTarget {
+	out := make([]model.ServiceTarget, 0)
 	// find the workload entry's service by label selector
 	// rather than scanning through our internal map of model.services, get the services via the k8s apis
 	dummyPod := &v1.Pod{
@@ -895,7 +895,7 @@ func (c *Controller) serviceInstancesFromWorkloadInstance(si *model.WorkloadInst
 
 				instance := serviceInstanceFromWorkloadInstance(service, servicePort, targetPort, si)
 				if instance != nil {
-					out = append(out, instance)
+					out = append(out, model.ServiceInstanceToTarget(instance))
 				}
 			}
 		}
@@ -975,10 +975,10 @@ func (c *Controller) isControllerForProxy(proxy *model.Proxy) bool {
 	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == c.Cluster()
 }
 
-// getProxyServiceInstancesFromMetadata retrieves ServiceInstances using proxy Metadata rather than
+// GetProxyServiceTargetsFromMetadata retrieves ServiceTargets using proxy Metadata rather than
 // from the Pod. This allows retrieving Instances immediately, regardless of delays in Kubernetes.
 // If the proxy doesn't have enough metadata, an error is returned
-func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetProxyServiceTargetsFromMetadata(proxy *model.Proxy) ([]model.ServiceTarget, error) {
 	if len(proxy.Labels) == 0 {
 		return nil, nil
 	}
@@ -1002,7 +1002,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 		return nil, fmt.Errorf("no instances found for %s", proxy.ID)
 	}
 
-	out := make([]*model.ServiceInstance, 0)
+	out := make([]model.ServiceTarget, 0)
 	for _, svc := range services {
 		hostname := kube.ServiceHostname(svc.Name, svc.Namespace, c.opts.DomainSuffix)
 		modelService := c.GetService(hostname)
@@ -1011,8 +1011,6 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 		}
 
 		for _, modelService := range c.servicesForNamespacedName(config.NamespacedName(svc)) {
-			discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(modelService)
-
 			tps := make(map[model.Port]*model.Port)
 			tpsList := make([]model.Port, 0)
 			for _, port := range svc.Spec.Ports {
@@ -1046,34 +1044,27 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 				}
 			}
 
-			epBuilder := NewEndpointBuilderFromMetadata(c, proxy)
 			// Iterate over target ports in the same order as defined in service spec, in case of
 			// protocol conflict for a port causes unstable protocol selection for a port.
 			for _, tp := range tpsList {
 				svcPort := tps[tp]
-				// consider multiple IP scenarios
-				for _, ip := range proxy.IPAddresses {
-					// Construct the ServiceInstance
-					out = append(out, &model.ServiceInstance{
-						Service:     modelService,
+				out = append(out, model.ServiceTarget{
+					Service: modelService,
+					Port: model.ServiceInstancePort{
 						ServicePort: svcPort,
-						Endpoint:    epBuilder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name, discoverabilityPolicy, model.Healthy),
-					})
-				}
+						TargetPort:  uint32(tp.Port),
+					},
+				})
 			}
 		}
 	}
 	return out, nil
 }
 
-func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
-	service *v1.Service, proxy *model.Proxy,
-) []*model.ServiceInstance {
-	var out []*model.ServiceInstance
+func (c *Controller) GetProxyServiceTargetsByPod(pod *v1.Pod, service *v1.Service) []model.ServiceTarget {
+	var out []model.ServiceTarget
 
 	for _, svc := range c.servicesForNamespacedName(config.NamespacedName(service)) {
-		discoverabilityPolicy := c.exports.EndpointDiscoverabilityPolicy(svc)
-
 		tps := make(map[model.Port]*model.Port)
 		tpsList := make([]model.Port, 0)
 		for _, port := range service.Spec.Ports {
@@ -1099,21 +1090,17 @@ func (c *Controller) getProxyServiceInstancesByPod(pod *v1.Pod,
 				tpsList = append(tpsList, targetPort)
 			}
 		}
-
-		builder := NewEndpointBuilder(c, pod)
 		// Iterate over target ports in the same order as defined in service spec, in case of
 		// protocol conflict for a port causes unstable protocol selection for a port.
 		for _, tp := range tpsList {
 			svcPort := tps[tp]
-			// consider multiple IP scenarios
-			for _, ip := range proxy.IPAddresses {
-				istioEndpoint := builder.buildIstioEndpoint(ip, int32(tp.Port), svcPort.Name, discoverabilityPolicy, model.Healthy)
-				out = append(out, &model.ServiceInstance{
-					Service:     svc,
+			out = append(out, model.ServiceTarget{
+				Service: svc,
+				Port: model.ServiceInstancePort{
 					ServicePort: svcPort,
-					Endpoint:    istioEndpoint,
-				})
-			}
+					TargetPort:  uint32(tp.Port),
+				},
+			})
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -326,7 +326,7 @@ func TestProxyK8sHostnameLabel(t *testing.T) {
 	}
 }
 
-func TestGetProxyServiceInstances(t *testing.T) {
+func TestGetProxyServiceTargets(t *testing.T) {
 	clusterID := cluster.ID("fakeCluster")
 	networkID := network.ID("fakeNetwork")
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{
@@ -382,20 +382,20 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		DNSDomain:   "nsa.svc.cluster.local",
 		Metadata:    &model.NodeMetadata{Namespace: "nsa", ClusterID: clusterID},
 	}
-	serviceInstances := controller.GetProxyServiceInstances(svcNode)
+	serviceInstances := controller.GetProxyServiceTargets(svcNode)
 
 	if len(serviceInstances) != 1 {
-		t.Fatalf("GetProxyServiceInstances() expected 1 instance, got %d", len(serviceInstances))
+		t.Fatalf("GetProxyServiceTargets() expected 1 instance, got %d", len(serviceInstances))
 	}
 
 	hostname := kube.ServiceHostname("svc1", "nsa", defaultFakeDomainSuffix)
 	if serviceInstances[0].Service.Hostname != hostname {
-		t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
+		t.Fatalf("GetProxyServiceTargets() wrong service instance returned => hostname %q, want %q",
 			serviceInstances[0].Service.Hostname, hostname)
 	}
 
 	// Test that we can look up instances just by Proxy metadata
-	metaServices := controller.GetProxyServiceInstances(&model.Proxy{
+	metaServices := controller.GetProxyServiceTargets(&model.Proxy{
 		Type:            "sidecar",
 		IPAddresses:     []string{"1.1.1.1"},
 		Locality:        &core.Locality{Region: "r", Zone: "z"},
@@ -414,7 +414,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		},
 	})
 
-	expected := &model.ServiceInstance{
+	expected := model.ServiceTarget{
 		Service: &model.Service{
 			Hostname: "svc1.nsa.svc.company.com",
 			ClusterVIPs: model.AddressMap{
@@ -433,35 +433,15 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				},
 			},
 		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Labels: labels.Instance{
-				"app":                      "prod-app",
-				label.SecurityTlsMode.Name: "mutual",
-				NodeRegionLabelGA:          "r",
-				NodeZoneLabelGA:            "z",
-				label.TopologyCluster.Name: clusterID.String(),
-				label.TopologyNetwork.Name: networkID.String(),
-			},
-			ServiceAccount:  "account",
-			Address:         "1.1.1.1",
-			Network:         networkID,
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality: model.Locality{
-				Label:     "r/z",
-				ClusterID: clusterID,
-			},
-			HealthStatus: model.Healthy,
-			TLSMode:      "mutual",
+		Port: model.ServiceInstancePort{
+			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+			TargetPort:  0,
 		},
 	}
 
 	if len(metaServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(metaServices))
 	}
-	// Remove the discoverability function so that it's ignored by DeepEqual.
-	clearDiscoverabilityPolicy(metaServices[0].Endpoint)
 	if !reflect.DeepEqual(expected, metaServices[0]) {
 		t.Fatalf("expected instance %v, got %v", expected, metaServices[0])
 	}
@@ -477,7 +457,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	addPods(t, controller, fx, p)
 
 	// this can test get pod by proxy ip address
-	podServices := controller.GetProxyServiceInstances(&model.Proxy{
+	podServices := controller.GetProxyServiceTargets(&model.Proxy{
 		Type:            "sidecar",
 		IPAddresses:     []string{"129.0.0.1"},
 		Locality:        &core.Locality{Region: "r", Zone: "z"},
@@ -494,7 +474,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		},
 	})
 
-	expected = &model.ServiceInstance{
+	expected = model.ServiceTarget{
 		Service: &model.Service{
 			Hostname: "svc1.nsa.svc.company.com",
 			ClusterVIPs: model.AddressMap{
@@ -513,37 +493,14 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				},
 			},
 		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Address:         "129.0.0.1",
-			Network:         networkID,
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality: model.Locality{
-				Label:     "region1/zone1/subzone1",
-				ClusterID: clusterID,
-			},
-			Labels: labels.Instance{
-				"app":                      "prod-app",
-				NodeRegionLabelGA:          "region1",
-				NodeZoneLabelGA:            "zone1",
-				labelutil.LabelHostname:    p.Spec.NodeName,
-				label.TopologySubzone.Name: "subzone1",
-				label.TopologyCluster.Name: clusterID.String(),
-				label.TopologyNetwork.Name: networkID.String(),
-			},
-			ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-			TLSMode:        model.DisabledTLSModeLabel,
-			WorkloadName:   "pod2",
-			Namespace:      "nsa",
-			HealthStatus:   model.Healthy,
-			NodeName:       p.Spec.NodeName,
+		Port: model.ServiceInstancePort{
+			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
+			TargetPort:  0,
 		},
 	}
 	if len(podServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(podServices))
 	}
-	clearDiscoverabilityPolicy(podServices[0].Endpoint)
 	if !reflect.DeepEqual(expected, podServices[0]) {
 		t.Fatalf("expected instance %v, got %v", expected, podServices[0])
 	}
@@ -554,7 +511,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	addPods(t, controller, fx, p)
 
 	// this can test get pod by proxy ip address
-	podServices = controller.GetProxyServiceInstances(&model.Proxy{
+	podServices = controller.GetProxyServiceTargets(&model.Proxy{
 		Type:            "sidecar",
 		IPAddresses:     []string{"129.0.0.2"},
 		Locality:        &core.Locality{Region: "r", Zone: "z"},
@@ -571,7 +528,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		},
 	})
 
-	expected = &model.ServiceInstance{
+	expected = model.ServiceTarget{
 		Service: &model.Service{
 			Hostname: "svc1.nsa.svc.company.com",
 			ClusterVIPs: model.AddressMap{
@@ -590,50 +547,26 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				},
 			},
 		},
-		ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
-		Endpoint: &model.IstioEndpoint{
-			Address:         "129.0.0.2",
-			Network:         networkID,
-			EndpointPort:    0,
-			ServicePortName: "tcp-port",
-			Locality: model.Locality{
-				Label:     "region/zone",
-				ClusterID: clusterID,
-			},
-			Labels: labels.Instance{
-				"app":                      "prod-app",
-				"istio-locality":           "region.zone",
-				NodeRegionLabelGA:          "region",
-				NodeZoneLabelGA:            "zone",
-				labelutil.LabelHostname:    p.Spec.NodeName,
-				label.TopologyCluster.Name: clusterID.String(),
-				label.TopologyNetwork.Name: networkID.String(),
-			},
-			ServiceAccount: "spiffe://cluster.local/ns/nsa/sa/svcaccount",
-			TLSMode:        model.DisabledTLSModeLabel,
-			WorkloadName:   "pod3",
-			Namespace:      "nsa",
-			HealthStatus:   model.Healthy,
-			NodeName:       p.Spec.NodeName,
+		Port: model.ServiceInstancePort{
+			ServicePort: &model.Port{Name: "tcp-port", Port: 8080, Protocol: protocol.TCP},
 		},
 	}
 	if len(podServices) != 1 {
 		t.Fatalf("expected 1 instance, got %v", len(podServices))
 	}
-	clearDiscoverabilityPolicy(podServices[0].Endpoint)
 	if !reflect.DeepEqual(expected, podServices[0]) {
 		t.Fatalf("expected instance %v, got %v", expected, podServices[0])
 	}
 }
 
-func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
+func TestGetProxyServiceTargetsWithMultiIPsAndTargetPorts(t *testing.T) {
 	pod1 := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	testCases := []struct {
-		name          string
-		pods          []*corev1.Pod
-		ips           []string
-		ports         []corev1.ServicePort
-		wantEndpoints []model.IstioEndpoint
+		name      string
+		pods      []*corev1.Pod
+		ips       []string
+		ports     []corev1.ServicePort
+		wantPorts []model.ServiceInstancePort
 	}{
 		{
 			name: "multiple proxy ips single port",
@@ -647,16 +580,14 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
-				},
-				{
-					Address:         "192.168.2.6",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port",
+						Port:     8080,
+						Protocol: "TCP",
+					},
+					TargetPort: 8080,
 				},
 			},
 		},
@@ -672,11 +603,14 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port",
+						Port:     8080,
+						Protocol: "TCP",
+					},
+					TargetPort: 8080,
 				},
 			},
 		},
@@ -698,26 +632,30 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 9090},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port-1",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port-1",
+						Port:     8080,
+						Protocol: "TCP",
+					},
+					TargetPort: 8080,
 				},
 				{
-					Address:         "192.168.2.6",
-					ServicePortName: "tcp-port-1",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port-2",
+						Port:     9090,
+						Protocol: "TCP",
+					},
+					TargetPort: 9090,
 				},
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port-2",
-					EndpointPort:    9090,
-				},
-				{
-					Address:         "192.168.2.6",
-					ServicePortName: "tcp-port-2",
-					EndpointPort:    9090,
+					ServicePort: &model.Port{
+						Name:     "tcp-port-1",
+						Port:     7442,
+						Protocol: "TCP",
+					},
+					TargetPort: 7442,
 				},
 			},
 		},
@@ -739,16 +677,22 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port",
+						Port:     8080,
+						Protocol: "TCP",
+					},
+					TargetPort: 8080,
 				},
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "http-port",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "http-port",
+						Port:     9090,
+						Protocol: "HTTP",
+					},
+					TargetPort: 8080,
 				},
 			},
 		},
@@ -776,16 +720,22 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 7442},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "http-7442",
-					EndpointPort:    7442,
+					ServicePort: &model.Port{
+						Name:     "http-7442",
+						Port:     7442,
+						Protocol: "HTTP",
+					},
+					TargetPort: 7442,
 				},
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-8443",
-					EndpointPort:    7442,
+					ServicePort: &model.Port{
+						Name:     "tcp-8443",
+						Port:     8443,
+						Protocol: "TCP",
+					},
+					TargetPort: 7442,
 				},
 			},
 		},
@@ -807,16 +757,22 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 					TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 9090},
 				},
 			},
-			wantEndpoints: []model.IstioEndpoint{
+			wantPorts: []model.ServiceInstancePort{
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+					ServicePort: &model.Port{
+						Name:     "tcp-port",
+						Port:     8080,
+						Protocol: "TCP",
+					},
+					TargetPort: 8080,
 				},
 				{
-					Address:         "128.0.0.1",
-					ServicePortName: "http-port",
-					EndpointPort:    9090,
+					ServicePort: &model.Port{
+						Name:     "http-port",
+						Port:     9090,
+						Protocol: "HTTP",
+					},
+					TargetPort: 9090,
 				},
 			},
 		},
@@ -837,24 +793,16 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 				c.ports, map[string]string{"app": "test-app"}, t)
 
 			fx.WaitOrFail(t, "service")
-			serviceInstances := controller.GetProxyServiceInstances(&model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: c.ips})
+			serviceInstances := controller.GetProxyServiceTargets(&model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: c.ips})
 
 			for i, svc := range serviceInstances {
-				if svc.Endpoint.Address != c.wantEndpoints[i].Address {
-					t.Errorf("wrong endpoint address at #i endpoint, got %v want %v", svc.Endpoint.Address, c.wantEndpoints[i].Address)
-				}
-				if svc.Endpoint.EndpointPort != c.wantEndpoints[i].EndpointPort {
-					t.Errorf("wrong endpoint port at #i endpoint, got %v want %v", svc.Endpoint.EndpointPort, c.wantEndpoints[i].EndpointPort)
-				}
-				if svc.Endpoint.ServicePortName != c.wantEndpoints[i].ServicePortName {
-					t.Errorf("wrong svc port at #i endpoint, got %v want %v", svc.Endpoint.ServicePortName, c.wantEndpoints[i].ServicePortName)
-				}
+				assert.Equal(t, svc.Port, c.wantPorts[i])
 			}
 		})
 	}
 }
 
-func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
+func TestGetProxyServiceTargets_WorkloadInstance(t *testing.T) {
 	ctl, _ := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 
 	createServiceWait(ctl, "ratings", "bookinfo-ratings",
@@ -938,7 +886,7 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 	cases := []struct {
 		name  string
 		proxy *model.Proxy
-		want  []*model.ServiceInstance
+		want  []model.ServiceTarget
 	}{
 		{
 			name:  "proxy with unspecified IP",
@@ -958,30 +906,26 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 		{
 			name:  "proxy with IP from the registry, 1 matching WE, and matching Service",
 			proxy: &model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: []string{"3.3.3.31"}},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "reviews.bookinfo-reviews.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "reviews"},
-					Address:         "3.3.3.31",
-					ServicePortName: "tcp-port",
-					EndpointPort:    7070,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  7070,
 				},
 			}},
 		},
 		{
 			name:  "proxy with IP from the registry, 2 matching WE, and matching Service",
 			proxy: &model.Proxy{Metadata: &model.NodeMetadata{}, IPAddresses: []string{"2.2.2.21"}},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "details.bookinfo-details.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "details"}, // should pick "details" because of ordering
-					Address:         "2.2.2.21",
-					ServicePortName: "tcp-port",
-					EndpointPort:    9090,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  9090,
 				},
 			}},
 		},
@@ -991,15 +935,13 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 				Metadata: &model.NodeMetadata{}, IPAddresses: []string{"2.2.2.21"},
 				ID: "reviews-1.bookinfo-reviews", ConfigNamespace: "bookinfo-reviews",
 			},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "details.bookinfo-details.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "details"}, // should pick "details" because of ordering
-					Address:         "2.2.2.21",
-					ServicePortName: "tcp-port",
-					EndpointPort:    9090,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  9090,
 				},
 			}},
 		},
@@ -1009,15 +951,13 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 				Metadata: &model.NodeMetadata{}, IPAddresses: []string{"2.2.2.21"},
 				ID: "ratings-1.bookinfo-ratings", ConfigNamespace: "wrong-namespace",
 			},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "details.bookinfo-details.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "details"}, // should pick "details" because of ordering
-					Address:         "2.2.2.21",
-					ServicePortName: "tcp-port",
-					EndpointPort:    9090,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  9090,
 				},
 			}},
 		},
@@ -1027,15 +967,13 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 				Metadata: &model.NodeMetadata{}, IPAddresses: []string{"2.2.2.21"},
 				ID: "ratings-1.bookinfo-ratings", ConfigNamespace: "bookinfo-ratings",
 			},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "ratings.bookinfo-ratings.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "ratings"}, // should pick "ratings"
-					Address:         "2.2.2.21",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  8080,
 				},
 			}},
 		},
@@ -1045,15 +983,13 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 				Metadata: &model.NodeMetadata{}, IPAddresses: []string{"2.2.2.21"},
 				ID: "wrong-name.bookinfo-ratings", ConfigNamespace: "bookinfo-ratings",
 			},
-			want: []*model.ServiceInstance{{
+			want: []model.ServiceTarget{{
 				Service: &model.Service{
 					Hostname: "ratings.bookinfo-ratings.svc.company.com",
 				},
-				Endpoint: &model.IstioEndpoint{
-					Labels:          map[string]string{"app": "ratings"}, // should pick "ratings"
-					Address:         "2.2.2.21",
-					ServicePortName: "tcp-port",
-					EndpointPort:    8080,
+				Port: model.ServiceInstancePort{
+					ServicePort: nil, // howardjohn: ??
+					TargetPort:  8080,
 				},
 			}},
 		},
@@ -1061,19 +997,15 @@ func TestGetProxyServiceInstances_WorkloadInstance(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ctl.GetProxyServiceInstances(tc.proxy)
+			got := ctl.GetProxyServiceTargets(tc.proxy)
 
 			if diff := cmp.Diff(len(tc.want), len(got)); diff != "" {
-				t.Fatalf("GetProxyServiceInstances() returned unexpected number of service instances (--want/++got): %v", diff)
+				t.Fatalf("GetProxyServiceTargets() returned unexpected number of service instances (--want/++got): %v", diff)
 			}
 
 			for i := range tc.want {
-				if diff := cmp.Diff(tc.want[i].Service.Hostname, got[i].Service.Hostname); diff != "" {
-					t.Fatalf("GetProxyServiceInstances() returned unexpected value [%d].Service.Hostname (--want/++got): %v", i, diff)
-				}
-				if diff := cmp.Diff(tc.want[i].Endpoint, got[i].Endpoint, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-					t.Fatalf("GetProxyServiceInstances() returned unexpected value [%d].Endpoint (--want/++got): %v", i, diff)
-				}
+				assert.Equal(t, tc.want[i].Service.Hostname, got[i].Service.Hostname)
+				assert.Equal(t, tc.want[i].Port.TargetPort, got[i].Port.TargetPort)
 			}
 		})
 	}
@@ -2708,12 +2640,6 @@ func TestDiscoverySelector(t *testing.T) {
 	svc = sds.GetService(missing)
 	if svc != nil {
 		t.Fatalf("GetService(%q) => %s, should not exist", missing, svc.Hostname)
-	}
-}
-
-func clearDiscoverabilityPolicy(ep *model.IstioEndpoint) {
-	if ep != nil {
-		ep.DiscoverabilityPolicy = nil
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -88,12 +88,12 @@ func (esc *endpointSliceController) onEvent(_, ep *v1.EndpointSlice, event model
 	return nil
 }
 
-// GetProxyServiceInstances returns service instances co-located with a given proxy
+// GetProxyServiceTargets returns service instances co-located with a given proxy
 // TODO: this code does not return k8s service instances when the proxy's IP is a workload entry
 // To tackle this, we need a ip2instance map like what we have in service entry.
-func (esc *endpointSliceController) GetProxyServiceInstances(proxy *model.Proxy) []*model.ServiceInstance {
+func (esc *endpointSliceController) GetProxyServiceTargets(proxy *model.Proxy) []model.ServiceTarget {
 	eps := esc.slices.List(proxy.Metadata.Namespace, endpointSliceSelector)
-	var out []*model.ServiceInstance
+	var out []model.ServiceTarget
 	for _, ep := range eps {
 		instances := esc.sliceServiceInstances(ep, proxy)
 		out = append(out, instances...)
@@ -106,8 +106,8 @@ func serviceNameForEndpointSlice(labels map[string]string) string {
 	return labels[v1beta1.LabelServiceName]
 }
 
-func (esc *endpointSliceController) sliceServiceInstances(ep *v1.EndpointSlice, proxy *model.Proxy) []*model.ServiceInstance {
-	var out []*model.ServiceInstance
+func (esc *endpointSliceController) sliceServiceInstances(ep *v1.EndpointSlice, proxy *model.Proxy) []model.ServiceTarget {
+	var out []model.ServiceTarget
 	esc.endpointCache.mu.RLock()
 	defer esc.endpointCache.mu.RUnlock()
 	for _, svc := range esc.c.servicesForNamespacedName(getServiceNamespacedName(ep)) {
@@ -117,14 +117,16 @@ func (esc *endpointSliceController) sliceServiceInstances(ep *v1.EndpointSlice, 
 				log.Warnf("unexpected state, svc %v missing port %v", svc.Hostname, instance.ServicePortName)
 				continue
 			}
-			si := &model.ServiceInstance{
-				Service:     svc,
-				ServicePort: port,
-				Endpoint:    instance,
-			}
 			// If the endpoint isn't ready, report this
 			if instance.HealthStatus == model.UnHealthy && esc.c.opts.Metrics != nil {
 				esc.c.opts.Metrics.AddMetric(model.ProxyStatusEndpointNotReady, proxy.ID, proxy.ID, "")
+			}
+			si := model.ServiceTarget{
+				Service: svc,
+				Port: model.ServiceInstancePort{
+					ServicePort: port,
+					TargetPort:  instance.EndpointPort,
+				},
 			}
 			out = append(out, si)
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -205,16 +205,13 @@ func (ic *serviceImportCacheImpl) createKubeService(t *testing.T, c *FakeControl
 			}
 		}
 
-		instances := ic.getProxyServiceInstances()
+		instances := ic.getProxyServiceTargets()
 		if len(instances) != len(expectedHosts) {
 			return fmt.Errorf("expected 1 service instance, found %d", len(instances))
 		}
 		for _, si := range instances {
 			if si.Service == nil {
 				return fmt.Errorf("proxy ServiceInstance has nil service")
-			}
-			if si.Endpoint == nil {
-				return fmt.Errorf("proxy ServiceInstance has nil endpoint")
 			}
 			if _, found := expectedHosts[si.Service.Hostname]; !found {
 				return fmt.Errorf("found proxy ServiceInstance for unexpected host: %s", si.Service.Hostname)
@@ -287,7 +284,7 @@ func (ic *serviceImportCacheImpl) deleteKubeService(t *testing.T, anotherCluster
 			return fmt.Errorf("found deleted service for host %s", serviceImportClusterSetHost)
 		}
 
-		instances := ic.getProxyServiceInstances()
+		instances := ic.getProxyServiceTargets()
 		if len(instances) != 0 {
 			return fmt.Errorf("expected 0 service instance, found %d", len(instances))
 		}
@@ -296,8 +293,8 @@ func (ic *serviceImportCacheImpl) deleteKubeService(t *testing.T, anotherCluster
 	}, serviceImportTimeout)
 }
 
-func (ic *serviceImportCacheImpl) getProxyServiceInstances() []*model.ServiceInstance {
-	return ic.GetProxyServiceInstances(&model.Proxy{
+func (ic *serviceImportCacheImpl) getProxyServiceTargets() []model.ServiceTarget {
+	return ic.GetProxyServiceTargets(&model.Proxy{
 		Type:            model.SidecarProxy,
 		IPAddresses:     []string{serviceImportPodIP},
 		Locality:        &core.Locality{Region: "r", Zone: "z"},
@@ -349,7 +346,7 @@ func (ic *serviceImportCacheImpl) checkServiceInstances(t *testing.T) {
 		expectMCSService = true
 	}
 
-	instances := ic.getProxyServiceInstances()
+	instances := ic.getProxyServiceTargets()
 	assert.Equal(t, len(instances), expectedServiceCount)
 
 	for _, inst := range instances {

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -811,10 +811,10 @@ func portMatchSingle(instance *model.ServiceInstance, port int) bool {
 	return port == 0 || port == instance.ServicePort.Port
 }
 
-// GetProxyServiceInstances lists service instances co-located with a given proxy
+// GetProxyServiceTargets lists service instances co-located with a given proxy
 // NOTE: The service objects in these instances do not have the auto allocated IP set.
-func (s *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
+func (s *Controller) GetProxyServiceTargets(node *model.Proxy) []model.ServiceTarget {
+	out := make([]model.ServiceTarget, 0)
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	for _, ip := range node.IPAddresses {
@@ -825,7 +825,7 @@ func (s *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.Servic
 			// possibility of other namespaces inserting service instances into namespaces they do not
 			// control.
 			if node.Metadata.Namespace == "" || i.Service.Attributes.Namespace == node.Metadata.Namespace {
-				out = append(out, i)
+				out = append(out, model.ServiceInstanceToTarget(i))
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -562,6 +562,37 @@ func makeInstanceWithServiceAccount(cfg *config.Config, address string, port int
 }
 
 // nolint: unparam
+func makeTarget(cfg *config.Config, address string, port int,
+	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
+) model.ServiceTarget {
+	services := convertServices(*cfg)
+	svc := services[0] // default
+	for _, s := range services {
+		if string(s.Hostname) == address {
+			svc = s
+			break
+		}
+	}
+	if mtlsMode == MTLS {
+		if svcLabels == nil {
+			svcLabels = map[string]string{}
+		}
+		svcLabels[label.SecurityTlsMode.Name] = model.IstioMutualTLSModeLabel
+	}
+	return model.ServiceTarget{
+		Service: svc,
+		Port: model.ServiceInstancePort{
+			ServicePort: &model.Port{
+				Name:     svcPort.Name,
+				Port:     int(svcPort.Number),
+				Protocol: protocol.Parse(svcPort.Protocol),
+			},
+			TargetPort: uint32(port),
+		},
+	}
+}
+
+// nolint: unparam
 func makeInstance(cfg *config.Config, address string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
 ) *model.ServiceInstance {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -600,7 +600,7 @@ func (s *DiscoveryServer) initProxyMetadata(node *core.Node) (*model.Proxy, erro
 }
 
 // setTopologyLabels sets locality, cluster, network label
-// must be called after `SetWorkloadLabels` and `SetServiceInstances`.
+// must be called after `SetWorkloadLabels` and `SetServiceTargets`.
 func setTopologyLabels(proxy *model.Proxy) {
 	// This is a bit un-intuitive, but pull the locality from Labels first. The service registries have the best access to
 	// locality information, as they can read from various sources (Node on Kubernetes, for example). They will take this
@@ -670,7 +670,7 @@ func (s *DiscoveryServer) initializeProxy(con *Connection) error {
 }
 
 func (s *DiscoveryServer) computeProxyState(proxy *model.Proxy, request *model.PushRequest) {
-	proxy.SetServiceInstances(s.Env.ServiceDiscovery)
+	proxy.SetServiceTargets(s.Env.ServiceDiscovery)
 	// only recompute workload labels when
 	// 1. stream established and proxy first time initialization
 	// 2. proxy update

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -487,7 +487,7 @@ func initPushContext(env *model.Environment, proxy *model.Proxy) {
 	pushContext.InitContext(env, nil, nil)
 	proxy.SetSidecarScope(pushContext)
 	proxy.SetGatewaysForProxy(pushContext)
-	proxy.SetServiceInstances(env.ServiceDiscovery)
+	proxy.SetServiceTargets(env.ServiceDiscovery)
 }
 
 var debugGeneration = env.Register("DEBUG_CONFIG_DUMP", false, "if enabled, print a full config dump of the generated config")

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -1075,11 +1075,11 @@ func (s *DiscoveryServer) getProxyConnection(proxyID string) *Connection {
 }
 
 func (s *DiscoveryServer) instancesz(w http.ResponseWriter, req *http.Request) {
-	instances := map[string][]*model.ServiceInstance{}
+	instances := map[string][]model.ServiceTarget{}
 	for _, con := range s.Clients() {
 		con.proxy.RLock()
 		if con.proxy != nil {
-			instances[con.proxy.ID] = con.proxy.ServiceInstances
+			instances[con.proxy.ID] = con.proxy.ServiceTargets
 		}
 		con.proxy.RUnlock()
 	}

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -96,14 +96,15 @@ func DefaultProxyNeedsPush(proxy *model.Proxy, req *model.PushRequest) bool {
 	}
 
 	// If the proxy's service updated, need push for it.
-	if len(proxy.ServiceInstances) > 0 && req.ConfigsUpdated != nil {
-		svc := proxy.ServiceInstances[0].Service
-		if _, ok := req.ConfigsUpdated[model.ConfigKey{
-			Kind:      kind.ServiceEntry,
-			Name:      string(svc.Hostname),
-			Namespace: svc.Attributes.Namespace,
-		}]; ok {
-			return true
+	if len(proxy.ServiceTargets) > 0 && req.ConfigsUpdated != nil {
+		for _, svc := range proxy.ServiceTargets {
+			if _, ok := req.ConfigsUpdated[model.ConfigKey{
+				Kind:      kind.ServiceEntry,
+				Name:      string(svc.Service.Hostname),
+				Namespace: svc.Service.Attributes.Namespace,
+			}]; ok {
+				return true
+			}
 		}
 	}
 

--- a/tests/fuzz/pilot_model_fuzzer.go
+++ b/tests/fuzz/pilot_model_fuzzer.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/slices"
 )
 
 var protocols = []protocol.Instance{
@@ -194,7 +195,7 @@ func FuzzInitContext(data []byte) int {
 
 	env.ConfigStore = store
 	sd := memory.NewServiceDiscovery(services...)
-	sd.WantGetProxyServiceInstances = serviceInstances
+	sd.WantGetProxyServiceTargets = slices.Map(serviceInstances, model.ServiceInstanceToTarget)
 	env.ServiceDiscovery = sd
 
 	env.Watcher = mesh.NewFixedWatcher(m)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/45241.

This PR swaps out ServiceInstances for ServiceTarget (an existing type
in XDS gen, now moved to model).

The intent here is to minimize the amount of information maintained.
Before, we had a Service+Endpoint+Port. Now we just have a Service+Port.

The Endpoint aspect was never used and was incorrect (see issue). Having
this extra information is dangerous, complex, and slow. By removing this
we can skip some wasteful processing, avoid accidentally using this
information that may or may not be accurate, etc. In the past, similar
"Struct is bigger than it needs to be" issues caused serious
regressions.

This change also can enable future optimizations.

---

The InstancesByPort usages:

  ResolveGatewayInstances for status; known to be broken
    Just whether there is instances on which ports
  BestEffortInferServiceMTLSMode
    Just need TLS mode
  buildLocalityLbEndpoints:
    Just endpoint (it mirrors EDS)
  buildSidecarOutboundListeners:
    for headless building. Just need endpoint address
  BuildNameTable:
    for headless. Its actually broken today a bit
    We want each endpoint


