### PR TITLE
Fix istioctl build failed

### DIFF
--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -87,13 +87,6 @@ type IptablesVersion struct {
 	legacy bool
 }
 
-// NoLocks returns true if this version does not use or support locks
-func (v IptablesVersion) NoLocks() bool {
-	// nf_tables does not use locks
-	// legacy added locks in 1.6.2
-	return !v.legacy || v.version.LessThan(IptablesRestoreLocking)
-}
-
 func DetectIptablesVersion(ver string) (IptablesVersion, error) {
 	if ver == "" {
 		var err error

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -30,6 +30,13 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
+// NoLocks returns true if this version does not use or support locks
+func (v IptablesVersion) NoLocks() bool {
+	// nf_tables does not use locks
+	// legacy added locks in 1.6.2
+	return !v.legacy || v.version.LessThan(IptablesRestoreLocking)
+}
+
 func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reader, args ...string) error {
 	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 


### PR DESCRIPTION
**Please provide a description of this PR:**
on mac:
```
GOOS=darwin GOARCH=arm64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh /Users/xiaopenghan/go/src/istio.io/istio/out/darwin_arm64/ -tags=agent ./pilot/cmd/pilot-agent
# istio.io/istio/tools/istio-iptables/pkg/dependencies
tools/istio-iptables/pkg/dependencies/implementation.go:94:41: undefined: IptablesRestoreLocking
make: *** [build] Error 1
```