### PR TITLE
Fix EDS test flakes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -144,10 +144,9 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	msd.AddGateways(opts.Gateways...)
 	msd.ClusterID = cluster2.ID(provider.Mock)
 	memserviceRegistry := serviceregistry.Simple{
-		ClusterID:        cluster2.ID(provider.Mock),
-		ProviderID:       provider.Mock,
-		ServiceDiscovery: msd,
-		Controller:       msd.Controller,
+		ClusterID:           cluster2.ID(provider.Mock),
+		ProviderID:          provider.Mock,
+		DiscoveryController: msd,
 	}
 	serviceDiscovery.AddRegistry(memserviceRegistry)
 	for _, reg := range opts.ServiceRegistries {

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -62,15 +62,13 @@ func buildMockController() *Controller {
 		discovery2.AddInstance(mock.MakeServiceInstance(mock.WorldService, port, 1, model.Locality{}))
 	}
 	registry1 := serviceregistry.Simple{
-		ProviderID:       provider.ID("mockAdapter1"),
-		ServiceDiscovery: discovery1,
-		Controller:       &mock.Controller{},
+		ProviderID:          provider.ID("mockAdapter1"),
+		DiscoveryController: discovery1,
 	}
 
 	registry2 := serviceregistry.Simple{
-		ProviderID:       provider.ID("mockAdapter2"),
-		ServiceDiscovery: discovery2,
-		Controller:       &mock.Controller{},
+		ProviderID:          provider.ID("mockAdapter2"),
+		DiscoveryController: discovery2,
 	}
 
 	ctls := NewController(Options{&mockMeshConfigHolder{}})
@@ -92,17 +90,15 @@ func buildMockControllerForMultiCluster() (*Controller, *memory.ServiceDiscovery
 	}), mock.WorldService)
 
 	registry1 := serviceregistry.Simple{
-		ProviderID:       provider.Kubernetes,
-		ClusterID:        "cluster-1",
-		ServiceDiscovery: discovery1,
-		Controller:       &mock.Controller{},
+		ProviderID:          provider.Kubernetes,
+		ClusterID:           "cluster-1",
+		DiscoveryController: discovery1,
 	}
 
 	registry2 := serviceregistry.Simple{
-		ProviderID:       provider.Kubernetes,
-		ClusterID:        "cluster-2",
-		ServiceDiscovery: discovery2,
-		Controller:       &mock.Controller{},
+		ProviderID:          provider.Kubernetes,
+		ClusterID:           "cluster-2",
+		DiscoveryController: discovery2,
 	}
 
 	ctls := NewController(Options{})
@@ -300,16 +296,14 @@ func TestInstances(t *testing.T) {
 func TestAddRegistry(t *testing.T) {
 	registries := []serviceregistry.Simple{
 		{
-			ProviderID:       "registry1",
-			ClusterID:        "cluster1",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			ProviderID:          "registry1",
+			ClusterID:           "cluster1",
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 		{
-			ProviderID:       "registry2",
-			ClusterID:        "cluster2",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			ProviderID:          "registry2",
+			ClusterID:           "cluster2",
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 	}
 	ctrl := NewController(Options{})
@@ -332,12 +326,12 @@ func TestAddRegistry(t *testing.T) {
 		t.Fatalf("Expected length of the registries slice should be 2, got %d", l)
 	}
 
-	registries[0].Controller.(*mock.Controller).OnServiceEvent(nil, mock.HelloService, model.EventAdd)
-	registries[1].Controller.(*mock.Controller).OnServiceEvent(nil, mock.WorldService, model.EventAdd)
+	registries[0].DiscoveryController.(*memory.ServiceDiscovery).AddService(mock.HelloService)
+	registries[1].DiscoveryController.(*memory.ServiceDiscovery).AddService(mock.HelloService)
 
 	ctrl.DeleteRegistry(registries[1].Cluster(), registries[1].Provider())
 	ctrl.UnRegisterHandlersForCluster(registries[1].Cluster())
-	registries[0].Controller.(*mock.Controller).OnServiceEvent(nil, mock.HelloService, model.EventAdd)
+	registries[0].DiscoveryController.(*memory.ServiceDiscovery).AddService(mock.HelloService)
 
 	if registry1Counter.Load() != 3 {
 		t.Errorf("cluster1 expected 3 event, but got %d", registry1Counter.Load())
@@ -350,22 +344,19 @@ func TestAddRegistry(t *testing.T) {
 func TestGetDeleteRegistry(t *testing.T) {
 	registries := []serviceregistry.Simple{
 		{
-			ProviderID:       "registry1",
-			ClusterID:        "cluster1",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			ProviderID:          "registry1",
+			ClusterID:           "cluster1",
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 		{
-			ProviderID:       "registry2",
-			ClusterID:        "cluster2",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			ProviderID:          "registry2",
+			ClusterID:           "cluster2",
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 		{
-			ProviderID:       "registry3",
-			ClusterID:        "cluster3",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			ProviderID:          "registry3",
+			ClusterID:           "cluster3",
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 	}
 	wrapRegistry := func(r serviceregistry.Instance) serviceregistry.Instance {
@@ -397,23 +388,20 @@ func TestGetDeleteRegistry(t *testing.T) {
 
 func TestSkipSearchingRegistryForProxy(t *testing.T) {
 	cluster1 := serviceregistry.Simple{
-		ClusterID:        "cluster-1",
-		ProviderID:       provider.Kubernetes,
-		Controller:       &mock.Controller{},
-		ServiceDiscovery: memory.NewServiceDiscovery(),
+		ClusterID:           "cluster-1",
+		ProviderID:          provider.Kubernetes,
+		DiscoveryController: memory.NewServiceDiscovery(),
 	}
 	cluster2 := serviceregistry.Simple{
-		ClusterID:        "cluster-2",
-		ProviderID:       provider.Kubernetes,
-		Controller:       &mock.Controller{},
-		ServiceDiscovery: memory.NewServiceDiscovery(),
+		ClusterID:           "cluster-2",
+		ProviderID:          provider.Kubernetes,
+		DiscoveryController: memory.NewServiceDiscovery(),
 	}
 	// external registries may eventually be associated with a cluster
 	external := serviceregistry.Simple{
-		ClusterID:        "cluster-1",
-		ProviderID:       provider.External,
-		Controller:       &mock.Controller{},
-		ServiceDiscovery: memory.NewServiceDiscovery(),
+		ClusterID:           "cluster-1",
+		ProviderID:          provider.External,
+		DiscoveryController: memory.NewServiceDiscovery(),
 	}
 
 	cases := []struct {
@@ -449,8 +437,7 @@ func runnableRegistry(name string) *RunnableRegistry {
 	return &RunnableRegistry{
 		Instance: serviceregistry.Simple{
 			ClusterID: cluster.ID(name), ProviderID: "test",
-			Controller:       &mock.Controller{},
-			ServiceDiscovery: memory.NewServiceDiscovery(),
+			DiscoveryController: memory.NewServiceDiscovery(),
 		},
 		running: atomic.NewBool(false),
 	}

--- a/pilot/pkg/serviceregistry/instance.go
+++ b/pilot/pkg/serviceregistry/instance.go
@@ -35,13 +35,17 @@ type Instance interface {
 
 var _ Instance = &Simple{}
 
+type DiscoveryController interface {
+	model.Controller
+	model.ServiceDiscovery
+}
+
 // Simple Instance implementation, where fields are set individually.
 type Simple struct {
 	ProviderID provider.ID
 	ClusterID  cluster.ID
 
-	model.Controller
-	model.ServiceDiscovery
+	DiscoveryController
 }
 
 func (r Simple) Provider() provider.ID {

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -114,7 +114,10 @@ func (sd *ServiceDiscovery) AddService(svc *model.Service) {
 		event = model.EventUpdate
 	}
 	sd.services[svc.Hostname] = svc
-	sd.XdsUpdater.SvcUpdate(sd.shardKey(), string(svc.Hostname), svc.Attributes.Namespace, model.EventAdd)
+
+	if sd.XdsUpdater != nil {
+		sd.XdsUpdater.SvcUpdate(sd.shardKey(), string(svc.Hostname), svc.Attributes.Namespace, model.EventAdd)
+	}
 	sd.handlers.NotifyServiceHandlers(old, svc, event)
 	sd.mutex.Unlock()
 }
@@ -124,7 +127,10 @@ func (sd *ServiceDiscovery) RemoveService(name host.Name) {
 	sd.mutex.Lock()
 	svc := sd.services[name]
 	delete(sd.services, name)
-	sd.XdsUpdater.SvcUpdate(sd.shardKey(), string(svc.Hostname), svc.Attributes.Namespace, model.EventDelete)
+
+	if sd.XdsUpdater != nil {
+		sd.XdsUpdater.SvcUpdate(sd.shardKey(), string(svc.Hostname), svc.Attributes.Namespace, model.EventDelete)
+	}
 	sd.handlers.NotifyServiceHandlers(nil, svc, model.EventDelete)
 	sd.mutex.Unlock()
 }
@@ -318,15 +324,15 @@ func (sd *ServiceDiscovery) MCSServices() []model.MCSServiceInfo {
 }
 
 // Memory does not support workload handlers; everything is done in terms of instances
-func (c *ServiceDiscovery) AppendWorkloadHandler(func(*model.WorkloadInstance, model.Event)) {}
+func (sd *ServiceDiscovery) AppendWorkloadHandler(func(*model.WorkloadInstance, model.Event)) {}
 
 // AppendServiceHandler appends a service handler to the controller
-func (c *ServiceDiscovery) AppendServiceHandler(f model.ServiceHandler) {
-	c.handlers.AppendServiceHandler(f)
+func (sd *ServiceDiscovery) AppendServiceHandler(f model.ServiceHandler) {
+	sd.handlers.AppendServiceHandler(f)
 }
 
 // Run will run the controller
-func (c *ServiceDiscovery) Run(<-chan struct{}) {}
+func (sd *ServiceDiscovery) Run(<-chan struct{}) {}
 
 // HasSynced always returns true
-func (c *ServiceDiscovery) HasSynced() bool { return true }
+func (sd *ServiceDiscovery) HasSynced() bool { return true }

--- a/pilot/pkg/serviceregistry/mock/discovery.go
+++ b/pilot/pkg/serviceregistry/mock/discovery.go
@@ -144,23 +144,3 @@ func MakeIP(service *model.Service, version int) string {
 	ip[3] = byte(version)
 	return netip.AddrFrom4(ip).String()
 }
-
-type Controller struct {
-	serviceHandler model.ControllerHandlers
-}
-
-func (c *Controller) AppendServiceHandler(f model.ServiceHandler) {
-	c.serviceHandler.AppendServiceHandler(f)
-}
-
-func (c *Controller) AppendWorkloadHandler(func(*model.WorkloadInstance, model.Event)) {}
-
-func (c *Controller) Run(<-chan struct{}) {}
-
-func (c *Controller) HasSynced() bool { return true }
-
-func (c *Controller) OnServiceEvent(prev, curr *model.Service, e model.Event) {
-	for _, h := range c.serviceHandler.GetServiceHandlers() {
-		h(prev, curr, e)
-	}
-}

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -109,9 +109,9 @@ func TestDeltaEDS(t *testing.T) {
 		t.Fatalf("received unexpected removed eds resource %v", resp.RemovedResources)
 	}
 
+	t.Logf("update svc")
 	// update svc, only send the eds for this service
 	s.MemRegistry.AddHTTPService(edsIncSvc, "10.10.1.3", 8080)
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: edsIncSvc, Namespace: ""})})
 
 	resp = ads.ExpectResponse()
 	if len(resp.Resources) != 1 || resp.Resources[0].Name != "outbound|8080||"+edsIncSvc {
@@ -123,7 +123,6 @@ func TestDeltaEDS(t *testing.T) {
 
 	// delete svc, only send eds for this service
 	s.MemRegistry.RemoveService(edsIncSvc)
-	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true, ConfigsUpdated: sets.New(model.ConfigKey{Kind: kind.ServiceEntry, Name: edsIncSvc, Namespace: ""})})
 
 	resp = ads.ExpectResponse()
 	if len(resp.RemovedResources) != 1 || resp.RemovedResources[0] != "outbound|8080||"+edsIncSvc {

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -262,10 +262,9 @@ func initRegistry(server *xds.FakeDiscoveryServer, networkNum int, gatewaysIP []
 	memRegistry.ClusterID = clusterID
 
 	reg := serviceregistry.Simple{
-		ClusterID:        clusterID,
-		ProviderID:       provider.Mock,
-		ServiceDiscovery: memRegistry,
-		Controller:       &memory.ServiceController{},
+		ClusterID:           clusterID,
+		ProviderID:          provider.Mock,
+		DiscoveryController: memRegistry,
 	}
 	server.Env().ServiceDiscovery.(*aggregate.Controller).AddRegistry(reg)
 

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -523,6 +523,7 @@ func TestEDSServiceResolutionUpdate(t *testing.T) {
 			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 			addEdsCluster(s, "edsdns.svc.cluster.local", "http", "10.0.0.53", 8080)
 			addEdsCluster(s, "other.local", "http", "1.1.1.1", 8080)
+			s.EnsureSynced(t) // Wait for debounce
 
 			adscConn := s.Connect(nil, nil, watchAll)
 
@@ -567,6 +568,7 @@ func TestEndpointFlipFlops(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 			addEdsCluster(s, "flipflop.com", "http", "10.0.0.53", 8080)
+			s.EnsureSynced(t) // Wait for debounce
 			adscConn := s.Connect(nil, nil, watchAll)
 
 			// Validate that endpoints are pushed correctly.

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -238,7 +238,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		Services:  opts.Services,
 		Gateways:  opts.Gateways,
 	})
-	cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler)
+	cg.Registry.AppendServiceHandler(serviceHandler)
 	s.Env = cg.Env()
 	s.Env.GatewayAPIController = gwc
 	if err := s.Env.InitNetworksManager(s); err != nil {

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -97,9 +97,8 @@ func NewXDS(stop chan struct{}) *SimpleServer {
 	sd := controllermemory.NewServiceDiscovery()
 	sd.XdsUpdater = ds
 	serviceControllers.AddRegistry(serviceregistry.Simple{
-		ProviderID:       "Mem",
-		ServiceDiscovery: sd,
-		Controller:       sd.Controller,
+		ProviderID:          "Mem",
+		DiscoveryController: sd,
 	})
 	env.ServiceDiscovery = serviceControllers
 

--- a/tests/fuzz/aggregate_controller_fuzzer.go
+++ b/tests/fuzz/aggregate_controller_fuzzer.go
@@ -87,7 +87,7 @@ func runAddRegistry(f *fuzz.ConsumeFuzzer, c *aggregate.Controller) error {
 	if err != nil {
 		return err
 	}
-	if registry.ServiceDiscovery == nil {
+	if registry.DiscoveryController == nil {
 		return fmt.Errorf("registry required")
 	}
 	c.AddRegistry(registry)


### PR DESCRIPTION
followup to https://github.com/istio/istio/pull/46333

This fixes EDS flakes, by making the mem registry more compliant with how controllers should behave. Mostly just around calling the right handlers at the right time.

This impacts tests only

All tests now pass >1000 iterations (except https://github.com/istio/istio/issues/46361, broken before my other PR)