### PR TITLE
[release-1.19] Run update_deps

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -36,7 +36,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=15adf1102ef73aa9b06a154728734faab14a85f4
+BUILDER_SHA=167e7b971663ba8a9848370ff65aa00477679b25
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
**Please provide a description of this PR:**

I'm running this to allow any 1.19 RM to approve this.

This is an update_dps.sh run after all the latest PRs were merged. The only difference from the prior PR is likely a common-files update to release-builder to pick up the Go 1.21.0 image.