### PR TITLE
install: fix warning with wrong control plane

### DIFF
--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -175,6 +175,7 @@ func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptio
 					Info: istioVersion.BuildInfo{
 						Version: "MISSING CP ID",
 					},
+					Revision: "MISSING CP ID",
 				},
 			}, nil
 		}
@@ -187,6 +188,7 @@ func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptio
 			istioVersion.ServerInfo{
 				Component: cpID.Component,
 				Info:      cpID.Info,
+				Revision:  opts.Revision,
 			},
 		}, nil
 	}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -297,6 +297,7 @@ func savedIOPName(iop *v1alpha12.IstioOperator) string {
 // nolint: interfacer
 func detectIstioVersionDiff(p Printer, tag string, ns string, kubeClient kube.CLIClient, setFlags []string) error {
 	warnMarker := color.New(color.FgYellow).Add(color.Italic).Sprint("WARNING:")
+	revision := manifest.GetValueForSetFlag(setFlags, "revision")
 	icps, err := kubeClient.GetIstioVersions(context.TODO(), ns)
 	if err != nil {
 		return err
@@ -306,6 +307,9 @@ func detectIstioVersionDiff(p Printer, tag string, ns string, kubeClient kube.CL
 		var icpTag string
 		// create normalized tags for multiple control plane revisions
 		for _, icp := range *icps {
+			if icp.Revision != revision {
+				continue
+			}
 			tagVer, err := GetTagVersion(icp.Info.GitTag)
 			if err != nil {
 				return err
@@ -320,7 +324,6 @@ func detectIstioVersionDiff(p Printer, tag string, ns string, kubeClient kube.CL
 				icpTag = val
 			}
 		}
-		revision := manifest.GetValueForSetFlag(setFlags, "revision")
 		// when the revision is passed
 		if icpTag != "" && tag != icpTag {
 			check := "         Before upgrading, you may wish to use 'istioctl x precheck' to check for upgrade warnings.\n"

--- a/operator/pkg/version/version.go
+++ b/operator/pkg/version/version.go
@@ -81,7 +81,7 @@ func TagToVersionString(path string) (string, error) {
 	return strings.Join(fmtParts, "."), nil
 }
 
-// TagToVersionString converts an istio container tag into a version string,
+// TagToVersionStringGrace converts an Istio container tag into a version string,
 // if any error, fallback to use the original tag.
 func TagToVersionStringGrace(path string) string {
 	v, err := TagToVersionString(path)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -818,7 +818,10 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 	res := version.MeshInfo{}
 	for _, pod := range readyPods {
 		component := pod.Labels["istio"]
-		server := version.ServerInfo{Component: component}
+		server := version.ServerInfo{
+			Component: component,
+			Revision:  pod.GetLabels()[label.IoIstioRev.Name],
+		}
 
 		// :15014/version returns something like
 		// 1.7-alpha.9c900ba74d10a1affe7c23557ef0eebd6103b03c-9c900ba74d10a1affe7c23557ef0eebd6103b03c-Clean

--- a/pkg/version/cobra_test.go
+++ b/pkg/version/cobra_test.go
@@ -110,15 +110,39 @@ func TestOpts(t *testing.T) {
 var meshEmptyVersion = MeshInfo{}
 
 var meshInfoSingleVersion = MeshInfo{
-	{"Pilot", BuildInfo{"1.2.0", "gitSHA123", "go1.10", "Clean", "tag"}},
-	{"Injector", BuildInfo{"1.2.0", "gitSHAabc", "go1.10.1", "Modified", "tag"}},
-	{"Citadel", BuildInfo{"1.2.0", "gitSHA321", "go1.11.0", "Clean", "tag"}},
+	{
+		Component: "Pilot",
+		Revision:  "default",
+		Info:      BuildInfo{"1.2.0", "gitSHA123", "go1.10", "Clean", "tag"},
+	},
+	{
+		Component: "Injector",
+		Revision:  "default",
+		Info:      BuildInfo{"1.2.0", "gitSHAabc", "go1.10.1", "Modified", "tag"},
+	},
+	{
+		Component: "Citadel",
+		Revision:  "default",
+		Info:      BuildInfo{"1.2.0", "gitSHA321", "go1.11.0", "Clean", "tag"},
+	},
 }
 
 var meshInfoMultiVersion = MeshInfo{
-	{"Pilot", BuildInfo{"1.0.0", "gitSHA123", "go1.10", "Clean", "1.0.0"}},
-	{"Injector", BuildInfo{"1.0.1", "gitSHAabc", "go1.10.1", "Modified", "1.0.1"}},
-	{"Citadel", BuildInfo{"1.2", "gitSHA321", "go1.11.0", "Clean", "1.2"}},
+	{
+		Component: "Pilot",
+		Revision:  "default",
+		Info:      BuildInfo{"1.0.0", "gitSHA123", "go1.10", "Clean", "1.0.0"},
+	},
+	{
+		Component: "Injector",
+		Revision:  "default",
+		Info:      BuildInfo{"1.0.1", "gitSHAabc", "go1.10.1", "Modified", "1.0.1"},
+	},
+	{
+		Component: "Citadel",
+		Revision:  "default",
+		Info:      BuildInfo{"1.2", "gitSHA321", "go1.11.0", "Clean", "1.2"},
+	},
 }
 
 func mockRemoteMesh(meshInfo *MeshInfo, err error) GetRemoteVersionFunc {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,6 +45,7 @@ type BuildInfo struct {
 // ServerInfo contains the version for a single control plane component
 type ServerInfo struct {
 	Component string
+	Revision  string
 	Info      BuildInfo
 }
 

--- a/releasenotes/notes/46511.yaml
+++ b/releasenotes/notes/46511.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where the upgrade warning is given incorrectly between default and revisioned control planes.


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently if I have a revisioned control plane, and I want to install a default revision control plane, there's a warning shows `WARNING: Istio is being upgraded from 1.19.0 to 1.20.0...`

However there's no control plane to be overwritten since only a revisioned control plane exists.

`GetIstioVersions` gets all the Istiods' versions without having their revisions.