### PR TITLE
fix: TestHelmReconciler flake

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -161,11 +161,10 @@ func copyDir(src string, dest string) error {
 		if info.IsDir() {
 			os.MkdirAll(outpath, info.Mode())
 			return nil
-		} else {
-			cpErr := file.AtomicCopy(path, filepath.Dir(outpath), filepath.Base(outpath))
-			if cpErr != nil {
-				return cpErr
-			}
+		}
+		cpErr := file.AtomicCopy(path, filepath.Dir(outpath), filepath.Base(outpath))
+		if cpErr != nil {
+			return cpErr
 		}
 
 		return nil

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -352,11 +352,6 @@ func writeFile(path string, data []byte) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-// removeFile removes given file from provided path.
-func removeFile(path string) error {
-	return os.Remove(path)
-}
-
 // inFileAbsolutePath returns the absolute path for an input file like "gateways".
 func inFileAbsolutePath(inFile string) string {
 	return filepath.Join(testDataDir, "input", inFile+".yaml")


### PR DESCRIPTION
This PR fixes issuse #45950.

The problem is caused by shared manifest directory. Both `TestHelmReconciler_DeleteControlPlaneByManifest` and `TestManifestGenerateWithDuplicateMutatingWebhookConfig` will use istio/manifests as workspace to load charts, `TestManifestGenerateWithDuplicateMutatingWebhookConfig` will copy `duplicate_mwc.yaml` into the directory and remove the file when test cleanup. 
```go
rs, err := readFile(filepath.Join(testDataDir, "input-extra-resources", testResourceFile+".yaml"))
if err != nil {
t.Fatal(err)
}

err = writeFile(filepath.Join(env.IstioSrc, operatorSubdirFilePath+"/"+testIstioDiscoveryChartPath+"/"+testResourceFile+".yaml"), []byte(rs))
if err != nil {
t.Fatal(err)
}
```

Go test run concurrently so in some cases `TestHelmReconciler_DeleteControlPlaneByManifest` will be affected:
- `duplicate_mwc.yaml ` was removed when test case starting, that's ok
- `duplicate_mwc.yaml ` was removed after test case finish, the file was loaded incorrectly but test still pass
- `duplicate_mwc.yaml ` was removed during the case, right between `GetFilesRecursive` and `ReadFile`, will cause the issue problem
```go
func (h *Renderer) loadChart() error {
	fnames, err := GetFilesRecursive(h.files, h.dir)
	if err != nil {
		if os.IsNotExist(err) {
			return fmt.Errorf("component %q does not exist", h.componentName)
		}
		return fmt.Errorf("list files: %v", err)
	}

        // *** file was removed here ***

	var bfs []*loader.BufferedFile
	for _, fname := range fnames {
		b, err := fs.ReadFile(h.files, fname)
		if err != nil {
			return fmt.Errorf("read file: %v", err)
		}
		// Helm expects unix / separator, but on windows this will be \
		name := strings.ReplaceAll(stripPrefix(fname, h.dir), string(filepath.Separator), "/")
		bf := &loader.BufferedFile{
			Name: name,
			Data: b,
		}
		bfs = append(bfs, bf)
		scope.Debugf("Chart loaded: %s", bf.Name)
	}

	h.chart, err = loader.LoadFiles(bfs)
	if err != nil {
		return fmt.Errorf("load files: %v", err)
	}
	return nil
}
```

In the flake case: https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1678718984729399296:
- TestManifestGenerateWithDuplicateMutatingWebhookConfig begin at `2023-07-11T10:59:08.198553Z` and finish at `2023-07-11T10:59:12.833734Z`
- TestHelmReconciler_DeleteControlPlaneByManifest begin after `2023-07-11T10:59:12.752736Z` and fail at `2023-07-11T10:59:13.129291Z`
Time matches.


There are some way to fix it such as use a mutex in these cases, or run these cases sequentially, but I think it's better to keep unit tests independent, not related to execution order. So I use `copyDir` func to copy manifests into a tmp dir, and load charts from the tmp dir in `TestManifestGenerateWithDuplicateMutatingWebhookConfig`.


- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
