### PR TITLE
Replace os.MkdirTemp with T.TempDir in tests

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -397,8 +397,8 @@ func TestManifestGenerateFlagsSetValues(t *testing.T) {
 }
 
 func TestManifestGenerateFlags(t *testing.T) {
-	flagOutputDir := createTempDirOrFail(t, "flag-output")
-	flagOutputValuesDir := createTempDirOrFail(t, "flag-output-values")
+	flagOutputDir := t.TempDir()
+	flagOutputValuesDir := t.TempDir()
 	runTestGroup(t, testGroup{
 		{
 			desc:                        "all_on",
@@ -434,8 +434,6 @@ func TestManifestGenerateFlags(t *testing.T) {
 			flags:      "--force",
 		},
 	})
-	removeDirOrFail(t, flagOutputDir)
-	removeDirOrFail(t, flagOutputValuesDir)
 }
 
 func TestManifestGeneratePilot(t *testing.T) {

--- a/operator/cmd/mesh/test-util_test.go
+++ b/operator/cmd/mesh/test-util_test.go
@@ -16,11 +16,9 @@ package mesh
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"regexp"
 	"strings"
-	"testing"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -424,21 +422,6 @@ func mustGetValueAtPath(g *gomega.WithT, t map[string]any, path string) any {
 	g.Expect(err).Should(gomega.BeNil(), "path %s should exist (%s)", path, err)
 	g.Expect(f).Should(gomega.BeTrue(), "path %s should exist", path)
 	return got.Node
-}
-
-func createTempDirOrFail(t *testing.T, prefix string) string {
-	dir, err := os.MkdirTemp("", prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
-
-func removeDirOrFail(t *testing.T, path string) {
-	err := os.RemoveAll(path)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 // toMap transforms a comma separated key:value list (e.g. "a:aval, b:bval") to a map.

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -28,16 +28,8 @@ import (
 )
 
 func TestBuildClientConfig(t *testing.T) {
-	config1, err := generateKubeConfig("1.1.1.1", "3.3.3.3")
-	if err != nil {
-		t.Fatalf("Failed to create a sample kubernetes config file. Err: %v", err)
-	}
-	defer os.RemoveAll(filepath.Dir(config1))
-	config2, err := generateKubeConfig("2.2.2.2", "4.4.4.4")
-	if err != nil {
-		t.Fatalf("Failed to create a sample kubernetes config file. Err: %v", err)
-	}
-	defer os.RemoveAll(filepath.Dir(config2))
+	config1 := generateKubeConfig(t, "1.1.1.1", "3.3.3.3")
+	config2 := generateKubeConfig(t, "2.2.2.2", "4.4.4.4")
 
 	tests := []struct {
 		name               string
@@ -99,11 +91,10 @@ func TestBuildClientConfig(t *testing.T) {
 	}
 }
 
-func generateKubeConfig(cluster1Host string, cluster2Host string) (string, error) {
-	tempDir, err := os.MkdirTemp("/tmp/", ".kube")
-	if err != nil {
-		return "", err
-	}
+func generateKubeConfig(t *testing.T, cluster1Host string, cluster2Host string) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "config")
 
 	template := `apiVersion: v1
@@ -136,11 +127,11 @@ users:
     token: sdsddsd`
 
 	sampleConfig := fmt.Sprintf(template, cluster1Host, cluster2Host)
-	err = os.WriteFile(filePath, []byte(sampleConfig), 0o644)
+	err := os.WriteFile(filePath, []byte(sampleConfig), 0o644)
 	if err != nil {
-		return "", err
+		t.Fatal(err)
 	}
-	return filePath, nil
+	return filePath
 }
 
 func TestCronJobMetadata(t *testing.T) {


### PR DESCRIPTION
This PR simplifies code by replacing `os.MkdirTemp` with [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir).