### PR TITLE
Authz for Inlined WorkloadEntries in Ambient

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -498,6 +498,21 @@ func (c *Controller) getSelectedWorkloadEntries(ns string, selector map[string]s
 			workloadEntries = append(workloadEntries, wl)
 		}
 	}
+
+	// Include workload entries inlined in service entries (endpoints)
+	allServiceEntries := c.configController.List(gvk.ServiceEntry, ns)
+	for _, se := range allServiceEntries {
+		if labels.Instance(selector).SubsetOf(se.Labels) {
+			for _, wl := range serviceentry.ConvertServiceEntry(se).Endpoints {
+				c := &apiv1alpha3.WorkloadEntry{
+					ObjectMeta: se.ToObjectMeta(),
+					Spec:       *wl.DeepCopy(),
+				}
+				workloadEntries = append(workloadEntries, c)
+			}
+		}
+	}
+
 	return workloadEntries
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -502,13 +502,12 @@ func (c *Controller) getSelectedWorkloadEntries(ns string, selector map[string]s
 	// Include workload entries inlined in service entries (endpoints)
 	allServiceEntries := c.configController.List(gvk.ServiceEntry, ns)
 	for _, se := range allServiceEntries {
-		if labels.Instance(selector).SubsetOf(se.Labels) {
-			for _, wl := range serviceentry.ConvertServiceEntry(se).Endpoints {
-				c := &apiv1alpha3.WorkloadEntry{
+		for _, wl := range serviceentry.ConvertServiceEntry(se).Endpoints {
+			if labels.Instance(selector).SubsetOf(wl.Labels) || (len(wl.Labels) == 0 && labels.Instance(selector).SubsetOf(se.Labels)) {
+				workloadEntries = append(workloadEntries, &apiv1alpha3.WorkloadEntry{
 					ObjectMeta: se.ToObjectMeta(),
 					Spec:       *wl.DeepCopy(),
-				}
-				workloadEntries = append(workloadEntries, c)
+				})
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
@@ -32,7 +32,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 
 	// test code path where service entry creates a workload entry via `ServiceEntry.endpoints`
 	// and the inlined WE has a port override
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, nil)
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, nil, true)
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
 	s.assertEvent(t, s.seIPXdsName("name1", "127.0.0.1"), "ns1/se.istio.io")
 	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RLock()
@@ -139,7 +139,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
 
 	// a service entry should not be able to select across namespaces
-	s.addServiceEntry(t, "mismatched.istio.io", []string{"240.240.23.45"}, "name1", "mismatched-ns", map[string]string{"app": "a"})
+	s.addServiceEntry(t, "mismatched.istio.io", []string{"240.240.23.45"}, "name1", "mismatched-ns", map[string]string{"app": "a"}, false)
 	s.assertEvent(t, "mismatched-ns/mismatched.istio.io")
 	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []*model.AddressInfo{{
 		Address: &workloadapi.Address{
@@ -183,7 +183,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 		},
 	}})
 
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"})
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, false)
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
 	// we should see an update for the workloads selected by the service entry
 	// do not expect event for pod2 since it is not selected by the service entry

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -979,14 +979,14 @@ func (s *ambientTestServer) deleteWorkloadEntry(t *testing.T, name string) {
 	_ = s.cfg.Delete(gvk.WorkloadEntry, name, "ns1", nil)
 }
 
-func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addresses []string, name, ns string, labels map[string]string) {
+func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addresses []string, name, ns string, labels map[string]string, inlined bool) {
 	t.Helper()
 
 	_, _ = s.controller.client.Kube().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{"istio.io/dataplane-mode": "ambient"}},
 	}, metav1.CreateOptions{})
 
-	serviceEntry := generateServiceEntry(hostStr, addresses, labels)
+	serviceEntry := generateServiceEntry(hostStr, addresses, labels, inlined)
 	w := config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.ServiceEntry,
@@ -1005,11 +1005,11 @@ func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addres
 	}
 }
 
-func generateServiceEntry(host string, addresses []string, labels map[string]string) *v1alpha3.ServiceEntry {
+func generateServiceEntry(host string, addresses []string, labels map[string]string, inlined bool) *v1alpha3.ServiceEntry {
 	var endpoints []*v1alpha3.WorkloadEntry
 	var workloadSelector *v1alpha3.WorkloadSelector
 
-	if len(labels) > 0 {
+	if !inlined {
 		workloadSelector = &v1alpha3.WorkloadSelector{
 			Labels: labels,
 		}
@@ -1017,6 +1017,7 @@ func generateServiceEntry(host string, addresses []string, labels map[string]str
 		endpoints = []*v1alpha3.WorkloadEntry{
 			{
 				Address: "127.0.0.1",
+				Labels:  labels,
 				Ports: map[string]uint32{
 					"http": 8081, // we will override the SE http port
 				},

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -297,3 +297,23 @@ func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
 	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "emptyaddr1")
 }
+
+func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	s := newAmbientTestServer(t, testC, testNW)
+
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, true)
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
+	s.assertEvent(t, s.seIPXdsName("name1", "127.0.0.1"), "ns1/se.istio.io")
+
+	s.addPolicy(t, "selector", "ns1", map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
+	assert.Equal(t,
+		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		[]string{"ns1/selector"})
+
+	_ = s.cfg.Delete(gvk.AuthorizationPolicy, "selector", "ns1", nil)
+	s.assertEvent(t, s.wleXdsName("name1"))
+	assert.Equal(t,
+		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		nil)
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -302,9 +302,9 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, true)
-	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
-	s.assertEvent(t, s.seIPXdsName("name1", "127.0.0.1"), "ns1/se.istio.io")
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, true)
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "se1")
+	s.assertEvent(t, s.seIPXdsName("se1", "127.0.0.1"), "ns1/se.istio.io")
 
 	s.addPolicy(t, "selector", "ns1", map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
 	assert.Equal(t,
@@ -312,7 +312,7 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 		[]string{"ns1/selector"})
 
 	_ = s.cfg.Delete(gvk.AuthorizationPolicy, "selector", "ns1", nil)
-	s.assertEvent(t, s.wleXdsName("name1"))
+	s.assertEvent(t, s.wleXdsName("se1"))
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
 		nil)


### PR DESCRIPTION
**Please provide a description of this PR:**

When applying an authz policy with selector it currently doesn't apply to WE that were inlined in SE ([endpoints](https://istio.io/latest/docs/reference/config/networking/service-entry/#ServiceEntry)).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure