### PR TITLE
locality: refactor and drop Service dependency

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -372,10 +372,9 @@ func WorkloadInstancesEqual(first, second *WorkloadInstance) bool {
 	return true
 }
 
-// GetLocalityLabelOrDefault returns the locality from the supplied label, or falls back to
-// the supplied default locality if the supplied label is empty. Because Kubernetes
+// GetLocalityLabel returns the locality from the supplied label. Because Kubernetes
 // labels don't support `/`, we replace "." with "/" in the supplied label as a workaround.
-func GetLocalityLabelOrDefault(label, defaultLabel string) string {
+func GetLocalityLabel(label string) string {
 	if len(label) > 0 {
 		// if there are /'s present we don't need to replace
 		if strings.Contains(label, "/") {
@@ -384,7 +383,7 @@ func GetLocalityLabelOrDefault(label, defaultLabel string) string {
 		// replace "." with "/"
 		return strings.Replace(label, k8sSeparator, "/", -1)
 	}
-	return defaultLabel
+	return ""
 }
 
 // Locality information for an IstioEndpoint

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -113,7 +113,7 @@ func TestIsValidSubsetKey(t *testing.T) {
 	}
 }
 
-func TestGetLocalityOrDefault(t *testing.T) {
+func TestGetLocalityLabel(t *testing.T) {
 	cases := []struct {
 		name     string
 		label    string

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -115,21 +115,14 @@ func TestIsValidSubsetKey(t *testing.T) {
 
 func TestGetLocalityOrDefault(t *testing.T) {
 	cases := []struct {
-		name         string
-		label        string
-		defaultLabel string
-		expected     string
+		name     string
+		label    string
+		expected string
 	}{
 		{
-			name:         "with label",
-			label:        "region/zone/subzone-1",
-			defaultLabel: "region/zone/subzone-2",
-			expected:     "region/zone/subzone-1",
-		},
-		{
-			name:         "default",
-			defaultLabel: "region/zone/subzone-1",
-			expected:     "region/zone/subzone-1",
+			name:     "with label",
+			label:    "region/zone/subzone-1",
+			expected: "region/zone/subzone-1",
 		},
 		{
 			name:     "label with k8s label separator",
@@ -145,7 +138,7 @@ func TestGetLocalityOrDefault(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := GetLocalityLabelOrDefault(testCase.label, testCase.defaultLabel)
+			got := GetLocalityLabel(testCase.label)
 			if got != testCase.expected {
 				t.Errorf("expected locality %s, but got %s", testCase.expected, got)
 			}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -364,13 +364,7 @@ func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) labels.Instance 
 	for _, r := range c.GetRegistries() {
 		// If proxy clusterID unset, we may find incorrect workload label.
 		// This can not happen in k8s env.
-		if clusterID == "" {
-			lbls := r.GetProxyWorkloadLabels(proxy)
-			if lbls != nil {
-				return lbls
-			}
-		} else if clusterID == r.Cluster() {
-			// find proxy in the specified cluster
+		if clusterID == "" || clusterID == r.Cluster() {
 			lbls := r.GetProxyWorkloadLabels(proxy)
 			if lbls != nil {
 				return lbls

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -276,7 +276,11 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 		sa = spiffe.MustGenSpiffeURI(service.Attributes.Namespace, wle.ServiceAccount)
 	}
 	networkID := s.workloadEntryNetwork(wle)
-	labels := labelutil.AugmentLabels(wle.Labels, clusterID, wle.Locality, "", networkID)
+	locality := wle.Locality
+	if locality == "" && len(wle.Labels[model.LocalityLabel]) > 0 {
+		locality = model.GetLocalityLabel(wle.Labels[model.LocalityLabel])
+	}
+	labels := labelutil.AugmentLabels(wle.Labels, clusterID, locality, "", networkID)
 	return &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         addr,
@@ -284,7 +288,7 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 			ServicePortName: servicePort.Name,
 			Network:         network.ID(wle.Network),
 			Locality: model.Locality{
-				Label:     wle.Locality,
+				Label:     locality,
 				ClusterID: clusterID,
 			},
 			LbWeight:       wle.Weight,
@@ -425,14 +429,18 @@ func (s *Controller) convertWorkloadEntryToWorkloadInstance(cfg config.Config, c
 		sa = spiffe.MustGenSpiffeURI(cfg.Namespace, we.ServiceAccount)
 	}
 	networkID := s.workloadEntryNetwork(we)
-	labels := labelutil.AugmentLabels(we.Labels, clusterID, we.Locality, "", networkID)
+	locality := we.Locality
+	if locality == "" && len(we.Labels[model.LocalityLabel]) > 0 {
+		locality = model.GetLocalityLabel(we.Labels[model.LocalityLabel])
+	}
+	labels := labelutil.AugmentLabels(we.Labels, clusterID, locality, "", networkID)
 	return &model.WorkloadInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address: addr,
 			// Not setting ports here as its done by k8s controller
 			Network: network.ID(we.Network),
 			Locality: model.Locality{
-				Label:     we.Locality,
+				Label:     locality,
 				ClusterID: clusterID,
 			},
 			LbWeight:  we.Weight,

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/meta/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -43,6 +45,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pilot/pkg/xds"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
@@ -53,6 +56,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	kubeclient "istio.io/istio/pkg/kube"
 	istiotest "istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -1315,6 +1319,18 @@ func makeService(t *testing.T, c kubernetes.Interface, svc *v1.Service) {
 	}
 }
 
+func makeNode(t *testing.T, c kubernetes.Interface, node *v1.Node) {
+	t.Helper()
+
+	_, err := c.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	if kerrors.IsAlreadyExists(err) {
+		_, err = c.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func makeIstioObject(t *testing.T, c model.ConfigStore, svc config.Config) {
 	t.Helper()
 	_, err := c.Create(svc)
@@ -1376,5 +1392,193 @@ func createEndpointSliceWithType(t *testing.T, c kubernetes.Interface, name, ser
 		if err != nil {
 			t.Fatalf("failed to create endpoint slice %s in namespace %s (error %v)", name, namespace, err)
 		}
+	}
+}
+
+func TestLocality(t *testing.T) {
+	namespace := "default"
+	basePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: namespace,
+			Labels:    map[string]string{},
+		},
+		Spec: v1.PodSpec{NodeName: "node"},
+		Status: v1.PodStatus{
+			PodIP: "1.2.3.4",
+			Phase: v1.PodRunning,
+		},
+	}
+	baseNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node",
+			Labels: map[string]string{},
+		},
+	}
+	cases := []struct {
+		name     string
+		pod      *v1.Pod
+		node     *v1.Node
+		obj      config.Config
+		expected *core.Locality
+	}{
+		{
+			name:     "no locality",
+			pod:      basePod,
+			node:     baseNode,
+			expected: &core.Locality{},
+		},
+		{
+			name: "pod specific label",
+			pod: func() *v1.Pod {
+				p := basePod.DeepCopy()
+				p.Labels[model.LocalityLabel] = "r.z.s"
+				return p
+			}(),
+			node: baseNode,
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+		{
+			name: "node specific label",
+			pod:  basePod,
+			node: func() *v1.Node {
+				p := baseNode.DeepCopy()
+				p.Labels[kubecontroller.NodeRegionLabelGA] = "r"
+				p.Labels[kubecontroller.NodeZoneLabelGA] = "z"
+				p.Labels[label.TopologySubzone.Name] = "s"
+				return p
+			}(),
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+		{
+			name: "pod and node labels",
+			pod: func() *v1.Pod {
+				p := basePod.DeepCopy()
+				p.Labels[model.LocalityLabel] = "r.z.s"
+				return p
+			}(),
+			node: func() *v1.Node {
+				p := baseNode.DeepCopy()
+				p.Labels[kubecontroller.NodeRegionLabelGA] = "nr"
+				p.Labels[kubecontroller.NodeZoneLabelGA] = "nz"
+				p.Labels[label.TopologySubzone.Name] = "ns"
+				return p
+			}(),
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+		{
+			name: "ServiceEntry with explicit locality",
+			obj: config.Config{
+				Meta: config.Meta{
+					Name:             "service-entry",
+					Namespace:        namespace,
+					GroupVersionKind: gvk.ServiceEntry,
+				},
+				Spec: &networking.ServiceEntry{
+					Hosts: []string{"service.namespace.svc.cluster.local"},
+					Ports: []*networking.ServicePort{{Name: "http", Number: 80, Protocol: "http"}},
+					Endpoints: []*networking.WorkloadEntry{{
+						Address:  "1.2.3.4",
+						Locality: "r/z/s",
+					}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+		{
+			name: "ServiceEntry with label locality",
+			obj: config.Config{
+				Meta: config.Meta{
+					Name:             "service-entry",
+					Namespace:        namespace,
+					GroupVersionKind: gvk.ServiceEntry,
+				},
+				Spec: &networking.ServiceEntry{
+					Hosts: []string{"service.namespace.svc.cluster.local"},
+					Ports: []*networking.ServicePort{{Name: "http", Number: 80, Protocol: "http"}},
+					Endpoints: []*networking.WorkloadEntry{{
+						Address: "1.2.3.4",
+						Labels: map[string]string{
+							model.LocalityLabel: "r.z.s",
+						},
+					}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+		{
+			name: "ServiceEntry with both locality",
+			obj: config.Config{
+				Meta: config.Meta{
+					Name:             "service-entry",
+					Namespace:        namespace,
+					GroupVersionKind: gvk.ServiceEntry,
+				},
+				Spec: &networking.ServiceEntry{
+					Hosts: []string{"service.namespace.svc.cluster.local"},
+					Ports: []*networking.ServicePort{{Name: "http", Number: 80, Protocol: "http"}},
+					Endpoints: []*networking.WorkloadEntry{{
+						Address:  "1.2.3.4",
+						Locality: "r/z/s",
+						Labels: map[string]string{
+							model.LocalityLabel: "lr.lz.ls",
+						},
+					}},
+					Resolution: networking.ServiceEntry_STATIC,
+				},
+			},
+			expected: &core.Locality{
+				Region:  "r",
+				Zone:    "z",
+				SubZone: "s",
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+			kube := s.KubeClient().Kube()
+			if tt.pod != nil {
+				makePod(t, kube, tt.pod)
+			}
+			if tt.node != nil {
+				makeNode(t, kube, tt.node)
+			}
+			if tt.obj.Name != "" {
+				makeIstioObject(t, s.Store(), tt.obj)
+			}
+
+			s.Connect(s.SetupProxy(&model.Proxy{IPAddresses: []string{"1.2.3.4"}}), nil, []string{v3.ClusterType})
+			retry.UntilSuccessOrFail(t, func() error {
+				clients := s.Discovery.AllClients()
+				if len(clients) != 1 {
+					return fmt.Errorf("got %d clients", len(clients))
+				}
+				locality := clients[0].Proxy().Locality
+				return assert.Compare(tt.expected, locality)
+			}, retry.Timeout(time.Second*2))
+		})
 	}
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
+	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/autoregistration"
 	"istio.io/istio/pilot/pkg/features"
 	istiogrpc "istio.io/istio/pilot/pkg/grpc"
@@ -601,19 +602,12 @@ func (s *DiscoveryServer) initProxyMetadata(node *core.Node) (*model.Proxy, erro
 // setTopologyLabels sets locality, cluster, network label
 // must be called after `SetWorkloadLabels` and `SetServiceInstances`.
 func setTopologyLabels(proxy *model.Proxy) {
-	var localityStr string
-	// Get the locality from the proxy's service instances.
-	// We expect all instances to have the same IP and therefore the same locality.
-	// So its enough to look at the first instance.
-	if len(proxy.ServiceInstances) > 0 {
-		localityStr = proxy.ServiceInstances[0].Endpoint.Locality.Label
-	} else {
-		// If no service instances(this maybe common for a pure client), respect LocalityLabel
-		localityStr = proxy.Labels[model.LocalityLabel]
-	}
-	if localityStr != "" {
-		proxy.Locality = util.ConvertLocality(localityStr)
-	} else {
+	// This is a bit un-intuitive, but pull the locality from Labels first. The service registries have the best access to
+	// locality information, as they can read from various sources (Node on Kubernetes, for example). They will take this
+	// information and add it to the labels. So while the proxy may not originally have these labels,
+	// it will by the time we get here (as a result of calling this after SetWorkloadLabels).
+	proxy.Locality = localityFromProxyLabels(proxy)
+	if proxy.Locality == nil {
 		// If there is no locality in the registry then use the one sent as part of the discovery request.
 		// This is not preferable as only the connected Pilot is aware of this proxies location, but it
 		// can still help provide some client-side Envoy context when load balancing based on location.
@@ -623,10 +617,28 @@ func setTopologyLabels(proxy *model.Proxy) {
 			SubZone: proxy.XdsNode.Locality.GetSubZone(),
 		}
 	}
-
-	locality := util.LocalityToString(proxy.Locality)
 	// add topology labels to proxy labels
-	proxy.Labels = labelutil.AugmentLabels(proxy.Labels, proxy.Metadata.ClusterID, locality, proxy.GetNodeName(), proxy.Metadata.Network)
+	proxy.Labels = labelutil.AugmentLabels(proxy.Labels, proxy.Metadata.ClusterID, util.LocalityToString(proxy.Locality), proxy.GetNodeName(), proxy.Metadata.Network)
+}
+
+func localityFromProxyLabels(proxy *model.Proxy) *core.Locality {
+	region, f1 := proxy.Labels[labelutil.LabelTopologyRegion]
+	zone, f2 := proxy.Labels[labelutil.LabelTopologyZone]
+	subzone, f3 := proxy.Labels[label.TopologySubzone.Name]
+	if !f1 && !f2 && !f3 {
+		// If no labels set, we didn't find the locality from the service registry. We do support a (mostly undocumented/internal)
+		// label to override the locality, so respect that here as well.
+		ls, f := proxy.Labels[model.LocalityLabel]
+		if f {
+			return util.ConvertLocality(ls)
+		}
+		return nil
+	}
+	return &core.Locality{
+		Region:  region,
+		Zone:    zone,
+		SubZone: subzone,
+	}
 }
 
 // initializeProxy completes the initialization of a proxy. It is expected to be called only after
@@ -942,6 +954,10 @@ func (conn *Connection) Clusters() []string {
 		return conn.proxy.WatchedResources[v3.EndpointType].ResourceNames
 	}
 	return []string{}
+}
+
+func (conn *Connection) Proxy() *model.Proxy {
+	return conn.proxy
 }
 
 func (conn *Connection) Routes() []string {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -618,7 +618,13 @@ func setTopologyLabels(proxy *model.Proxy) {
 		}
 	}
 	// add topology labels to proxy labels
-	proxy.Labels = labelutil.AugmentLabels(proxy.Labels, proxy.Metadata.ClusterID, util.LocalityToString(proxy.Locality), proxy.GetNodeName(), proxy.Metadata.Network)
+	proxy.Labels = labelutil.AugmentLabels(
+		proxy.Labels,
+		proxy.Metadata.ClusterID,
+		util.LocalityToString(proxy.Locality),
+		proxy.GetNodeName(),
+		proxy.Metadata.Network,
+	)
 }
 
 func localityFromProxyLabels(proxy *model.Proxy) *core.Locality {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -35,6 +35,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -221,8 +222,8 @@ func TestEds(t *testing.T) {
 	})
 	reconcileServiceShards(s, s.MemServiceRegistry)
 
-	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
-	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
+	adscConn := s.Connect(&model.Proxy{Locality: util.ConvertLocality(asdcLocality), IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
+	adscConn2 := s.Connect(&model.Proxy{Locality: util.ConvertLocality(asdc2Locality), IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
 
 	t.Run("TCPEndpoints", func(t *testing.T) {
 		testTCPEndpoints("127.0.0.1", adscConn, t)

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -656,7 +656,7 @@ func GetNodeMetaData(options MetadataOptions) (*model.Node, error) {
 		l = options.Platform.Locality()
 	} else {
 		// replace "." with "/"
-		localityString := model.GetLocalityLabelOrDefault(meta.Labels[model.LocalityLabel], "")
+		localityString := model.GetLocalityLabel(meta.Labels[model.LocalityLabel])
 		if localityString != "" {
 			// override the label with the sanitized value
 			meta.Labels[model.LocalityLabel] = localityString

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -45,6 +45,13 @@ var compareErrors = cmp.Comparer(func(x, y error) bool {
 
 var cmpOpts = []cmp.Option{protocmp.Transform(), cmpopts.EquateEmpty(), compareErrors}
 
+func Compare[T any](a, b T) error {
+	if !cmp.Equal(a, b, cmpOpts...) {
+		return fmt.Errorf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
+	}
+	return nil
+}
+
 // Equal
 func Equal[T any](t test.Failer, a, b T, context ...string) {
 	t.Helper()

--- a/releasenotes/notes/locality-service.yaml
+++ b/releasenotes/notes/locality-service.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Removed** the requirement for a workload to have a Service associated with it in order for locality load balancing to work.


### PR DESCRIPTION
Split out from https://github.com/istio/istio/pull/46295/files

This *is* user facing. If a user had a pod without Service before, we would ignore locality. Now we do not. I *think* this is the last case of "You must have a service" requirement, but need more investigation before we fully drop that from
https://istio.io/latest/docs/ops/deployment/requirements/

The primary change is to use GetProxyWorkloadLabels instead of GetProxyServiceInstances. An issue with this is that the SE and k8s controller are behaving differently - one sets istio-locality label (synthetic) and the other the 3 k8s labels (also synthetic). This moves the k8s controller to use labelutil.AugmentLabels (and thus the 3 k8s labels), and the SE controller to properly respect the istio-locality label. This makes the two behaviors identical.

Then in  setTopologyLabels we can just read the labels