### PR TITLE
[cherry-pick 1.18] Add E2E option to patch SHARED_MESH_CONFIG (#46074)

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -358,15 +358,11 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("EnableCNI:                      %v\n", c.EnableCNI)
 	result += fmt.Sprintf("IngressGatewayServiceName:      %v\n", c.IngressGatewayServiceName)
 	result += fmt.Sprintf("IngressGatewayServiceNamespace: %v\n", c.IngressGatewayServiceNamespace)
-<<<<<<< HEAD
-	result += fmt.Sprintf("IngressGatewayIstioLabel:     	 %v\n", c.IngressGatewayIstioLabel)
-=======
 	result += fmt.Sprintf("IngressGatewayIstioLabel:       %v\n", c.IngressGatewayIstioLabel)
 	result += fmt.Sprintf("EgressGatewayServiceName:       %v\n", c.EgressGatewayServiceName)
 	result += fmt.Sprintf("EressGatewayServiceNamespace:   %v\n", c.EgressGatewayServiceNamespace)
 	result += fmt.Sprintf("EgressGatewayIstioLabel:        %v\n", c.EgressGatewayIstioLabel)
 	result += fmt.Sprintf("SharedMeshConfigName:           %v\n", c.SharedMeshConfigName)
->>>>>>> a83476a60d (Add E2E option to patch SHARED_MESH_CONFIG (#46074))
 
 	return result
 }

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -171,6 +171,23 @@ type Config struct {
 	// IngressGatewayIstioLabel allows overriding the selector of the ingressgateway service (defaults to istio=ingressgateway)
 	// This field should only be set when DeployIstio is false
 	IngressGatewayIstioLabel string
+
+	// EgressGatewayServiceName is the service name to use to reference the egressgateway
+	// This field should only be set when DeployIstio is false
+	EgressGatewayServiceName string
+
+	// EgressGatewayServiceNamespace allows overriding the namespace of the egressgateway service (defaults to SystemNamespace)
+	// This field should only be set when DeployIstio is false
+	EgressGatewayServiceNamespace string
+
+	// EgressGatewayIstioLabel allows overriding the selector of the egressgateway service (defaults to istio=egressgateway)
+	// This field should only be set when DeployIstio is false
+	EgressGatewayIstioLabel string
+
+	// SharedMeshConfigName is the name of the user's local ConfigMap to be patched, which the user sets as the SHARED_MESH_CONFIG pilot env variable
+	// upon installing Istio.
+	// This field should only be set when DeployIstio is false.
+	SharedMeshConfigName string
 }
 
 func (c *Config) OverridesYAML(s *resource.Settings) string {
@@ -341,7 +358,15 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("EnableCNI:                      %v\n", c.EnableCNI)
 	result += fmt.Sprintf("IngressGatewayServiceName:      %v\n", c.IngressGatewayServiceName)
 	result += fmt.Sprintf("IngressGatewayServiceNamespace: %v\n", c.IngressGatewayServiceNamespace)
+<<<<<<< HEAD
 	result += fmt.Sprintf("IngressGatewayIstioLabel:     	 %v\n", c.IngressGatewayIstioLabel)
+=======
+	result += fmt.Sprintf("IngressGatewayIstioLabel:       %v\n", c.IngressGatewayIstioLabel)
+	result += fmt.Sprintf("EgressGatewayServiceName:       %v\n", c.EgressGatewayServiceName)
+	result += fmt.Sprintf("EressGatewayServiceNamespace:   %v\n", c.EgressGatewayServiceNamespace)
+	result += fmt.Sprintf("EgressGatewayIstioLabel:        %v\n", c.EgressGatewayIstioLabel)
+	result += fmt.Sprintf("SharedMeshConfigName:           %v\n", c.SharedMeshConfigName)
+>>>>>>> a83476a60d (Add E2E option to patch SHARED_MESH_CONFIG (#46074))
 
 	return result
 }

--- a/pkg/test/framework/components/istio/configmap.go
+++ b/pkg/test/framework/components/istio/configmap.go
@@ -239,7 +239,12 @@ func (mc *meshConfig) MeshConfig() (*meshconfig.MeshConfig, error) {
 	if mymc == nil {
 		c := mc.ctx.AllClusters().Configs()[0]
 
-		cfgMap, err := mc.getConfigMap(c, mc.configMapName())
+		cfgMapName, err := mc.configMapName()
+		if err != nil {
+			return nil, err
+		}
+
+		cfgMap, err := mc.getConfigMap(c, cfgMapName)
 		if err != nil {
 			return nil, err
 		}
@@ -287,7 +292,12 @@ func (mc *meshConfig) UpdateMeshConfig(t resource.Context, update func(*meshconf
 	for _, c := range mc.ctx.AllClusters().Kube() {
 		c := c
 		errG.Go(func() error {
-			cfgMap, err := mc.getConfigMap(c, mc.configMapName())
+			cfgMapName, err := mc.configMapName()
+			if err != nil {
+				return err
+			}
+
+			cfgMap, err := mc.getConfigMap(c, cfgMapName)
 			if err != nil {
 				return err
 			}
@@ -343,7 +353,11 @@ func (mc *meshConfig) UpdateMeshConfig(t resource.Context, update func(*meshconf
 			cn, mcYAML := cn, mcYAML
 			c := mc.ctx.AllClusters().GetByName(cn)
 			errG.Go(func() error {
-				cfgMap, err := mc.getConfigMap(c, mc.configMapName())
+				cfgMapName, err := mc.configMapName()
+				if err != nil {
+					return err
+				}
+				cfgMap, err := mc.getConfigMap(c, cfgMapName)
 				if err != nil {
 					return err
 				}
@@ -382,12 +396,22 @@ func (mc *meshConfig) PatchMeshConfigOrFail(ctx resource.Context, t test.Failer,
 	}
 }
 
-func (mc *meshConfig) configMapName() string {
+func (mc *meshConfig) configMapName() (string, error) {
+	i, err := Get(mc.ctx)
+	if err != nil {
+		return "", err
+	}
+
+	sharedCfgMapName := i.Settings().SharedMeshConfigName
+	if sharedCfgMapName != "" {
+		return sharedCfgMapName, nil
+	}
+
 	cmName := "istio"
 	if rev := mc.revisions.Default(); rev != "default" && rev != "" {
 		cmName += "-" + rev
 	}
-	return cmName
+	return cmName, nil
 }
 
 func (cm *configMap) getConfigMap(c cluster.Cluster, name string) (*corev1.ConfigMap, error) {

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -53,4 +53,20 @@ func init() {
 		settingsFromCommandline.IngressGatewayIstioLabel,
 		`Specifies the istio label of the ingressgateway to search for when running tests in a preinstalled istio installation.
 		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayServiceName, "istio.test.kube.egressGatewayServiceName",
+		settingsFromCommandline.EgressGatewayServiceName,
+		`Specifies the name of the egressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayServiceNamespace, "istio.test.kube.egressGatewayServiceNamespace",
+		settingsFromCommandline.IngressGatewayServiceNamespace,
+		`Specifies the namespace of the egressgateway service to use when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.EgressGatewayIstioLabel, "istio.test.kube.egressGatewayIstioLabel",
+		settingsFromCommandline.EgressGatewayIstioLabel,
+		`Specifies the istio label of the egressgateway to search for when running tests in a preinstalled istio installation.
+		Should only be set when istio.test.kube.deploy=false`)
+	flag.StringVar(&settingsFromCommandline.SharedMeshConfigName, "istio.test.kube.sharedMeshConfigName",
+		settingsFromCommandline.SharedMeshConfigName,
+		`Specifies the name of the SHARED_MESH_CONFIG defined and created by the user upon installing Istio.
+		Should only be set when istio.test.kube.userSharedMeshConfig=true and istio.test.kube.deploy=false.`)
 }


### PR DESCRIPTION
* Add shared mesh config option to e2es



* rm artifacts files



* Update methods



* Remove extra flag



* Adjust spacing



* Import istio



* fix return



* Fix nil check



* Fix var assignment



* Fix flag



---------

**Please provide a description of this PR:**

Resolves: https://github.com/istio/istio/issues/46788