### PR TITLE
clean unuse code

### DIFF
--- a/tools/docker-builder/builder/tar.go
+++ b/tools/docker-builder/builder/tar.go
@@ -111,8 +111,6 @@ func WriteArchiveFromFiles(base string, files map[string]string, out io.Writer) 
 	return nil
 }
 
-var WriteTime = time.Time{}
-
 // Writes a raw TAR archive to out, given an fs.FS.
 func WriteArchiveFromFS(base string, fsys fs.FS, out io.Writer, sourceDateEpoch time.Time) error {
 	tw := tar.NewWriter(out)


### PR DESCRIPTION
**Please provide a description of this PR:**

clean unuse code  

WriteTime is not used here as a global variable, and I think it is better to return the write time directly through the function if we need to return it.