### PR TITLE
cni: move ambient iptables detection off bash

### DIFF
--- a/cni/pkg/ambient/server.go
+++ b/cni/pkg/ambient/server.go
@@ -69,7 +69,9 @@ func NewServer(ctx context.Context, args AmbientArgs) (*Server, error) {
 	}
 
 	s.iptablesCommand = lazy.New(func() (string, error) {
-		return s.detectIptablesCommand(), nil
+		mode := detectIptablesCommand()
+		log.Infof("running with iptables command %q", mode)
+		return mode, nil
 	})
 
 	switch args.RedirectMode {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -19,6 +19,7 @@ package ambient
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,6 +77,9 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireMinVersion(24).
+		SkipIf("https://github.com/istio/istio/issues/43243", func(ctx resource.Context) bool {
+			return os.Getenv("VARIANT") == "distroless"
+		}).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/41008
 		Setup(func(t resource.Context) error {
 			t.Settings().Ambient = true


### PR DESCRIPTION
One step closer to distroless support. However, we still use `ip` which isn't in the image.

**Please provide a description of this PR:**