### PR TITLE
Enable dual-stack for pilot integration tests

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -409,13 +409,13 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 				},
 			},
 		}
-		// There is an usage doc here:
+		// There is a usage doc here:
 		// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#config-core-v3-bindconfig
-		// to support the Dual Stack via Envoy bindconfig, and belows are related issue and PR in Envoy:
+		// to support Dual Stack via Envoy BindConfig, and below is the related issue/PR in Envoy:
 		// https://github.com/envoyproxy/envoy/issues/9811
-		// https://github.com/envoyproxy/envoy/pull/22639
-		// the extra source address for UpstreamBindConfig shoulde be added if dual stack is enabled and there are
-		// more than 1 IP for proxy
+		// https://github.com/envoyproxy/envoy/pull/22639.
+		// The extra source address for UpstreamBindConfig should be added if dual stack is enabled and there is
+		// more than one IP for the proxy.
 		if features.EnableDualStack && len(cb.passThroughBindIPs) > 1 {
 			// add extra source addresses to cluster builder
 			var extraSrcAddrs []*core.ExtraSourceAddress

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -41,7 +41,20 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(istio.Setup(&i, nil)).
+		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
+			if c.Settings().EnableDualStack {
+				cfg.ControlPlaneValues = `
+values:
+  pilot:
+    env:
+      ISTIO_DUAL_STACK: true
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_DUAL_STACK: "true"
+`
+			}
+		})).
 		Setup(deployment.SetupSingleNamespace(&apps, deployment.Config{})).
 		Setup(func(t resource.Context) error {
 			gatewayConformanceInputs.Client = t.Clusters().Default()

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -126,5 +126,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot)
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
 endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -126,5 +126,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot)
 endif


### PR DESCRIPTION
Even though we have a dual-stack pre-submit job, the dual-stack flag seems to be set only in the security tests. See: https://github.com/istio/istio/blob/3e8f29a160c06d57dc0436f8d9ce7db72f3de4b1/tests/integration/security/main_test.go#L52