### PR TITLE
Add ability to install gateway helm chart with dual-stack service def…

### DIFF
--- a/manifests/charts/gateway/templates/service.yaml
+++ b/manifests/charts/gateway/templates/service.yaml
@@ -15,6 +15,13 @@ spec:
 {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ . }}"
 {{- end }}
+{{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: "{{ . }}"
+{{- end }}
+{{- with .Values.service.ipFamilies }}
+  ipFamilies:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml . | indent 4 }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -129,6 +129,16 @@
         "loadBalancerSourceRanges": {
           "type": "array"
         },
+        "ipFamilies" : {
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+        }
+        },
+        "ipFamilyPolicy" : {
+          "type": "string",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
         "ports": {
           "type": "array",
           "items": {

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -57,6 +57,8 @@ service:
   loadBalancerSourceRanges: []
   externalTrafficPolicy: ""
   externalIPs: []
+  ipFamilyPolicy: ""
+  ipFamilies: []
 
 resources:
   requests:

--- a/releasenotes/notes/gateway-dual-stack.yaml
+++ b/releasenotes/notes/gateway-dual-stack.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+releaseNotes:
+- |
+  **Added** ability to install gateway helm chart with a dual-stack service definition.

--- a/releasenotes/notes/gateway-dual-stack.yaml
+++ b/releasenotes/notes/gateway-dual-stack.yaml
@@ -1,7 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: installation
-issue:
 releaseNotes:
 - |
   **Added** ability to install gateway helm chart with a dual-stack service definition.


### PR DESCRIPTION
…inition

**Please provide a description of this PR:**
Gateway routing currently functions for experimental dual-stack, but this PR adds the ability to modify the service definition to support dual-stack configurations.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure