### PR TITLE
Dual-stack: /healthz/ready should have both v4/v6 wildcard listeners

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -153,15 +153,18 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv6),
 					option.Wildcard(option.WildcardIPv6),
+					option.AdditionalWildCard(option.WildcardIPv4),
 					option.DNSLookupFamily(option.DNSLookupFamilyIPS))
 			} else {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv4),
 					option.Wildcard(option.WildcardIPv4),
+					option.AdditionalWildCard(option.WildcardIPv6),
 					option.DNSLookupFamily(option.DNSLookupFamilyIPS))
 			}
+			opts = append(opts, option.DualStack(true))
 		} else {
-			// keep the original logic if Dual Stack is disable
+			// keep the original logic if Dual Stack is disabled
 			opts = append(opts,
 				option.Localhost(option.LocalhostIPv4),
 				option.Wildcard(option.WildcardIPv4),

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -105,6 +105,14 @@ func Wildcard(value WildcardValue) Instance {
 	return newOption("wildcard", value)
 }
 
+func AdditionalWildCard(value WildcardValue) Instance {
+	return newOption("additional_wildcard", value)
+}
+
+func DualStack(value bool) Instance {
+	return newOption("dual_stack", value)
+}
+
 func DNSLookupFamily(value DNSLookupFamilyValue) Instance {
 	return newOption("dns_lookup_family", value)
 }

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -99,6 +100,9 @@ type Instance interface {
 	// InternalDiscoveryAddressFor returns an internal (port-forwarded) address for an Istiod instance in the
 	// cluster.
 	InternalDiscoveryAddressFor(cluster cluster.Cluster) (string, error)
+
+	// Return POD IPs for the pod with the specified label in the system namespace
+	PodIPsFor(cluster cluster.Cluster, label string) ([]corev1.PodIP, error)
 
 	// Values returns the operator values for the installed control plane.
 	Values() (OperatorValues, error)

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -171,6 +171,18 @@ func (i *istioImpl) CustomIngressFor(c cluster.Cluster, service types.Namespaced
 	return i.ingress[c.Name()][labelSelector]
 }
 
+func (i *istioImpl) PodIPsFor(c cluster.Cluster, label string) ([]corev1.PodIP, error) {
+	// Find the pod with the specified label in the system namespace
+	fetchFn := testKube.NewSinglePodFetch(c, i.cfg.SystemNamespace, label)
+	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
+	if err != nil {
+		return nil, err
+	}
+
+	pod := pods[0]
+	return pod.Status.PodIPs, nil
+}
+
 func (i *istioImpl) InternalDiscoveryAddressFor(c cluster.Cluster) (string, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -563,3 +563,36 @@ func StatusGatewayTest(t framework.TestContext) {
 	// It should be added back
 	retry.UntilSuccessOrFail(t, check)
 }
+
+// Verify that the envoy readiness probes are reachable at
+// https://GatewayPodIP:15021/healthz/ready . This is being explicitly done
+// to make sure, in dual-stack scenarios both v4 and v6 probes are reachable.
+func TestGatewayReadinessProbes(t *testing.T) {
+	// nolint: staticcheck
+	framework.NewTest(t).
+		RequiresSingleCluster().
+		RequiresLocalControlPlane().
+		Features("traffic.gateway.readiness").
+		Run(func(t framework.TestContext) {
+			c := t.Clusters().Default()
+			podIPs, err := i.PodIPsFor(c, "app=istio-ingressgateway")
+			if err != nil {
+				t.Fatalf("error getting ingress gateway pod ips: %v", err)
+			}
+			for _, ip := range podIPs {
+				t.NewSubTest("gateway-readiness-probe-" + ip.IP).Run(func(t framework.TestContext) {
+					apps.External.All[0].CallOrFail(t, echo.CallOptions{
+						Address: ip.IP,
+						Port:    echo.Port{ServicePort: 15021},
+						Scheme:  scheme.HTTP,
+						HTTP: echo.HTTP{
+							Path: "/healthz/ready",
+						},
+						Check: check.And(
+							check.Status(200),
+						),
+					})
+				})
+			}
+		})
+}

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -550,6 +550,19 @@
              "port_value": {{ .envoy_status_port }}
            }
         },
+        {{- if .dual_stack }}
+        "additionalAddresses": [
+          {
+            "address": {
+              "socket_address": {
+                "protocol": "TCP",
+                "address": "{{ .additional_wildcard }}",
+                "port_value": {{ .envoy_status_port }}
+              }
+            }
+          }
+        ],
+        {{- end}}
         "filter_chains": [
           {
             "filters": [


### PR DESCRIPTION
**Please provide a description of this PR:**

- Enhance DualStack integration tests as per [RFC](https://docs.google.com/document/d/1sou7tc52HZsH2vRjcuP-N7VvtvWH-7_f/edit) - added gateway readiness probe tests
- Fix issue with probe test as mentioned in https://github.com/istio/istio/issues/47013