### PR TITLE
fix: ip <nil> is also empty

### DIFF
--- a/cni/pkg/ambient/net.go
+++ b/cni/pkg/ambient/net.go
@@ -65,7 +65,7 @@ func AddPodToMesh(client kubernetes.Interface, pod *corev1.Pod, ip string) error
 }
 
 func addPodToMeshWithIptables(pod *corev1.Pod, ip string) error {
-	if ip == "" {
+	if ip == "" || ip == "<nil>" {
 		ip = pod.Status.PodIP
 	}
 	// TODO: bug, pod may have multiple IPs in PodIPs


### PR DESCRIPTION
According to this 
err = ambient.AddPodToMesh(client, pod, ip.IP.String()) ip.IP.String() Its empty is <nil>, so we need to determine that this is also empty

```go
// String returns the string form of the IP address ip.
// It returns one of 4 forms:
//   - "<nil>", if ip has length 0
//   - dotted decimal ("192.0.2.1"), if ip is an IPv4 or IP4-mapped IPv6 address
//   - IPv6 conforming to RFC 5952 ("2001:db8::1"), if ip is a valid IPv6 address
//   - the hexadecimal form of ip, without punctuation, if no other cases apply
func (ip IP) String() string {
	if len(ip) == 0 {
		return "<nil>"
	}

	if len(ip) != IPv4len && len(ip) != IPv6len {
		return "?" + hexString(ip)
	}
	// If IPv4, use dotted notation.
	if p4 := ip.To4(); len(p4) == IPv4len {
		return netip.AddrFrom4([4]byte(p4)).String()
	}
	return netip.AddrFrom16([16]byte(ip)).String()
}
```

**Please provide a description of this PR:**