### PR TITLE
Add option to disable creation and management of default GatewayClasses

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -288,13 +288,15 @@ func (c *Controller) RegisterEventHandler(typ config.GroupVersionKind, handler m
 }
 
 func (c *Controller) Run(stop <-chan struct{}) {
-	go func() {
-		if c.waitForCRD(gvr.GatewayClass, stop) {
-			gcc := NewClassController(c.client)
-			c.client.RunAndWait(stop)
-			gcc.Run(stop)
-		}
-	}()
+	if features.EnableGatewayAPIGatewayClassController {
+		go func() {
+			if c.waitForCRD(gvr.GatewayClass, stop) {
+				gcc := NewClassController(c.client)
+				c.client.RunAndWait(stop)
+				gcc.Run(stop)
+			}
+		}()
+	}
 }
 
 func (c *Controller) HasSynced() bool {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -345,6 +345,9 @@ var (
 	EnableGatewayAPIDeploymentController = env.Register("PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER", true,
 		"If this is set to true, gateway-api resources will automatically provision in cluster deployment, services, etc").Get()
 
+	EnableGatewayAPIGatewayClassController = env.Register("PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER", true,
+		"If this is set to true, istiod will create and manage its default GatewayClasses").Get()
+
 	ClusterName = env.Register("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance belongs to").Get()
 

--- a/releasenotes/notes/46553.yaml
+++ b/releasenotes/notes/46553.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 46553
+releaseNotes:
+  - |
+    **Added** env var PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER to enable/disable management of built-in GatewayClasses.


### PR DESCRIPTION
By setting the environment variable PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER to false, users can instruct pilot not to create and manage the default GatewayClass objects. This lets other controllers manage these (or different) GatewayClasses.