### PR TITLE
router: include attempt count for response in virtual hosts

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -489,11 +489,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 						}
 					}
 					newVHost := &route.VirtualHost{
-						Name:                       util.DomainName(string(hostname), port),
-						Domains:                    []string{hostname.String()},
-						Routes:                     routes,
-						TypedPerFilterConfig:       perRouteFilters,
-						IncludeRequestAttemptCount: ph.IncludeRequestAttemptCount,
+						Name:                          util.DomainName(string(hostname), port),
+						Domains:                       []string{hostname.String()},
+						Routes:                        routes,
+						TypedPerFilterConfig:          perRouteFilters,
+						IncludeRequestAttemptCount:    ph.IncludeRequestAttemptCount,
+						IncludeAttemptCountInResponse: ph.IncludeResponseAttemptCount,
 					}
 					if server.Tls != nil && server.Tls.HttpsRedirect {
 						newVHost.RequireTls = route.VirtualHost_ALL
@@ -514,10 +515,11 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				continue
 			}
 			newVHost := &route.VirtualHost{
-				Name:                       util.DomainName(hostname, port),
-				Domains:                    []string{hostname},
-				IncludeRequestAttemptCount: ph.IncludeRequestAttemptCount,
-				RequireTls:                 route.VirtualHost_ALL,
+				Name:                          util.DomainName(hostname, port),
+				Domains:                       []string{hostname},
+				IncludeRequestAttemptCount:    ph.IncludeRequestAttemptCount,
+				IncludeAttemptCountInResponse: ph.IncludeResponseAttemptCount,
+				RequireTls:                    route.VirtualHost_ALL,
 			}
 			vHostDedupMap[host.Name(hostname)] = newVHost
 		}
@@ -616,6 +618,9 @@ func collapseDuplicateRoutes(input map[host.Name]*route.VirtualHost) map[host.Na
 // We explicitly do not check domains or name, as those are the keys for the merge
 func vhostMergeable(a, b *route.VirtualHost) bool {
 	if a.IncludeRequestAttemptCount != b.IncludeRequestAttemptCount {
+		return false
+	}
+	if a.IncludeAttemptCountInResponse != b.IncludeAttemptCountInResponse {
 		return false
 	}
 	if a.RequireTls != b.RequireTls {

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -2317,7 +2317,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 			for _, h := range r.VirtualHosts {
 				vh[h.Name] = h.Domains
 				hr[h.Name] = len(h.Routes)
-				if h.Name != "blackhole:80" && !h.IncludeRequestAttemptCount {
+				if h.Name != "blackhole:80" && !h.IncludeRequestAttemptCount && !h.IncludeAttemptCountInResponse {
 					t.Errorf("expected attempt count to be set in virtual host, but not found")
 				}
 				if tt.redirect != (h.RequireTls == route.VirtualHost_ALL) {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -1645,7 +1645,11 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 		}
 
 		if !vhost.GetIncludeRequestAttemptCount() {
-			t.Fatal("Expected that include request attempt count is set to true, but set to false")
+			t.Fatal("Expected that include request attempt count in request is set to true, but set to false")
+		}
+
+		if !vhost.GetIncludeAttemptCountInResponse() {
+			t.Fatal("Expected that include request attempt count in response is set to true, but set to false")
 		}
 	}
 	if (expectedRoutes >= 0) && (numberOfRoutes != expectedRoutes) {


### PR DESCRIPTION
Following the same logic as #21198

Where #21198 included x-envoy-attempt-count for the upstream requests, this PR adds the same header to the respective downstream responses.

**Please provide a description of this PR:**