### PR TITLE
Add ability to add custom selectors to pdbs and deploys

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
+      {{- with .Values.additionalDeploymentSelectorLabels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/manifests/charts/gateway/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateway/templates/poddisruptionbudget.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
   {{- include "gateway.selectorLabels" . | nindent 6 }}
+  {{- with .Values.additionalPodDisruptionBudgetSelectorLabels }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   {{- with .Values.podDisruptionBudget }}
     {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -225,6 +225,24 @@
         }
       }
     },
+    "additionalPodDisruptionBudgetSelectorLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "integer"
+        ]
+      }
+    },
+    "additionalDeploymentSelectorLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "integer"
+        ]
+      }
+    },
     "terminationGracePeriodSeconds": {
       "type": "number"
     },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -130,8 +130,6 @@ imagePullSecrets: []
 #
 podDisruptionBudget: {}
 
-# In addition to the standard set of labels used as selector on the service obj, add these labels to pods and as selector
-# on deploy and pdb objects. Note that these additional selector labels *are not*
 additionalPodDisruptionBudgetSelectorLabels: {}
 
 additionalDeploymentSelectorLabels: {}

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -130,6 +130,12 @@ imagePullSecrets: []
 #
 podDisruptionBudget: {}
 
+# In addition to the standard set of labels used as selector on the service obj, add these labels to pods and as selector
+# on deploy and pdb objects. Note that these additional selector labels *are not*
+additionalPodDisruptionBudgetSelectorLabels: {}
+
+additionalDeploymentSelectorLabels: {}
+
 terminationGracePeriodSeconds: 30
 
 # A list of `Volumes` added into the Gateway Pods. See


### PR DESCRIPTION
**Please provide a description of this PR:**

It is possible within the gateway helm chart to customize the set of labels applied to pods via the deploy object, but it is not possible to customize the selector labels for the pdb and deploy objects.  This change adds an ability to add additional selector labels to the pdb and deploy objects.