### PR TITLE
Remove sync.WaitGroup from production code in adsc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stoewer/go-strcase v1.3.0
+	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/yl2chen/cidranger v1.0.2
 	go.opentelemetry.io/otel v1.16.0
@@ -223,7 +224,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -210,9 +210,6 @@ type ADSC struct {
 	// restarts.
 	LocalCacheDir string
 
-	// RecvWg is for letting goroutines know when the goroutine handling the ADS stream finishes.
-	RecvWg sync.WaitGroup
-
 	cfg *Config
 
 	// sendNodeMeta is set to true if the connection is new - and we need to send node meta.,
@@ -274,7 +271,6 @@ func New(discoveryAddr string, opts *Config) (*ADSC, error) {
 		VersionInfo: map[string]string{},
 		url:         discoveryAddr,
 		Received:    map[string]*discovery.DiscoveryResponse{},
-		RecvWg:      sync.WaitGroup{},
 		cfg:         opts,
 		sync:        map[string]time.Time{},
 		errChan:     make(chan error, 10),
@@ -441,10 +437,6 @@ func (a *ADSC) Run() error {
 		}
 		_ = a.Send(r)
 	}
-	// by default, we assume 1 goroutine decrements the waitgroup (go a.handleRecv()).
-	// for synchronizing when the goroutine finishes reading from the gRPC stream.
-
-	a.RecvWg.Add(1)
 
 	go a.handleRecv()
 	return nil
@@ -498,7 +490,6 @@ func (a *ADSC) handleRecv() {
 		var err error
 		msg, err := a.stream.Recv()
 		if err != nil {
-			a.RecvWg.Done()
 			adscLog.Infof("Connection closed for node %v with err: %v", a.nodeID, err)
 			select {
 			case a.errChan <- err:

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -187,14 +187,18 @@ func TestADSC_Run(t *testing.T) {
 				return
 			}
 			assert.Eventually(t, func() bool {
-				if tt.inAdsc.Received == nil && len(tt.inAdsc.Received) != len(tt.expectedADSResources.Received) {
+				tt.inAdsc.mutex.Lock()
+				defer tt.inAdsc.mutex.Unlock()
+				rec := tt.inAdsc.Received
+
+				if rec == nil && len(rec) != len(tt.expectedADSResources.Received) {
 					return false
 				}
 				for tpe, rsrcs := range tt.expectedADSResources.Received {
-					if _, ok := tt.inAdsc.Received[tpe]; !ok {
+					if _, ok := rec[tpe]; !ok {
 						return false
 					}
-					if len(rsrcs.Resources) != len(tt.inAdsc.Received[tpe].Resources) {
+					if len(rsrcs.Resources) != len(rec[tpe].Resources) {
 						return false
 					}
 				}

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/api/label"
 	mcp "istio.io/api/mcp/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/collections"


### PR DESCRIPTION
`sync.WaitGroup` is only present because tests depend on this. Tests can be written in a way that will not require this by using retry with backoff. This is a much safer solution with a built in timeout. This will remove the risk of production code changing in a way that will cause this particular test to wait forever.

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure