### PR TITLE
move ambient install into framework

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -328,7 +328,7 @@ func (c Config) HasSidecar() bool {
 		perPodDisable = c.Subsets[0].Labels["sidecar.istio.io/inject"] == "false"
 	}
 
-	return perPodEnable || (!perPodDisable && c.Namespace.IsInjected())
+	return perPodEnable || (!perPodDisable && c.Namespace != nil && c.Namespace.IsInjected())
 }
 
 func (c Config) IsUncaptured() bool {

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -61,6 +61,9 @@ const (
 	// on external istiod config clusters for integration tests
 	IntegrationTestExternalIstiodConfigDefaultsIOP = "tests/integration/iop-externalistiod-config-integration-test-defaults.yaml"
 
+	// IntegrationTestAmbientDefaultsIOP is the path of the default IstioOperator for ambient
+	IntegrationTestAmbientDefaultsIOP = "tests/integration/iop-ambient-test-defaults.yaml"
+
 	// hubValuesKey values key for the Docker image hub.
 	hubValuesKey = "global.hub"
 

--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -76,6 +76,9 @@ func (i *installer) Install(c cluster.Cluster, args installArgs) error {
 		ManifestsPath: filepath.Join(testenv.IstioSrc, "manifests"),
 		Revision:      args.Revision,
 	}
+	if i.ctx.Settings().Ambient {
+		iArgs.InFilenames = append(iArgs.InFilenames, filepath.Join(testenv.IstioSrc, IntegrationTestAmbientDefaultsIOP))
+	}
 
 	rc, err := kube.DefaultRestConfig(kubeConfigFile, "", func(config *rest.Config) {
 		config.QPS = 50
@@ -91,6 +94,7 @@ func (i *installer) Install(c cluster.Cluster, args installArgs) error {
 
 	// Generate the manifest YAML, so that we can uninstall it in Close.
 	var stdOut, stdErr bytes.Buffer
+	fmt.Println("INFILES: ", iArgs.InFilenames)
 	if err := mesh.ManifestGenerate(kubeClient, &mesh.RootArgs{}, &mesh.ManifestGenerateArgs{
 		InFilenames:   iArgs.InFilenames,
 		Set:           iArgs.Set,

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -284,6 +284,9 @@ func (n *kubeNamespace) IsAmbient() bool {
 }
 
 func (n *kubeNamespace) IsInjected() bool {
+	if n == nil {
+		return false
+	}
 	// TODO cache labels and invalidate on SetLabel to avoid a ton of kube calls
 	labels, err := n.Labels()
 	if err != nil {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -69,26 +69,6 @@ type EchoDeployments struct {
 	WaypointProxy ambient.WaypointProxy
 }
 
-var ControlPlaneValues = `
-profile: ambient
-components:
-  ingressGateways:
-  - name: istio-ingressgateway
-    enabled: true
-values:
-  ztunnel:
-    meshConfig:
-      defaultConfig:
-        proxyMetadata:
-          ISTIO_META_DNS_CAPTURE: "true"
-          DNS_PROXY_ADDR: "0.0.0.0:15053"
-  meshConfig:
-    defaultConfig:
-      proxyMetadata:
-        ISTIO_META_DNS_CAPTURE: "true"
-        DNS_PROXY_ADDR: "0.0.0.0:15053"
-    accessLogFile: /dev/stdout`
-
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
 // If a test requires a custom install it should go into its own package, otherwise it should go
 // here to reuse a single install across tests.
@@ -107,7 +87,6 @@ func TestMain(m *testing.M) {
 			// can't deploy VMs without eastwest gateway
 			ctx.Settings().SkipVMs()
 			cfg.DeployEastWestGW = false
-			cfg.ControlPlaneValues = ControlPlaneValues
 		})).
 		Setup(func(t resource.Context) error {
 			gatewayConformanceInputs.Client = t.Clusters().Default()

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -79,10 +79,11 @@ func TestMain(m *testing.M) {
 		SkipIf("https://github.com/istio/istio/issues/43243", func(ctx resource.Context) bool {
 			return os.Getenv("VARIANT") == "distroless"
 		}).
-		SkipIf("https://github.com/istio/istio/issues/43508", func(ctx resource.Context) bool {
-			return !ctx.Settings().Ambient
-		}).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/41008
+		Setup(func(t resource.Context) error {
+			t.Settings().Ambient = true
+			return nil
+		}).
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			// can't deploy VMs without eastwest gateway
 			ctx.Settings().SkipVMs()

--- a/tests/integration/iop-ambient-test-defaults.yaml
+++ b/tests/integration/iop-ambient-test-defaults.yaml
@@ -1,0 +1,24 @@
+# This file provides some defaults for integration testing.
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: install
+spec:
+  profile: ambient
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: true
+  values:
+    ztunnel:
+      meshConfig:
+        defaultConfig:
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+            DNS_PROXY_ADDR: "0.0.0.0:15053"
+    meshConfig:
+      defaultConfig:
+        proxyMetadata:
+          ISTIO_META_DNS_CAPTURE: "true"
+          DNS_PROXY_ADDR: "0.0.0.0:15053"
+      accessLogFile: /dev/stdout


### PR DESCRIPTION
`./prow/integ-suite-kind.sh test.integration.ambient.kube` passes just fine. No logner needs a special flag.

It also allows using the flag to turn on ambient in other suites. 