### PR TITLE
Fix ingressgateway being enabled in ambient profile

### DIFF
--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -21,7 +21,7 @@ spec:
       enabled: true
     ingressGateways:
     - name: istio-ingressgateway
-      enabled: true
+      enabled: false
 
   values:
     pilot:


### PR DESCRIPTION
**Please provide a description of this PR:**
When installing ambient with ambient profile, the ingressgateway is being installed as well. This feature was enabled after the merge of https://github.com/istio/istio/pull/46725. I think the fix should not affect ingressgateway?