### PR TITLE
Improve address configuration for waypoints

### DIFF
--- a/pilot/pkg/config/kube/gateway/context.go
+++ b/pilot/pkg/config/kube/gateway/context.go
@@ -44,6 +44,7 @@ func NewGatewayContext(ps *model.PushContext) GatewayContext {
 // The actual configuration generation is done on a per-workload basis and will get the exact set of matched instances for that workload.
 // Four sets are exposed:
 // * Internal addresses (eg istio-ingressgateway.istio-system.svc.cluster.local:80).
+// * Internal IP addresses (eg 1.2.3.4). This comes from ClusterIP.
 // * External addresses (eg 1.2.3.4), this comes from LoadBalancer services. There may be multiple in some cases (especially multi cluster).
 // * Pending addresses (eg istio-ingressgateway.istio-system.svc), are LoadBalancer-type services with pending external addresses.
 // * Warnings for references that could not be resolved. These are intended to be user facing.
@@ -51,12 +52,13 @@ func (gc GatewayContext) ResolveGatewayInstances(
 	namespace string,
 	gwsvcs []string,
 	servers []*networking.Server,
-) (internal, external, pending, warns []string) {
+) (internal, internalIP, external, pending, warns []string) {
 	ports := map[int]struct{}{}
 	for _, s := range servers {
 		ports[int(s.Port.Number)] = struct{}{}
 	}
 	foundInternal := sets.New[string]()
+	foundInternalIP := sets.New[string]()
 	foundExternal := sets.New[string]()
 	foundPending := sets.New[string]()
 	warnings := []string{}
@@ -81,6 +83,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil)
 			if len(instances) > 0 {
 				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
+				foundInternalIP.InsertAll(svc.GetAddresses(&model.Proxy{})...)
 				if svc.Attributes.ClusterExternalAddresses.Len() > 0 {
 					// Fetch external IPs from all clusters
 					svc.Attributes.ClusterExternalAddresses.ForEach(func(c cluster.ID, externalIPs []string) {
@@ -117,7 +120,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 		}
 	}
 	sort.Strings(warnings)
-	return sets.SortedList(foundInternal), sets.SortedList(foundExternal), sets.SortedList(foundPending), warnings
+	return sets.SortedList(foundInternal), sets.SortedList(foundInternalIP), sets.SortedList(foundExternal), sets.SortedList(foundPending), warnings
 }
 
 func (gc GatewayContext) GetService(hostname, namespace string) *model.Service {

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1907,7 +1907,7 @@ func convertGateways(r configContext) ([]config.Config, map[parentKey][]*parentI
 		gatewayServices, err := extractGatewayServices(r.GatewayResources, kgw, obj)
 		if len(gatewayServices) == 0 && err != nil {
 			// Short circuit if its a hard failure
-			reportGatewayStatus(r, obj, gatewayServices, servers, err)
+			reportGatewayStatus(r, obj, classInfo, gatewayServices, servers, err)
 			continue
 		}
 		for i, l := range kgw.Listeners {
@@ -1982,7 +1982,7 @@ func convertGateways(r configContext) ([]config.Config, map[parentKey][]*parentI
 			gwMap[ref] = gwMap[alias]
 		}
 
-		reportGatewayStatus(r, obj, gatewayServices, servers, err)
+		reportGatewayStatus(r, obj, classInfo, gatewayServices, servers, err)
 	}
 	// Insert a parent for Mesh references.
 	gwMap[meshParentKey] = []*parentInfo{
@@ -2025,12 +2025,13 @@ func getListenerNames(obj config.Config) sets.Set[k8s.SectionName] {
 func reportGatewayStatus(
 	r configContext,
 	obj config.Config,
+	classInfo classInfo,
 	gatewayServices []string,
 	servers []*istio.Server,
 	gatewayErr *ConfigError,
 ) {
 	// TODO: we lose address if servers is empty due to an error
-	internal, external, pending, warnings := r.Context.ResolveGatewayInstances(obj.Namespace, gatewayServices, servers)
+	internal, internalIP, external, pending, warnings := r.Context.ResolveGatewayInstances(obj.Namespace, gatewayServices, servers)
 
 	// Setup initial conditions to the success state. If we encounter errors, we will update this.
 	// We have two status
@@ -2085,20 +2086,27 @@ func reportGatewayStatus(
 		if len(addressesToReport) == 0 {
 			// There are no external addresses, so report the internal ones
 			// TODO: should we always report both?
-			addrType = k8s.HostnameAddressType
-			for _, hostport := range internal {
-				svchost, _, _ := net.SplitHostPort(hostport)
-				if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
-					addressesToReport = append(addressesToReport, svchost)
+			if classInfo.addressType == k8s.IPAddressType {
+				addressesToReport = internalIP
+			} else {
+				addrType = k8s.HostnameAddressType
+				for _, hostport := range internal {
+					svchost, _, _ := net.SplitHostPort(hostport)
+					if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
+						addressesToReport = append(addressesToReport, svchost)
+					}
 				}
 			}
 		}
-		gs.Addresses = make([]k8sbeta.GatewayStatusAddress, 0, len(addressesToReport))
-		for _, addr := range addressesToReport {
-			gs.Addresses = append(gs.Addresses, k8sbeta.GatewayStatusAddress{
-				Value: addr,
-				Type:  &addrType,
-			})
+		// Do not report an address until we are ready. But once we are ready, never remove the address.
+		if len(addressesToReport) > 0 {
+			gs.Addresses = make([]k8sbeta.GatewayStatusAddress, 0, len(addressesToReport))
+			for _, addr := range addressesToReport {
+				gs.Addresses = append(gs.Addresses, k8sbeta.GatewayStatusAddress{
+					Value: addr,
+					Type:  &addrType,
+				})
+			}
 		}
 		// Prune listeners that have been removed
 		haveListeners := getListenerNames(obj)

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -110,6 +110,9 @@ type classInfo struct {
 
 	// disableRouteGeneration, if set, will make it so the controller ignores this class.
 	disableRouteGeneration bool
+
+	// addressType is the default address type to report
+	addressType gateway.AddressType
 }
 
 var classInfos = getClassInfos()
@@ -134,6 +137,7 @@ func getClassInfos() map[gateway.GatewayController]classInfo {
 			description:        "The default Istio GatewayClass",
 			templates:          "kube-gateway",
 			defaultServiceType: corev1.ServiceTypeLoadBalancer,
+			addressType:        gateway.HostnameAddressType,
 		},
 		constants.UnmanagedGatewayController: {
 			// This represents a gateway that our control plane cannot discover directly via the API server.
@@ -141,6 +145,7 @@ func getClassInfos() map[gateway.GatewayController]classInfo {
 			controller:             constants.UnmanagedGatewayController,
 			description:            "Remote to this cluster. Does not deploy or affect configuration.",
 			disableRouteGeneration: true,
+			addressType:            gateway.HostnameAddressType,
 		},
 	}
 	if features.EnableAmbientControllers {
@@ -149,6 +154,7 @@ func getClassInfos() map[gateway.GatewayController]classInfo {
 			description:        "The default Istio waypoint GatewayClass",
 			templates:          "waypoint",
 			defaultServiceType: corev1.ServiceTypeClusterIP,
+			addressType:        gateway.IPAddressType,
 		}
 	}
 	return m


### PR DESCRIPTION
This changes waypoint Gateway's to report IP address as status instead of Hostname. This will allow us to ready Gateway's for waypoints instead of Service, helping with things like https://github.com/istio/istio/issues/46495.

This moves towards the goal of having Waypoints solely configured based on Gateway, with the Service/Pods being an implementation detail that is not depended on. This would allow, for example, running the waypoint via a different mechanism.

hold: discussing with gateway community if this makes sense