### PR TITLE
Fix analyze keep watching resources when api server cannot be connected

### DIFF
--- a/istioctl/pkg/analyze/analyze.go
+++ b/istioctl/pkg/analyze/analyze.go
@@ -136,15 +136,18 @@ func Analyze(ctx cli.Context) *cobra.Command {
 			selectedNamespace = ctx.NamespaceOrDefault(ctx.Namespace())
 
 			// check whether selected namespace exists.
-			if ctx.Namespace() != "" && useKube {
+			namespace := ctx.NamespaceOrDefault(ctx.Namespace())
+			if namespace != "" && useKube {
 				client, err := ctx.CLIClient()
 				if err != nil {
 					return err
 				}
-				_, err = client.Kube().CoreV1().Namespaces().Get(context.TODO(), ctx.Namespace(), metav1.GetOptions{})
+				_, err = client.Kube().CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 				if errors.IsNotFound(err) {
 					fmt.Fprintf(cmd.ErrOrStderr(), "namespace %q not found\n", ctx.Namespace())
 					return nil
+				} else if err != nil {
+					return err
 				}
 			}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
If using kube environment, we can just stop when the get request fails instead of proceeding to next steps, otherwise it continues trying to establish a watch:

```
2023-09-04T02:45:49.407365Z     error   watch error in cluster : failed to list *v1.Pod: Get "https://127.0.0.1:42643/api/v1/pods?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:49.475099Z     error   watch error in cluster : failed to list *v1.MutatingWebhookConfiguration: Get "https://127.0.0.1:42643/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:51.676395Z     error   watch error in cluster : failed to list *v1.ConfigMap: Get "https://127.0.0.1:42643/api/v1/namespaces/istio-system/configmaps?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:51.792031Z     error   watch error in cluster : failed to list *v1.CustomResourceDefinition: Get "https://127.0.0.1:42643/apis/apiextensions.k8s.io/v1/customresourcedefinitions?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:52.417912Z     error   watch error in cluster : failed to list apiextensions.k8s.io/v1, Resource=customresourcedefinitions: Get "https://127.0.0.1:42643/apis/apiextensions.k8s.io/v1/customresourcedefinitions?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:52.463886Z     error   watch error in cluster : failed to list *v1.Secret: Get "https://127.0.0.1:42643/api/v1/secrets?fieldSelector=type%21%3Dhelm.sh%2Frelease.v1%2Ctype%21%3Dkubernetes.io%2Fservice-account-token&limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
2023-09-04T02:45:53.527112Z     error   watch error in cluster : failed to list *v1.Namespace: Get "https://127.0.0.1:42643/api/v1/namespaces?limit=500&resourceVersion=0": dial tcp 127.0.0.1:42643: connect: connection refused
...
```