### PR TITLE
Fix MustParse crash if ingress doesn't have an IP

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -854,7 +854,10 @@ func getVIPs(svc *v1.Service) []string {
 		res = append(res, svc.Spec.ClusterIP)
 	}
 	for _, ing := range svc.Status.LoadBalancer.Ingress {
-		res = append(res, ing.IP)
+		// IPs are strictly optional for loadbalancers - they may just have a hostname.
+		if ing.IP != "" {
+			res = append(res, ing.IP)
+		}
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -815,6 +815,25 @@ func TestRBACConvert(t *testing.T) {
 	}
 }
 
+func TestEmptyVIPsExcluded(t *testing.T) {
+	testSVC := corev1.Service{
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						IP: "",
+					},
+				},
+			},
+		},
+	}
+	vips := getVIPs(&testSVC)
+	assert.Equal(t, 0, len(vips), "optional IP fields should be ignored if empty")
+}
+
 type ambientTestServer struct {
 	cfg        *memory.Controller
 	controller *FakeController

--- a/releasenotes/notes/46465.yaml
+++ b/releasenotes/notes/46465.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** Do not include empty IP strings in VIPs (fixes crash when LoadBalancer.Ingress.IP is unset/not present)


### PR DESCRIPTION
LoadBalancer ingress IPs are explicitly optional - so `getVIPs` should exclude empty IP strings to avoid MustParse panics