### PR TITLE
Refactor: Avoid conversion to []byte by using WriteString

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -509,7 +509,7 @@ func writeToTempFile(content string) (string, error) {
 	}
 	defer func() { _ = outFile.Close() }()
 
-	if _, err := outFile.Write([]byte(content)); err != nil {
+	if _, err := outFile.WriteString(content); err != nil {
 		return "", fmt.Errorf("failed writing manifest file: %v", err)
 	}
 	return outFile.Name(), nil

--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -401,7 +401,7 @@ func writeToTempFile(content string) (string, error) {
 	}
 	defer func() { _ = outFile.Close() }()
 
-	if _, err := outFile.Write([]byte(content)); err != nil {
+	if _, err := outFile.WriteString(content); err != nil {
 		return "", fmt.Errorf("failed writing manifest file: %w", err)
 	}
 	return outFile.Name(), nil

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -334,7 +334,7 @@ func (os K8sObjects) YAMLManifest() (string, error) {
 		if _, err := b.Write(ym); err != nil {
 			return "", err
 		}
-		if _, err := b.Write([]byte(YAMLSeparator)); err != nil {
+		if _, err := b.WriteString(YAMLSeparator); err != nil {
 			return "", err
 		}
 

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -245,7 +245,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 					return err
 				}
 				buf.Write(b)
-				buf.Write([]byte("---\n"))
+				buf.WriteString("---\n")
 				return nil
 			}
 			client.RunAndWait(stop)

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -319,7 +319,7 @@ func TestGolden(t *testing.T) {
 			}
 			defer os.Remove(annoFile.Name())
 			for k, v := range c.annotations {
-				annoFile.Write([]byte(fmt.Sprintf("%s=%q\n", k, v)))
+				annoFile.WriteString(fmt.Sprintf("%s=%q\n", k, v))
 			}
 
 			node, err := GetNodeMetaData(MetadataOptions{

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -259,13 +259,13 @@ _complete istio 2>/dev/null
 		defer func() { _ = outFile.Close() }()
 
 		// Concatenate the head, initialization, generated bash, and tail to the file
-		if _, err = outFile.Write([]byte(zshInitialization)); err != nil {
+		if _, err = outFile.WriteString(zshInitialization); err != nil {
 			return fmt.Errorf("unable to output zsh initialization: %v", err)
 		}
 		if err = root.GenBashCompletion(outFile); err != nil {
 			return fmt.Errorf("unable to output zsh completion file: %v", err)
 		}
-		if _, err = outFile.Write([]byte(zshTail)); err != nil {
+		if _, err = outFile.WriteString(zshTail); err != nil {
 			return fmt.Errorf("unable to output zsh tail: %v", err)
 		}
 	}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -707,7 +707,7 @@ func customizeVMEnvironment(ctx resource.Context, cfg echo.Config, clusterEnv st
 	if cfg.VMEnvironment != nil {
 		for k, v := range cfg.VMEnvironment {
 			addition := fmt.Sprintf("%s=%s\n", k, v)
-			_, err = f.Write([]byte(addition))
+			_, err = f.WriteString(addition)
 			if err != nil {
 				return fmt.Errorf("failed writing %q to %s: %v", addition, clusterEnv, err)
 			}
@@ -715,7 +715,7 @@ func customizeVMEnvironment(ctx resource.Context, cfg echo.Config, clusterEnv st
 	}
 	if !ctx.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
 		// customize cluster.env with NodePort mapping
-		_, err = f.Write([]byte(fmt.Sprintf("ISTIO_PILOT_PORT=%d\n", istiodAddr.Port())))
+		_, err = f.WriteString(fmt.Sprintf("ISTIO_PILOT_PORT=%d\n", istiodAddr.Port()))
 		if err != nil {
 			return err
 		}

--- a/security/pkg/nodeagent/caclient/credentials_test.go
+++ b/security/pkg/nodeagent/caclient/credentials_test.go
@@ -143,7 +143,7 @@ func writeToTempFile(content, fileNamePrefix string) (string, error) {
 	}
 	defer func() { _ = outFile.Close() }()
 
-	if _, err := outFile.Write([]byte(content)); err != nil {
+	if _, err := outFile.WriteString(content); err != nil {
 		return "", fmt.Errorf("failed writing to the temp file: %v", err)
 	}
 	return outFile.Name(), nil


### PR DESCRIPTION
This PR replaces `.Write([]byte(...))` with `.WriteString(...)`.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
