### PR TITLE
Remove unused external CA type ISTIOD_RA_ISTIO_API

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -47,7 +47,6 @@ import (
 )
 
 type caOptions struct {
-	// Either extCAK8s or extCAGrpc
 	ExternalCAType   ra.CaExternalType
 	ExternalCASigner string
 	// domain to use in SPIFFE identity URLs
@@ -133,8 +132,7 @@ var (
 
 	// TODO: Likely to be removed and added to mesh config
 	externalCaType = env.Register("EXTERNAL_CA", "",
-		"External CA Integration Type. Permitted Values are ISTIOD_RA_KUBERNETES_API or "+
-			"ISTIOD_RA_ISTIO_API").Get()
+		"External CA Integration Type. Permitted value is ISTIOD_RA_KUBERNETES_API.").Get()
 
 	// TODO: Likely to be removed and added to mesh config
 	k8sSigner = env.Register("K8S_SIGNER", "",

--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -64,9 +64,6 @@ const (
 	// ExtCAK8s : Integrate with external CA using k8s CSR API
 	ExtCAK8s CaExternalType = "ISTIOD_RA_KUBERNETES_API"
 
-	// ExtCAGrpc : Integration with external CA using Istio CA gRPC API
-	ExtCAGrpc CaExternalType = "ISTIOD_RA_ISTIO_API"
-
 	// DefaultExtCACertDir : Location of external CA certificate
 	DefaultExtCACertDir string = "./etc/external-ca-cert"
 )


### PR DESCRIPTION
**Please provide a description of this PR:**

Value `ISTIOD_RA_ISTIO_API` is no longer supported for `EXTERNAL_CA`. `ISTIOD_RA_KUBERNETES_API` is the only supported value. 