### PR TITLE
Improve proxy-config log command with envoy all loggers format

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -835,6 +835,9 @@ func logCmd(ctx cli.Context) *cobra.Command {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("--level cannot be combined with --reset")
 			}
+			if outputFormat != "" && outputFormat != summaryOutput {
+				return fmt.Errorf("--output is not applicable for this command")
+			}
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
@@ -898,7 +901,7 @@ func logCmd(ctx cli.Context) *cobra.Command {
 								// TODO validate ztunnel logger name when available: https://github.com/istio/ztunnel/issues/426
 								continue
 							}
-							if !strings.Contains(logName, loggerLevel[0]) {
+							if !strings.Contains(logName, loggerLevel[0]) && loggerLevel[0] != defaultLoggerName {
 								return fmt.Errorf("unrecognized logger name: %v", loggerLevel[0])
 							}
 						}
@@ -971,9 +974,8 @@ func logCmd(ctx cli.Context) *cobra.Command {
 	logCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	logCmd.PersistentFlags().StringVar(&loggerLevelString, "level", loggerLevelString,
 		fmt.Sprintf("Comma-separated minimum per-logger level of messages to output, in the form of"+
-			" [<logger>:]<level>,[<logger>:]<level>,... where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
+			" [<logger>:]<level>,[<logger>:]<level>,... or <level> to change all active loggers, where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
 			"or referred from https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h, and level can be one of %s", levelListString))
-
 	return logCmd
 }
 

--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -974,7 +974,8 @@ func logCmd(ctx cli.Context) *cobra.Command {
 	logCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	logCmd.PersistentFlags().StringVar(&loggerLevelString, "level", loggerLevelString,
 		fmt.Sprintf("Comma-separated minimum per-logger level of messages to output, in the form of"+
-			" [<logger>:]<level>,[<logger>:]<level>,... or <level> to change all active loggers, where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
+			" [<logger>:]<level>,[<logger>:]<level>,... or <level> to change all active loggers, "+
+			"where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
 			"or referred from https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h, and level can be one of %s", levelListString))
 	return logCmd
 }

--- a/releasenotes/notes/47252.yaml
+++ b/releasenotes/notes/47252.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for setting loggers' levels of istio-proxy in `istioctl proxy-config log` command with `--level <level>` or `--level level=<level>`.


### PR DESCRIPTION
**Please provide a description of this PR:**
1. Currently there's no mention of how to set all loggers to a level in `proxy-config log`. Upon looking through the code I found it could be set directly with `istioctl pc log pod-name --level debug`, added an explaination to the flag description.

2. Also, this can not be configured intuitively like the Envoy style - other separate loggers are conforming this format:
```
curl localhost:15000/logging?level=debug
```
So the defaultLogger check to set all active loggers has been excluded.

3. The `output` flag is a persistent flag of proxy-config, and it's not funcioning in this command, added an info log.