### PR TITLE
Add option to set net.ipv4.ip_early_demux to 0 through istio-cni

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -38,8 +38,9 @@ import (
 )
 
 var (
-	injectAnnotationKey = annotation.SidecarInject.Name
-	sidecarStatusKey    = annotation.SidecarStatus.Name
+	injectAnnotationKey              = annotation.SidecarInject.Name
+	sidecarStatusKey                 = annotation.SidecarStatus.Name
+	disableIPEarlyDemuxAnnotationKey = annotation.SidecarDisableIPEarlyDemux.Name
 
 	podRetrievalMaxRetries = 30
 	podRetrievalInterval   = 1 * time.Second
@@ -324,6 +325,7 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 	}
 
 	redirect.hostNSEnterExec = conf.HostNSEnterExec
+	redirect.disableIPEarlyDemux = pi.Annotations[disableIPEarlyDemuxAnnotationKey] == "true"
 	rulesMgr := interceptMgrCtor()
 	if err := rulesMgr.Program(podName, args.Netns, redirect); err != nil {
 		return err

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -90,6 +90,7 @@ type Redirect struct {
 	dnsRedirect          bool
 	invalidDrop          bool
 	hostNSEnterExec      bool
+	disableIPEarlyDemux  bool
 }
 
 type annotationValidationFunc func(value string) error

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ exclude k8s.io/kubernetes v1.13.0
 // Client-go does not handle different versions of mergo due to some breaking changes - use the matching version
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 
+replace istio.io/api => github.com/luksa/istio-api v0.0.0-20230810084852-7a6042a0a8b2
+
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/logging v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
+github.com/luksa/istio-api v0.0.0-20230810084852-7a6042a0a8b2/go.mod h1:dDMe1TsOtrRoUlBzdxqNolWXpXPQjLfbcXvqPMtQ6eo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #38982 

By setting the annotation `sidecar.istio.io/disableIPEarlyDemux` on a pod, users can instruct istio-cni to set the Kernel option `net.ipv4.ip_early_demux` to `0`. This disables the "[early TCP socket demux](https://lwn.net/Articles/503420/)" feature, which causes issues when the application in the pod exposes multiple ports. If two concurrent connections are opened to two different ports from the same client IP and port, Istio's REDIRECT rule causes the Kernel to mishandle the second connection, because the 4-tuples of those connections end up being identical (across the two connections, the client IP and port are the same, as are the destinatio IP and port due to the many-to-one REDIRECT rule used by Istio). By disabling the early demux feature, the Kernel properly handles the two connections without any issues.