### PR TITLE
Have the DUAL_STACK env variable uniform across the repo

### DIFF
--- a/operator/pkg/manifest/shared_test.go
+++ b/operator/pkg/manifest/shared_test.go
@@ -108,7 +108,7 @@ func TestConvertIOPMapValues(t *testing.T) {
 			name:         "convention_boolean",
 			convertPaths: defaultSetFlagConvertPaths,
 			inputFlags: []string{
-				"meshConfig.defaultConfig.proxyMetadata.ISTIO_AGENT_DUAL_STACK=false",
+				"meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK=false",
 				"meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT=false",
 			},
 		}, {

--- a/operator/pkg/util/testdata/yaml/input/convention_boolean.yaml
+++ b/operator/pkg/util/testdata/yaml/input/convention_boolean.yaml
@@ -7,7 +7,7 @@ spec:
   meshConfig:
     defaultConfig:
       proxyMetadata:
-        ISTIO_AGENT_DUAL_STACK: false
+        ISTIO_DUAL_STACK: false
         PROXY_XDS_VIA_AGENT: false
   values:
     pilot:

--- a/operator/pkg/util/testdata/yaml/output/convention_boolean.yaml
+++ b/operator/pkg/util/testdata/yaml/output/convention_boolean.yaml
@@ -7,7 +7,7 @@ spec:
   meshConfig:
     defaultConfig:
       proxyMetadata:
-        ISTIO_AGENT_DUAL_STACK: "false"
+        ISTIO_DUAL_STACK: "false"
         PROXY_XDS_VIA_AGENT: "false"
   values:
     pilot:


### PR DESCRIPTION
As per https://github.com/istio/istio.io/pull/13542 the older env variable is removed.
So, better not to use that anywhere in the tests, though this is not impacting anything.