### PR TITLE
Fix some time measurement for istioctl bug-report command

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -371,12 +371,13 @@ func gatherInfo(runner *kubectlcmd.Runner, config *config.BugReportConfig, resou
 // getFromCluster runs a cluster info fetching function f against the cluster and writes the results to fileName.
 // Runs if a goroutine, with errors reported through gErrors.
 func getFromCluster(f func(params *content.Params) (map[string]string, error), params *content.Params, dir string, wg *sync.WaitGroup) {
+	startTime := time.Now()
 	wg.Add(1)
 	log.Infof("Waiting on %s", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
 	go func() {
 		defer func() {
 			wg.Done()
-			logRuntime(time.Now(), "Done getting from cluster for %v", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
+			logRuntime(startTime, "Done getting from cluster for %v", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
 		}()
 
 		out, err := f(params)
@@ -394,12 +395,13 @@ func getFromCluster(f func(params *content.Params) (map[string]string, error), p
 func getProxyLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, resources *cluster2.Resources,
 	path, namespace, pod, container string, wg *sync.WaitGroup,
 ) {
+	startTime := time.Now()
 	wg.Add(1)
 	log.Infof("Waiting on proxy logs %v/%v/%v", namespace, pod, container)
 	go func() {
 		defer func() {
 			wg.Done()
-			logRuntime(time.Now(), "Done getting from proxy logs for %v/%v/%v", namespace, pod, container)
+			logRuntime(startTime, "Done getting from proxy logs for %v/%v/%v", namespace, pod, container)
 		}()
 
 		clog, cstat, imp, err := getLog(runner, resources, config, namespace, pod, container)
@@ -418,12 +420,13 @@ func getProxyLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, res
 func getIstiodLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, resources *cluster2.Resources,
 	namespace, pod string, wg *sync.WaitGroup,
 ) {
+	startTime := time.Now()
 	wg.Add(1)
 	log.Infof("Waiting on Istiod logs for %v/%v", namespace, pod)
 	go func() {
 		defer func() {
 			wg.Done()
-			logRuntime(time.Now(), "Done getting Istiod logs for %v/%v", namespace, pod)
+			logRuntime(startTime, "Done getting Istiod logs for %v/%v", namespace, pod)
 		}()
 
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, common.DiscoveryContainerName)
@@ -437,12 +440,13 @@ func getIstiodLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, re
 func getOperatorLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, resources *cluster2.Resources,
 	namespace, pod string, wg *sync.WaitGroup,
 ) {
+	startTime := time.Now()
 	wg.Add(1)
 	log.Infof("Waiting on operator logs for %v/%v", namespace, pod)
 	go func() {
 		defer func() {
 			wg.Done()
-			logRuntime(time.Now(), "Done getting operator logs for %v/%v", namespace, pod)
+			logRuntime(startTime, "Done getting operator logs for %v/%v", namespace, pod)
 		}()
 
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, common.OperatorContainerName)
@@ -457,12 +461,13 @@ func getOperatorLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, 
 func getCniLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, resources *cluster2.Resources,
 	namespace, pod string, wg *sync.WaitGroup,
 ) {
+	startTime := time.Now()
 	wg.Add(1)
 	log.Infof("Waiting on CNI logs for %v", pod)
 	go func() {
 		defer func() {
 			wg.Done()
-			logRuntime(time.Now(), "Done getting CNI logs for %v", pod)
+			logRuntime(startTime, "Done getting CNI logs for %v", pod)
 		}()
 
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, "")


### PR DESCRIPTION
**Please provide a description of this PR:**

The deferred call's arguments are evaluated immediately, but the function call is not executed until the surrounding function returns.

There's a quick way to tell if the runtime is correct: manually add a 1s delay using `time.Sleep(time.Second)` in each function that needs to log time, and if the time is still less than 1s in the log, then it must be wrong.
The diff is as follows:
```diff
diff --git a/tools/bug-report/pkg/bugreport/bugreport.go b/tools/bug-report/pkg/bugreport/bugreport.go
index 33cbd7db7b..9c01fc3610 100644
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -213,6 +213,7 @@ func runBugReportCommand(ctx cli.Context, _ *cobra.Command, logOpts *log.Options
 func dumpRevisionsAndVersions(ctx cli.Context, resources *cluster2.Resources, istioNamespace string, dryRun bool) {
 	defer logRuntime(time.Now(), "Done getting control plane revisions/versions")
 
+	time.Sleep(time.Second)
 	text := ""
 	text += fmt.Sprintf("CLI version:\n%s\n\n", version.Info.LongForm())
 
@@ -379,6 +380,7 @@ func getFromCluster(f func(params *content.Params) (map[string]string, error), p
 			logRuntime(time.Now(), "Done getting from cluster for %v", runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
 		}()
 
+		time.Sleep(time.Second)
 		out, err := f(params)
 		appendGlobalErr(err)
 		if err == nil {
@@ -402,6 +404,7 @@ func getProxyLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, res
 			logRuntime(time.Now(), "Done getting from proxy logs for %v/%v/%v", namespace, pod, container)
 		}()
 
+		time.Sleep(time.Second)
 		clog, cstat, imp, err := getLog(runner, resources, config, namespace, pod, container)
 		appendGlobalErr(err)
 		lock.Lock()
@@ -426,6 +429,7 @@ func getIstiodLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, re
 			logRuntime(time.Now(), "Done getting Istiod logs for %v/%v", namespace, pod)
 		}()
 
+		time.Sleep(time.Second)
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, common.DiscoveryContainerName)
 		appendGlobalErr(err)
 		writeFile(filepath.Join(archive.IstiodPath(tempDir, namespace, pod), "discovery.log"), clog, config.DryRun)
@@ -445,6 +449,7 @@ func getOperatorLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig,
 			logRuntime(time.Now(), "Done getting operator logs for %v/%v", namespace, pod)
 		}()
 
+		time.Sleep(time.Second)
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, common.OperatorContainerName)
 		appendGlobalErr(err)
 		writeFile(filepath.Join(archive.OperatorPath(tempDir, namespace, pod), "operator.log"), clog, config.DryRun)
@@ -465,6 +470,7 @@ func getCniLogs(runner *kubectlcmd.Runner, config *config.BugReportConfig, resou
 			logRuntime(time.Now(), "Done getting CNI logs for %v", pod)
 		}()
 
+		time.Sleep(time.Second)
 		clog, _, _, err := getLog(runner, resources, config, namespace, pod, "")
 		appendGlobalErr(err)
 		writeFile(filepath.Join(archive.CniPath(tempDir, pod), "cni.log"), clog, config.DryRun)
@@ -478,6 +484,7 @@ func getLog(runner *kubectlcmd.Runner, resources *cluster2.Resources, config *co
 ) (string, *processlog.Stats, int, error) {
 	defer logRuntime(time.Now(), "Done getting logs only for %v/%v/%v", namespace, pod, container)
 
+	time.Sleep(time.Second)
 	log.Infof("Getting logs for %s/%s/%s...", namespace, pod, container)
 	clog, err := runner.Logs(namespace, pod, container, false, config.DryRun)
 	if err != nil {
@@ -501,6 +508,7 @@ func runAnalyze(config *config.BugReportConfig, params *content.Params, analyzeT
 
 	defer logRuntime(time.Now(), "Done running Istio analyze on all namespaces and report")
 
+	time.Sleep(time.Second)
 	common.LogAndPrintf("Running Istio analyze on all namespaces and report as below:")
 	out, err := content.GetAnalyze(newParam.SetIstioNamespace(config.IstioNamespace), analyzeTimeout)
 	if err != nil {
@@ -515,6 +523,7 @@ func runAnalyze(config *config.BugReportConfig, params *content.Params, analyzeT
 
 func writeFiles(dir string, files map[string]string, dryRun bool) {
 	defer logRuntime(time.Now(), "Done writing files for dir %v", dir)
+	time.Sleep(time.Second)
 	for fname, text := range files {
 		writeFile(filepath.Join(dir, fname), text, dryRun)
 	}
@@ -531,6 +540,7 @@ func writeFile(path, text string, dryRun bool) {
 
 	defer logRuntime(time.Now(), "Done writing file for path %v", path)
 
+	time.Sleep(time.Second)
 	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
 		log.Errorf(err.Error())
 	}
```