### PR TITLE
gateway api: Fix the status address type

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/netip"
 	"sort"
 	"strings"
 
@@ -2102,6 +2103,11 @@ func reportGatewayStatus(
 		if len(addressesToReport) > 0 {
 			gs.Addresses = make([]k8sbeta.GatewayStatusAddress, 0, len(addressesToReport))
 			for _, addr := range addressesToReport {
+				if _, err := netip.ParseAddr(addr); err == nil {
+					addrType = k8s.IPAddressType
+				} else {
+					addrType = k8s.HostnameAddressType
+				}
 				gs.Addresses = append(gs.Addresses, k8sbeta.GatewayStatusAddress{
 					Value: addr,
 					Type:  &addrType,


### PR DESCRIPTION
Set it to `Hostname` when reporting an external address.

Otherwise we get:

```
2023-09-01T14:34:05.859797Z	error	status	Encountered unexpected error updating status for &{{gateway.networking.k8s.io/v1beta1/Gateway bdf115cc-e417-4f14-ba45-216caaa5c133 bookinfo-gateway book cluster.local map[] map[gateway.istio.io/controller-version:5 kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{},"name":"bookinfo-gateway","namespace":"book"},"spec":{"gatewayClassName":"istio","listeners":[{"allowedRoutes":{"namespaces":{"from":"Same"}},"name":"http","port":80,"protocol":"HTTP"}]}}
] 91705 2023-09-01 14:33:56 +0000 UTC [] 1} 0xc004fcb488 0xc00396ec80}, will try again later: Gateway.gateway.networking.k8s.io "bookinfo-gateway" is invalid: [<nil>: Invalid value: "": "status.addresses[0]" must validate one and only one schema (oneOf). Found none valid, <nil>: Invalid value: "": "status.addresses[0].value" must validate at least one schema (anyOf), status.addresses[0].value: Invalid value: "XYZ.us-west-1.elb.amazonaws.com": status.addresses[0].value in body must be of type ipv4: "XYZ.us-west-1.elb.amazonaws.com", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```
