### PR TITLE
[Test Framework] Fix incorrect duration in log

### DIFF
--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -65,7 +65,9 @@ func callInternal(srcName string, from echo.Caller, opts echo.CallOptions, send 
 	if opts.Retry.NoRetry {
 		// Retry is disabled, just send once.
 		t0 := time.Now()
-		defer scopes.Framework.Debugf("echo call complete with duration %v", time.Since(t0))
+		defer func() {
+			scopes.Framework.Debugf("echo call complete with duration %v", time.Since(t0))
+		}()
 		return sendAndValidate()
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
The deferred call's arguments are evaluated immediately, but the function call is not executed until the surrounding function returns.

see example in https://go.dev/play/p/cyhhUBcZUJj