### PR TITLE
operator: fix typos in comments and tests

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -312,7 +312,7 @@ func detectIstioVersionDiff(p Printer, tag string, ns string, kubeClient kube.CL
 			}
 			icpTags = append(icpTags, tagVer)
 		}
-		// sort different versions of control plane revsions
+		// sort different versions of control plane revisions
 		sort.Strings(icpTags)
 		// capture latest revision installed for comparison
 		for _, val := range icpTags {

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -89,7 +89,7 @@ type testGroup []struct {
 	// By default we hide these changes to make developers life's a bit easier. However,
 	// it is still useful to sometimes override this behavior and show the full diff.
 	// When this flag is true, use an alternative file suffix that is not hidden by
-	// default github in pull requests.
+	// default GitHub in pull requests.
 	showOutputFileInPullRequest bool
 	flags                       string
 	noInput                     bool
@@ -142,7 +142,7 @@ func extract(gzipStream io.Reader, destination string) error {
 			}
 			outFile.Close()
 		default:
-			return fmt.Errorf("uknown type: %v in %v", header.Typeflag, header.Name)
+			return fmt.Errorf("unknown type: %v in %v", header.Typeflag, header.Name)
 		}
 	}
 	return nil

--- a/operator/cmd/mesh/test-util_test.go
+++ b/operator/cmd/mesh/test-util_test.go
@@ -441,7 +441,7 @@ func toMap(s string) map[string]any {
 	return out
 }
 
-// endpointSubsetAddressVal returns a map having subset address type for an endpint.
+// endpointSubsetAddressVal returns a map having subset address type for an endpoint.
 func endpointSubsetAddressVal(hostname, ip, nodeName string) map[string]any {
 	out := make(map[string]any)
 	if hostname != "" {

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -169,7 +169,7 @@ func checkDeprecatedSettings(iop *v1alpha1.IstioOperatorSpec) (util.Errors, []st
 
 type FeatureValidator func(*valuesv1alpha1.Values, *v1alpha1.IstioOperatorSpec) (util.Errors, []string)
 
-// validateFeatures check whether the config sematically make sense. For example, feature X and feature Y can't be enabled together.
+// validateFeatures check whether the config semantically make sense. For example, feature X and feature Y can't be enabled together.
 func validateFeatures(values *valuesv1alpha1.Values, spec *v1alpha1.IstioOperatorSpec) (errs util.Errors, warnings []string) {
 	validators := []FeatureValidator{
 		CheckServicePorts,
@@ -311,7 +311,7 @@ func ValidateSubTypes(e reflect.Value, failOnMissingValidation bool, values *val
 		return validationErrors
 	}
 	for i := 0; i < e.NumField(); i++ {
-		// Corner case of a slice of something, if something is defined type, then process it recursiveley.
+		// Corner case of a slice of something, if something is defined type, then process it recursively.
 		if e.Field(i).Kind() == reflect.Slice {
 			validationErrors = append(validationErrors, processSlice(e.Field(i), failOnMissingValidation, values, iopls)...)
 			continue

--- a/operator/pkg/component/component.go
+++ b/operator/pkg/component/component.go
@@ -357,7 +357,7 @@ func renderManifest(cf *IstioComponentBase) (string, error) {
 }
 
 // createHelmRenderer creates a helm renderer for the component defined by c and returns a ptr to it.
-// If a helm subdir is not found in ComponentMap translations, it is assumed to be "addon/<component name>.
+// If a helm subdir is not found in ComponentMap translations, it is assumed to be "addon/<component name>".
 func createHelmRenderer(c *CommonComponentFields) helm.TemplateRenderer {
 	iop := c.InstallSpec
 	cns := string(c.ComponentName)

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -144,7 +144,7 @@ func (h *HelmReconciler) PruneControlPlaneByRevisionWithController(iopSpec *v1al
 			fmt.Errorf("failed to get enabled components: %v", err)
 	}
 	pilotEnabled := false
-	// check wherther the istiod is enabled
+	// check whether the istiod is enabled
 	for _, c := range enabledComponents {
 		if c == string(name.PilotComponentName) {
 			pilotEnabled = true

--- a/operator/pkg/helmreconciler/wait.go
+++ b/operator/pkg/helmreconciler/wait.go
@@ -67,7 +67,7 @@ func WaitForResources(objects object.K8sObjects, client kube.Client,
 	var notReady []string
 	var debugInfo map[string]string
 
-	// Check if we are ready immediately, to avoid the 2s delay below when we are already redy
+	// Check if we are ready immediately, to avoid the 2s delay below when we are already ready
 	if ready, _, _, err := waitForResources(objects, client.Kube(), l); err == nil && ready {
 		return nil
 	}
@@ -310,7 +310,7 @@ func daemonsetsReady(daemonsets []*appsv1.DaemonSet) (bool, []string) {
 			if ds.Spec.UpdateStrategy.Type == appsv1.RollingUpdateDaemonSetStrategyType {
 				if ds.Status.DesiredNumberScheduled <= 0 {
 					// If DesiredNumberScheduled less then or equal 0, there some cases:
-					// 1) daemenset is just created
+					// 1) daemonset is just created
 					// 2) daemonset desired no pod
 					// 3) somebody changed it manually
 					// All the case is not a ready signal
@@ -342,7 +342,7 @@ func statefulsetsReady(statefulsets []*appsv1.StatefulSet) (bool, []string) {
 		if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType {
 			// Dereference all the pointers because StatefulSets like them
 			var partition int
-			// default replicasfor sts is 1
+			// default replicas for sts is 1
 			replicas := 1
 			// the rollingUpdate field can be nil even if the update strategy is a rolling update.
 			if sts.Spec.UpdateStrategy.RollingUpdate != nil &&

--- a/operator/pkg/metrics/monitoring.go
+++ b/operator/pkg/metrics/monitoring.go
@@ -56,7 +56,7 @@ const (
 	CannotFetchProfileError MergeErrorType = "cannot_fetch_profile"
 
 	// OverlayError overlaying YAMLs to combine profile, user
-	// defined settings in CR, Hub-tag etc fails.
+	// defined settings in CR, Hub-tag etc. fails.
 	OverlayError MergeErrorType = "overlay"
 
 	// IOPFormatError occurs when supplied CR cannot be marshaled

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -564,7 +564,7 @@ func resolvePDBConflict(o *K8sObject) *K8sObject {
 	if spec["maxUnavailable"] != nil && spec["minAvailable"] != nil {
 		// When both maxUnavailable and minAvailable present and
 		// neither has value 0, this is considered a conflict,
-		// then maxUnavailale will take precedence.
+		// then maxUnavailable will take precedence.
 		if !isDefault(spec["maxUnavailable"]) && !isDefault(spec["minAvailable"]) {
 			delete(spec, "minAvailable")
 			// Make sure that the json and yaml representation of the object

--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -33,7 +33,7 @@ Some examples are given below. Given a resource:
 	    - "vv1"
 	    - vv2=foo
 
-values and list entries can be added, modifed or deleted.
+values and list entries can be added, modified or deleted.
 
 # MODIFY
 

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -997,14 +997,14 @@ func MergeK8sObject(base *object.K8sObject, overlayNode any, path util.Path) (*o
 }
 
 // createPatchObjectFromPath constructs patch object for node with path, returns nil object and error if the path is invalid.
-// eg. node:
+// e.g. node:
 //   - name: NEW_VAR
 //     value: new_value
 //
 // and path:
 //
 //	  spec.template.spec.containers.[name:discovery].env
-//	will constructs the following patch object:
+//	will construct the following patch object:
 //	  spec:
 //	    template:
 //	      spec:

--- a/operator/pkg/translate/translate_test.go
+++ b/operator/pkg/translate/translate_test.go
@@ -83,7 +83,7 @@ components:
 			expectSkip: true,
 		},
 		{
-			name:       "hpa enabled for ingressgateway with replicass",
+			name:       "hpa enabled for ingressgateway with replicas",
 			component:  name.IngressComponentName,
 			values:     fmt.Sprintf(valuesWithHPAndReplicaCountFormat, false, true, false),
 			expectSkip: true,

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -328,7 +328,7 @@ func getValidationFuncForPath(validations map[string]ValidatorFunc, path util.Pa
 }
 
 // check whether the pn path node match pattern.
-// pattern may container '*', eg. [1] match [*].
+// pattern may contain '*', e.g. [1] match [*].
 func matchPathNode(pattern, pn string) bool {
 	if !strings.Contains(pattern, "[") && !strings.Contains(pattern, "]") {
 		return pattern == pn


### PR DESCRIPTION
This PR fixes spelling and grammar issues in the `operator` folder.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
