### PR TITLE
Ambient: fix incorrect updates when ambient namespace label is changed

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -38,7 +38,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/util/workloadinstances"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -244,22 +243,6 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)
 
-	if features.EnableAmbientControllers {
-		registerHandlers[*v1.Namespace](
-			c,
-			c.namespaces,
-			"Namespaces",
-			func(old *v1.Namespace, cur *v1.Namespace, event model.Event) error {
-				c.handleSelectedNamespace(cur.Name)
-				return nil
-			},
-			func(old, cur *v1.Namespace) bool {
-				oldLabel := old.Labels[constants.DataplaneMode]
-				newLabel := cur.Labels[constants.DataplaneMode]
-				return oldLabel == newLabel
-			},
-		)
-	}
 	if c.opts.SystemNamespace != "" {
 		registerHandlers[*v1.Namespace](
 			c,

--- a/releasenotes/notes/46614.yaml
+++ b/releasenotes/notes/46614.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where Ambient pods are incorrectly processed when Ambient namespace label is changed.


### PR DESCRIPTION
**Please provide a description of this PR:**
It seems strange and incorrect to me to perform the update when the ambient label is changed - without checking the value. I think all of the resources have been processed when the namespace or pod is added.