### PR TITLE
Ambient/CNI: be more selective about hostIP skips

### DIFF
--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -433,9 +433,22 @@ func (s *Server) CreateRulesOnNode(ztunnelVeth, ztunnelIP string, captureDNS boo
 			"--nfmask", constants.ProxyMask,
 			"--ctmask", constants.ProxyMask,
 		),
+
+		// Mark healthcheck probes from the node IP as skippable, so we don't capture them.
+		//
+		// We consider a packet as "from the host node" if it comes from a local socket in the host netns, and has
+		// the SRC host IP we derived elsewhere.
+		//
+		// Notably, this excludes `kubelet` node traffic from capture, but *not* `kube-proxy` node traffic.
+		// -t mangle -A ztunnel-OUTPUT -m owner --socket-exists -p tcp -m set --match-set ambient-pods dst -j MARK --set-mark 0x220
 		newIptableRule(
 			constants.TableMangle,
 			constants.ChainZTunnelOutput,
+			"-m", "owner",
+			"--socket-exists",
+			"-p", "tcp",
+			"-m", "set",
+			"--match-set", Ipset.Name, "dst",
 			"--source", HostIP,
 			"-j", "MARK",
 			"--set-mark", constants.ConnSkipMask,


### PR DESCRIPTION
-------

**Please provide a description of this PR:**

Tighten the conditions under which we skip packets with a HostIP src (only healthcheck probes). 

Only skip packets coming from a local node socket, versus anything with the node IP.

This should catch HOSTIP-src packets coming from `kubelet` (probes) but not HOSTIP-src packets coming from `kube-proxy` (everything else) 


### Details

Previously, we excluded everything with SRC == HostIP from ambient capture and ztunnel proxy. This was done to prevent healthchecks from the node `kubelet` from being proxied thru ztunnel.

The problem with this is that it would allow *any* packet with a HostIP SRC to bypass capture. Including forwarded packets (potentially `kube-proxy` packets, say from a LoadBalancer type Service). This change modifies that so only packets with a HostIP SRC that the kernel knows *originated from a local process-owned socket on the node* get skipped for capture.

This improves the security posture somewhat and makes the hostIP exclusions less broadly permissive.

This means that non-probe hostIP traffic will _not_ be excluded from capture anymore - the upshot of this is that probe behavior shouldn't change at all, but if you are running with PeerAuthentication STRICT, we won't allow src-identity-less node traffic to bypass the capture logic anymore (as that is arguably a security concern).