### PR TITLE
Gateway ports resolve update

### DIFF
--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -234,7 +234,7 @@ func TestParseGatewayRDSRouteName(t *testing.T) {
 	}
 }
 
-func Test_resolvePorts(t *testing.T) {
+func TestResolvePorts(t *testing.T) {
 	placeHolderService := &Service{}
 	type args struct {
 		gwPort                uint32
@@ -252,7 +252,8 @@ func Test_resolvePorts(t *testing.T) {
 				gwPort: 1000,
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
-					makeServiceTarget(placeHolderService, 1001, 2001)},
+					makeServiceTarget(placeHolderService, 1001, 2001),
+				},
 				legacyGatewaySelector: true,
 			},
 			want: []uint32{2000},
@@ -264,7 +265,8 @@ func Test_resolvePorts(t *testing.T) {
 				gwPort: 1005,
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
-					makeServiceTarget(placeHolderService, 1001, 2001)},
+					makeServiceTarget(placeHolderService, 1001, 2001),
+				},
 				legacyGatewaySelector: true,
 			},
 			want: []uint32{1005},
@@ -275,7 +277,8 @@ func Test_resolvePorts(t *testing.T) {
 				gwPort: 1000,
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
-					makeServiceTarget(placeHolderService, 1000, 2008)},
+					makeServiceTarget(placeHolderService, 1000, 2008),
+				},
 				legacyGatewaySelector: true,
 			},
 			want: []uint32{2000},
@@ -287,7 +290,8 @@ func Test_resolvePorts(t *testing.T) {
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
 					makeServiceTarget(placeHolderService, 1000, 2008),
-					makeServiceTarget(placeHolderService, 1000, 1000)},
+					makeServiceTarget(placeHolderService, 1000, 1000),
+				},
 				legacyGatewaySelector: true,
 			},
 			want: []uint32{1000},
@@ -298,7 +302,8 @@ func Test_resolvePorts(t *testing.T) {
 				gwPort: 1000,
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
-					makeServiceTarget(placeHolderService, 1001, 2001)},
+					makeServiceTarget(placeHolderService, 1001, 2001),
+				},
 				legacyGatewaySelector: false,
 			},
 			want: []uint32{2000},
@@ -310,7 +315,8 @@ func Test_resolvePorts(t *testing.T) {
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
 					makeServiceTarget(placeHolderService, 1000, 2008),
-					makeServiceTarget(placeHolderService, 1000, 1000)},
+					makeServiceTarget(placeHolderService, 1000, 1000),
+				},
 				legacyGatewaySelector: false,
 			},
 			want: []uint32{1000, 2000, 2008},
@@ -321,7 +327,8 @@ func Test_resolvePorts(t *testing.T) {
 				gwPort: 1005,
 				serviceTargets: []ServiceTarget{
 					makeServiceTarget(placeHolderService, 1000, 2000),
-					makeServiceTarget(placeHolderService, 1001, 2001)},
+					makeServiceTarget(placeHolderService, 1001, 2001),
+				},
 				legacyGatewaySelector: false,
 			},
 			want: []uint32{},

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -160,6 +160,10 @@ func TestMergeGateways(t *testing.T) {
 	}
 }
 
+func TestResolvePorts(t *testing.T) {
+	// TODO: add tests
+}
+
 func makeConfig(name, namespace, host, portName, portProtocol string, portNumber uint32, gw string, bind string,
 	mode networking.ServerTLSSettings_TLSmode,
 ) config.Config {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2070,9 +2070,6 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 			if len(matchingInstances) > 0 {
 				gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, false, matchingInstances})
 			}
-		} else if gw.GetSelector() == nil {
-			// no selector. Applies to all workloads asking for the gateway
-			gatewayInstances = append(gatewayInstances, gatewayWithInstances{cfg, true, proxy.ServiceTargets})
 		} else {
 			gatewaySelector := labels.Instance(gw.GetSelector())
 			if gatewaySelector.SubsetOf(proxy.Labels) {


### PR DESCRIPTION
**Please provide a description of this PR:**

We prioritize resolve gateway port to the targetPort that also matches server port.  So it can not conflict when we have 

a two services as below:

Port A -> targetPort A

Port A -> targetPort B



With this, for gateway server port A, we will always resolve to A, while before we can resolve to B randomly.


Fix: https://github.com/istio/istio/issues/46820