### PR TITLE
Revert "test framework: drop sslip.io dependencyfor tracing tests"

### DIFF
--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -226,7 +226,6 @@ func SendTraffic(t framework.TestContext, headers map[string][]string, cl cluste
 			HTTP: echo.HTTP{
 				Headers: headers,
 			},
-			Count: 25, // Send many requests so traces get exported faster
 			Retry: echo.Retry{
 				NoRetry: true,
 			},


### PR DESCRIPTION
Reverts istio/istio#46502

This breaks ipv6. Not sure a better way to handle it for now...