### PR TITLE
Fix inconsistency of sidecar workloadselector

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1689,14 +1689,14 @@ func (ps *PushContext) initSidecarScopes(env *Environment) {
 	for _, sidecarConfig := range rawSidecarConfigs {
 		sidecar := sidecarConfig.Spec.(*networking.Sidecar)
 		// sidecars with selector take preference
-		if sidecar.WorkloadSelector != nil {
+		if sidecar.WorkloadSelector != nil && len(sidecar.WorkloadSelector.Labels) > 0 {
 			sidecarConfigs = append(sidecarConfigs, sidecarConfig)
 		}
 	}
 	for _, sidecarConfig := range rawSidecarConfigs {
 		sidecar := sidecarConfig.Spec.(*networking.Sidecar)
 		// sidecars without selector placed behind
-		if sidecar.WorkloadSelector == nil {
+		if sidecar.WorkloadSelector == nil || len(sidecar.WorkloadSelector.Labels) == 0 {
 			sidecarConfigs = append(sidecarConfigs, sidecarConfig)
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently the sidecarScope workloadSelector has an inconsistent behavior:
If we have a sidecar resource with label, a namespace default resource without selector(created before the resource with label): the former one will be used.
If we have a sidecar resource with label, a namespace default resource without selector("workloadSelector: {}", and created before the resource with label), the later will be used.