### PR TITLE
Correctly assign conntrack zone to return packets from upstream DNS resolvers.

### DIFF
--- a/releasenotes/notes/46935.yaml
+++ b/releasenotes/notes/46935.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: 46935
+releaseNotes:
+  - |
+    **Fixed** An issue where upstream DNS queries would result in pairs of permanently UNREPLIED conntrack entries.

--- a/releasenotes/notes/46935.yaml
+++ b/releasenotes/notes/46935.yaml
@@ -1,7 +1,8 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
-issue: 46935
+issue: 
+  - 46935
 releaseNotes:
   - |
     **Fixed** An issue where upstream DNS queries would result in pairs of permanently UNREPLIED conntrack entries.

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/dns-uid-gid.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/dns-uid-gid.golden
@@ -28,9 +28,9 @@ iptables -t raw -D OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 
 iptables -t raw -D OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 iptables -t raw -D OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 iptables -t raw -D OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-iptables -t raw -D PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+iptables -t raw -D PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1
 iptables -t raw -D OUTPUT -p udp --dport 53 -d ::127.0.0.53/128 -j CT --zone 2
-iptables -t raw -D PREROUTING -p udp --sport 53 -d ::127.0.0.53/128 -j CT --zone 1
+iptables -t raw -D PREROUTING -p udp --sport 53 -s ::127.0.0.53/128 -j CT --zone 1
 iptables -t nat -F ISTIO_OUTPUT
 iptables -t nat -X ISTIO_OUTPUT
 iptables -t nat -F ISTIO_INBOUND
@@ -75,9 +75,9 @@ ip6tables -t raw -D OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone
 ip6tables -t raw -D OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 ip6tables -t raw -D OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 ip6tables -t raw -D OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-ip6tables -t raw -D PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+ip6tables -t raw -D PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1
 ip6tables -t raw -D OUTPUT -p udp --dport 53 -d ::127.0.0.53/128 -j CT --zone 2
-ip6tables -t raw -D PREROUTING -p udp --sport 53 -d ::127.0.0.53/128 -j CT --zone 1
+ip6tables -t raw -D PREROUTING -p udp --sport 53 -s ::127.0.0.53/128 -j CT --zone 1
 ip6tables -t nat -F ISTIO_OUTPUT
 ip6tables -t nat -X ISTIO_OUTPUT
 ip6tables -t nat -F ISTIO_INBOUND

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -627,11 +627,11 @@ func HandleDNSUDP(
 	}
 
 	if captureAllDNS {
-		// Redirect all TCP dns traffic on port 53 to the agent on port 15053
+		// Redirect all UDP dns traffic on port 53 to the agent on port 15053
 		// This will be useful for the CNI case where pod DNS server address cannot be decided.
 		f.Run("-p", "udp", "--dport", "53", "-j", constants.REDIRECT, "--to-port", constants.IstioAgentDNSListenerPort)
 	} else {
-		// redirect all TCP dns traffic on port 53 to the agent on port 15053 for all servers
+		// redirect all UDP dns traffic on port 53 to the agent on port 15053 for all servers
 		// in etc/resolv.conf
 		// We avoid redirecting all IP ranges to avoid infinite loops when there are local DNS proxies
 		// such as: app -> istio dns server -> dnsmasq -> upstream

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -689,7 +689,7 @@ func addConntrackZoneDNSUDP(
 			f.RunV4("-p", "udp", "--dport", "53", "-d", s+"/32",
 				"-j", constants.CT, "--zone", "2")
 			// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
-			f.WithChain(constants.PREROUTING).RunV4("-p", "udp", "--sport", "53", "-d", s+"/32",
+			f.WithChain(constants.PREROUTING).RunV4("-p", "udp", "--sport", "53", "-s", s+"/32",
 				"-j", constants.CT, "--zone", "1")
 		}
 		for _, s := range dnsServersV6 {
@@ -697,7 +697,7 @@ func addConntrackZoneDNSUDP(
 			f.RunV6("-p", "udp", "--dport", "53", "-d", s+"/128",
 				"-j", constants.CT, "--zone", "2")
 			// Mark all UDP dns traffic with src port 53 as zone 1. These are response packets from the DNS resolvers.
-			f.WithChain(constants.PREROUTING).RunV6("-p", "udp", "--sport", "53", "-d", s+"/128",
+			f.WithChain(constants.PREROUTING).RunV6("-p", "udp", "--sport", "53", "-s", s+"/128",
 				"-j", constants.CT, "--zone", "1")
 		}
 	}

--- a/tools/istio-iptables/pkg/capture/testdata/dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/dns-uid-gid.golden
@@ -35,7 +35,7 @@ iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zo
 iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1
 iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+iptables -t raw -A PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1
 ip6tables -t nat -N ISTIO_INBOUND
 ip6tables -t nat -N ISTIO_REDIRECT
 ip6tables -t nat -N ISTIO_IN_REDIRECT
@@ -73,4 +73,4 @@ ip6tables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --z
 ip6tables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1
 ip6tables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 ip6tables -t raw -A OUTPUT -p udp --dport 53 -d ::127.0.0.53/128 -j CT --zone 2
-ip6tables -t raw -A PREROUTING -p udp --sport 53 -d ::127.0.0.53/128 -j CT --zone 1
+ip6tables -t raw -A PREROUTING -p udp --sport 53 -s ::127.0.0.53/128 -j CT --zone 1

--- a/tools/istio-iptables/pkg/capture/testdata/ip-range.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ip-range.golden
@@ -38,4 +38,4 @@ iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zo
 iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1
 iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+iptables -t raw -A PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1

--- a/tools/istio-iptables/pkg/capture/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/loopback-outbound-iprange.golden
@@ -33,4 +33,4 @@ iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1 -j CT --zo
 iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j CT --zone 1
 iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 2 -j CT --zone 2
 iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+iptables -t raw -A PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1

--- a/tools/istio-iptables/pkg/capture/testdata/tproxy.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/tproxy.golden
@@ -39,7 +39,7 @@ iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --uid-owner 1337 -j CT -
 iptables -t raw -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1337 -j CT --zone 1
 iptables -t raw -A OUTPUT -p udp --sport 15053 -m owner --gid-owner 1337 -j CT --zone 2
 iptables -t raw -A OUTPUT -p udp --dport 53 -d 127.0.0.53/32 -j CT --zone 2
-iptables -t raw -A PREROUTING -p udp --sport 53 -d 127.0.0.53/32 -j CT --zone 1
+iptables -t raw -A PREROUTING -p udp --sport 53 -s 127.0.0.53/32 -j CT --zone 1
 iptables -t mangle -A PREROUTING -p tcp -m mark --mark 1337 -j CONNMARK --save-mark
 iptables -t mangle -A OUTPUT -p tcp -o lo -m mark --mark 1337 -j RETURN
 iptables -t mangle -A OUTPUT ! -d 127.0.0.1/32 -p tcp -o lo -m owner --uid-owner 1337 -j MARK --set-mark 1338


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/46935. Also cleaned up a couple places where comments did not match code that I saw when trying to track this down originally.