### PR TITLE
Add `istioctl` Analyzer for External Control Plane Installations

### DIFF
--- a/pkg/config/analysis/analyzers/all.go
+++ b/pkg/config/analysis/analyzers/all.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/pkg/config/analysis/analyzers/destinationrule"
 	"istio.io/istio/pkg/config/analysis/analyzers/envoyfilter"
+	"istio.io/istio/pkg/config/analysis/analyzers/externalcontrolplane"
 	"istio.io/istio/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/pkg/config/analysis/analyzers/multicluster"
@@ -43,6 +44,7 @@ func All() []analysis.Analyzer {
 		&deployment.ServiceAssociationAnalyzer{},
 		&deployment.ApplicationUIDAnalyzer{},
 		&deprecation.FieldAnalyzer{},
+		&externalcontrolplane.ExternalControlPlaneAnalyzer{},
 		&gateway.IngressGatewayPortAnalyzer{},
 		&gateway.CertificateAnalyzer{},
 		&gateway.SecretAnalyzer{},

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -118,8 +118,16 @@ var testGrid = []testCase{
 		inputFiles: []string{"testdata/externalcontrolplane-missing-urls.yaml"},
 		analyzer:   &externalcontrolplane.ExternalControlPlaneAnalyzer{},
 		expected: []message{
-			{msg.InvalidWebhook, "MutatingWebhookConfiguration istio-sidecar-injector-external-istiod"},
-			{msg.InvalidWebhook, "ValidatingWebhookConfiguration istio-validator-external-istiod"},
+			{msg.InvalidExternalControlPlaneConfig, "MutatingWebhookConfiguration istio-sidecar-injector-external-istiod"},
+			{msg.InvalidExternalControlPlaneConfig, "ValidatingWebhookConfiguration istio-validator-external-istiod"},
+		},
+	},
+	{
+		name:       "externalControlPlaneUsingIpAddresses",
+		inputFiles: []string{"testdata/externalcontrolplane-using-ip-addr.yaml"},
+		analyzer:   &externalcontrolplane.ExternalControlPlaneAnalyzer{},
+		expected: []message{
+			{msg.ExternalControlPlaneAddressIsNotAHostname, "MutatingWebhookConfiguration istio-sidecar-injector-external-istiod"},
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/pkg/config/analysis/analyzers/destinationrule"
 	"istio.io/istio/pkg/config/analysis/analyzers/envoyfilter"
+	"istio.io/istio/pkg/config/analysis/analyzers/externalcontrolplane"
 	"istio.io/istio/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/pkg/config/analysis/analyzers/maturity"
@@ -110,6 +111,23 @@ var testGrid = []testCase{
 		expected: []message{
 			{msg.Deprecated, "VirtualService foo/productpage"},
 			{msg.Deprecated, "Sidecar default/no-selector"},
+		},
+	},
+	{
+		name:       "externalControlPlaneMissingWebhooks",
+		inputFiles: []string{"testdata/externalcontrolplane-missing-urls.yaml"},
+		analyzer:   &externalcontrolplane.ExternalControlPlaneAnalyzer{},
+		expected: []message{
+			{msg.InvalidWebhook, "MutatingWebhookConfiguration istio-sidecar-injector-external-istiod"},
+			{msg.InvalidWebhook, "ValidatingWebhookConfiguration istio-validator-external-istiod"},
+		},
+	},
+	{
+		name:       "externalControlPlaneValidWebhooks",
+		inputFiles: []string{"testdata/externalcontrolplane-valid-urls.yaml"},
+		analyzer:   &externalcontrolplane.ExternalControlPlaneAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
 		},
 	},
 	{

--- a/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
+++ b/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
@@ -48,7 +48,8 @@ func (s *ExternalControlPlaneAnalyzer) Metadata() analysis.Metadata {
 
 // Analyze implements Analyzer
 func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
-	isRemoteCluster := c.Exists(gvk.ValidatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-validator-external-istiod")) && c.Exists(gvk.MutatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-sidecar-injector-external-istiod"))
+	isRemoteCluster := c.Exists(gvk.ValidatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-validator-external-istiod")) &&
+		c.Exists(gvk.MutatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-sidecar-injector-external-istiod"))
 
 	if isRemoteCluster {
 		requiredValidatingWebhooks := []string{"istio-validator-external-istiod", "istiod-default-validator"}

--- a/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
+++ b/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
@@ -1,0 +1,107 @@
+package externalcontrolplane
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/analysis"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/slices"
+)
+
+type ExternalControlPlaneAnalyzer struct{}
+
+// Compile-time check that this Analyzer correctly implements the interface
+var _ analysis.Analyzer = &ExternalControlPlaneAnalyzer{}
+
+// Metadata implements Analyzer
+func (s *ExternalControlPlaneAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "externalcontrolplane.ExternalControlPlaneAnalyzer",
+		Description: "Checks that the remote IstioOperator resources reference an external controle plane",
+		Inputs: []config.GroupVersionKind{
+			gvk.ValidatingWebhookConfiguration,
+			gvk.MutatingWebhookConfiguration,
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
+	isRemoteCluster := c.Exists(gvk.ValidatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-validator-external-istiod")) && c.Exists(gvk.MutatingWebhookConfiguration, resource.NewShortOrFullName("", "istio-sidecar-injector-external-istiod"))
+
+	if isRemoteCluster {
+		requiredValidatingWebhooks := []string{"istio-validator-external-istiod", "istiod-default-validator"}
+		c.ForEach(gvk.ValidatingWebhookConfiguration, func(resource *resource.Instance) bool {
+			webhookConfig := resource.Message.(*v1.ValidatingWebhookConfiguration)
+
+			if slices.Contains(requiredValidatingWebhooks, webhookConfig.Name) {
+				for _, hook := range webhookConfig.Webhooks {
+					if hook.ClientConfig.URL != nil {
+
+						webhookLintResults := lintWebhookUrl(*hook.ClientConfig.URL, hook.Name)
+						if webhookLintResults != "" {
+							c.Report(gvk.ValidatingWebhookConfiguration, msg.NewInvalidWebhook(resource, webhookLintResults))
+							return false
+						}
+
+					} else {
+						c.Report(gvk.ValidatingWebhookConfiguration, msg.NewInvalidWebhook(resource, fmt.Sprintf("The webhook (%v) does not contain a URL.", hook.Name)))
+						return false
+					}
+				}
+			}
+
+			return true
+		})
+
+		requiredMutatingWebhooks := []string{"istio-sidecar-injector-external-istiod"}
+		c.ForEach(gvk.MutatingWebhookConfiguration, func(resource *resource.Instance) bool {
+			webhookConfig := resource.Message.(*v1.MutatingWebhookConfiguration)
+
+			if slices.Contains(requiredMutatingWebhooks, webhookConfig.Name) {
+				for _, hook := range webhookConfig.Webhooks {
+					if hook.ClientConfig.URL != nil {
+
+						webhookLintResults := lintWebhookUrl(*hook.ClientConfig.URL, hook.Name)
+						if webhookLintResults != "" {
+							c.Report(gvk.ValidatingWebhookConfiguration, msg.NewInvalidWebhook(resource, webhookLintResults))
+							return false
+						}
+
+					} else {
+						c.Report(gvk.MutatingWebhookConfiguration, msg.NewInvalidWebhook(resource, fmt.Sprintf("The webhook (%v) does not contain a URL.", hook.Name)))
+						return false
+					}
+				}
+			}
+
+			return true
+		})
+	}
+}
+
+func lintWebhookUrl(webhookURL string, webhookName string) string {
+	url, err := url.Parse(webhookURL)
+	if err != nil {
+		return fmt.Sprintf("Unable to parse the domain from the URL (%v) set in the webhook (%v).", webhookURL, webhookName)
+	}
+
+	domainName := url.Hostname()
+	ips, err := net.LookupIP(domainName)
+	if err != nil {
+		return fmt.Sprintf("Unable to resolve the domain (%v) associated with the webhook (%v).", domainName, webhookName)
+	}
+
+	if len(ips) == 0 {
+		return fmt.Sprintf("No IP addresses are associated with the domain (%v) assigned to the webhook (%v).", domainName, webhookName)
+	}
+
+	return ""
+}

--- a/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
+++ b/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package externalcontrolplane
 
 import (

--- a/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
+++ b/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
@@ -59,7 +59,7 @@ func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
 				for _, hook := range webhookConfig.Webhooks {
 					if hook.ClientConfig.URL != nil {
 
-						webhookLintResults := lintWebhookUrl(*hook.ClientConfig.URL, hook.Name)
+						webhookLintResults := lintWebhookURL(*hook.ClientConfig.URL, hook.Name)
 						if webhookLintResults != "" {
 							c.Report(gvk.ValidatingWebhookConfiguration, msg.NewInvalidWebhook(resource, webhookLintResults))
 							return false
@@ -83,7 +83,7 @@ func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
 				for _, hook := range webhookConfig.Webhooks {
 					if hook.ClientConfig.URL != nil {
 
-						webhookLintResults := lintWebhookUrl(*hook.ClientConfig.URL, hook.Name)
+						webhookLintResults := lintWebhookURL(*hook.ClientConfig.URL, hook.Name)
 						if webhookLintResults != "" {
 							c.Report(gvk.ValidatingWebhookConfiguration, msg.NewInvalidWebhook(resource, webhookLintResults))
 							return false
@@ -101,7 +101,7 @@ func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
 	}
 }
 
-func lintWebhookUrl(webhookURL string, webhookName string) string {
+func lintWebhookURL(webhookURL string, webhookName string) string {
 	url, err := url.Parse(webhookURL)
 	if err != nil {
 		return fmt.Sprintf("Unable to parse the domain from the URL (%v) set in the webhook (%v).", webhookURL, webhookName)

--- a/pkg/config/analysis/analyzers/testdata/externalcontrolplane-missing-urls.yaml
+++ b/pkg/config/analysis/analyzers/testdata/externalcontrolplane-missing-urls.yaml
@@ -1,0 +1,60 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istio-validator-external-istiod
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: 
+  name: rev.validation.istio.io
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-default-validator
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com:15017/validate
+  failurePolicy: Ignore
+  name: validation.istio.io
+  
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector-external-istiod
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url:
+  failurePolicy: Fail
+  name: rev.namespace.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: rev.object.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: namespace.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: object.sidecar-injector.istio.io

--- a/pkg/config/analysis/analyzers/testdata/externalcontrolplane-using-ip-addr.yaml
+++ b/pkg/config/analysis/analyzers/testdata/externalcontrolplane-using-ip-addr.yaml
@@ -34,7 +34,7 @@ webhooks:
   - v1beta1
   - v1
   clientConfig:
-    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+    url: https://1.1.1.1:5100/inject/cluster/your-cluster-name/net/network1
   failurePolicy: Fail
   name: rev.namespace.sidecar-injector.istio.io
 - admissionReviewVersions:

--- a/pkg/config/analysis/analyzers/testdata/externalcontrolplane-valid-urls.yaml
+++ b/pkg/config/analysis/analyzers/testdata/externalcontrolplane-valid-urls.yaml
@@ -1,0 +1,60 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istio-validator-external-istiod
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com:15017/validate
+  name: rev.validation.istio.io
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: istiod-default-validator
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com:15017/validate
+  failurePolicy: Ignore
+  name: validation.istio.io
+  
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: istio-sidecar-injector-external-istiod
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://1.1.1.1:5100/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: rev.namespace.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://1.1.1.1:5100/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: rev.object.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: namespace.sidecar-injector.istio.io
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://test.com/inject/cluster/your-cluster-name/net/network1
+  failurePolicy: Fail
+  name: object.sidecar-injector.istio.io

--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -231,6 +231,14 @@ var (
 	// GatewayPortNotDefinedOnService defines a diag.MessageType for message "GatewayPortNotDefinedOnService".
 	// Description: Gateway port not exposed by service
 	GatewayPortNotDefinedOnService = diag.NewMessageType(diag.Warning, "IST0162", "The gateway is listening on a target port (port %d) that is not defined in the Service associated with its workload instances (Pod selector %s). If you need to access the gateway port through the gateway Service, it will not be available.")
+
+	// InvalidExternalControlPlaneConfig defines a diag.MessageType for message "InvalidExternalControlPlaneConfig".
+	// Description: Address for the ingress gateway on the external control plane is not valid
+	InvalidExternalControlPlaneConfig = diag.NewMessageType(diag.Warning, "IST0163", "The hostname (%s) that was provided for the webhook (%s) to reach the ingress gateway on the external control plane cluster %s. Traffic may not flow properly.")
+
+	// ExternalControlPlaneAddressIsNotAHostname defines a diag.MessageType for message "ExternalControlPlaneAddressIsNotAHostname".
+	// Description: Address for the ingress gateway on the external control plane is an IP address and not a hostname
+	ExternalControlPlaneAddressIsNotAHostname = diag.NewMessageType(diag.Info, "IST0164", "The address (%s) that was provided for the webhook (%s) to reach the ingress gateway on the external control plane cluster is an IP address. This is not recommended for a production environment.")
 )
 
 // All returns a list of all known message types.
@@ -292,6 +300,8 @@ func All() []*diag.MessageType {
 		MultipleTelemetriesWithoutWorkloadSelectors,
 		InvalidGatewayCredential,
 		GatewayPortNotDefinedOnService,
+		InvalidExternalControlPlaneConfig,
+		ExternalControlPlaneAddressIsNotAHostname,
 	}
 }
 
@@ -843,5 +853,26 @@ func NewGatewayPortNotDefinedOnService(r *resource.Instance, port int, selector 
 		r,
 		port,
 		selector,
+	)
+}
+
+// NewInvalidExternalControlPlaneConfig returns a new diag.Message based on InvalidExternalControlPlaneConfig.
+func NewInvalidExternalControlPlaneConfig(r *resource.Instance, hostname string, webhook string, msg string) diag.Message {
+	return diag.NewMessage(
+		InvalidExternalControlPlaneConfig,
+		r,
+		hostname,
+		webhook,
+		msg,
+	)
+}
+
+// NewExternalControlPlaneAddressIsNotAHostname returns a new diag.Message based on ExternalControlPlaneAddressIsNotAHostname.
+func NewExternalControlPlaneAddressIsNotAHostname(r *resource.Instance, hostname string, webhook string) diag.Message {
+	return diag.NewMessage(
+		ExternalControlPlaneAddressIsNotAHostname,
+		r,
+		hostname,
+		webhook,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -601,3 +601,27 @@ messages:
         type: int
       - name: selector
         type: string
+
+  - name: "InvalidExternalControlPlaneConfig"
+    code: IST0163
+    level: Warning
+    description: "Address for the ingress gateway on the external control plane is not valid"
+    template: "The hostname (%s) that was provided for the webhook (%s) to reach the ingress gateway on the external control plane cluster %s. Traffic may not flow properly."
+    args:
+      - name: hostname
+        type: string
+      - name: webhook
+        type: string
+      - name: msg
+        type: string
+
+  - name: "ExternalControlPlaneAddressIsNotAHostname"
+    code: IST0164
+    level: Info
+    description: "Address for the ingress gateway on the external control plane is an IP address and not a hostname"
+    template: "The address (%s) that was provided for the webhook (%s) to reach the ingress gateway on the external control plane cluster is an IP address. This is not recommended for a production environment."
+    args:
+      - name: hostname
+        type: string
+      - name: webhook
+        type: string

--- a/releasenotes/notes/47269.yaml
+++ b/releasenotes/notes/47269.yaml
@@ -7,4 +7,4 @@ issue:
 
 releaseNotes:
 - |
-  **Added** an analyzer for showing warning messages for Istio installations using an External Control Plane
+  **Added** An analyzer for showing warning messages about incorrect/missing information related to Istio installations using an External Control Plane

--- a/releasenotes/notes/47269.yaml
+++ b/releasenotes/notes/47269.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+
+issue:
+  - 47269
+
+releaseNotes:
+- |
+  **Added** an analyzer for showing warning messages for Istio installations using an External Control Plane


### PR DESCRIPTION
Closes: https://github.com/istio/istio/issues/47269

This PR adds a new analyzer for Istio installations that use an External Control Plane: https://istio.io/latest/docs/setup/install/external-controlplane/

The unique aspect of an installation that uses an External Control Plane is that there is both a remote and external cluster. This analyzer works to ensure that [the address of the external `istiod`](https://istio.io/latest/docs/setup/install/external-controlplane/#set-up-the-remote-config-cluster) that the user provides for the remote cluster is valid. We are not checking that the `istiod` service is actually running in the external cluster, but rather that the value provided is a valid address that can be resolved.  