### PR TITLE
Use file watch for istio-generated self-signed CA cert

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -166,6 +166,7 @@ func (s *Server) initDNSCerts() error {
 			return nil
 		})
 	} else {
+		// TODO(jaellio): Does this also need a root cert watch? Would this have used the plugged in cert workflow?
 		customCACertPath := security.DefaultRootCertFilePath
 		log.Infof("User specified cert provider: %v, mounted in a well known location %v",
 			features.PilotCertProvider, customCACertPath)
@@ -173,7 +174,6 @@ func (s *Server) initDNSCerts() error {
 		if err != nil {
 			return fmt.Errorf("failed reading %s: %v", customCACertPath, err)
 		}
-		//TODO(jaellio): Does this also need a root cert watch? Would this have used the plugged in cert workflow?
 	}
 	s.istiodCertBundleWatcher.SetAndNotify(keyPEM, certChain, caBundle)
 	return nil

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -457,6 +457,9 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 			maxWorkloadCertTTL.Get(), opts.TrustDomain, true,
 			opts.Namespace, s.kubeClient.Kube().CoreV1(), fileBundle.RootCertFile,
 			enableJitterForRootCertRotator.Get(), caRSAKeySize.Get())
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// The secret is mounted and the "istio-generated" key is not used.
 		log.Info("Use local CA certificate")

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -304,6 +304,7 @@ func handleEvent(s *Server) {
 
 	var newCABundle []byte
 	var err error
+	var istioGenerated bool
 
 	currentCABundle := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 
@@ -314,13 +315,17 @@ func handleEvent(s *Server) {
 	}
 	newCABundle, err = os.ReadFile(fileBundle.RootCertFile)
 
+	if _, err := os.Stat(path.Join(LocalCertDir.Get(), ca.IstioGenerated)); err == nil {
+		istioGenerated = true
+	}
+
 	if err != nil {
 		log.Errorf("failed reading root-cert.pem: %v", err)
 		return
 	}
 
-	// Only updating intermediate CA is supported now
-	if !bytes.Equal(currentCABundle, newCABundle) {
+	// Only updating intermediate CA is supported now for pluggin certs
+	if !bytes.Equal(currentCABundle, newCABundle) && !istioGenerated {
 		log.Info("Updating new ROOT-CA not supported")
 		return
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Part 2 of #41507 

Resolves #45686 

Adds additional internal ca secret type, `selfSignedMounted`. If the CA cert is self-signed and volume mounted a file watch and the `selfsignedcarootcertrotator` will both facilitate root cert rotation. The `selfsignedcarootcertrotator` checks the k8s secret periodically for expiration, generates a new CA cert from the existing private key, and updates the k8s secret. The file watch is responsible for watching the ca cert files, responding to events, and updating the KeyCertBundle if required. Previously, the `selfsignedcarootcertrotator` was also responsible for updating the KeyCertBundle when the CA cert was self-signed and istio generated (mounted or not).

Currently, root certificate rotation with pluggin root CAs is not supported in the file watch. This change adds support for root cert rotation via the file watch when the CA cert is istio-generated. If it is not istio generated it is still not supported. Without this change, the self-signed mounted CA cert option could not utilize the existing file watch implementation without a loss in functionality. 

Additionally, the change removes the dns/istiod cert update from the CA cert file watch. Updating Istiod/dns certs should happen separately from updating the `KeyCertBundle`. Istiod cert is the certificate used by Istiod as its identity. It is normally generated and signed by Istiod as the CA, but the cert can be file mounted using the `FILE_MOUNTED_CERT` env variable. During implementation I ran into a race condition when the Istiod cert was file mounted and Istiod as the CA was using a self-signed istiod generated root certificate. Istiod first sets up the CA (detects no CA secret, creates `cacerts` secret, and populates it with a self-signed cert), starts the ca file watcher, and starts the self signed ca root cert rotator.  The `cacerts` might not be mounted at this point. Then, Istiod begins the process of initializing its own cert. It will detect that custom certs were provided by the user and will use those and set up a watch on those files. If the `cacerts` secret is mounted after the istiod certs are loaded, the file watcher would have previously updated the KeyCertBundle **and** the istiod certs, overriding the custom istiod certs. 

**Testing:**
- Unit tests
- Manually test root cert rotation and non-root cert secret update for self-signed istio generated ca cert. Set a small expiration time to check for natural rotation and forced a rotation with a secret update.