### PR TITLE
manifests: fix setting proxy UID and GID in gateway templates on OpenShift

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -65,8 +65,10 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            runAsUser: {{ .ProxyUID | default "1337" }}
-            runAsGroup: {{ .ProxyGID | default "1337" }}
+          {{- if not (eq .Values.global.platform "openshift") }}
+            runAsUser: 1337
+            runAsGroup: 1337
+          {{- end }}
             runAsNonRoot: true
           {{- else }}
             capabilities:

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -91,6 +91,8 @@ topologySpreadConstraints: []
 
 affinity: {}
 
+global: {}
+
 # If specified, the gateway will act as a network gateway for the given network.
 networkGateway: ""
 

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -57,8 +57,10 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
-        runAsUser: {{ .ProxyUID | default "1337" }}
-        runAsGroup: {{ .ProxyGID | default "1337" }}
+      {{- if not (eq .Values.global.platform "openshift") }}
+        runAsUser: 1337
+        runAsGroup: 1337
+      {{- end }}
         runAsNonRoot: true
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-egressgateway" }}-service-account

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -57,8 +57,10 @@ spec:
     spec:
 {{- if not $gateway.runAsRoot }}
       securityContext:
-        runAsUser: {{ .ProxyUID | default "1337" }}
-        runAsGroup: {{ .ProxyGID | default "1337" }}
+      {{- if not (eq .Values.global.platform "openshift") }}
+        runAsUser: 1337
+        runAsGroup: 1337
+      {{- end }}
         runAsNonRoot: true
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -72,10 +72,8 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true
-{{- if not (eq .Values.global.platform "openshift") }}
-          runAsUser: 1337
-          runAsGroup: 1337
-{{- end }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsGroup: {{ .ProxyUID | default "1337" }}
           runAsNonRoot: true
         {{- else }}
           capabilities:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -73,7 +73,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           runAsUser: {{ .ProxyUID | default "1337" }}
-          runAsGroup: {{ .ProxyUID | default "1337" }}
+          runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: true
         {{- else }}
           capabilities:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1499,10 +1499,8 @@ templates:
               allowPrivilegeEscalation: false
               privileged: false
               readOnlyRootFilesystem: true
-    {{- if not (eq .Values.global.platform "openshift") }}
-              runAsUser: 1337
-              runAsGroup: 1337
-    {{- end }}
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyUID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1500,7 +1500,7 @@ templates:
               privileged: false
               readOnlyRootFilesystem: true
               runAsUser: {{ .ProxyUID | default "1337" }}
-              runAsGroup: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
             {{- else }}
               capabilities:


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a follow-up to #45394.

Currently, deployments for gateways created from charts `gateway`, `gateways/istio-ingress` and `gateways/istio-egress` with injection template fail to create pods, because got UID/GID 1337, so still require anyuid SCC. I removed `.ProxyUID` and `.ProxyGID` from those templates, because injection webhook does not use them. Instead, we should set `.ProxyUID` and `.ProxyGID` in `gateway-injection-template`, but it's not trivial, because `gateway` chart allows to customize securityContext, so it's not obvious how to overwrite it.

On the other hand, we didn't set `ProxyUID` and `ProxyGID` in the kube-gateway template, while we know these values during template evaluation, so I fixed it.

This PR fixes the following installations on OpenShift:
1. `helm install istio-ingressgateway istio/gateway`
2. 
```
istioctl install -f <<EOF
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  name: istio-ingress-gw-install
spec:
  profile: empty
  components:
    ingressGateways:
    - name: istio-ingressgateway
      namespace: istio-ingress
      enabled: true
  values:
    global:
      platform: openshift
    gateways:
      istio-ingressgateway:
        injectionTemplate: gateway
EOF
```

cc: @jwendell 