### PR TITLE
Fix ambient CNI

### DIFF
--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -24,9 +24,10 @@ spec:
       enabled: false
 
   values:
-    global:
+    ztunnel:
       variant: distroless
     pilot:
+      variant: distroless
       env:
         # Setup more secure default that is off in 'default' only for backwards compatibility
         VERIFY_CERTIFICATE_AT_CLIENT: "true"
@@ -36,7 +37,6 @@ spec:
         CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     cni:
-      variant: debug
       logLevel: info
       privileged: true
       ambient:

--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -36,6 +36,7 @@ spec:
         CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     cni:
+      variant: debug
       logLevel: info
       privileged: true
       ambient:

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -81,7 +81,7 @@ type values struct {
 	MeshConfig             *meshConfig                      `json:"meshConfig" patchStrategy:"merge"`
 	Base                   *v1alpha12.BaseConfig            `json:"base" patchStrategy:"merge"`
 	IstiodRemote           *v1alpha12.IstiodRemoteConfig    `json:"istiodRemote" patchStrategy:"merge"`
-	Ztunnel                map[string]string                `json:"ztunnel" patchStrategy:"merge"`
+	Ztunnel                map[string]any                   `json:"ztunnel" patchStrategy:"merge"`
 }
 
 type gatewaysConfig struct {

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -81,6 +81,7 @@ type values struct {
 	MeshConfig             *meshConfig                      `json:"meshConfig" patchStrategy:"merge"`
 	Base                   *v1alpha12.BaseConfig            `json:"base" patchStrategy:"merge"`
 	IstiodRemote           *v1alpha12.IstiodRemoteConfig    `json:"istiodRemote" patchStrategy:"merge"`
+	Ztunnel                map[string]string                `json:"ztunnel" patchStrategy:"merge"`
 }
 
 type gatewaysConfig struct {

--- a/tests/integration/base.yaml
+++ b/tests/integration/base.yaml
@@ -12,7 +12,10 @@ spec:
       proxyMetadata:
         ISTIO_META_DNS_CAPTURE: "true"
   values:
+    ztunnel:
+      variant: "" # we decide variant in framework
     pilot:
+      variant: "" # we decide variant in framework
       # Lower the reconnect time so we test reconnects. The default of 30min means we almost never trigger in tests.
       keepaliveMaxServerConnectionAge: 120s
       autoscaleEnabled: false


### PR DESCRIPTION
CNI distroless doesn't work yet, at all. I think CI passes since it ignores the 'variant'