### PR TITLE
basic ztunnel support for revision

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -75,6 +75,14 @@ spec:
         - proxy
         - ztunnel
         env:
+        - name: CA_ADDRESS
+        {{- if .Values.caAddress }}
+          value: {{ .Values.caAddress }}
+        {{- else }}
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.istioNamespace }}.svc:15012
+        {{- end }}
+        - name: XDS_ADDRESS
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.istioNamespace }}.svc:15012
         - name: CLUSTER_ID
           value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}
         - name: POD_NAME

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -65,3 +65,13 @@ redirectMode: "iptables"
 # 2. how many seconds ztunnel waits to drain its own connections (this value - 1 sec)
 # Default K8S value is 30 seconds
 terminationGracePeriodSeconds: 30
+
+# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
+revision: ""
+
+# The customized CA address to retrieve certificates for the pods in the cluster.
+# CSR clients such as the Istio Agent and ingress gateways can use this to specify the CA endpoint.
+caAddress: ""
+
+# Used to locate istiod.
+istioNamespace: istio-system

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -603,16 +603,19 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 			return "", fmt.Errorf("component value isn't a map")
 		}
 		finalVals := map[string]any{}
+		// strip out anything from the original apiVals which are a map[string]any but populate other top-level fields
+		for k, v := range apiVals {
+			_, isMap := v.(map[string]any)
+			if !isMap {
+				finalVals[k] = v
+			}
+		}
 		for k, v := range globals {
 			finalVals[k] = v
 		}
 		for k, v := range components {
 			finalVals[k] = v
 		}
-		// this seems hacky to me but if we want to have even basic support for revisions
-		//    I think we need to do something to pass the value down to components which use
-		//    FlattenValues
-		finalVals["revision"] = mergedVals["revision"]
 		mergedVals = finalVals
 	}
 

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -609,6 +609,10 @@ func (t *Translator) TranslateHelmValues(iop *v1alpha1.IstioOperatorSpec, compon
 		for k, v := range components {
 			finalVals[k] = v
 		}
+		// this seems hacky to me but if we want to have even basic support for revisions
+		//    I think we need to do something to pass the value down to components which use
+		//    FlattenValues
+		finalVals["revision"] = mergedVals["revision"]
 		mergedVals = finalVals
 	}
 

--- a/releasenotes/notes/46421.yaml
+++ b/releasenotes/notes/46421.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 46421
+releaseNotes:
+  - |
+    **Added** basic ztunnel support for revisions when installing with istioctl.


### PR DESCRIPTION
**Please provide a description of this PR:**

Presently when you install if you specify a revision we'll create a service for istiod in the form of `istio-<revision>.istio-system.svc`  and componets like the sidecar proxies and gateways would get configured to use the revisioned istiod svc but ztunnel will not. ztunnel will still try to use `istio.istio-system.svc` and fail to start. To remedy that this PR:

- adds basic support for configuring xds and ca addresses in ztunnel when a revision is used
- adds ztunnel support for caAddress (to provide an experience similar to other components)

PR likely requires some documentation and/or release notes but wanting to get feedback on the helm/code/concept before spending too much more time on it.