### PR TITLE
test framework: detect and reconnect if port-forward is terminated

### DIFF
--- a/istioctl/pkg/cli/mock_client.go
+++ b/istioctl/pkg/cli/mock_client.go
@@ -34,6 +34,10 @@ func (m MockPortForwarder) Address() string {
 func (m MockPortForwarder) Close() {
 }
 
+func (m MockPortForwarder) ErrChan() <-chan error {
+	return make(chan error)
+}
+
 func (m MockPortForwarder) WaitForStop() {
 }
 

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -381,7 +381,7 @@ func (b builder) deployWaypoints(instances echo.Instances) error {
 		k := waypoint{i.NamespaceName(), i.Config().AccountName()}
 		waypoints[k] = i.Config().Namespace
 	}
-	scopes.Framework.Infof("%v", waypoints)
+
 	errG := multierror.Group{}
 	for w, ns := range waypoints {
 		w, ns := w, ns

--- a/pkg/test/framework/components/echo/kube/workload_manager.go
+++ b/pkg/test/framework/components/echo/kube/workload_manager.go
@@ -192,6 +192,7 @@ func (m *workloadManager) onPodAddOrUpdate(pod *corev1.Pod) error {
 		cluster:    m.cfg.Cluster,
 		grpcPort:   m.grpcPort,
 		tls:        m.tls,
+		stop:       m.stopCh,
 	}, m.ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Port forward is not 100% reliable and actually fails a decent amount.
When this happens, we just break forever.
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/46400/integ-pilot-multicluster_istio/1689018314652651520
is an example.

In this PR, we have a (somewhat crude) mechanism to detect the
port-forward was terminated and reconnect.

I also considered making the port-forwarder do this transparently, but
its too complex because that means the Address() can change dynamically
which makes it harder to consume - best to do it explicitly.

To test this, I ran a fake test that just sends in a loop:

```go
func TestPortForward(t *testing.T) {
	framework.
		NewTest(t).
		Run(func(t framework.TestContext) {
			for {
				time.Sleep(time.Second)
				t.Logf("howardjohn: sending...")
				t0 := time.Now()
				res, err := apps.A.Callers()[0].Call(echo.CallOptions{
					To: apps.B[0],
					Port: echo.Port{
						Name: "http",
					},
					Check: check.OK(),
				})
				_ = res
				t.Logf("howardjohn: done %v... %v", err, time.Since(t0))
			}
		})
}
```

Then I killed api-server: `docker exec kind-control-plane sh -c 'crictl stopp `crictl pods --name kube-apiserver -q`'`

Because the "kill api-server" takes like 20s to recover, the test does fail sometimes - but I think in the cases we see, the dropped port-forward is totally ephemeral so an immediate reconnect will be fine
