### PR TITLE
Fix istio-cni-node crash when the Kubernetes pod network is not implemented using veth

### DIFF
--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -102,6 +102,7 @@ func (s *Server) updateNodeProxyEBPF(pod *corev1.Pod, captureDNS bool) error {
 	veth, err := getVethWithDestinationOf(ip)
 	if err != nil {
 		log.Warnf("failed to get device: %v", err)
+		return err
 	}
 	peerIndex, err := getPeerIndex(veth)
 	if err != nil {


### PR DESCRIPTION

**Please provide a description of this PR:**

Fix istio-cni-node crash when the Kubernetes pod network is not implemented using veth

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure