### PR TITLE
Better ExternalName support

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -654,7 +654,7 @@ var (
 	EnableNativeSidecars = env.Register("ENABLE_NATIVE_SIDECARS", false,
 		"If set, used Kubernetes native Sidecar container support. Requires SidecarContainer feature flag.")
 
-	EnableExternalNameAlias = env.Register("ENABLE_EXTERNAL_NAME_ALIAS", true,
+	EnableExternalNameAlias = env.Register("ENABLE_EXTERNAL_NAME_ALIAS", false,
 		"If enabled, ExternalName Services will be treated as simple aliases: anywhere where we would match the concrete service, "+
 			"we also match the ExternalName. In general, this mirrors Kubernetes behavior more closely. However, it means that policies (routes and DestinationRule) "+
 			"cannot be applied to the ExternalName service. "+

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -654,6 +654,14 @@ var (
 	EnableNativeSidecars = env.Register("ENABLE_NATIVE_SIDECARS", false,
 		"If set, used Kubernetes native Sidecar container support. Requires SidecarContainer feature flag.")
 
+	EnableExternalNameAlias = env.Register("ENABLE_EXTERNAL_NAME_ALIAS", true,
+		"If enabled, ExternalName Services will be treated as simple aliases: anywhere where we would match the concrete service, "+
+			"we also match the ExternalName. In general, this mirrors Kubernetes behavior more closely. However, it means that policies (routes and DestinationRule) "+
+			"cannot be applied to the ExternalName service. "+
+			"If disabled, ExternalName behaves in fairly unexpected manner. Port matters, while it does not in Kubernetes. If it is a TCP port, "+
+			"all traffic on that port will be matched, which can have disastrous consequences. Additionally, the destination is seen as an opaque destination; "+
+			"even if it is another service in the mesh, policies such as mTLS and load balancing will not be used when connecting to it.").Get()
+
 	// This is an experimental feature flag, can be removed once it became stable, and should introduced to Telemetry API.
 	MetricRotationInterval = env.Register("METRIC_ROTATION_INTERVAL", 0*time.Second,
 		"Metric scope rotation interval, set to 0 to disable the metric scope rotation").Get()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -1545,11 +1546,11 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 	}
 	// Sort aliases so order is deterministic.
 	for _, v := range aliasesForService {
-		slices.SortFunc(v, func(a, b NamespacedHostname) bool {
-			if a.Hostname == b.Hostname {
-				return a.Namespace < b.Namespace
+		slices.SortFunc(v, func(a, b NamespacedHostname) int {
+			if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
+				return r
 			}
-			return a.Hostname < b.Hostname
+			return cmp.Compare(a.Hostname, b.Hostname)
 		})
 	}
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1467,7 +1467,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 // resolveServiceAliases walks this 'graph' of services and updates the Alias field in-place.
 func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[ConfigKey]) {
 	// rawAlias builds a map of Service -> AliasFor. So this will be ExternalName -> Service.
-	// In an edge case, we can have ExternalName -> ExternalName; we resolve that below
+	// In an edge case, we can have ExternalName -> ExternalName; we resolve that below.
 	rawAlias := map[NamespacedHostname]host.Name{}
 	for _, s := range allServices {
 		if s.Resolution != Alias {
@@ -1479,6 +1479,7 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 		}
 		rawAlias[nh] = host.Name(s.Attributes.K8sAttributes.ExternalName)
 	}
+
 	// unnamespacedRawAlias is like rawAlias but without namespaces.
 	// This is because an `ExternalName` isn't namespaced. If there is a conflict, the behavior is undefined.
 	// This is split from above as a minor optimization to right-size the map
@@ -1517,15 +1518,19 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 	}
 
 	// aliasesForService builds a map of Concrete -> []Aliases
+	// This basically reverses our resolvedAliased map, which is Alias -> Concrete,
 	aliasesForService := map[host.Name][]NamespacedHostname{}
 	for alias, concrete := range resolvedAliases {
-		ak := ConfigKey{
+		aliasesForService[concrete] = append(aliasesForService[concrete], alias)
+
+		// We also need to update configsUpdated, such that any "alias" updated also marks the concrete service as updated.
+		aliasKey := ConfigKey{
 			Kind:      kind.ServiceEntry,
 			Name:      alias.Hostname.String(),
 			Namespace: alias.Namespace,
 		}
 		// Alias. We should mark all the concrete services as updated as well.
-		if configsUpdated.Contains(ak) {
+		if configsUpdated.Contains(aliasKey) {
 			// We only have the hostname, but we need the namespace...
 			for _, svc := range allServices {
 				if svc.Hostname == concrete {
@@ -1537,8 +1542,8 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 				}
 			}
 		}
-		aliasesForService[concrete] = append(aliasesForService[concrete], alias)
 	}
+	// Sort aliases so order is deterministic.
 	for _, v := range aliasesForService {
 		slices.SortFunc(v, func(a, b NamespacedHostname) bool {
 			if a.Hostname == b.Hostname {
@@ -1547,6 +1552,8 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 			return a.Hostname < b.Hostname
 		})
 	}
+
+	// Finally, we can traverse all services and update the ones that have aliases
 	for i, s := range allServices {
 		if aliases, f := aliasesForService[s.Hostname]; f {
 			// This service has an alias; set it. We need to make a copy since the underlying Service is shared

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1244,7 +1244,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 }
 
 func (ps *PushContext) createNewContext(env *Environment) error {
-	ps.initServiceRegistry(env)
+	ps.initServiceRegistry(env, nil)
 
 	if err := ps.initKubernetesGateways(env); err != nil {
 		return err
@@ -1317,7 +1317,7 @@ func (ps *PushContext) updateContext(
 
 	if servicesChanged {
 		// Services have changed. initialize service registry
-		ps.initServiceRegistry(env)
+		ps.initServiceRegistry(env, pushReq.ConfigsUpdated)
 	} else {
 		// make sure we copy over things that would be generated in initServiceRegistry
 		ps.ServiceIndex = oldPushContext.ServiceIndex
@@ -1403,9 +1403,11 @@ func (ps *PushContext) updateContext(
 
 // Caches list of services in the registry, and creates a map
 // of hostname to service
-func (ps *PushContext) initServiceRegistry(env *Environment) {
+func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.Set[ConfigKey]) {
 	// Sort the services in order of creation.
 	allServices := SortServicesByCreationTime(env.Services())
+	resolveServiceAliases(allServices, configsUpdate)
+
 	for _, s := range allServices {
 		portMap := map[string]int{}
 		for _, port := range s.Ports {
@@ -1456,6 +1458,102 @@ func (ps *PushContext) initServiceRegistry(env *Environment) {
 	}
 
 	ps.initServiceAccounts(env, allServices)
+}
+
+// resolveServiceAliases sets the Aliases attributes on all services. The incoming Service's will just have AliasFor set,
+// but in our usage we often need the opposite: for a given service, what are all the aliases?
+// resolveServiceAliases walks this 'graph' of services and updates the Alias field in-place.
+func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[ConfigKey]) {
+	// rawAlias builds a map of Service -> AliasFor. So this will be ExternalName -> Service.
+	// In an edge case, we can have ExternalName -> ExternalName; we resolve that below
+	rawAlias := map[NamespacedHostname]host.Name{}
+	for _, s := range allServices {
+		if s.Resolution != Alias {
+			continue
+		}
+		nh := NamespacedHostname{
+			Hostname:  s.Hostname,
+			Namespace: s.Attributes.Namespace,
+		}
+		rawAlias[nh] = host.Name(s.Attributes.K8sAttributes.ExternalName)
+	}
+	// unnamespacedRawAlias is like rawAlias but without namespaces.
+	// This is because an `ExternalName` isn't namespaced. If there is a conflict, the behavior is undefined.
+	unnamespacedRawAlias := make(map[host.Name]host.Name, len(rawAlias))
+	for k, v := range rawAlias {
+		unnamespacedRawAlias[k.Hostname] = v
+	}
+
+	// resolvedAliases builds a map of Alias -> Concrete, fully resolving through multiple hops.
+	// Ex: Alias1 -> Alias2 -> Concrete will flatten to Alias1 -> Concrete.
+	resolvedAliases := make(map[NamespacedHostname]host.Name, len(rawAlias))
+	for alias, referencedService := range rawAlias {
+		// referencedService may be another alias or a concrete service.
+		if _, f := unnamespacedRawAlias[referencedService]; !f {
+			// Common case: alias pointing to a concrete service
+			resolvedAliases[alias] = referencedService
+			continue
+		}
+		// Otherwise, we need to traverse the alias "graph".
+		// In an obscure edge case, a user could make a loop, so we will need to handle that.
+		seen := sets.New(alias.Hostname, referencedService)
+		for {
+			n, f := unnamespacedRawAlias[referencedService]
+			if !f {
+				// The destination we are pointing to is not an alias, so this is the terminal step
+				resolvedAliases[alias] = referencedService
+				break
+			}
+			if seen.InsertContains(n) {
+				// We did a loop!
+				// Kubernetes will make these NXDomain, so we can just treat it like it doesn't exist at all
+				break
+			}
+			referencedService = n
+		}
+	}
+
+	// referencedHostnames := ConfigNameOfKind(configsUpdated, kind.ServiceEntry)
+
+	// aliasesForService builds a map of Concrete -> []Aliases
+	aliasesForService := map[host.Name][]NamespacedHostname{}
+	for alias, concrete := range resolvedAliases {
+		ak := ConfigKey{
+			Kind:      kind.ServiceEntry,
+			Name:      alias.Hostname.String(),
+			Namespace: alias.Namespace,
+		}
+		// Alias. We should mark all the concrete services as updated as well.
+		if configsUpdated.Contains(ak) {
+			// We only have the hostname, but we need the namespace...
+			for _, svc := range allServices {
+				if svc.Hostname == concrete {
+					configsUpdated.Insert(ConfigKey{
+						Kind:      kind.ServiceEntry,
+						Name:      concrete.String(),
+						Namespace: svc.Attributes.Namespace,
+					})
+				}
+			}
+		}
+		aliasesForService[concrete] = append(aliasesForService[concrete], alias)
+	}
+	for _, v := range aliasesForService {
+		slices.SortFunc(v, func(a, b NamespacedHostname) bool {
+			if a.Hostname == b.Hostname {
+				return a.Namespace < b.Namespace
+			}
+			return a.Hostname < b.Hostname
+		})
+	}
+	for i, s := range allServices {
+		if aliases, f := aliasesForService[s.Hostname]; f {
+			// This service has an alias; set it. We need to make a copy since the underlying Service is shared
+			s = s.DeepCopy()
+			s.Attributes.Aliases = aliases
+			allServices[i] = s
+		}
+	}
 }
 
 // SortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1513,8 +1513,6 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 		}
 	}
 
-	// referencedHostnames := ConfigNameOfKind(configsUpdated, kind.ServiceEntry)
-
 	// aliasesForService builds a map of Concrete -> []Aliases
 	aliasesForService := map[host.Name][]NamespacedHostname{}
 	for alias, concrete := range resolvedAliases {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1406,7 +1406,9 @@ func (ps *PushContext) updateContext(
 func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.Set[ConfigKey]) {
 	// Sort the services in order of creation.
 	allServices := SortServicesByCreationTime(env.Services())
-	resolveServiceAliases(allServices, configsUpdate)
+	if features.EnableExternalNameAlias {
+		resolveServiceAliases(allServices, configsUpdate)
+	}
 
 	for _, s := range allServices {
 		portMap := map[string]int{}
@@ -1479,6 +1481,7 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 	}
 	// unnamespacedRawAlias is like rawAlias but without namespaces.
 	// This is because an `ExternalName` isn't namespaced. If there is a conflict, the behavior is undefined.
+	// This is split from above as a minor optimization to right-size the map
 	unnamespacedRawAlias := make(map[host.Name]host.Name, len(rawAlias))
 	for k, v := range rawAlias {
 		unnamespacedRawAlias[k.Hostname] = v

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -735,7 +735,7 @@ func matchingService(importedHosts hostClassification, service *Service, ilw *Is
 	return nil
 }
 
-// Return the original service or a trimmed service which has a subset of the ports in original service.
+// matchingAliasService the original service or a trimmed service which has a subset of aliases, based on imports from sidecar
 func matchingAliasService(importedHosts hostClassification, service *Service) *Service {
 	if service == nil {
 		return nil

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -290,6 +290,9 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 	efKeys := cp.efw.KeysApplyingTo(networking.EnvoyFilter_CLUSTER)
 	hit, miss := 0, 0
 	for _, service := range services {
+		if service.Resolution == model.Alias {
+			continue
+		}
 		for _, port := range service.Ports {
 			if port.Protocol == protocol.UDP {
 				continue

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -388,6 +388,10 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 
 	servicesByName := make(map[host.Name]*model.Service)
 	for _, svc := range services {
+		if svc.Resolution == model.Alias {
+			// Will be handled by the service it is an alias for
+			continue
+		}
 		if listenerPort == 0 {
 			// Take all ports when listen port is 0 (http_proxy or uds)
 			// Expect virtualServices to resolve to right port
@@ -403,6 +407,8 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 					Namespace:       svc.Attributes.Namespace,
 					ServiceRegistry: svc.Attributes.ServiceRegistry,
 					Labels:          svc.Attributes.Labels,
+					Aliases:         svc.Attributes.Aliases,
+					K8sAttributes:   svc.Attributes.K8sAttributes,
 				},
 			}
 			if features.EnableDualStack {
@@ -614,10 +620,18 @@ func generateVirtualHostDomains(service *model.Service, listenerPort int, port i
 		// Indicate we do not need port, as we will set IgnorePortInHostMatching
 		port = portNoAppendPortSuffix
 	}
-	altHosts := GenerateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)
-	domains := make([]string, 0, 4+len(altHosts))
-	domains = appendDomainPort(domains, string(service.Hostname), port)
-	domains = append(domains, altHosts...)
+	domains := []string{}
+	allAltHosts := []string{}
+	all := []string{string(service.Hostname)}
+	for _, a := range service.Attributes.Aliases {
+		all = append(all, a.Hostname.String())
+	}
+	for _, s := range all {
+		altHosts := GenerateAltVirtualHosts(s, port, node.DNSDomain)
+		domains = appendDomainPort(domains, s, port)
+		domains = append(domains, altHosts...)
+		allAltHosts = append(allAltHosts, altHosts...)
+	}
 
 	if service.Resolution == model.Passthrough &&
 		service.Attributes.ServiceRegistry == provider.Kubernetes {
@@ -638,7 +652,7 @@ func generateVirtualHostDomains(service *model.Service, listenerPort int, port i
 		domains = appendDomainPort(domains, addr, port)
 	}
 
-	return domains, altHosts
+	return domains, allAltHosts
 }
 
 // appendDomainPort appends `domain` and `domain:port` to `domains`. The `domain:port` variant is skipped

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -276,6 +276,24 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			enableDualStack: true,
 		},
+		{
+			name: "alias",
+			service: &model.Service{
+				Hostname:     "foo.local.campus.net",
+				MeshExternal: false,
+				Attributes:   model.ServiceAttributes{Aliases: []model.NamespacedHostname{{Hostname: "alias.local.campus.net", Namespace: "ns"}}},
+			},
+			port: 80,
+			node: &model.Proxy{
+				DNSDomain: "local.campus.net",
+			},
+			want: []string{
+				"foo.local.campus.net",
+				"foo",
+				"alias.local.campus.net",
+				"alias",
+			},
+		},
 	}
 
 	testFn := func(t test.Failer, service *model.Service, port int, node *model.Proxy, want []string) {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -770,6 +770,10 @@ func buildSidecarOutboundTCPListenerOpts(opts outboundListenerOpts, virtualServi
 func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundListenerOpts,
 	listenerMap map[listenerKey]*outboundListenerEntry, virtualServices []config.Config, actualWildcards []string,
 ) {
+	// Alias services do not get listeners generated
+	if listenerOpts.service.Resolution == model.Alias {
+		return
+	}
 	// TODO: remove actualWildcard
 	var currentListenerEntry *outboundListenerEntry
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -293,6 +293,12 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 		// only happens when the gateway-api BackendRef is invalid
 		return "UnknownService"
 	}
+	h := host.Name(destination.Host)
+	// If this is an Alias, point to the concrete service
+	// TODO: this will not work if we have Alias -> Alias -> Concrete service.
+	if service != nil && service.Attributes.K8sAttributes.ExternalName != "" {
+		h = host.Name(service.Attributes.K8sAttributes.ExternalName)
+	}
 	port := listenerPort
 	if destination.GetPort() != nil {
 		port = int(destination.GetPort().GetNumber())
@@ -306,7 +312,7 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 		// If blackhole cluster is needed, do the check on the caller side. See gateway and tls.go for examples.
 	}
 
-	return model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, host.Name(destination.Host), port)
+	return model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, h, port)
 }
 
 type RouteOptions struct {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache_test.go
@@ -208,3 +208,46 @@ func TestDependentConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractNamespaceForKubernetesService(t *testing.T) {
+	tests := []struct {
+		hostname string
+		want     string
+	}{
+		{
+			"foo.ns.svc.cluster.local",
+			"ns",
+		},
+		{
+			"foo.svc.cluster.local",
+			"",
+		},
+		{
+			"svc.ns.svc.svc.svc",
+			"ns",
+		},
+		{
+			".svc.",
+			"",
+		},
+		{
+			"..svc.",
+			"",
+		},
+		{
+			"x.svc.",
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			got, err := extractNamespaceForKubernetesService(tt.hostname)
+			if (err != nil) != (tt.want == "") {
+				t.Fatalf("unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1132,6 +1132,7 @@ ports:
 }
 
 func TestExternalNameServices(t *testing.T) {
+	test.SetForTest(t, &features.EnableExternalNameAlias, true)
 	ports := `
   - name: http
     port: 80

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -205,6 +205,11 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 
 		if len(destinationCIDR) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
 			sniHosts = []string{string(service.Hostname)}
+			for _, a := range service.Attributes.Aliases {
+				alt := GenerateAltVirtualHosts(a.Hostname.String(), 0, node.DNSDomain)
+				sniHosts = append(sniHosts, a.Hostname.String())
+				sniHosts = append(sniHosts, alt...)
+			}
 		}
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
 			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -427,7 +427,7 @@ func (c *Controller) addOrUpdateService(curr *v1.Service, currConv *model.Servic
 	}
 
 	// For ExternalName, we need to update the EndpointIndex, as we will store endpoints just based on the Service.
-	if curr != nil && curr.Spec.Type == v1.ServiceTypeExternalName {
+	if !features.EnableExternalNameAlias && curr != nil && curr.Spec.Type == v1.ServiceTypeExternalName {
 		updateEDSCache = true
 	}
 
@@ -469,7 +469,9 @@ func (c *Controller) buildEndpointsForService(svc *model.Service, updateCache bo
 		fep := c.collectWorkloadInstanceEndpoints(svc)
 		endpoints = append(endpoints, fep...)
 	}
-	endpoints = append(endpoints, kube.ExternalNameEndpoints(svc)...)
+	if !features.EnableExternalNameAlias {
+		endpoints = append(endpoints, kube.ExternalNameEndpoints(svc)...)
+	}
 	return endpoints
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1670,6 +1670,7 @@ func TestEndpoints_WorkloadInstances(t *testing.T) {
 
 func TestExternalNameServiceInstances(t *testing.T) {
 	t.Run("alias", func(t *testing.T) {
+		test.SetForTest(t, &features.EnableExternalNameAlias, true)
 		controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 		createExternalNameService(controller, "svc5", "nsA",
 			[]int32{1, 2, 3}, "foo.co", t, fx)

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -51,8 +51,12 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 	nodeLocal := false
 
 	if svc.Spec.Type == corev1.ServiceTypeExternalName && svc.Spec.ExternalName != "" {
-		resolution = model.DNSLB
 		externalName = svc.Spec.ExternalName
+		if features.EnableExternalNameAlias {
+			resolution = model.Alias
+		} else {
+			resolution = model.DNSLB
+		}
 	}
 	if svc.Spec.InternalTrafficPolicy != nil && *svc.Spec.InternalTrafficPolicy == corev1.ServiceInternalTrafficPolicyLocal {
 		nodeLocal = true

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -127,6 +127,11 @@ var testCases = []ConfigInput{
 		OnlyRunType: v3.ListenerType,
 	},
 
+	{
+		Name:     "externalname",
+		Services: 100,
+	},
+
 	// Test usage of various APIs
 	{
 		Name:     "telemetry-api",
@@ -450,7 +455,7 @@ func getConfigsWithCache(t testing.TB, input ConfigInput) ([]config.Config, stri
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
-	scrt, count := parseSecrets(inputYAML)
+	k8sTypes, count := parseKubernetesTypes(inputYAML)
 	if len(badKinds) != count {
 		t.Fatalf("Got unknown resources: %v", badKinds)
 	}
@@ -462,15 +467,19 @@ func getConfigsWithCache(t testing.TB, input ConfigInput) ([]config.Config, stri
 		configs[i] = c
 	}
 	configCache[input] = configs
-	k8sConfigCache[input] = scrt
-	return configs, scrt
+	k8sConfigCache[input] = k8sTypes
+	return configs, k8sTypes
 }
 
-func parseSecrets(inputs string) (string, int) {
+func parseKubernetesTypes(inputs string) (string, int) {
 	matches := 0
 	sb := strings.Builder{}
 	for _, text := range strings.Split(inputs, "\n---") {
 		if strings.Contains(text, "kind: Secret") {
+			sb.WriteString(text + "\n---\n")
+			matches++
+		}
+		if strings.Contains(text, "kind: Service\n") {
 			sb.WriteString(text + "\n---\n")
 			matches++
 		}

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -501,7 +501,7 @@ func kubernetesObjectsFromString(s string) ([]runtime.Object, error) {
 		}
 		o, _, err := decode([]byte(s), nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed deserializing kubernetes object: %v", err)
+			return nil, fmt.Errorf("failed deserializing kubernetes object: %v (%v)", err, s)
 		}
 		objects = append(objects, o)
 	}

--- a/pilot/pkg/xds/testdata/benchmarks/externalname.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/externalname.yaml
@@ -1,0 +1,31 @@
+# Set up a Service associated with our proxy, which will run as 1.1.1.1 IP
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: proxy-service-instance
+spec:
+  hosts:
+    - example.com
+  ports:
+    - number: 80
+      name: http
+      protocol: HTTP
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+    - address: 1.1.1.1
+      labels:
+        security.istio.io/tlsMode: istio
+{{- range $i := until .Services }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-{{$i}}
+spec:
+  type: ExternalName
+  externalName: random-{{$i}}.example.com
+  ports:
+    - port: 80
+      name: http
+{{- end }}

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -214,16 +214,14 @@ func (c *ingressImpl) callEcho(opts echo.CallOptions) (echo.CallResult, error) {
 
 	// Even if they set ServicePort, when load balancer is disabled, we may need to switch to NodePort, so replace it.
 	opts.Port.ServicePort = port
-	if len(opts.Address) == 0 {
-		// Default address based on port
-		opts.Address = addr
-	}
 	if opts.HTTP.Headers == nil {
 		opts.HTTP.Headers = map[string][]string{}
 	}
 	if host := opts.GetHost(); len(host) > 0 {
 		opts.HTTP.Headers.Set(headers.Host, host)
 	}
+	// Default address based on port
+	opts.Address = addr
 	if len(c.cluster.HTTPProxy()) > 0 && !c.cluster.ProxyKubectlOnly() {
 		opts.HTTP.HTTPProxy = c.cluster.HTTPProxy()
 	}

--- a/releasenotes/notes/external-name.yaml
+++ b/releasenotes/notes/external-name.yaml
@@ -1,0 +1,33 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issues:
+  - 37331
+releaseNotes:
+  - |
+    **Improved** support for `ExternalName` services. See Upgrade Notes for more information
+upgradeNotes:
+  - title: "`ExternalName` support changes"
+    content: |
+      Kubernetes `ExternalName` `Service`s allow users to create new DNS entries. For example, you can create an `example` service
+      that points to `example.com`. This is implemented by a DNS `CNAME` redirect.
+      
+      In Istio, the implementation of `ExternalName`, historically, was a substantially different. Each `ExternalName` represented its own
+      service, and traffic matching the service was sent to the configured DNS name.
+      
+      This caused a few issues:
+      * Ports are required in Istio, but not in Kubernetes. This can result in broken traffic if ports are not configured as Istio expects, despite them working without Istio.
+      * Ports not declared as `HTTP` would match *all* traffic on that port, making it easy to accidentally send all traffic on a port to the wrong place.
+      * Because the destination DNS name is treated as opaque, we cannot apply Istio policies to it as expected. For example, if I point
+        an external name at another in-cluster Service (for example, `example.default.svc.cluster.local`), mTLS would not be used.
+      
+      In this release, `ExternalName` support is revamped to fix these problems. `ExternalName`s are now simply treated as aliases.
+      Wherever we would match `Host: <concrete service>` we additionally will match `Host: <external name service>`.
+      Note that the primary implementation of `ExternalName` -- DNS -- is handled outside of Istio in the Kubernetes DNS implementation, and remains unchanged.
+      
+      If you are using `ExternalName` with Istio, please be advised of the following behavioral changes:
+      * The `ports` field is no longer needed, matching Kubernetes behavior. If it is set, it will have no impact.
+      * `VirtualServices` that match on an `ExternalName` service will generally no longer match. Instead, the match should be rewritten to the referenced service.
+      * `DestinationRule` can no longer apply to `ExternalName` services. Instead, create rules where the `host` references service.
+      
+      These changes are on-by-default. To opt-out, the `ENABLE_EXTERNAL_NAME_ALIAS` environment variable can be set to retain the old behavior.

--- a/releasenotes/notes/external-name.yaml
+++ b/releasenotes/notes/external-name.yaml
@@ -16,7 +16,7 @@ upgradeNotes:
       Kubernetes `ExternalName` `Service`s allow users to create new DNS entries. For example, you can create an `example` service
       that points to `example.com`. This is implemented by a DNS `CNAME` redirect.
       
-      In Istio, the implementation of `ExternalName`, historically, was a substantially different. Each `ExternalName` represented its own
+      In Istio, the implementation of `ExternalName`, historically, was substantially different. Each `ExternalName` represented its own
       service, and traffic matching the service was sent to the configured DNS name.
       
       This caused a few issues:

--- a/releasenotes/notes/external-name.yaml
+++ b/releasenotes/notes/external-name.yaml
@@ -7,8 +7,12 @@ releaseNotes:
   - |
     **Improved** support for `ExternalName` services. See Upgrade Notes for more information
 upgradeNotes:
-  - title: "`ExternalName` support changes"
+  - title: "Upcoming `ExternalName` support changes"
     content: |
+      Below describes *upcoming* changes to `ExternalName`.
+      In this release, there is no behavioral changes by default.
+      However, you can explicitly opt-in to the new behavior early if desired, and prepare your environments for the upcoming change.
+      
       Kubernetes `ExternalName` `Service`s allow users to create new DNS entries. For example, you can create an `example` service
       that points to `example.com`. This is implemented by a DNS `CNAME` redirect.
       
@@ -21,7 +25,7 @@ upgradeNotes:
       * Because the destination DNS name is treated as opaque, we cannot apply Istio policies to it as expected. For example, if I point
         an external name at another in-cluster Service (for example, `example.default.svc.cluster.local`), mTLS would not be used.
       
-      In this release, `ExternalName` support is revamped to fix these problems. `ExternalName`s are now simply treated as aliases.
+      `ExternalName` support has been revamped to fix these problems. `ExternalName`s are now simply treated as aliases.
       Wherever we would match `Host: <concrete service>` we additionally will match `Host: <external name service>`.
       Note that the primary implementation of `ExternalName` -- DNS -- is handled outside of Istio in the Kubernetes DNS implementation, and remains unchanged.
       
@@ -30,4 +34,5 @@ upgradeNotes:
       * `VirtualServices` that match on an `ExternalName` service will generally no longer match. Instead, the match should be rewritten to the referenced service.
       * `DestinationRule` can no longer apply to `ExternalName` services. Instead, create rules where the `host` references service.
       
-      These changes are on-by-default. To opt-out, the `ENABLE_EXTERNAL_NAME_ALIAS` environment variable can be set to retain the old behavior.
+      These changes are off-by-default in this release, but will be on-by-default in the near future.
+      To opt-in early, the `ENABLE_EXTERNAL_NAME_ALIAS=true` environment variable can be set.

--- a/tests/integration/base.yaml
+++ b/tests/integration/base.yaml
@@ -20,6 +20,7 @@ spec:
       keepaliveMaxServerConnectionAge: 120s
       autoscaleEnabled: false
       env:
+        ENABLE_EXTERNAL_NAME_ALIAS: true
         UNSAFE_ENABLE_ADMIN_ENDPOINTS: true
         PILOT_REMOTE_CLUSTER_TIMEOUT: 15s
         PILOT_ENABLE_ALPHA_GATEWAY_API: "true"

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2273,7 +2273,8 @@ func externalNameCases(t TrafficContext) {
 	}
 
 	t.RunTraffic(TrafficTestCase{
-		name: "without port",
+		name:         "without port",
+		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: v1
 kind: Service
 metadata:
@@ -2285,7 +2286,8 @@ spec:
 	})
 
 	t.RunTraffic(TrafficTestCase{
-		name: "with port",
+		name:         "with port",
+		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: v1
 kind: Service
 metadata:
@@ -2304,6 +2306,11 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name: "service entry",
+		skip: skip{
+			skip:   true,
+			reason: "not currently working, as SE doesn't have a VIP",
+		},
+		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: v1
 kind: Service
 metadata:
@@ -2318,7 +2325,8 @@ spec:
 	gatewayListenPort := 80
 	gatewayListenPortName := "http"
 	t.RunTraffic(TrafficTestCase{
-		name: "gateway",
+		name:         "gateway",
+		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: v1
 kind: Service
 metadata:

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2325,7 +2325,7 @@ spec:
 	gatewayListenPort := 80
 	gatewayListenPortName := "http"
 	t.RunTraffic(TrafficTestCase{
-		name:         "gateway",
+		name: "gateway",
 		skip: skip{
 			skip:   t.Clusters().IsMulticluster(),
 			reason: "we need to apply service to all but Istio config to only Istio clusters, which we don't support",

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2250,6 +2250,95 @@ spec:
 	}
 }
 
+func externalNameCases(t TrafficContext) {
+	calls := func(name string, checks ...echo.Checker) []TrafficCall {
+		checks = append(checks, check.OK())
+		ch := []TrafficCall{}
+		for _, c := range t.Apps.A {
+			for _, port := range []echo.Port{ports.HTTP, ports.AutoHTTP, ports.TCP, ports.HTTPS} {
+				c, port := c, port
+				ch = append(ch, TrafficCall{
+					name: port.Name,
+					call: c.CallOrFail,
+					opts: echo.CallOptions{
+						Address: name,
+						Port:    port,
+						Timeout: time.Millisecond * 250,
+						Check:   check.And(checks...),
+					},
+				})
+			}
+		}
+		return ch
+	}
+
+	t.RunTraffic(TrafficTestCase{
+		name: "without port",
+		config: fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-ext-no-port
+spec:
+  type: ExternalName
+  externalName: b.%s.svc.cluster.local`, t.Apps.Namespace.Name()),
+		children: calls("b-ext-no-port", check.MTLSForHTTP()),
+	})
+
+	t.RunTraffic(TrafficTestCase{
+		name: "with port",
+		config: fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-ext-port
+spec:
+  ports:
+  - name: http
+    port: %d
+    protocol: TCP
+    targetPort: %d
+  type: ExternalName
+  externalName: b.%s.svc.cluster.local`,
+			ports.HTTP.ServicePort, ports.HTTP.WorkloadPort, t.Apps.Namespace.Name()),
+		children: calls("b-ext-port", check.MTLSForHTTP()),
+	})
+
+	t.RunTraffic(TrafficTestCase{
+		name: "service entry",
+		config: fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-ext-se
+spec:
+  type: ExternalName
+  externalName: %s`,
+			t.Apps.External.All.Config().HostHeader()),
+		children: calls("b-ext-se"),
+	})
+
+	gatewayListenPort := 80
+	gatewayListenPortName := "http"
+	t.RunTraffic(TrafficTestCase{
+		name: "gateway",
+		config: fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-ext-se
+spec:
+  type: ExternalName
+  externalName: b.%s.svc.cluster.local
+---`,
+			t.Apps.Namespace.Name()) +
+			httpGateway("*", gatewayListenPort, gatewayListenPortName, "HTTP", t.Istio.Settings().IngressGatewayIstioLabel) +
+			httpVirtualService("gateway", fmt.Sprintf("b-ext-se.%s.svc.cluster.local", t.Apps.Namespace.Name()), ports.HTTP.ServicePort),
+		call: t.Istio.Ingresses().Callers()[0].CallOrFail,
+		opts: echo.CallOptions{
+			Address: fmt.Sprintf("b-ext-se.%s.svc.cluster.local", t.Apps.Namespace.Name()),
+			Port:    ports.HTTP,
+			Check:   check.OK(),
+		},
+	})
+}
+
 // consistentHashCases tests destination rule's consistent hashing mechanism
 func consistentHashCases(t TrafficContext) {
 	if len(t.Clusters().ByNetwork()) != 1 {

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2326,6 +2326,10 @@ spec:
 	gatewayListenPortName := "http"
 	t.RunTraffic(TrafficTestCase{
 		name:         "gateway",
+		skip: skip{
+			skip:   t.Clusters().IsMulticluster(),
+			reason: "we need to apply service to all but Istio config to only Istio clusters, which we don't support",
+		},
 		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: v1
 kind: Service

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -278,6 +278,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	RunSkipAmbient("tls-origination", tlsOriginationCases, "not workload agnostic")
 	RunSkipAmbient("instanceip", instanceIPTests, "not supported")
 	RunCase("services", serviceCases)
+	RunCase("externalname", externalNameCases)
 	RunSkipAmbient("host", hostCases, "Relies on X-Forwarded-Client-Cert in checker")
 	RunSkipAmbient("envoyfilter", envoyFilterCases, "not supported")
 	RunSkipAmbient("consistent-hash", consistentHashCases, "likey the same issue as https://github.com/istio/istio/issues/43161")

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -230,7 +230,11 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 				}
 			}
 			cfg := yml.MustApplyNamespace(t, tmpl.MustEvaluate(c.config, tmplData), namespace)
-			t.ConfigIstio().YAML("", cfg).ApplyOrFail(t)
+			scope := t.ConfigIstio()
+			if c.globalConfig {
+				scope = t.ConfigKube()
+			}
+			scope.YAML("", cfg).ApplyOrFail(t)
 		}
 
 		if c.call != nil && len(c.children) > 0 {


### PR DESCRIPTION
Github won't let me use my old PR (https://github.com/istio/istio/pull/37365) so making a new one...
Fixes https://github.com/istio/istio/issues/37331

Example config:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: b-ext
  namespace: echo
spec:
  ports:
  - name: tcp
    port: 80
    targetPort: 18080
  type: ExternalName
  externalName: b.echo.svc.cluster.local
```

Kubernetes behavior: `b-ext` creates a CNAME record for `b`. Port is not relevant.

Istio (today): Create a DNS cluster for each port, which ends up resolving to Cluster IP. Match on Host header (http), SNI (tls), or just port (TCP) (meaning it captures all traffic on that port).

Issues:
* Port matters in Istio but not Kubernetes
* We get minimal functionality because we only have the cluster IP. No load balancing, auto mtls, etc
* TCP doesn't work well since there is no VIP - instead we capture ALL traffic on the configured port 

This PR changes the implementation to more closely align with Kubernetes.

ExternalName becomes a new "Alias" service type internally. An alias simply adds extra matching logic to _existing_ Services.  For example, above we would add a match for `b-ext` everywhere we match for `b`. This works for HTTP and TLS; for TCP it is already not needed as it works today (envoy will see traffic to `b` and `b-ext` as the same). If there was no Service/ServiceEntry defined at all for the target `externalName`, then we would end up just passing through.

Note that port from ExternalName is not used at all, just like in Kubernetes.

If we have a `destination` in VirtualService referring to an ExternalName service explicitly, this will now no longer work unless they have also defined the referenced `externalName` as a concrete service. For example:
```
apiVersion: v1
kind: Service
metadata:
  name: google
spec:
  type: ExternalName
  externalName: google.com
```
If I forward to this in a VS, it will work IFF I have a ServiceEntry defined for google.com. As such, it is generally not recommended to do this (you could just point to google.com directly), but can be useful when use third party Ingress configs, etc. Other Ingress implementations have extremely inconsistent support for ExternalName -- I couldn't find two implementations that behaved the same way -- so there isn't much of a standard to follow here.

One major difference in functionality with this change is that the ExternalName service is now just an alias, not its own "thing" (Envoy cluster). This means we cannot apply different rules for it. However, this can be done with standard DR subsets.

TODO:
* ~Add tests. Critical ones are Sidecar scoping~
* ~Add feature flag to retain old behavior~
* ~Add release note~
* How should VS behave? if I bind to the alias service, does it apply or not?