### PR TITLE
fix: name parameter of create-remote-secret should support DNS1123Subdomain

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -753,4 +753,22 @@ func TestRemoteSecretOptions(t *testing.T) {
 		"?-invalid-name",
 	})).Should(Succeed())
 	g.Expect(o.prepare(ctx)).Should(Not(Succeed()))
+
+	o = RemoteSecretOptions{}
+	flags = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	o.addFlags(flags)
+	g.Expect(flags.Parse([]string{
+		"--name",
+		"example.com",
+	})).Should(Succeed())
+	g.Expect(o.prepare(ctx)).Should(Succeed())
+
+	o = RemoteSecretOptions{}
+	flags = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	o.addFlags(flags)
+	g.Expect(flags.Parse([]string{
+		"--name",
+		"valid-name.example.com",
+	})).Should(Succeed())
+	g.Expect(o.prepare(ctx)).Should(Succeed())
 }


### PR DESCRIPTION
Signed-off-by: aimuz <mr.imuz@gmail.com>

**Please provide a description of this PR:**

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

According to the documentation, the name of the secret object is supported in DNS1123Subdomain format.

Creating the name in DNS1123Subdomain format as a secret via kubectl also succeeded

```bash
$ kubectl create secret generic example.com                                        
secret/example.com created
```



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
