### PR TITLE
Autheticate crane `Exists` with DefaultKeychain for private registries

### DIFF
--- a/pkg/util/image/registry.go
+++ b/pkg/util/image/registry.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -31,7 +32,7 @@ func Exists(image string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("parsing reference %q: %w", image, err)
 	}
-	_, err = remote.Get(ref)
+	_, err = remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err == nil {
 		// image exists
 		return true, nil


### PR DESCRIPTION
`./tools/build-base-images.sh` fails to authenticate if `HUBS` include private registries.

Patching per https://github.com/google/go-containerregistry/tree/main/pkg/authn

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
