### PR TITLE
Fix platform type

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -16,12 +16,10 @@ package platform
 
 import "istio.io/istio/pkg/env"
 
-type PlatformType string
-
 const (
-	Default   PlatformType = ""
-	OpenShift PlatformType = "openshift"
-	GCP       PlatformType = "gcp"
+	Default   = ""
+	OpenShift = "openshift"
+	GCP       = "gcp"
 )
 
 var Platform = env.Register(


### PR DESCRIPTION
Istiod reports this at initialization:

```
warn	Invalid environment variable value `gcp` defaulting to "": invalid character 'g' looking for beginning of value
```

No matter the value this variable is assigned.

Using the type `string` directly fixes it.
