### PR TITLE
Fix Istioctl Analyze not consistently respecting Exports for ServiceEntry used by VirtualService

### DIFF
--- a/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -64,6 +64,17 @@ spec:
   - "other.bookinfo.com" # This ServiceEntry should not match any instance as it isn't exported to other namespaces
 ---
 apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-entry-exported
+  namespace: other
+spec:
+  exportTo:
+    - "default"
+  hosts:
+  - "abc.bookinfo.com" # This ServiceEntry matches a destination host in a virtualService in another namespace
+---
+apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: reviews
@@ -341,3 +352,14 @@ spec:
     - route:
         - destination:
             host: hello.hello.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: vs-to-extporto-serviceentry
+  namespace: default
+spec:
+  http:
+  - route:
+    - destination:  # This virtualservice has no validation errors
+        host: abc.bookinfo.com # Host defined in an SE in another namespace, but exported to this namespace

--- a/releasenotes/notes/46597.yaml
+++ b/releasenotes/notes/46597.yaml
@@ -5,4 +5,4 @@ issue:
 - 46597
 releaseNotes:
 - |
-  **Fixed** istioctl analyze incorrectly showing an error when ServiceEntry hosts are used in a VirtualService destination across namespace boundary.
+  **Fixed** `istioctl analyze` incorrectly showing an error when ServiceEntry hosts are used in a VirtualService destination across namespace boundary.

--- a/releasenotes/notes/46597.yaml
+++ b/releasenotes/notes/46597.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 46597
+releaseNotes:
+- |
+  **Fixed** istioctl analyze incorrectly showing an error when ServiceEntry hosts are used in a VirtualService destination across namespace boundary.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/46597

When a ServiceEntry exports to a namespace by name (rather than wildcard `"*"`), any VirtualService in that target namespace which references the ServiceEntry's hostname was showing as an error.



<details open>
  <summary>Example Config showing the issue</summary>

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: external-svc-virtualdestination
  namespace: foo
spec:
  hosts:
  - foobar.staging.mesh
  location: MESH_INTERNAL
  ports:
  - number: 80
    name: https
    protocol: HTTP
    targetPort: 80
  resolution: DNS
  exportTo:
    - "bar" # Note exporting to the bar namespace of the VS below
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: foo-route
  namespace: bar
spec:
  hosts:
  - foo.foo.svc.cluster.local
  http:
  - name: "foo-route"
    match:
    - uri:
        prefix: "/"
    route:
    - destination:
        host: foobar.staging.mesh
        port:
          number: 80
```
</details>

This was resulting in an error:
> Error [IST0101] (VirtualService bar/foo-route) Referenced host not found: "foobar.staging.mesh"