### PR TITLE
Improve iptables locking

### DIFF
--- a/releasenotes/notes/iptables-lock.yaml
+++ b/releasenotes/notes/iptables-lock.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** `iptables` locking. The new implementation uses `iptables` builtin lock waiting when needed, and disables locking entirely when not needed.

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -67,9 +67,14 @@ var rootCmd = &cobra.Command{
 		if cfg.DryRun {
 			ext = &dep.StdoutStubDependencies{}
 		} else {
+			ipv, err := dep.DetectIptablesVersion(cfg.IPTablesVersion)
+			if err != nil {
+				handleErrorWithCode(err, 1)
+			}
 			ext = &dep.RealDependencies{
 				CNIMode:          cfg.CNIMode,
 				NetworkNamespace: cfg.NetworkNamespace,
+				IptablesVersion:  ipv,
 			}
 		}
 
@@ -276,6 +281,7 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	bind(constants.CaptureAllDNS, false)
 	bind(constants.NetworkNamespace, "")
 	bind(constants.CNIMode, false)
+	bind(constants.IptablesVersion, "")
 	bind(constants.DualStack, DualStack)
 }
 
@@ -362,6 +368,8 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 
 	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
+
+	rootCmd.Flags().String(constants.IptablesVersion, "", "version of iptables command. If not set, this is automatically detected.")
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
+	IPTablesVersion         string        `json:"IPTABLES_VERSION"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 	DualStack               bool          `json:"DUAL_STACK"`
 }
@@ -73,6 +74,7 @@ func (c *Config) String() string {
 
 func (c *Config) Print() {
 	var b strings.Builder
+	b.WriteString(fmt.Sprintf("IPTABLES_VERSION=%s\n", c.IPTablesVersion))
 	b.WriteString(fmt.Sprintf("PROXY_PORT=%s\n", c.ProxyPort))
 	b.WriteString(fmt.Sprintf("PROXY_INBOUND_CAPTURE_PORT=%s\n", c.InboundCapturePort))
 	b.WriteString(fmt.Sprintf("PROXY_TUNNEL_PORT=%s\n", c.InboundTunnelPort))

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -107,6 +107,7 @@ const (
 	CaptureAllDNS             = "capture-all-dns"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
+	IptablesVersion           = "iptables-version"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -15,12 +15,14 @@
 package dependencies
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
@@ -61,10 +63,58 @@ var XTablesCmds = sets.New(
 	constants.IP6TABLESSAVE,
 )
 
+// XTablesWriteCmds contains all xtables commands that do write actions (and thus need a lock)
+var XTablesWriteCmds = sets.New(
+	constants.IPTABLES,
+	constants.IP6TABLES,
+	constants.IPTABLESRESTORE,
+	constants.IP6TABLESRESTORE,
+)
+
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
+	IptablesVersion  IptablesVersion
 	NetworkNamespace string
 	CNIMode          bool
+}
+
+const iptablesVersionPattern = `v([0-9]+(\.[0-9]+)+)`
+
+type IptablesVersion struct {
+	// the actual version
+	version *utilversion.Version
+	// true if legacy mode, false if nf_tables
+	legacy bool
+}
+
+// NoLocks returns true if this version does not use or support locks
+func (v IptablesVersion) NoLocks() bool {
+	// nf_tables does not use locks
+	// legacy added locks in 1.6.2
+	return !v.legacy || v.version.LessThan(IptablesRestoreLocking)
+}
+
+func DetectIptablesVersion(ver string) (IptablesVersion, error) {
+	if ver == "" {
+		var err error
+		verb, err := exec.Command("iptables", "--version").CombinedOutput()
+		if err != nil {
+			return IptablesVersion{}, err
+		}
+		ver = string(verb)
+	}
+	// Legacy will have no marking or 'legacy', so just look for nf_tables
+	nft := strings.Contains(ver, "nf_tables")
+	versionMatcher := regexp.MustCompile(iptablesVersionPattern)
+	match := versionMatcher.FindStringSubmatch(ver)
+	if match == nil {
+		return IptablesVersion{}, fmt.Errorf("no iptables version found: %q", ver)
+	}
+	version, err := utilversion.ParseGeneric(match[1])
+	if err != nil {
+		return IptablesVersion{}, fmt.Errorf("iptables version %q is not a valid version string: %v", match[1], err)
+	}
+	return IptablesVersion{version: version, legacy: !nft}, nil
 }
 
 // transformToXTablesErrorMessage returns an updated error message with explicit xtables error hints, if applicable.
@@ -93,37 +143,6 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 	}
 
 	return stderr
-}
-
-func isXTablesLockError(stderr *bytes.Buffer, exitcode int) bool {
-	// xtables lock acquire failure maps to resource problem exit code.
-	// https://git.netfilter.org/iptables/tree/iptables/iptables.c?h=v1.6.0#n1769
-	if exitcode != int(XTablesResourceProblem) {
-		return false
-	}
-
-	// check stderr output and see if there is `xtables lock` in it.
-	// https://git.netfilter.org/iptables/tree/iptables/iptables.c?h=v1.6.0#n1763
-	if strings.Contains(stderr.String(), "xtables lock") {
-		return true
-	}
-
-	return false
-}
-
-func exitCode(err error) (int, bool) {
-	if err == nil {
-		return 0, false
-	}
-
-	ee, ok := err.(*exec.ExitError)
-	if !ok {
-		// Not common, but can happen if file not found error, etc
-		return 0, false
-	}
-
-	exitcode := ee.ExitCode()
-	return exitcode, true
 }
 
 // RunOrFail runs a command and exits with an error message, if it fails

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -16,17 +16,17 @@ package dependencies
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"os/exec"
 	"strings"
-	"time"
+	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 
-	"istio.io/istio/pkg/backoff"
 	"istio.io/istio/pkg/log"
 )
 
@@ -49,22 +49,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 		}
 		externalCommand.Env = append(externalCommand.Env, fmt.Sprintf("%s=%v", strings.ToUpper(repl.Replace(k)), v))
 	}
-	var err error
-	var nsContainer ns.NetNS
-	if r.CNIMode {
-		nsContainer, err = ns.GetNS(r.NetworkNamespace)
-		if err != nil {
-			return err
-		}
-
-		err = nsContainer.Do(func(ns.NetNS) error {
-			return externalCommand.Run()
-		})
-		nsContainer.Close()
-	} else {
-		err = externalCommand.Run()
-	}
-
+	err := r.runCommand(externalCommand)
 	if len(stdout.String()) != 0 {
 		log.Infof("Command output: \n%v", stdout.String())
 	}
@@ -76,67 +61,73 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 	return err
 }
 
-func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
-
-	var stdout, stderr *bytes.Buffer
-	var err error
-	var nsContainer ns.NetNS
-
+func (r *RealDependencies) runCommand(c *exec.Cmd) error {
 	if r.CNIMode {
-		nsContainer, err = ns.GetNS(r.NetworkNamespace)
+		n, err := ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
 		}
-		defer nsContainer.Close()
+		defer n.Close()
+
+		return n.Do(func(ns.NetNS) error {
+			return c.Run()
+		})
 	}
-	o := backoff.Option{
-		InitialInterval: 100 * time.Millisecond,
-		MaxInterval:     2 * time.Second,
-	}
-	b := backoff.NewExponentialBackOff(o)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	backoffError := b.RetryWithContext(ctx, func() error {
-		externalCommand := exec.Command(cmd, args...)
-		stdout = &bytes.Buffer{}
-		stderr = &bytes.Buffer{}
-		externalCommand.Stdout = stdout
-		externalCommand.Stderr = stderr
-		externalCommand.Stdin = stdin
-		if stdin != nil {
-			if _, err := stdin.Seek(0, io.SeekStart); err != nil {
-				return err
-			}
-		}
+	return c.Run()
+}
+
+var (
+	// IptablesRestoreLocking is the version where locking and -w is added to iptables-restore
+	IptablesRestoreLocking = utilversion.MustParseGeneric("1.6.2")
+	// IptablesLockfileEnv is the version where XTABLES_LOCKFILE is added to iptables.
+	IptablesLockfileEnv = utilversion.MustParseGeneric("1.8.6")
+)
+
+func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+	mode := "without lock"
+	var c *exec.Cmd
+	_, needLock := XTablesWriteCmds[cmd]
+	if !needLock || r.IptablesVersion.NoLocks() {
+		// No locking supported/needed, just run as is. Nothing special
+		c = exec.Command(cmd, args...)
+	} else {
 		if r.CNIMode {
-			err = nsContainer.Do(func(ns.NetNS) error {
-				return externalCommand.Run()
-			})
+			// In CNI, we are running the pod network namespace, but the host filesystem. Locking the host is both useless and harmful,
+			// as it opens the risk of lock contention with other node actors (such as kube-proxy), and isn't actually needed at all.
+			// In both cases we are setting the lockfile to `r.NetworkNamespace`.
+			// * /dev/null looks like a good option, but actually doesn't work (it will ensure only one actor can access it)
+			// * `mktemp` works, but it is slightly harder to deal with cleanup and in some platforms we may not have write access.
+			if r.IptablesVersion.version.LessThan(IptablesLockfileEnv) {
+				// Older iptables cannot turn off the lock explicitly, so we hack around it...
+				// Overwrite the lock file with /dev/null
+				// cmd is repeated twice as the first 'cmd' instance becomes $0
+				args := append([]string{"-c", fmt.Sprintf("mount --bind %s /run/xtables.lock; exec $@", r.NetworkNamespace), cmd, cmd}, args...)
+				c = exec.Command("sh", args...)
+				// Run in a new mount namespace so our mount doesn't impact any other processes.
+				c.SysProcAttr = &syscall.SysProcAttr{Unshareflags: unix.CLONE_NEWNS}
+				mode = "without lock by mount"
+			} else {
+				// Available since iptables 1.8.6+, just point to a different file directly
+				c = exec.Command(cmd, args...)
+				c.Env = append(c.Env, "XTABLES_LOCKFILE="+r.NetworkNamespace)
+				mode = "without lock by environment"
+			}
 		} else {
-			err = externalCommand.Run()
+			// We want the lock. Wait up to 30s for it.
+			args = append(args, "--wait=30")
+			c = exec.Command(cmd, args...)
+			log.Debugf("running with lock")
+			mode = "with wait lock"
 		}
-		exitCode, ok := exitCode(err)
-		if !ok {
-			// cannot get exit code. consider this as non-retriable.
-			return nil
-		}
-
-		if !isXTablesLockError(stderr, exitCode) {
-			// Command succeeded, or failed not because of xtables lock.
-			return nil
-		}
-
-		// If command failed because xtables was locked, try the command again.
-		// Note we retry invoking iptables command explicitly instead of using the `-w` option of iptables,
-		// because as of iptables 1.6.x (version shipped with bionic), iptables-restore does not support `-w`.
-		log.Debugf("Failed to acquire XTables lock, retry iptables command..")
-		return err
-	})
-	if backoffError != nil {
-		return fmt.Errorf("timed out trying to acquire XTables lock: %v", err)
 	}
 
+	log.Infof("Running command (%s): %s %s", mode, cmd, strings.Join(args, " "))
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c.Stdout = stdout
+	c.Stderr = stderr
+	c.Stdin = stdin
+	err := r.runCommand(c)
 	if len(stdout.String()) != 0 {
 		log.Infof("Command output: \n%v", stdout.String())
 	}


### PR DESCRIPTION
Our current iptables locking strategy is "retry a few times if we fail to get the lock". This is broken in a number of different ways, depending on the environment.

For background, iptables execution is network namespace scoped, but the lock is in the filesystem. We want exclusive access in the network namespace when we do any writes.

iptables 1.6.2 adds locking to iptables-restore. Before then, there is no locking in this command since its atomic -- but the lock ensures that others using raw `iptables` commands do not cause issues.

In CNI, we are in the host filesystem. So the lock we acquire is the host lock -- the same one kube-proxy and others acquire. This can cause extreme contention - in some cases we have seen users effectively unable to schedule any pods for hours due to this. **The lock is useless**, because we are running the commands in the pod network namespace, not the host!

In init-container mode, we should never have lock contention so its not a big deal.

The new logic is based on the iptables version and whether we are in CNI:
* If we are using an old version without locking, just run the command. No need to do anything tricky or retry
* if we are in istio-init mode, let iptables wait for us with `--wait=30` (30s wait)
* if we are in CNI mode, we will disable locking. This is done differently based on the version. See code for details 