### PR TITLE
NodeInternalIP is a valid address type for a Node

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -497,7 +497,7 @@ func (c *Controller) onNodeEvent(_, node *v1.Node, event model.Event) error {
 	} else {
 		k8sNode := kubernetesNode{labels: node.Labels}
 		for _, address := range node.Status.Addresses {
-			if address.Type == v1.NodeExternalIP && address.Address != "" {
+			if (address.Type == v1.NodeExternalIP || address.Type == v1.NodeInternalIP) && address.Address != "" {
 				k8sNode.address = address.Address
 				break
 			}


### PR DESCRIPTION
Makes Node InternalIP a valid address type for Nodes.