### PR TITLE
tests: remove external dependencies for tracing and speed up

### DIFF
--- a/pkg/test/framework/components/opentelemetry/kube.go
+++ b/pkg/test/framework/components/opentelemetry/kube.go
@@ -16,103 +16,25 @@ package opentelemetry
 
 import (
 	"fmt"
-	"net"
 	"os"
-	"strings"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	testKube "istio.io/istio/pkg/test/kube"
 )
 
 type otel struct {
-	id      resource.ID
-	cluster cluster.Cluster
+	id        resource.ID
+	cluster   cluster.Cluster
+	forwarder kube.PortForwarder
 }
 
 const (
-	appName         = "opentelemetry-collector"
-	remoteOtelEntry = `
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: otel-gateway
-  namespace: istio-system
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - port:
-      number: 55678
-      name: http-tracing-span
-      protocol: HTTP
-    hosts:
-    - "opentelemetry-collector.{INGRESS_DOMAIN}"
----
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: opentelemetry-collector
-  namespace: istio-system
-spec:
-  hosts:
-  - "opentelemetry-collector.{INGRESS_DOMAIN}"
-  gateways:
-  - otel-gateway
-  http:
-  - match:
-    - port: 55678
-    route:
-    - destination:
-        host: opentelemetry-collector
-        port:
-          number: 55678
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: opentelemetry-collector
-  namespace: istio-system
-spec:
-  host: opentelemetry-collector
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----`
-
-	extServiceEntry = `
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: opentelemetry-collector
-spec:
-  hosts:
-  # must be of form name.namespace.global
-  - opentelemetry-collector.istio-system.global
-  # Treat remote cluster services as part of the service mesh
-  # as all clusters in the service mesh share the same root of trust.
-  location: MESH_INTERNAL
-  ports:
-  - name: http-tracing-span
-    number: 55678
-    protocol: http
-  resolution: DNS
-  addresses:
-  # the IP address to which opentelemetry-collector.istio-system.global will resolve to
-  # must be unique for each remote service, within a given cluster.
-  # This address need not be routable. Traffic for this IP will be captured
-  # by the sidecar and routed appropriately.
-  - 240.0.0.2
-  endpoints:
-  # This is the routable address of the ingress gateway in cluster1 that
-  # sits in front of otel service. Traffic from the sidecar will be
-  # routed to this address.
-  - address: {INGRESS_DOMAIN}
-    ports:
-      http-tracing-span: 15443 # Do not change this port value
-`
+	appName = "opentelemetry-collector"
 )
 
 func getYaml() (string, error) {
@@ -128,22 +50,7 @@ func install(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
-	return ctx.ConfigKube().YAML(ns, y).Apply()
-}
-
-func installServiceEntry(ctx resource.Context, ns, ingressAddr string) error {
-	// Setup remote access to zipkin in cluster
-	yaml := strings.ReplaceAll(remoteOtelEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	if err := ctx.ConfigIstio().YAML(ns, yaml).Apply(); err != nil {
-		return err
-	}
-	// For all other clusters, add a service entry so that can access
-	// zipkin in cluster installed.
-	yaml = strings.ReplaceAll(extServiceEntry, "{INGRESS_DOMAIN}", ingressAddr)
-	if err := ctx.ConfigIstio().YAML(ns, yaml).Apply(); err != nil {
-		return err
-	}
-	return nil
+	return ctx.ConfigKube().YAML(ns, y).Apply(apply.CleanupConditionally)
 }
 
 func newCollector(ctx resource.Context, c Config) (*otel, error) {
@@ -163,24 +70,32 @@ func newCollector(ctx resource.Context, c Config) (*otel, error) {
 	}
 
 	f := testKube.NewSinglePodFetch(o.cluster, ns, fmt.Sprintf("app=%s", appName))
-	_, err = testKube.WaitUntilPodsAreReady(f)
+	pods, err := testKube.WaitUntilPodsAreReady(f)
+	if err != nil {
+		return nil, err
+	}
+	pod := pods[0]
+
+	forwarder, err := o.cluster.NewPortForwarder(pod.Name, pod.Namespace, "", 0, 55678)
 	if err != nil {
 		return nil, err
 	}
 
-	isIP := net.ParseIP(c.IngressAddr).String() != "<nil>"
-	ingressDomain := c.IngressAddr
-	if isIP {
-		ingressDomain = fmt.Sprintf("%s.sslip.io", strings.ReplaceAll(c.IngressAddr, ":", "-"))
-	}
-
-	err = installServiceEntry(ctx, istioCfg.TelemetryNamespace, ingressDomain)
-	if err != nil {
+	if err := forwarder.Start(); err != nil {
 		return nil, err
 	}
+	o.forwarder = forwarder
 	return o, nil
 }
 
 func (o *otel) ID() resource.ID {
 	return o.id
+}
+
+// Close implements io.Closer.
+func (o *otel) Close() error {
+	if o.forwarder != nil {
+		o.forwarder.Close()
+	}
+	return nil
 }

--- a/pkg/test/framework/components/opentelemetry/opentelemetry-collector.go
+++ b/pkg/test/framework/components/opentelemetry/opentelemetry-collector.go
@@ -26,9 +26,6 @@ import (
 type Config struct {
 	// Cluster to be used in a multicluster environment
 	Cluster cluster.Cluster
-
-	// HTTP Address of ingress gateway of the cluster to be used to install open telemetry collector in.
-	IngressAddr string
 }
 
 // Instance represents a opencensus collector deployment on kubernetes.

--- a/pkg/test/framework/components/zipkin/zipkin.go
+++ b/pkg/test/framework/components/zipkin/zipkin.go
@@ -33,9 +33,6 @@ type Instance interface {
 type Config struct {
 	// Cluster to be used in a multicluster environment
 	Cluster cluster.Cluster
-
-	// HTTP Address of ingress gateway of the cluster to be used to install zipkin in.
-	IngressAddr string
 }
 
 // Span represents a single span, which includes span attributes for verification

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -145,7 +145,6 @@ meshConfig:
 }
 
 func testSetup(ctx resource.Context) (err error) {
-	addr, _ := tracing.GetIngressInstance().HTTPAddress()
-	_, err = opentelemetry.New(ctx, opentelemetry.Config{IngressAddr: addr})
+	_, err = opentelemetry.New(ctx, opentelemetry.Config{})
 	return
 }

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -114,9 +114,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	}
 	client = servicePrefix("client").GetMatches(echos)
 	server = match.ServiceName(echo.NamespacedName{Name: "server", Namespace: appNsInst}).GetMatches(echos)
-	ingInst = ist.IngressFor(ctx.Clusters().Default())
-	addr, _ := ingInst.HTTPAddress()
-	zipkinInst, err = zipkin.New(ctx, zipkin.Config{Cluster: ctx.Clusters().Default(), IngressAddr: addr})
+	zipkinInst, err = zipkin.New(ctx, zipkin.Config{Cluster: ctx.Clusters().Default()})
 	if err != nil {
 		return
 	}
@@ -226,6 +224,7 @@ func SendTraffic(t framework.TestContext, headers map[string][]string, cl cluste
 			HTTP: echo.HTTP{
 				Headers: headers,
 			},
+			Count: 25, // Send many requests so traces get exported faster
 			Retry: echo.Retry{
 				NoRetry: true,
 			},


### PR DESCRIPTION
Before we depend on sslip.io. This isn't needed; the rest of tests use
port-forward instead of ingress to reach internal components.

sslip.io is down which inspired this. Also a few tweaks to speed things
up and make them more consistent with other tests
