### PR TITLE
Revert "Support CliContext for all install commands"

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -195,8 +195,8 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(admin.Cmd(ctx))
 	experimentalCmd.AddCommand(injector.Cmd(ctx))
 
-	rootCmd.AddCommand(install.NewVerifyCommand(ctx))
-	rootCmd.AddCommand(mesh.UninstallCmd(ctx, root.LoggingOptions))
+	rootCmd.AddCommand(install.NewVerifyCommand())
+	rootCmd.AddCommand(mesh.UninstallCmd(root.LoggingOptions))
 
 	experimentalCmd.AddCommand(authz.AuthZ(ctx))
 	rootCmd.AddCommand(seeExperimentalCmd("authz"))
@@ -220,23 +220,23 @@ debug and diagnose their Istio mesh.
 	hideInheritedFlags(dashboardCmd, cli.FlagNamespace, cli.FlagIstioNamespace)
 	rootCmd.AddCommand(dashboardCmd)
 
-	manifestCmd := mesh.ManifestCmd(ctx, root.LoggingOptions)
+	manifestCmd := mesh.ManifestCmd(root.LoggingOptions)
 	hideInheritedFlags(manifestCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(manifestCmd)
 
-	operatorCmd := mesh.OperatorCmd(ctx)
+	operatorCmd := mesh.OperatorCmd()
 	hideInheritedFlags(operatorCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(operatorCmd)
 
-	installCmd := mesh.InstallCmd(ctx, root.LoggingOptions)
+	installCmd := mesh.InstallCmd(root.LoggingOptions)
 	hideInheritedFlags(installCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(installCmd)
 
-	profileCmd := mesh.ProfileCmd(ctx, root.LoggingOptions)
+	profileCmd := mesh.ProfileCmd(root.LoggingOptions)
 	hideInheritedFlags(profileCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(profileCmd)
 
-	upgradeCmd := mesh.UpgradeCmd(ctx, root.LoggingOptions)
+	upgradeCmd := mesh.UpgradeCmd(root.LoggingOptions)
 	hideInheritedFlags(upgradeCmd, cli.FlagNamespace, cli.FlagIstioNamespace, FlagCharts)
 	rootCmd.AddCommand(upgradeCmd)
 

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -18,20 +18,29 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/istioctl/pkg/verifier"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/ptr"
 )
 
 // NewVerifyCommand creates a new command for verifying Istio Installation Status
-func NewVerifyCommand(ctx cli.Context) *cobra.Command {
+func NewVerifyCommand() *cobra.Command {
 	var (
-		filenames     = []string{}
-		opts          clioptions.ControlPlaneOptions
-		manifestsPath string
+		kubeConfigFlags = &genericclioptions.ConfigFlags{
+			Context:    ptr.Of(""),
+			Namespace:  ptr.Of(""),
+			KubeConfig: ptr.Of(""),
+		}
+
+		filenames      = []string{}
+		istioNamespace string
+		opts           clioptions.ControlPlaneOptions
+		manifestsPath  string
 	)
 	verifyInstallCmd := &cobra.Command{
 		Use:   "verify-install [-f <deployment or istio operator file>] [--revision <revision>]",
@@ -67,11 +76,8 @@ istioctl experimental precheck.
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			client, err := ctx.CLIClient()
-			if err != nil {
-				return err
-			}
-			installationVerifier, err := verifier.NewStatusVerifier(client, ctx.IstioNamespace(), manifestsPath, filenames, opts)
+			installationVerifier, err := verifier.NewStatusVerifier(istioNamespace, manifestsPath,
+				*kubeConfigFlags.KubeConfig, *kubeConfigFlags.Context, filenames, opts)
 			if err != nil {
 				return err
 			}
@@ -83,6 +89,9 @@ istioctl experimental precheck.
 	}
 
 	flags := verifyInstallCmd.PersistentFlags()
+	flags.StringVarP(&istioNamespace, "istioNamespace", "i", constants.IstioSystemNamespace,
+		"Istio system namespace")
+	kubeConfigFlags.AddFlags(flags)
 	flags.StringSliceVarP(&filenames, "filename", "f", filenames, "Istio YAML installation file.")
 	verifyInstallCmd.PersistentFlags().StringVarP(&manifestsPath, "manifests", "d", "", util.ManifestsFlagHelpStr)
 	opts.AttachControlPlaneFlags(verifyInstallCmd)

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -82,10 +82,15 @@ func WithIOP(iop *v1alpha1.IstioOperator) StatusVerifierOptions {
 
 // NewStatusVerifier creates a new instance of post-install verifier
 // which checks the status of various resources from the manifest.
-func NewStatusVerifier(client kube.CLIClient, istioNamespace, manifestsPath string,
+func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string,
 	filenames []string, controlPlaneOpts clioptions.ControlPlaneOptions,
 	options ...StatusVerifierOptions,
 ) (*StatusVerifier, error) {
+	client, err := kube.NewCLIClient(kube.BuildClientCmd(kubeconfig, context), "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
+	}
+
 	verifier := StatusVerifier{
 		logger:           clog.NewDefaultLogger(),
 		successMarker:    "✔",

--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -38,7 +38,7 @@ import (
 )
 
 func NewVersionCommand(ctx cli.Context) *cobra.Command {
-	profileCmd := mesh.ProfileCmd(ctx, log.DefaultOptions())
+	profileCmd := mesh.ProfileCmd(log.DefaultOptions())
 	var opts clioptions.ControlPlaneOptions
 	versionCmd := istioVersion.CobraCommandWithOptions(istioVersion.CobraOptions{
 		GetRemoteVersion: getRemoteInfoWrapper(ctx, &profileCmd, &opts),

--- a/operator/cmd/mesh.go
+++ b/operator/cmd/mesh.go
@@ -17,7 +17,6 @@ package main
 import (
 	"os"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/operator/cmd/mesh"
 	binversion "istio.io/istio/operator/version"
 	"istio.io/istio/pkg/version"
@@ -25,7 +24,7 @@ import (
 
 func main() {
 	version.Info.Version = binversion.OperatorVersionString
-	rootCmd := mesh.GetRootCmd(cli.NewCLIContext(nil), os.Args[1:])
+	rootCmd := mesh.GetRootCmd(os.Args[1:])
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	revtag "istio.io/istio/istioctl/pkg/tag"
 	"istio.io/istio/istioctl/pkg/util"
@@ -54,6 +53,10 @@ import (
 type InstallArgs struct {
 	// InFilenames is an array of paths to the input IstioOperator CR files.
 	InFilenames []string
+	// KubeConfigPath is the path to kube config file.
+	KubeConfigPath string
+	// Context is the cluster context in the kube config
+	Context string
 	// ReadinessTimeout is maximum time to wait for all Istio resources to be ready. wait must be true for this setting
 	// to take effect.
 	ReadinessTimeout time.Duration
@@ -76,6 +79,8 @@ type InstallArgs struct {
 func (a *InstallArgs) String() string {
 	var b strings.Builder
 	b.WriteString("InFilenames:      " + fmt.Sprint(a.InFilenames) + "\n")
+	b.WriteString("KubeConfigPath:   " + a.KubeConfigPath + "\n")
+	b.WriteString("Context:          " + a.Context + "\n")
 	b.WriteString("ReadinessTimeout: " + fmt.Sprint(a.ReadinessTimeout) + "\n")
 	b.WriteString("SkipConfirmation: " + fmt.Sprint(a.SkipConfirmation) + "\n")
 	b.WriteString("Force:            " + fmt.Sprint(a.Force) + "\n")
@@ -88,6 +93,8 @@ func (a *InstallArgs) String() string {
 
 func addInstallFlags(cmd *cobra.Command, args *InstallArgs) {
 	cmd.PersistentFlags().StringSliceVarP(&args.InFilenames, "filename", "f", nil, filenameFlagHelpStr)
+	cmd.PersistentFlags().StringVarP(&args.KubeConfigPath, "kubeconfig", "c", "", KubeConfigFlagHelpStr)
+	cmd.PersistentFlags().StringVar(&args.Context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().DurationVar(&args.ReadinessTimeout, "readiness-timeout", 300*time.Second,
 		"Maximum time to wait for Istio resources in each component to be ready.")
 	cmd.PersistentFlags().BoolVarP(&args.SkipConfirmation, "skip-confirmation", "y", false, skipConfirmationFlagHelpStr)
@@ -100,7 +107,7 @@ func addInstallFlags(cmd *cobra.Command, args *InstallArgs) {
 }
 
 // InstallCmdWithArgs generates an Istio install manifest and applies it to a cluster
-func InstallCmdWithArgs(ctx cli.Context, rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options) *cobra.Command {
+func InstallCmdWithArgs(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options) *cobra.Command {
 	ic := &cobra.Command{
 		Use:     "install",
 		Short:   "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
@@ -127,13 +134,9 @@ func InstallCmdWithArgs(ctx cli.Context, rootArgs *RootArgs, iArgs *InstallArgs,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kubeClient, err := ctx.CLIClient()
-			if err != nil {
-				return err
-			}
 			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			p := NewPrinterForWriter(cmd.OutOrStderr())
-			return Install(kubeClient, rootArgs, iArgs, logOpts, cmd.OutOrStdout(), l, p)
+			return Install(rootArgs, iArgs, logOpts, cmd.OutOrStdout(), l, p)
 		},
 	}
 
@@ -143,13 +146,12 @@ func InstallCmdWithArgs(ctx cli.Context, rootArgs *RootArgs, iArgs *InstallArgs,
 }
 
 // InstallCmd generates an Istio install manifest and applies it to a cluster
-func InstallCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
-	return InstallCmdWithArgs(ctx, &RootArgs{}, &InstallArgs{}, logOpts)
+func InstallCmd(logOpts *log.Options) *cobra.Command {
+	return InstallCmdWithArgs(&RootArgs{}, &InstallArgs{}, logOpts)
 }
 
-func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOut io.Writer, l clog.Logger, p Printer,
-) error {
-	kubeClient, client, err := KubernetesClients(kubeClient, l)
+func Install(rootArgs *RootArgs, iArgs *InstallArgs, logOpts *log.Options, stdOut io.Writer, l clog.Logger, p Printer) error {
+	kubeClient, client, err := KubernetesClients(iArgs.KubeConfigPath, iArgs.Context, l)
 	if err != nil {
 		return err
 	}
@@ -219,8 +221,8 @@ func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, 
 			return nil
 		}
 		l.LogAndPrint("\n\nVerifying installation:")
-		installationVerifier, err := verifier.NewStatusVerifier(kubeClient, iop.Namespace, iArgs.ManifestsPath,
-			iArgs.InFilenames, clioptions.ControlPlaneOptions{Revision: iop.Spec.Revision},
+		installationVerifier, err := verifier.NewStatusVerifier(iop.Namespace, iArgs.ManifestsPath, iArgs.KubeConfigPath,
+			iArgs.Context, iArgs.InFilenames, clioptions.ControlPlaneOptions{Revision: iop.Spec.Revision},
 			verifier.WithLogger(l),
 			verifier.WithIOP(iop),
 		)

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/helmreconciler"
 	"istio.io/istio/operator/pkg/manifest"
@@ -42,6 +41,10 @@ type ManifestGenerateArgs struct {
 	// EnableClusterSpecific determines if the current Kubernetes cluster will be used to autodetect values.
 	// If false, generic defaults will be used. This is useful when generating once and then applying later.
 	EnableClusterSpecific bool
+	// KubeConfigPath is the path to kube config file.
+	KubeConfigPath string
+	// Context is the cluster context in the kube config
+	Context string
 
 	// Set is a string with element format "path=value" where path is an IstioOperator path and the value is a
 	// value to set the node at that path to.
@@ -57,8 +60,6 @@ type ManifestGenerateArgs struct {
 	// Filter is the list of components to render
 	Filter []string
 }
-
-var kubeClientFunc func() (kube.CLIClient, error)
 
 func (a *ManifestGenerateArgs) String() string {
 	var b strings.Builder
@@ -84,11 +85,13 @@ func addManifestGenerateFlags(cmd *cobra.Command, args *ManifestGenerateArgs) {
 	cmd.PersistentFlags().StringSliceVar(&args.Filter, "filter", nil, "")
 	_ = cmd.PersistentFlags().MarkHidden("filter")
 
+	cmd.PersistentFlags().StringVarP(&args.KubeConfigPath, "kubeconfig", "c", "", KubeConfigFlagHelpStr+" Requires --cluster-specific.")
+	cmd.PersistentFlags().StringVar(&args.Context, "context", "", ContextFlagHelpStr+" Requires --cluster-specific.")
 	cmd.PersistentFlags().BoolVar(&args.EnableClusterSpecific, "cluster-specific", false,
 		"If enabled, the current cluster will be checked for cluster-specific setting detection.")
 }
 
-func ManifestGenerateCmd(ctx cli.Context, rootArgs *RootArgs, mgArgs *ManifestGenerateArgs, logOpts *log.Options) *cobra.Command {
+func ManifestGenerateCmd(rootArgs *RootArgs, mgArgs *ManifestGenerateArgs, logOpts *log.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "generate",
 		Short: "Generates an Istio install manifest",
@@ -113,25 +116,20 @@ func ManifestGenerateCmd(ctx cli.Context, rootArgs *RootArgs, mgArgs *ManifestGe
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if kubeClientFunc == nil {
-				kubeClientFunc = ctx.CLIClient
-			}
-			kubeClient, err := kubeClientFunc()
-			if err != nil {
-				return err
-			}
 			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
-			return ManifestGenerate(kubeClient, rootArgs, mgArgs, logOpts, l)
+			return ManifestGenerate(rootArgs, mgArgs, logOpts, l)
 		},
 	}
 }
 
-func ManifestGenerate(kubeClient kube.CLIClient, args *RootArgs, mgArgs *ManifestGenerateArgs, logopts *log.Options, l clog.Logger) error {
+func ManifestGenerate(args *RootArgs, mgArgs *ManifestGenerateArgs, logopts *log.Options, l clog.Logger) error {
 	if err := configLogs(logopts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
+
+	var kubeClient kube.CLIClient
 	if mgArgs.EnableClusterSpecific {
-		kc, _, err := KubernetesClients(kubeClient, l)
+		kc, _, err := KubernetesClients(mgArgs.KubeConfigPath, mgArgs.Context, l)
 		if err != nil {
 			return err
 		}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -43,7 +43,6 @@ import (
 	"istio.io/istio/operator/pkg/util/clog"
 	tutil "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/file"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/version"
@@ -101,12 +100,6 @@ type testGroup []struct {
 	diffSelect                  string
 	diffIgnore                  string
 	chartSource                 chartSourceType
-}
-
-func init() {
-	kubeClientFunc = func() (kube.CLIClient, error) {
-		return nil, nil
-	}
 }
 
 func extract(gzipStream io.Reader, destination string) error {

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -17,12 +17,11 @@ package mesh
 import (
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/pkg/log"
 )
 
 // ManifestCmd is a group of commands related to manifest generation, installation, diffing and migration.
-func ManifestCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
+func ManifestCmd(logOpts *log.Options) *cobra.Command {
 	mc := &cobra.Command{
 		Use:   "manifest",
 		Short: "Commands related to Istio manifests",
@@ -34,9 +33,9 @@ func ManifestCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
 
 	args := &RootArgs{}
 
-	mgc := ManifestGenerateCmd(ctx, args, mgcArgs, logOpts)
+	mgc := ManifestGenerateCmd(args, mgcArgs, logOpts)
 	mdc := manifestDiffCmd(args, mdcArgs)
-	ic := InstallCmd(ctx, logOpts)
+	ic := InstallCmd(logOpts)
 
 	addFlags(mc, args)
 	addFlags(mgc, args)

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/yaml"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"
@@ -301,9 +300,7 @@ func runManifestCommand(command string, filenames []string, flags string, chartS
 // runCommand runs the given command string.
 func runCommand(command string) (string, error) {
 	var out bytes.Buffer
-	rootCmd := GetRootCmd(cli.NewFakeContext(&cli.NewFakeContextOption{
-		Version: "25",
-	}), strings.Split(command, " "))
+	rootCmd := GetRootCmd(strings.Split(command, " "))
 	rootCmd.SetOut(&out)
 
 	err := rootCmd.Execute()

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -21,13 +21,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/istioctl/pkg/cli"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/helmreconciler"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util/clog"
-	"istio.io/istio/pkg/kube"
 )
 
 type operatorRemoveArgs struct {
@@ -58,29 +56,24 @@ func addOperatorRemoveFlags(cmd *cobra.Command, oiArgs *operatorRemoveArgs) {
 	cmd.PersistentFlags().BoolVar(&oiArgs.purge, "purge", false, AllOperatorRevFlagHelpStr)
 }
 
-func operatorRemoveCmd(ctx cli.Context, rootArgs *RootArgs, orArgs *operatorRemoveArgs) *cobra.Command {
+func operatorRemoveCmd(rootArgs *RootArgs, orArgs *operatorRemoveArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove",
 		Short: "Removes the Istio operator controller from the cluster.",
 		Long:  "The remove subcommand removes the Istio operator controller from the cluster.",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := ctx.CLIClient()
-			if err != nil {
-				return err
-			}
+		Run: func(cmd *cobra.Command, args []string) {
 			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), installerScope)
-			operatorRemove(cmd, client, rootArgs, orArgs, l)
-			return nil
+			operatorRemove(cmd, rootArgs, orArgs, l)
 		},
 	}
 }
 
 // operatorRemove removes the Istio operator controller from the cluster.
-func operatorRemove(cmd *cobra.Command, cliClient kube.CLIClient, args *RootArgs, orArgs *operatorRemoveArgs, l clog.Logger) {
+func operatorRemove(cmd *cobra.Command, args *RootArgs, orArgs *operatorRemoveArgs, l clog.Logger) {
 	initLogsOrExit(args)
 
-	kubeClient, client, err := KubernetesClients(cliClient, l)
+	kubeClient, client, err := KubernetesClients(orArgs.kubeConfigPath, orArgs.context, l)
 	if err != nil {
 		l.LogAndFatal(err)
 	}

--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -16,12 +16,10 @@ package mesh
 
 import (
 	"github.com/spf13/cobra"
-
-	"istio.io/istio/istioctl/pkg/cli"
 )
 
 // OperatorCmd is a group of commands related to installation and management of the operator controller.
-func OperatorCmd(ctx cli.Context) *cobra.Command {
+func OperatorCmd() *cobra.Command {
 	oc := &cobra.Command{
 		Use:   "operator",
 		Short: "Commands related to Istio operator controller.",
@@ -34,8 +32,8 @@ func OperatorCmd(ctx cli.Context) *cobra.Command {
 	args := &RootArgs{}
 
 	odc := operatorDumpCmd(args, odArgs)
-	oic := operatorInitCmd(ctx, args, oiArgs)
-	orc := operatorRemoveCmd(ctx, args, orArgs)
+	oic := operatorInitCmd(args, oiArgs)
+	orc := operatorRemoveCmd(args, orArgs)
 
 	addFlags(odc, args)
 	addFlags(oic, args)

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/kube"
@@ -170,7 +169,7 @@ func TestOperatorInit(t *testing.T) {
 	}
 }
 
-func MockKubernetesClients(_ kube.CLIClient, _ clog.Logger) (kube.CLIClient, client.Client, error) {
+func MockKubernetesClients(_, _ string, _ clog.Logger) (kube.CLIClient, client.Client, error) {
 	extendedClient = kube.NewFakeClient()
 	kubeClient, _ = client.New(&rest.Config{}, client.Options{})
 	return extendedClient, kubeClient, nil
@@ -208,12 +207,7 @@ func TestOperatorInitDryRun(t *testing.T) {
 				args = append(args, "--watchedNamespaces", test.watchedNamespaces)
 			}
 
-			kubeClientFunc = func() (kube.CLIClient, error) {
-				return nil, nil
-			}
-			rootCmd := GetRootCmd(cli.NewFakeContext(&cli.NewFakeContextOption{
-				Version: "25",
-			}), args)
+			rootCmd := GetRootCmd(args)
 			err := rootCmd.Execute()
 			assert.NoError(t, err)
 

--- a/operator/cmd/mesh/profile-list_test.go
+++ b/operator/cmd/mesh/profile-list_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/onsi/gomega"
 
-	"istio.io/istio/istioctl/pkg/cli"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/env"
 )
 
@@ -30,12 +28,7 @@ func TestProfileList(t *testing.T) {
 	g := gomega.NewWithT(t)
 	args := []string{"profile", "list", "--dry-run", "--manifests", filepath.Join(env.IstioSrc, "manifests")}
 
-	kubeClientFunc = func() (kube.CLIClient, error) {
-		return nil, nil
-	}
-	rootCmd := GetRootCmd(cli.NewFakeContext(&cli.NewFakeContextOption{
-		Version: "25",
-	}), args)
+	rootCmd := GetRootCmd(args)
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -17,12 +17,11 @@ package mesh
 import (
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/pkg/log"
 )
 
 // ProfileCmd is a group of commands related to profile listing, dumping and diffing.
-func ProfileCmd(_ cli.Context, logOpts *log.Options) *cobra.Command {
+func ProfileCmd(logOpts *log.Options) *cobra.Command {
 	pc := &cobra.Command{
 		Use:   "profile",
 		Short: "Commands related to Istio configuration profiles",

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/istioctl/pkg/cli"
 	binversion "istio.io/istio/operator/version"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/url"
@@ -72,7 +71,7 @@ func addFlags(cmd *cobra.Command, rootArgs *RootArgs) {
 }
 
 // GetRootCmd returns the root of the cobra command-tree.
-func GetRootCmd(ctx cli.Context, args []string) *cobra.Command {
+func GetRootCmd(args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:          "mesh",
 		Short:        "Command line Istio install utility.",
@@ -83,12 +82,12 @@ func GetRootCmd(ctx cli.Context, args []string) *cobra.Command {
 	rootCmd.SetArgs(args)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
-	rootCmd.AddCommand(ManifestCmd(ctx, log.DefaultOptions()))
-	rootCmd.AddCommand(InstallCmd(ctx, log.DefaultOptions()))
-	rootCmd.AddCommand(ProfileCmd(ctx, log.DefaultOptions()))
-	rootCmd.AddCommand(OperatorCmd(ctx))
+	rootCmd.AddCommand(ManifestCmd(log.DefaultOptions()))
+	rootCmd.AddCommand(InstallCmd(log.DefaultOptions()))
+	rootCmd.AddCommand(ProfileCmd(log.DefaultOptions()))
+	rootCmd.AddCommand(OperatorCmd())
 	rootCmd.AddCommand(version.CobraCommand())
-	rootCmd.AddCommand(UpgradeCmd(ctx, log.DefaultOptions()))
+	rootCmd.AddCommand(UpgradeCmd(log.DefaultOptions()))
 
 	return rootCmd
 }

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/istio/istioctl/pkg/install/k8sversion"
@@ -109,7 +110,20 @@ func Confirm(msg string, writer io.Writer) bool {
 	}
 }
 
-func KubernetesClients(kubeClient kube.CLIClient, l clog.Logger) (kube.CLIClient, client.Client, error) {
+func KubernetesClients(kubeConfigPath, context string, l clog.Logger) (kube.CLIClient, client.Client, error) {
+	rc, err := kube.DefaultRestConfig(kubeConfigPath, context, func(config *rest.Config) {
+		// We are running a one-off command locally, so we don't need to worry too much about rate limiting
+		// Bumping this up greatly decreases install time
+		config.QPS = 50
+		config.Burst = 100
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	kubeClient, err := kube.NewCLIClient(kube.NewClientConfigForRestConfig(rc), "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Kubernetes client: %v", err)
+	}
 	client, err := client.New(kubeClient.RESTConfig(), client.Options{Scheme: kube.IstioScheme})
 	if err != nil {
 		return nil, nil, err

--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/tag"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
@@ -93,7 +92,7 @@ func addUninstallFlags(cmd *cobra.Command, args *uninstallArgs) {
 }
 
 // UninstallCmd command uninstalls Istio from a cluster
-func UninstallCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
+func UninstallCmd(logOpts *log.Options) *cobra.Command {
 	rootArgs := &RootArgs{}
 	uiArgs := &uninstallArgs{}
 	uicmd := &cobra.Command{
@@ -118,11 +117,7 @@ func UninstallCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := ctx.CLIClient()
-			if err != nil {
-				return err
-			}
-			return uninstall(cmd, client, rootArgs, uiArgs, logOpts)
+			return uninstall(cmd, rootArgs, uiArgs, logOpts)
 		},
 	}
 	addFlags(uicmd, rootArgs)
@@ -131,12 +126,12 @@ func UninstallCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
 }
 
 // uninstall uninstalls control plane by either pruning by target revision or deleting specified manifests.
-func uninstall(cmd *cobra.Command, cliClient kube.CLIClient, rootArgs *RootArgs, uiArgs *uninstallArgs, logOpts *log.Options) error {
+func uninstall(cmd *cobra.Command, rootArgs *RootArgs, uiArgs *uninstallArgs, logOpts *log.Options) error {
 	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 	if err := configLogs(logOpts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
-	kubeClient, client, err := KubernetesClients(cliClient, l)
+	kubeClient, client, err := KubernetesClients(uiArgs.kubeConfigPath, uiArgs.context, l)
 	if err != nil {
 		l.LogAndFatal(err)
 	}

--- a/tests/integration/operator/operator_dumper.go
+++ b/tests/integration/operator/operator_dumper.go
@@ -21,7 +21,7 @@ package operator
 
 import (
 	"istio.io/istio/pkg/test/framework/resource"
-	"istio.io/istio/pkg/test/kube"
+	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -43,7 +43,7 @@ func (d *operatorDumper) Dump(ctx resource.Context) {
 		scopes.Framework.Errorf("Unable to create directory for dumping operator contents: %v", err)
 		return
 	}
-	kube.DumpPods(ctx, dir, ns, []string{"name=istio-operator"})
+	kube2.DumpPods(ctx, dir, ns, []string{"name=istio-operator"})
 }
 
 func (d *operatorDumper) ID() resource.ID {

--- a/tests/integration/operator/verify_test.go
+++ b/tests/integration/operator/verify_test.go
@@ -51,8 +51,8 @@ func TestPostInstallControlPlaneVerification(t *testing.T) {
 			}
 			istioCtl.InvokeOrFail(t, installCmd)
 			tfLogger := clog.NewConsoleLogger(io.Discard, io.Discard, scopes.Framework)
-			statusVerifier, err := verifier.NewStatusVerifier(cs, IstioNamespace, ManifestPath, []string{},
-				clioptions.ControlPlaneOptions{}, verifier.WithLogger(tfLogger))
+			statusVerifier, err := verifier.NewStatusVerifier(IstioNamespace, ManifestPath, "",
+				"", []string{}, clioptions.ControlPlaneOptions{}, verifier.WithLogger(tfLogger))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Reverts istio/istio#46690

This PR causes a regression in not accepting a context argument, for example: `istioctl uninstall --revision=default --context=kind-doc-cluster2`.

Noting also that there were no release notes about the lose of functionality.