### PR TITLE
Operator: do not allow installing ambient profile in operator controller

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -279,6 +279,10 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 			return reconcile.Result{}, nil
 		}
 	}
+	if iop.Spec.Profile == "ambient" {
+		scope.Infof("Ignoring the IstioOperator CR %s because it is using the unsupported profile 'ambient'.", iopName)
+		return reconcile.Result{}, nil
+	}
 
 	var err error
 	iopMerged := &iopv1alpha1.IstioOperator{}

--- a/releasenotes/notes/46651.yaml
+++ b/releasenotes/notes/46651.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 46524
+releaseNotes:
+- |
+  **Removed** support for installing `ambient` profile with in-cluster operator.


### PR DESCRIPTION
**Please provide a description of this PR:**
Part of https://github.com/istio/istio/issues/46524


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure