### PR TITLE
wasm metadata exchange removed from proxy build

### DIFF
--- a/bin/update_proxy.sh
+++ b/bin/update_proxy.sh
@@ -40,14 +40,5 @@ until curl --output /dev/null --silent --head --fail "$ISTIO_ENVOY_RELEASE_URL";
 done
 printf '\n'
 
-plugin=metadata_exchange
-WASM_URL=${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm
-printf "Verifying %s is available\n" "$WASM_URL"
-until curl --output /dev/null --silent --head --fail "$WASM_URL"; do
-    printf '.'
-    sleep $SLEEP_TIME
-done
-printf '\n'
-
 # Update the dependency in istio.deps
 sed -i '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$1"'"/  }' istio.deps


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/proxy/pull/4891 removed the Wasm metadata exchange from the build. The update_proxy script verifies that it is there so it is now failing (ex: https://prow.istio.io/view/gs/istio-prow/logs/update-istio_proxy_postsubmit/1690592966046912512). This remove the check.