### PR TITLE
start webhooks informer explicitly

### DIFF
--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -89,6 +89,7 @@ func newWebhookPatcherQueue(reconciler controllers.ReconcilerFn) controllers.Que
 // Run runs the WebhookCertPatcher
 func (w *WebhookCertPatcher) Run(stopChan <-chan struct{}) {
 	go w.startCaBundleWatcher(stopChan)
+	w.webhooks.Start(stopChan)
 	kubelib.WaitForCacheSync("webhook patcher", stopChan, w.webhooks.HasSynced)
 	w.queue.Run(stopChan)
 }


### PR DESCRIPTION
 webhook patching waits for sync with log line "info	waiting for sync...	name=default revision attempt=1015700 time=28h54m16.487998565s"

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure