### PR TITLE
adding waypoints should be non-disruptive

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -529,7 +529,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			}
 
 			if len(updates) > 0 {
-				log.Debug("Waypoint svc ready: Pushing Updates")
+				log.Debug("Waypoint ready: Pushing Updates")
 				c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 					ConfigsUpdated: updates,
 					Reason:         model.NewReasonStats(model.AmbientUpdate),

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -517,10 +517,8 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 			idx.mu.Lock()
 			defer idx.mu.Unlock()
 			if ev == model.EventDelete {
-				if proto.Equal(idx.waypoints[scope], addr) {
-					delete(idx.waypoints, scope)
-					updates.Merge(idx.updateWaypoint(scope, addr, true))
-				}
+				delete(idx.waypoints, scope)
+				updates.Merge(idx.updateWaypoint(scope, addr, true))
 			} else {
 				if !proto.Equal(idx.waypoints[scope], addr) {
 					idx.waypoints[scope] = addr

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -37,12 +37,10 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kind"
 	kubeutil "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
-	"istio.io/istio/pkg/kube/kubetypes"
 	kubelabels "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/spiffe"
@@ -552,7 +550,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 	// initNetworkManager initializes this if features.MultiNetworkGatewayAPI is enabled
 	// TODO: sort this out, it's probably not good to have 2 points of initialization
 	if !features.MultiNetworkGatewayAPI {
-		c.gatewayResourceClient = kclient.NewDelayedInformer[*k8sbeta.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
+		c.gatewayResourceClient = kclient.New[*k8sbeta.Gateway](c.client)
 	}
 	c.gatewayResourceClient.AddEventHandler(kubeGatewayHandler)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -37,10 +37,12 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kind"
 	kubeutil "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kubetypes"
 	kubelabels "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/spiffe"
@@ -550,7 +552,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 	// initNetworkManager initializes this if features.MultiNetworkGatewayAPI is enabled
 	// TODO: sort this out, it's probably not good to have 2 points of initialization
 	if !features.MultiNetworkGatewayAPI {
-		c.gatewayResourceClient = kclient.New[*k8sbeta.Gateway](c.client)
+		c.gatewayResourceClient = kclient.NewDelayedInformer[*k8sbeta.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
 	}
 	c.gatewayResourceClient.AddEventHandler(kubeGatewayHandler)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -683,62 +683,6 @@ func (a *AmbientIndexImpl) handleService(obj any, isDelete bool, c *Controller) 
 	svc := controllers.Extract[*v1.Service](obj)
 	updates := sets.New[model.ConfigKey]()
 
-	// TODO: temporarily commented out in case I missed something. This logic has all been moved to the Kubernetes Gateway handler
-	// if svc.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
-	// 	scope := model.WaypointScope{Namespace: svc.Namespace, ServiceAccount: svc.Annotations[constants.WaypointServiceAccount]}
-
-	// 	// TODO get IP+Port from the Gateway CRD
-	// 	// https://github.com/istio/istio/issues/44230
-	// 	if svc.Spec.ClusterIP == v1.ClusterIPNone {
-	// 		// TODO handle headless Service
-	// 		log.Warn("headless service currently not supported as a waypoint")
-	// 		return updates
-	// 	}
-	// 	waypointPort := uint32(15008)
-	// 	for _, p := range svc.Spec.Ports {
-	// 		if strings.Contains(p.Name, "hbone") {
-	// 			waypointPort = uint32(p.Port)
-	// 		}
-	// 	}
-
-	// 	useSvc := true
-	// 	gatewayClient := c.client.GatewayAPI().GatewayV1beta1().Gateways(svc.Namespace)
-	// 	// TODO: handle error
-	// 	gateway, _ := gatewayClient.Get(context.TODO(), strings.TrimSuffix(svc.Name, "-istio-waypoint"), metav1.GetOptions{})
-	// 	if gateway != nil {
-	// 		gatewayAddresses := gateway.Status.Addresses
-	// 		if len(gatewayAddresses) == 0 {
-	// 			// in order to ensure adding waypoints isn't disruptive we're only going to configure them once they have reported being ready
-	// 			// gateway controller will add address only once one pod has become ready
-	// 			log.Info(fmt.Sprintf("waypoint %s has not reported being ready", gateway.Name))
-	// 			useSvc = false
-	// 		}
-	// 	}
-
-	// 	svcIP := netip.MustParseAddr(svc.Spec.ClusterIP)
-	// 	addr := &workloadapi.GatewayAddress{
-	// 		Destination: &workloadapi.GatewayAddress_Address{
-	// 			Address: &workloadapi.NetworkAddress{
-	// 				Network: c.Network(svcIP.String(), make(labels.Instance, 0)).String(),
-	// 				Address: svcIP.AsSlice(),
-	// 			},
-	// 		},
-	// 		Port: waypointPort,
-	// 	}
-
-	// 	if isDelete {
-	// 		if proto.Equal(a.waypoints[scope], addr) {
-	// 			delete(a.waypoints, scope)
-	// 			updates.Merge(a.updateWaypoint(scope, addr, true))
-	// 		}
-	// 	} else {
-	// 		if !proto.Equal(a.waypoints[scope], addr) && useSvc {
-	// 			a.waypoints[scope] = addr
-	// 			updates.Merge(a.updateWaypoint(scope, addr, false))
-	// 		}
-	// 	}
-	// }
-
 	si := c.constructService(svc)
 	networkAddrs := toInternalNetworkAddresses(si.GetAddresses())
 	pods := c.getPodsInService(svc)

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -28,7 +28,6 @@ import (
 
 	"istio.io/api/networking/v1alpha3"
 	apiv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
@@ -37,12 +36,9 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kind"
 	kubeutil "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
-	"istio.io/istio/pkg/kube/kclient"
-	"istio.io/istio/pkg/kube/kubetypes"
 	kubelabels "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/spiffe"
@@ -549,11 +545,7 @@ func (c *Controller) setupIndex() *AmbientIndexImpl {
 		},
 	}
 
-	// initNetworkManager initializes this if features.MultiNetworkGatewayAPI is enabled
-	// TODO: sort this out, it's probably not good to have 2 points of initialization
-	if !features.MultiNetworkGatewayAPI {
-		c.gatewayResourceClient = kclient.NewDelayedInformer[*k8sbeta.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
-	}
+	// initNetworkManager initializes the gatewayResourceClient, it should not be re-initialized in setupIndex
 	c.gatewayResourceClient.AddEventHandler(kubeGatewayHandler)
 
 	return &idx

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -936,7 +936,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	controller.network = networkID
 	pc := clienttest.Wrap(t, controller.podsClient)
 	sc := clienttest.Wrap(t, controller.services)
-	grc := clienttest.WrapReadWriter[*k8sbeta.Gateway](t, controller.gatewayResourceClient)
+	grc := clienttest.Wrap(t, controller.gatewayResourceClient)
 	cfg.RegisterEventHandler(gvk.AuthorizationPolicy, controller.AuthorizationPolicyHandler)
 	cfg.RegisterEventHandler(gvk.PeerAuthentication, controller.PeerAuthenticationHandler)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -429,11 +429,11 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		map[string]string{constants.WaypointServiceAccount: "sa2"}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-sa"))
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
+	s.assertEvent(t, s.podXdsName("pod1"))
 	s.addService(t, "waypoint-ns",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{},
 		[]int32{80}, map[string]string{constants.GatewayNameLabel: "namespace-wide"}, "10.0.0.2")
-	s.assertEvent(t, s.podXdsName("pod1"))
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"), s.svcXdsName("waypoint-ns"))
 
 	s.clearEvents()

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -943,6 +943,11 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa st
 		Spec:   &gatewaySpec,
 		Status: &k8sbeta.GatewayStatus{},
 	}
+	if sa != "" {
+		annotations := make(map[string]string, 1)
+		annotations[constants.WaypointServiceAccount] = sa
+		gwconfig.Meta.Annotations = annotations
+	}
 	_, err := s.cfg.Create(gwconfig)
 	if err != nil {
 		t.Fatal(err)

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -252,14 +252,14 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	s.assertAddresses(t, "", "pod1", "pod2", "pod3", "pod4", "waypoint-ns-pod", "waypoint-sa2-pod")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
 
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", testNS, "", time.Duration(0))
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
 	// create the waypoint service
 	s.addService(t, "waypoint-ns",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{},
 		[]int32{80}, map[string]string{constants.GatewayNameLabel: "namespace-wide"}, "10.0.0.2")
 
-	s.addWaypoint(t, "10.0.0.3", "waypoint-sa2", testNS, "sa2", time.Duration(0))
+	s.addWaypoint(t, "10.0.0.3", "waypoint-sa2", "sa2")
 	// create the waypoint service
 	s.addService(t, "waypoint-sa2",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
@@ -389,14 +389,14 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	s.deletePod(t, "pod2")
 	s.assertEvent(t, s.podXdsName("pod2"))
 
-	s.deleteWaypoint(t, "waypoint-ns", testNS)
+	s.deleteWaypoint(t, "waypoint-ns")
 	s.deleteService(t, "waypoint-ns")
 	s.assertEvent(t, s.podXdsName("pod1"))
 	s.assertEvent(t,
 		s.podXdsName("waypoint-ns-pod"),
 		s.svcXdsName("waypoint-ns"))
 
-	s.deleteWaypoint(t, "waypoint-sa2", testNS)
+	s.deleteWaypoint(t, "waypoint-sa2")
 	s.deleteService(t, "waypoint-sa2")
 	s.assertEvent(t, s.podXdsName("pod4"))
 	s.assertEvent(t,
@@ -425,7 +425,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{constants.WaypointServiceAccount: "sa2"}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-sa"))
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", testNS, "", 0)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
 	s.addService(t, "waypoint-ns",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
 		map[string]string{},
@@ -946,7 +946,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	}
 }
 
-func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa string, delay time.Duration) {
+func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, sa string) {
 	t.Helper()
 
 	fromSame := k8sbeta.NamespacesFromSame
@@ -970,7 +970,7 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa st
 		Meta: config.Meta{
 			GroupVersionKind: gvk.KubernetesGateway,
 			Name:             name,
-			Namespace:        namespace,
+			Namespace:        testNS,
 		},
 		Spec:   &gatewaySpec,
 		Status: &k8sbeta.GatewayStatus{},
@@ -984,7 +984,6 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa st
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(delay)
 	addrType := k8sbeta.IPAddressType
 	gwconfig.Status = &k8sbeta.GatewayStatus{
 		// addresses:
@@ -1003,9 +1002,9 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa st
 	}
 }
 
-func (s *ambientTestServer) deleteWaypoint(t *testing.T, name, namespace string) {
+func (s *ambientTestServer) deleteWaypoint(t *testing.T, name string) {
 	t.Helper()
-	_ = s.cfg.Delete(gvk.KubernetesGateway, name, namespace, nil)
+	_ = s.cfg.Delete(gvk.KubernetesGateway, name, testNS, nil)
 }
 
 func (s *ambientTestServer) addPods(t *testing.T, ip string, name, sa string, labels map[string]string,

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -964,7 +964,6 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, namespace, sa st
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func (s *ambientTestServer) deleteWaypoint(t *testing.T, name, namespace string) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -44,8 +44,11 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -936,7 +939,8 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	controller.network = networkID
 	pc := clienttest.Wrap(t, controller.podsClient)
 	sc := clienttest.Wrap(t, controller.services)
-	grc := clienttest.Wrap(t, controller.gatewayResourceClient)
+	clienttest.MakeCRD(t, controller.client, gvr.KubernetesGateway)
+	grc := clienttest.Wrap(t, kclient.NewFiltered[*k8sbeta.Gateway](controller.client, kubetypes.Filter{}))
 	cfg.RegisterEventHandler(gvk.AuthorizationPolicy, controller.AuthorizationPolicyHandler)
 	cfg.RegisterEventHandler(gvk.PeerAuthentication, controller.PeerAuthenticationHandler)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -993,7 +993,6 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, sa string) {
 		annotations[constants.WaypointServiceAccount] = sa
 		gateway.Annotations = annotations
 	}
-	_ = s.grc.Create(&gateway)
 	addrType := k8sbeta.IPAddressType
 	gateway.Status = k8sbeta.GatewayStatus{
 		// addresses:
@@ -1006,7 +1005,7 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, sa string) {
 			},
 		},
 	}
-	_ = s.grc.UpdateStatus(&gateway)
+	_ = s.grc.Create(&gateway)
 }
 
 func (s *ambientTestServer) deleteWaypoint(t *testing.T, name string) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -243,6 +243,13 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	s.addPods(t, "127.0.0.4", "pod4", "sa2", map[string]string{"app": "b"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod4"))
 
+	// Prime gateway informer with throw away events
+	s.addWaypoint(t, "10.0.0.2", "primer", "")
+	s.deleteWaypoint(t, "primer")
+	s.clearEvents()
+	stop := test.NewStop(t)
+	s.controller.client.WaitForCacheSync("test", stop)
+
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
 	// All these workloads updated, so push them
 	s.assertEvent(t, s.podXdsName("pod1"),

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -138,6 +138,12 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns-pod")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
+	// All these workloads updated, so push them
+	s.assertEvent(t,
+		s.wleXdsName("name1"),
+		s.wleXdsName("name2"),
+		s.wleXdsName("name3"),
+	)
 	// create the waypoint service
 	s.addService(t, "waypoint-ns",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel}, // labels
@@ -146,16 +152,10 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 		map[string]string{constants.GatewayNameLabel: "namespace-wide"}, // selector
 		"10.0.0.2",
 	)
-	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns", "waypoint-ns-pod")
-	// All these workloads updated, so push them
-	s.assertEvent(t,
-		s.wleXdsName("name1"),
-		s.wleXdsName("name2"),
-		s.wleXdsName("name3"),
-	)
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"),
 		s.svcXdsName("waypoint-ns"),
 	)
+	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns", "waypoint-ns-pod")
 	// We should now see the waypoint service IP
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.3"))[0].Address.GetWorkload().Waypoint.GetAddress().Address,

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -137,7 +137,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 		}, nil, true, corev1.PodRunning)
 	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns-pod")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "", true)
 	// All these workloads updated, so push them
 	s.assertEvent(t,
 		s.wleXdsName("name1"),

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -205,13 +205,13 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	s.assertEvent(t, s.wleXdsName("name6"))
 
 	s.deleteWaypoint(t, "waypoint-ns")
-	s.deleteService(t, "waypoint-ns")
 	// all affected addresses with the waypoint should be updated
 	s.assertEvent(t,
 		s.wleXdsName("name1"),
 		s.wleXdsName("name2"),
 		s.wleXdsName("name3"))
 
+	s.deleteService(t, "waypoint-ns")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"),
 		s.svcXdsName("waypoint-ns"))
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"net/netip"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +137,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 		}, nil, true, corev1.PodRunning)
 	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns-pod")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", testNS, "", time.Duration(0))
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "")
 	// create the waypoint service
 	s.addService(t, "waypoint-ns",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel}, // labels
@@ -205,7 +204,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	s.deleteWorkloadEntry(t, "name6")
 	s.assertEvent(t, s.wleXdsName("name6"))
 
-	s.deleteWaypoint(t, "waypoint-ns", testNS)
+	s.deleteWaypoint(t, "waypoint-ns")
 	s.deleteService(t, "waypoint-ns")
 	// all affected addresses with the waypoint should be updated
 	s.assertEvent(t,

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -46,7 +46,6 @@ type networkManager struct {
 	ranger    cidranger.Ranger
 	clusterID cluster.ID
 
-	// this should be an informer instead of a client however unit tests with an Informer were problematic and need further investigation
 	gatewayResourceClient kclient.Informer[*v1beta1.Gateway]
 	meshNetworksWatcher   mesh.NetworksWatcher
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -81,8 +81,10 @@ func initNetworkManager(c *Controller, options Options) *networkManager {
 		gatewaysFromResource:           make(map[types.UID]model.NetworkGatewaySet),
 		discoverRemoteGatewayResources: options.ConfigCluster,
 	}
-	// always initialize the gatewayResourceClient since ambient index will use it to configure waypoints
-	n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
+	// initialize the gateway resource client when any feature that uses it is enabled
+	if features.MultiNetworkGatewayAPI || features.EnableAmbientControllers {
+		n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
+	}
 	if features.MultiNetworkGatewayAPI {
 		// conditionally register this handler
 		registerHandlers(c, n.gatewayResourceClient, "Gateways", n.handleGatewayResource, nil)

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -81,8 +81,10 @@ func initNetworkManager(c *Controller, options Options) *networkManager {
 		gatewaysFromResource:           make(map[types.UID]model.NetworkGatewaySet),
 		discoverRemoteGatewayResources: options.ConfigCluster,
 	}
+	// always initialize the gatewayResourceClient since ambient index will use it to configure waypoints
+	n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
 	if features.MultiNetworkGatewayAPI {
-		n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
+		// conditionally register this handler
 		registerHandlers(c, n.gatewayResourceClient, "Gateways", n.handleGatewayResource, nil)
 	}
 	return n

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -33,7 +33,9 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/slices"
 )
@@ -45,7 +47,7 @@ type networkManager struct {
 	clusterID cluster.ID
 
 	// this should be an informer instead of a client however unit tests with an Informer were problematic and need further investigation
-	gatewayResourceClient kclient.Client[*v1beta1.Gateway]
+	gatewayResourceClient kclient.Informer[*v1beta1.Gateway]
 	meshNetworksWatcher   mesh.NetworksWatcher
 
 	// Network name for to be used when the meshNetworks fromRegistry nor network label on pod is specified
@@ -81,7 +83,7 @@ func initNetworkManager(c *Controller, options Options) *networkManager {
 		discoverRemoteGatewayResources: options.ConfigCluster,
 	}
 	if features.MultiNetworkGatewayAPI {
-		n.gatewayResourceClient = kclient.New[*v1beta1.Gateway](c.client)
+		n.gatewayResourceClient = kclient.NewDelayedInformer[*v1beta1.Gateway](c.client, gvr.KubernetesGateway, kubetypes.StandardInformer, kubetypes.Filter{})
 		registerHandlers(c, n.gatewayResourceClient, "Gateways", n.handleGatewayResource, nil)
 	}
 	return n

--- a/releasenotes/notes/46540.yaml
+++ b/releasenotes/notes/46540.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 46540
+
+releaseNotes:
+- |
+  **Fixed** adding waypoints can cause traffic disruption


### PR DESCRIPTION
**Please provide a description of this PR:**

- gateway status updater avoids populating the address field if there are no pods in the deployment ready
- gateway status updater prevents removing this if deployment become unready
- move waypoint configuration from svc to kube gateway
- new kube gateway handler only configures waypoint once the address field is populated on the kube gateway resource

addresses #46495