### PR TITLE
cni: remove unneeded fmt.Sprintf in tests

### DIFF
--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -405,7 +405,7 @@ func TestCmdAddWithKubevirtInterfaces(t *testing.T) {
 	}
 
 	if value != testAnnotations[kubevirtInterfacesKey] {
-		t.Fatalf(fmt.Sprintf("expected kubevirtInterfaces annotation to equals %s", testAnnotations[kubevirtInterfacesKey]))
+		t.Fatalf("expected kubevirtInterfaces annotation to equals %s", testAnnotations[kubevirtInterfacesKey])
 	}
 }
 
@@ -423,7 +423,7 @@ func TestCmdAddWithExcludeInterfaces(t *testing.T) {
 	}
 
 	if value != testAnnotations[excludeInterfacesKey] {
-		t.Fatalf(fmt.Sprintf("expected excludeInterfaces annotation to equals %s", testAnnotations[excludeInterfacesKey]))
+		t.Fatalf("expected excludeInterfaces annotation to equals %s", testAnnotations[excludeInterfacesKey])
 	}
 }
 


### PR DESCRIPTION
This PR refactors `TestCmdAddWithKubevirtInterfaces` test.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
