### PR TITLE
Add endpoints to proxy-config all output

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -450,7 +450,7 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 					if ztunnelPod {
 						dump, err = extractZtunnelConfigDump(kubeClient, podName, podNamespace)
 					} else {
-						dump, err = extractConfigDump(kubeClient, podName, podNamespace, false)
+						dump, err = extractConfigDump(kubeClient, podName, podNamespace, true)
 					}
 					if err != nil {
 						return err

--- a/releasenotes/notes/fix-proxyconfig-endpoints-json.yaml
+++ b/releasenotes/notes/fix-proxyconfig-endpoints-json.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** the output of `istioctl proxy-config all` to include EDS configuration when the `--json` or `--yaml` flags are used.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix the output of `istioctl proxy-config all` to include EDS configuration when the `--json` or `--yaml` flags are used. Also add a test