### PR TITLE
Gateway API: Honor global proxy image value

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -53,7 +53,11 @@ spec:
       serviceAccountName: {{.ServiceAccount | quote}}
       containers:
       - name: istio-proxy
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+      {{- else }}
         image: "{{ .ProxyImage }}"
+      {{- end }}
         {{- if .Values.global.proxy.resources }}
         resources:
           {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1480,7 +1480,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{- if .Values.global.proxy.resources }}
             resources:
               {{- toYaml .Values.global.proxy.resources | nindent 10 }}


### PR DESCRIPTION
Just like sidecar template, if the proxy image global value contains a "/", then use it unconditionally in the gateway api template.
