### PR TITLE
regional failover to work with failover priority

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -182,7 +182,10 @@ func applyLocalityFailover(
 				}
 			}
 		}
-
+		// priority is calculated using the already assigned priority using failoverPriority.
+		// Since there are at most 5 priorities can be assigned using locality failover(0-4),
+		// we multiply the priority by 5 for maintaining the priorities already assigned.
+		// Afterwards the final priorities can be calculted from 0 (highest) to N (lowest) without skipping.
 		priorityInt := int(loadAssignment.Endpoints[i].Priority*5) + priority
 		loadAssignment.Endpoints[i].Priority = uint32(priorityInt)
 		priorityMap[priorityInt] = append(priorityMap[priorityInt], i)
@@ -216,7 +219,7 @@ type WrappedLocalityLbEndpoints struct {
 	LocalityLbEndpoints *endpoint.LocalityLbEndpoints
 }
 
-// set loadbalancing priority by failover priority label and returns the number of priorities assigned.
+// set loadbalancing priority by failover priority label.
 func applyPriorityFailover(
 	loadAssignment *endpoint.ClusterLoadAssignment,
 	wrappedLocalityLbEndpoints []*WrappedLocalityLbEndpoints,

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -183,7 +183,7 @@ func applyLocalityFailover(
 			}
 		}
 
-		priorityInt := int(loadAssignment.Endpoints[i].Priority * 5) + priority
+		priorityInt := int(loadAssignment.Endpoints[i].Priority*5) + priority
 		loadAssignment.Endpoints[i].Priority = uint32(priorityInt)
 		priorityMap[priorityInt] = append(priorityMap[priorityInt], i)
 	}
@@ -254,7 +254,6 @@ func applyPriorityFailover(
 		}
 	}
 	loadAssignment.Endpoints = localityLbEndpoints
-	return
 }
 
 // Returning the label names in a separate array as the iteration of map is not ordered.

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -694,7 +694,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 						LoadBalancingWeight: &wrappers.UInt32Value{
 							Value: 1,
 						},
-						Priority: 1, // p1 is the next priority as failover is configured and it matches the proxy locality
+						Priority: 2, // does not match failoverPriority but same locality
 					},
 					{
 						Locality: &core.Locality{
@@ -713,7 +713,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 						LoadBalancingWeight: &wrappers.UInt32Value{
 							Value: 1,
 						},
-						Priority: 2, // p2 is the next priority according to the failover configuration of region1 -> region2
+						Priority: 3, // does not match failoverPriority and locality but mentioned in locality failover settings for the client region.
 					},
 					{
 						Locality: &core.Locality{
@@ -732,7 +732,26 @@ func TestApplyLocalitySetting(t *testing.T) {
 						LoadBalancingWeight: &wrappers.UInt32Value{
 							Value: 1,
 						},
-						Priority: 3,
+						Priority: 4,
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone2",
+							SubZone: "subzone2",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("5.5.5.5"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 1, // matching the same failoverPriority but different locality(zone and subzone different)
 					},
 				},
 			},
@@ -1286,6 +1305,21 @@ func buildSmallClusterForFailOverPriorityWithFailover() *cluster.Cluster {
 						},
 					},
 				},
+				{
+					Locality: &core.Locality{
+						Region:  "region1",
+						Zone:    "zone2",
+						SubZone: "subzone2",
+					},
+					LbEndpoints: []*endpoint.LbEndpoint{
+						{
+							HostIdentifier: buildEndpoint("5.5.5.5"),
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 1,
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1408,6 +1442,18 @@ func buildWrappedLocalityLbEndpointsForFailoverPriorityWithFailover() []*Wrapped
 				},
 			},
 			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[3],
+		},
+		{
+			IstioEndpoints: []*model.IstioEndpoint{
+				{
+					Labels: map[string]string{
+						"topology.istio.io/network": "n1",
+						"topology.istio.io/cluster": "c1",
+					},
+					Address: "5.5.5.5",
+				},
+			},
+			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[4],
 		},
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -643,6 +643,123 @@ func TestApplyLocalitySetting(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("FailoverPriority with Failover", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			failoverPriority []string
+			proxyLabels      map[string]string
+			expected         []*endpoint.LocalityLbEndpoints
+		}{
+			{
+				name:             "match all labels",
+				failoverPriority: []string{"topology.istio.io/cluster"},
+				proxyLabels: map[string]string{
+					"topology.istio.io/cluster": "c1",
+				},
+				expected: []*endpoint.LocalityLbEndpoints{
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone1",
+							SubZone: "subzone1",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("2.2.2.2"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 0, // highest priority because of label matching
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region1",
+							Zone:    "zone1",
+							SubZone: "subzone1",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("1.1.1.1"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 1, // p1 is the next priority as failover is configured and it matches the proxy locality
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region2",
+							Zone:    "zone2",
+							SubZone: "subzone2",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("4.4.4.4"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 2, // p2 is the next priority according to the failover configuration of region1 -> region2
+					},
+					{
+						Locality: &core.Locality{
+							Region:  "region3",
+							Zone:    "zone3",
+							SubZone: "subzone3",
+						},
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: buildEndpoint("3.3.3.3"),
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: 1,
+						},
+						Priority: 3,
+					},
+				},
+			},
+		}
+		wrappedEndpoints := buildWrappedLocalityLbEndpointsForFailoverPriorityWithFailover()
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				env := buildEnvForClustersWithMixedFailoverPriorityAndLocalityFailover(tt.failoverPriority)
+				cluster := buildFakeCluster()
+				ApplyLocalityLBSetting(cluster.LoadAssignment, wrappedEndpoints, locality, tt.proxyLabels, env.Mesh().LocalityLbSetting, true)
+
+				if len(cluster.LoadAssignment.Endpoints) != len(tt.expected) {
+					t.Fatalf("expected endpoints %d but got %d", len(cluster.LoadAssignment.Endpoints), len(tt.expected))
+				}
+				for i := range cluster.LoadAssignment.Endpoints {
+					// TODO Below assertions are not robust to ordering changes in cluster.LoadAssignment.Endpoints[i]
+					if cluster.LoadAssignment.Endpoints[i].LoadBalancingWeight.GetValue() != tt.expected[i].LoadBalancingWeight.GetValue() {
+						t.Errorf("Got unexpected lb weight %v expected %v", cluster.LoadAssignment.Endpoints[i].LoadBalancingWeight, tt.expected[i].LoadBalancingWeight)
+					}
+					if cluster.LoadAssignment.Endpoints[i].Priority != tt.expected[i].Priority {
+						t.Errorf("Got unexpected priority %v expected %v", cluster.LoadAssignment.Endpoints[i].Priority, tt.expected[i].Priority)
+					}
+				}
+			})
+		}
+	})
 }
 
 func TestGetLocalityLbSetting(t *testing.T) {
@@ -874,6 +991,64 @@ func buildEnvForClustersWithFailoverPriority(failoverPriority []string) *model.E
 	return env
 }
 
+func buildEnvForClustersWithMixedFailoverPriorityAndLocalityFailover(failoverPriority []string) *model.Environment {
+	serviceDiscovery := memregistry.NewServiceDiscovery(&model.Service{
+		Hostname:       "test.example.org",
+		DefaultAddress: "1.1.1.1",
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "default",
+				Port:     8080,
+				Protocol: protocol.HTTP,
+			},
+		},
+	})
+
+	meshConfig := &meshconfig.MeshConfig{
+		ConnectTimeout: &durationpb.Duration{
+			Seconds: 10,
+			Nanos:   1,
+		},
+		LocalityLbSetting: &networking.LocalityLoadBalancerSetting{
+			FailoverPriority: failoverPriority,
+			Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+				{
+					From: "region1",
+					To:   "region2",
+				},
+			},
+		},
+	}
+
+	configStore := memory.Make(collections.Pilot)
+
+	env := model.NewEnvironment()
+	env.ServiceDiscovery = serviceDiscovery
+	env.ConfigStore = configStore
+	env.Watcher = mesh.NewFixedWatcher(meshConfig)
+
+	pushContext := model.NewPushContext()
+	env.Init()
+	_ = pushContext.InitContext(env, nil, nil)
+	env.SetPushContext(pushContext)
+	pushContext.SetDestinationRulesForTesting([]config.Config{
+		{
+			Meta: config.Meta{
+				GroupVersionKind: gvk.DestinationRule,
+				Name:             "acme",
+			},
+			Spec: &networking.DestinationRule{
+				Host: "test.example.org",
+				TrafficPolicy: &networking.TrafficPolicy{
+					OutlierDetection: &networking.OutlierDetection{},
+				},
+			},
+		},
+	})
+
+	return env
+}
+
 func buildFakeCluster() *cluster.Cluster {
 	return &cluster.Cluster{
 		Name: "outbound|8080||test.example.org",
@@ -1045,6 +1220,77 @@ func buildSmallClusterForFailOverPriority() *cluster.Cluster {
 	}
 }
 
+func buildSmallClusterForFailOverPriorityWithFailover() *cluster.Cluster {
+	return &cluster.Cluster{
+		Name: "outbound|8080||test.example.org",
+		LoadAssignment: &endpoint.ClusterLoadAssignment{
+			ClusterName: "outbound|8080||test.example.org",
+			Endpoints: []*endpoint.LocalityLbEndpoints{
+				{
+					Locality: &core.Locality{
+						Region:  "region1",
+						Zone:    "zone1",
+						SubZone: "subzone1",
+					},
+					LbEndpoints: []*endpoint.LbEndpoint{
+						{
+							HostIdentifier: buildEndpoint("1.1.1.1"),
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 1,
+							},
+						},
+					},
+				},
+				{
+					Locality: &core.Locality{
+						Region:  "region1",
+						Zone:    "zone2",
+						SubZone: "subzone2",
+					},
+					LbEndpoints: []*endpoint.LbEndpoint{
+						{
+							HostIdentifier: buildEndpoint("2.2.2.2"),
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 1,
+							},
+						},
+					},
+				},
+				{
+					Locality: &core.Locality{
+						Region:  "region2",
+						Zone:    "zone2",
+						SubZone: "subzone2",
+					},
+					LbEndpoints: []*endpoint.LbEndpoint{
+						{
+							HostIdentifier: buildEndpoint("3.3.3.3"),
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 1,
+							},
+						},
+					},
+				},
+				{
+					Locality: &core.Locality{
+						Region:  "region3",
+						Zone:    "zone3",
+						SubZone: "subzone3",
+					},
+					LbEndpoints: []*endpoint.LbEndpoint{
+						{
+							HostIdentifier: buildEndpoint("4.4.4.4"),
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func buildEndpoint(ip string) *endpoint.LbEndpoint_Endpoint {
 	return &endpoint.LbEndpoint_Endpoint{
 		Endpoint: &endpoint.Endpoint{
@@ -1105,6 +1351,63 @@ func buildWrappedLocalityLbEndpoints() []*WrappedLocalityLbEndpoints {
 				},
 			},
 			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[1],
+		},
+	}
+}
+
+func buildWrappedLocalityLbEndpointsForFailoverPriorityWithFailover() []*WrappedLocalityLbEndpoints {
+	cluster := buildSmallClusterForFailOverPriorityWithFailover()
+	return []*WrappedLocalityLbEndpoints{
+		{
+			IstioEndpoints: []*model.IstioEndpoint{
+				{
+					Labels: map[string]string{
+						"topology.istio.io/network": "n1",
+						"topology.istio.io/cluster": "c1",
+					},
+					Address: "1.1.1.1",
+				},
+			},
+			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[0],
+		},
+		{
+			IstioEndpoints: []*model.IstioEndpoint{
+				{
+					Labels: map[string]string{
+						"key":                       "value",
+						"topology.istio.io/network": "n2",
+						"topology.istio.io/cluster": "c2",
+					},
+					Address: "2.2.2.2",
+				},
+			},
+			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[1],
+		},
+		{
+			IstioEndpoints: []*model.IstioEndpoint{
+				{
+					Labels: map[string]string{
+						"key":                       "value",
+						"topology.istio.io/network": "n1",
+						"topology.istio.io/cluster": "c3",
+					},
+					Address: "3.3.3.3",
+				},
+			},
+			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[2],
+		},
+		{
+			IstioEndpoints: []*model.IstioEndpoint{
+				{
+					Labels: map[string]string{
+						"key":                       "value",
+						"topology.istio.io/network": "n2",
+						"topology.istio.io/cluster": "c4",
+					},
+					Address: "4.4.4.4",
+				},
+			},
+			LocalityLbEndpoints: cluster.LoadAssignment.Endpoints[3],
 		},
 	}
 }

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -29,7 +29,7 @@ const (
 	LabelHostname = "kubernetes.io/hostname"
 
 	LabelTopologyZone    = "topology.kubernetes.io/zone"
-	LabelTopologySubZone = "topology.istio.io/subzone"
+	LabelTopologySubzone = "topology.istio.io/subzone"
 	LabelTopologyRegion  = "topology.kubernetes.io/region"
 )
 

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -29,6 +29,7 @@ const (
 	LabelHostname = "kubernetes.io/hostname"
 
 	LabelTopologyZone   = "topology.kubernetes.io/zone"
+	LabelTopologySubZone =  "topology.istio.io/subzone"
 	LabelTopologyRegion = "topology.kubernetes.io/region"
 )
 

--- a/pilot/pkg/serviceregistry/util/label/label.go
+++ b/pilot/pkg/serviceregistry/util/label/label.go
@@ -28,9 +28,9 @@ import (
 const (
 	LabelHostname = "kubernetes.io/hostname"
 
-	LabelTopologyZone   = "topology.kubernetes.io/zone"
-	LabelTopologySubZone =  "topology.istio.io/subzone"
-	LabelTopologyRegion = "topology.kubernetes.io/region"
+	LabelTopologyZone    = "topology.kubernetes.io/zone"
+	LabelTopologySubZone = "topology.istio.io/subzone"
+	LabelTopologyRegion  = "topology.kubernetes.io/region"
 )
 
 // AugmentLabels adds additional labels to the those provided.

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3652,9 +3652,9 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 	if len(lb.GetFailover()) > 0 && len(lb.GetFailoverPriority()) > 0 {
 		for _, priorityLabel := range lb.GetFailoverPriority() {
 			switch priorityLabel {
-				case label.LabelTopologyRegion, label.LabelTopologyZone, label.LabelTopologySubZone:
-					errs = appendValidation(errs, fmt.Errorf("can not simultaneously use 'failover' and mention topology label '%s' in 'failover_priority'", priorityLabel))
-					return
+			case label.LabelTopologyRegion, label.LabelTopologyZone, label.LabelTopologySubZone:
+				errs = appendValidation(errs, fmt.Errorf("can not simultaneously use 'failover' and mention topology label '%s' in 'failover_priority'", priorityLabel))
+				return
 			}
 		}
 	}
@@ -3669,9 +3669,9 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 			if weight <= 0 || weight > 100 {
 				errs = appendValidation(errs, fmt.Errorf("locality weight must be in range [1, 100]"))
 				return
-		    }
+			}
 			totalWeight += weight
-	    }
+		}
 		if totalWeight != 100 {
 			errs = appendValidation(errs, fmt.Errorf("total locality weight %v != 100", totalWeight))
 			return

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3652,8 +3652,8 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 	if len(lb.GetFailover()) > 0 && len(lb.GetFailoverPriority()) > 0 {
 		for _, priorityLabel := range lb.GetFailoverPriority() {
 			switch priorityLabel {
-			case label.LabelTopologyRegion, label.LabelTopologyZone, label.LabelTopologySubZone:
-				errs = appendValidation(errs, fmt.Errorf("can not simultaneously use 'failover' and mention topology label '%s' in 'failover_priority'", priorityLabel))
+			case label.LabelTopologyRegion, label.LabelTopologyZone, label.LabelTopologySubzone:
+				errs = appendValidation(errs, fmt.Errorf("can not simultaneously set 'failover' and topology label '%s' in 'failover_priority'", priorityLabel))
 				return
 			}
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -47,6 +47,7 @@ import (
 	telemetry "istio.io/api/telemetry/v1alpha1"
 	type_beta "istio.io/api/type/v1beta1"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
@@ -3648,6 +3649,16 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 		return
 	}
 
+	if len(lb.GetFailover()) > 0 && len(lb.GetFailoverPriority()) > 0 {
+		for _, priorityLabel := range lb.GetFailoverPriority() {
+			switch priorityLabel {
+				case label.LabelTopologyRegion, label.LabelTopologyZone, label.LabelTopologySubZone:
+					errs = appendValidation(errs, fmt.Errorf("can not simultaneously use 'failover' and mention topology label '%s' in 'failover_priority'", priorityLabel))
+					return
+			}
+		}
+	}
+
 	srcLocalities := make([]string, 0, len(lb.GetDistribute()))
 	for _, locality := range lb.GetDistribute() {
 		srcLocalities = append(srcLocalities, locality.From)
@@ -3658,9 +3669,9 @@ func validateLocalityLbSetting(lb *networking.LocalityLoadBalancerSetting, outli
 			if weight <= 0 || weight > 100 {
 				errs = appendValidation(errs, fmt.Errorf("locality weight must be in range [1, 100]"))
 				return
-			}
+		    }
 			totalWeight += weight
-		}
+	    }
 		if totalWeight != 100 {
 			errs = appendValidation(errs, fmt.Errorf("total locality weight %v != 100", totalWeight))
 			return

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -7448,6 +7448,21 @@ func TestValidateLocalityLbSetting(t *testing.T) {
 			err:     false,
 			warn:    true,
 		},
+		{
+			name: "invalid LocalityLoadBalancerSetting specify both failoverPriority and region in failover",
+			in: &networking.LocalityLoadBalancerSetting{
+				Failover: []*networking.LocalityLoadBalancerSetting_Failover{
+					{
+						From: "region1",
+						To:   "region2",
+					},
+				},
+				FailoverPriority: []string{"topology.kubernetes.io/region"},
+			},
+			outlier: &networking.OutlierDetection{},
+			err:     true,
+			warn:    false,
+		},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/47099.yaml
+++ b/releasenotes/notes/47099.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** `failoverPriority` and `failover` to work together with each other.


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to https://github.com/istio/istio/issues/47068

Failover and FailoverPriority can't be used together at the moment. There is no validation as such to prevent this but `FailoverPriority` takes precedence in case it is defined. There could be a requirement such that failoverPriority should be considered for calculating priorities of endpoint and at the same time of failover is defined it can be taken into account for determining priorities of the endpoints remaining.

The example is given in the issue attached.

This PR needs a document change if merged