### PR TITLE
Fix istioctl using crd watcher logging issue

### DIFF
--- a/istioctl/pkg/root/root.go
+++ b/istioctl/pkg/root/root.go
@@ -48,6 +48,6 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("default", log.WarnLevel)
 	o.SetOutputLevel("klog", log.WarnLevel)
 	o.SetOutputLevel("kube", log.ErrorLevel)
-
+	o.SetOutputLevel("controllers", log.WarnLevel)
 	return o
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
If using crd watcher in the code, there will be unexpected logs to the output like:
```
istioctl analyze -A
2023-10-08T03:26:17.713436Z     info    controllers     starting        controller=crd watcher
Warning [IST0158] (Namespace default) The Istio proxy images of the pods running in the namespace do not match the image defin
```