### PR TITLE
Fix potential test flake and wrong map nil check

### DIFF
--- a/pilot/pkg/model/network.go
+++ b/pilot/pkg/model/network.go
@@ -296,7 +296,7 @@ func (gws *NetworkGateways) GatewaysForNetwork(nw network.ID) []NetworkGateway {
 func (gws *NetworkGateways) GatewaysForNetworkAndCluster(nw network.ID, c cluster.ID) []NetworkGateway {
 	gws.mu.RLock()
 	defer gws.mu.RUnlock()
-	if gws.byNetwork == nil {
+	if gws.byNetworkAndCluster == nil {
 		return nil
 	}
 	return gws.byNetworkAndCluster[networkAndClusterFor(nw, c)]

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
@@ -35,7 +35,9 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, nil)
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
 	s.assertEvent(t, s.seIPXdsName("name1", "127.0.0.1"), "ns1/se.istio.io")
+	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RLock()
 	assert.Equal(t, len(s.controller.ambientIndex.(*AmbientIndexImpl).byWorkloadEntry), 1)
+	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RUnlock()
 	assert.Equal(t, s.lookup(s.addrXdsName("127.0.0.1")), []*model.AddressInfo{{
 		Address: &workloadapi.Address{
 			Type: &workloadapi.Address_Workload{
@@ -66,7 +68,9 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	}})
 
 	s.deleteServiceEntry(t, "name1", testNS)
+	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RLock()
 	assert.Equal(t, len(s.controller.ambientIndex.(*AmbientIndexImpl).byWorkloadEntry), 0)
+	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RUnlock()
 	assert.Equal(t, s.lookup(s.addrXdsName("127.0.0.1")), nil)
 	s.clearEvents()
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes the wrong nil check in `pilot/pkg/model/network.go` and fixes a potential test race that reads memory that should be behind a read lock.