### PR TITLE
iptables: cleanup legacy host nsenter flag

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -26,8 +26,6 @@ import (
 	"istio.io/istio/cni/pkg/plugin"
 	"istio.io/istio/pkg/log"
 	istioversion "istio.io/istio/pkg/version"
-	"istio.io/istio/tools/istio-iptables/pkg/cmd"
-	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 func main() {
@@ -41,24 +39,6 @@ func main() {
 		// to https://github.com/uber-go/zap/issues/328
 		_ = log.Sync()
 	}()
-
-	// configure-routes allows setting up the iproute2 configuration.
-	// This is an old workaround and kept in place to preserve old behavior.
-	// It is called standalone when HostNSEnterExec=true.
-	// Default behavior is to use go netns, which is not in need for this:
-
-	// Older versions of Go < 1.10 cannot change network namespaces safely within a go program
-	// (see https://www.weave.works/blog/linux-namespaces-and-go-don-t-mix).
-	// As a result, the flow is:
-	// * CNI plugin is called with no args, skipping this section.
-	// * CNI code invokes iptables code with CNIMode=true. This in turn runs 'nsenter -- istio-cni configure-routes'
-	if len(os.Args) > 1 && os.Args[1] == constants.CommandConfigureRoutes {
-		if err := cmd.GetRouteCommand().Execute(); err != nil {
-			log.Errorf("failed to configure routes: %v", err)
-			os.Exit(1)
-		}
-		return
-	}
 
 	// TODO: implement plugin version
 	skel.PluginMain(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -76,9 +76,6 @@ type InstallConfig struct {
 
 	// Whether ebpf is enabled
 	EbpfEnabled bool
-
-	// Use the external nsenter command for network namespace switching
-	HostNSEnterExec bool
 }
 
 // RepairConfig struct defines the Istio CNI race repair configuration
@@ -132,7 +129,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("K8sNodeName: " + c.K8sNodeName + "\n")
 	b.WriteString("MonitoringPort: " + fmt.Sprint(c.MonitoringPort) + "\n")
 	b.WriteString("LogUDSAddress: " + fmt.Sprint(c.LogUDSAddress) + "\n")
-	b.WriteString("HostNSEnterExec: " + fmt.Sprint(c.HostNSEnterExec) + "\n")
 
 	b.WriteString("AmbientEnabled: " + fmt.Sprint(c.AmbientEnabled) + "\n")
 

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -35,7 +35,6 @@ var getNs = ns.GetNS
 // provided in Redirect.
 func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.CNIMode, true)
-	viper.Set(constants.HostNSEnterExec, rdrct.hostNSEnterExec)
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -79,11 +79,10 @@ type Config struct {
 	PrevResult    *cniv1.Result   `json:"-"`
 
 	// Add plugin-specific flags here
-	LogLevel        string     `json:"log_level"`
-	LogUDSAddress   string     `json:"log_uds_address"`
-	AmbientEnabled  bool       `json:"ambient_enabled"`
-	Kubernetes      Kubernetes `json:"kubernetes"`
-	HostNSEnterExec bool       `json:"hostNSEnterExec"`
+	LogLevel       string     `json:"log_level"`
+	LogUDSAddress  string     `json:"log_uds_address"`
+	AmbientEnabled bool       `json:"ambient_enabled"`
+	Kubernetes     Kubernetes `json:"kubernetes"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -323,7 +322,6 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 		return fmt.Errorf("redirect failed to find InterceptRuleMgr")
 	}
 
-	redirect.hostNSEnterExec = conf.HostNSEnterExec
 	rulesMgr := interceptMgrCtor()
 	if err := rulesMgr.Program(podName, args.Netns, redirect); err != nil {
 		return err

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -89,7 +89,6 @@ type Redirect struct {
 	excludeInterfaces    string
 	dnsRedirect          bool
 	invalidDrop          bool
-	hostNSEnterExec      bool
 }
 
 type annotationValidationFunc func(value string) error

--- a/tools/istio-iptables/pkg/capture/run_linux.go
+++ b/tools/istio-iptables/pkg/capture/run_linux.go
@@ -16,7 +16,6 @@ package capture
 import (
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -95,11 +94,6 @@ func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
 		return nil
 	}
 	if ext != nil && cfg.CNIMode {
-		if cfg.HostNSEnterExec {
-			command := os.Args[0]
-			return ext.Run(command, nil, constants.CommandConfigureRoutes)
-		}
-
 		nsContainer, err := ns.GetNS(cfg.NetworkNamespace)
 		if err != nil {
 			return err

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -69,7 +69,6 @@ var rootCmd = &cobra.Command{
 		} else {
 			ext = &dep.RealDependencies{
 				CNIMode:          cfg.CNIMode,
-				HostNSEnterExec:  cfg.HostNSEnterExec,
 				NetworkNamespace: cfg.NetworkNamespace,
 			}
 		}
@@ -99,23 +98,6 @@ If installed with 'cni.repair.deletePods=true', this pod should automatically be
 Otherwise, this pod will need to be manually removed so that it is scheduled on a node with istio-cni running, allowing iptables rules to be established.
 `)
 				handleErrorWithCode(msg, constants.ValidationErrorCode)
-			}
-		}
-	},
-}
-
-var configureRoutesCommand = &cobra.Command{
-	Use:    "configure-routes",
-	Short:  "Configures iproute2 rules for the Istio sidecar",
-	PreRun: bindFlags,
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := constructConfig()
-		if err := cfg.Validate(); err != nil {
-			handleErrorWithCode(err, 1)
-		}
-		if !cfg.SkipRuleApply {
-			if err := capture.ConfigureRoutes(cfg, nil); err != nil {
-				handleErrorWithCode(err, 1)
 			}
 		}
 	},
@@ -153,7 +135,6 @@ func constructConfig() *config.Config {
 		CaptureAllDNS:           viper.GetBool(constants.CaptureAllDNS),
 		NetworkNamespace:        viper.GetString(constants.NetworkNamespace),
 		CNIMode:                 viper.GetBool(constants.CNIMode),
-		HostNSEnterExec:         viper.GetBool(constants.HostNSEnterExec),
 	}
 
 	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
@@ -293,7 +274,6 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	bind(constants.CaptureAllDNS, false)
 	bind(constants.NetworkNamespace, "")
 	bind(constants.CNIMode, false)
-	bind(constants.HostNSEnterExec, false)
 }
 
 // https://github.com/spf13/viper/issues/233.
@@ -301,7 +281,6 @@ func bindFlags(cmd *cobra.Command, args []string) {
 // Otherwise, the flag with the same name shared across subcommands will be overwritten by the last.
 func init() {
 	bindCmdlineFlags(rootCmd)
-	bindCmdlineFlags(configureRoutesCommand)
 }
 
 func bindCmdlineFlags(rootCmd *cobra.Command) {
@@ -378,14 +357,8 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 
 	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
-
-	rootCmd.Flags().Bool(constants.HostNSEnterExec, false, "Instead of using the internal go netns, use the nsenter command for switching network namespaces.")
 }
 
 func GetCommand() *cobra.Command {
 	return rootCmd
-}
-
-func GetRouteCommand() *cobra.Command {
-	return configureRoutesCommand
 }

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -59,7 +59,6 @@ type Config struct {
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
-	HostNSEnterExec         bool          `json:"HOST_NSENTER_EXEC"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 }
 
@@ -97,7 +96,6 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.CNIMode)))
-	b.WriteString(fmt.Sprintf("HOST_NSENTER_EXEC=%s\n", strconv.FormatBool(c.HostNSEnterExec)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))
 	log.Infof("Istio iptables variables:\n%s", b.String())
 }

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -96,7 +96,6 @@ const (
 	KubeVirtInterfaces        = "kube-virt-interfaces"
 	DryRun                    = "dry-run"
 	TraceLogging              = "iptables-trace-logging"
-	Clean                     = "clean"
 	RestoreFormat             = "restore-format"
 	SkipRuleApply             = "skip-rule-apply"
 	RunValidation             = "run-validation"
@@ -107,7 +106,6 @@ const (
 	CaptureAllDNS             = "capture-all-dns"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
-	HostNSEnterExec           = "host-nsenter-exec"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.
@@ -140,8 +138,7 @@ const (
 
 // Constants used in environment variables
 const (
-	DisableRedirectionOnLocalLoopback = "DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK"
-	EnvoyUser                         = "ENVOY_USER"
+	EnvoyUser = "ENVOY_USER"
 )
 
 // Constants for iptables commands
@@ -152,7 +149,6 @@ const (
 	IP6TABLES        = "ip6tables"
 	IP6TABLESRESTORE = "ip6tables-restore"
 	IP6TABLESSAVE    = "ip6tables-save"
-	NSENTER          = "nsenter"
 )
 
 // Constants for syscall
@@ -174,8 +170,4 @@ const (
 // DNS ports
 const (
 	IstioAgentDNSListenerPort = "15053"
-)
-
-const (
-	CommandConfigureRoutes = "configure-routes"
 )

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -64,7 +64,6 @@ var XTablesCmds = sets.New(
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
 	NetworkNamespace string
-	HostNSEnterExec  bool
 	CNIMode          bool
 }
 

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -28,15 +28,9 @@ import (
 
 	"istio.io/istio/pkg/backoff"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reader, args ...string) error {
-	if r.CNIMode && r.HostNSEnterExec {
-		originalCmd := cmd
-		cmd = constants.NSENTER
-		args = append([]string{fmt.Sprintf("--net=%v", r.NetworkNamespace), "--", originalCmd}, args...)
-	}
 	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 
 	externalCommand := exec.Command(cmd, args...)
@@ -57,7 +51,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 	}
 	var err error
 	var nsContainer ns.NetNS
-	if r.CNIMode && !r.HostNSEnterExec {
+	if r.CNIMode {
 		nsContainer, err = ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
@@ -83,18 +77,13 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 }
 
 func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	if r.CNIMode && r.HostNSEnterExec {
-		originalCmd := cmd
-		cmd = constants.NSENTER
-		args = append([]string{fmt.Sprintf("--net=%v", r.NetworkNamespace), "--", originalCmd}, args...)
-	}
 	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 
 	var stdout, stderr *bytes.Buffer
 	var err error
 	var nsContainer ns.NetNS
 
-	if r.CNIMode && !r.HostNSEnterExec {
+	if r.CNIMode {
 		nsContainer, err = ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
@@ -120,7 +109,7 @@ func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin i
 				return err
 			}
 		}
-		if r.CNIMode && !r.HostNSEnterExec {
+		if r.CNIMode {
 			err = nsContainer.Do(func(ns.NetNS) error {
 				return externalCommand.Run()
 			})


### PR DESCRIPTION
This was added as a temporary feature flag, not intended as a long term
feature. Since we haven't heard any issues with the new approach (which
is used by many other projects) it makes sense to do some cleanup
