### PR TITLE
Clarify telemetry deployment namespace

### DIFF
--- a/samples/open-telemetry/otel.yaml
+++ b/samples/open-telemetry/otel.yaml
@@ -20,7 +20,7 @@ data:
         # Export to zipkin for easy querying
         endpoint: http://zipkin.istio-system.svc:9411/api/v2/spans
       logging:
-        verbosity: detailed
+        loglevel: debug
       jaeger:
         endpoint: jaeger-collector.istio-system.svc.cluster.local:14250
         tls:
@@ -30,8 +30,8 @@ data:
         retry_on_failure:
           enabled: true
     extensions:
-      # default health check endpoint is 0.0.0.0:13133
       health_check:
+        port: 13133
     service:
       extensions:
       - health_check
@@ -102,7 +102,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: otel/opentelemetry-collector:0.85.0
+          image: otel/opentelemetry-collector:0.54.0
           imagePullPolicy: IfNotPresent
           name: opentelemetry-collector
           ports:

--- a/samples/open-telemetry/otel.yaml
+++ b/samples/open-telemetry/otel.yaml
@@ -20,7 +20,7 @@ data:
         # Export to zipkin for easy querying
         endpoint: http://zipkin.istio-system.svc:9411/api/v2/spans
       logging:
-        loglevel: debug
+        verbosity: detailed
       jaeger:
         endpoint: jaeger-collector.istio-system.svc.cluster.local:14250
         tls:
@@ -30,8 +30,8 @@ data:
         retry_on_failure:
           enabled: true
     extensions:
+      # default health check endpoint is 0.0.0.0:13133
       health_check:
-        port: 13133
     service:
       extensions:
       - health_check
@@ -102,7 +102,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: otel/opentelemetry-collector:0.54.0
+          image: otel/opentelemetry-collector:0.85.0
           imagePullPolicy: IfNotPresent
           name: opentelemetry-collector
           ports:

--- a/samples/open-telemetry/tracing/README.md
+++ b/samples/open-telemetry/tracing/README.md
@@ -12,7 +12,7 @@ kubectl -n <namespace> apply -f ../otel.yaml
 
 In this example, we use `otel-collector` as the namespace to deploy the `otel-collector` backend:
 
-```ba
+```bash
 kubectl -n otel-collector apply -f ../otel.yaml
 ```
 
@@ -66,7 +66,7 @@ You may also choose any existing tracing system if you have, and you should chan
 
 You may also choose to use your own otel collector if you have, and the key part is to have the `otlp` grpc protocol receiver to receive the traces. One important thing is to make sure your otel collector service's grpc port starts with `grpc-` prefix, which is like:
 
-```ya
+```yaml
 spec:
   ports:
     - name: grpc-otlp
@@ -102,8 +102,15 @@ Make sure the service name matches the one you deployed if you select a differen
 
 Next, add a Telemetry resource that tells Istio to send trace records to the OpenTelemetry collector.
 
-```yaml
-kubectl -n otel-collector apply -f ./telemetry.yaml
+```bash
+kubectl -n <namespace> apply -f ./telemetry.yaml
+```
+
+In this example, we deploy it to the default namespace, which is where the sample apps
+from the [getting started](https://istio.io/latest/docs/setup/getting-started) are also deployed.
+
+```bash
+kubectl apply -f ./telemetry.yaml
 ```
 
 The core config is:

--- a/samples/open-telemetry/tracing/README.md
+++ b/samples/open-telemetry/tracing/README.md
@@ -13,6 +13,7 @@ kubectl -n <namespace> apply -f ../otel.yaml
 In this example, we use `otel-collector` as the namespace to deploy the `otel-collector` backend:
 
 ```bash
+kubectl create namespace otel-collector
 kubectl -n otel-collector apply -f ../otel.yaml
 ```
 


### PR DESCRIPTION
I was going through the sample and got stuck with spans not being exported to the OTel collector. In discussions on Slack, it was pointed that the `Telemetry` resource needs to be either deployed on the `istio-system` namespace or on the same namespace where the apps are running. 

The OTel guide here uses the sample apps from the getting started guide https://istio.io/latest/docs/setup/getting-started/#bookinfo, which are deployed on the default namespace, thus if you follow it as is, it does not work. 

This PR does:

- ~~Update the OTel collector image, which is very old. Adapts some minor things that changed~~
- Make it clear that the Telemetry resource needs to be deployed on the default namespace, if you are following the getting started guide