### PR TITLE
Fix wrong key when adding a WE to Ambient index

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -106,7 +106,7 @@ func (a *AmbientIndexImpl) handleServiceEntry(svcEntry *apiv1alpha3.ServiceEntry
 			for _, networkAddr := range networkAddressFromWorkload(wl) {
 				a.byWorkloadEntry[networkAddr] = wl
 			}
-			a.byUID[c.generateServiceEntryUID(svcEntry.GetNamespace(), svcEntry.GetName(), w.Spec.GetAddress())] = wl
+			a.byUID[c.generateWorkloadEntryUID(wl.GetNamespace(), wl.GetName())] = wl
 			updates.Insert(model.ConfigKey{Kind: kind.Address, Name: wl.ResourceName()})
 			wls[wl.Uid] = wl
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
@@ -274,6 +274,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 
 	s.deleteServiceEntry(t, "name1", testNS)
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
+	s.assertUniqueWorkloads(t)
 	// we should see an update for the workloads selected by the service entry
 	s.assertEvent(t, s.podXdsName("pod1"), s.wleXdsName("name0"), s.wleXdsName("name1"), "ns1/se.istio.io")
 	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []*model.AddressInfo{{

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -1080,6 +1080,18 @@ func (s *ambientTestServer) assertWorkloads(t *testing.T, lookup string, state w
 	}, want, retry.Timeout(time.Second*3))
 }
 
+// Make sure there are no two workloads in the index with similar UIDs
+func (s *ambientTestServer) assertUniqueWorkloads(t *testing.T) {
+	t.Helper()
+	uids := sets.New[string]()
+	workloads := s.lookup("")
+	for _, wl := range workloads {
+		if wl.GetWorkload() != nil && uids.InsertContains(wl.GetWorkload().GetUid()) {
+			t.Fatal("Index has workloads with the same UID")
+		}
+	}
+}
+
 func (s *ambientTestServer) addPolicy(t *testing.T, name, ns string, selector map[string]string,
 	kind config.GroupVersionKind, modify func(*config.Config),
 ) {


### PR DESCRIPTION
**Please provide a description of this PR:**

Wrong key used when adding a WorkloadEntry to the ambient index caused duplicated entries with similar UIDs but different keys in some scenarios.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure