### PR TITLE
Spell Marshal/Unmarshal consistently

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -87,7 +87,7 @@ type Config struct {
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
-// The field names need to match exact keys in kubelet args for unmarshalling
+// The field names need to match exact keys in kubelet args for unmarshaling
 type K8sArgs struct {
 	types.CommonArgs
 	IP                         net.IP

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -195,7 +195,7 @@ func testCmdAddWithStdinData(t *testing.T, stdinData string) {
 	}
 }
 
-// Validate k8sArgs struct works for unmarshalling kubelet args
+// Validate k8sArgs struct works for unmarshaling kubelet args
 func TestLoadArgs(t *testing.T) {
 	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
 		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +

--- a/cni/pkg/util/util.go
+++ b/cni/pkg/util/util.go
@@ -98,7 +98,7 @@ func watchFiles(watcher *fsnotify.Watcher, fileModified chan struct{}, errChan c
 	}
 }
 
-// Read CNI config from file and return the unmarshalled JSON as a map
+// Read CNI config from file and return the unmarshaled JSON as a map
 func ReadCNIConfigMap(path string) (map[string]any, error) {
 	cniConfig, err := os.ReadFile(path)
 	if err != nil {
@@ -113,7 +113,7 @@ func ReadCNIConfigMap(path string) (map[string]any, error) {
 	return cniConfigMap, nil
 }
 
-// Given an unmarshalled CNI config JSON map, return the plugin list asserted as a []interface{}
+// Given an unmarshaled CNI config JSON map, return the plugin list asserted as a []interface{}
 func GetPlugins(cniConfigMap map[string]any) (plugins []any, err error) {
 	plugins, ok := cniConfigMap["plugins"].([]any)
 	if !ok {

--- a/istioctl/pkg/util/clusters/wrapper.go
+++ b/istioctl/pkg/util/clusters/wrapper.go
@@ -26,12 +26,12 @@ type Wrapper struct {
 	*admin.Clusters
 }
 
-// MarshalJSON is a custom marshaller to handle protobuf pain
+// MarshalJSON is a custom marshaler to handle protobuf pain
 func (w *Wrapper) MarshalJSON() ([]byte, error) {
 	return protomarshal.Marshal(w)
 }
 
-// UnmarshalJSON is a custom unmarshaller to handle protobuf pain
+// UnmarshalJSON is a custom unmarshaler to handle protobuf pain
 func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	cd := &admin.Clusters{}
 	err := protomarshal.UnmarshalAllowUnknown(b, cd)

--- a/istioctl/pkg/util/configdump/wrapper.go
+++ b/istioctl/pkg/util/configdump/wrapper.go
@@ -52,12 +52,12 @@ type Wrapper struct {
 	*admin.ConfigDump
 }
 
-// MarshalJSON is a custom marshaller to handle protobuf pain
+// MarshalJSON is a custom marshaler to handle protobuf pain
 func (w *Wrapper) MarshalJSON() ([]byte, error) {
 	return protomarshal.Marshal(w)
 }
 
-// UnmarshalJSON is a custom unmarshaller to handle protobuf pain
+// UnmarshalJSON is a custom unmarshaler to handle protobuf pain
 func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	cd := &admin.ConfigDump{}
 	err := protomarshal.UnmarshalAllowUnknownWithAnyResolver(&envoyResolver, b, cd)

--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -92,11 +92,11 @@ func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter, outputFormat string
 	if err != nil {
 		return err
 	}
-	marshaller := make(proto.MessageSlice, 0, len(dump))
+	marshaler := make(proto.MessageSlice, 0, len(dump))
 	for _, eds := range dump {
-		marshaller = append(marshaller, eds)
+		marshaler = append(marshaler, eds)
 	}
-	out, err := json.MarshalIndent(marshaller, "", "    ")
+	out, err := json.MarshalIndent(marshaler, "", "    ")
 	if err != nil {
 		return err
 	}

--- a/operator/pkg/apis/istio/v1alpha1/value_types_json.go
+++ b/operator/pkg/apis/istio/v1alpha1/value_types_json.go
@@ -29,7 +29,7 @@ import (
 
 var _ github_com_golang_protobuf_jsonpb.JSONPBUnmarshaler = &IntOrString{}
 
-// UnmarshalJSON implements the json.Unmarshaller interface.
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (this *IntOrString) UnmarshalJSON(value []byte) error {
 	if value[0] == '"' {
 		this.Type = int64(intstr.String)

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -195,7 +195,7 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 		return "", nil, err
 	}
 
-	// convertDefaultIOPMapValues converts default paths values into string, prevent errors when unmarshalling.
+	// convertDefaultIOPMapValues converts default paths values into string, prevent errors when unmarshaling.
 	outYAML, err = convertDefaultIOPMapValues(outYAML, setFlags)
 	if err != nil {
 		return "", nil, err

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -509,7 +509,7 @@ func (s *StringBool) UnmarshalJSON(data []byte) error {
 }
 
 // ProxyConfig can only be marshaled using (gogo) jsonpb. However, the rest of node meta is not a proto
-// To allow marshaling, we need to define a custom type that calls out to the gogo marshaller
+// To allow marshaling, we need to define a custom type that calls out to the gogo marshaler
 type NodeMetaProxyConfig meshconfig.ProxyConfig
 
 func (s *NodeMetaProxyConfig) MarshalJSON() ([]byte, error) {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -718,7 +718,7 @@ func (ps *PushContext) AddServiceInstances(service *Service, instances map[int][
 	}
 }
 
-// StatusJSON implements json.Marshaller, with a lock.
+// StatusJSON implements json.Marshaler, with a lock.
 func (ps *PushContext) StatusJSON() ([]byte, error) {
 	if ps == nil {
 		return []byte{'{', '}'}, nil

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -127,7 +127,7 @@ type SidecarScope struct {
 	RootNamespace string
 }
 
-// MarshalJSON implements json.Marshaller
+// MarshalJSON implements json.Marshaler
 func (sc *SidecarScope) MarshalJSON() ([]byte, error) {
 	// Json cannot expose unexported fields, so copy the ones we want here
 	return json.MarshalIndent(map[string]any{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -615,7 +615,7 @@ func (mc *clusterWrapper) build() *cluster.Cluster {
 	if mc == nil {
 		return nil
 	}
-	// Marshall Http Protocol options if they exist.
+	// Marshal Http Protocol options if they exist.
 	if mc.httpProtocolOptions != nil {
 		// UpstreamProtocolOptions is required field in Envoy. If we have not set this option earlier
 		// we need to set it to default http protocol options.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1796,7 +1796,7 @@ func getTLSContext(t *testing.T, c *cluster.Cluster) *tls.UpstreamTlsContext {
 	tlsContext := &tls.UpstreamTlsContext{}
 	err := c.TransportSocket.GetTypedConfig().UnmarshalTo(tlsContext)
 	if err != nil {
-		t.Fatalf("Failed to unmarshall tls context: %v", err)
+		t.Fatalf("Failed to unmarshal tls context: %v", err)
 	}
 	return tlsContext
 }

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -124,7 +124,7 @@ func (wh *Webhook) GetConfig() WebhookConfig {
 	}
 }
 
-// ParsedContainers holds the unmarshalled containers and initContainers
+// ParsedContainers holds the unmarshaled containers and initContainers
 type ParsedContainers struct {
 	Containers     []corev1.Container `json:"containers,omitempty"`
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
@@ -578,8 +578,8 @@ func reapplyOverwrittenContainers(finalPod *corev1.Pod, originalPod *corev1.Pod,
 // parseStatus extracts containers from injected SidecarStatus annotation
 func parseStatus(status string) ParsedContainers {
 	parsedContainers := ParsedContainers{}
-	var unMarshalledStatus map[string]interface{}
-	if err := json.Unmarshal([]byte(status), &unMarshalledStatus); err != nil {
+	var unmarshaledStatus map[string]interface{}
+	if err := json.Unmarshal([]byte(status), &unmarshaledStatus); err != nil {
 		log.Errorf("Failed to unmarshal %s : %v", annotation.SidecarStatus.Name, err)
 		return parsedContainers
 	}
@@ -592,8 +592,8 @@ func parseStatus(status string) ParsedContainers {
 		}
 		return out
 	}
-	parsedContainers.Containers = parser(Containers, unMarshalledStatus)
-	parsedContainers.InitContainers = parser(InitContainers, unMarshalledStatus)
+	parsedContainers.Containers = parser(Containers, unmarshaledStatus)
+	parsedContainers.InitContainers = parser(InitContainers, unmarshaledStatus)
 
 	return parsedContainers
 }
@@ -780,13 +780,13 @@ func mergeOrAppendProbers(previouslyInjected bool, envVars []corev1.EnvVar, newP
 				// merge old and new probers.
 				newKubeAppProber[k] = v
 			}
-			marshalledKubeAppProber, err := json.Marshal(newKubeAppProber)
+			marshaledKubeAppProber, err := json.Marshal(newKubeAppProber)
 			if err != nil {
 				log.Errorf("failed to serialize the merged app prober config %v", err)
 				return envVars
 			}
 			// replace old env var with new value.
-			envVars[idx] = corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: string(marshalledKubeAppProber)}
+			envVars[idx] = corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: string(marshaledKubeAppProber)}
 			return envVars
 		}
 	}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -220,7 +220,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "bootstrap", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()),
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput := jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput := jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.HaveKey("bootstrap"))
 
 			args = []string{
@@ -228,7 +228,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "cluster", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "-o", "json",
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput = jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{
@@ -236,7 +236,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "endpoint", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "-o", "json",
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput = jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{
@@ -244,7 +244,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "listener", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "-o", "json",
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput = jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{
@@ -252,7 +252,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "route", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "-o", "json",
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput = jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{
@@ -260,7 +260,7 @@ func TestProxyConfig(t *testing.T) {
 				"pc", "secret", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "-o", "json",
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
-			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
+			jsonOutput = jsonUnmarshalOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.HaveKey("dynamicActiveSecrets"))
 			dump := &admin.SecretsConfigDump{}
 			if err := protomarshal.Unmarshal([]byte(output), dump); err != nil {
@@ -278,7 +278,7 @@ func TestProxyConfig(t *testing.T) {
 		})
 }
 
-func jsonUnmarshallOrFail(t test.Failer, context, s string) any {
+func jsonUnmarshalOrFail(t test.Failer, context, s string) any {
 	t.Helper()
 	var val any
 


### PR DESCRIPTION
This PR renames unexported functions and variables, changes comments to use only `Marshal/Unmarshal` with a single `el` for consistency. Details: [Go Spelling](https://github.com/golang/go/wiki/Spelling), [json.Marshaler](https://pkg.go.dev/encoding/json#Marshaler).