### PR TITLE
Fix filter ordering and WASM NETWORK implementation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
+++ b/pilot/pkg/networking/core/v1alpha3/extension/wasmplugin.go
@@ -65,16 +65,6 @@ func PopAppendNetwork(list []*listener.Filter,
 	return list
 }
 
-func PopAppendNetworkFilters(list []*listener.Filter,
-	filterMap map[extensions.PluginPhase][]*model.WasmPluginWrapper,
-) []*listener.Filter {
-	list = PopAppendNetwork(list, filterMap, extensions.PluginPhase_AUTHN)
-	list = PopAppendNetwork(list, filterMap, extensions.PluginPhase_AUTHZ)
-	list = PopAppendNetwork(list, filterMap, extensions.PluginPhase_STATS)
-	list = PopAppendNetwork(list, filterMap, extensions.PluginPhase_UNSPECIFIED_PHASE)
-	return list
-}
-
 func toEnvoyHTTPFilter(wasmPlugin *model.WasmPluginWrapper) *hcm.HttpFilter {
 	return &hcm.HttpFilter{
 		Name: wasmPlugin.ResourceName,

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -242,7 +242,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayTCPBasedFilterChains(
 	mergedGateway *model.MergedGateway,
 	tlsHostsByPort map[uint32]map[string]string,
 ) {
-	tcpAuthFilters := []*listener.Filter{xdsfilters.IstioNetworkAuthenticationFilter}
 	// Add network level WASM filters if any configured.
 	wasm := builder.push.WasmPluginsByListenerInfo(builder.node, model.WasmPluginListenerInfo{
 		Port:  opts.port,
@@ -255,7 +254,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayTCPBasedFilterChains(
 			proxyConfig, istionetworking.ListenerProtocolTCP, builder.push)
 		// In HTTP, we need to have RBAC, etc. upfront so that they can enforce policies immediately
 		httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_AUTHN)
-		httpFilterChainOpts.networkFilters = append(httpFilterChainOpts.networkFilters, tcpAuthFilters...)
+		httpFilterChainOpts.networkFilters = append(httpFilterChainOpts.networkFilters, xdsfilters.IstioNetworkAuthenticationFilter)
 		httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_AUTHZ)
 		httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_STATS)
 		httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)
@@ -274,7 +273,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayTCPBasedFilterChains(
 					routeName, proxyConfig, istionetworking.TransportProtocolTCP, builder.push)
 				// In HTTP, we need to have RBAC, etc. upfront so that they can enforce policies immediately
 				httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_AUTHN)
-				httpFilterChainOpts.networkFilters = append(httpFilterChainOpts.networkFilters, tcpAuthFilters...)
+				httpFilterChainOpts.networkFilters = append(httpFilterChainOpts.networkFilters, xdsfilters.IstioNetworkAuthenticationFilter)
 				httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_AUTHZ)
 				httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_STATS)
 				httpFilterChainOpts.networkFilters = extension.PopAppendNetwork(httpFilterChainOpts.networkFilters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)
@@ -283,28 +282,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayTCPBasedFilterChains(
 				// we are building a network filter chain (no http connection manager) for this filter chain
 				// For network filters such as mysql, mongo, etc., we need the filter codec upfront. Data from this
 				// codec is used by RBAC later.
-				var tcpAuthAndWasmFilters []*listener.Filter
-				tcpAuthAndWasmFilters = extension.PopAppendNetwork(tcpAuthAndWasmFilters, wasm, extensions.PluginPhase_AUTHN)
-				tcpAuthAndWasmFilters = append(tcpAuthAndWasmFilters, xdsfilters.IstioNetworkAuthenticationFilter)
-				tcpAuthAndWasmFilters = extension.PopAppendNetwork(tcpAuthAndWasmFilters, wasm, extensions.PluginPhase_AUTHZ)
-				tcpAuthAndWasmFilters = append(tcpAuthAndWasmFilters, builder.authzCustomBuilder.BuildTCP()...)
-				tcpAuthAndWasmFilters = append(tcpAuthAndWasmFilters, builder.authzBuilder.BuildTCP()...)
-				tcpAuthAndWasmFilters = extension.PopAppendNetwork(tcpAuthAndWasmFilters, wasm, extensions.PluginPhase_STATS)
-				tcpAuthAndWasmFilters = extension.PopAppendNetwork(tcpAuthAndWasmFilters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)
-
 				// This is the case of TCP or PASSTHROUGH.
-				tcpChainOpts := configgen.createGatewayTCPFilterChainOpts(builder.node, builder.push,
+				tcpChainOpts := builder.createGatewayTCPFilterChainOpts(
 					server, port.Number, mergedGateway.GatewayNameForServer[server], tlsHostsByPort)
-				for _, opt := range tcpChainOpts {
-					if len(opt.networkFilters) > 0 {
-						// this is the terminating filter
-						lastNetworkFilter := opt.networkFilters[len(opt.networkFilters)-1]
-						opt.networkFilters = append(opt.networkFilters[:len(opt.networkFilters)-1], tcpAuthAndWasmFilters...)
-						opt.networkFilters = append(opt.networkFilters, lastNetworkFilter)
-					} else {
-						opt.networkFilters = append(opt.networkFilters, tcpAuthAndWasmFilters...)
-					}
-				}
 				opts.filterChainOpts = append(opts.filterChainOpts, tcpChainOpts...)
 			}
 		}
@@ -796,8 +776,8 @@ func convertTLSProtocol(in networking.ServerTLSSettings_TLSProtocol) tls.TlsPara
 	return out
 }
 
-func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
-	node *model.Proxy, push *model.PushContext, server *networking.Server, listenerPort uint32,
+func (lb *ListenerBuilder) createGatewayTCPFilterChainOpts(
+	server *networking.Server, listenerPort uint32,
 	gatewayName string, tlsHostsByPort map[uint32]map[string]string,
 ) []*filterChainOpts {
 	// We have a TCP/TLS server. This could be TLS termination (user specifies server.TLS with simple/mutual)
@@ -805,8 +785,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 
 	// This is opaque TCP server. Find matching virtual services with TCP blocks and forward
 	if server.Tls == nil {
-		if filters := buildGatewayNetworkFiltersFromTCPRoutes(node,
-			push, server, gatewayName); len(filters) > 0 {
+		if filters := lb.buildGatewayNetworkFiltersFromTCPRoutes(server, gatewayName); len(filters) > 0 {
 			return []*filterChainOpts{
 				{
 					sniHosts:       nil,
@@ -820,12 +799,11 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 		// TCP with TLS termination and forwarding. Setup TLS context to terminate, find matching services with TCP blocks
 		// and forward to backend
 		// Validation ensures that non-passthrough servers will have certs
-		if filters := buildGatewayNetworkFiltersFromTCPRoutes(node,
-			push, server, gatewayName); len(filters) > 0 {
+		if filters := lb.buildGatewayNetworkFiltersFromTCPRoutes(server, gatewayName); len(filters) > 0 {
 			return []*filterChainOpts{
 				{
-					sniHosts:       node.MergedGateway.TLSServerInfo[server].SNIHosts,
-					tlsContext:     buildGatewayListenerTLSContext(push.Mesh, server, node, istionetworking.TransportProtocolTCP),
+					sniHosts:       lb.node.MergedGateway.TLSServerInfo[server].SNIHosts,
+					tlsContext:     buildGatewayListenerTLSContext(lb.push.Mesh, server, lb.node, istionetworking.TransportProtocolTCP),
 					networkFilters: filters,
 				},
 			}
@@ -833,7 +811,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 		log.Warnf("gateway %s:%d listener missed network filter", gatewayName, server.Port.Number)
 	} else {
 		// Passthrough server.
-		return buildGatewayNetworkFiltersFromTLSRoutes(node, push, server, listenerPort, gatewayName, tlsHostsByPort)
+		return lb.buildGatewayNetworkFiltersFromTLSRoutes(server, listenerPort, gatewayName, tlsHostsByPort)
 	}
 
 	return []*filterChainOpts{}
@@ -842,7 +820,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 // buildGatewayNetworkFiltersFromTCPRoutes builds tcp proxy routes for all VirtualServices with TCP blocks.
 // It first obtains all virtual services bound to the set of Gateways for this workload, filters them by this
 // server's port and hostnames, and produces network filters for each destination from the filtered services.
-func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.PushContext, server *networking.Server, gateway string) []*listener.Filter {
+func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTCPRoutes(server *networking.Server, gateway string) []*listener.Filter {
 	port := &model.Port{
 		Name:     server.Port.Name,
 		Port:     int(server.Port.Number),
@@ -854,7 +832,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 		gatewayServerHosts.Insert(host.Name(hostname))
 	}
 
-	virtualServices := push.VirtualServicesForGateway(node.ConfigNamespace, gateway)
+	virtualServices := lb.push.VirtualServicesForGateway(lb.node.ConfigNamespace, gateway)
 	if len(virtualServices) == 0 {
 		log.Warnf("no virtual service bound to gateway: %v", gateway)
 	}
@@ -875,12 +853,8 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
 			if l4MultiMatch(tcp.Match, server, gateway) {
-				out := make([]*listener.Filter, 0)
-				if server.GetTls().GetMode() == networking.ServerTLSSettings_ISTIO_MUTUAL {
-					out = append(out,
-						buildMetadataExchangeNetworkFiltersForTCPIstioMTLSGateway()...)
-				}
-				return append(out, buildOutboundNetworkFilters(node, tcp.Route, push, port, v.Meta)...)
+				includeMx := server.GetTls().GetMode() == networking.ServerTLSSettings_ISTIO_MUTUAL
+				return lb.buildOutboundNetworkFilters(tcp.Route, port, v.Meta, includeMx)
 			}
 		}
 	}
@@ -891,7 +865,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 // buildGatewayNetworkFiltersFromTLSRoutes builds tcp proxy routes for all VirtualServices with TLS blocks.
 // It first obtains all virtual services bound to the set of Gateways for this workload, filters them by this
 // server's port and hostnames, and produces network filters for each destination from the filtered services
-func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.PushContext, server *networking.Server,
+func (lb *ListenerBuilder) buildGatewayNetworkFiltersFromTLSRoutes(server *networking.Server,
 	listenerPort uint32, gatewayName string, tlsHostsByPort map[uint32]map[string]string,
 ) []*filterChainOpts {
 	port := &model.Port{
@@ -908,9 +882,9 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 	filterChains := make([]*filterChainOpts, 0)
 
 	if server.Tls.Mode == networking.ServerTLSSettings_AUTO_PASSTHROUGH {
-		filterChains = append(filterChains, builtAutoPassthroughFilterChains(push, node, node.MergedGateway.TLSServerInfo[server].SNIHosts)...)
+		filterChains = append(filterChains, builtAutoPassthroughFilterChains(lb.push, lb.node, lb.node.MergedGateway.TLSServerInfo[server].SNIHosts)...)
 	} else {
-		virtualServices := push.VirtualServicesForGateway(node.ConfigNamespace, gatewayName)
+		virtualServices := lb.push.VirtualServicesForGateway(lb.node.ConfigNamespace, gatewayName)
 		for _, v := range virtualServices {
 			vsvc := v.Spec.(*networking.VirtualService)
 			// We have two cases here:
@@ -949,7 +923,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 						filterChains = append(filterChains, &filterChainOpts{
 							sniHosts:       match.SniHosts,
 							tlsContext:     nil, // NO TLS context because this is passthrough
-							networkFilters: buildOutboundNetworkFilters(node, tls.Route, push, port, v.Meta),
+							networkFilters: lb.buildOutboundNetworkFilters(tls.Route, port, v.Meta, false),
 						})
 					}
 				}
@@ -964,6 +938,11 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 // These servers allow connecting to any SNI-DNAT upstream cluster that matches the server's hostname.
 // To handle this, we generate a filter chain per upstream cluster
 func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Proxy, hosts []string) []*filterChainOpts {
+	// We do not want any authz here, so build a new LB without it set
+	lb := &ListenerBuilder{
+		node: proxy,
+		push: push,
+	}
 	filterChains := make([]*filterChainOpts, 0)
 	for _, service := range proxy.SidecarScope.Services() {
 		if service.MeshExternal {
@@ -1001,8 +980,8 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 				sniHosts:             []string{clusterName},
 				applicationProtocols: allIstioMtlsALPNs,
 				tlsContext:           nil, // NO TLS context because this is passthrough
-				networkFilters: buildOutboundNetworkFiltersWithSingleDestination(
-					push, proxy, statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip),
+				networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
+					statPrefix, clusterName, "", port, destinationRule, tunnelingconfig.Skip, false),
 			})
 
 			// Do the same, but for each subset
@@ -1017,8 +996,8 @@ func builtAutoPassthroughFilterChains(push *model.PushContext, proxy *model.Prox
 					sniHosts:             []string{subsetClusterName},
 					applicationProtocols: allIstioMtlsALPNs,
 					tlsContext:           nil, // NO TLS context because this is passthrough
-					networkFilters: buildOutboundNetworkFiltersWithSingleDestination(
-						push, proxy, subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip),
+					networkFilters: lb.buildOutboundNetworkFiltersWithSingleDestination(
+						subsetStatPrefix, subsetClusterName, subset.Name, port, destinationRule, tunnelingconfig.Skip, false),
 				})
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	security "istio.io/api/security/v1beta1"
@@ -45,6 +46,7 @@ import (
 	"istio.io/istio/pilot/test/xdstest"
 	config "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
@@ -3556,9 +3558,9 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 					{
 						TotalMatch: true,
 						NetworkFilters: []string{
-							xds.StatsFilterName,
 							xdsfilters.IstioNetworkAuthenticationFilter.GetName(),
 							wellknown.RoleBasedAccessControl,
+							xds.StatsFilterName,
 							wellknown.TCPProxy,
 						},
 					},
@@ -3566,7 +3568,101 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 			},
 		},
 		{
-			name: "HTTP RBAC and Stats",
+			name: "mTLS, RBAC, WASM, and Stats",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{Name: "gateway", Namespace: "testns", GroupVersionKind: gvk.Gateway},
+					Spec: &networking.Gateway{
+						Servers: []*networking.Server{
+							{
+								Port:  &networking.Port{Name: "tcp", Number: 100, Protocol: "TCP"},
+								Tls:   &networking.ServerTLSSettings{Mode: networking.ServerTLSSettings_ISTIO_MUTUAL},
+								Hosts: []string{"www.example.com"},
+							},
+						},
+					},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: uuid.NewString(), GroupVersionKind: gvk.VirtualService},
+					Spec: &networking.VirtualService{
+						Gateways: []string{"testns/gateway"},
+						Hosts:    []string{"www.example.com"},
+						Tcp: []*networking.TCPRoute{
+							{
+								Route: []*networking.RouteDestination{
+									{
+										Destination: &networking.Destination{
+											Host: "http.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-authz", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHZ,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-authn", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHN,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-stats", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_STATS,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
+					Spec: &security.AuthorizationPolicy{},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
+					Spec: &security.AuthorizationPolicy{
+						Action:       security.AuthorizationPolicy_CUSTOM,
+						ActionDetail: &security.AuthorizationPolicy_Provider{Provider: &security.AuthorizationPolicy_ExtensionProvider{Name: "extauthz"}},
+					},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.Telemetry},
+					Spec: &telemetry.Telemetry{
+						Metrics: []*telemetry.Metrics{{Providers: []*telemetry.ProviderRef{{Name: "prometheus"}}}},
+					},
+				},
+			},
+			expectedListener: listenertest.ListenerTest{
+				TotalMatch: true,
+				FilterChains: []listenertest.FilterChainTest{
+					{
+						TotalMatch: true,
+						NetworkFilters: []string{
+							xdsfilters.MxFilterName,
+							// Ext auth makes 2 filters
+							wellknown.RoleBasedAccessControl,
+							wellknown.ExternalAuthorization,
+							"istio-system.wasm-authn",
+							xdsfilters.AuthnFilterName,
+							"istio-system.wasm-authz",
+							wellknown.RoleBasedAccessControl,
+							"istio-system.wasm-stats",
+							xds.StatsFilterName,
+							wellknown.TCPProxy,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "HTTP RBAC, WASM, and Stats",
 			configs: []config.Config{
 				{
 					Meta: config.Meta{Name: "gateway", Namespace: "testns", GroupVersionKind: gvk.Gateway},
@@ -3577,6 +3673,45 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 								Hosts: []string{"www.example.com"},
 							},
 						},
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-network-authz", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHZ,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-network-authn", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHN,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-network-stats", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_STATS,
+						Type:  extensions.PluginType_NETWORK,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-authz", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHZ,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-authn", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_AUTHN,
+					},
+				},
+				{
+					Meta: config.Meta{Name: "wasm-stats", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+					Spec: &extensions.WasmPlugin{
+						Phase: extensions.PluginPhase_STATS,
 					},
 				},
 				{
@@ -3599,6 +3734,13 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 				},
 				{
 					Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
+					Spec: &security.AuthorizationPolicy{
+						Action:       security.AuthorizationPolicy_CUSTOM,
+						ActionDetail: &security.AuthorizationPolicy_Provider{Provider: &security.AuthorizationPolicy_ExtensionProvider{Name: "extauthz"}},
+					},
+				},
+				{
+					Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
 					Spec: &security.AuthorizationPolicy{},
 				},
 				{
@@ -3614,16 +3756,25 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 					{
 						TotalMatch: true,
 						NetworkFilters: []string{
-							xdsfilters.IstioNetworkAuthenticationFilter.GetName(),
+							"istio-system.wasm-network-authn",
+							xdsfilters.AuthnFilterName,
+							"istio-system.wasm-network-authz",
+							"istio-system.wasm-network-stats",
 							wellknown.HTTPConnectionManager,
 						},
 						HTTPFilters: []string{
 							xdsfilters.MxFilterName,
+							// Ext auth makes 2 filters
 							wellknown.HTTPRoleBasedAccessControl,
+							wellknown.HTTPExternalAuthorization,
+							"istio-system.wasm-authn",
+							"istio-system.wasm-authz",
+							wellknown.HTTPRoleBasedAccessControl,
+							"istio-system.wasm-stats",
 							wellknown.HTTPGRPCStats,
-							xdsfilters.Alpn.GetName(),
-							xdsfilters.Fault.GetName(),
-							xdsfilters.Cors.GetName(),
+							xdsfilters.Alpn.Name,
+							xdsfilters.Fault.Name,
+							xdsfilters.Cors.Name,
 							xds.StatsFilterName,
 							wellknown.Router,
 						},
@@ -3634,9 +3785,28 @@ func TestBuildGatewayListenersFilters(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			cg := NewConfigGenTest(t, TestOptions{
-				Configs: tt.configs,
+			mc := mesh.DefaultMeshConfig()
+			mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+				Name: "extauthz",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
+					EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
+						Service: "foo/example.local",
+						Port:    1234,
+					},
+				},
 			})
+
+			cg := NewConfigGenTest(t, TestOptions{
+				Configs:    tt.configs,
+				MeshConfig: mc,
+			})
+			cg.PushContext().ServiceIndex.HostnameAndNamespace = map[host.Name]map[string]*pilot_model.Service{
+				"example.local": {
+					"foo": &pilot_model.Service{
+						Hostname: "example.local",
+					},
+				},
+			}
 			proxy := cg.SetupProxy(&proxyGateway)
 			metadata := proxyGatewayMetadata
 			metadata.ProxyConfig = tt.proxyConfig

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -29,13 +29,17 @@ import (
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	extensions "istio.io/api/extensions/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	security "istio.io/api/security/v1beta1"
+	telemetry "istio.io/api/telemetry/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/listenertest"
@@ -48,6 +52,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/xds"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -199,6 +204,117 @@ func TestInboundListenerConfig(t *testing.T) {
 		features.EnableSidecarServiceInboundListenerMerge = true
 		testInboundListenerConfigWithSidecar(t, getProxy(),
 			buildService("test.com", wildcardIPv4, protocol.HTTP, tnow))
+	})
+
+	t.Run("wasm, stats, authz", func(t *testing.T) {
+		tcp := buildService("tcp.example.com", wildcardIPv4, protocol.TCP, tnow)
+		tcp.Ports[0].Port = 1234
+		tcp.Ports[0].Name = "tcp"
+		services := []*model.Service{
+			tcp,
+			buildService("http.example.com", wildcardIPv4, protocol.HTTP, tnow),
+		}
+		mc := mesh.DefaultMeshConfig()
+		mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+			Name: "extauthz",
+			Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
+				EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
+					Service: "default/http.example.com",
+					Port:    8080,
+				},
+			},
+		})
+		o := TestOptions{
+			Services:   services,
+			MeshConfig: mc,
+			Configs:    filterTestConfigs,
+		}
+		cg := NewConfigGenTest(t, o)
+		p := getProxy()
+		for _, s := range o.Services {
+			i := &model.ServiceInstance{
+				Service: s,
+				Endpoint: &model.IstioEndpoint{
+					Address:      "1.1.1.1",
+					EndpointPort: uint32(s.Ports[0].Port),
+				},
+				ServicePort: s.Ports[0],
+			}
+			cg.MemRegistry.AddInstance(i)
+		}
+		listeners := cg.Listeners(cg.SetupProxy(p))
+		xdstest.ValidateListeners(t, listeners)
+		l := xdstest.ExtractListener(model.VirtualInboundListenerName, listeners)
+		httpFilters := []string{
+			xdsfilters.MxFilterName,
+			// Ext auth makes 2 filters
+			wellknown.HTTPRoleBasedAccessControl,
+			wellknown.HTTPExternalAuthorization,
+			"istio-system.wasm-authn",
+			"istio-system.wasm-authz",
+			wellknown.HTTPRoleBasedAccessControl,
+			"istio-system.wasm-stats",
+			wellknown.HTTPGRPCStats,
+			xdsfilters.Fault.Name,
+			xdsfilters.Cors.Name,
+			xds.StatsFilterName,
+			wellknown.Router,
+		}
+		httpNetworkFilters := []string{
+			xdsfilters.MxFilterName,
+			"istio-system.wasm-network-authn",
+			xdsfilters.AuthnFilterName,
+			"istio-system.wasm-network-authz",
+			"istio-system.wasm-network-stats",
+			wellknown.HTTPConnectionManager,
+		}
+		tcpNetworkFilters := []string{
+			xdsfilters.MxFilterName,
+			// Ext auth makes 2 filters
+			wellknown.RoleBasedAccessControl,
+			wellknown.ExternalAuthorization,
+			"istio-system.wasm-network-authn",
+			xdsfilters.AuthnFilterName,
+			"istio-system.wasm-network-authz",
+			wellknown.RoleBasedAccessControl,
+			"istio-system.wasm-network-stats",
+			xds.StatsFilterName,
+			wellknown.TCPProxy,
+		}
+		verifyInboundFilterChains(t, l, httpFilters, httpNetworkFilters, tcpNetworkFilters)
+		// verifyInboundFilterChains only checks the passthrough. Ensure the main filters get created as expected, too.
+		listenertest.VerifyListener(t, l, listenertest.ListenerTest{
+			FilterChains: []listenertest.FilterChainTest{
+				{
+					Name:           "0.0.0.0_8080",
+					Type:           listenertest.MTLSHTTP,
+					HTTPFilters:    httpFilters,
+					NetworkFilters: httpNetworkFilters,
+					TotalMatch:     true,
+				},
+				{
+					Name:           "0.0.0.0_8080",
+					Type:           listenertest.PlainTCP,
+					HTTPFilters:    httpFilters,
+					NetworkFilters: httpNetworkFilters,
+					TotalMatch:     true,
+				},
+				{
+					Name:           "0.0.0.0_1234",
+					Type:           listenertest.StandardTLS,
+					HTTPFilters:    []string{},
+					NetworkFilters: tcpNetworkFilters,
+					TotalMatch:     true,
+				},
+				{
+					Name:           "0.0.0.0_1234",
+					Type:           listenertest.PlainTCP,
+					HTTPFilters:    []string{},
+					NetworkFilters: tcpNetworkFilters,
+					TotalMatch:     true,
+				},
+			},
+		})
 	})
 }
 
@@ -890,6 +1006,144 @@ func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
 		},
 	}
 	testOutboundListenerFilterTimeout(t, services...)
+}
+
+var filterTestConfigs = []config.Config{
+	{
+		Meta: config.Meta{Name: "wasm-network-authz", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_AUTHZ,
+			Type:  extensions.PluginType_NETWORK,
+		},
+	},
+	{
+		Meta: config.Meta{Name: "wasm-network-authn", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_AUTHN,
+			Type:  extensions.PluginType_NETWORK,
+		},
+	},
+	{
+		Meta: config.Meta{Name: "wasm-network-stats", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_STATS,
+			Type:  extensions.PluginType_NETWORK,
+		},
+	},
+	{
+		Meta: config.Meta{Name: "wasm-authz", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_AUTHZ,
+		},
+	},
+	{
+		Meta: config.Meta{Name: "wasm-authn", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_AUTHN,
+		},
+	},
+	{
+		Meta: config.Meta{Name: "wasm-stats", Namespace: "istio-system", GroupVersionKind: gvk.WasmPlugin},
+		Spec: &extensions.WasmPlugin{
+			Phase: extensions.PluginPhase_STATS,
+		},
+	},
+	{
+		Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
+		Spec: &security.AuthorizationPolicy{},
+	},
+	{
+		Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.AuthorizationPolicy},
+		Spec: &security.AuthorizationPolicy{
+			Selector:     nil,
+			TargetRef:    nil,
+			Rules:        nil,
+			Action:       security.AuthorizationPolicy_CUSTOM,
+			ActionDetail: &security.AuthorizationPolicy_Provider{Provider: &security.AuthorizationPolicy_ExtensionProvider{Name: "extauthz"}},
+		},
+	},
+	{
+		Meta: config.Meta{Name: uuid.NewString(), Namespace: "istio-system", GroupVersionKind: gvk.Telemetry},
+		Spec: &telemetry.Telemetry{
+			Metrics: []*telemetry.Metrics{{Providers: []*telemetry.ProviderRef{{Name: "prometheus"}}}},
+		},
+	},
+}
+
+func TestOutboundFilters(t *testing.T) {
+	mc := mesh.DefaultMeshConfig()
+	mc.ExtensionProviders = append(mc.ExtensionProviders, &meshconfig.MeshConfig_ExtensionProvider{
+		Name: "extauthz",
+		Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzGrpc{
+			EnvoyExtAuthzGrpc: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationGrpcProvider{
+				Service: "foo/example.local",
+				Port:    1234,
+			},
+		},
+	})
+
+	t.Run("HTTP", func(t *testing.T) {
+		cg := NewConfigGenTest(t, TestOptions{
+			Services:   []*model.Service{buildService("test.com", wildcardIPv4, protocol.HTTP, tnow)},
+			Configs:    filterTestConfigs,
+			MeshConfig: mc,
+		})
+		proxy := cg.SetupProxy(getProxy())
+		listeners := NewListenerBuilder(proxy, cg.env.PushContext()).buildSidecarOutboundListeners(proxy, cg.env.PushContext())
+		xdstest.ValidateListeners(t, listeners)
+		l := xdstest.ExtractListener("0.0.0.0_8080", listeners)
+		listenertest.VerifyListener(t, l, listenertest.ListenerTest{
+			FilterChains: []listenertest.FilterChainTest{
+				{
+					TotalMatch: true,
+					HTTPFilters: []string{
+						xdsfilters.MxFilterName,
+						"istio-system.wasm-authn",
+						"istio-system.wasm-authz",
+						"istio-system.wasm-stats",
+						wellknown.HTTPGRPCStats,
+						xdsfilters.AlpnFilterName,
+						xdsfilters.Fault.Name,
+						xdsfilters.Cors.Name,
+						xds.StatsFilterName,
+						wellknown.Router,
+					},
+					NetworkFilters: []string{
+						"istio-system.wasm-network-authn",
+						"istio-system.wasm-network-authz",
+						"istio-system.wasm-network-stats",
+						wellknown.HTTPConnectionManager,
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("TCP", func(t *testing.T) {
+		cg := NewConfigGenTest(t, TestOptions{
+			Services:   []*model.Service{buildService("test.com", wildcardIPv4, protocol.TCP, tnow)},
+			Configs:    filterTestConfigs,
+			MeshConfig: mc,
+		})
+		proxy := cg.SetupProxy(getProxy())
+		listeners := NewListenerBuilder(proxy, cg.env.PushContext()).buildSidecarOutboundListeners(proxy, cg.env.PushContext())
+		xdstest.ValidateListeners(t, listeners)
+		l := xdstest.ExtractListener("0.0.0.0_8080", listeners)
+		listenertest.VerifyListener(t, l, listenertest.ListenerTest{
+			FilterChains: []listenertest.FilterChainTest{
+				{
+					TotalMatch: true,
+					NetworkFilters: []string{
+						"istio-system.wasm-network-authn",
+						"istio-system.wasm-network-authz",
+						"istio-system.wasm-network-stats",
+						xds.StatsFilterName,
+						wellknown.TCPProxy,
+					},
+				},
+			},
+		})
+	})
 }
 
 func TestOutboundTls(t *testing.T) {
@@ -2413,6 +2667,7 @@ func verifyOutboundTCPListenerHostname(t *testing.T, l *listener.Listener, hostn
 }
 
 func verifyFilterChainMatch(t *testing.T, listener *listener.Listener) {
+	t.Helper()
 	httpFilters := []string{
 		xdsfilters.MxFilterName,
 		xdsfilters.GrpcStats.Name,
@@ -2420,6 +2675,13 @@ func verifyFilterChainMatch(t *testing.T, listener *listener.Listener) {
 		xdsfilters.Cors.Name,
 		wellknown.Router,
 	}
+	httpNetworkFilters := []string{xdsfilters.MxFilterName, xdsfilters.AuthnFilterName, wellknown.HTTPConnectionManager}
+	tcpNetworkFilters := []string{xdsfilters.MxFilterName, xdsfilters.AuthnFilterName, wellknown.TCPProxy}
+	verifyInboundFilterChains(t, listener, httpFilters, httpNetworkFilters, tcpNetworkFilters)
+}
+
+func verifyInboundFilterChains(t *testing.T, listener *listener.Listener, httpFilters []string, httpNetworkFilters []string, tcpNetworkFilters []string) {
+	t.Helper()
 	listenertest.VerifyListener(t, listener, listenertest.ListenerTest{
 		FilterChains: []listenertest.FilterChainTest{
 			{
@@ -2431,35 +2693,35 @@ func verifyFilterChainMatch(t *testing.T, listener *listener.Listener) {
 				Name:           model.VirtualInboundCatchAllHTTPFilterChainName,
 				Type:           listenertest.MTLSHTTP,
 				HTTPFilters:    httpFilters,
-				NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, wellknown.HTTPConnectionManager},
+				NetworkFilters: httpNetworkFilters,
 				TotalMatch:     true,
 			},
 			{
 				Name:           model.VirtualInboundCatchAllHTTPFilterChainName,
 				Type:           listenertest.PlainHTTP,
 				HTTPFilters:    httpFilters,
-				NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, wellknown.HTTPConnectionManager},
+				NetworkFilters: httpNetworkFilters,
 				TotalMatch:     true,
 			},
 			{
 				Name:           model.VirtualInboundListenerName,
 				Type:           listenertest.MTLSTCP,
 				HTTPFilters:    []string{},
-				NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, wellknown.TCPProxy},
+				NetworkFilters: tcpNetworkFilters,
 				TotalMatch:     true,
 			},
 			{
 				Name:           model.VirtualInboundListenerName,
 				Type:           listenertest.PlainTCP,
 				HTTPFilters:    []string{},
-				NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, wellknown.TCPProxy},
+				NetworkFilters: tcpNetworkFilters,
 				TotalMatch:     true,
 			},
 			{
 				Name:           model.VirtualInboundListenerName,
 				Type:           listenertest.StandardTLS,
 				HTTPFilters:    []string{},
-				NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, wellknown.TCPProxy},
+				NetworkFilters: tcpNetworkFilters,
 				TotalMatch:     true,
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -45,17 +45,7 @@ import (
 // redisOpTimeout is the default operation timeout for the Redis proxy filter.
 var redisOpTimeout = 5 * time.Second
 
-func buildMetadataExchangeNetworkFilters(class istionetworking.ListenerClass) []*listener.Filter {
-	filterstack := make([]*listener.Filter, 0)
-	// We add metadata exchange on inbound only; outbound is handled in cluster filter
-	if class == istionetworking.ListenerClassSidecarInbound && features.MetadataExchange {
-		filterstack = append(filterstack, xdsfilters.TCPListenerMx)
-	}
-
-	return filterstack
-}
-
-func buildMetadataExchangeNetworkFiltersForTCPIstioMTLSGateway() []*listener.Filter {
+func buildMetadataExchangeNetworkFilters() []*listener.Filter {
 	filterstack := make([]*listener.Filter, 0)
 	// We add metadata exchange on inbound only; outbound is handled in cluster filter
 	if features.MetadataExchange {
@@ -83,13 +73,14 @@ func setAccessLogAndBuildTCPFilter(push *model.PushContext, node *model.Proxy, c
 
 // buildOutboundNetworkFiltersWithSingleDestination takes a single cluster name
 // and builds a stack of network filters.
-func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, node *model.Proxy,
+func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithSingleDestination(
 	statPrefix, clusterName, subsetName string, port *model.Port, destinationRule *networking.DestinationRule, applyTunnelingConfig tunnelingconfig.ApplyFunc,
+	includeMx bool,
 ) []*listener.Filter {
 	tcpProxy := &tcp.TcpProxy{
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: clusterName},
-		IdleTimeout:      parseDuration(node.Metadata.IdleTimeout),
+		IdleTimeout:      parseDuration(lb.node.Metadata.IdleTimeout),
 	}
 	maxConnectionDuration := destinationRule.GetTrafficPolicy().GetConnectionPool().GetTcp().GetMaxConnectionDuration()
 	if maxConnectionDuration != nil {
@@ -97,29 +88,57 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 	}
 	maybeSetHashPolicy(destinationRule, tcpProxy, subsetName)
 	applyTunnelingConfig(tcpProxy, destinationRule, subsetName)
-	class := model.OutboundListenerClass(node.Type)
-	tcpFilter := setAccessLogAndBuildTCPFilter(push, node, tcpProxy, class)
+	class := model.OutboundListenerClass(lb.node.Type)
+	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, class)
+	networkFilterStack := buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)
 
+	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx)
+}
+
+func (lb *ListenerBuilder) buildCompleteNetworkFilters(
+	class istionetworking.ListenerClass,
+	port int,
+	networkFilterStack []*listener.Filter,
+	includeMx bool,
+) []*listener.Filter {
 	var filters []*listener.Filter
-	if !node.IsAmbient() {
-		filters = append(filters, buildMetadataExchangeNetworkFilters(class)...)
-	}
-	wasm := push.WasmPluginsByListenerInfo(node, model.WasmPluginListenerInfo{
-		Port:  port.Port,
+	wasm := lb.push.WasmPluginsByListenerInfo(lb.node, model.WasmPluginListenerInfo{
+		Port:  port,
 		Class: class,
 	}, model.WasmPluginTypeNetwork)
 
+	// Metadata exchange goes first, so RBAC failures, etc can access the state. See https://github.com/istio/istio/issues/41066
+	if features.MetadataExchange && includeMx {
+		filters = append(filters, xdsfilters.TCPListenerMx)
+	}
+	// TODO: not sure why it goes here
+	filters = append(filters, lb.authzCustomBuilder.BuildTCP()...)
+
+	// Authn
 	filters = extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_AUTHN)
+	if class != istionetworking.ListenerClassSidecarOutbound {
+		filters = append(filters, xdsfilters.IstioNetworkAuthenticationFilter)
+	}
+
+	// Authz
 	filters = extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_AUTHZ)
-	filters = append(filters, buildMetricsNetworkFilters(push, node, class)...)
-	filters = append(filters, buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)...)
+	filters = append(filters, lb.authzBuilder.BuildTCP()...)
+
+	// Stats
+	filters = extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_STATS)
+	filters = extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)
+	filters = append(filters, buildMetricsNetworkFilters(lb.push, lb.node, class)...)
+
+	// Terminal filters
+	filters = append(filters, networkFilterStack...)
 	return filters
 }
 
 // buildOutboundNetworkFiltersWithWeightedClusters takes a set of weighted
 // destination routes and builds a stack of network filters.
-func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes []*networking.RouteDestination,
-	push *model.PushContext, port *model.Port, configMeta config.Meta, destinationRule *networking.DestinationRule,
+func (lb *ListenerBuilder) buildOutboundNetworkFiltersWithWeightedClusters(routes []*networking.RouteDestination,
+	port *model.Port, configMeta config.Meta, destinationRule *networking.DestinationRule,
+	includeMx bool,
 ) []*listener.Filter {
 	statPrefix := configMeta.Name + "." + configMeta.Namespace
 	clusterSpecifier := &tcp.TcpProxy_WeightedClusters{
@@ -130,7 +149,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: clusterSpecifier,
 
-		IdleTimeout: parseDuration(node.Metadata.IdleTimeout),
+		IdleTimeout: parseDuration(lb.node.Metadata.IdleTimeout),
 	}
 
 	maxConnectionDuration := destinationRule.GetTrafficPolicy().GetConnectionPool().GetTcp().GetMaxConnectionDuration()
@@ -139,7 +158,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	}
 
 	for _, route := range routes {
-		service := push.ServiceForHostname(node, host.Name(route.Destination.Host))
+		service := lb.push.ServiceForHostname(lb.node, host.Name(route.Destination.Host))
 		if route.Weight > 0 {
 			clusterName := istioroute.GetDestinationCluster(route.Destination, service, port.Port)
 			clusterSpecifier.WeightedClusters.Clusters = append(clusterSpecifier.WeightedClusters.Clusters, &tcp.TcpProxy_WeightedCluster_ClusterWeight{
@@ -157,26 +176,11 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 
 	// TODO: Need to handle multiple cluster names for Redis
 	clusterName := clusterSpecifier.WeightedClusters.Clusters[0].Name
-	class := model.OutboundListenerClass(node.Type)
-	tcpFilter := setAccessLogAndBuildTCPFilter(push, node, tcpProxy, class)
+	class := model.OutboundListenerClass(lb.node.Type)
+	tcpFilter := setAccessLogAndBuildTCPFilter(lb.push, lb.node, tcpProxy, class)
+	networkFilterStack := buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)
 
-	var filters []*listener.Filter
-	if !node.IsAmbient() {
-		filters = append(filters, buildMetadataExchangeNetworkFilters(class)...)
-	}
-	wasm := push.WasmPluginsByListenerInfo(node, model.WasmPluginListenerInfo{
-		Port:  port.Port,
-		Class: class,
-	}, model.WasmPluginTypeNetwork)
-
-	filters = append(filters, extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_AUTHN)...)
-	filters = append(filters, extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_AUTHZ)...)
-	filters = append(filters, extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_STATS)...)
-	filters = append(filters, buildMetricsNetworkFilters(push, node, class)...)
-	filters = append(filters, extension.PopAppendNetwork(filters, wasm, extensions.PluginPhase_UNSPECIFIED_PHASE)...)
-	filters = append(filters, buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)...)
-	filters = append(filters, buildNetworkFiltersStack(port.Protocol, tcpFilter, statPrefix, clusterName)...)
-	return filters
+	return lb.buildCompleteNetworkFilters(class, port.Port, networkFilterStack, includeMx)
 }
 
 func maybeSetHashPolicy(destinationRule *networking.DestinationRule, tcpProxy *tcp.TcpProxy, subsetName string) {
@@ -239,10 +243,11 @@ func buildNetworkFiltersStack(p protocol.Instance, tcpFilter *listener.Filter, s
 // buildOutboundNetworkFilters generates a TCP proxy network filter for outbound
 // connections. In addition, it generates protocol specific filters (e.g., Mongo
 // filter).
-func buildOutboundNetworkFilters(node *model.Proxy,
-	routes []*networking.RouteDestination, push *model.PushContext,
-	port *model.Port, configMeta config.Meta,
+func (lb *ListenerBuilder) buildOutboundNetworkFilters(
+	routes []*networking.RouteDestination,
+	port *model.Port, configMeta config.Meta, includeMx bool,
 ) []*listener.Filter {
+	push, node := lb.push, lb.node
 	service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
 	var destinationRule *networking.DestinationRule
 	if service != nil {
@@ -257,10 +262,10 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 				routes[0].Destination.Subset, port, 0, &service.Attributes)
 		}
 
-		return buildOutboundNetworkFiltersWithSingleDestination(
-			push, node, statPrefix, clusterName, routes[0].Destination.Subset, port, destinationRule, tunnelingconfig.Apply)
+		return lb.buildOutboundNetworkFiltersWithSingleDestination(
+			statPrefix, clusterName, routes[0].Destination.Subset, port, destinationRule, tunnelingconfig.Apply, includeMx)
 	}
-	return buildOutboundNetworkFiltersWithWeightedClusters(node, routes, push, port, configMeta, destinationRule)
+	return lb.buildOutboundNetworkFiltersWithWeightedClusters(routes, port, configMeta, destinationRule, includeMx)
 }
 
 // buildMongoFilter builds an outbound Envoy MongoProxy filter.

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -135,7 +135,7 @@ func TestInboundNetworkFilterOrder(t *testing.T) {
 			Filters: listenerFilters,
 		}
 		listenertest.VerifyFilterChain(t, listenerFilterChain, listenertest.FilterChainTest{
-			NetworkFilters: []string{"istio_authn", xdsfilters.MxFilterName, RBACTCPFilterName, wellknown.TCPProxy},
+			NetworkFilters: []string{xdsfilters.MxFilterName, "istio_authn", RBACTCPFilterName, wellknown.TCPProxy},
 			TotalMatch:     true,
 		})
 	})
@@ -382,9 +382,9 @@ func TestBuildOutboundNetworkFiltersTunnelingConfig(t *testing.T) {
 				},
 			})
 			proxy := cg.SetupProxy(&model.Proxy{ConfigNamespace: ns})
-
-			filters := buildOutboundNetworkFilters(proxy, tt.routeDestinations, cg.PushContext(),
-				&model.Port{Port: 443}, config.Meta{Name: "routing-config-for-example-com", Namespace: ns})
+			lb := ListenerBuilder{node: proxy, push: cg.PushContext()}
+			filters := lb.buildOutboundNetworkFilters(tt.routeDestinations,
+				&model.Port{Port: 443}, config.Meta{Name: "routing-config-for-example-com", Namespace: ns}, false)
 
 			tcpProxy := xdstest.ExtractTCPProxy(t, &listener.FilterChain{Filters: filters})
 			if tt.expectedTunnelingConfig == nil {
@@ -504,9 +504,10 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 			m.OutboundClusterStatName = tt.statPattern
 			cg := NewConfigGenTest(t, TestOptions{MeshConfig: m, Services: services})
 
-			listeners := buildOutboundNetworkFilters(
-				cg.SetupProxy(nil), tt.routes, cg.PushContext(),
-				&model.Port{Port: 9999}, config.Meta{Name: "test.com", Namespace: "ns"})
+			lb := ListenerBuilder{node: cg.SetupProxy(nil), push: cg.PushContext()}
+			listeners := lb.buildOutboundNetworkFilters(
+				tt.routes,
+				&model.Port{Port: 9999}, config.Meta{Name: "test.com", Namespace: "ns"}, false)
 			tcp := &tcp.TcpProxy{}
 			listeners[0].GetTypedConfig().UnmarshalTo(tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {
@@ -700,7 +701,8 @@ func TestOutboundNetworkFilterWithSourceIPHashing(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			listeners := buildOutboundNetworkFilters(proxy, tt.routes, cg.PushContext(), &model.Port{Port: 9999}, tt.configMeta)
+			lb := ListenerBuilder{node: proxy, push: cg.PushContext()}
+			listeners := lb.buildOutboundNetworkFilters(tt.routes, &model.Port{Port: 9999}, tt.configMeta, false)
 			tcp := &tcp.TcpProxy{}
 			listeners[0].GetTypedConfig().UnmarshalTo(tcp)
 			hasSourceIP := tcp.HashPolicy != nil && len(tcp.HashPolicy) == 1 && tcp.HashPolicy[0].GetSourceIp() != nil

--- a/releasenotes/notes/filter-order.yaml
+++ b/releasenotes/notes/filter-order.yaml
@@ -1,0 +1,26 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** the ordering of HTTP and TCP envoy filters to improve consistency
+upgradeNotes:
+  - title: "Envoy filter ordering"
+    content: |
+      This change impacts internal implementation of how Envoy "filters" are ordered. These filters run in order to implement various functionality.
+      
+      The ordering is now consistent across inbound, outbound and gateway proxy modes, as well as HTTP and TCP protocols:
+      
+      * Metadata Exchange
+      * CUSTOM Authz
+      * WASM Authn
+      * Authn
+      * WASM Authz
+      * Authz
+      * WASM Stats
+      * Stats
+      * WASM unspecified
+      
+      This changes the following areas:
+      * Inbound TCP filters now place Metadata Exchange before Authn.
+      * Gateway TCP filters now place stats after Authz, and CUSTOM Authz before Authn.


### PR DESCRIPTION
This fixes a few bugs introduced in https://github.com/istio/istio/pull/46514 and adds consistency to the ordering of filters with inbound, outbound, and gateways.

The order is as-follows:

- **Metadata Exchange**
- Custom Authz (ext authz)
- WASM Authn
- **Builtin Authn**
- WASM Authz
- **Builtin Authz**
- WASM Stats
- **Builtin Stats**
- WASM Rest
- **Terminal (TCP/HCM)**

Bugs fixed:

* Wasm outbound network was not implemented for HTTP protocols
* Wasm outbound network for weighted clusters does double appends, so we have many copies of every filter
* Inconsistent filter ordering between inbound, outbound, and gateways. Now all of them follow the above
  * Inbound network: MX now comes before istio_authn
  * Gateway network: before: [mx, wasm authn, wasm authz, stats, wasm authn, authn, wasm authz, ext_authz, rbac, wasm stats, tcp proxy]. Now: above. Ext authz is first like HTTP; removed duplicate WASM insertion; moved stats to after authn and RBAC.
