### PR TITLE
Dual-stack: /stats/prometheus should have both v4/v6 listeners

### DIFF
--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -501,6 +501,19 @@
             "port_value": {{ .envoy_prometheus_port }}
           }
         },
+        {{- if .dual_stack }}
+        "additionalAddresses": [
+          {
+            "address": {
+              "socket_address": {
+                "protocol": "TCP",
+                "address": "{{ .additional_wildcard }}",
+                "port_value": {{ .envoy_prometheus_port }}
+              }
+            }
+          }
+        ],
+        {{- end}}
         "filter_chains": [
           {
             "filters": [


### PR DESCRIPTION
**Please provide a description of this PR:**

Allows envoy metric scraping (:15090/stats/prometheus) using either pod IP family in dual-stack clusters.

Similar updates to readiness probe listeners done here: https://github.com/istio/istio/pull/47022