### PR TITLE
fix TestXdsProxyStatus flake: race condition in connection

### DIFF
--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -89,11 +89,12 @@ func (sg *StatusGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req 
 			break
 		}
 		var err error
-		res, err = sg.debugConfigDump(w.ResourceNames[0])
+		dumpRes, err := sg.debugConfigDump(w.ResourceNames[0])
 		if err != nil {
 			log.Infof("%s failed: %v", TypeDebugConfigDump, err)
 			break
 		}
+		res = dumpRes
 	}
 	return res, model.DefaultXdsLogDetails, nil
 }


### PR DESCRIPTION
Fix #42448.

When istioctl invoke `proxy status` connect right when the envoy disconnects, `debugConfigDump` func will print fail log as in issue, and return nil resource, nil resource will not send response so istioctl hang to timeout.

Fix it by returning empty resource when encountering error, it's reasonable for debug interface returning empty response when encountering error(I don't find a proper way to return an error response).