### PR TITLE
Don't deploy a bunch of gateways uncessarily for RA tests

### DIFF
--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -593,9 +593,9 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 				})).
 				Source(config.File("testdata/requestauthn/gateway-jwt.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Ns1.Namespace,
-					"Services":               apps.Ns1.All,
+					"Services":               apps.Ns1.A.Append(apps.Ns1.B).Services(),
 				})).
-				BuildAll(nil, apps.Ns1.All).
+				BuildAll(nil, apps.Ns1.A.Append(apps.Ns1.B).Services()).
 				Apply()
 
 			t.NewSubTest("gateway-authn").Run(func(t framework.TestContext) {
@@ -712,7 +712,7 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 					},
 				}
 
-				newTrafficTest(t, apps.Ns1.All.Instances()).
+				newTrafficTest(t, apps.Ns1.A.Append(apps.Ns1.B)).
 					RunViaGatewayIngress("istio", func(t framework.TestContext, from ingress.Instance, to echo.Target) {
 						for _, c := range cases {
 							t.NewSubTest(c.name).Run(func(t framework.TestContext) {

--- a/tests/integration/security/policy_attachment_only/jwt_gateway_test.go
+++ b/tests/integration/security/policy_attachment_only/jwt_gateway_test.go
@@ -50,9 +50,9 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 				})).
 				Source(config.File("testdata/requestauthn/gateway-jwt.yaml.tmpl").WithParams(param.Params{
 					param.Namespace.String(): apps.Namespace,
-					"Services":               apps.All,
+					"Services":               apps.A.Append(apps.B).Services(),
 				})).
-				BuildAll(nil, apps.All).
+				BuildAll(nil, apps.A.Append(apps.B).Services()).
 				Apply()
 
 			t.NewSubTest("gateway-authn-policy-attachment-only").Run(func(t framework.TestContext) {
@@ -170,7 +170,7 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 					},
 				}
 
-				newTrafficTest(t, apps.All.Instances()).
+				newTrafficTest(t, apps.A.Append(apps.B)).
 					RunViaGatewayIngress("istio", func(t framework.TestContext, from ingress.Instance, to echo.Target) {
 						for _, c := range cases {
 							t.NewSubTest(c.name).Run(func(t framework.TestContext) {


### PR DESCRIPTION
**Please provide a description of this PR:**
We were deploying like 5 gateways; that's too much and unnecessary. Now we'll just apply 2

