### PR TITLE
delta xds: fix panic when service is not found

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -650,7 +650,10 @@ func (sc *SidecarScope) DestinationRuleByName(name, namespace string) *config.Co
 // can be a wildcard.
 func (sc *SidecarScope) ServicesForHostname(hostname host.Name) []*Service {
 	if !hostname.IsWildCarded() {
-		return []*Service{sc.servicesByHostname[hostname]}
+		if svc, f := sc.servicesByHostname[hostname]; f {
+			return []*Service{svc}
+		}
+		return nil
 	}
 	services := make([]*Service, 0)
 	for _, svc := range sc.services {


### PR DESCRIPTION
Fixes https://storage.googleapis.com/istio-prow/logs/integ-distroless_istio_postsubmit/1706750269011791872/artifacts/pilot-24ed18b8836d4a0e86dad5350/_suite_context/istio-state-620402818/primary-0/istiod-f7f8bfb76-t25br_discovery.previous.log. This can happen when DR references a removed service