### PR TITLE
NetworkGateways no longer short circuits if no networkGatewaysBySvc

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -218,10 +218,6 @@ func (c *Controller) NetworkGateways() []model.NetworkGateway {
 	c.networkManager.RLock()
 	defer c.networkManager.RUnlock()
 
-	if len(c.networkGatewaysBySvc) == 0 {
-		return nil
-	}
-
 	// Merge all the gateways into a single set to eliminate duplicates.
 	out := make(model.NetworkGatewaySet)
 	for _, gateways := range c.networkGatewaysBySvc {

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -116,6 +116,15 @@ func TestNetworkUpdateTriggers(t *testing.T) {
 		removeLabeledServiceGateway(t, c)
 		expectGateways(t, 2)
 	})
+	// gateways are created even with out service
+	t.Run("add kubernetes gateway", func(t *testing.T) {
+		addOrUpdateGatewayResource(t, c, 35443)
+		expectGateways(t, 6)
+	})
+	t.Run("remove kubernetes gateway", func(t *testing.T) {
+		removeGatewayResource(t, c)
+		expectGateways(t, 2)
+	})
 	t.Run("remove meshnetworks", func(t *testing.T) {
 		meshNetworks.SetNetworks(nil)
 		expectGateways(t, 0)

--- a/releasenotes/notes/46437.yaml
+++ b/releasenotes/notes/46437.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 46437
+releaseNotes:
+- |
+  **Fixed** Remote Gateways not being recognized when valid local gateways are not present. Fixes https://github.com/istio/istio/issues/46435.


### PR DESCRIPTION
This PR fixes https://github.com/istio/istio/issues/46435

We no longer want to short circuit our NetworkGateways logic based on if there are no `networkGatewaysBySvc`, because there could still be `networkGatewaysByResource`.