### PR TITLE
Fix empty profile do not have components info during installation

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -186,9 +186,6 @@ func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, 
 	if !rootArgs.DryRun && !iArgs.SkipConfirmation {
 		prompt := fmt.Sprintf("This will install the Istio %s %q profile (with components: %s) into the cluster. Proceed? (y/N)",
 			tag, profile, humanReadableJoin(enabledComponents))
-		if profile == "empty" {
-			prompt = fmt.Sprintf("This will install the Istio %s %s profile into the cluster. Proceed? (y/N)", tag, profile)
-		}
 		if !Confirm(prompt, stdOut) {
 			p.Println("Cancelled.")
 			os.Exit(1)

--- a/releasenotes/notes/46780.yaml
+++ b/releasenotes/notes/46780.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where installing Istio with `empty` profile did not have components information displayed.


### PR DESCRIPTION
**Please provide a description of this PR:**
Not sure why there is specific logic to exclude the display of components of empty profile, but I think this is not accurate, especially since an empty profile can be installed with custom components enabled.