### PR TITLE
Enable DUAL_STACK flags at test framework level

### DIFF
--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -606,6 +606,11 @@ func commonInstallArgs(ctx resource.Context, cfg Config, c cluster.Cluster, defa
 		args.AppendSet("components.cni.enabled", "true")
 	}
 
+	if ctx.Settings().EnableDualStack {
+		args.AppendSet("values.pilot.env.ISTIO_DUAL_STACK", "true")
+		args.AppendSet("meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK", "true")
+	}
+
 	// Include all user-specified values.
 	for k, v := range cfg.Values {
 		args.AppendSet("values."+k, v)

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -41,20 +41,7 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
-			if c.Settings().EnableDualStack {
-				cfg.ControlPlaneValues = `
-values:
-  pilot:
-    env:
-      ISTIO_DUAL_STACK: true
-meshConfig:
-  defaultConfig:
-    proxyMetadata:
-      ISTIO_DUAL_STACK: "true"
-`
-			}
-		})).
+		Setup(istio.Setup(&i, nil)).
 		Setup(deployment.SetupSingleNamespace(&apps, deployment.Config{})).
 		Setup(func(t resource.Context) error {
 			gatewayConformanceInputs.Client = t.Clusters().Default()

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -49,8 +49,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
-			if !c.Settings().EnableDualStack {
-				cfg.ControlPlaneValues = `
+			cfg.ControlPlaneValues = `
 values:
   pilot: 
     env: 
@@ -60,21 +59,6 @@ meshConfig:
     gatewayTopology:
       numTrustedProxies: 1 # Needed for X-Forwarded-For (See https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/)
 `
-			} else {
-				cfg.ControlPlaneValues = `
-values:
-  pilot: 
-    env: 
-      PILOT_JWT_ENABLE_REMOTE_JWKS: true
-      ISTIO_DUAL_STACK: true
-meshConfig:
-  defaultConfig:
-    proxyMetadata:
-      ISTIO_DUAL_STACK: "true"
-    gatewayTopology:
-      numTrustedProxies: 1 # Needed for X-Forwarded-For (See https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/)
-`
-			}
 		})).
 		// Create namespaces first. This way, echo can correctly configure egress to all namespaces.
 		SetupParallel(

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -123,8 +123,4 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT) check-go-tag
 # In presubmit, this target runs a minimal set. In postsubmit, all tests are run
 .PHONY: test.integration.kube.environment
 test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
-ifeq (${JOB_TYPE},postsubmit)
-	$(call run-test,./tests/integration/...)
-else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
-endif
+    $(call run-test,./tests/integration/...)

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -126,5 +126,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/...)
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
 endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -123,4 +123,8 @@ test.integration.kube.presubmit: | $(JUNIT_REPORT) check-go-tag
 # In presubmit, this target runs a minimal set. In postsubmit, all tests are run
 .PHONY: test.integration.kube.environment
 test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
-    $(call run-test,./tests/integration/...)
+ifeq (${JOB_TYPE},postsubmit)
+	$(call run-test,./tests/integration/...)
+else
+	$(call run-test,./tests/integration/...)
+endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -126,5 +126,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot)
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
 endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -126,5 +126,5 @@ test.integration.kube.environment: | $(JUNIT_REPORT) check-go-tag
 ifeq (${JOB_TYPE},postsubmit)
 	$(call run-test,./tests/integration/...)
 else
-	$(call run-test,./tests/integration/security/ ./tests/integration/pilot,-run="TestReachability|TestTraffic")
+	$(call run-test,./tests/integration/security/ ./tests/integration/pilot)
 endif


### PR DESCRIPTION
Currently the tests are run without enabling this flag for majority of tests. Only some of the pre-submit
tests were enabling the flag. So, let us try to enable the required DUAL_STACK flags at the framework level.