### PR TITLE
optimize envoyfilter REMOVE operation performance

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/runtime"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto/merge"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -93,13 +94,9 @@ func patchListeners(
 		}
 	}
 	if listenersRemoved {
-		tempArray := make([]*listener.Listener, 0, len(listeners))
-		for _, l := range listeners {
-			if l.Name != "" {
-				tempArray = append(tempArray, l)
-			}
-		}
-		return tempArray
+		return slices.FilterInPlace(listeners, func(l *listener.Listener) bool {
+			return l.Name != ""
+		})
 	}
 	return listeners
 }
@@ -218,13 +215,9 @@ func patchListenerFilters(patchContext networking.EnvoyFilter_PatchContext,
 			if !hasListenerFilterMatch(lp) {
 				continue
 			}
-			tempListenerFilters := []*listener.ListenerFilter{}
-			for _, filter := range lis.ListenerFilters {
-				if !listenerFilterMatch(filter, lp) {
-					tempListenerFilters = append(tempListenerFilters, filter)
-				}
-			}
-			lis.ListenerFilters = tempListenerFilters
+			lis.ListenerFilters = slices.FilterInPlace(lis.ListenerFilters, func(filter *listener.ListenerFilter) bool {
+				return !listenerFilterMatch(filter, lp)
+			})
 		}
 		IncrementEnvoyFilterMetric(lp.Key(), ListenerFilter, applied)
 	}
@@ -260,13 +253,9 @@ func patchFilterChains(patchContext networking.EnvoyFilter_PatchContext,
 		}
 	}
 	if filterChainsRemoved {
-		tempArray := make([]*listener.FilterChain, 0, len(lis.FilterChains))
-		for _, fc := range lis.FilterChains {
-			if fc.Filters != nil {
-				tempArray = append(tempArray, fc)
-			}
-		}
-		lis.FilterChains = tempArray
+		lis.FilterChains = slices.FilterInPlace(lis.FilterChains, func(fc *listener.FilterChain) bool {
+			return fc.Filters != nil
+		})
 	}
 }
 
@@ -432,14 +421,9 @@ func patchNetworkFilters(patchContext networking.EnvoyFilter_PatchContext,
 			if !hasNetworkFilterMatch(lp) {
 				continue
 			}
-
-			var tempFilters []*listener.Filter
-			for _, filter := range fc.Filters {
-				if !networkFilterMatch(filter, lp) {
-					tempFilters = append(tempFilters, filter)
-				}
-			}
-			fc.Filters = tempFilters
+			fc.Filters = slices.FilterInPlace(fc.Filters, func(filter *listener.Filter) bool {
+				return !networkFilterMatch(filter, lp)
+			})
 		}
 		IncrementEnvoyFilterMetric(lp.Key(), NetworkFilter, applied)
 	}
@@ -609,13 +593,9 @@ func patchHTTPFilters(patchContext networking.EnvoyFilter_PatchContext,
 			if !hasHTTPFilterMatch(lp) {
 				continue
 			}
-			var httpFilters []*hcm.HttpFilter
-			for _, h := range httpconn.HttpFilters {
-				if !httpFilterMatch(h, lp) {
-					httpFilters = append(httpFilters, h)
-				}
-			}
-			httpconn.HttpFilters = httpFilters
+			httpconn.HttpFilters = slices.FilterInPlace(httpconn.HttpFilters, func(h *hcm.HttpFilter) bool {
+				return !httpFilterMatch(h, lp)
+			})
 		}
 		IncrementEnvoyFilterMetric(lp.Key(), HttpFilter, applied)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go
@@ -95,14 +95,9 @@ func patchVirtualHosts(patchContext networking.EnvoyFilter_PatchContext,
 		}
 	}
 	if removedVirtualHosts.Len() > 0 {
-		trimmedVirtualHosts := make([]*route.VirtualHost, 0, len(routeConfiguration.VirtualHosts)-removedVirtualHosts.Len())
-		for _, virtualHost := range routeConfiguration.VirtualHosts {
-			if removedVirtualHosts.Contains(virtualHost.Name) {
-				continue
-			}
-			trimmedVirtualHosts = append(trimmedVirtualHosts, virtualHost)
-		}
-		routeConfiguration.VirtualHosts = trimmedVirtualHosts
+		routeConfiguration.VirtualHosts = slices.FilterInPlace(routeConfiguration.VirtualHosts, func(virtualHost *route.VirtualHost) bool {
+			return !removedVirtualHosts.Contains(virtualHost.Name)
+		})
 	}
 }
 
@@ -230,14 +225,9 @@ func patchHTTPRoutes(patchContext networking.EnvoyFilter_PatchContext,
 		IncrementEnvoyFilterMetric(rp.Key(), Route, applied)
 	}
 	if routesRemoved {
-		trimmedRoutes := make([]*route.Route, 0, len(virtualHost.Routes))
-		for i := range virtualHost.Routes {
-			if virtualHost.Routes[i] == nil {
-				continue
-			}
-			trimmedRoutes = append(trimmedRoutes, virtualHost.Routes[i])
-		}
-		virtualHost.Routes = trimmedRoutes
+		virtualHost.Routes = slices.FilterInPlace(virtualHost.Routes, func(r *route.Route) bool {
+			return r != nil
+		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -564,9 +564,10 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 
 // dedupeDomains removes the duplicate domains from the passed in domains.
 func dedupeDomains(domains []string, vhdomains sets.String, expandedHosts []string, knownFQDNs sets.String) []string {
-	return slices.FilterInPlace(domains, func(d string) bool {
+	temp := domains[:0]
+	for _, d := range domains {
 		if vhdomains.Contains(strings.ToLower(d)) {
-			return false
+			continue
 		}
 		// Check if the domain is an "expanded" host, and its also a known FQDN
 		// This prevents a case where a domain like "foo.com.cluster.local" gets expanded to "foo.com", overwriting
@@ -574,11 +575,12 @@ func dedupeDomains(domains []string, vhdomains sets.String, expandedHosts []stri
 		// This works by providing a list of domains that were added as expanding the DNS domain as part of expandedHosts,
 		// and a list of known unexpanded FQDNs to compare against
 		if slices.Contains(expandedHosts, d) && knownFQDNs.Contains(d) { // O(n) search, but n is at most 10
-			return false
+			continue
 		}
+		temp = append(temp, d)
 		vhdomains.Insert(strings.ToLower(d))
-		return true
-	})
+	}
+	return temp
 }
 
 // Returns the set of virtual hosts that correspond to the listener that has HTTP protocol detection

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -767,14 +767,10 @@ func mergeAllVirtualHosts(vHostPortMap map[int][]*route.VirtualHost) []*route.Vi
 			virtualHosts = append(virtualHosts, vhosts...)
 		} else {
 			for _, vhost := range vhosts {
-				var newDomains []string
-				for _, domain := range vhost.Domains {
-					if strings.Contains(domain, ":") {
-						newDomains = append(newDomains, domain)
-					}
-				}
-				if len(newDomains) > 0 {
-					vhost.Domains = newDomains
+				vhost.Domains = slices.FilterInPlace(vhost.Domains, func(domain string) bool {
+					return strings.Contains(domain, ":")
+				})
+				if len(vhost.Domains) > 0 {
 					virtualHosts = append(virtualHosts, vhost)
 				}
 			}


### PR DESCRIPTION
`FilterInPlace` uses `mutated in place`, so it avoids allocating temporary space during execution.