### PR TITLE
Fix applying resource error lead to undefined behavior during installation

### DIFF
--- a/releasenotes/notes/46901.yaml
+++ b/releasenotes/notes/46901.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 43312
+releaseNotes:
+- |
+  **Fixed** an issue where the installation process continued even if a resource failed to be applied, causing unexpected behavior.


### PR DESCRIPTION
**Please provide a description of this PR:**
This fixes issue https://github.com/istio/istio/issues/43312, not only for the operator but also for istioctl install. The Helm reconciler continues to apply resources even if the previous one encounters an error. This can lead to situations where the service selector does not match the deployment any more after the installation. Since we also have the object applying ordering, I think the installation process can be improved by simply return if we encounter an error.