### PR TITLE
wip: cleanup ambient flag

### DIFF
--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -163,3 +163,10 @@ spec:
           periodSeconds: 1
           tcpSocket:
             port: tcp-health-port
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: a
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -123,7 +123,7 @@ func (c *Config) fillDefaults(ctx resource.Context) error {
 	}
 
 	nsLabels := map[string]string{}
-	if ctx.Settings().Ambient {
+	if ctx.Settings().Ambient() {
 		nsLabels["istio.io/dataplane-mode"] = "ambient"
 	}
 
@@ -134,7 +134,7 @@ func (c *Config) fillDefaults(ctx resource.Context) error {
 			// If only using a single namespace, preserve the "echo" prefix.
 			g.Go(func() error {
 				ns, err := namespace.New(ctx, namespace.Config{
-					Inject: !ctx.Settings().AmbientEverywhere,
+					Inject: !ctx.Settings().AddWaypoints,
 					Prefix: "echo",
 					Labels: nsLabels,
 				})
@@ -312,8 +312,8 @@ ISTIO_DELTA_XDS: "true"`),
 		defaultConfigs = append(defaultConfigs, proxylessGRPC)
 	}
 
-	if t.Settings().Ambient {
-		if t.Settings().AmbientEverywhere {
+	if t.Settings().Ambient() {
+		if t.Settings().AddWaypoints {
 			for i, config := range defaultConfigs {
 				if !config.HasSidecar() && !config.IsProxylessGRPC() {
 					scopes.Framework.Infof("adding waypoint to %s", config.NamespacedName())

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -567,3 +567,7 @@ func (c Config) WorkloadClass() WorkloadClass {
 	}
 	return Standard
 }
+
+func (c Config) CanCreateIstioProxy() bool {
+	return !c.ZTunnelCaptured() && !c.HasWaypointProxy() && c.HasSidecar()
+}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -380,8 +380,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 		"Revisions":               settings.Revisions.TemplateMap(),
 		"Compatibility":           settings.Compatibility,
 		"WorkloadClass":           cfg.WorkloadClass(),
-		"OverlayIstioProxy":       canCreateIstioProxy(settings.Revisions.Minimum()) && !settings.Ambient,
-		"Ambient":                 settings.Ambient,
+		"OverlayIstioProxy":       canCreateIstioProxy(settings.Revisions.Minimum()) && cfg.HasSidecar(),
 	}
 
 	vmIstioHost, vmIstioIP := "", ""

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -52,7 +52,6 @@ spec:
         proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
 {{- end }}
     spec:
-{{- if $.Ambient }}
       topologySpreadConstraints:
       - topologyKey: "kubernetes.io/hostname"
         whenUnsatisfiable: "ScheduleAnyway"
@@ -60,7 +59,6 @@ spec:
         labelSelector:
           matchLabels:
             app: {{ $.Service }}
-{{- end }}
 {{- if $.ServiceAccount }}
       serviceAccountName: {{ $.Service }}
 {{- end }}

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -36,6 +36,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
@@ -41,6 +41,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       serviceAccountName: foo
       automountServiceAccountToken: false
       imagePullSecrets:

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -37,6 +37,13 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: healthcheck
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
@@ -37,6 +37,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:
@@ -112,6 +119,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
@@ -37,6 +37,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:
@@ -117,6 +124,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -39,6 +39,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: multiversion
       imagePullSecrets:
       - name: myregistrykey
       containers:
@@ -121,6 +128,13 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/inject: "false"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: multiversion
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
@@ -35,6 +35,13 @@ spec:
         inject.istio.io/templates: "grpc-agent"
         proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
@@ -35,6 +35,13 @@ spec:
         inject.istio.io/templates: "grpc-agent"
         proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -36,6 +36,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:
@@ -116,6 +123,13 @@ spec:
         prometheus.io/port: "15014"
         sidecar.istio.io/inject: "false"
     spec:
+      topologySpreadConstraints:
+      - topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        maxSkew: 1
+        labelSelector:
+          matchLabels:
+            app: foo
       imagePullSecrets:
       - name: myregistrykey
       containers:

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -178,10 +178,10 @@ func init() {
 	flag.BoolVar(&settingsFromCommandLine.SkipTProxy, "istio.test.skipTProxy", settingsFromCommandLine.SkipTProxy,
 		"Skip TProxy related parts in all tests.")
 
-	flag.BoolVar(&settingsFromCommandLine.Ambient, "istio.test.ambient", settingsFromCommandLine.Ambient,
-		"Indicate the use of ambient mesh.")
+	flag.BoolVar(&settingsFromCommandLine.ambient, "istio.test.ambient", settingsFromCommandLine.noopTemp,
+		"Deprecated. This flag will be removed once it isn't referenced in CI.")
 
-	flag.BoolVar(&settingsFromCommandLine.AmbientEverywhere, "istio.test.ambient.everywhere", settingsFromCommandLine.AmbientEverywhere,
+	flag.BoolVar(&settingsFromCommandLine.AddWaypoints, "istio.test.ambient.addWaypoints", settingsFromCommandLine.AddWaypoints,
 		"Make Waypoint proxies the default instead of sidecar proxies for all echo apps. Must be used with istio.test.ambient")
 
 	flag.BoolVar(&settingsFromCommandLine.Compatibility, "istio.test.compatibility", settingsFromCommandLine.Compatibility,

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -139,10 +139,11 @@ type Settings struct {
 	SkipTProxy bool
 
 	// Ambient mesh is being used
-	Ambient bool
+	ambient  bool
+	noopTemp bool
 
 	// Use ambient instead of sidecars
-	AmbientEverywhere bool
+	AddWaypoints bool
 
 	// Compatibility determines whether we should transparently deploy echo workloads attached to each revision
 	// specified in `Revisions` when creating echo instances. Used primarily for compatibility testing between revisions
@@ -201,6 +202,14 @@ func (s *Settings) SkipWorkloadClassesAsSet() sets.String {
 
 func (s *Settings) OnlyWorkloadClassesAsSet() sets.String {
 	return sets.New[string](s.OnlyWorkloadClasses...)
+}
+
+func (s *Settings) Ambient() bool {
+	return s.ambient || s.AddWaypoints
+}
+
+func (s *Settings) SetAmbient() {
+	s.ambient = true
 }
 
 // RunDir is the name of the dir to output, for this particular run.

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -99,11 +99,9 @@ func TestMain(m *testing.M) {
 		SkipIf("https://github.com/istio/istio/issues/43243", func(ctx resource.Context) bool {
 			return os.Getenv("VARIANT") == "distroless"
 		}).
-		SkipIf("https://github.com/istio/istio/issues/43508", func(ctx resource.Context) bool {
-			return !ctx.Settings().Ambient
-		}).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/41008
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+			ctx.Settings().SetAmbient()
 			// can't deploy VMs without eastwest gateway
 			ctx.Settings().SkipVMs()
 			cfg.DeployEastWestGW = false
@@ -216,11 +214,13 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 				{
 					Replicas:    1,
 					Version:     "v1",
+					Labels:      map[string]string{echo.SidecarInject.Name: "false"},
 					Annotations: echo.NewAnnotations().Set(echo.AmbientType, constants.AmbientRedirectionDisabled),
 				},
 				{
 					Replicas:    1,
 					Version:     "v2",
+					Labels:      map[string]string{echo.SidecarInject.Name: "false"},
 					Annotations: echo.NewAnnotations().Set(echo.AmbientType, constants.AmbientRedirectionDisabled),
 				},
 			},

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -96,6 +96,7 @@ func TestMain(m *testing.M) {
 	// nolint: staticcheck
 	framework.
 		NewSuite(m).
+		RequireMinVersion(25).
 		SkipIf("https://github.com/istio/istio/issues/43243", func(ctx resource.Context) bool {
 			return os.Getenv("VARIANT") == "distroless"
 		}).

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -249,7 +249,7 @@ func (c TrafficTestCase) Run(t framework.TestContext, namespace string) {
 }
 
 func skipAmbient(t framework.TestContext, reason string) skip {
-	return skip{skip: t.Settings().Ambient, reason: reason}
+	return skip{skip: t.Settings().Ambient(), reason: reason}
 }
 
 func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployment.SingleNamespaceView) {
@@ -260,7 +260,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	}
 	RunSkipAmbient := func(name string, f func(t TrafficContext), reason string) {
 		t.NewSubTest(name).Run(func(t framework.TestContext) {
-			if t.Settings().Ambient {
+			if t.Settings().Ambient() {
 				t.Skipf("ambient skipped: %v", reason)
 			} else {
 				f(TrafficContext{TestContext: t, Apps: apps, Istio: i})


### PR DESCRIPTION
re-do of #46730 

This will let us run other suites with ambient on. 
It also lets us run "global" jobs like unsafe assertions mode. 
That job is broken due to a real caching bug #46849 