### PR TITLE
operator: fix missing rbac permissions in openshift platform

### DIFF
--- a/manifests/charts/istio-operator/templates/clusterrole.yaml
+++ b/manifests/charts/istio-operator/templates/clusterrole.yaml
@@ -102,6 +102,7 @@ rules:
   resources:
   - configmaps
   - endpoints
+  - endpoints/restricted
   - events
   - namespaces
   - pods

--- a/releasenotes/notes/47118.yaml
+++ b/releasenotes/notes/47118.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** missing rbac permissions when istio-operator installs multi-cluster mesh on the openshift platform.


### PR DESCRIPTION
**Please provide a description of this PR:**

If we use istio-operator to install multi-cluster mesh on the openshfit platform, when istio-operator creates the `istio-remote` endpoint associated with external services, the status of `istiooperator` CR will be `ERROR` due to insufficient permissions.

<img width="1310" alt="image" src="https://github.com/istio/istio/assets/76980726/8195d63f-13d8-4ca4-b3e1-099051ccbac5">

The openshift docs:https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/pods_and_services.html#endpoints