### PR TITLE
telemetry: fix crash with bad provider config

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -663,6 +663,11 @@ func (t *Telemetries) fetchProvider(m string) *meshconfig.MeshConfig_ExtensionPr
 	return nil
 }
 
+func (t *Telemetries) Debug(proxy *Proxy) any {
+	at := t.applicableTelemetries(proxy)
+	return at
+}
+
 var allMetrics = func() []string {
 	r := make([]string, 0, len(tpb.MetricSelector_IstioMetric_value))
 	for k := range tpb.MetricSelector_IstioMetric_value {
@@ -900,6 +905,11 @@ var waypointStatsConfig = protoconv.MessageToAny(&udpa.TypedStruct{
 		},
 	},
 })
+
+// telemetryFilterHandled contains the number of providers we handle below.
+// This is to ensure this stays in sync as new handlers are added
+// STOP. DO NOT UPDATE THIS WITHOUT UPDATING buildHTTPTelemetryFilter and buildTCPTelemetryFilter.
+const telemetryFilterHandled = 14
 
 func buildHTTPTelemetryFilter(class networking.ListenerClass, metricsCfg []telemetryFilterConfig) []*hcm.HttpFilter {
 	res := make([]*hcm.HttpFilter, 0, len(metricsCfg))

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -122,6 +122,11 @@ var (
 	}
 )
 
+// configureFromProviderConfigHandled contains the number of providers we handle below.
+// This is to ensure this stays in sync as new handlers are added
+// STOP. DO NOT UPDATE THIS WITHOUT UPDATING telemetryAccessLog.
+const telemetryAccessLogHandled = 14
+
 func telemetryAccessLog(push *PushContext, fp *meshconfig.MeshConfig_ExtensionProvider) *accesslog.AccessLog {
 	var al *accesslog.AccessLog
 	switch prov := fp.Provider.(type) {
@@ -138,6 +143,19 @@ func telemetryAccessLog(push *PushContext, fp *meshconfig.MeshConfig_ExtensionPr
 		al = tcpGrpcAccessLogFromTelemetry(push, prov.EnvoyTcpAls)
 	case *meshconfig.MeshConfig_ExtensionProvider_EnvoyOtelAls:
 		al = openTelemetryLog(push, prov.EnvoyOtelAls)
+	case *meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzHttp,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc,
+		*meshconfig.MeshConfig_ExtensionProvider_Zipkin,
+		*meshconfig.MeshConfig_ExtensionProvider_Lightstep,
+		*meshconfig.MeshConfig_ExtensionProvider_Datadog,
+		*meshconfig.MeshConfig_ExtensionProvider_Skywalking,
+		*meshconfig.MeshConfig_ExtensionProvider_Opencensus,
+		*meshconfig.MeshConfig_ExtensionProvider_Opentelemetry,
+		*meshconfig.MeshConfig_ExtensionProvider_Prometheus,
+		*meshconfig.MeshConfig_ExtensionProvider_Stackdriver:
+		// No access logs supported for this provider
+		// Stackdriver is a special case as its handled in the Metrics logic, as it uses a shared filter
+		return nil
 	}
 
 	return al

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -1012,6 +1012,10 @@ func TestBuildOpenTelemetryAccessLogConfig(t *testing.T) {
 	}
 }
 
+func TestTelemetryAccessLogExhaustiveness(t *testing.T) {
+	AssertProvidersHandled(telemetryAccessLogHandled)
+}
+
 func TestTelemetryAccessLog(t *testing.T) {
 	stdoutFormat := &meshconfig.MeshConfig_ExtensionProvider{
 		Name: "stdout",

--- a/pilot/pkg/model/telemetry_metric_test.go
+++ b/pilot/pkg/model/telemetry_metric_test.go
@@ -25,6 +25,10 @@ import (
 	"istio.io/istio/pkg/test/util/assert"
 )
 
+func TestTelemetryMetricsExhaustiveness(t *testing.T) {
+	AssertProvidersHandled(telemetryFilterHandled)
+}
+
 func TestMergeMetrics(t *testing.T) {
 	withoutMetricsProviders := mesh.DefaultMeshConfig()
 	withMetricsProviders := mesh.DefaultMeshConfig()

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -133,6 +133,11 @@ func configureTracingFromTelemetry(
 	return routerFilterCtx, reqIDExtension
 }
 
+// configureFromProviderConfigHandled contains the number of providers we handle below.
+// This is to ensure this stays in sync as new handlers are added
+// STOP. DO NOT UPDATE THIS WITHOUT UPDATING configureFromProviderConfig.
+const configureFromProviderConfigHandled = 14
+
 func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 	providerCfg *meshconfig.MeshConfig_ExtensionProvider,
 ) (*hcm.HttpConnectionManager_Tracing, *xdsfilters.RouterFilterContext, error) {
@@ -218,7 +223,19 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 			}
 			return otelConfig(serviceCluster, hostname, clusterName)
 		}
-
+		// Providers without any tracing support
+		// Explicitly list to be clear what does and does not support tracing
+	case *meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzHttp,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyHttpAls,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyTcpAls,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyOtelAls,
+		*meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog,
+		*meshconfig.MeshConfig_ExtensionProvider_Prometheus:
+		return nil, nil, fmt.Errorf("provider %T does not support tracing", provider)
+		// Should enver happen, but just in case we forget to add one
+	default:
+		return nil, nil, fmt.Errorf("provider %T does not support tracing", provider)
 	}
 	tracing, err := buildHCMTracing(providerName, maxTagLength, providerConfig)
 	return tracing, rfCtx, err

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -35,6 +35,10 @@ import (
 	"istio.io/istio/pkg/slices"
 )
 
+func TestConfigureTracingExhaustiveness(t *testing.T) {
+	model.AssertProvidersHandled(configureFromProviderConfigHandled)
+}
+
 func TestConfigureTracing(t *testing.T) {
 	clusterName := "testcluster"
 	authority := "testhost"
@@ -167,6 +171,14 @@ func TestConfigureTracing(t *testing.T) {
 			want:            fakeTracingConfig(fakeSkywalkingProvider(clusterName, authority), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
 			wantRfCtx:       &xdsfilters.RouterFilterContext{StartChildSpan: true},
 			wantReqIDExtCtx: &requestidextension.UUIDRequestIDExtensionContext{UseRequestIDForTraceSampling: false},
+		},
+		{
+			name:            "invalid provider",
+			inSpec:          fakeTracingSpec(fakePrometheus(), 99.999, false, true),
+			opts:            fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
+			want:            nil,
+			wantRfCtx:       nil,
+			wantReqIDExtCtx: nil,
 		},
 	}
 
@@ -314,6 +326,13 @@ func fakeZipkin() *meshconfig.MeshConfig_ExtensionProvider {
 				MaxTagLength: 256,
 			},
 		},
+	}
+}
+
+func fakePrometheus() *meshconfig.MeshConfig_ExtensionProvider {
+	return &meshconfig.MeshConfig_ExtensionProvider{
+		Name:     "foo",
+		Provider: &meshconfig.MeshConfig_ExtensionProvider_Prometheus{},
 	}
 }
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -484,10 +484,22 @@ type TelemetryDebug struct {
 }
 
 func (s *DiscoveryServer) telemetryz(w http.ResponseWriter, req *http.Request) {
-	info := TelemetryDebug{
-		Telemetries: s.globalPushContext().Telemetry,
+	proxyID, con := s.getDebugConnection(req)
+	if proxyID != "" && con == nil {
+		// We can't guarantee the Pilot we are connected to has a connection to the proxy we requested
+		// There isn't a great way around this, but for debugging purposes its suitable to have the caller retry.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("Proxy not connected to this Pilot instance. It may be connected to another instance.\n"))
+		return
 	}
-	writeJSON(w, info, req)
+	if con == nil {
+		info := TelemetryDebug{
+			Telemetries: s.globalPushContext().Telemetry,
+		}
+		writeJSON(w, info, req)
+		return
+	}
+	writeJSON(w, s.globalPushContext().Telemetry.Debug(con.proxy), req)
 }
 
 // connectionsHandler implements interface for displaying current connections.


### PR DESCRIPTION
```
apiVersion: telemetry.istio.io/v1alpha1
kind: Telemetry
metadata:
  name: default
spec:
  tracing:
  - providers:
    - name: envoy
```

causes a crash.

This fixes the crash. In addition, it adds a per-proxy debug interface to `telemetryz` for better debugging, and tries to improve the exhaustiveness checks to prevent future bugs (Go can't handle this well :shrug: )