### PR TITLE
Set root-cert.pem to ca-cert.pem in ca secret

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -194,7 +194,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 				return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
 			}
 			// Write the key/cert back to secret, so they will be persistent when CA restarts.
-			secret := BuildSecret(caCertName, namespace, nil, nil, nil, pemCert, pemKey, istioCASecretType)
+			secret := BuildSecret(caCertName, namespace, nil, nil, pemCert, pemCert, pemKey, istioCASecretType)
 			_, err = client.Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 			if apierror.IsAlreadyExists(err) {
 				pkiCaLog.Debugf("Failed to create secret %s (%v)", caCertName, err)


### PR DESCRIPTION
**Please provide a description of this PR:**

Set root-cert.pem when creating istios generated self-signed ca cert.

Resolves #46600

**Testing:**
- This regression may have been caught by the downgrade equivalent of `revisioned_upgrade_test.go`. It might be worth revisiting https://github.com/istio/istio/pull/46213

**Open Questions:**
- What was the reasoning behind not setting `root-cert.pem` in the self-signed istiod generated ca secret? Will setting this field have any unintended consequences for the user?
