### PR TITLE
optimize: select virtual services

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -195,7 +195,7 @@ func (c *Controller) setupAutoRecreate() {
 
 	c.store.RegisterEventHandler(gvk.WorkloadGroup, func(_ config.Config, cfg config.Config, event model.Event) {
 		if event == model.EventAdd {
-			c.lateRegistrationQueue.Add(config.NamespacedName(cfg))
+			c.lateRegistrationQueue.Add(cfg.NamespacedName())
 		}
 	})
 }

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -117,7 +117,7 @@ func (cr *store) List(typ config.GroupVersionKind, namespace string) []config.Co
 	for _, store := range cr.stores[typ] {
 		storeConfigs := store.List(typ, namespace)
 		for _, cfg := range storeConfigs {
-			if !configMap.InsertContains(config.NamespacedName(cfg)) {
+			if !configMap.InsertContains(cfg.NamespacedName()) {
 				configs = append(configs, cfg)
 			}
 		}

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -74,7 +74,7 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 			// This can happen when there are more than one destination rule of same host in one namespace.
 			copied := mdr.rule.DeepCopy()
 			mdr.rule = &copied
-			mdr.from = append(mdr.from, config.NamespacedName(destRuleConfig))
+			mdr.from = append(mdr.from, destRuleConfig.NamespacedName())
 			mergedRule := copied.Spec.(*networking.DestinationRule)
 
 			existingSubset := sets.String{}
@@ -122,7 +122,7 @@ func (ps *PushContext) mergeDestinationRule(p *consolidatedDestRules, destRuleCo
 func ConvertConsolidatedDestRule(cfg *config.Config) *ConsolidatedDestRule {
 	return &ConsolidatedDestRule{
 		rule: cfg,
-		from: []types.NamespacedName{config.NamespacedName(cfg)},
+		from: []types.NamespacedName{cfg.NamespacedName()},
 	}
 }
 

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -40,17 +40,16 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		key := config.NamespacedName(vs)
 		rule := vs.Spec.(*networking.VirtualService)
 
-		if vsset.Contains(key) {
-			return
-		}
-
 		for _, vh := range rule.Hosts {
+			if vsset.Contains(key) {
+				return
+			}
+
 			// first, check exactHosts
 			if hosts.exactHosts.Contains(host.Name(vh)) {
 				importedVirtualServices = append(importedVirtualServices, vs)
 				vsset.Insert(key)
-				// since this VS has already been added there's no need to continue processing
-				return
+				break
 			}
 
 			// exactHosts not found, fallback to loop allHosts
@@ -58,8 +57,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 				if vsHostMatches(vh, ah, vs) {
 					importedVirtualServices = append(importedVirtualServices, vs)
 					vsset.Insert(key)
-					// since this VS has already been added there's no need to continue processing
-					return
+					break
 				}
 			}
 		}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -40,10 +40,11 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		key := config.NamespacedName(vs)
 		rule := vs.Spec.(*networking.VirtualService)
 
+		if vsset.Contains(key) {
+			return
+		}
+
 		for _, vh := range rule.Hosts {
-			if vsset.Contains(key) {
-				return
-			}
 
 			// first, check exactHosts
 			if hosts.exactHosts.Contains(host.Name(vh)) {

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -37,7 +37,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 	vsset := sets.New[types.NamespacedName]()
 
 	addVirtualService := func(vs config.Config, hosts hostClassification) {
-		key := types.NamespacedName{Namespace: vs.Namespace, Name: vs.Name}
+		key := vs.NamespacedName()
 
 		if vsset.Contains(key) {
 			return
@@ -191,7 +191,7 @@ func mergeVirtualServicesIfNeeded(
 		rule := vs.Spec.(*networking.VirtualService)
 		// it is delegate, add it to the indexer cache along with the exportTo for the delegate
 		if len(rule.Hosts) == 0 {
-			delegatesMap[config.NamespacedName(vs)] = vs
+			delegatesMap[vs.NamespacedName()] = vs
 			var exportToSet sets.Set[visibility.Instance]
 			if len(rule.ExportTo) == 0 {
 				// No exportTo in virtualService. Use the global default
@@ -213,7 +213,7 @@ func mergeVirtualServicesIfNeeded(
 					}
 				}
 			}
-			delegatesExportToMap[config.NamespacedName(vs)] = exportToSet
+			delegatesExportToMap[vs.NamespacedName()] = exportToSet
 
 			continue
 		}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -37,7 +37,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 	vsset := sets.New[types.NamespacedName]()
 
 	addVirtualService := func(vs config.Config, hosts hostClassification) {
-		key := config.NamespacedName(vs)
+		key := types.NamespacedName{Namespace: vs.Namespace, Name: vs.Name}
 		rule := vs.Spec.(*networking.VirtualService)
 
 		if vsset.Contains(key) {
@@ -49,7 +49,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 			if hosts.exactHosts.Contains(host.Name(vh)) {
 				importedVirtualServices = append(importedVirtualServices, vs)
 				vsset.Insert(key)
-				break
+				return
 			}
 
 			// exactHosts not found, fallback to loop allHosts
@@ -57,7 +57,8 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 				if vsHostMatches(vh, ah, vs) {
 					importedVirtualServices = append(importedVirtualServices, vs)
 					vsset.Insert(key)
-					break
+					// break both loops
+					return
 				}
 			}
 		}

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -45,7 +45,6 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		}
 
 		for _, vh := range rule.Hosts {
-
 			// first, check exactHosts
 			if hosts.exactHosts.Contains(host.Name(vh)) {
 				importedVirtualServices = append(importedVirtualServices, vs)

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -38,12 +38,12 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 
 	addVirtualService := func(vs config.Config, hosts hostClassification) {
 		key := types.NamespacedName{Namespace: vs.Namespace, Name: vs.Name}
-		rule := vs.Spec.(*networking.VirtualService)
 
 		if vsset.Contains(key) {
 			return
 		}
 
+		rule := vs.Spec.(*networking.VirtualService)
 		for _, vh := range rule.Hosts {
 			// first, check exactHosts
 			if hosts.exactHosts.Contains(host.Name(vh)) {

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -96,7 +96,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, re
 
 		b, err := config.PilotConfigToResource(&c)
 		if err != nil {
-			log.WithLabels("resource", config.NamespacedName(c)).Warnf("resource error: %v", err)
+			log.WithLabels("resource", c.NamespacedName()).Warnf("resource error: %v", err)
 			continue
 		}
 		resp = append(resp, &discovery.Resource{
@@ -119,7 +119,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, re
 			c := serviceentry.ServiceToServiceEntry(s, proxy)
 			b, err := config.PilotConfigToResource(c)
 			if err != nil {
-				log.WithLabels("resource", config.NamespacedName(c)).Warnf("resource error: %v", err)
+				log.WithLabels("resource", c.NamespacedName()).Warnf("resource error: %v", err)
 				continue
 			}
 			resp = append(resp, &discovery.Resource{

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -363,7 +363,7 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
 	cs := convertServices(curr)
 	configsUpdated := sets.New[model.ConfigKey]()
-	key := config.NamespacedName(curr)
+	key := curr.NamespacedName()
 
 	s.mutex.Lock()
 	// If it is add/delete event we should always do a full push. If it is update event, we should do full push,
@@ -538,7 +538,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 		// Case 2 : The labelsChanged and the new wi is still a subset of se
 		// Case 3 : The labelsChanged and the new wi is NOT a subset of se anymore
 
-		seNamespacedName := config.NamespacedName(cfg)
+		seNamespacedName := cfg.NamespacedName()
 		services := s.services.getServices(seNamespacedName)
 		currInstance := convertWorkloadInstanceToServiceInstance(wi, services, se)
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1120,7 +1120,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 		expectEvents(t, events, Event{Type: "eds", ID: "selector.com", Namespace: selector.Namespace, EndpointCount: 2})
 
 		key := instancesKey{namespace: selector.Namespace, hostname: "selector.com"}
-		namespacedName := config.NamespacedName(selector)
+		namespacedName := selector.NamespacedName()
 		if len(sd.serviceInstances.ip2instance) != 1 {
 			t.Fatalf("service instances store `ip2instance` memory leak, expect 1, got %d", len(sd.serviceInstances.ip2instance))
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -22,7 +22,6 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -75,7 +74,7 @@ func TestServiceInstancesStore(t *testing.T) {
 		makeInstance(selector, "1.1.1.1", 444, selector.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 		makeInstance(selector, "1.1.1.1", 445, selector.Spec.(*networking.ServiceEntry).Ports[1], nil, PlainText),
 	}}
-	key := config.NamespacedName(selector)
+	key := selector.NamespacedName()
 	store.updateServiceEntryInstances(key, expectedSeInstances)
 
 	gotSeInstances := store.getServiceEntryInstances(key)
@@ -115,8 +114,8 @@ func TestServiceStore(t *testing.T) {
 		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 	}
 
-	store.updateServices(config.NamespacedName(httpDNSRR), expectedServices)
-	got := store.getServices(config.NamespacedName(httpDNSRR))
+	store.updateServices(httpDNSRR.NamespacedName(), expectedServices)
+	got := store.getServices(httpDNSRR.NamespacedName())
 	if !reflect.DeepEqual(got, expectedServices) {
 		t.Errorf("got unexpected services %v", got)
 	}
@@ -129,7 +128,7 @@ func TestServiceStore(t *testing.T) {
 		t.Errorf("expected allocate needed")
 	}
 	store.allocateNeeded = false
-	store.deleteServices(config.NamespacedName(httpDNSRR))
+	store.deleteServices(httpDNSRR.NamespacedName())
 	got = store.getAllServices()
 	if got != nil {
 		t.Errorf("got unexpected services %v", got)

--- a/pilot/pkg/serviceregistry/serviceentry/util.go
+++ b/pilot/pkg/serviceregistry/serviceentry/util.go
@@ -27,7 +27,7 @@ func getWorkloadServiceEntries(ses []config.Config, wle *networking.WorkloadEntr
 	for i, cfg := range ses {
 		se := cfg.Spec.(*networking.ServiceEntry)
 		if se.WorkloadSelector != nil && labels.Instance(se.WorkloadSelector.Labels).Match(wle.Labels) {
-			out[config.NamespacedName(cfg)] = &ses[i]
+			out[cfg.NamespacedName()] = &ses[i]
 		}
 	}
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -365,6 +365,13 @@ func (c Config) GetNamespace() string {
 	return c.Namespace
 }
 
+func (c Config) NamespacedName() kubetypes.NamespacedName {
+	return kubetypes.NamespacedName{
+		Namespace: c.Namespace,
+		Name:      c.Name,
+	}
+}
+
 var _ fmt.Stringer = GroupVersionKind{}
 
 type GroupVersionKind struct {
@@ -412,9 +419,9 @@ type Namer interface {
 	GetNamespace() string
 }
 
-func NamespacedName(n Namer) kubetypes.NamespacedName {
+func NamespacedName(o metav1.Object) kubetypes.NamespacedName {
 	return kubetypes.NamespacedName{
-		Namespace: n.GetNamespace(),
-		Name:      n.GetName(),
+		Namespace: o.GetNamespace(),
+		Name:      o.GetName(),
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
Optimizations to SelectVirtualServices which is a very hot method:
- use `types.NamespacedName` as `set` type to avoid string concatenation and allocations
- move `vsset.Contains` to the top, to prevent multiple checks for each non-matched rule
- use `return` instead of `break` to break both loops instead of only one