### PR TITLE
add volumes/volume mounts to ztunnel helm values/daemonset

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -114,6 +114,9 @@ spec:
           name: istiod-ca-cert
         - mountPath: /var/run/secrets/tokens
           name: istio-token
+        {{- with .Values.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
       - name: istio-token
@@ -126,3 +129,6 @@ spec:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 6}}
+      {{- end }}

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -14,6 +14,12 @@ labels: {}
 # Annotations to apply to all top level resources
 annotations: {}
 
+# Additional volumeMounts to the ztunnel container
+volumeMounts: []
+
+# Additional volumes to the ztunnel pod
+volumes: []
+
 # Annotations added to each pod. The default annotations are required for scraping prometheus (in most environments).
 podAnnotations:
   prometheus.io/port: "15020"


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds the ability to customize the zTunnel with additional volumes/volumeMounts.

this can be useful for adding certificates to the zTunnel or other tasks that require file system access.