### PR TITLE
Improve agent shutdown, with native sidecar support

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -65,7 +65,9 @@ metadata:
 {{- end }}
   }
 spec:
-  {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+  {{- $holdProxy := and
+      (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+      (not $nativeSidecar) }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
   {{ if .Values.istio_cni.enabled -}}
@@ -223,6 +225,17 @@ spec:
           command:
           - pilot-agent
           - wait
+  {{- else if $nativeSidecar }}
+    {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - pilot-agent
+          - request
+          - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+          - POST
+          - drain
   {{- end }}
     env:
     {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -65,7 +65,9 @@ metadata:
 {{- end }}
   }
 spec:
-  {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+  {{- $holdProxy := and
+      (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+      (not $nativeSidecar) }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
   {{ if .Values.istio_cni.enabled -}}
@@ -223,6 +225,17 @@ spec:
           command:
           - pilot-agent
           - wait
+  {{- else if $nativeSidecar }}
+    {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - pilot-agent
+          - request
+          - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+          - POST
+          - drain
   {{- end }}
     env:
     {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -163,7 +163,7 @@ func newProxyCommand() *cobra.Command {
 			// If a status port was provided, start handling status probes.
 			if proxyConfig.StatusPort > 0 {
 				if err := initStatusServer(ctx, proxy, proxyConfig,
-					agentOptions.EnvoyPrometheusPort, proxyArgs.EnableProfiling, agent); err != nil {
+					agentOptions.EnvoyPrometheusPort, proxyArgs.EnableProfiling, agent, cancel); err != nil {
 					return err
 				}
 			}
@@ -214,13 +214,20 @@ func addFlags(proxyCmd *cobra.Command) {
 		"Enable profiling via web interface host:port/debug/pprof/.")
 }
 
-func initStatusServer(ctx context.Context, proxy *model.Proxy, proxyConfig *meshconfig.ProxyConfig,
-	envoyPrometheusPort int, enableProfiling bool, agent *istio_agent.Agent,
+func initStatusServer(
+	ctx context.Context,
+	proxy *model.Proxy,
+	proxyConfig *meshconfig.ProxyConfig,
+	envoyPrometheusPort int,
+	enableProfiling bool,
+	agent *istio_agent.Agent,
+	shutdown context.CancelFunc,
 ) error {
 	o := options.NewStatusServerOptions(proxy, proxyConfig, agent)
 	o.EnvoyPrometheusPort = envoyPrometheusPort
 	o.EnableProfiling = enableProfiling
 	o.Context = ctx
+	o.Shutdown = shutdown
 	statusServer, err := status.NewServer(*o)
 	if err != nil {
 		return err

--- a/pilot/cmd/pilot-agent/options/statusserver.go
+++ b/pilot/cmd/pilot-agent/options/statusserver.go
@@ -34,5 +34,11 @@ func NewStatusServerOptions(proxy *model.Proxy, proxyConfig *meshconfig.ProxyCon
 		NoEnvoy:        agent.EnvoyDisabled(),
 		FetchDNS:       agent.GetDNSTable,
 		GRPCBootstrap:  agent.GRPCBootstrapPath(),
+		TriggerDrain: func() {
+			agent.DrainNow()
+		},
+		DisableDrain: func() {
+			agent.DisableDraining()
+		},
 	}
 }

--- a/pilot/cmd/pilot-agent/options/statusserver.go
+++ b/pilot/cmd/pilot-agent/options/statusserver.go
@@ -37,8 +37,5 @@ func NewStatusServerOptions(proxy *model.Proxy, proxyConfig *meshconfig.ProxyCon
 		TriggerDrain: func() {
 			agent.DrainNow()
 		},
-		DisableDrain: func() {
-			agent.DisableDraining()
-		},
 	}
 }

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -132,7 +132,6 @@ type Options struct {
 	PrometheusRegistry prometheus.Gatherer
 	Shutdown           context.CancelFunc
 	TriggerDrain       func()
-	DisableDrain       func()
 }
 
 // Server provides an endpoint for handling status probes.
@@ -220,8 +219,6 @@ func NewServer(config Options) (*Server, error) {
 		enableProfiling:       config.EnableProfiling,
 		registry:              registry,
 		shutdown: func() {
-			// Disable draining, as we want to shutdown immediately
-			config.DisableDrain()
 			config.Shutdown()
 		},
 		drain: config.TriggerDrain,

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -54,6 +54,7 @@ import (
 	"istio.io/istio/pkg/kube/apimirror"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -61,7 +62,8 @@ const (
 	// readyPath is for the pilot agent readiness itself.
 	readyPath = "/healthz/ready"
 	// quitPath is to notify the pilot agent to quit.
-	quitPath = "/quitquitquit"
+	quitPath  = "/quitquitquit"
+	drainPath = "/drain"
 	// KubeAppProberEnvName is the name of the command line flag for pilot agent to pass app prober config.
 	// The json encoded string to pass app HTTP probe information from injector(istioctl or webhook).
 	// For example, ISTIO_KUBE_APP_PROBERS='{"/app-health/httpbin/livez":{"httpGet":{"path": "/hello", "port": 8080}}.
@@ -128,6 +130,9 @@ type Options struct {
 	EnableProfiling     bool
 	// PrometheusRegistry to use. Just for testing.
 	PrometheusRegistry prometheus.Gatherer
+	Shutdown           context.CancelFunc
+	TriggerDrain       func()
+	DisableDrain       func()
 }
 
 // Server provides an endpoint for handling status probes.
@@ -147,6 +152,8 @@ type Server struct {
 	http                  *http.Client
 	enableProfiling       bool
 	registry              prometheus.Gatherer
+	shutdown              context.CancelFunc
+	drain                 func()
 }
 
 func initializeMonitoring() (prometheus.Gatherer, error) {
@@ -212,6 +219,12 @@ func NewServer(config Options) (*Server, error) {
 		config:                config,
 		enableProfiling:       config.EnableProfiling,
 		registry:              registry,
+		shutdown: func() {
+			// Disable draining, as we want to shutdown immediately
+			config.DisableDrain()
+			config.Shutdown()
+		},
+		drain: config.TriggerDrain,
 	}
 	if LegacyLocalhostProbeDestination.Get() {
 		s.appProbersDestination = "localhost"
@@ -358,6 +371,7 @@ func (s *Server) Run(ctx context.Context) {
 	// Keep for backward compat with configs.
 	mux.HandleFunc(`/stats/prometheus`, s.handleStats)
 	mux.HandleFunc(quitPath, s.handleQuit)
+	mux.HandleFunc(drainPath, s.handleDrain)
 	mux.HandleFunc("/app-health/", s.handleAppProbe)
 
 	if s.enableProfiling {
@@ -387,7 +401,9 @@ func (s *Server) Run(ctx context.Context) {
 
 	go func() {
 		if err := http.Serve(l, mux); err != nil {
-			log.Error(err)
+			if network.IsUnexpectedListenerError(err) {
+				log.Error(err)
+			}
 			select {
 			case <-ctx.Done():
 				// We are shutting down already, don't trigger SIGTERM
@@ -671,7 +687,22 @@ func (s *Server) handleQuit(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK"))
 	log.Infof("handling %s, notifying pilot-agent to exit", quitPath)
-	notifyExit()
+	s.shutdown()
+}
+
+func (s *Server) handleDrain(w http.ResponseWriter, r *http.Request) {
+	if !isRequestFromLocalhost(r) {
+		http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+	log.Infof("handling %s, starting drain", drainPath)
+	s.drain()
 }
 
 func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -24,12 +24,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/signal"
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -204,26 +201,39 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
-func TestPprof(t *testing.T) {
-	pprofPath := "/debug/pprof/cmdline"
-	// Starts the pilot agent status server.
-	server, err := NewServer(Options{StatusPort: 0, EnableProfiling: true, PrometheusRegistry: TestingRegistry(t)})
+func NewTestServer(t test.Failer, o Options) *Server {
+	if o.PrometheusRegistry == nil {
+		o.PrometheusRegistry = TestingRegistry(t)
+	}
+	server, err := NewServer(o)
 	if err != nil {
 		t.Fatalf("failed to create status server %v", err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 	go server.Run(ctx)
 
-	var statusPort uint16
-	for statusPort == 0 {
+	if err := retry.UntilSuccess(func() error {
 		server.mutex.RLock()
-		statusPort = server.statusPort
+		statusPort := server.statusPort
 		server.mutex.RUnlock()
+		if statusPort == 0 {
+			return fmt.Errorf("no port allocated")
+		}
+		return nil
+	}, retry.Delay(time.Microsecond)); err != nil {
+		t.Fatalf("failed to getport: %v", err)
 	}
 
+	return server
+}
+
+func TestPprof(t *testing.T) {
+	pprofPath := "/debug/pprof/cmdline"
+	// Starts the pilot agent status server.
+	server := NewTestServer(t, Options{EnableProfiling: true})
 	client := http.Client{}
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v/%s", statusPort, pprofPath), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v/%s", server.statusPort, pprofPath), nil)
 	if err != nil {
 		t.Fatalf("[%v] failed to create request", pprofPath)
 	}
@@ -871,34 +881,18 @@ func TestAppProbe(t *testing.T) {
 			t.Fatalf("invalid app probers")
 		}
 		config := Options{
-			StatusPort:         0,
-			PrometheusRegistry: TestingRegistry(t),
-			KubeAppProbers:     string(appProber),
-			PodIP:              tc.podIP,
-			IPv6:               tc.ipv6,
+			KubeAppProbers: string(appProber),
+			PodIP:          tc.podIP,
+			IPv6:           tc.ipv6,
 		}
+		server := NewTestServer(t, config)
 		// Starts the pilot agent status server.
-		server, err := NewServer(config)
-		if err != nil {
-			t.Fatalf("failed to create status server %v", err)
-		}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go server.Run(ctx)
-
 		if tc.ipv6 {
 			server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
 		}
 
-		var statusPort uint16
-		for statusPort == 0 {
-			server.mutex.RLock()
-			statusPort = server.statusPort
-			server.mutex.RUnlock()
-		}
-
 		client := http.Client{}
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v/%s", statusPort, tc.probePath), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v/%s", server.statusPort, tc.probePath), nil)
 		if err != nil {
 			t.Fatalf("[%v] failed to create request", tc.probePath)
 		}
@@ -979,31 +973,11 @@ func TestHttpsAppProbe(t *testing.T) {
 		appPort := listener.Addr().(*net.TCPAddr).Port
 
 		// Starts the pilot agent status server.
-		server, err := NewServer(Options{
-			StatusPort:         0,
-			PrometheusRegistry: TestingRegistry(t),
+		server := NewTestServer(t, Options{
 			KubeAppProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"httpGet": {"path": "/hello/sunnyvale", "port": %v, "scheme": "HTTPS"}},
 "/app-health/hello-world/livez": {"httpGet": {"port": %v, "scheme": "HTTPS"}}}`, appPort, appPort),
 		})
-		if err != nil {
-			t.Fatalf("failed to create status server %v", err)
-		}
-		go server.Run(context.Background())
-
-		var statusPort uint16
-		if err := retry.UntilSuccess(func() error {
-			server.mutex.RLock()
-			statusPort = server.statusPort
-			server.mutex.RUnlock()
-			if statusPort == 0 {
-				return fmt.Errorf("no port allocated")
-			}
-			return nil
-		}); err != nil {
-			t.Fatalf("failed to getport: %v", err)
-		}
-		t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
-		return statusPort, h.lastAlpn.Load
+		return server.statusPort, h.lastAlpn.Load
 	}
 	testCases := []struct {
 		name             string
@@ -1105,9 +1079,7 @@ func TestGRPCAppProbe(t *testing.T) {
 
 	appPort := listener.Addr().(*net.TCPAddr).Port
 	// Starts the pilot agent status server.
-	server, err := NewServer(Options{
-		StatusPort:         0,
-		PrometheusRegistry: TestingRegistry(t),
+	server := NewTestServer(t, Options{
 		KubeAppProbers: fmt.Sprintf(`
 {
     "/app-health/foo/livez": {
@@ -1140,24 +1112,7 @@ func TestGRPCAppProbe(t *testing.T) {
     }
 }`, appPort, appPort, appPort, appPort),
 	})
-	if err != nil {
-		t.Errorf("failed to create status server %v", err)
-		return
-	}
-	go server.Run(context.Background())
-
-	var statusPort uint16
-	if err := retry.UntilSuccess(func() error {
-		server.mutex.RLock()
-		statusPort = server.statusPort
-		server.mutex.RUnlock()
-		if statusPort == 0 {
-			return fmt.Errorf("no port allocated")
-		}
-		return nil
-	}); err != nil {
-		t.Fatalf("failed to getport: %v", err)
-	}
+	statusPort := server.statusPort
 	t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
 
 	testCases := []struct {
@@ -1227,11 +1182,9 @@ func TestGRPCAppProbeWithIPV6(t *testing.T) {
 
 	appPort := listener.Addr().(*net.TCPAddr).Port
 	// Starts the pilot agent status server.
-	server, err := NewServer(Options{
-		StatusPort:         0,
-		IPv6:               true,
-		PodIP:              "::1",
-		PrometheusRegistry: TestingRegistry(t),
+	server := NewTestServer(t, Options{
+		IPv6:  true,
+		PodIP: "::1",
 		KubeAppProbers: fmt.Sprintf(`
 {
     "/app-health/foo/livez": {
@@ -1264,27 +1217,8 @@ func TestGRPCAppProbeWithIPV6(t *testing.T) {
     }
 }`, appPort, appPort, appPort, appPort),
 	})
-	if err != nil {
-		t.Errorf("failed to create status server %v", err)
-		return
-	}
 
 	server.upstreamLocalAddress = &net.TCPAddr{IP: net.ParseIP("::1")} // required because ::6 is NOT a loopback address (IPv6 only has ::1)
-	go server.Run(context.Background())
-
-	var statusPort uint16
-	if err := retry.UntilSuccess(func() error {
-		server.mutex.RLock()
-		statusPort = server.statusPort
-		server.mutex.RUnlock()
-		if statusPort == 0 {
-			return fmt.Errorf("no port allocated")
-		}
-		return nil
-	}); err != nil {
-		t.Fatalf("failed to getport: %v", err)
-	}
-	t.Logf("status server starts at port %v, app starts at port %v", statusPort, appPort)
 
 	testCases := []struct {
 		name       string
@@ -1293,27 +1227,27 @@ func TestGRPCAppProbeWithIPV6(t *testing.T) {
 	}{
 		{
 			name:       "bad-path-should-be-disallowed",
-			probePath:  fmt.Sprintf(":%v/bad-path-should-be-disallowed", statusPort),
+			probePath:  fmt.Sprintf(":%v/bad-path-should-be-disallowed", server.statusPort),
 			statusCode: http.StatusNotFound,
 		},
 		{
 			name:       "foo-livez",
-			probePath:  fmt.Sprintf(":%v/app-health/foo/livez", statusPort),
+			probePath:  fmt.Sprintf(":%v/app-health/foo/livez", server.statusPort),
 			statusCode: http.StatusOK,
 		},
 		{
 			name:       "foo-readyz",
-			probePath:  fmt.Sprintf(":%v/app-health/foo/readyz", statusPort),
+			probePath:  fmt.Sprintf(":%v/app-health/foo/readyz", server.statusPort),
 			statusCode: http.StatusInternalServerError,
 		},
 		{
 			name:       "bar-livez",
-			probePath:  fmt.Sprintf(":%v/app-health/bar/livez", statusPort),
+			probePath:  fmt.Sprintf(":%v/app-health/bar/livez", server.statusPort),
 			statusCode: http.StatusOK,
 		},
 		{
 			name:       "bar-readyz",
-			probePath:  fmt.Sprintf(":%v/app-health/bar/readyz", statusPort),
+			probePath:  fmt.Sprintf(":%v/app-health/bar/readyz", server.statusPort),
 			statusCode: http.StatusInternalServerError,
 		},
 	}
@@ -1450,28 +1384,12 @@ func TestProbeHeader(t *testing.T) {
 				t.Fatalf("invalid app probers")
 			}
 			config := Options{
-				StatusPort:         0,
-				PrometheusRegistry: TestingRegistry(t),
-				KubeAppProbers:     string(appProber),
+				KubeAppProbers: string(appProber),
 			}
 			// Starts the pilot agent status server.
-			server, err := NewServer(config)
-			if err != nil {
-				t.Fatal("failed to create status server: ", err)
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go server.Run(ctx)
-
-			var statusPort uint16
-			for statusPort == 0 {
-				server.mutex.RLock()
-				statusPort = server.statusPort
-				server.mutex.RUnlock()
-			}
-
+			server := NewTestServer(t, config)
 			client := http.Client{}
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v%s", statusPort, probePath), nil)
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v%s", server.statusPort, probePath), nil)
 			if err != nil {
 				t.Fatal("failed to create request: ", err)
 			}
@@ -1489,12 +1407,6 @@ func TestProbeHeader(t *testing.T) {
 }
 
 func TestHandleQuit(t *testing.T) {
-	statusPort := 15020
-	s, err := NewServer(Options{StatusPort: uint16(statusPort), PrometheusRegistry: TestingRegistry(t)})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	tests := []struct {
 		name       string
 		method     string
@@ -1528,18 +1440,22 @@ func TestHandleQuit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Need to stop SIGTERM from killing the whole test run
-			termChannel := make(chan os.Signal, 1)
-			signal.Notify(termChannel, syscall.SIGTERM)
-			defer signal.Reset(syscall.SIGTERM)
-
+			drain, shutdown := make(chan struct{}), make(chan struct{})
+			s := NewTestServer(t, Options{
+				DisableDrain: func() {
+					close(drain)
+				},
+				Shutdown: func() {
+					close(shutdown)
+				},
+			})
 			req, err := http.NewRequest(tt.method, "/quitquitquit", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if tt.remoteAddr != "" {
-				req.RemoteAddr = tt.remoteAddr + ":15020"
+				req.RemoteAddr = tt.remoteAddr + ":" + fmt.Sprint(s.statusPort)
 			}
 
 			resp := httptest.NewRecorder()
@@ -1550,12 +1466,26 @@ func TestHandleQuit(t *testing.T) {
 
 			if tt.expected == http.StatusOK {
 				select {
-				case <-termChannel:
+				case <-drain:
 				case <-time.After(time.Second):
-					t.Fatalf("Failed to receive expected SIGTERM")
+					t.Fatalf("Failed to receive expected drain")
 				}
-			} else if len(termChannel) != 0 {
-				t.Fatalf("A SIGTERM was sent when it should not have been")
+				select {
+				case <-shutdown:
+				case <-time.After(time.Second):
+					t.Fatalf("Failed to receive expected shutdown")
+				}
+			} else {
+				select {
+				case <-drain:
+					t.Fatalf("unexpected drain")
+				default:
+				}
+				select {
+				case <-shutdown:
+					t.Fatalf("unexpected shutdown")
+				default:
+				}
 			}
 		})
 	}
@@ -1589,9 +1519,8 @@ func TestAdditionalProbes(t *testing.T) {
 	defer testServer.Close()
 	for _, tc := range testCases {
 		server, err := NewServer(Options{
-			Probes:             tc.probes,
-			PrometheusRegistry: TestingRegistry(t),
-			AdminPort:          uint16(testServer.Listener.Addr().(*net.TCPAddr).Port),
+			Probes:    tc.probes,
+			AdminPort: uint16(testServer.Listener.Addr().(*net.TCPAddr).Port),
 		})
 		if err != nil {
 			t.Errorf("failed to construct server")

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -1440,11 +1440,8 @@ func TestHandleQuit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			drain, shutdown := make(chan struct{}), make(chan struct{})
+			shutdown := make(chan struct{})
 			s := NewTestServer(t, Options{
-				DisableDrain: func() {
-					close(drain)
-				},
 				Shutdown: func() {
 					close(shutdown)
 				},
@@ -1466,21 +1463,11 @@ func TestHandleQuit(t *testing.T) {
 
 			if tt.expected == http.StatusOK {
 				select {
-				case <-drain:
-				case <-time.After(time.Second):
-					t.Fatalf("Failed to receive expected drain")
-				}
-				select {
 				case <-shutdown:
 				case <-time.After(time.Second):
 					t.Fatalf("Failed to receive expected shutdown")
 				}
 			} else {
-				select {
-				case <-drain:
-					t.Fatalf("unexpected drain")
-				default:
-				}
 				select {
 				case <-shutdown:
 					t.Fatalf("unexpected shutdown")

--- a/pkg/envoy/admin.go
+++ b/pkg/envoy/admin.go
@@ -26,12 +26,15 @@ import (
 
 // DrainListeners drains inbound listeners of Envoy so that inflight requests
 // can gracefully finish and even continue making outbound calls as needed.
-func DrainListeners(adminPort uint32, inboundonly bool) error {
+func DrainListeners(adminPort uint32, inboundonly bool, skipExit bool) error {
 	var drainURL string
 	if inboundonly {
 		drainURL = "drain_listeners?inboundonly&graceful"
 	} else {
 		drainURL = "drain_listeners?graceful"
+	}
+	if skipExit {
+		drainURL += "&skip_exit"
 	}
 	res, err := doEnvoyPost(drainURL, "", "", adminPort)
 	log.Debugf("Drain listener endpoint response : %s", res.String())

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -70,7 +70,7 @@ func (tp TestProxy) Run(stop <-chan error) error {
 	return tp.run(stop)
 }
 
-func (tp TestProxy) Drain() error {
+func (tp TestProxy) Drain(bool) error {
 	tp.blockChannel <- "unblock"
 	return nil
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -103,10 +103,10 @@ func splitComponentLog(level string) (string, []string) {
 	return logLevel, componentLogs
 }
 
-func (e *envoy) Drain() error {
+func (e *envoy) Drain(skipExit bool) error {
 	adminPort := uint32(e.AdminPort)
 
-	err := DrainListeners(adminPort, e.Sidecar)
+	err := DrainListeners(adminPort, e.Sidecar, skipExit)
 	if err != nil {
 		log.Infof("failed draining listeners for Envoy on port %d: %v", adminPort, err)
 	}

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -79,6 +79,13 @@ const (
 
 var _ ready.Prober = &Agent{}
 
+type LifecycleEvent string
+
+const (
+	DrainLifecycleEvent LifecycleEvent = "drain"
+	ExitLifecycleEvent  LifecycleEvent = "exit"
+)
+
 // Agent contains the configuration of the agent, based on the injected
 // environment:
 // - SDS hostPath if node-agent was used
@@ -842,4 +849,12 @@ func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 // GRPCBootstrapPath returns the most recently generated gRPC bootstrap or nil if there is none.
 func (a *Agent) GRPCBootstrapPath() string {
 	return a.cfg.GRPCBootstrapPath
+}
+
+func (a *Agent) DrainNow() {
+	a.envoyAgent.DrainNow()
+}
+
+func (a *Agent) DisableDraining() {
+	a.envoyAgent.DisableDraining()
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -854,7 +854,3 @@ func (a *Agent) GRPCBootstrapPath() string {
 func (a *Agent) DrainNow() {
 	a.envoyAgent.DrainNow()
 }
-
-func (a *Agent) DisableDraining() {
-	a.envoyAgent.DisableDraining()
-}

--- a/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
@@ -144,6 +144,15 @@ spec:
     - name: ISTIO_KUBE_APP_PROBERS
       value: '{"/app-health/other-sidecar/readyz":{"httpGet":{"port":3333}}}'
     image: gcr.io/istio-testing/proxyv2:latest
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - pilot-agent
+          - request
+          - --debug-port=15020
+          - POST
+          - drain
     name: istio-proxy
     ports:
     - containerPort: 15090

--- a/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
@@ -145,6 +145,15 @@ spec:
         - name: TRUST_DOMAIN
           value: cluster.local
         image: gcr.io/istio-testing/proxyv2:latest
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port=15020
+              - POST
+              - drain
         name: istio-proxy
         ports:
         - containerPort: 15090

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -76,7 +76,9 @@ templates:
     {{- end }}
       }
     spec:
-      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+      {{- $holdProxy := and
+          (or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts)
+          (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}
@@ -234,6 +236,17 @@ templates:
               command:
               - pilot-agent
               - wait
+      {{- else if $nativeSidecar }}
+        {{- /* preStop is called when the pod starts shutdown. Initialize drain. We will get SIGTERM once applications are torn down. */}}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - pilot-agent
+              - request
+              - --debug-port={{(annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort)}}
+              - POST
+              - drain
       {{- end }}
         env:
         {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}


### PR DESCRIPTION
Builds on https://github.com/istio/istio/pull/47207

Depends on https://github.com/envoyproxy/envoy/pull/30003 (although works sort of without it)

Depends on K8s updates.

Basically, now K8s will do: on pod shutdown start, call preStop. On rest of app containers stop, call SIGTERM.

We want the behavior: on pod shutdown start, drain forever. This is to encourage clients to go away. On the rest of the application stops, we are done -- just exit immediately.

We do this by:
* A new drain endpoint. Call it in preStop hook. This drains **forever** (other drain stops accepting anything after 45s).
* On SIGTERM, if we already drained, exit immediately.

This should have no impact for non-native sidecar users (i.e. 100% of current users)