### PR TITLE
Fix ext authz deny all traffic if encountering error with the provider

### DIFF
--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -24,12 +25,12 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	rbactcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	"github.com/hashicorp/go-multierror"
-
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
 	authzmodel "istio.io/istio/pilot/pkg/security/authz/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -272,8 +273,8 @@ func (b Builder) buildHTTP(rules *rbacpb.RBAC, shadowRules *rbacpb.RBAC, provide
 
 	extauthz, err := getExtAuthz(b.extensions, providers)
 	if err != nil {
-		b.logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action:"))
-		rbac := &rbachttp.RBAC{Rules: rbacDefaultDenyAll}
+		b.logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
+		rbac := &rbachttp.RBAC{Rules: getBadCustomDenyRules(rules)}
 		return []*hcm.HttpFilter{
 			{
 				Name:       wellknown.HTTPRoleBasedAccessControl,
@@ -319,9 +320,9 @@ func (b Builder) buildTCP(rules *rbacpb.RBAC, shadowRules *rbacpb.RBAC, provider
 	}
 
 	if extauthz, err := getExtAuthz(b.extensions, providers); err != nil {
-		b.logger.AppendError(multierror.Prefix(err, "failed to parse CUSTOM action, will generate a deny all config:"))
+		b.logger.AppendError(multierror.Prefix(err, "failed to process CUSTOM action, will generate deny configs for the specified rules:"))
 		rbac := &rbactcp.RBAC{
-			Rules:      rbacDefaultDenyAll,
+			Rules:      getBadCustomDenyRules(rules),
 			StatPrefix: authzmodel.RBACTCPFilterStatPrefix,
 		}
 		return []*listener.Filter{
@@ -350,6 +351,19 @@ func (b Builder) buildTCP(rules *rbacpb.RBAC, shadowRules *rbacpb.RBAC, provider
 			},
 		}
 	}
+}
+
+func getBadCustomDenyRules(rules *rbacpb.RBAC) *rbacpb.RBAC {
+	rbac := &rbacpb.RBAC{
+		Action:   rbacpb.RBAC_DENY,
+		Policies: map[string]*rbacpb.Policy{},
+	}
+	keys := maps.Keys(rules.Policies)
+	sort.Strings(keys)
+	for i, key := range keys {
+		rbac.Policies[fmt.Sprintf(badCustomActionTemplate, i)] = rules.Policies[key]
+	}
+	return rbac
 }
 
 func policyName(namespace, name string, rule int, option Option) string {

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -16,7 +16,6 @@ package builder
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -359,10 +358,8 @@ func getBadCustomDenyRules(rules *rbacpb.RBAC) *rbacpb.RBAC {
 		Action:   rbacpb.RBAC_DENY,
 		Policies: map[string]*rbacpb.Policy{},
 	}
-	keys := maps.Keys(rules.Policies)
-	sort.Strings(keys)
-	for i, key := range keys {
-		rbac.Policies[fmt.Sprintf(badCustomActionTemplate, i)] = rules.Policies[key]
+	for _, key := range maps.Keys(rules.Policies) {
+		rbac.Policies[key+badCustomActionSuffix] = rules.Policies[key]
 	}
 	return rbac
 }

--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -25,6 +25,7 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	rbactcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
 	authzmodel "istio.io/istio/pilot/pkg/security/authz/model"

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -39,20 +39,18 @@ import (
 )
 
 const (
-	extAuthzMatchPrefix     = "istio-ext-authz"
+	extAuthzMatchPrefix   = "istio-ext-authz"
 	badCustomActionSuffix = `-deny-due-to-bad-CUSTOM-action`
 )
 
-var (
-	supportedStatus = func() []int {
-		var supported []int
-		for code := range envoytypev3.StatusCode_name {
-			supported = append(supported, int(code))
-		}
-		sort.Ints(supported)
-		return supported
-	}()
-)
+var supportedStatus = func() []int {
+	var supported []int
+	for code := range envoytypev3.StatusCode_name {
+		supported = append(supported, int(code))
+	}
+	sort.Ints(supported)
+	return supported
+}()
 
 type builtExtAuthz struct {
 	http *extauthzhttp.ExtAuthz

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	extauthzhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	extauthztcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ext_authz/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -40,20 +39,11 @@ import (
 )
 
 const (
-	extAuthzMatchPrefix = "istio-ext-authz"
+	extAuthzMatchPrefix     = "istio-ext-authz"
+	badCustomActionTemplate = `default-deny-due-to-bad-CUSTOM-action[%d]`
 )
 
 var (
-	rbacPolicyMatchAll = &rbacpb.Policy{
-		Permissions: []*rbacpb.Permission{{Rule: &rbacpb.Permission_Any{Any: true}}},
-		Principals:  []*rbacpb.Principal{{Identifier: &rbacpb.Principal_Any{Any: true}}},
-	}
-	rbacDefaultDenyAll = &rbacpb.RBAC{
-		Action: rbacpb.RBAC_DENY,
-		Policies: map[string]*rbacpb.Policy{
-			"default-deny-all-due-to-bad-CUSTOM-action": rbacPolicyMatchAll,
-		},
-	}
 	supportedStatus = func() []int {
 		var supported []int
 		for code := range envoytypev3.StatusCode_name {

--- a/pilot/pkg/security/authz/builder/extauthz.go
+++ b/pilot/pkg/security/authz/builder/extauthz.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	extAuthzMatchPrefix     = "istio-ext-authz"
-	badCustomActionTemplate = `default-deny-due-to-bad-CUSTOM-action[%d]`
+	badCustomActionSuffix = `-deny-due-to-bad-CUSTOM-action`
 )
 
 var (

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-bad-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-bad-out.yaml
@@ -4,8 +4,29 @@ typedConfig:
   rules:
     action: DENY
     policies:
-      default-deny-all-due-to-bad-CUSTOM-action:
+      default-deny-due-to-bad-CUSTOM-action[0]:
         permissions:
-        - any: true
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
         principals:
-        - any: true
+        - andIds:
+            ids:
+            - any: true
+      default-deny-due-to-bad-CUSTOM-action[1]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-bad-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-bad-out.yaml
@@ -4,7 +4,7 @@ typedConfig:
   rules:
     action: DENY
     policies:
-      default-deny-due-to-bad-CUSTOM-action[0]:
+      istio-ext-authz-ns[foo]-policy[httpbin-1]-rule[0]-deny-due-to-bad-CUSTOM-action:
         permissions:
         - andRules:
             rules:
@@ -17,7 +17,7 @@ typedConfig:
         - andIds:
             ids:
             - any: true
-      default-deny-due-to-bad-CUSTOM-action[1]:
+      istio-ext-authz-ns[foo]-policy[httpbin-2]-rule[0]-deny-due-to-bad-CUSTOM-action:
         permissions:
         - andRules:
             rules:

--- a/releasenotes/notes/46968.yaml
+++ b/releasenotes/notes/46968.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+- 46951
+releaseNotes:
+- |
+  **Fixed** an issue where all requests were being denied when the custom external authorization service had an issue. Now only requests that are delegated to the custom external authorization service are denied.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/46951.

I think this will loose the rbac, however it makes sense to only deny rules that are delegated to the ext authz provider.