### PR TITLE
add option to set sidecarInjectorWebhook timeoutSeconds to the istio control plane helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -29,7 +29,7 @@ a unique prefix to each. */}}
     resources: ["pods"]
   failurePolicy: Fail
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
-  timeoutSeconds: "{{ .timeoutSeconds }}"
+  timeoutSeconds: {{ .timeoutSeconds }}
   admissionReviewVersions: ["v1beta1", "v1"]
 {{- end }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -5,6 +5,7 @@
   "injectionPath" .Values.istiodRemote.injectionPath
   "injectionURL" .Values.istiodRemote.injectionURL
   "reinvocationPolicy" .Values.sidecarInjectorWebhook.reinvocationPolicy
+  "timeoutSeconds" .Values.sidecarInjectorWebhook.timeoutSeconds
   "namespace" .Release.Namespace }}
 {{- define "core" }}
 {{- /* Kubernetes unfortunately requires a unique name for the webhook in some newer versions, so we assign
@@ -28,6 +29,7 @@ a unique prefix to each. */}}
     resources: ["pods"]
   failurePolicy: Fail
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
+  timeoutSeconds: "{{ .timeoutSeconds }}"
   admissionReviewVersions: ["v1beta1", "v1"]
 {{- end }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -108,6 +108,12 @@ sidecarInjectorWebhook:
   # Setting this to `IfNeeded` will result in the sidecar injector being run again if additonal mutations occur.
   reinvocationPolicy: Never
 
+  # timeoutSeconds specifies the timeout for this webhook. After the timeout passes,
+  # the webhook call will be ignored or the API call will fail based on the failure policy.
+  # The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#mutatingwebhook-v1-admissionregistration-k8s-io
+  timeoutSeconds: 10
+
   rewriteAppHTTPProbe: true
 
   # Templates defines a set of custom injection templates that can be used. For example, defining:


### PR DESCRIPTION
**Please provide a description of this PR:**

The default `MutatingWebhook` timeout is 10 seconds.

The sidecar injection could be really slow when the pod resource is a very big chunk of yaml. 
We have seen an extreme case that took about 22 seconds with a pod resource of 64K.

It is all pinned down to this line of code
https://github.com/istio/istio/blob/f2c1f1240b5fb5faa96a1b7d78f6558be734ee76/pkg/kube/inject/webhook.go#L644

We're working on reducing the pod resource size.

It would be nice to have an option to adjust the webhook timeout.