### PR TITLE
tf: properly assign available port for port-forward

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -205,9 +204,6 @@ type CLIClient interface {
 	// UtilFactory returns a kubectl factory
 	UtilFactory() PartialFactory
 
-	// SetPortManager overrides the default port manager to provision local ports
-	SetPortManager(PortManager)
-
 	// InvalidateDiscovery invalidates the discovery client, useful after manually changing CRD's
 	InvalidateDiscovery()
 }
@@ -341,8 +337,6 @@ type client struct {
 
 	version lazy.Lazy[*kubeVersion.Info]
 
-	portManager PortManager
-
 	crdWatcher kubetypes.CrdWatcher
 
 	// http is a client for HTTP requests
@@ -409,7 +403,6 @@ func newClientInternal(clientFactory *clientFactory, revision string, cluster cl
 	if err != nil {
 		return nil, err
 	}
-	c.portManager = defaultAvailablePort
 
 	c.http = &http.Client{
 		Timeout: time.Second * 15,
@@ -1104,10 +1097,6 @@ func (c *client) DeleteYAMLFilesDryRun(namespace string, yamlFiles ...string) (e
 	return multierror.Append(nil, errs...).ErrorOrNil()
 }
 
-func (c *client) SetPortManager(manager PortManager) {
-	c.portManager = manager
-}
-
 func closeQuietly(c io.Closer) {
 	_ = c.Close()
 }
@@ -1223,20 +1212,6 @@ func setServerInfoWithIstiodVersionInfo(serverInfo *version.BuildInfo, istioInfo
 	} else {
 		serverInfo.Version = istioInfo
 	}
-}
-
-func defaultAvailablePort() (uint16, error) {
-	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("127.0.0.1", "0"))
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	port := l.Addr().(*net.TCPAddr).Port
-	return uint16(port), l.Close()
 }
 
 func SetRevisionForTest(c CLIClient, rev string) CLIClient {

--- a/pkg/test/framework/components/cluster/kube/factory.go
+++ b/pkg/test/framework/components/cluster/kube/factory.go
@@ -24,7 +24,6 @@ import (
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/reserveport"
 )
 
 const (
@@ -64,11 +63,6 @@ func buildKube(origCfg cluster.Config, topology cluster.Topology) (cluster.Clust
 			return nil, err
 		}
 	}
-	m, err := reserveport.NewPortManager()
-	if err != nil {
-		return nil, err
-	}
-	client.SetPortManager(m.ReservePortNumber)
 
 	// support fake VMs by default
 	vmSupport := true


### PR DESCRIPTION
Currently we use our own PortManager, which is known to be best-effort
and often runs into port conflicts. With this, we let the OS assign us a
port which cannot fail (unless we run out of ports, of course).

This should have no impact on users of port-forward; they always had to
call Address() after running.
