### PR TITLE
Implement GEP 1762 - In-Cluster Gateway Deployments

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: {{.Name}}
+      gateway.networking.k8s.io/gateway-name: {{.Name}}
   template:
     metadata:
       annotations:
@@ -41,7 +41,8 @@ spec:
             "service.istio.io/canonical-revision" "latest"
            )
           .Labels
-          (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+          (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8
+          }}
     spec:
       {{- if .KubeVersion122 }}
       {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -320,7 +321,7 @@ spec:
     appProtocol: {{ $val.AppProtocol }}
   {{- end }}
   selector:
-    istio.io/gateway-name: {{.Name}}
+    gateway.networking.k8s.io/gateway-name: {{.Name}}
   {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
   loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -3,6 +3,15 @@ kind: ServiceAccount
 metadata:
   name: {{.ServiceAccount | quote}}
   namespace: {{.Namespace | quote}}
+  annotations:
+    {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+  labels:
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+      ) | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -10,9 +19,14 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   annotations:
-    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+    {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    {{- toJsonMap .Labels | nindent 4 }}
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+      ) | nindent 4 }}
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
@@ -21,12 +35,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      gateway.networking.k8s.io/gateway-name: {{.Name}}
+      "{{.GatewayNameLabel}}": {{.Name}}
   template:
     metadata:
       annotations:
         {{- toJsonMap
-          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+          (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict "istio.io/rev" (.Revision | default "default"))
           (strdict
             "prometheus.io/path" "/stats/prometheus"
@@ -40,9 +54,11 @@ spec:
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
            )
-          .Labels
-          (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8
-          }}
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 8 }}
     spec:
       {{- if .KubeVersion122 }}
       {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -174,7 +190,7 @@ spec:
               fieldPath: spec.nodeName
         - name: ISTIO_META_INTERCEPTION_MODE
           value: "{{ .ProxyConfig.InterceptionMode.String }}"
-        {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+        {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
         - name: ISTIO_META_NETWORK
           value: {{.|quote}}
         {{- end }}
@@ -197,7 +213,7 @@ spec:
         - name: {{ $key }}
           value: "{{ $value }}"
         {{- end }}
-        {{- with (index .Labels "topology.istio.io/network") }}
+        {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
         - name: ISTIO_META_REQUESTED_NETWORK_VIEW
           value: {{.|quote}}
         {{- end }}
@@ -302,9 +318,14 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+    {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    {{ toJsonMap .Labels | nindent 4}}
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+      ) | nindent 4 }}
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   ownerReferences:
@@ -321,7 +342,7 @@ spec:
     appProtocol: {{ $val.AppProtocol }}
   {{- end }}
   selector:
-    gateway.networking.k8s.io/gateway-name: {{.Name}}
+    "{{.GatewayNameLabel}}": {{.Name}}
   {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
   loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -3,6 +3,15 @@ kind: ServiceAccount
 metadata:
   name: {{.ServiceAccount | quote}}
   namespace: {{.Namespace | quote}}
+  annotations:
+    {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+  labels:
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+      ) | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -10,9 +19,15 @@ metadata:
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   annotations:
-    {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+    {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    {{- toJsonMap .Labels | nindent 4 }}
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+        "gateway.istio.io/managed" "istio.io-mesh-controller"
+      ) | nindent 4 }}
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
     kind: Gateway
@@ -21,12 +36,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+      "{{.GatewayNameLabel}}": "{{.Name}}"
   template:
     metadata:
       annotations:
         {{- toJsonMap
-          (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+          (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict "istio.io/rev" (.Revision | default "default"))
           (strdict
             "ambient.istio.io/redirection" "disabled"
@@ -35,22 +50,16 @@ spec:
             "prometheus.io/scrape" "true"
           ) | nindent 8 }}
       labels:
-        {{- $requiredLabels := .Labels }}
-        {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-        {{- if $network }}
-        {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-            "topology.istio.io/network" $network
-        )}}
-        {{- end }}
         {{- toJsonMap
           (strdict
             "sidecar.istio.io/inject" "false"
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
            )
-          $requiredLabels
+          .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
             "gateway.istio.io/managed" "istio.io-mesh-controller"
           ) | nindent 8}}
     spec:
@@ -149,7 +158,7 @@ spec:
               resource: limits.cpu
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-        {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+        {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
         {{- if $network }}
         - name: ISTIO_META_NETWORK
           value: "{{ $network }}"
@@ -254,9 +263,14 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+    {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
-    {{ toJsonMap .Labels | nindent 4}}
+    {{- toJsonMap
+      .InfrastructureLabels
+      (strdict
+        "gateway.networking.k8s.io/gateway-name" .Name
+        "istio.io/gateway-name" .Name
+      ) | nindent 4 }}
   name: {{.DeploymentName | quote}}
   namespace: {{.Namespace | quote}}
   ownerReferences:
@@ -273,7 +287,7 @@ spec:
     appProtocol: {{ $val.AppProtocol }}
   {{- end }}
   selector:
-    gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+    "{{.GatewayNameLabel}}": "{{.Name}}"
   {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
   loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: "{{.Name}}"
+      gateway.networking.k8s.io/gateway-name: "{{.Name}}"
   template:
     metadata:
       annotations:
@@ -50,7 +50,7 @@ spec:
            )
           $requiredLabels
           (strdict
-            "istio.io/gateway-name" .Name
+            "gateway.networking.k8s.io/gateway-name" .Name
             "gateway.istio.io/managed" "istio.io-mesh-controller"
           ) | nindent 8}}
     spec:
@@ -273,7 +273,7 @@ spec:
     appProtocol: {{ $val.AppProtocol }}
   {{- end }}
   selector:
-    istio.io/gateway-name: "{{.Name}}"
+    gateway.networking.k8s.io/gateway-name: "{{.Name}}"
   {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
   loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -10114,7 +10114,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+              istio.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -10143,7 +10143,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "gateway.networking.k8s.io/gateway-name" .Name
+                    "istio.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -10396,7 +10396,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: {{.Name}}
+              istio.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -10416,7 +10416,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -10695,7 +10695,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            gateway.networking.k8s.io/gateway-name: {{.Name}}
+            istio.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -10114,7 +10114,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: "{{.Name}}"
+              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -10143,7 +10143,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "istio.io/gateway-name" .Name
+                    "gateway.networking.k8s.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -10396,7 +10396,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: {{.Name}}
+              gateway.networking.k8s.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -10416,7 +10416,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -10695,7 +10695,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            istio.io/gateway-name: {{.Name}}
+            gateway.networking.k8s.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1675,7 +1675,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: "{{.Name}}"
+              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -1704,7 +1704,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "istio.io/gateway-name" .Name
+                    "gateway.networking.k8s.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -1957,7 +1957,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: {{.Name}}
+              gateway.networking.k8s.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -1977,7 +1977,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -2256,7 +2256,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            istio.io/gateway-name: {{.Name}}
+            gateway.networking.k8s.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1675,7 +1675,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+              istio.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -1704,7 +1704,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "gateway.networking.k8s.io/gateway-name" .Name
+                    "istio.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -1957,7 +1957,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: {{.Name}}
+              istio.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -1977,7 +1977,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -2256,7 +2256,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            gateway.networking.k8s.io/gateway-name: {{.Name}}
+            istio.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -1210,7 +1210,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: "{{.Name}}"
+              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -1239,7 +1239,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "istio.io/gateway-name" .Name
+                    "gateway.networking.k8s.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -1492,7 +1492,7 @@ data:
         spec:
           selector:
             matchLabels:
-              istio.io/gateway-name: {{.Name}}
+              gateway.networking.k8s.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -1512,7 +1512,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1791,7 +1791,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            istio.io/gateway-name: {{.Name}}
+            gateway.networking.k8s.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -1210,7 +1210,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+              istio.io/gateway-name: "{{.Name}}"
           template:
             metadata:
               annotations:
@@ -1239,7 +1239,7 @@ data:
                    )
                   $requiredLabels
                   (strdict
-                    "gateway.networking.k8s.io/gateway-name" .Name
+                    "istio.io/gateway-name" .Name
                     "gateway.istio.io/managed" "istio.io-mesh-controller"
                   ) | nindent 8}}
             spec:
@@ -1492,7 +1492,7 @@ data:
         spec:
           selector:
             matchLabels:
-              gateway.networking.k8s.io/gateway-name: {{.Name}}
+              istio.io/gateway-name: {{.Name}}
           template:
             metadata:
               annotations:
@@ -1512,7 +1512,7 @@ data:
                     "service.istio.io/canonical-revision" "latest"
                    )
                   .Labels
-                  (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+                  (strdict "istio.io/gateway-name" .Name) | nindent 8}}
             spec:
               {{- if .KubeVersion122 }}
               {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1791,7 +1791,7 @@ data:
             appProtocol: {{ $val.AppProtocol }}
           {{- end }}
           selector:
-            gateway.networking.k8s.io/gateway-name: {{.Name}}
+            istio.io/gateway-name: {{.Name}}
           {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -104,8 +104,10 @@ func TestConfigureIstioGateway(t *testing.T) {
 			name: "simple",
 			gw: v1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "default",
+					Name:        "default",
+					Namespace:   "default",
+					Labels:      map[string]string{"should": "see"},
+					Annotations: map[string]string{"should": "see"},
 				},
 				Spec: v1alpha2.GatewaySpec{
 					GatewayClassName: defaultClassName,
@@ -277,6 +279,25 @@ func TestConfigureIstioGateway(t *testing.T) {
 				},
 				Spec: v1beta1.GatewaySpec{
 					GatewayClassName: v1beta1.ObjectName(customClass.Name),
+				},
+			},
+			objects: defaultObjects,
+		},
+		{
+			name: "infrastructure-labels-annotations",
+			gw: v1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Namespace:   "default",
+					Labels:      map[string]string{"should-not": "see"},
+					Annotations: map[string]string{"should-not": "see"},
+				},
+				Spec: v1alpha2.GatewaySpec{
+					GatewayClassName: defaultClassName,
+					Infrastructure: &k8sv1.GatewayInfrastructure{
+						Labels:      map[v1beta1.AnnotationKey]v1beta1.AnnotationValue{"foo": "bar", "gateway.networking.k8s.io/ignore": "true"},
+						Annotations: map[v1beta1.AnnotationKey]v1beta1.AnnotationValue{"fizz": "buzz", "gateway.networking.k8s.io/ignore": "true"},
+					},
 				},
 			},
 			objects: defaultObjects,

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -80,7 +80,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 		Spec: &istioio_networking_v1beta1.ProxyConfig{
 			Selector: &istio_type_v1beta1.WorkloadSelector{
 				MatchLabels: map[string]string{
-					"istio.io/gateway-name": "default",
+					"gateway.networking.k8s.io/gateway-name": "default",
 				},
 			},
 			Image: &istioio_networking_v1beta1.ProxyImage{

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -39,7 +39,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -222,6 +222,6 @@ spec:
     port: 80
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: ClusterIP
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -7,8 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-istio
   namespace: default
 ---
@@ -19,6 +23,8 @@ metadata:
     networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default
   namespace: default
   ownerReferences:
@@ -40,6 +46,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -204,6 +211,8 @@ metadata:
     networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default
   namespace: default
   ownerReferences:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -37,7 +37,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default-custom
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -215,6 +215,6 @@ spec:
     port: 15021
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
@@ -7,8 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-custom
   namespace: default
 ---
@@ -18,6 +21,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-custom
   namespace: default
   ownerReferences:
@@ -38,6 +43,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default-custom
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -201,6 +207,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-custom
   namespace: default
   ownerReferences:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
@@ -7,19 +7,23 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations: {}
+  annotations:
+    fizz: buzz
   labels:
+    foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
     istio.io/gateway-name: default
-  name: custom-sa
+  name: default-istio
   namespace: default
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations: {}
+  annotations:
+    fizz: buzz
   labels:
+    foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
     istio.io/gateway-name: default
@@ -37,11 +41,13 @@ spec:
   template:
     metadata:
       annotations:
+        fizz: buzz
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
+        foo: bar
         gateway.networking.k8s.io/gateway-name: default
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
@@ -178,7 +184,7 @@ spec:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
-      serviceAccountName: custom-sa
+      serviceAccountName: default-istio
       volumes:
       - emptyDir: {}
         name: workload-socket
@@ -204,8 +210,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
+  annotations:
+    fizz: buzz
   labels:
+    foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
     istio.io/gateway-name: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -37,7 +37,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -216,6 +216,6 @@ spec:
     port: 15021
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -7,8 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-istio
   namespace: default
 ---
@@ -18,6 +21,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default
   namespace: default
   ownerReferences:
@@ -38,6 +43,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -201,6 +207,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default
   namespace: default
   ownerReferences:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -37,7 +37,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -215,6 +215,6 @@ spec:
     port: 15021
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -7,8 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
+    topology.istio.io/network: network-1
   name: default-istio
   namespace: default
 ---
@@ -18,6 +22,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
     topology.istio.io/network: network-1
   name: default
   namespace: default
@@ -39,6 +45,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -207,6 +214,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
     topology.istio.io/network: network-1
   name: default
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -38,7 +38,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -226,6 +226,6 @@ spec:
     port: 80
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
@@ -7,8 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-istio
   namespace: default
 ---
@@ -18,6 +21,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-istio
   namespace: default
   ownerReferences:
@@ -38,6 +43,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -201,6 +207,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
   name: default-istio
   namespace: default
   ownerReferences:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -37,7 +37,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -215,6 +215,6 @@ spec:
     port: 15021
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: default
+      gateway.networking.k8s.io/gateway-name: default
   template:
     metadata:
       annotations:
@@ -37,7 +37,7 @@ spec:
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
-        istio.io/gateway-name: default
+        gateway.networking.k8s.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -215,6 +215,6 @@ spec:
     port: 15021
     protocol: TCP
   selector:
-    istio.io/gateway-name: default
+    gateway.networking.k8s.io/gateway-name: default
   type: LoadBalancer
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -7,17 +7,26 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
+    should: see
   name: default-istio
   namespace: default
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations: {}
+  annotations:
+    should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
+    should: see
   name: default-istio
   namespace: default
   ownerReferences:
@@ -36,10 +45,13 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
+        should: see
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
+        should: see
         sidecar.istio.io/inject: "false"
     spec:
       containers:
@@ -198,9 +210,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
+  annotations:
+    should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: default
+    istio.io/gateway-name: default
+    should: see
   name: default-istio
   namespace: default
   ownerReferences:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -7,8 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
+    topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default
 ---
@@ -18,6 +22,9 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
+    topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default
   ownerReferences:
@@ -28,7 +35,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: namespace
+      gateway.networking.k8s.io/gateway-name: namespace
   template:
     metadata:
       annotations:
@@ -39,6 +46,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.istio.io/managed: istio.io-mesh-controller
+        gateway.networking.k8s.io/gateway-name: namespace
         istio.io/gateway-name: namespace
         service.istio.io/canonical-name: namespace-istio-waypoint
         service.istio.io/canonical-revision: latest
@@ -215,6 +223,9 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
+    topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default
   ownerReferences:
@@ -233,6 +244,6 @@ spec:
     port: 15008
     protocol: TCP
   selector:
-    istio.io/gateway-name: namespace
+    gateway.networking.k8s.io/gateway-name: namespace
   type: ClusterIP
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: namespace
+      gateway.networking.k8s.io/gateway-name: namespace
   template:
     metadata:
       annotations:
@@ -40,7 +40,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.istio.io/managed: istio.io-mesh-controller
-        istio.io/gateway-name: namespace
+        gateway.networking.k8s.io/gateway-name: namespace
         service.istio.io/canonical-name: namespace-istio-waypoint
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -235,6 +235,6 @@ spec:
     port: 15008
     protocol: TCP
   selector:
-    istio.io/gateway-name: namespace
+    gateway.networking.k8s.io/gateway-name: namespace
   type: ClusterIP
 ---

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -7,8 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
+    topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default
 ---
@@ -18,6 +22,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default
@@ -41,6 +47,7 @@ spec:
       labels:
         gateway.istio.io/managed: istio.io-mesh-controller
         gateway.networking.k8s.io/gateway-name: namespace
+        istio.io/gateway-name: namespace
         service.istio.io/canonical-name: namespace-istio-waypoint
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
@@ -216,6 +223,8 @@ metadata:
   annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: namespace
+    istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
   name: namespace-istio-waypoint
   namespace: default

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -50,15 +50,11 @@ const (
 func KubernetesGatewayNameAndExists(l labels.Instance) (string, bool) {
 	gwName, exists := l[constants.GatewayNameLabel]
 	if !exists {
-		// TODO: Remove deprecated gateway name label (1.21 or 1.22)
+		// TODO: Remove deprecated gateway name label (1.22 or 1.23)
 		gwName, exists = l[constants.DeprecatedGatewayNameLabel]
 	}
 
-	if !exists {
-		return "", false
-	}
-
-	return gwName, true
+	return gwName, exists
 }
 
 func getPolicyMatcher(kind config.GroupVersionKind, policyName string, opts WorkloadSelectionOpts, policy policyTargetGetter) policyMatch {

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -47,8 +47,22 @@ const (
 	policyMatchIgnore policyMatch = "ignore"
 )
 
+func KubernetesGatewayNameAndExists(l labels.Instance) (string, bool) {
+	gwName, exists := l[constants.GatewayNameLabel]
+	if !exists {
+		// TODO: Remove deprecated gateway name label (1.21 or 1.22)
+		gwName, exists = l[constants.DeprecatedGatewayNameLabel]
+	}
+
+	if !exists {
+		return "", false
+	}
+
+	return gwName, true
+}
+
 func getPolicyMatcher(kind config.GroupVersionKind, policyName string, opts WorkloadSelectionOpts, policy policyTargetGetter) policyMatch {
-	gatewayName, isGatewayAPI := opts.WorkloadLabels[constants.GatewayNameLabel]
+	gatewayName, isGatewayAPI := KubernetesGatewayNameAndExists(opts.WorkloadLabels)
 	targetRef := policy.GetTargetRef()
 	if isGatewayAPI && targetRef == nil && policy.GetSelector() != nil {
 		if opts.IsWaypoint || !features.EnableSelectorBasedK8sGatewayPolicy {

--- a/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
+++ b/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
@@ -375,6 +375,7 @@ spec:
       labels:
         sidecar.istio.io/inject: "false"
         gateway.networking.k8s.io/gateway-name: productpage
+        istio.io/gateway-name: productpage
     spec:
       serviceAccountName: productpage-istio-waypoint
       containers:

--- a/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
+++ b/pkg/config/analysis/analyzers/testdata/deployment-multi-service.yaml
@@ -369,12 +369,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      istio.io/gateway-name: productpage
+      gateway.networking.k8s.io/gateway-name: productpage
   template:
     metadata:
       labels:
         sidecar.istio.io/inject: "false"
-        istio.io/gateway-name: productpage
+        gateway.networking.k8s.io/gateway-name: productpage
     spec:
       serviceAccountName: productpage-istio-waypoint
       containers:

--- a/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
+++ b/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
@@ -36,7 +36,7 @@ spec:
     protocol: TCP
     targetPort: 15008
   selector:
-    istio.io/gateway-name: reviews
+    gateway.networking.k8s.io/gateway-name: reviews
   sessionAffinity: None
   type: ClusterIP
 ---
@@ -65,5 +65,5 @@ spec:
     protocol: TCP
     targetPort: 80
   selector:
-    istio.io/gateway-name: gateway
+    gateway.networking.k8s.io/gateway-name: gateway
   type: LoadBalancer

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -169,9 +169,10 @@ const (
 	RemoteGatewayClassName   = "istio-remote"
 	WaypointGatewayClassName = "istio-waypoint"
 
+	// DeprecatedGatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
+	DeprecatedGatewayNameLabel = "istio.io/gateway-name"
 	// GatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
-	// TODO: Formalize this API
-	GatewayNameLabel = "istio.io/gateway-name"
+	GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
 
 	// TODO formalize this API
 	// TODO additional values to represent passthrough and hbone or both

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1187,6 +1187,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1194,9 +1203,15 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+            "gateway.istio.io/managed" "istio.io-mesh-controller"
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1205,12 +1220,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+          "{{.GatewayNameLabel}}": "{{.Name}}"
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "ambient.istio.io/redirection" "disabled"
@@ -1219,22 +1234,16 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
-            {{- $requiredLabels := .Labels }}
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
-            {{- if $network }}
-            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
-                "topology.istio.io/network" $network
-            )}}
-            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              $requiredLabels
+              .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1333,7 +1342,7 @@ templates:
                   resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- $network := valueOrDefault (index .InfrastructureLabels `topology.istio.io/network`) .Values.global.network }}
             {{- if $network }}
             - name: ISTIO_META_NETWORK
               value: "{{ $network }}"
@@ -1438,9 +1447,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1457,7 +1471,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
+        "{{.GatewayNameLabel}}": "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1469,6 +1483,15 @@ templates:
     metadata:
       name: {{.ServiceAccount | quote}}
       namespace: {{.Namespace | quote}}
+      annotations:
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+      labels:
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
     ---
     apiVersion: apps/v1
     kind: Deployment
@@ -1476,9 +1499,14 @@ templates:
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       annotations:
-        {{- toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{- toJsonMap .Labels | nindent 4 }}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       ownerReferences:
       - apiVersion: gateway.networking.k8s.io/v1beta1
         kind: Gateway
@@ -1487,12 +1515,12 @@ templates:
     spec:
       selector:
         matchLabels:
-          gateway.networking.k8s.io/gateway-name: {{.Name}}
+          "{{.GatewayNameLabel}}": {{.Name}}
       template:
         metadata:
           annotations:
             {{- toJsonMap
-              (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
+              (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
                 "prometheus.io/path" "/stats/prometheus"
@@ -1506,8 +1534,11 @@ templates:
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
-              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
+              .InfrastructureLabels
+              (strdict
+                "gateway.networking.k8s.io/gateway-name" .Name
+                "istio.io/gateway-name" .Name
+              ) | nindent 8 }}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1639,7 +1670,7 @@ templates:
                   fieldPath: spec.nodeName
             - name: ISTIO_META_INTERCEPTION_MODE
               value: "{{ .ProxyConfig.InterceptionMode.String }}"
-            {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
+            {{- with (valueOrDefault  (index .InfrastructureLabels "topology.istio.io/network") .Values.global.network) }}
             - name: ISTIO_META_NETWORK
               value: {{.|quote}}
             {{- end }}
@@ -1662,7 +1693,7 @@ templates:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            {{- with (index .Labels "topology.istio.io/network") }}
+            {{- with (index .InfrastructureLabels "topology.istio.io/network") }}
             - name: ISTIO_META_REQUESTED_NETWORK_VIEW
               value: {{.|quote}}
             {{- end }}
@@ -1767,9 +1798,14 @@ templates:
     kind: Service
     metadata:
       annotations:
-        {{ toJsonMap (omit .Annotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+        {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
-        {{ toJsonMap .Labels | nindent 4}}
+        {{- toJsonMap
+          .InfrastructureLabels
+          (strdict
+            "gateway.networking.k8s.io/gateway-name" .Name
+            "istio.io/gateway-name" .Name
+          ) | nindent 4 }}
       name: {{.DeploymentName | quote}}
       namespace: {{.Namespace | quote}}
       ownerReferences:
@@ -1786,7 +1822,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        gateway.networking.k8s.io/gateway-name: {{.Name}}
+        "{{.GatewayNameLabel}}": {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1205,7 +1205,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: "{{.Name}}"
+          gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       template:
         metadata:
           annotations:
@@ -1234,7 +1234,7 @@ templates:
                )
               $requiredLabels
               (strdict
-                "istio.io/gateway-name" .Name
+                "gateway.networking.k8s.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"
               ) | nindent 8}}
         spec:
@@ -1457,7 +1457,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: "{{.Name}}"
+        gateway.networking.k8s.io/gateway-name: "{{.Name}}"
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}
@@ -1487,7 +1487,7 @@ templates:
     spec:
       selector:
         matchLabels:
-          istio.io/gateway-name: {{.Name}}
+          gateway.networking.k8s.io/gateway-name: {{.Name}}
       template:
         metadata:
           annotations:
@@ -1507,7 +1507,7 @@ templates:
                 "service.istio.io/canonical-revision" "latest"
                )
               .Labels
-              (strdict "istio.io/gateway-name" .Name) | nindent 8}}
+              (strdict "gateway.networking.k8s.io/gateway-name" .Name) | nindent 8}}
         spec:
           {{- if .KubeVersion122 }}
           {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
@@ -1786,7 +1786,7 @@ templates:
         appProtocol: {{ $val.AppProtocol }}
       {{- end }}
       selector:
-        istio.io/gateway-name: {{.Name}}
+        gateway.networking.k8s.io/gateway-name: {{.Name}}
       {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
       loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
       {{- end }}

--- a/releasenotes/notes/gateway-infra-gep.yaml
+++ b/releasenotes/notes/gateway-infra-gep.yaml
@@ -1,0 +1,23 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for [In-Cluster Gateway Deployments](https://gateway-api.sigs.k8s.io/geps/gep-1762/).
+  Deployment also now has both `istio.io/gateway-name` and `gateway.networking.k8s.io/gateway-name` labels
+  just like the Pods and Services.
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+upgradeNotes:
+  - title: Gateway Name label modified
+    content: If you are using the [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
+      to manage your istio gateways, the label key used to identify the gateway name is changing from `istio.io/gateway-name`
+      to `gateway.networking.k8s.io/gateway-name`. The old label will continue to be appended to the relevant label sets for backwards
+      compatibility, but it will be removed in a future release. Furthermore, istiod's gateway controller will automatically detect
+      and continue to use the old label for label selectors belonging to existing `Deployment` and `Service` resources. Therefore, once
+      you've completed your Istio upgrade, you can change the label selector in `Deployment` and `Service` resources whenever you are
+      ready to use the new label. Additionally, please upgrade any other policies, resources, or scripts that rely on the old label.
+

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -370,7 +370,7 @@ metadata:
 spec:
   workloadSelector:
     labels:
-      istio.io/gateway-name: "{{.Destination}}"
+      gateway.networking.k8s.io/gateway-name: "{{.Destination}}"
   configPatches:
   - applyTo: HTTP_FILTER
     match:
@@ -727,7 +727,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
 `+policySpec+`
 ---
 apiVersion: security.istio.io/v1beta1
@@ -772,7 +772,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
 `+policySpec).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				opt.Check = CheckDeny
@@ -872,7 +872,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
 `+policySpec+`
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -1034,7 +1034,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
 `+policySpec+`
 ---
 apiVersion: security.istio.io/v1beta1
@@ -1054,7 +1054,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
 `+denySpec).ApplyOrFail(t)
 			overrideCheck := func(opt *echo.CallOptions) {
 				switch {

--- a/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
+++ b/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint # This should be ignored because it's not a targetRef
+      gateway.networking.k8s.io/gateway-name: waypoint # This should be ignored because it's not a targetRef
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"
@@ -32,7 +32,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: waypoint # TODO: Replace this with a targetRef after https://github.com/istio/istio/pull/46560 merges
+      gateway.networking.k8s.io/gateway-name: waypoint # TODO: Replace this with a targetRef after https://github.com/istio/istio/pull/46560 merges
   rules:
   - from:
     - source:

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -71,7 +71,7 @@ spec:
     name: default
     port: 80
   selector:
-    istio.io/gateway-name: managed-owner
+    gateway.networking.k8s.io/gateway-name: managed-owner
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,19 +80,19 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: managed-owner
+      gateway.networking.k8s.io/gateway-name: managed-owner
   replicas: 1
   template:
     metadata:
       labels:
-        istio.io/gateway-name: managed-owner
+        gateway.networking.k8s.io/gateway-name: managed-owner
     spec:
       containers:
       - name: fake
         image: %s
 `, image)).ApplyOrFail(t)
 	cls := t.Clusters().Kube().Default()
-	fetchFn := testKube.NewSinglePodFetch(cls, apps.Namespace.Name(), "istio.io/gateway-name=managed-owner")
+	fetchFn := testKube.NewSinglePodFetch(cls, apps.Namespace.Name(), "gateway.networking.k8s.io/gateway-name=managed-owner")
 	if _, err := testKube.WaitUntilPodsAreReady(fetchFn); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -86,6 +86,7 @@ spec:
     metadata:
       labels:
         gateway.networking.k8s.io/gateway-name: managed-owner
+        istio.io/gateway-name: managed-owner
     spec:
       containers:
       - name: fake

--- a/tests/integration/security/policy_attachment_only/testdata/requestauthn/gateway-jwt.yaml.tmpl
+++ b/tests/integration/security/policy_attachment_only/testdata/requestauthn/gateway-jwt.yaml.tmpl
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: {{ .To.ServiceName }}-gateway # This should be ignored because it's not a targetRef
+      gateway.networking.k8s.io/gateway-name: {{ .To.ServiceName }}-gateway # This should be ignored because it's not a targetRef
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"

--- a/tests/integration/security/testdata/requestauthn/gateway-jwt.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/gateway-jwt.yaml.tmpl
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      istio.io/gateway-name: {{ .To.ServiceName }}-gateway # This would be ignored (not a targetRef) but the feature flag isn't on, so it's applied
+      gateway.networking.k8s.io/gateway-name: {{ .To.ServiceName }}-gateway # This would be ignored (not a targetRef) but the feature flag isn't on, so it's applied
   jwtRules:
   - issuer: "test-issuer-3@istio.io"
     jwksUri: "https://raw.githubusercontent.com/istio/istio/master/tests/common/jwt/jwks.json"


### PR DESCRIPTION
**Please provide a description of this PR:**

Implements [in-cluster Gateway deployments GEP](https://gateway-api.sigs.k8s.io/geps/gep-1762/). Diff looks large, but that's mostly because of renaming in golden files. Big changes:
- Renames `istio.io/gateway-name` label to `gateway.networking.k8s.io/gateway-name`. We continue to read (from the control plane) and write both labels for backwards compatibility, but the release note will encourage users to adopt the Gateway standard. We can remove the deprecated label in a release or 2.
- Introduce support for the new gateway.infrastructure field for propagating labels and annotations to Istio-managed gateway resources. We continue existing behavior if this field is not used with the small caveat that labels + annotations are propagated to _all_ generated resources (e.g. ServiceAccounts) per the spec

