### PR TITLE
Refactor cluster builder

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -23,52 +23,31 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes/duration"
 	"google.golang.org/protobuf/proto"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authn_model "istio.io/istio/pilot/pkg/security/model"
-	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	networkutil "istio.io/istio/pilot/pkg/util/network"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	istio_cluster "istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/sets"
 )
-
-var istioMtlsTransportSocketMatch = &structpb.Struct{
-	Fields: map[string]*structpb.Value{
-		model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.IstioMutualTLSModeLabel}},
-	},
-}
-
-var hboneTransportSocket = &cluster.Cluster_TransportSocketMatch{
-	Name: "hbone",
-	Match: &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			model.TunnelLabelShortName: {Kind: &structpb.Value_StringValue{StringValue: model.TunnelHTTP}},
-		},
-	},
-	TransportSocket: InternalUpstreamSocket,
-}
 
 // passthroughHttpProtocolOptions are http protocol options used for pass through clusters.
 // nolint
@@ -179,7 +158,8 @@ func (cb *ClusterBuilder) sidecarProxy() bool {
 	return cb.proxyType == model.SidecarProxy
 }
 
-func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *config.Config, subset *networking.Subset, service *model.Service,
+func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts,
+	destRule *config.Config, subset *networking.Subset, service *model.Service,
 	proxyView model.ProxyView,
 ) *cluster.Cluster {
 	opts.serviceMTLSMode = cb.req.Push.BestEffortInferServiceMTLSMode(subset.GetTrafficPolicy(), service, opts.port)
@@ -211,14 +191,9 @@ func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *co
 		}
 	}
 
-	subsetCluster := cb.buildDefaultCluster(subsetClusterName, clusterType, lbEndpoints, model.TrafficDirectionOutbound, opts.port, service, nil)
+	subsetCluster := cb.buildCluster(subsetClusterName, clusterType, lbEndpoints, model.TrafficDirectionOutbound, opts.port, service, nil)
 	if subsetCluster == nil {
 		return nil
-	}
-
-	if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
-		subsetCluster.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName,
-			string(service.Hostname), subset.Name, opts.port, 0, &service.Attributes)
 	}
 
 	// Apply traffic policy for subset cluster with the destination rule traffic policy.
@@ -237,19 +212,17 @@ func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *co
 
 	maybeApplyEdsConfig(subsetCluster.cluster)
 
-	if cb.proxyType == model.Router || opts.direction == model.TrafficDirectionOutbound {
-		cb.applyMetadataExchange(opts.mutable.cluster)
-	}
+	cb.applyMetadataExchange(opts.mutable.cluster)
 
 	// Add the DestinationRule+subsets metadata. Metadata here is generated on a per-cluster
-	// basis in buildDefaultCluster, so we can just insert without a copy.
+	// basis in buildCluster, so we can just insert without a copy.
 	subsetCluster.cluster.Metadata = util.AddConfigInfoMetadata(subsetCluster.cluster.Metadata, destRule.Meta)
 	util.AddSubsetToMetadata(subsetCluster.cluster.Metadata, subset.Name)
 	return subsetCluster.build()
 }
 
-// applyDestinationRule applies the destination rule if it exists for the Service. It returns the subset clusters if any created as it
-// applies the destination rule.
+// applyDestinationRule applies the destination rule if it exists for the Service.
+// It returns the subset clusters if any created as it applies the destination rule.
 func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode ClusterMode, service *model.Service,
 	port *model.Port, proxyView model.ProxyView, destRule *config.Config, serviceAccounts []string,
 ) []*cluster.Cluster {
@@ -284,9 +257,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	// discovery type.
 	maybeApplyEdsConfig(mc.cluster)
 
-	if cb.proxyType == model.Router || opts.direction == model.TrafficDirectionOutbound {
-		cb.applyMetadataExchange(opts.mutable.cluster)
-	}
+	cb.applyMetadataExchange(opts.mutable.cluster)
 
 	if destRule != nil {
 		mc.cluster.Metadata = util.AddConfigInfoMetadata(mc.cluster.Metadata, destRule.Meta)
@@ -361,8 +332,9 @@ func MergeTrafficPolicy(original, subsetPolicy *networking.TrafficPolicy, port *
 	return mergedPolicy
 }
 
-// buildDefaultCluster builds the default cluster and also applies default traffic policy.
-func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster.Cluster_DiscoveryType,
+// buildCluster builds the default cluster and also applies global options.
+// It is used for building both inbound and outbound cluster.
+func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluster_DiscoveryType,
 	localityLbEndpoints []*endpoint.LocalityLbEndpoints, direction model.TrafficDirection,
 	port *model.Port, service *model.Service, inboundServices []ServiceTarget,
 ) *clusterWrapper {
@@ -371,7 +343,6 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
-	ec := newClusterWrapper(c)
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:
 		if networkutil.AllIPv4(cb.proxyIPAddresses) {
@@ -390,8 +361,7 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 				c.DnsLookupFamily = cluster.Cluster_V4_ONLY
 			}
 		}
-		dnsRate := cb.req.Push.Mesh.DnsRefreshRate
-		c.DnsRefreshRate = dnsRate
+		c.DnsRefreshRate = cb.req.Push.Mesh.DnsRefreshRate
 		c.RespectDnsTtl = true
 		fallthrough
 	case cluster.Cluster_STATIC:
@@ -406,30 +376,17 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 		}
 	}
 
-	// For inbound clusters, the default traffic policy is used. For outbound clusters, the default traffic policy
-	// will be applied, which would be overridden by traffic policy specified in destination rule, if any.
-	opts := buildClusterOpts{
-		mesh:             cb.req.Push.Mesh,
-		mutable:          ec,
-		policy:           nil,
-		port:             port,
-		serviceAccounts:  nil,
-		istioMtlsSni:     "",
-		clusterMode:      DefaultClusterMode,
-		direction:        direction,
-		serviceInstances: cb.serviceInstances,
-	}
-	// decides whether the cluster corresponds to a service external to mesh or not.
-	if direction == model.TrafficDirectionInbound {
-		// Inbound cluster always corresponds to service in the mesh.
-		opts.meshExternal = false
-	} else if service != nil {
-		// otherwise, read this information from service object.
-		opts.meshExternal = service.MeshExternal
+	ec := newClusterWrapper(c)
+	cb.setUpstreamProtocol(ec, port)
+	addTelemetryMetadata(c, port, service, direction, inboundServices)
+	if direction == model.TrafficDirectionOutbound {
+		// If stat name is configured, build the alternate stats name.
+		if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
+			ec.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName,
+				string(service.Hostname), "", port, 0, &service.Attributes)
+		}
 	}
 
-	cb.setUpstreamProtocol(ec, port)
-	addTelemetryMetadata(opts, service, direction, inboundServices)
 	return ec
 }
 
@@ -442,14 +399,14 @@ type ServiceTarget struct {
 	Port    ServiceInstancePort
 }
 
-// buildInboundClusterForPortOrUDS constructs a single inbound cluster. The cluster will be bound to
+// buildInboundCluster constructs a single inbound cluster. The cluster will be bound to
 // `inbound|clusterPort||`, and send traffic to <bind>:<instance.Endpoint.EndpointPort>. A workload
 // will have a single inbound cluster per port. In general this works properly, with the exception of
 // the Service-oriented DestinationRule, and upstream protocol selection. Our documentation currently
 // requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
 // Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however,
 // Sidecar.Ingress allows these to be different.
-func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind string,
+func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 	proxy *model.Proxy, instance ServiceTarget, inboundServices []ServiceTarget,
 ) *clusterWrapper {
 	clusterName := model.BuildInboundSubsetKey(clusterPort)
@@ -458,7 +415,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	if len(localityLbEndpoints) > 0 {
 		clusterType = cluster.Cluster_STATIC
 	}
-	localCluster := cb.buildDefaultCluster(clusterName, clusterType, localityLbEndpoints,
+	localCluster := cb.buildCluster(clusterName, clusterType, localityLbEndpoints,
 		model.TrafficDirectionInbound, instance.Port.ServicePort, instance.Service, inboundServices)
 	// If stat name is configured, build the alt statname.
 	if len(cb.req.Push.Mesh.InboundClusterStatName) != 0 {
@@ -484,7 +441,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(clusterPort int, bind 
 	// choice of inbound cluster is arbitrary. So the connection pool settings may not apply cleanly.
 	cfg := proxy.SidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, instance.Service.Hostname).GetRule()
 	if cfg != nil {
-		destinationRule := cfg.Spec.(*networking.DestinationRule)
+		destinationRule := CastDestinationRule(cfg)
 		opts.isDrWithSelector = destinationRule.GetWorkloadSelector() != nil
 		if destinationRule.TrafficPolicy != nil {
 			opts.policy = MergeTrafficPolicy(opts.policy, destinationRule.TrafficPolicy, instance.Port.ServicePort)
@@ -710,52 +667,8 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 	return cluster
 }
 
-// applyH2Upgrade function will upgrade cluster to http2 if specified by configuration.
-// applyH2Upgrade can only be called for outbound cluster
-func (cb *ClusterBuilder) applyH2Upgrade(mc *clusterWrapper, port *model.Port,
-	mesh *meshconfig.MeshConfig, connectionPool *networking.ConnectionPoolSettings,
-) {
-	if cb.shouldH2Upgrade(mc.cluster.Name, port, mesh, connectionPool) {
-		cb.setH2Options(mc)
-	}
-}
-
-// shouldH2Upgrade function returns true if the cluster should be upgraded to http2.
-// shouldH2Upgrade can only be called for outbound cluster
-func (cb *ClusterBuilder) shouldH2Upgrade(clusterName string, port *model.Port, mesh *meshconfig.MeshConfig,
-	connectionPool *networking.ConnectionPoolSettings,
-) bool {
-	// TODO (mjog)
-	// Upgrade if tls.GetMode() == networking.TLSSettings_ISTIO_MUTUAL
-	if connectionPool != nil && connectionPool.Http != nil {
-		override := connectionPool.Http.H2UpgradePolicy
-		// If user wants an upgrade at destination rule/port level that means he is sure that
-		// it is a Http port - upgrade in such case. This is useful incase protocol sniffing is
-		// enabled and user wants to upgrade/preserve http protocol from client.
-		if override == networking.ConnectionPoolSettings_HTTPSettings_UPGRADE {
-			log.Debugf("Upgrading cluster: %v (%v %v)", clusterName, mesh.H2UpgradePolicy, override)
-			return true
-		}
-		if override == networking.ConnectionPoolSettings_HTTPSettings_DO_NOT_UPGRADE {
-			log.Debugf("Not upgrading cluster: %v (%v %v)", clusterName, mesh.H2UpgradePolicy, override)
-			return false
-		}
-	}
-
-	// Do not upgrade non-http ports. This also ensures that we are only upgrading
-	// named ports so that protocol sniffing does not interfere. Protocol sniffing
-	// uses downstream protocol. Therefore if the client upgrades connection to http2,
-	// the server will send h2 stream to the application,even though the application only
-	// supports http 1.1.
-	if port != nil && !port.Protocol.IsHTTP() {
-		return false
-	}
-
-	return mesh.H2UpgradePolicy == meshconfig.MeshConfig_UPGRADE
-}
-
 // setH2Options make the cluster an h2 cluster by setting http2ProtocolOptions.
-func (cb *ClusterBuilder) setH2Options(mc *clusterWrapper) {
+func setH2Options(mc *clusterWrapper) {
 	if mc == nil {
 		return
 	}
@@ -774,481 +687,12 @@ func (cb *ClusterBuilder) setH2Options(mc *clusterWrapper) {
 	}
 }
 
-func (cb *ClusterBuilder) applyTrafficPolicy(opts buildClusterOpts) {
-	connectionPool, outlierDetection, loadBalancer, tls := selectTrafficPolicyComponents(opts.policy)
-	// Connection pool settings are applicable for both inbound and outbound clusters.
-	if connectionPool == nil {
-		connectionPool = &networking.ConnectionPoolSettings{}
-	}
-	cb.applyConnectionPool(opts.mesh, opts.mutable, connectionPool)
-	if opts.direction != model.TrafficDirectionInbound {
-		cb.applyH2Upgrade(opts.mutable, opts.port, opts.mesh, connectionPool)
-		applyOutlierDetection(opts.mutable.cluster, outlierDetection)
-		applyLoadBalancer(opts.mutable.cluster, loadBalancer, opts.port, cb.locality, cb.proxyLabels, opts.mesh)
-		if opts.clusterMode != SniDnatClusterMode {
-			autoMTLSEnabled := opts.mesh.GetEnableAutoMtls().Value
-			tls, mtlsCtxType := cb.buildAutoMtlsSettings(tls, opts.serviceAccounts, opts.istioMtlsSni,
-				autoMTLSEnabled, opts.meshExternal, opts.serviceMTLSMode)
-			cb.applyUpstreamTLSSettings(&opts, tls, mtlsCtxType)
-		}
-	}
-
-	if opts.mutable.cluster.GetType() == cluster.Cluster_ORIGINAL_DST {
-		opts.mutable.cluster.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
-	}
-}
-
-// buildAutoMtlsSettings fills key cert fields for all TLSSettings when the mode is `ISTIO_MUTUAL`.
-// If the (input) TLS setting is nil (i.e not set), *and* the service mTLS mode is STRICT, it also
-// creates and populates the config as if they are set as ISTIO_MUTUAL.
-func (cb *ClusterBuilder) buildAutoMtlsSettings(
-	tls *networking.ClientTLSSettings,
-	serviceAccounts []string,
-	sni string,
-	autoMTLSEnabled bool,
-	meshExternal bool,
-	serviceMTLSMode model.MutualTLSMode,
-) (*networking.ClientTLSSettings, mtlsContextType) {
-	if tls != nil {
-		if tls.Mode == networking.ClientTLSSettings_DISABLE || tls.Mode == networking.ClientTLSSettings_SIMPLE {
-			return tls, userSupplied
-		}
-		// For backward compatibility, use metadata certs if provided.
-		if cb.hasMetadataCerts() {
-			// When building Mutual TLS settings, we should always use user supplied SubjectAltNames and SNI
-			// in destination rule. The Service Accounts and auto computed SNI should only be used for
-			// ISTIO_MUTUAL.
-			return cb.buildMutualTLS(tls.SubjectAltNames, tls.Sni), userSupplied
-		}
-		if tls.Mode != networking.ClientTLSSettings_ISTIO_MUTUAL {
-			return tls, userSupplied
-		}
-		// Update TLS settings for ISTIO_MUTUAL. Use client provided SNI if set. Otherwise,
-		// overwrite with the auto generated SNI. User specified SNIs in the istio mtls settings
-		// are useful when routing via gateways. Use Service Accounts if Subject Alt names
-		// are not specified in TLS settings.
-		sniToUse := tls.Sni
-		if len(sniToUse) == 0 {
-			sniToUse = sni
-		}
-		subjectAltNamesToUse := tls.SubjectAltNames
-		if subjectAltNamesToUse == nil {
-			subjectAltNamesToUse = serviceAccounts
-		}
-		return cb.buildIstioMutualTLS(subjectAltNamesToUse, sniToUse), userSupplied
-	}
-
-	if meshExternal || !autoMTLSEnabled || serviceMTLSMode == model.MTLSUnknown || serviceMTLSMode == model.MTLSDisable {
-		return nil, userSupplied
-	}
-
-	// For backward compatibility, use metadata certs if provided.
-	if cb.hasMetadataCerts() {
-		return cb.buildMutualTLS(serviceAccounts, sni), autoDetected
-	}
-
-	// Build settings for auto MTLS.
-	return cb.buildIstioMutualTLS(serviceAccounts, sni), autoDetected
-}
-
-func (cb *ClusterBuilder) hasMetadataCerts() bool {
-	return cb.metadataCerts != nil
-}
-
 type mtlsContextType int
 
 const (
 	userSupplied mtlsContextType = iota
 	autoDetected
 )
-
-// buildMutualTLS returns a `TLSSettings` for MUTUAL mode with proxy metadata certificates.
-func (cb *ClusterBuilder) buildMutualTLS(serviceAccounts []string, sni string) *networking.ClientTLSSettings {
-	return &networking.ClientTLSSettings{
-		Mode:              networking.ClientTLSSettings_MUTUAL,
-		CaCertificates:    cb.metadataCerts.tlsClientRootCert,
-		ClientCertificate: cb.metadataCerts.tlsClientCertChain,
-		PrivateKey:        cb.metadataCerts.tlsClientKey,
-		SubjectAltNames:   serviceAccounts,
-		Sni:               sni,
-	}
-}
-
-// buildIstioMutualTLS returns a `TLSSettings` for ISTIO_MUTUAL mode.
-func (cb *ClusterBuilder) buildIstioMutualTLS(san []string, sni string) *networking.ClientTLSSettings {
-	return &networking.ClientTLSSettings{
-		Mode:            networking.ClientTLSSettings_ISTIO_MUTUAL,
-		SubjectAltNames: san,
-		Sni:             sni,
-	}
-}
-
-func (cb *ClusterBuilder) applyDefaultConnectionPool(cluster *cluster.Cluster) {
-	cluster.ConnectTimeout = proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration)
-}
-
-// FIXME: there isn't a way to distinguish between unset values and zero values
-func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
-	mc *clusterWrapper, settings *networking.ConnectionPoolSettings,
-) {
-	if settings == nil {
-		return
-	}
-
-	threshold := getDefaultCircuitBreakerThresholds()
-	var idleTimeout *durationpb.Duration
-	var maxRequestsPerConnection uint32
-	var maxConnectionDuration *duration.Duration
-
-	if settings.Http != nil {
-		if settings.Http.Http2MaxRequests > 0 {
-			// Envoy only applies MaxRequests in HTTP/2 clusters
-			threshold.MaxRequests = &wrappers.UInt32Value{Value: uint32(settings.Http.Http2MaxRequests)}
-		}
-		if settings.Http.Http1MaxPendingRequests > 0 {
-			// Envoy only applies MaxPendingRequests in HTTP/1.1 clusters
-			threshold.MaxPendingRequests = &wrappers.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
-		}
-
-		// FIXME: zero is a valid value if explicitly set, otherwise we want to use the default
-		if settings.Http.MaxRetries > 0 {
-			threshold.MaxRetries = &wrappers.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
-		}
-
-		idleTimeout = settings.Http.IdleTimeout
-		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
-	}
-
-	cb.applyDefaultConnectionPool(mc.cluster)
-	if settings.Tcp != nil {
-		if settings.Tcp.ConnectTimeout != nil {
-			mc.cluster.ConnectTimeout = settings.Tcp.ConnectTimeout
-		}
-
-		if settings.Tcp.MaxConnections > 0 {
-			threshold.MaxConnections = &wrappers.UInt32Value{Value: uint32(settings.Tcp.MaxConnections)}
-		}
-		if settings.Tcp.MaxConnectionDuration != nil {
-			maxConnectionDuration = settings.Tcp.MaxConnectionDuration
-		}
-	}
-	applyTCPKeepalive(mesh, mc.cluster, settings.Tcp)
-
-	mc.cluster.CircuitBreakers = &cluster.CircuitBreakers{
-		Thresholds: []*cluster.CircuitBreakers_Thresholds{threshold},
-	}
-
-	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 {
-		if mc.httpProtocolOptions == nil {
-			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
-		}
-		commonOptions := mc.httpProtocolOptions
-		if commonOptions.CommonHttpProtocolOptions == nil {
-			commonOptions.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
-		}
-		if idleTimeout != nil {
-			idleTimeoutDuration := idleTimeout
-			commonOptions.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
-		}
-		if maxRequestsPerConnection > 0 {
-			commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrappers.UInt32Value{Value: maxRequestsPerConnection}
-		}
-		if maxConnectionDuration != nil {
-			commonOptions.CommonHttpProtocolOptions.MaxConnectionDuration = maxConnectionDuration
-		}
-	}
-	if settings.Http != nil && settings.Http.UseClientProtocol {
-		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
-		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
-		// the upstream cluster will use HTTP2.
-		cb.setUseDownstreamProtocol(mc)
-	}
-}
-
-func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSSettings, mtlsCtxType mtlsContextType) {
-	c := opts.mutable
-
-	tlsContext, err := cb.buildUpstreamClusterTLSContext(opts, tls)
-	if err != nil {
-		log.Errorf("failed to build Upstream TLSContext: %s", err.Error())
-		return
-	}
-
-	if tlsContext != nil {
-		c.cluster.TransportSocket = &core.TransportSocket{
-			Name:       wellknown.TransportSocketTls,
-			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
-		}
-	}
-	istioAutodetectedMtls := tls != nil && tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL &&
-		mtlsCtxType == autoDetected
-	if cb.hbone {
-		cb.applyHBONETransportSocketMatches(c.cluster, tls, istioAutodetectedMtls)
-	} else if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {
-		// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
-		// Apply auto mtls to clusters excluding these kind of headless services.
-		if istioAutodetectedMtls {
-			// convert to transport socket matcher if the mode was auto detected
-			transportSocket := c.cluster.TransportSocket
-			c.cluster.TransportSocket = nil
-			c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-				{
-					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
-					Match:           istioMtlsTransportSocketMatch,
-					TransportSocket: transportSocket,
-				},
-				defaultTransportSocketMatch(),
-			}
-		}
-	}
-}
-
-func (cb *ClusterBuilder) applyHBONETransportSocketMatches(c *cluster.Cluster, tls *networking.ClientTLSSettings,
-	istioAutoDetectedMtls bool,
-) {
-	if tls == nil {
-		c.TransportSocketMatches = HboneOrPlaintextSocket
-		return
-	}
-	// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
-	// Apply auto mtls to clusters excluding these kind of headless services.
-	if c.GetType() != cluster.Cluster_ORIGINAL_DST {
-		// convert to transport socket matcher if the mode was auto detected
-		if istioAutoDetectedMtls {
-			transportSocket := c.TransportSocket
-			c.TransportSocket = nil
-			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-				hboneTransportSocket,
-				{
-					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
-					Match:           istioMtlsTransportSocketMatch,
-					TransportSocket: transportSocket,
-				},
-				defaultTransportSocketMatch(),
-			}
-		} else {
-			if c.TransportSocket == nil {
-				c.TransportSocketMatches = HboneOrPlaintextSocket
-			} else {
-				ts := c.TransportSocket
-				c.TransportSocket = nil
-
-				c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
-					hboneTransportSocket,
-					{
-						Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
-						TransportSocket: ts,
-					},
-				}
-			}
-		}
-	}
-}
-
-func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.ClientTLSSettings) (*auth.UpstreamTlsContext, error) {
-	if tls == nil {
-		return nil, nil
-	}
-	// Hack to avoid egress sds cluster config generation for sidecar when
-	// CredentialName is set in DestinationRule without a workloadSelector.
-	// We do not want to support CredentialName setting in non workloadSelector based DestinationRules, because
-	// that would result in the CredentialName being supplied to all the sidecars which the DestinationRule is scoped to,
-	// resulting in delayed startup of sidecars who do not have access to the credentials.
-	if tls.CredentialName != "" && cb.sidecarProxy() && !opts.isDrWithSelector {
-		if tls.Mode == networking.ClientTLSSettings_SIMPLE || tls.Mode == networking.ClientTLSSettings_MUTUAL {
-			return nil, nil
-		}
-	}
-
-	c := opts.mutable
-	var tlsContext *auth.UpstreamTlsContext
-
-	switch tls.Mode {
-	case networking.ClientTLSSettings_DISABLE:
-		tlsContext = nil
-	case networking.ClientTLSSettings_ISTIO_MUTUAL:
-		tlsContext = &auth.UpstreamTlsContext{
-			CommonTlsContext: defaultUpstreamCommonTLSContext(),
-			Sni:              tls.Sni,
-		}
-
-		tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName))
-
-		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
-			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName),
-			},
-		}
-		// Set default SNI of cluster name for istio_mutual if sni is not set.
-		if len(tlsContext.Sni) == 0 {
-			tlsContext.Sni = c.cluster.Name
-		}
-		// `istio-peer-exchange` alpn is only used when using mtls communication between peers.
-		// We add `istio-peer-exchange` to the list of alpn strings.
-		// The code has repeated snippets because We want to use predefined alpn strings for efficiency.
-		if cb.isHttp2Cluster(c) {
-			// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
-			if features.MetadataExchange {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2WithMxc
-			} else {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2
-			}
-		} else {
-			// This is in-mesh cluster, advertise it with ALPN.
-			if features.MetadataExchange {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
-			} else {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
-			}
-		}
-	case networking.ClientTLSSettings_SIMPLE:
-		tlsContext = &auth.UpstreamTlsContext{
-			CommonTlsContext: defaultUpstreamCommonTLSContext(),
-			Sni:              tls.Sni,
-		}
-
-		cb.setAutoSniAndAutoSanValidation(c, tls)
-
-		// Use subject alt names specified in service entry if TLS settings does not have subject alt names.
-		if opts.serviceRegistry == provider.External && len(tls.SubjectAltNames) == 0 {
-			tls = tls.DeepCopy()
-			tls.SubjectAltNames = opts.serviceAccounts
-		}
-		if tls.CredentialName != "" {
-			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
-			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
-		} else {
-			// If CredentialName is not set fallback to files specified in DR.
-			res := security.SdsCertificateConfig{
-				CaCertificatePath: tls.CaCertificates,
-			}
-			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
-			// don't set up SdsSecretConfig
-			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
-				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
-			} else {
-				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
-					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
-					},
-				}
-			}
-		}
-
-		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
-
-		if cb.isHttp2Cluster(c) {
-			// This is HTTP/2 cluster, advertise it with ALPN.
-			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
-		}
-
-	case networking.ClientTLSSettings_MUTUAL:
-		tlsContext = &auth.UpstreamTlsContext{
-			CommonTlsContext: defaultUpstreamCommonTLSContext(),
-			Sni:              tls.Sni,
-		}
-
-		cb.setAutoSniAndAutoSanValidation(c, tls)
-
-		// Use subject alt names specified in service entry if TLS settings does not have subject alt names.
-		if opts.serviceRegistry == provider.External && len(tls.SubjectAltNames) == 0 {
-			tls = tls.DeepCopy()
-			tls.SubjectAltNames = opts.serviceAccounts
-		}
-		if tls.CredentialName != "" {
-			// If credential name is specified at Destination Rule config and originating node is egress gateway, create
-			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
-		} else {
-			// If CredentialName is not set fallback to file based approach
-			if tls.ClientCertificate == "" || tls.PrivateKey == "" {
-				err := fmt.Errorf("failed to apply tls setting for %s: client certificate and private key must not be empty",
-					c.cluster.Name)
-				return nil, err
-			}
-			// These are certs being mounted from within the pod and specified in Destination Rules.
-			// Rather than reading directly in Envoy, which does not support rotation, we will
-			// serve them over SDS by reading the files.
-			res := security.SdsCertificateConfig{
-				CertificatePath:   tls.ClientCertificate,
-				PrivateKeyPath:    tls.PrivateKey,
-				CaCertificatePath: tls.CaCertificates,
-			}
-			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-				authn_model.ConstructSdsSecretConfig(res.GetResourceName()))
-
-			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
-			// don't set up SdsSecretConfig
-			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
-				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{}
-			} else {
-				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
-					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
-					},
-				}
-			}
-		}
-
-		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
-
-		if cb.isHttp2Cluster(c) {
-			// This is HTTP/2 cluster, advertise it with ALPN.
-			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
-		}
-	}
-	return tlsContext, nil
-}
-
-// applyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
-func applyTLSDefaults(tlsContext *auth.UpstreamTlsContext, tlsDefaults *meshconfig.MeshConfig_TLSConfig) {
-	if tlsDefaults == nil {
-		return
-	}
-	if len(tlsDefaults.EcdhCurves) > 0 {
-		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsDefaults.EcdhCurves
-	}
-	if len(tlsDefaults.CipherSuites) > 0 {
-		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsDefaults.CipherSuites
-	}
-}
-
-// Set auto_sni if EnableAutoSni feature flag is enabled and if sni field is not explicitly set in DR.
-// Set auto_san_validation if VerifyCertAtClient feature flag is enabled and if there is no explicit SubjectAltNames specified  in DR.
-func (cb *ClusterBuilder) setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTLSSettings) {
-	if mc == nil || !features.EnableAutoSni {
-		return
-	}
-
-	setAutoSni := false
-	setAutoSanValidation := false
-	if len(tls.Sni) == 0 {
-		setAutoSni = true
-	}
-	if features.VerifyCertAtClient && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
-		setAutoSanValidation = true
-	}
-
-	if setAutoSni || setAutoSanValidation {
-		if mc.httpProtocolOptions == nil {
-			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
-		}
-		if mc.httpProtocolOptions.UpstreamHttpProtocolOptions == nil {
-			mc.httpProtocolOptions.UpstreamHttpProtocolOptions = &core.UpstreamHttpProtocolOptions{}
-		}
-		if setAutoSni {
-			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni = true
-		}
-		if setAutoSanValidation {
-			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSanValidation = true
-		}
-	}
-}
 
 func (cb *ClusterBuilder) setUseDownstreamProtocol(mc *clusterWrapper) {
 	if mc.httpProtocolOptions == nil {
@@ -1275,9 +719,9 @@ func (cb *ClusterBuilder) isHttp2Cluster(mc *clusterWrapper) bool {
 }
 
 // This is called after traffic policy applied
-func (cb *ClusterBuilder) setUpstreamProtocol(mc *clusterWrapper, port *model.Port) {
+func (cb *ClusterBuilder) setUpstreamProtocol(cluster *clusterWrapper, port *model.Port) {
 	if port.Protocol.IsHTTP2() {
-		cb.setH2Options(mc)
+		setH2Options(cluster)
 		return
 	}
 
@@ -1293,7 +737,7 @@ func (cb *ClusterBuilder) setUpstreamProtocol(mc *clusterWrapper, port *model.Po
 		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
 		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
 		// the upstream cluster will use HTTP2.
-		cb.setUseDownstreamProtocol(mc)
+		cb.setUseDownstreamProtocol(cluster)
 	}
 }
 
@@ -1392,26 +836,6 @@ func maybeApplyEdsConfig(c *cluster.Cluster) {
 	}
 }
 
-func defaultUpstreamCommonTLSContext() *auth.CommonTlsContext {
-	return &auth.CommonTlsContext{
-		TlsParams: &auth.TlsParameters{
-			// if not specified, envoy use TLSv1_2 as default for client.
-			TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
-			TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
-		},
-	}
-}
-
-// defaultTransportSocketMatch applies to endpoints that have no security.istio.io/tlsMode label
-// or those whose label value does not match "istio"
-func defaultTransportSocketMatch() *cluster.Cluster_TransportSocketMatch {
-	return &cluster.Cluster_TransportSocketMatch{
-		Name:            "tlsMode-disabled",
-		Match:           &structpb.Struct{},
-		TransportSocket: xdsfilters.RawBufferTransportSocket,
-	}
-}
-
 // buildExternalSDSCluster generates a cluster that acts as external SDS server
 func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster {
 	ep := &endpoint.LbEndpoint{
@@ -1462,4 +886,59 @@ func configureALPNOverride(tlsMode networking.ClientTLSSettings_TLSmode, md *cor
 		return util.AddALPNOverrideToMetadata(md, alpnOverride)
 	}
 	return md
+}
+
+func addTelemetryMetadata(cluster *cluster.Cluster,
+	port *model.Port,
+	service *model.Service, direction model.TrafficDirection, inboundServices []ServiceTarget) {
+	if !features.EnableTelemetryLabel {
+		return
+	}
+	if cluster == nil {
+		return
+	}
+	if direction == model.TrafficDirectionInbound && (len(inboundServices) == 0 || port == nil) {
+		// At inbound, port and local service instance has to be provided
+		return
+	}
+	if direction == model.TrafficDirectionOutbound && service == nil {
+		// At outbound, the service corresponding to the cluster has to be provided.
+		return
+	}
+
+	im := getOrCreateIstioMetadata(cluster)
+
+	// Add services field into istio metadata
+	im.Fields["services"] = &structpb.Value{
+		Kind: &structpb.Value_ListValue{
+			ListValue: &structpb.ListValue{
+				Values: []*structpb.Value{},
+			},
+		},
+	}
+
+	svcMetaList := im.Fields["services"].GetListValue()
+
+	// Add service related metadata. This will be consumed by telemetry v2 filter for metric labels.
+	if direction == model.TrafficDirectionInbound {
+		// For inbound cluster, add all services on the cluster port
+		have := make(map[host.Name]bool)
+		for _, svc := range inboundServices {
+			if svc.Port.Port != port.Port {
+				// If the service port is different from the port of the cluster that is being built,
+				// skip adding telemetry metadata for the service to the cluster.
+				continue
+			}
+			if _, ok := have[svc.Service.Hostname]; ok {
+				// Skip adding metadata for instance with the same host name.
+				// This could happen when a service has multiple IPs.
+				continue
+			}
+			svcMetaList.Values = append(svcMetaList.Values, buildServiceMetadata(svc.Service))
+			have[svc.Service.Hostname] = true
+		}
+	} else if direction == model.TrafficDirectionOutbound {
+		// For outbound cluster, add telemetry metadata based on the service that the cluster is built for.
+		svcMetaList.Values = append(svcMetaList.Values, buildServiceMetadata(service))
+	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1152,7 +1152,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 				MeshExternal: false,
 				Attributes:   model.ServiceAttributes{Name: "svc", Namespace: "default"},
 			}
-			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery, tt.endpoints, tt.direction, servicePort, service, nil)
+			defaultCluster := cb.buildCluster(tt.clusterName, tt.discovery, tt.endpoints, tt.direction, servicePort, service, nil)
 			if defaultCluster != nil {
 				_ = cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, servicePort, cb.proxyView, nil, nil)
 			}
@@ -2059,7 +2059,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 				mesh: push.Mesh,
 			}
 			if test.h2 {
-				cb.setH2Options(opts.mutable)
+				setH2Options(opts.mutable)
 			}
 			cb.applyUpstreamTLSSettings(opts, test.tls, test.mtlsCtx)
 
@@ -3208,7 +3208,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 			}
 			cb := NewClusterBuilder(proxy, nil, model.DisabledCache{})
 			if tc.h2 {
-				cb.setH2Options(tc.opts.mutable)
+				setH2Options(tc.opts.mutable)
 			}
 			ret, err := cb.buildUpstreamClusterTLSContext(tc.opts, tc.tls)
 			if err != nil && tc.result.err == nil || err == nil && tc.result.err != nil {
@@ -3235,11 +3235,10 @@ func newTestCluster() *clusterWrapper {
 }
 
 func newH2TestCluster() *clusterWrapper {
-	cb := NewClusterBuilder(newSidecarProxy(), nil, model.DisabledCache{})
 	mc := newClusterWrapper(&cluster.Cluster{
 		Name: "test-cluster",
 	})
-	cb.setH2Options(mc)
+	setH2Options(mc)
 	return mc
 }
 
@@ -3358,11 +3357,9 @@ func TestShouldH2Upgrade(t *testing.T) {
 		},
 	}
 
-	cb := NewClusterBuilder(newSidecarProxy(), nil, model.DisabledCache{})
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			upgrade := cb.shouldH2Upgrade(test.clusterName, test.port, test.mesh, test.connectionPool)
+			upgrade := shouldH2Upgrade(test.clusterName, test.port, test.mesh, test.connectionPool)
 
 			if upgrade != test.upgrade {
 				t.Fatalf("got: %t, want: %t (%v, %v)", upgrade, test.upgrade, test.mesh.H2UpgradePolicy, test.connectionPool.Http.H2UpgradePolicy)
@@ -3574,7 +3571,7 @@ func TestBuildAutoMtlsSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cb := NewClusterBuilder(tt.proxy, nil, nil)
-			gotTLS, gotCtxType := cb.buildAutoMtlsSettings(tt.tls, tt.sans, tt.sni, tt.autoMTLSEnabled, tt.meshExternal, tt.serviceMTLSMode)
+			gotTLS, gotCtxType := cb.buildUpstreamTlsSettings(tt.tls, tt.sans, tt.sni, tt.autoMTLSEnabled, tt.meshExternal, tt.serviceMTLSMode)
 			if !reflect.DeepEqual(gotTLS, tt.want) {
 				t.Errorf("cluster TLS does not match expected result want %#v, got %#v", tt.want, gotTLS)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -165,10 +165,9 @@ func (c cacheStats) merge(other cacheStats) cacheStats {
 	}
 }
 
-func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilder, proxy *model.Proxy, efKeys []string) *clusterCache {
-	clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
-	clusterKey := &clusterCache{
-		clusterName:     clusterName,
+func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilder, proxy *model.Proxy, efKeys []string) clusterCache {
+	return clusterCache{
+		clusterName:     model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port),
 		proxyVersion:    cb.proxyVersion,
 		locality:        cb.locality,
 		proxyClusterID:  cb.clusterID,
@@ -185,5 +184,4 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		peerAuthVersion: cb.req.Push.AuthnPolicies.GetVersion(),
 		serviceAccounts: cb.req.Push.ServiceAccounts(service.Hostname, service.Attributes.Namespace, port.Port),
 	}
-	return clusterKey
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2574,7 +2574,7 @@ func TestTelemetryMetadata(t *testing.T) {
 				mutable: newClusterWrapper(tt.cluster),
 				port:    &model.Port{Port: 80},
 			}
-			addTelemetryMetadata(opt, tt.service, tt.direction, tt.svcInsts)
+			addTelemetryMetadata(tt.cluster, opt.port, tt.service, tt.direction, tt.svcInsts)
 			if opt.mutable.cluster != nil && !reflect.DeepEqual(opt.mutable.cluster.Metadata, tt.want) {
 				t.Errorf("cluster metadata does not match expectation want %+v, got %+v", tt.want, opt.mutable.cluster.Metadata)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_tls.go
@@ -1,0 +1,392 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"fmt"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	internalupstream "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
+	"github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	metadata "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"istio.io/api/mesh/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	sec_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pilot/pkg/util/protoconv"
+	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/security"
+)
+
+var istioMtlsTransportSocketMatch = &structpb.Struct{
+	Fields: map[string]*structpb.Value{
+		model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.IstioMutualTLSModeLabel}},
+	},
+}
+
+var internalUpstreamSocket = &core.TransportSocket{
+	Name: "envoy.transport_sockets.internal_upstream",
+	ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&internalupstream.InternalUpstreamTransport{
+		PassthroughMetadata: []*internalupstream.InternalUpstreamTransport_MetadataValueSource{
+			{
+				Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Host_{}},
+				Name: "tunnel",
+			},
+			{
+				Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Cluster_{
+					Cluster: &metadata.MetadataKind_Cluster{},
+				}},
+				Name: "istio",
+			},
+			{
+				Kind: &metadata.MetadataKind{Kind: &metadata.MetadataKind_Host_{
+					Host: &metadata.MetadataKind_Host{},
+				}},
+				Name: "istio",
+			},
+		},
+		TransportSocket: xdsfilters.RawBufferTransportSocket,
+	})},
+}
+
+var hboneTransportSocket = &cluster.Cluster_TransportSocketMatch{
+	Name: "hbone",
+	Match: &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			model.TunnelLabelShortName: {Kind: &structpb.Value_StringValue{StringValue: model.TunnelHTTP}},
+		},
+	},
+	TransportSocket: internalUpstreamSocket,
+}
+
+var hboneOrPlaintextSocket = []*cluster.Cluster_TransportSocketMatch{
+	hboneTransportSocket,
+	defaultTransportSocketMatch(),
+}
+
+// applyUpstreamTLSSettings applies upstream tls context to the cluster
+func (cb *ClusterBuilder) applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSSettings, mtlsCtxType mtlsContextType) {
+	c := opts.mutable
+	tlsContext, err := cb.buildUpstreamClusterTLSContext(opts, tls)
+	if err != nil {
+		log.Errorf("failed to build Upstream TLSContext: %s", err.Error())
+		return
+	}
+
+	if tlsContext != nil {
+		c.cluster.TransportSocket = &core.TransportSocket{
+			Name:       wellknown.TransportSocketTls,
+			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
+		}
+	}
+	istioAutodetectedMtls := tls != nil && tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL &&
+		mtlsCtxType == autoDetected
+	if cb.hbone {
+		cb.applyHBONETransportSocketMatches(c.cluster, tls, istioAutodetectedMtls)
+	} else if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {
+		// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
+		// Apply auto mtls to clusters excluding these kind of headless services.
+		if istioAutodetectedMtls {
+			// convert to transport socket matcher if the mode was auto detected
+			transportSocket := c.cluster.TransportSocket
+			c.cluster.TransportSocket = nil
+			c.cluster.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
+				{
+					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+					Match:           istioMtlsTransportSocketMatch,
+					TransportSocket: transportSocket,
+				},
+				defaultTransportSocketMatch(),
+			}
+		}
+	}
+}
+
+func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *v1alpha3.ClientTLSSettings) (*tlsv3.UpstreamTlsContext, error) {
+	if tls == nil {
+		return nil, nil
+	}
+	// Hack to avoid egress sds cluster config generation for sidecar when
+	// CredentialName is set in DestinationRule without a workloadSelector.
+	// We do not want to support CredentialName setting in non workloadSelector based DestinationRules, because
+	// that would result in the CredentialName being supplied to all the sidecars which the DestinationRule is scoped to,
+	// resulting in delayed startup of sidecars who do not have access to the credentials.
+	if tls.CredentialName != "" && cb.sidecarProxy() && !opts.isDrWithSelector {
+		if tls.Mode == v1alpha3.ClientTLSSettings_SIMPLE || tls.Mode == v1alpha3.ClientTLSSettings_MUTUAL {
+			return nil, nil
+		}
+	}
+
+	c := opts.mutable
+	var tlsContext *tlsv3.UpstreamTlsContext
+
+	switch tls.Mode {
+	case v1alpha3.ClientTLSSettings_DISABLE:
+		tlsContext = nil
+	case v1alpha3.ClientTLSSettings_ISTIO_MUTUAL:
+		tlsContext = &tlsv3.UpstreamTlsContext{
+			CommonTlsContext: defaultUpstreamCommonTLSContext(),
+			Sni:              tls.Sni,
+		}
+
+		tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
+			sec_model.ConstructSdsSecretConfig(sec_model.SDSDefaultResourceName))
+
+		tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &tlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext:         &tlsv3.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+				ValidationContextSdsSecretConfig: sec_model.ConstructSdsSecretConfig(sec_model.SDSRootResourceName),
+			},
+		}
+		// Set default SNI of cluster name for istio_mutual if sni is not set.
+		if len(tlsContext.Sni) == 0 {
+			tlsContext.Sni = c.cluster.Name
+		}
+		// `istio-peer-exchange` alpn is only used when using mtls communication between peers.
+		// We add `istio-peer-exchange` to the list of alpn strings.
+		// The code has repeated snippets because We want to use predefined alpn strings for efficiency.
+		if cb.isHttp2Cluster(c) {
+			// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
+			if features.MetadataExchange {
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2WithMxc
+			} else {
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2
+			}
+		} else {
+			// This is in-mesh cluster, advertise it with ALPN.
+			if features.MetadataExchange {
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
+			} else {
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
+			}
+		}
+	case v1alpha3.ClientTLSSettings_SIMPLE:
+		tlsContext = &tlsv3.UpstreamTlsContext{
+			CommonTlsContext: defaultUpstreamCommonTLSContext(),
+			Sni:              tls.Sni,
+		}
+
+		cb.setAutoSniAndAutoSanValidation(c, tls)
+
+		// Use subject alt names specified in service entry if TLS settings does not have subject alt names.
+		if opts.serviceRegistry == provider.External && len(tls.SubjectAltNames) == 0 {
+			tls = tls.DeepCopy()
+			tls.SubjectAltNames = opts.serviceAccounts
+		}
+		if tls.CredentialName != "" {
+			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
+			// SDS config for egress gateway to fetch key/cert at gateway agent.
+			sec_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
+		} else {
+			// If CredentialName is not set fallback to files specified in DR.
+			res := security.SdsCertificateConfig{
+				CaCertificatePath: tls.CaCertificates,
+			}
+			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
+			// don't set up SdsSecretConfig
+			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
+				tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_ValidationContext{}
+			} else {
+				tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &tlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+						DefaultValidationContext:         &tlsv3.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						ValidationContextSdsSecretConfig: sec_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
+					},
+				}
+			}
+		}
+
+		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
+
+		if cb.isHttp2Cluster(c) {
+			// This is HTTP/2 cluster, advertise it with ALPN.
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
+		}
+
+	case v1alpha3.ClientTLSSettings_MUTUAL:
+		tlsContext = &tlsv3.UpstreamTlsContext{
+			CommonTlsContext: defaultUpstreamCommonTLSContext(),
+			Sni:              tls.Sni,
+		}
+
+		cb.setAutoSniAndAutoSanValidation(c, tls)
+
+		// Use subject alt names specified in service entry if TLS settings does not have subject alt names.
+		if opts.serviceRegistry == provider.External && len(tls.SubjectAltNames) == 0 {
+			tls = tls.DeepCopy()
+			tls.SubjectAltNames = opts.serviceAccounts
+		}
+		if tls.CredentialName != "" {
+			// If credential name is specified at Destination Rule config and originating node is egress gateway, create
+			// SDS config for egress gateway to fetch key/cert at gateway agent.
+			sec_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, cb.credentialSocketExist)
+		} else {
+			// If CredentialName is not set fallback to file based approach
+			if tls.ClientCertificate == "" || tls.PrivateKey == "" {
+				err := fmt.Errorf("failed to apply tls setting for %s: client certificate and private key must not be empty",
+					c.cluster.Name)
+				return nil, err
+			}
+			// These are certs being mounted from within the pod and specified in Destination Rules.
+			// Rather than reading directly in Envoy, which does not support rotation, we will
+			// serve them over SDS by reading the files.
+			res := security.SdsCertificateConfig{
+				CertificatePath:   tls.ClientCertificate,
+				PrivateKeyPath:    tls.PrivateKey,
+				CaCertificatePath: tls.CaCertificates,
+			}
+			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
+				sec_model.ConstructSdsSecretConfig(res.GetResourceName()))
+
+			// If tls.CaCertificate or CaCertificate in Metadata isn't configured, or tls.InsecureSkipVerify is true,
+			// don't set up SdsSecretConfig
+			if !res.IsRootCertificate() || tls.GetInsecureSkipVerify().GetValue() {
+				tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_ValidationContext{}
+			} else {
+				tlsContext.CommonTlsContext.ValidationContextType = &tlsv3.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &tlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+						DefaultValidationContext:         &tlsv3.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+						ValidationContextSdsSecretConfig: sec_model.ConstructSdsSecretConfig(res.GetRootResourceName()),
+					},
+				}
+			}
+		}
+
+		applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
+
+		if cb.isHttp2Cluster(c) {
+			// This is HTTP/2 cluster, advertise it with ALPN.
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
+		}
+	}
+	return tlsContext, nil
+}
+
+// applyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
+func applyTLSDefaults(tlsContext *tlsv3.UpstreamTlsContext, tlsDefaults *v1alpha1.MeshConfig_TLSConfig) {
+	if tlsDefaults == nil {
+		return
+	}
+	if len(tlsDefaults.EcdhCurves) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsDefaults.EcdhCurves
+	}
+	if len(tlsDefaults.CipherSuites) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsDefaults.CipherSuites
+	}
+}
+
+// Set auto_sni if EnableAutoSni feature flag is enabled and if sni field is not explicitly set in DR.
+// Set auto_san_validation if VerifyCertAtClient feature flag is enabled and if there is no explicit SubjectAltNames specified  in DR.
+func (cb *ClusterBuilder) setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *v1alpha3.ClientTLSSettings) {
+	if mc == nil || !features.EnableAutoSni {
+		return
+	}
+
+	setAutoSni := false
+	setAutoSanValidation := false
+	if len(tls.Sni) == 0 {
+		setAutoSni = true
+	}
+	if features.VerifyCertAtClient && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
+		setAutoSanValidation = true
+	}
+
+	if setAutoSni || setAutoSanValidation {
+		if mc.httpProtocolOptions == nil {
+			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
+		}
+		if mc.httpProtocolOptions.UpstreamHttpProtocolOptions == nil {
+			mc.httpProtocolOptions.UpstreamHttpProtocolOptions = &core.UpstreamHttpProtocolOptions{}
+		}
+		if setAutoSni {
+			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni = true
+		}
+		if setAutoSanValidation {
+			mc.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSanValidation = true
+		}
+	}
+}
+
+func (cb *ClusterBuilder) applyHBONETransportSocketMatches(c *cluster.Cluster, tls *networking.ClientTLSSettings,
+	istioAutoDetectedMtls bool,
+) {
+	if tls == nil {
+		c.TransportSocketMatches = hboneOrPlaintextSocket
+		return
+	}
+	// For headless service, discovery type will be `Cluster_ORIGINAL_DST`
+	// Apply auto mtls to clusters excluding these kind of headless services.
+	if c.GetType() != cluster.Cluster_ORIGINAL_DST {
+		// convert to transport socket matcher if the mode was auto detected
+		if istioAutoDetectedMtls {
+			transportSocket := c.TransportSocket
+			c.TransportSocket = nil
+			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
+				hboneTransportSocket,
+				{
+					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+					Match:           istioMtlsTransportSocketMatch,
+					TransportSocket: transportSocket,
+				},
+				defaultTransportSocketMatch(),
+			}
+		} else {
+			if c.TransportSocket == nil {
+				c.TransportSocketMatches = hboneOrPlaintextSocket
+			} else {
+				ts := c.TransportSocket
+				c.TransportSocket = nil
+
+				c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
+					hboneTransportSocket,
+					{
+						Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+						TransportSocket: ts,
+					},
+				}
+			}
+		}
+	}
+}
+
+func defaultUpstreamCommonTLSContext() *tlsv3.CommonTlsContext {
+	return &tlsv3.CommonTlsContext{
+		TlsParams: &tlsv3.TlsParameters{
+			// if not specified, envoy use TLSv1_2 as default for client.
+			TlsMaximumProtocolVersion: tlsv3.TlsParameters_TLSv1_3,
+			TlsMinimumProtocolVersion: tlsv3.TlsParameters_TLSv1_2,
+		},
+	}
+}
+
+// defaultTransportSocketMatch applies to endpoints that have no security.istio.io/tlsMode label
+// or those whose label value does not match "istio"
+func defaultTransportSocketMatch() *cluster.Cluster_TransportSocketMatch {
+	return &cluster.Cluster_TransportSocketMatch{
+		Name:            "tlsMode-disabled",
+		Match:           &structpb.Struct{},
+		TransportSocket: xdsfilters.RawBufferTransportSocket,
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
@@ -1,0 +1,523 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"math"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/log"
+)
+
+// applyTrafficPolicy applies the trafficPolicy defined within destinationRule,
+// which can be called for both outbound and inbound cluster, but only connection pool will be applied to inbound cluster.
+func (cb *ClusterBuilder) applyTrafficPolicy(opts buildClusterOpts) {
+	connectionPool, outlierDetection, loadBalancer, tls := selectTrafficPolicyComponents(opts.policy)
+	// Connection pool settings are applicable for both inbound and outbound clusters.
+	cb.applyConnectionPool(opts.mesh, opts.mutable, connectionPool)
+	if opts.direction != model.TrafficDirectionInbound {
+		cb.applyH2Upgrade(opts.mutable, opts.port, opts.mesh, connectionPool)
+		applyOutlierDetection(opts.mutable.cluster, outlierDetection)
+		applyLoadBalancer(opts.mutable.cluster, loadBalancer, opts.port, cb.locality, cb.proxyLabels, opts.mesh)
+		if opts.clusterMode != SniDnatClusterMode {
+			autoMTLSEnabled := opts.mesh.GetEnableAutoMtls().Value
+			tls, mtlsCtxType := cb.buildUpstreamTlsSettings(tls, opts.serviceAccounts, opts.istioMtlsSni,
+				autoMTLSEnabled, opts.meshExternal, opts.serviceMTLSMode)
+			cb.applyUpstreamTLSSettings(&opts, tls, mtlsCtxType)
+		}
+	}
+
+	if opts.mutable.cluster.GetType() == cluster.Cluster_ORIGINAL_DST {
+		opts.mutable.cluster.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
+	}
+}
+
+// selectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
+func selectTrafficPolicyComponents(policy *v1alpha3.TrafficPolicy) (
+	*v1alpha3.ConnectionPoolSettings, *v1alpha3.OutlierDetection, *v1alpha3.LoadBalancerSettings, *v1alpha3.ClientTLSSettings,
+) {
+	if policy == nil {
+		return nil, nil, nil, nil
+	}
+	connectionPool := policy.ConnectionPool
+	outlierDetection := policy.OutlierDetection
+	loadBalancer := policy.LoadBalancer
+	tls := policy.Tls
+
+	// Check if CA Certificate should be System CA Certificate
+	if features.VerifyCertAtClient && tls != nil && tls.CaCertificates == "" {
+		tls.CaCertificates = "system"
+	}
+
+	return connectionPool, outlierDetection, loadBalancer, tls
+}
+
+// FIXME: there isn't a way to distinguish between unset values and zero values
+func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
+	mc *clusterWrapper, settings *v1alpha3.ConnectionPoolSettings) {
+	if settings == nil {
+		return
+	}
+
+	threshold := getDefaultCircuitBreakerThresholds()
+	var idleTimeout *durationpb.Duration
+	var maxRequestsPerConnection uint32
+	var maxConnectionDuration *duration.Duration
+
+	if settings.Http != nil {
+		if settings.Http.Http2MaxRequests > 0 {
+			// Envoy only applies MaxRequests in HTTP/2 clusters
+			threshold.MaxRequests = &wrapperspb.UInt32Value{Value: uint32(settings.Http.Http2MaxRequests)}
+		}
+		if settings.Http.Http1MaxPendingRequests > 0 {
+			// Envoy only applies MaxPendingRequests in HTTP/1.1 clusters
+			threshold.MaxPendingRequests = &wrapperspb.UInt32Value{Value: uint32(settings.Http.Http1MaxPendingRequests)}
+		}
+
+		// FIXME: zero is a valid value if explicitly set, otherwise we want to use the default
+		if settings.Http.MaxRetries > 0 {
+			threshold.MaxRetries = &wrapperspb.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
+		}
+
+		idleTimeout = settings.Http.IdleTimeout
+		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
+	}
+
+	cb.applyDefaultConnectionPool(mc.cluster)
+	if settings.Tcp != nil {
+		if settings.Tcp.ConnectTimeout != nil {
+			mc.cluster.ConnectTimeout = settings.Tcp.ConnectTimeout
+		}
+
+		if settings.Tcp.MaxConnections > 0 {
+			threshold.MaxConnections = &wrapperspb.UInt32Value{Value: uint32(settings.Tcp.MaxConnections)}
+		}
+		if settings.Tcp.MaxConnectionDuration != nil {
+			maxConnectionDuration = settings.Tcp.MaxConnectionDuration
+		}
+	}
+	applyTCPKeepalive(mesh, mc.cluster, settings.Tcp)
+
+	mc.cluster.CircuitBreakers = &cluster.CircuitBreakers{
+		Thresholds: []*cluster.CircuitBreakers_Thresholds{threshold},
+	}
+
+	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 {
+		if mc.httpProtocolOptions == nil {
+			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
+		}
+		commonOptions := mc.httpProtocolOptions
+		if commonOptions.CommonHttpProtocolOptions == nil {
+			commonOptions.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
+		}
+		if idleTimeout != nil {
+			idleTimeoutDuration := idleTimeout
+			commonOptions.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
+		}
+		if maxRequestsPerConnection > 0 {
+			commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrapperspb.UInt32Value{Value: maxRequestsPerConnection}
+		}
+		if maxConnectionDuration != nil {
+			commonOptions.CommonHttpProtocolOptions.MaxConnectionDuration = maxConnectionDuration
+		}
+	}
+	if settings.Http != nil && settings.Http.UseClientProtocol {
+		// Use downstream protocol. If the incoming traffic use HTTP 1.1, the
+		// upstream cluster will use HTTP 1.1, if incoming traffic use HTTP2,
+		// the upstream cluster will use HTTP2.
+		cb.setUseDownstreamProtocol(mc)
+	}
+}
+
+// applyH2Upgrade function will upgrade cluster to http2 if specified by configuration.
+// applyH2Upgrade can only be called for outbound cluster
+func (cb *ClusterBuilder) applyH2Upgrade(mc *clusterWrapper, port *model.Port,
+	mesh *meshconfig.MeshConfig, connectionPool *v1alpha3.ConnectionPoolSettings) {
+	if shouldH2Upgrade(mc.cluster.Name, port, mesh, connectionPool) {
+		setH2Options(mc)
+	}
+}
+
+// shouldH2Upgrade function returns true if the cluster should be upgraded to http2.
+// shouldH2Upgrade can only be called for outbound cluster
+func shouldH2Upgrade(clusterName string, port *model.Port, mesh *meshconfig.MeshConfig,
+	connectionPool *v1alpha3.ConnectionPoolSettings,
+) bool {
+	// TODO (mjog)
+	// Upgrade if tls.GetMode() == networking.TLSSettings_ISTIO_MUTUAL
+	if connectionPool != nil && connectionPool.Http != nil {
+		override := connectionPool.Http.H2UpgradePolicy
+		// If user wants an upgrade at destination rule/port level that means he is sure that
+		// it is a Http port - upgrade in such case. This is useful incase protocol sniffing is
+		// enabled and user wants to upgrade/preserve http protocol from client.
+		if override == v1alpha3.ConnectionPoolSettings_HTTPSettings_UPGRADE {
+			log.Debugf("Upgrading cluster: %v (%v %v)", clusterName, mesh.H2UpgradePolicy, override)
+			return true
+		}
+		if override == v1alpha3.ConnectionPoolSettings_HTTPSettings_DO_NOT_UPGRADE {
+			log.Debugf("Not upgrading cluster: %v (%v %v)", clusterName, mesh.H2UpgradePolicy, override)
+			return false
+		}
+	}
+
+	// Do not upgrade non-http ports. This also ensures that we are only upgrading
+	// named ports so that protocol sniffing does not interfere. Protocol sniffing
+	// uses downstream protocol. Therefore if the client upgrades connection to http2,
+	// the server will send h2 stream to the application,even though the application only
+	// supports http 1.1.
+	if port != nil && !port.Protocol.IsHTTP() {
+		return false
+	}
+
+	return mesh.H2UpgradePolicy == meshconfig.MeshConfig_UPGRADE
+}
+
+func (cb *ClusterBuilder) applyDefaultConnectionPool(cluster *cluster.Cluster) {
+	cluster.ConnectTimeout = proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration)
+}
+
+func applyLoadBalancer(c *cluster.Cluster, lb *v1alpha3.LoadBalancerSettings, port *model.Port,
+	locality *core.Locality, proxyLabels map[string]string, meshConfig *meshconfig.MeshConfig,
+) {
+	// Disable panic threshold when SendUnhealthyEndpoints is enabled as enabling it "may" send traffic to unready
+	// end points when load balancer is in panic mode.
+	if features.SendUnhealthyEndpoints.Load() {
+		c.CommonLbConfig.HealthyPanicThreshold = &xdstype.Percent{Value: 0}
+	}
+	localityLbSetting := loadbalancer.GetLocalityLbSetting(meshConfig.GetLocalityLbSetting(), lb.GetLocalityLbSetting())
+	if localityLbSetting != nil {
+		c.CommonLbConfig.LocalityConfigSpecifier = &cluster.Cluster_CommonLbConfig_LocalityWeightedLbConfig_{
+			LocalityWeightedLbConfig: &cluster.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
+		}
+	}
+	// Use locality lb settings from load balancer settings if present, else use mesh wide locality lb settings
+	applyLocalityLBSetting(locality, proxyLabels, c, localityLbSetting)
+
+	if c.GetType() == cluster.Cluster_ORIGINAL_DST {
+		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
+		return
+	}
+
+	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
+	if features.EnableRedisFilter && port != nil && port.Protocol == protocol.Redis {
+		c.LbPolicy = cluster.Cluster_MAGLEV
+		return
+	}
+
+	// DO not do if else here. since lb.GetSimple returns a enum value (not pointer).
+	switch lb.GetSimple() {
+	// nolint: staticcheck
+	case v1alpha3.LoadBalancerSettings_LEAST_CONN, v1alpha3.LoadBalancerSettings_LEAST_REQUEST:
+		applyLeastRequestLoadBalancer(c, lb)
+	case v1alpha3.LoadBalancerSettings_RANDOM:
+		c.LbPolicy = cluster.Cluster_RANDOM
+	case v1alpha3.LoadBalancerSettings_ROUND_ROBIN:
+		applyRoundRobinLoadBalancer(c, lb)
+	case v1alpha3.LoadBalancerSettings_PASSTHROUGH:
+		c.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
+		c.ClusterDiscoveryType = &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}
+		// Wipe out any LoadAssignment, if set. This can occur when we have a STATIC Service but PASSTHROUGH traffic policy
+		c.LoadAssignment = nil
+	default:
+		applySimpleDefaultLoadBalancer(c, lb)
+	}
+
+	ApplyRingHashLoadBalancer(c, lb)
+}
+
+func applyLocalityLBSetting(locality *core.Locality, proxyLabels map[string]string, cluster *cluster.Cluster,
+	localityLB *v1alpha3.LocalityLoadBalancerSetting,
+) {
+	// Failover should only be applied with outlier detection, or traffic will never failover.
+	enabledFailover := cluster.OutlierDetection != nil
+	if cluster.LoadAssignment != nil {
+		// TODO: enable failoverPriority for `STRICT_DNS` cluster type
+		loadbalancer.ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, proxyLabels, localityLB, enabledFailover)
+	}
+}
+
+// applySimpleDefaultLoadBalancer will set the DefaultLBPolicy and create an LbConfig if used in LoadBalancerSettings
+func applySimpleDefaultLoadBalancer(c *cluster.Cluster, loadbalancer *networking.LoadBalancerSettings) {
+	c.LbPolicy = defaultLBAlgorithm()
+	switch c.LbPolicy {
+	case cluster.Cluster_ROUND_ROBIN:
+		applyRoundRobinLoadBalancer(c, loadbalancer)
+	case cluster.Cluster_LEAST_REQUEST:
+		applyLeastRequestLoadBalancer(c, loadbalancer)
+	}
+}
+
+func defaultLBAlgorithm() cluster.Cluster_LbPolicy {
+	return cluster.Cluster_LEAST_REQUEST
+}
+
+// applyRoundRobinLoadBalancer will set the LbPolicy and create an LbConfig for ROUND_ROBIN if used in LoadBalancerSettings
+func applyRoundRobinLoadBalancer(c *cluster.Cluster, loadbalancer *networking.LoadBalancerSettings) {
+	c.LbPolicy = cluster.Cluster_ROUND_ROBIN
+
+	if loadbalancer.GetWarmupDurationSecs() != nil {
+		c.LbConfig = &cluster.Cluster_RoundRobinLbConfig_{
+			RoundRobinLbConfig: &cluster.Cluster_RoundRobinLbConfig{
+				SlowStartConfig: setSlowStartConfig(loadbalancer.GetWarmupDurationSecs()),
+			},
+		}
+	}
+}
+
+// applyLeastRequestLoadBalancer will set the LbPolicy and create an LbConfig for LEAST_REQUEST if used in LoadBalancerSettings
+func applyLeastRequestLoadBalancer(c *cluster.Cluster, loadbalancer *networking.LoadBalancerSettings) {
+	c.LbPolicy = cluster.Cluster_LEAST_REQUEST
+
+	if loadbalancer.GetWarmupDurationSecs() != nil {
+		c.LbConfig = &cluster.Cluster_LeastRequestLbConfig_{
+			LeastRequestLbConfig: &cluster.Cluster_LeastRequestLbConfig{
+				SlowStartConfig: setSlowStartConfig(loadbalancer.GetWarmupDurationSecs()),
+			},
+		}
+	}
+}
+
+// setSlowStartConfig will set the warmupDurationSecs for LEAST_REQUEST and ROUND_ROBIN if provided in DestinationRule
+func setSlowStartConfig(dur *durationpb.Duration) *cluster.Cluster_SlowStartConfig {
+	return &cluster.Cluster_SlowStartConfig{
+		SlowStartWindow: dur,
+	}
+}
+
+// getDefaultCircuitBreakerThresholds returns a copy of the default circuit breaker thresholds for the given traffic direction.
+func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
+	return &cluster.CircuitBreakers_Thresholds{
+		// DefaultMaxRetries specifies the default for the Envoy circuit breaker parameter max_retries. This
+		// defines the maximum number of parallel retries a given Envoy will allow to the upstream cluster. Envoy defaults
+		// this value to 3, however that has shown to be insufficient during periods of pod churn (e.g. rolling updates),
+		// where multiple endpoints in a cluster are terminated. In these scenarios the circuit breaker can kick
+		// in before Pilot is able to deliver an updated endpoint list to Envoy, leading to client-facing 503s.
+		MaxRetries:         &wrappers.UInt32Value{Value: math.MaxUint32},
+		MaxRequests:        &wrappers.UInt32Value{Value: math.MaxUint32},
+		MaxConnections:     &wrappers.UInt32Value{Value: math.MaxUint32},
+		MaxPendingRequests: &wrappers.UInt32Value{Value: math.MaxUint32},
+		TrackRemaining:     true,
+	}
+}
+
+// FIXME: there isn't a way to distinguish between unset values and zero values
+func applyOutlierDetection(c *cluster.Cluster, outlier *v1alpha3.OutlierDetection) {
+	if outlier == nil {
+		return
+	}
+
+	out := &cluster.OutlierDetection{}
+
+	// SuccessRate based outlier detection should be disabled.
+	out.EnforcingSuccessRate = &wrapperspb.UInt32Value{Value: 0}
+
+	if e := outlier.Consecutive_5XxErrors; e != nil {
+		v := e.GetValue()
+
+		out.Consecutive_5Xx = &wrapperspb.UInt32Value{Value: v}
+
+		if v > 0 {
+			v = 100
+		}
+		out.EnforcingConsecutive_5Xx = &wrapperspb.UInt32Value{Value: v}
+	}
+	if e := outlier.ConsecutiveGatewayErrors; e != nil {
+		v := e.GetValue()
+
+		out.ConsecutiveGatewayFailure = &wrapperspb.UInt32Value{Value: v}
+
+		if v > 0 {
+			v = 100
+		}
+		out.EnforcingConsecutiveGatewayFailure = &wrapperspb.UInt32Value{Value: v}
+	}
+
+	if outlier.Interval != nil {
+		out.Interval = outlier.Interval
+	}
+	if outlier.BaseEjectionTime != nil {
+		out.BaseEjectionTime = outlier.BaseEjectionTime
+	}
+	if outlier.MaxEjectionPercent > 0 {
+		out.MaxEjectionPercent = &wrapperspb.UInt32Value{Value: uint32(outlier.MaxEjectionPercent)}
+	}
+
+	if outlier.SplitExternalLocalOriginErrors {
+		out.SplitExternalLocalOriginErrors = true
+		if outlier.ConsecutiveLocalOriginFailures.GetValue() > 0 {
+			out.ConsecutiveLocalOriginFailure = &wrapperspb.UInt32Value{Value: outlier.ConsecutiveLocalOriginFailures.Value}
+			out.EnforcingConsecutiveLocalOriginFailure = &wrapperspb.UInt32Value{Value: 100}
+		}
+		// SuccessRate based outlier detection should be disabled.
+		out.EnforcingLocalOriginSuccessRate = &wrapperspb.UInt32Value{Value: 0}
+	}
+
+	c.OutlierDetection = out
+
+	// Disable panic threshold by default as its not typically applicable in k8s environments
+	// with few pods per service.
+	// To do so, set the healthy_panic_threshold field even if its value is 0 (defaults to 50 in Envoy).
+	// FIXME: we can't distinguish between it being unset or being explicitly set to 0
+	minHealthPercent := outlier.MinHealthPercent
+	if minHealthPercent >= 0 {
+		// When we are sending unhealthy endpoints, we should disable Panic Threshold. Otherwise
+		// Envoy will send traffic to "Unready" pods when the percentage of healthy hosts fall
+		// below minimum health percentage.
+		if features.SendUnhealthyEndpoints.Load() {
+			minHealthPercent = 0
+		}
+		c.CommonLbConfig.HealthyPanicThreshold = &xdstype.Percent{Value: float64(minHealthPercent)}
+	}
+}
+
+// ApplyRingHashLoadBalancer will set the LbPolicy and create an LbConfig for RING_HASH if  used in LoadBalancerSettings
+func ApplyRingHashLoadBalancer(c *cluster.Cluster, lb *v1alpha3.LoadBalancerSettings) {
+	consistentHash := lb.GetConsistentHash()
+	if consistentHash == nil {
+		return
+	}
+
+	switch {
+	case consistentHash.GetMaglev() != nil:
+		c.LbPolicy = cluster.Cluster_MAGLEV
+		if consistentHash.GetMaglev().TableSize != 0 {
+			c.LbConfig = &cluster.Cluster_MaglevLbConfig_{
+				MaglevLbConfig: &cluster.Cluster_MaglevLbConfig{
+					TableSize: &wrapperspb.UInt64Value{Value: consistentHash.GetMaglev().TableSize},
+				},
+			}
+		}
+	case consistentHash.GetRingHash() != nil:
+		c.LbPolicy = cluster.Cluster_RING_HASH
+		if consistentHash.GetRingHash().MinimumRingSize != 0 {
+			c.LbConfig = &cluster.Cluster_RingHashLbConfig_{
+				RingHashLbConfig: &cluster.Cluster_RingHashLbConfig{
+					MinimumRingSize: &wrapperspb.UInt64Value{Value: consistentHash.GetRingHash().MinimumRingSize},
+				},
+			}
+		}
+	default:
+		// Check the deprecated MinimumRingSize.
+		// TODO: MinimumRingSize is an int, and zero could potentially
+		// be a valid value unable to distinguish between set and unset
+		// case currently.
+		// 1024 is the default value for envoy.
+		minRingSize := &wrapperspb.UInt64Value{Value: 1024}
+
+		if consistentHash.MinimumRingSize != 0 { // nolint: staticcheck
+			minRingSize = &wrapperspb.UInt64Value{Value: consistentHash.GetMinimumRingSize()} // nolint: staticcheck
+		}
+		c.LbPolicy = cluster.Cluster_RING_HASH
+		c.LbConfig = &cluster.Cluster_RingHashLbConfig_{
+			RingHashLbConfig: &cluster.Cluster_RingHashLbConfig{
+				MinimumRingSize: minRingSize,
+			},
+		}
+	}
+}
+
+// buildUpstreamTlsSettings fills key cert fields for all TLSSettings when the mode is `ISTIO_MUTUAL`.
+// If the (input) TLS setting is nil (i.e not set), *and* the service mTLS mode is STRICT, it also
+// creates and populates the config as if they are set as ISTIO_MUTUAL.
+func (cb *ClusterBuilder) buildUpstreamTlsSettings(
+	tls *v1alpha3.ClientTLSSettings,
+	serviceAccounts []string,
+	sni string,
+	autoMTLSEnabled bool,
+	meshExternal bool,
+	serviceMTLSMode model.MutualTLSMode,
+) (*v1alpha3.ClientTLSSettings, mtlsContextType) {
+	if tls != nil {
+		if tls.Mode == v1alpha3.ClientTLSSettings_DISABLE || tls.Mode == v1alpha3.ClientTLSSettings_SIMPLE {
+			return tls, userSupplied
+		}
+		// For backward compatibility, use metadata certs if provided.
+		if cb.hasMetadataCerts() {
+			// When building Mutual TLS settings, we should always use user supplied SubjectAltNames and SNI
+			// in destination rule. The Service Accounts and auto computed SNI should only be used for
+			// ISTIO_MUTUAL.
+			return cb.buildMutualTLS(tls.SubjectAltNames, tls.Sni), userSupplied
+		}
+		if tls.Mode != v1alpha3.ClientTLSSettings_ISTIO_MUTUAL {
+			return tls, userSupplied
+		}
+		// Update TLS settings for ISTIO_MUTUAL. Use client provided SNI if set. Otherwise,
+		// overwrite with the auto generated SNI. User specified SNIs in the istio mtls settings
+		// are useful when routing via gateways. Use Service Accounts if Subject Alt names
+		// are not specified in TLS settings.
+		sniToUse := tls.Sni
+		if len(sniToUse) == 0 {
+			sniToUse = sni
+		}
+		subjectAltNamesToUse := tls.SubjectAltNames
+		if subjectAltNamesToUse == nil {
+			subjectAltNamesToUse = serviceAccounts
+		}
+		return cb.buildIstioMutualTLS(subjectAltNamesToUse, sniToUse), userSupplied
+	}
+
+	if meshExternal || !autoMTLSEnabled || serviceMTLSMode == model.MTLSUnknown || serviceMTLSMode == model.MTLSDisable {
+		return nil, userSupplied
+	}
+
+	// For backward compatibility, use metadata certs if provided.
+	if cb.hasMetadataCerts() {
+		return cb.buildMutualTLS(serviceAccounts, sni), autoDetected
+	}
+
+	// Build settings for auto MTLS.
+	return cb.buildIstioMutualTLS(serviceAccounts, sni), autoDetected
+}
+
+func (cb *ClusterBuilder) hasMetadataCerts() bool {
+	return cb.metadataCerts != nil
+}
+
+// buildMutualTLS returns a `TLSSettings` for MUTUAL mode with proxy metadata certificates.
+func (cb *ClusterBuilder) buildMutualTLS(serviceAccounts []string, sni string) *networking.ClientTLSSettings {
+	return &networking.ClientTLSSettings{
+		Mode:              networking.ClientTLSSettings_MUTUAL,
+		CaCertificates:    cb.metadataCerts.tlsClientRootCert,
+		ClientCertificate: cb.metadataCerts.tlsClientCertChain,
+		PrivateKey:        cb.metadataCerts.tlsClientKey,
+		SubjectAltNames:   serviceAccounts,
+		Sni:               sni,
+	}
+}
+
+// buildIstioMutualTLS returns a `TLSSettings` for ISTIO_MUTUAL mode.
+func (cb *ClusterBuilder) buildIstioMutualTLS(san []string, sni string) *networking.ClientTLSSettings {
+	return &networking.ClientTLSSettings{
+		Mode:            networking.ClientTLSSettings_ISTIO_MUTUAL,
+		SubjectAltNames: san,
+		Sni:             sni,
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -91,7 +91,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(svc *model.Service, por
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, subset, svc.Hostname, port.Port)
 
 	clusterType := cluster.Cluster_EDS
-	localCluster := cb.buildDefaultCluster(clusterName, clusterType, nil,
+	localCluster := cb.buildCluster(clusterName, clusterType, nil,
 		model.TrafficDirectionInbound, &port, nil, nil)
 
 	// Ensure VIP cluster has services metadata for stats filter usage


### PR DESCRIPTION
It is focused on cluster builder, it split out traffic policy and upstream tls settings apply. 

And also move out some helper functions from cluster.go.

The target is to make the cluster building more readable and now the calling stack like cluster.go->clusterbuilder.go
->cluster_traffic_policy.go->cluster_tls.go. 

In theory, we should not allow calling in the opposite direction, which can make circular dependency. And it can also prevent us from moving the cluster builder out to a separate pkg.
