### PR TITLE
Drop InstancesByPort

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2711,7 +2711,8 @@ func TestInitVirtualService(t *testing.T) {
 
 func TestServiceWithExportTo(t *testing.T) {
 	ps := NewPushContext()
-	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})}
+	env := NewEnvironment()
+	env.Watcher = mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})
 	ps.Mesh = env.Mesh()
 
 	svc1 := &Service{
@@ -2935,10 +2936,6 @@ func (l *localServiceDiscovery) Services() []*Service {
 
 func (l *localServiceDiscovery) GetService(host.Name) *Service {
 	panic("implement me")
-}
-
-func (l *localServiceDiscovery) InstancesByPort(*Service, int) []*ServiceInstance {
-	return l.serviceInstances
 }
 
 func (l *localServiceDiscovery) GetProxyServiceTargets(*Proxy) []ServiceTarget {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -814,30 +814,6 @@ type ServiceDiscovery interface {
 	// GetService retrieves a service by host name if it exists
 	GetService(hostname host.Name) *Service
 
-	// InstancesByPort retrieves instances for a service on the given ports with labels that match
-	// any of the supplied labels. All instances match an empty tag list.
-	//
-	// For example, consider an example of catalog.mystore.com:
-	// Instances(catalog.myservice.com, 80) ->
-	//      --> IstioEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> IstioEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> IstioEndpoint(172.16.0.3:8888), Service(catalog.myservice.com), Labels(kitty=cat)
-	//      --> IstioEndpoint(172.16.0.4:8888), Service(catalog.myservice.com), Labels(kitty=cat)
-	//
-	// Calling Instances with specific labels returns a trimmed list.
-	// e.g., Instances(catalog.myservice.com, 80, foo=bar) ->
-	//      --> IstioEndpoint(172.16.0.1:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//      --> IstioEndpoint(172.16.0.2:8888), Service(catalog.myservice.com), Labels(foo=bar)
-	//
-	// Similar concepts apply for calling this function with a specific
-	// port, hostname and labels.
-	//
-	// Introduced in Istio 0.8. It is only called with 1 port.
-	// CDS (clusters.go) calls it for building 'dnslb' type clusters.
-	// EDS calls it for building the endpoints result.
-	// Consult istio-dev before using this for anything else (except debugging/tools)
-	InstancesByPort(svc *Service, servicePort int) []*ServiceInstance
-
 	// GetProxyServiceTargets returns the service instances that co-located with a given Proxy
 	//
 	// Co-located generally means running in the same network namespace and security context.
@@ -845,10 +821,10 @@ type ServiceDiscovery interface {
 	// A Proxy operating as a Sidecar will return a non-empty slice.  A stand-alone Proxy
 	// will return an empty slice.
 	//
-	// There are two reasons why this returns multiple ServiceInstances instead of one:
-	// - A ServiceInstance has a single IstioEndpoint which has a single Port.  But a Service
+	// There are two reasons why this returns multiple ServiceTargets instead of one:
+	// - A ServiceTargets has a single IstioEndpoint which has a single Port.  But a Service
 	//   may have many ports.  So a workload implementing such a Service would need
-	//   multiple ServiceInstances, one for each port.
+	//   multiple ServiceEndpoints, one for each port.
 	// - A single workload may implement multiple logical Services.
 	//
 	// In the second case, multiple services may be implemented by the same physical port number,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -666,8 +666,9 @@ func TestApplyDestinationRule(t *testing.T) {
 					Service:     tt.service,
 					ServicePort: tt.port,
 					Endpoint: &model.IstioEndpoint{
-						Address:      "192.168.1.1",
-						EndpointPort: 10001,
+						ServicePortName: tt.port.Name,
+						Address:         "192.168.1.1",
+						EndpointPort:    10001,
 						Locality: model.Locality{
 							ClusterID: "",
 							Label:     "region1/zone1/subzone1",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -296,8 +296,9 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			Service:     service,
 			ServicePort: servicePort[0],
 			Endpoint: &model.IstioEndpoint{
-				Address:      "6.6.6.6",
-				EndpointPort: 10001,
+				Address:         "6.6.6.6",
+				ServicePortName: servicePort[0].Name,
+				EndpointPort:    10001,
 				Locality: model.Locality{
 					ClusterID: "",
 					Label:     "region1/zone1/subzone1",
@@ -310,8 +311,9 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			Service:     service,
 			ServicePort: servicePort[0],
 			Endpoint: &model.IstioEndpoint{
-				Address:      "6.6.6.6",
-				EndpointPort: 10001,
+				Address:         "6.6.6.6",
+				ServicePortName: servicePort[0].Name,
+				EndpointPort:    10001,
 				Locality: model.Locality{
 					ClusterID: "",
 					Label:     "region1/zone1/subzone2",
@@ -324,8 +326,9 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			Service:     service,
 			ServicePort: servicePort[0],
 			Endpoint: &model.IstioEndpoint{
-				Address:      "6.6.6.6",
-				EndpointPort: 10001,
+				Address:         "6.6.6.6",
+				ServicePortName: servicePort[0].Name,
+				EndpointPort:    10001,
 				Locality: model.Locality{
 					ClusterID: "",
 					Label:     "region2/zone1/subzone1",
@@ -338,8 +341,9 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			Service:     service,
 			ServicePort: servicePort[1],
 			Endpoint: &model.IstioEndpoint{
-				Address:      "6.6.6.6",
-				EndpointPort: 10002,
+				ServicePortName: servicePort[1].Name,
+				Address:         "6.6.6.6",
+				EndpointPort:    10002,
 				Locality: model.Locality{
 					ClusterID: "",
 					Label:     "region1/zone1/subzone1",

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -472,7 +472,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 					// wildcard route match to get to the appropriate IP through original dst clusters.
 					if features.EnableHeadlessService && bind.Primary() == "" && service.Resolution == model.Passthrough &&
 						saddress == constants.UnspecifiedIP && (servicePort.Protocol.IsTCP() || servicePort.Protocol.IsUnsupported()) {
-						instances := push.ServiceInstancesByPort(service, servicePort.Port, nil)
+						instances := push.ServiceEndpointsByPort(service, servicePort.Port, nil)
 						if service.Attributes.ServiceRegistry != provider.Kubernetes && len(instances) == 0 && service.Attributes.LabelSelectors == nil {
 							// A Kubernetes service with no endpoints means there are no endpoints at
 							// all, so don't bother sending, as traffic will never work. If we did
@@ -489,16 +489,16 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 							// Make sure each endpoint address is a valid address
 							// as service entries could have NONE resolution with label selectors for workload
 							// entries (which could technically have hostnames).
-							if !netutil.IsValidIPAddress(instance.Endpoint.Address) {
+							if !netutil.IsValidIPAddress(instance.Address) {
 								continue
 							}
 							// Skip build outbound listener to the node itself,
 							// as when app access itself by pod ip will not flow through this listener.
 							// Simultaneously, it will be duplicate with inbound listener.
-							if instance.Endpoint.Address == node.IPAddresses[0] {
+							if instance.Address == node.IPAddresses[0] {
 								continue
 							}
-							listenerOpts.bind.binds = []string{instance.Endpoint.Address}
+							listenerOpts.bind.binds = []string{instance.Address}
 							lb.buildSidecarOutboundListener(listenerOpts, listenerMap, virtualServices, actualWildcards)
 						}
 					} else {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2572,7 +2572,8 @@ func buildServiceWithPort(hostname string, port int, protocol protocol.Instance,
 func buildServiceInstance(service *model.Service, instanceIP string) *model.ServiceInstance {
 	return &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
-			Address: instanceIP,
+			Address:         instanceIP,
+			ServicePortName: service.Ports[0].Name,
 		},
 		ServicePort: service.Ports[0],
 		Service:     service,

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -310,16 +310,6 @@ func (c *Controller) MCSServices() []model.MCSServiceInfo {
 	return out
 }
 
-// InstancesByPort retrieves instances for a service on a given port that match
-// any of the supplied labels. All instances match an empty label list.
-func (c *Controller) InstancesByPort(svc *model.Service, port int) []*model.ServiceInstance {
-	var instances []*model.ServiceInstance
-	for _, r := range c.GetRegistries() {
-		instances = append(instances, r.InstancesByPort(svc, port)...)
-	}
-	return instances
-}
-
 func nodeClusterID(node *model.Proxy) cluster.ID {
 	if node.Metadata == nil || node.Metadata.ClusterID == "" {
 		return ""

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -261,38 +261,6 @@ func TestGetProxyWorkloadLabels(t *testing.T) {
 	}
 }
 
-func TestInstances(t *testing.T) {
-	aggregateCtl := buildMockController()
-
-	// Get Instances from mockAdapter1
-	instances := aggregateCtl.InstancesByPort(mock.HelloService, 80)
-	if len(instances) != 2 {
-		t.Fatal("Returned wrong number of instances from controller")
-	}
-	for _, instance := range instances {
-		if instance.Service.Hostname != mock.HelloService.Hostname {
-			t.Fatal("Returned instance's hostname does not match desired value")
-		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHTTPName); !ok {
-			t.Fatal("Returned instance does not contain desired port")
-		}
-	}
-
-	// Get Instances from mockAdapter2
-	instances = aggregateCtl.InstancesByPort(mock.WorldService, 80)
-	if len(instances) != 2 {
-		t.Fatal("Returned wrong number of instances from controller")
-	}
-	for _, instance := range instances {
-		if instance.Service.Hostname != mock.WorldService.Hostname {
-			t.Fatal("Returned instance's hostname does not match desired value")
-		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHTTPName); !ok {
-			t.Fatal("Returned instance does not contain desired port")
-		}
-	}
-}
-
 func TestAddRegistry(t *testing.T) {
 	registries := []serviceregistry.Simple{
 		{

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -209,8 +209,6 @@ type Controller struct {
 	// we run through the label selectors here to pick only ones that we need.
 	// Only nodes with ExternalIP addresses are included in this map !
 	nodeInfoMap map[string]kubernetesNode
-	// externalNameSvcInstanceMap stores hostname ==> instance, is used to store instances for ExternalName k8s services
-	externalNameSvcInstanceMap map[host.Name][]*model.ServiceInstance
 	// index over workload instances from workload entries
 	workloadInstancesIndex workloadinstances.Index
 
@@ -231,16 +229,16 @@ type Controller struct {
 // Created by bootstrap and multicluster (see multicluster.Controller).
 func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c := &Controller{
-		opts:                       options,
-		client:                     kubeClient,
-		queue:                      queue.NewQueueWithID(1*time.Second, string(options.ClusterID)),
-		servicesMap:                make(map[host.Name]*model.Service),
-		nodeSelectorsForServices:   make(map[host.Name]labels.Instance),
-		nodeInfoMap:                make(map[string]kubernetesNode),
-		externalNameSvcInstanceMap: make(map[host.Name][]*model.ServiceInstance),
-		workloadInstancesIndex:     workloadinstances.NewIndex(),
-		initialSyncTimedout:        atomic.NewBool(false),
-		configCluster:              options.ConfigCluster,
+		opts:                     options,
+		client:                   kubeClient,
+		queue:                    queue.NewQueueWithID(1*time.Second, string(options.ClusterID)),
+		servicesMap:              make(map[host.Name]*model.Service),
+		nodeSelectorsForServices: make(map[host.Name]labels.Instance),
+		nodeInfoMap:              make(map[string]kubernetesNode),
+		workloadInstancesIndex:   workloadinstances.NewIndex(),
+		initialSyncTimedout:      atomic.NewBool(false),
+
+		configCluster: options.ConfigCluster,
 	}
 	c.networkManager = initNetworkManager(c, options)
 
@@ -394,6 +392,7 @@ func (c *Controller) onServiceEvent(_, curr *v1.Service, event model.Event) erro
 
 	// Create the standard (cluster.local) service.
 	svcConv := kube.ConvertService(*curr, c.opts.DomainSuffix, c.Cluster())
+
 	switch event {
 	case model.EventDelete:
 		c.deleteService(svcConv)
@@ -408,7 +407,6 @@ func (c *Controller) deleteService(svc *model.Service) {
 	c.Lock()
 	delete(c.servicesMap, svc.Hostname)
 	delete(c.nodeSelectorsForServices, svc.Hostname)
-	delete(c.externalNameSvcInstanceMap, svc.Hostname)
 	_, isNetworkGateway := c.networkGatewaysBySvc[svc.Hostname]
 	delete(c.networkGatewaysBySvc, svc.Hostname)
 	c.Unlock()
@@ -444,15 +442,15 @@ func (c *Controller) addOrUpdateService(curr *v1.Service, currConv *model.Servic
 		needsFullPush = c.updateServiceNodePortAddresses(currConv)
 	}
 
+	// For ExternalName, we need to update the EndpointIndex, as we will store endpoints just based on the Service.
+	if curr != nil && curr.Spec.Type == v1.ServiceTypeExternalName {
+		updateEDSCache = true
+	}
 	var prevConv *model.Service
 	// instance conversion is only required when service is added/updated.
-	instances := kube.ExternalNameServiceInstances(curr, currConv)
 	c.Lock()
 	prevConv = c.servicesMap[currConv.Hostname]
 	c.servicesMap[currConv.Hostname] = currConv
-	if len(instances) > 0 {
-		c.externalNameSvcInstanceMap[currConv.Hostname] = instances
-	}
 	c.Unlock()
 
 	// This full push needed to update ALL ends endpoints, even though we do a full push on service add/update
@@ -484,6 +482,7 @@ func (c *Controller) buildEndpointsForService(svc *model.Service, updateCache bo
 		fep := c.collectWorkloadInstanceEndpoints(svc)
 		endpoints = append(endpoints, fep...)
 	}
+	endpoints = append(endpoints, kube.ExternalNameEndpoints(svc)...)
 	return endpoints
 }
 
@@ -676,29 +675,6 @@ func (c *Controller) getPodLocality(pod *v1.Pod) string {
 	return region + "/" + zone + "/" + subzone // Format: "%s/%s/%s"
 }
 
-// InstancesByPort implements a service catalog operation
-func (c *Controller) InstancesByPort(svc *model.Service, reqSvcPort int) []*model.ServiceInstance {
-	// First get k8s standard service instances and the workload entry instances
-	outInstances := c.endpoints.InstancesByPort(svc, reqSvcPort)
-	outInstances = append(outInstances, c.serviceInstancesFromWorkloadInstances(svc, reqSvcPort)...)
-
-	// return when instances found or an error occurs
-	if len(outInstances) > 0 {
-		return outInstances
-	}
-
-	// Fall back to external name service since we did not find any instances of normal services
-	c.RLock()
-	externalNameInstances := c.externalNameSvcInstanceMap[svc.Hostname]
-	c.RUnlock()
-	if externalNameInstances != nil {
-		return slices.Filter(externalNameInstances, func(i *model.ServiceInstance) bool {
-			return i.Service.Attributes.Namespace == svc.Attributes.Namespace && i.ServicePort.Port == reqSvcPort
-		})
-	}
-	return nil
-}
-
 func (c *Controller) serviceInstancesFromWorkloadInstances(svc *model.Service, reqSvcPort int) []*model.ServiceInstance {
 	// Run through all the workload instances, select ones that match the service labels
 	// only if this is a kubernetes internal service and of ClientSideLB (eds) type
@@ -843,7 +819,7 @@ func (c *Controller) GetProxyServiceTargets(proxy *model.Proxy) []model.ServiceT
 		// 3. The pod is not present when this is called
 		// due to eventual consistency issues. However, we have a lot of information about the pod from the proxy
 		// metadata already. Because of this, we can still get most of the information we need.
-		// If we cannot accurately construct ServiceInstances from just the metadata, this will return an error and we can
+		// If we cannot accurately construct ServiceEndpoints from just the metadata, this will return an error and we can
 		// attempt to read the real pod.
 		out, err := c.GetProxyServiceTargetsFromMetadata(proxy)
 		if err != nil {
@@ -924,35 +900,15 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 		ObjectMeta: metav1.ObjectMeta{Namespace: si.Namespace, Labels: si.Endpoint.Labels},
 	}
 
-	shard := model.ShardKeyFromRegistry(c)
+	// We got an instance update, which probably effects EDS. However, EDS is keyed by Hostname. We need to find all
+	// Hostnames (services) that were updated and recompute them
 	// find the services that map to this workload entry, fire off eds updates if the service is of type client-side lb
 	allServices := c.services.List(si.Namespace, klabels.Everything())
-	if k8sServices := getPodServices(allServices, dummyPod); len(k8sServices) > 0 {
-		for _, k8sSvc := range k8sServices {
-			service := c.GetService(kube.ServiceHostname(k8sSvc.Name, k8sSvc.Namespace, c.opts.DomainSuffix))
-			// Note that this cannot be an external service because k8s external services do not have label selectors.
-			if service == nil || service.Resolution != model.ClientSideLB {
-				// may be a headless service
-				continue
-			}
-
-			// Get the updated list of endpoints that includes k8s pods and the workload entries for this service
-			// and then notify the EDS server that endpoints for this service have changed.
-			// We need one endpoint object for each service port
-			endpoints := make([]*model.IstioEndpoint, 0)
-			for _, port := range service.Ports {
-				if port.Protocol == protocol.UDP {
-					continue
-				}
-				instances := c.InstancesByPort(service, port.Port)
-				for _, inst := range instances {
-					endpoints = append(endpoints, inst.Endpoint)
-				}
-			}
-			// fire off eds update
-			c.opts.XDSUpdater.EDSUpdate(shard, string(service.Hostname), service.Attributes.Namespace, endpoints)
-		}
-	}
+	matchedServices := getPodServices(allServices, dummyPod)
+	matchedHostnames := slices.Map(matchedServices, func(e *v1.Service) host.Name {
+		return kube.ServiceHostname(e.Name, e.Namespace, c.opts.DomainSuffix)
+	})
+	c.endpoints.updateEDS(matchedHostnames, si.Namespace)
 }
 
 func (c *Controller) onSystemNamespaceEvent(_, ns *v1.Namespace, ev model.Event) error {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -134,7 +134,7 @@ func (esc *endpointSliceController) sliceServiceInstances(ep *v1.EndpointSlice, 
 	return out
 }
 
-func (esc *endpointSliceController) forgetEndpoint(slice *v1.EndpointSlice) map[host.Name][]*model.IstioEndpoint {
+func (esc *endpointSliceController) deleteEndpointSlice(slice *v1.EndpointSlice) {
 	key := config.NamespacedName(slice)
 	for _, e := range slice.Endpoints {
 		for _, a := range e.Addresses {
@@ -142,22 +142,20 @@ func (esc *endpointSliceController) forgetEndpoint(slice *v1.EndpointSlice) map[
 		}
 	}
 
-	out := make(map[host.Name][]*model.IstioEndpoint)
 	esc.endpointCache.mu.Lock()
 	defer esc.endpointCache.mu.Unlock()
 	for _, hostName := range esc.c.hostNamesForNamespacedName(getServiceNamespacedName(slice)) {
 		// endpointSlice cache update
 		if esc.endpointCache.has(hostName) {
 			esc.endpointCache.delete(hostName, slice.Name)
-			out[hostName] = esc.endpointCache.get(hostName)
 		}
 	}
-	return out
 }
 
-func (esc *endpointSliceController) buildIstioEndpoints(es *v1.EndpointSlice, hostName host.Name) []*model.IstioEndpoint {
-	esc.updateEndpointCacheForSlice(hostName, es)
-	return esc.endpointCache.Get(hostName)
+func (esc *endpointSliceController) updateEndpointSlice(slice *v1.EndpointSlice) {
+	for _, hostname := range esc.c.hostNamesForNamespacedName(getServiceNamespacedName(slice)) {
+		esc.updateEndpointCacheForSlice(hostname, slice)
+	}
 }
 
 func endpointHealthStatus(svc *model.Service, e v1.Endpoint) model.HealthStatus {
@@ -244,25 +242,6 @@ func getServiceNamespacedName(slice *v1.EndpointSlice) types.NamespacedName {
 		Namespace: slice.GetNamespace(),
 		Name:      serviceNameForEndpointSlice(slice.GetLabels()),
 	}
-}
-
-func (esc *endpointSliceController) InstancesByPort(svc *model.Service, reqSvcPort int) []*model.ServiceInstance {
-	// Locate all ports in the actual service
-	svcPort, exists := svc.Ports.GetByPort(reqSvcPort)
-	if !exists {
-		return nil
-	}
-	var out []*model.ServiceInstance
-	for _, ep := range esc.endpointCache.Get(svc.Hostname) {
-		if svcPort.Name == ep.ServicePortName {
-			out = append(out, &model.ServiceInstance{
-				Service:     svc,
-				ServicePort: svcPort,
-				Endpoint:    ep,
-			})
-		}
-	}
-	return out
 }
 
 // endpointKey unique identifies an endpoint by IP and port name
@@ -363,7 +342,7 @@ func endpointSliceSelectorForService(name string) klabels.Selector {
 func (esc *endpointSliceController) processEndpointEvent(name string, namespace string, event model.Event, ep *v1.EndpointSlice) error {
 	// Update internal endpoint cache no matter what kind of service, even headless service.
 	// As for gateways, the cluster discovery type is `EDS` for headless service.
-	esc.updateEDS(ep, event)
+	esc.handleEndpointSlice(ep, event)
 	if svc := esc.c.services.Get(name, namespace); svc != nil {
 		// if the service is headless service, trigger a full push if EnableHeadlessService is true,
 		// otherwise push endpoint updates - needed for NDS output.
@@ -384,35 +363,37 @@ func (esc *endpointSliceController) processEndpointEvent(name string, namespace 
 	return nil
 }
 
-func (esc *endpointSliceController) updateEDS(ep *v1.EndpointSlice, event model.Event) {
+func (esc *endpointSliceController) handleEndpointSlice(ep *v1.EndpointSlice, event model.Event) {
 	namespacedName := getServiceNamespacedName(ep)
 	log.Debugf("Handle EDS endpoint %s %s in namespace %s", namespacedName.Name, event, namespacedName.Namespace)
-	var forgottenEndpointsByHost map[host.Name][]*model.IstioEndpoint
+
 	if event == model.EventDelete {
-		forgottenEndpointsByHost = esc.forgetEndpoint(ep)
+		esc.deleteEndpointSlice(ep)
+	} else {
+		esc.updateEndpointSlice(ep)
 	}
 
+	hostnames := esc.c.hostNamesForNamespacedName(namespacedName)
+	esc.updateEDS(hostnames, namespacedName.Namespace)
+}
+
+func (esc *endpointSliceController) updateEDS(hostnames []host.Name, namespace string) {
 	shard := model.ShardKeyFromRegistry(esc.c)
-
-	for _, hostName := range esc.c.hostNamesForNamespacedName(namespacedName) {
-		var endpoints []*model.IstioEndpoint
-		if forgottenEndpointsByHost != nil {
-			endpoints = forgottenEndpointsByHost[hostName]
-		} else {
-			endpoints = esc.buildIstioEndpoints(ep, hostName)
-		}
-
+	esc.endpointCache.mu.Lock()
+	defer esc.endpointCache.mu.Unlock()
+	for _, hostname := range hostnames {
+		endpoints := esc.endpointCache.get(hostname)
 		if features.EnableK8SServiceSelectWorkloadEntries {
-			svc := esc.c.GetService(hostName)
+			svc := esc.c.GetService(hostname)
 			if svc != nil {
 				fep := esc.c.collectWorkloadInstanceEndpoints(svc)
 				endpoints = append(endpoints, fep...)
 			} else {
-				log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/%s has not been populated",
-					namespacedName.Namespace, namespacedName.Name)
+				log.Debugf("Handle EDS endpoint: skip collecting workload entry endpoints, service %s/ has not been populated",
+					hostname)
 			}
 		}
 
-		esc.c.opts.XDSUpdater.EDSUpdate(shard, string(hostName), namespacedName.Namespace, endpoints)
+		esc.c.opts.XDSUpdater.EDSUpdate(shard, string(hostname), namespace, endpoints)
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestEndpointSliceFromMCSShouldBeIgnored(t *testing.T) {
@@ -67,11 +68,9 @@ func TestEndpointSliceFromMCSShouldBeIgnored(t *testing.T) {
 	})
 	fx.AssertEmpty(t, time.Millisecond*50)
 
-	// Ensure that getting by port returns no ServiceInstances.
-	instances := controller.InstancesByPort(svc, svc.Ports[0].Port)
-	if len(instances) != 0 {
-		t.Fatalf("should be 0 instances: len(instances) = %v", len(instances))
-	}
+	// Ensure that no endpoint is create
+	endpoints := GetEndpoints(svc, controller.Endpoints)
+	assert.Equal(t, len(endpoints), 0)
 }
 
 func TestEndpointSliceCache(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -57,12 +57,16 @@ type FakeControllerOptions struct {
 
 type FakeController struct {
 	*Controller
+	Endpoints *model.EndpointIndex
 }
 
 func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*FakeController, *xdsfake.Updater) {
 	xdsUpdater := opts.XDSUpdater
+	var endpoints *model.EndpointIndex
 	if xdsUpdater == nil {
-		xdsUpdater = xdsfake.NewFakeXDS()
+		endpoints = model.NewEndpointIndex(model.DisabledCache{})
+		delegate := model.NewEndpointIndexUpdater(endpoints)
+		xdsUpdater = xdsfake.NewWithDelegate(delegate)
 	}
 
 	domainSuffix := defaultFakeDomainSuffix
@@ -124,5 +128,5 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 		kubelib.WaitForCacheSync("test", c.stop, c.HasSynced)
 	}
 
-	return &FakeController{c}, fx
+	return &FakeController{Controller: c, Endpoints: endpoints}, fx
 }

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -220,7 +220,7 @@ func (ic *serviceImportCacheImpl) createKubeService(t *testing.T, c *FakeControl
 		}
 
 		if len(expectedHosts) > 0 {
-			return fmt.Errorf("failed to find proxy ServiceInstances for hosts: %v", expectedHosts)
+			return fmt.Errorf("failed to find proxy ServiceEndpoints for hosts: %v", expectedHosts)
 		}
 
 		return nil

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -447,18 +447,13 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	// When doing a full push, the non DNS added, updated, unchanged services trigger an eds update
 	// so that endpoint shards are updated.
 	allServices := make([]*model.Service, 0, len(addedSvcs)+len(updatedSvcs)+len(unchangedSvcs))
-	nonDNSServices := make([]*model.Service, 0, len(addedSvcs)+len(updatedSvcs)+len(unchangedSvcs))
 	allServices = append(allServices, addedSvcs...)
 	allServices = append(allServices, updatedSvcs...)
 	allServices = append(allServices, unchangedSvcs...)
-	for _, svc := range allServices {
-		if !(svc.Resolution == model.DNSLB || svc.Resolution == model.DNSRoundRobinLB) {
-			nonDNSServices = append(nonDNSServices, svc)
-		}
-	}
+
 	// non dns service instances
-	keys := sets.NewWithLength[instancesKey](len(nonDNSServices))
-	for _, svc := range nonDNSServices {
+	keys := sets.NewWithLength[instancesKey](len(allServices))
+	for _, svc := range allServices {
 		keys.Insert(instancesKey{hostname: svc.Hostname, namespace: curr.Namespace})
 	}
 
@@ -678,22 +673,6 @@ func (s *Controller) GetService(hostname host.Name) *model.Service {
 	return nil
 }
 
-// InstancesByPort retrieves instances for a service on the given ports with labels that
-// match any of the supplied labels. All instances match an empty tag list.
-func (s *Controller) InstancesByPort(svc *model.Service, port int) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
-	s.mutex.RLock()
-	instanceLists := s.serviceInstances.getByKey(instancesKey{svc.Hostname, svc.Attributes.Namespace})
-	s.mutex.RUnlock()
-	for _, instance := range instanceLists {
-		if portMatchSingle(instance, port) {
-			out = append(out, instance)
-		}
-	}
-
-	return out
-}
-
 // ResyncEDS will do a full EDS update. This is needed for some tests where we have many configs loaded without calling
 // the config handlers.
 // This should probably not be used in production code.
@@ -804,11 +783,6 @@ func (s *Controller) buildEndpoints(keys map[instancesKey]struct{}) map[instance
 
 	}
 	return endpoints
-}
-
-// returns true if an instance's port matches with any in the provided list
-func portMatchSingle(instance *model.ServiceInstance, port int) bool {
-	return port == 0 || port == instance.ServicePort.Port
 }
 
 // GetProxyServiceTargets lists service instances co-located with a given proxy

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -305,7 +305,7 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 	}
 }
 
-// convertWorkloadEntryToServiceInstances translates a WorkloadEntry into ServiceInstances. This logic is largely the
+// convertWorkloadEntryToServiceInstances translates a WorkloadEntry into ServiceEndpoints. This logic is largely the
 // same as the ServiceEntry convertServiceEntryToInstances.
 func (s *Controller) convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, services []*model.Service,
 	se *networking.ServiceEntry, configKey *configKey, clusterID cluster.ID,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -1287,7 +1287,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 	}
 }
 
-func compare(t testing.TB, actual, expected any) error {
+func compare[T any](t testing.TB, actual, expected T) error {
 	return util.Compare(jsonBytes(t, actual), jsonBytes(t, expected))
 }
 

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -31,14 +31,14 @@ import (
 )
 
 // nolint
-func makeServiceInstances(proxy *model.Proxy, service *model.Service, hostname, subdomain string) map[int][]*model.ServiceInstance {
-	instances := make(map[int][]*model.ServiceInstance)
+func makeServiceInstances(proxy *model.Proxy, service *model.Service, hostname, subdomain string) map[int][]*model.IstioEndpoint {
+	instances := make(map[int][]*model.IstioEndpoint)
 	for _, port := range service.Ports {
 		instances[port.Port] = makeInstances(proxy, service, port.Port, port.Port)
-		instances[port.Port][0].Endpoint.HostName = hostname
-		instances[port.Port][0].Endpoint.SubDomain = subdomain
-		instances[port.Port][0].Endpoint.Network = proxy.Metadata.Network
-		instances[port.Port][0].Endpoint.Locality.ClusterID = proxy.Metadata.ClusterID
+		instances[port.Port][0].HostName = hostname
+		instances[port.Port][0].SubDomain = subdomain
+		instances[port.Port][0].Network = proxy.Metadata.Network
+		instances[port.Port][0].Locality.ClusterID = proxy.Metadata.ClusterID
 	}
 	return instances
 }
@@ -517,20 +517,16 @@ func TestNameTable(t *testing.T) {
 	}
 }
 
-func makeInstances(proxy *model.Proxy, svc *model.Service, servicePort int, targetPort int) []*model.ServiceInstance {
-	ret := make([]*model.ServiceInstance, 0)
+func makeInstances(proxy *model.Proxy, svc *model.Service, servicePort int, targetPort int) []*model.IstioEndpoint {
+	ret := make([]*model.IstioEndpoint, 0)
 	for _, p := range svc.Ports {
 		if p.Port != servicePort {
 			continue
 		}
-		ret = append(ret, &model.ServiceInstance{
-			Service:     svc,
-			ServicePort: p,
-			Endpoint: &model.IstioEndpoint{
-				Address:         proxy.IPAddresses[0],
-				ServicePortName: p.Name,
-				EndpointPort:    uint32(targetPort),
-			},
+		ret = append(ret, &model.IstioEndpoint{
+			Address:         proxy.IPAddresses[0],
+			ServicePortName: p.Name,
+			EndpointPort:    uint32(targetPort),
 		})
 	}
 	return ret

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -163,3 +163,12 @@ func Dereference[E any](s []*E) []E {
 	}
 	return res
 }
+
+// Flatten merges a slice of slices into a single slice.
+func Flatten[E any](s [][]E) []E {
+	res := make([]E, 0)
+	for _, v := range s {
+		res = append(res, v...)
+	}
+	return res
+}


### PR DESCRIPTION
Related PRs:
* https://github.com/istio/istio/pull/46295 - similar idea, although entirely decoupled
* https://github.com/istio/istio/pull/45733 - should be able to implement that PR more safely with this change

Today, we have two distinct paths for endpoints. Each registry will write EDSUpdate events which are point-in-time updates of a Service's endpoints. These are aggregated and persistently stored in EndpointIndex. EndpointIndex is always incrementally updated based on these updates and is never rebuilt. This is used for EDS serving.

However, each registry also must expose an InstancesByPort, requiring it to rebuild all endpoints again. This is then snapshotted in PushContext on each new push.

This PR consolidates everything around EndpointIndex. It maintains the expectations of PushContext (that it is a snapshot) by copying a point-in-time snapshot of EndpointIndex. This may sound expensive but it is way cheaper (I assume - no hard numbers yet) than what we do today; today we _rebuild_ each endpoint, while this change simply copies endpoint pointers (not even a deep copy).

Overall the user facing behavior is the same, this is just a lot simpler and less likely to have bugs.

---

There are two main changes:

* Previously, DNS types (from DNS ServiceEntry or ExternalName service) are not in endpoint index. Now they are. This does not impact EDS, as there will be no EDS requests for these (and if there somehow is, we filter them out already).
* Tests. Lots of tests changes