### PR TITLE
testing: better cmp opts

### DIFF
--- a/pilot/pkg/model/fuzz_test.go
+++ b/pilot/pkg/model/fuzz_test.go
@@ -17,41 +17,35 @@ package model
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/testing/protocmp"
-
 	"istio.io/istio/pkg/fuzz"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func FuzzDeepCopyService(f *testing.F) {
-	fuzzDeepCopy[*Service](f, cmp.AllowUnexported(), cmpopts.IgnoreFields(AddressMap{}, "mutex"))
+	fuzzDeepCopy[*Service](f)
 }
 
 func FuzzDeepCopyServiceInstance(f *testing.F) {
-	fuzzDeepCopy[*ServiceInstance](f, protocmp.Transform(), cmp.AllowUnexported(), cmpopts.IgnoreFields(AddressMap{}, "mutex"))
+	fuzzDeepCopy[*ServiceInstance](f)
 }
 
 func FuzzDeepCopyWorkloadInstance(f *testing.F) {
-	fuzzDeepCopy[*WorkloadInstance](f, protocmp.Transform(), cmp.AllowUnexported())
+	fuzzDeepCopy[*WorkloadInstance](f)
 }
 
 func FuzzDeepCopyIstioEndpoint(f *testing.F) {
-	fuzzDeepCopy[*IstioEndpoint](f, protocmp.Transform(), cmp.AllowUnexported(), cmpopts.IgnoreUnexported(IstioEndpoint{}))
+	fuzzDeepCopy[*IstioEndpoint](f)
 }
 
 type deepCopier[T any] interface {
 	DeepCopy() T
 }
 
-func fuzzDeepCopy[T deepCopier[T]](f test.Fuzzer, opts ...cmp.Option) {
+func fuzzDeepCopy[T deepCopier[T]](f test.Fuzzer) {
 	fuzz.Fuzz(f, func(fg fuzz.Helper) {
 		orig := fuzz.Struct[T](fg)
 		copied := orig.DeepCopy()
-		if !cmp.Equal(orig, copied, opts...) {
-			diff := cmp.Diff(orig, copied, opts...)
-			fg.T().Fatalf("unexpected diff %v", diff)
-		}
+		assert.Equal(fg.T(), orig, copied)
 	})
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -27,7 +27,6 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -2448,9 +2447,7 @@ func TestWorkloadInstanceHandler_WorkloadInstanceIndex(t *testing.T) {
 	verifyGetByIP := func(address string, want []*model.WorkloadInstance) {
 		got := ctl.workloadInstancesIndex.GetByIP(address)
 
-		if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-			t.Fatalf("workload index is not valid (--want/++got): %v", diff)
-		}
+		assert.Equal(t, want, got)
 	}
 
 	wi1 := &model.WorkloadInstance{

--- a/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
+++ b/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
@@ -18,15 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 var GlobalTime = time.Now()
@@ -95,17 +93,7 @@ func TestIndex(t *testing.T) {
 	index.Insert(wi3)
 
 	verifyGetByIP := func(ip string, expected []*model.WorkloadInstance) {
-		actual := index.GetByIP(ip)
-
-		if diff := cmp.Diff(len(expected), len(actual), cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-			t.Errorf("GetByIP() returned unexpected number of workload instances (--want/++got): %v", diff)
-		}
-
-		for i := range expected {
-			if diff := cmp.Diff(expected[i], actual[i], cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-				t.Errorf("GetByIP() returned unexpected workload instance %d (--want/++got): %v", i, diff)
-			}
-		}
+		assert.Equal(t, expected, index.GetByIP(ip))
 	}
 
 	// GetByIP should return 2 workload instances
@@ -115,9 +103,7 @@ func TestIndex(t *testing.T) {
 	// Delete should return previously inserted value
 
 	deleted := index.Delete(wi1)
-	if diff := cmp.Diff(wi1, deleted, cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-		t.Errorf("1st Delete() returned unexpected value (--want/++got): %v", diff)
-	}
+	assert.Equal(t, wi1, deleted)
 
 	// GetByIP should return 1 workload instance
 
@@ -126,9 +112,7 @@ func TestIndex(t *testing.T) {
 	// Delete should return nil since there is no such element in the index
 
 	deleted = index.Delete(wi1)
-	if diff := cmp.Diff((*model.WorkloadInstance)(nil), deleted); diff != "" {
-		t.Errorf("2nd Delete() returned unexpected value (--want/++got): %v", diff)
-	}
+	assert.Equal(t, nil, deleted)
 
 	// GetByIP should return nil
 
@@ -185,9 +169,7 @@ func TestIndex_FindAll(t *testing.T) {
 	actual := FindAllInIndex(index, ByServiceSelector(selector.Namespace, labels.Instance{"app": "wle"}))
 	want := []*model.WorkloadInstance{wi1, wi2}
 
-	if diff := cmp.Diff(len(want), len(actual)); diff != "" {
-		t.Errorf("FindAllInIndex() returned unexpected number of workload instances (--want/++got): %v", diff)
-	}
+	assert.Equal(t, len(want), len(actual))
 
 	got := map[string]*model.WorkloadInstance{}
 	for _, instance := range actual {
@@ -195,8 +177,6 @@ func TestIndex_FindAll(t *testing.T) {
 	}
 
 	for _, expected := range want {
-		if diff := cmp.Diff(expected, got[expected.Name], cmpopts.IgnoreUnexported(model.IstioEndpoint{})); diff != "" {
-			t.Fatalf("FindAllInIndex() returned unexpected workload instance %q (--want/++got): %v", expected.Name, diff)
-		}
+		assert.Equal(t, expected, got[expected.Name])
 	}
 }

--- a/pkg/test/util/assert/assert.go
+++ b/pkg/test/util/assert/assert.go
@@ -16,6 +16,7 @@ package assert
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -43,45 +44,74 @@ var compareErrors = cmp.Comparer(func(x, y error) bool {
 	}
 })
 
+// cmpOptioner can be implemented to provide custom options that should be used when comparing a type.
+// Warning: this is no recursive, unfortunately. So a type `A{B}` cannot rely on `B` implementing this to customize comparing `B`.
+type cmpOptioner interface {
+	CmpOpts() []cmp.Option
+}
+
+// opts gets the comparison opts for a type. This includes some defaults, but allows each type to explicitly append their own.
+func opts[T any](a T) []cmp.Option {
+	if o, ok := any(a).(cmpOptioner); ok {
+		opts := append([]cmp.Option{}, cmpOpts...)
+		opts = append(opts, o.CmpOpts()...)
+		return opts
+	}
+	// if T is actually a slice (ex: []A), check that and get the opts for the element type (A).
+	t := reflect.TypeOf(a)
+	if t != nil && t.Kind() == reflect.Slice {
+		v := reflect.New(t.Elem()).Elem().Interface()
+		if o, ok := v.(cmpOptioner); ok {
+			opts := append([]cmp.Option{}, cmpOpts...)
+			opts = append(opts, o.CmpOpts()...)
+			return opts
+		}
+	}
+	return cmpOpts
+}
+
 var cmpOpts = []cmp.Option{protocmp.Transform(), cmpopts.EquateEmpty(), compareErrors}
 
+// Compare compares two objects and returns and error if they are not the same.
 func Compare[T any](a, b T) error {
-	if !cmp.Equal(a, b, cmpOpts...) {
-		return fmt.Errorf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
+	if !cmp.Equal(a, b, opts(a)...) {
+		return fmt.Errorf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, opts(a)...), a, b)
 	}
 	return nil
 }
 
-// Equal
+// Equal compares two objects and fails if they are not the same.
 func Equal[T any](t test.Failer, a, b T, context ...string) {
 	t.Helper()
-	if !cmp.Equal(a, b, cmpOpts...) {
+	if !cmp.Equal(a, b, opts(a)...) {
 		cs := ""
 		if len(context) > 0 {
 			cs = " " + strings.Join(context, ", ") + ":"
 		}
-		t.Fatalf("found diff:%s %v\nLeft: %v\nRight: %v", cs, cmp.Diff(a, b, cmpOpts...), a, b)
+		t.Fatalf("found diff:%s %v\nLeft: %v\nRight: %v", cs, cmp.Diff(a, b, opts(a)...), a, b)
 	}
 }
 
-func EventuallyEqual[T any](t test.Failer, fetchA func() T, b T, opts ...retry.Option) {
+// EventuallyEqual compares repeatedly calls the fetch function until the result matches the expectation.
+func EventuallyEqual[T any](t test.Failer, fetch func() T, expected T, retryOpts ...retry.Option) {
 	t.Helper()
 	var a T
 	// Unit tests typically need shorter default; opts can override though
 	ro := []retry.Option{retry.Timeout(time.Second * 2)}
-	ro = append(ro, opts...)
+	ro = append(ro, retryOpts...)
 	err := retry.UntilSuccess(func() error {
-		a = fetchA()
-		if !cmp.Equal(a, b, cmpOpts...) {
+		a = fetch()
+		if !cmp.Equal(a, expected, opts(expected)...) {
 			return fmt.Errorf("not equal")
 		}
 		return nil
 	}, ro...)
 	if err != nil {
-		t.Fatalf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, b, cmpOpts...), a, b)
+		t.Fatalf("found diff: %v\nLeft: %v\nRight: %v", cmp.Diff(a, expected, opts(expected)...), a, expected)
 	}
 }
 
+// Error asserts the provided err is non-nil
 func Error(t test.Failer, err error) {
 	t.Helper()
 	if err == nil {
@@ -89,6 +119,7 @@ func Error(t test.Failer, err error) {
 	}
 }
 
+// NoError asserts the provided err is nil
 func NoError(t test.Failer, err error) {
 	t.Helper()
 	if err != nil {


### PR DESCRIPTION
This allows each type to specify how they should be compared, rather
than forcing each test to do remember to do so. This should make testing
objects more straightforward.
