### PR TITLE
Remove github.com/stretchr/testify dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stoewer/go-strcase v1.3.0
-	github.com/stretchr/testify v1.8.4
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/yl2chen/cidranger v1.0.2
 	go.opentelemetry.io/otel v1.17.0
@@ -224,6 +223,7 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -28,7 +28,6 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 	anypb "google.golang.org/protobuf/types/known/anypb"
@@ -41,6 +40,8 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 type testAdscRunServer struct{}
@@ -185,7 +186,7 @@ func TestADSC_Run(t *testing.T) {
 				t.Errorf("ADSC: failed running %v", err)
 				return
 			}
-			assert.Eventually(t, func() bool {
+			assert.EventuallyEqual(t, func() bool {
 				tt.inAdsc.mutex.Lock()
 				defer tt.inAdsc.mutex.Unlock()
 				rec := tt.inAdsc.Received
@@ -202,7 +203,7 @@ func TestADSC_Run(t *testing.T) {
 					}
 				}
 				return true
-			}, time.Second, time.Millisecond)
+			}, true, retry.Timeout(time.Second), retry.Delay(time.Millisecond))
 
 			if tt.validator != nil {
 				if err := tt.validator(tt); err != nil {


### PR DESCRIPTION
This PR removes the direct dependency `github.com/stretchr/testify` because it's not needed. The package `pkg/test/util/assert` already contains `EventuallyEqual` function which can be used instead.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure