### PR TITLE
e2e: improve operator test

### DIFF
--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -53,7 +53,7 @@ const (
 	IstioNamespace    = "istio-system"
 	OperatorNamespace = "istio-operator"
 	retryDelay        = time.Second
-	retryTimeOut      = 20 * time.Minute
+	retryTimeOut      = 5 * time.Minute
 	nsDeletionTimeout = 5 * time.Minute
 )
 

--- a/tests/integration/operator/uninstall_test.go
+++ b/tests/integration/operator/uninstall_test.go
@@ -87,7 +87,9 @@ func TestReconcileDelete(t *testing.T) {
 				// later just run `kubectl apply -f newcr.yaml` to apply new installation cr files and verify.
 				applyIop(t, t, cs, "minimal", r)
 
-				checkInstallStatus(cs, r)
+				if err := checkInstallStatus(cs, r); err != nil {
+					t.Errorf("failed to check install status: %v", err)
+				}
 
 				iopName := revName("test-istiocontrolplane", r)
 
@@ -151,7 +153,9 @@ func TestReconcileDelete(t *testing.T) {
 				// later just run `kubectl apply -f newcr.yaml` to apply new installation cr files and verify.
 				applyIop(t, t, cs, "default", r)
 
-				checkInstallStatus(cs, r)
+				if err := checkInstallStatus(cs, r); err != nil {
+					t.Errorf("failed to check install status: %v", err)
+				}
 
 				iopName := revName("test-istiocontrolplane", r)
 


### PR DESCRIPTION
**Please provide a description of this PR:**

1. fail fast
2. reduce `retryTimeOut` to `5m`, this will make test fail fast if there's a network issue.