### PR TITLE
Fix mesh config sync

### DIFF
--- a/releasenotes/notes/mesh-sync.yaml
+++ b/releasenotes/notes/mesh-sync.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 45739
+
+releaseNotes:
+  - |
+    **Fixed** an issue causing mesh configuration to not be properly synced, typically resulting in a misconfigured trust domain.


### PR DESCRIPTION
We do not check the handler is synced, so we can return too early and
miss the config. This results in using the default MC instead of the one
from configmap.

for https://github.com/istio/istio/issues/45739 (not fixes, there is
some followup).

1.19 is already fixed by a larger refactor, so this is a targetted fix.
