### PR TITLE
guarantee we don't end up with empty address endpoints

### DIFF
--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -489,7 +489,7 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint, svcPort *
 		return false
 	}
 	// If we don't know the address we must eventually use a gateway address
-	if ep.Address == "" && ep.Network == b.network {
+	if ep.Address == "" && (!b.gateways().IsMultiNetworkEnabled() || b.proxy.InNetwork(ep.Network)) {
 		return false
 	}
 	// Draining endpoints are only sent to 'persistent session' clusters.


### PR DESCRIPTION
This line assumes we will hit this logic later:

https://github.com/istio/istio/blob/93758c226683acea24867e365386ab4da567444f/pilot/pkg/xds/endpoints/ep_filters.go#L96-L101

But that logic is skipped if there are 0 gateways total:

https://github.com/istio/istio/blob/93758c226683acea24867e365386ab4da567444f/pilot/pkg/xds/endpoints/ep_filters.go#L40-L43