### PR TITLE
Filter remote endpoints to prevent request hairpinning

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -306,7 +306,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			// We have a cache miss, so we will re-generate the cluster and later store it in the cache.
 			var lbEndpoints []*endpoint.LocalityLbEndpoints
 			if clusterKey.endpointBuilder != nil {
-				lbEndpoints = clusterKey.endpointBuilder.FromServiceEndpoints()
+				lbEndpoints = clusterKey.endpointBuilder.FromServiceEndpoints(false)
 			}
 
 			// create default cluster
@@ -430,7 +430,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 					clusterName, model.TrafficDirectionOutbound, "", service.Hostname, port.Port,
 					service, destRule,
 				)
-				lbEndpoints = endpointBuilder.FromServiceEndpoints()
+				lbEndpoints = endpointBuilder.FromServiceEndpoints(true)
 			}
 
 			defaultCluster := cb.buildCluster(clusterName, discoveryType, lbEndpoints, model.TrafficDirectionOutbound, port, service, nil)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -177,7 +177,7 @@ func (cb *ClusterBuilder) buildSubsetCluster(
 		clusterType = cluster.Cluster_ORIGINAL_DST
 	}
 	if !(isPassthrough || clusterType == cluster.Cluster_EDS) {
-		lbEndpoints = endpointBuilder.WithSubset(subset.Name).FromServiceEndpoints()
+		lbEndpoints = endpointBuilder.WithSubset(subset.Name).FromServiceEndpoints(false)
 	}
 
 	subsetCluster := cb.buildCluster(subsetClusterName, clusterType, lbEndpoints, model.TrafficDirectionOutbound, opts.port, service, nil)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1570,7 +1570,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 					model.TrafficDirectionOutbound, "v1", "foo.com", 8080,
 					service, drWithLabels(tt.labels),
 				)
-				actual := eb.FromServiceEndpoints()
+				actual := eb.FromServiceEndpoints(false)
 				sortEndpoints(actual)
 				if v := cmp.Diff(tt.expected, actual, protocmp.Transform()); v != "" {
 					t.Fatalf("Expected (-) != actual (+):\n%s", v)
@@ -1786,7 +1786,7 @@ func TestConcurrentBuildLocalityLbEndpoints(t *testing.T) {
 				model.TrafficDirectionOutbound, "v1", "foo.com", 8080,
 				service, dr,
 			)
-			eps := eb.FromServiceEndpoints()
+			eps := eb.FromServiceEndpoints(false)
 			mu.Lock()
 			actual = eps
 			mu.Unlock()


### PR DESCRIPTION
## For Reviewers

Wanted to get a pulse on this idea. I think it's reasonable. Don't want to merge without a unit test.

## Context

When generating envoy clusters for SNI DNAT, I noticed that we included remote endpoints if they were present. This seems erroneous because this could result in request hairpinning (for example, infinitely between two different network gateways).

Instead, it seems like we should filter those out and let typical circuit breaking take effect, if the only healthy endpoints we had were in another network.

I only want this change to take effect in SNI DNAT because those clusters are _known_ to be receiving traffic from another network.