### PR TITLE
Use shallow copy when merging HTTPMatchRequests

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -380,7 +380,8 @@ func mergeHTTPMatchRequests(root, delegate []*networking.HTTPMatchRequest) (out 
 }
 
 func mergeHTTPMatchRequest(root, delegate *networking.HTTPMatchRequest) *networking.HTTPMatchRequest {
-	out := delegate
+	// shallow copy
+	out := *delegate
 	if out.Name == "" {
 		out.Name = root.Name
 	} else if root.Name != "" {
@@ -425,7 +426,7 @@ func mergeHTTPMatchRequest(root, delegate *networking.HTTPMatchRequest) *network
 	if len(out.StatPrefix) == 0 {
 		out.StatPrefix = root.StatPrefix
 	}
-	return out
+	return &out
 }
 
 func hasConflict(root, leaf *networking.HTTPMatchRequest) bool {

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -1301,6 +1301,48 @@ func TestMergeHTTPMatchRequests(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple header matches",
+			root: []*networking.HTTPMatchRequest{
+				{
+					Headers: map[string]*networking.StringMatch{
+						"a": {
+							MatchType: &networking.StringMatch_Exact{Exact: "a"},
+						},
+					},
+				},
+				{
+					Headers: map[string]*networking.StringMatch{
+						"b": {
+							MatchType: &networking.StringMatch_Exact{Exact: "b"},
+						},
+					},
+				},
+			},
+			delegate: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/"}},
+				},
+			},
+			expected: []*networking.HTTPMatchRequest{
+				{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/"}},
+					Headers: map[string]*networking.StringMatch{
+						"a": {
+							MatchType: &networking.StringMatch_Exact{Exact: "a"},
+						},
+					},
+				},
+				{
+					Uri: &networking.StringMatch{MatchType: &networking.StringMatch_Prefix{Prefix: "/"}},
+					Headers: map[string]*networking.StringMatch{
+						"b": {
+							MatchType: &networking.StringMatch_Exact{Exact: "b"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "complicated merge",
 			root: []*networking.HTTPMatchRequest{
 				{


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/47148

Use shallow copy to avoid mutating the delegateVS match, otherwise merging result will be messed up when there are multiple rootVS matches

https://github.com/istio/istio/blob/ea9b33aff25012960a060f658118ddd50a006f45/pilot/pkg/model/virtualservice.go#L361-L369