### PR TITLE
Warn muiltple istio namespace labels in analyze, include ambient

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -204,6 +204,9 @@ var testGrid = []testCase{
 			{msg.NamespaceNotInjected, "Namespace bar"},
 			{msg.PodMissingProxy, "Pod default/noninjectedpod"},
 			{msg.NamespaceMultipleInjectionLabels, "Namespace busted"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-1"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-2"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-3"},
 		},
 	},
 	{
@@ -217,6 +220,9 @@ var testGrid = []testCase{
 			{msg.NamespaceInjectionEnabledByDefault, "Namespace bar"},
 			{msg.PodMissingProxy, "Pod default/noninjectedpod"},
 			{msg.NamespaceMultipleInjectionLabels, "Namespace busted"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-1"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-2"},
+			{msg.NamespaceMultipleInjectionLabels, "Namespace multi-ns-3"},
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/injection/injection.go
+++ b/pkg/config/analysis/analyzers/injection/injection.go
@@ -76,8 +76,18 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		injectionLabel := r.Metadata.Labels[util.InjectionLabelName]
 		nsRevision, okNewInjectionLabel := r.Metadata.Labels[RevisionInjectionLabelName]
 
+		istioLabels := make([]string, 0)
+		for _, l := range []string{util.InjectionLabelName, RevisionInjectionLabelName, constants.DataplaneMode} {
+			if _, ok := r.Metadata.Labels[l]; ok {
+				istioLabels = append(istioLabels, fmt.Sprintf("%s=%s", l, r.Metadata.Labels[l]))
+			}
+		}
+		if len(istioLabels) > 1 {
+			m := msg.NewNamespaceMultipleInjectionLabels(r, istioLabels)
+			c.Report(gvk.Namespace, m)
+		}
+
 		if r.Metadata.Labels[constants.DataplaneMode] == constants.DataplaneModeAmbient {
-			// TODO (GregHanson): warn if namespace is labeled for injection and ambient?
 			return true
 		}
 
@@ -111,19 +121,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 			return true
 		}
 
-		if okNewInjectionLabel {
-			if injectionLabel != "" {
-
-				m := msg.NewNamespaceMultipleInjectionLabels(r, ns, ns)
-
-				if line, ok := util.ErrorLine(r, fmt.Sprintf(util.MetadataName)); ok {
-					m.Line = line
-				}
-
-				c.Report(gvk.Namespace, m)
-				return true
-			}
-		} else if injectionLabel != util.InjectionLabelEnableValue {
+		if injectionLabel != util.InjectionLabelEnableValue {
 			// If legacy label has any value other than the enablement value, they are deliberately not injecting it, so ignore
 			return true
 		}

--- a/pkg/config/analysis/analyzers/testdata/injection.yaml
+++ b/pkg/config/analysis/analyzers/testdata/injection.yaml
@@ -147,3 +147,27 @@ spec:
   containers:
   - image: gcr.io/google-samples/microservices-demo/adservice:v0.1.1
     name: server
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+    istio.io/rev: test
+  name: multi-ns-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+    istio.io/dataplane-mode: ambient
+  name: multi-ns-2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/rev: test
+    istio.io/dataplane-mode: ambient
+  name: multi-ns-3

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -86,8 +86,8 @@ var (
 	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Field %q regular expression invalid: %q (%s)")
 
 	// NamespaceMultipleInjectionLabels defines a diag.MessageType for message "NamespaceMultipleInjectionLabels".
-	// Description: A namespace has both new and legacy injection labels
-	NamespaceMultipleInjectionLabels = diag.NewMessageType(diag.Warning, "IST0123", "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'")
+	// Description: A namespace has more than one type of injection labels
+	NamespaceMultipleInjectionLabels = diag.NewMessageType(diag.Warning, "IST0123", "The namespace has more than one type of injection labels %v, which may lead to undefined behavior. Make sure only one injection label exists.")
 
 	// InvalidAnnotation defines a diag.MessageType for message "InvalidAnnotation".
 	// Description: An Istio annotation that is not valid
@@ -494,12 +494,11 @@ func NewInvalidRegexp(r *resource.Instance, where string, re string, problem str
 }
 
 // NewNamespaceMultipleInjectionLabels returns a new diag.Message based on NamespaceMultipleInjectionLabels.
-func NewNamespaceMultipleInjectionLabels(r *resource.Instance, namespace string, namespace2 string) diag.Message {
+func NewNamespaceMultipleInjectionLabels(r *resource.Instance, labels []string) diag.Message {
 	return diag.NewMessage(
 		NamespaceMultipleInjectionLabels,
 		r,
-		namespace,
-		namespace2,
+		labels,
 	)
 }
 

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -224,13 +224,11 @@ messages:
   - name: "NamespaceMultipleInjectionLabels"
     code: IST0123
     level: Warning
-    description: "A namespace has both new and legacy injection labels"
-    template: "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'"
+    description: "A namespace has more than one type of injection labels"
+    template: "The namespace has more than one type of injection labels %v, which may lead to undefined behavior. Make sure only one injection label exists."
     args:
-      - name: namespace
-        type: string
-      - name: namespace2
-        type: string
+      - name: labels
+        type: "[]string"
 
   - name: "InvalidAnnotation"
     code: IST0125


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently, using several labels in the namespace may cause unintended behavior for users. This PR reworks the old multi-injection message and adds an ambient label to the list.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
