### PR TITLE
Don't check port updates for managed gateways

### DIFF
--- a/pilot/pkg/config/kube/gateway/context.go
+++ b/pilot/pkg/config/kube/gateway/context.go
@@ -25,6 +25,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -114,7 +115,20 @@ func (gc GatewayContext) ResolveGatewayInstances(
 							"port %d not found for hostname %q (hint: the service port should be specified, not the workload port. Did you mean one of these ports: %v?)",
 							port, g, sets.SortedList(hintPort)))
 					} else {
-						warnings = append(warnings, fmt.Sprintf("port %d not found for hostname %q", port, g))
+						_, isManaged := svc.Attributes.Labels[constants.ManagedGatewayLabel]
+						var portExistsOnService bool
+						for _, p := range svc.Ports {
+							if p.Port == port {
+								portExistsOnService = true
+								break
+							}
+						}
+						// If this is a managed gateway, the only possible explanation for no instances for the port
+						// is a delay in endpoint sync. Therefore, we don't want to warn/change the Programmed condition
+						// in this case as long as the port exists on the `Service` object.
+						if !isManaged || !portExistsOnService {
+							warnings = append(warnings, fmt.Sprintf("port %d not found for hostname %q", port, g))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #44850 by not checking port instance existence for managed gateways. If they're managed, we can be pretty confident that endpoints for the port will eventually exist as long as the endpointslice controller is functioning