### PR TITLE
Adjust DNS Proxy CNAME wildcard response to be compatible with glibc and musl

### DIFF
--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -182,6 +182,12 @@ func testDNS(t *testing.T, d *LocalDNSServer) {
 			expected: a("a.b.wildcard.", []netip.Addr{netip.MustParseAddr("11.11.11.11")}),
 		},
 		{
+			name: "success: wild card with with search namespace chained pointer correctly",
+			host: "foo.wildcard.ns1.svc.cluster.local.",
+			expected: append(cname("foo.wildcard.ns1.svc.cluster.local.", "*.wildcard."),
+				a("*.wildcard.", []netip.Addr{netip.MustParseAddr("10.10.10.10")})...),
+		},
+		{
 			name:     "success: wild card with domain returns A record correctly",
 			host:     "foo.svc.mesh.company.net.",
 			expected: a("foo.svc.mesh.company.net.", []netip.Addr{netip.MustParseAddr("10.1.2.3")}),
@@ -194,8 +200,8 @@ func testDNS(t *testing.T, d *LocalDNSServer) {
 		{
 			name: "success: wild card with search domain returns A record correctly",
 			host: "foo.svc.mesh.company.net.ns1.svc.cluster.local.",
-			expected: append(cname("*.svc.mesh.company.net.ns1.svc.cluster.local.", "*.svc.mesh.company.net."),
-				a("foo.svc.mesh.company.net.ns1.svc.cluster.local.", []netip.Addr{netip.MustParseAddr("10.1.2.3")})...),
+			expected: append(cname("foo.svc.mesh.company.net.ns1.svc.cluster.local.", "*.svc.mesh.company.net."),
+				a("*.svc.mesh.company.net.", []netip.Addr{netip.MustParseAddr("10.1.2.3")})...),
 		},
 		{
 			name:      "success: TypeAAAA query returns AAAA records only",

--- a/releasenotes/notes/47290.yaml
+++ b/releasenotes/notes/47290.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47290
+  - 47264
+  - 31250
+  - 33360
+  - 30531
+  - 38484
+releaseNotes:
+- |
+  **Fixed** DNS Proxy resolution for wildcard ServiceEntry with the search domain suffix for glibc based containers.


### PR DESCRIPTION
As reported on #47264, the DNS Proxy component is capable of returning a CNAME chained response for wildcard `ServiceEntry` objects. Unfortunately, this only worked for `musl` based DNS resolution leading to a few inconsistent reports of DNS resolution issues, likely on `glibc` based systems.

The issue on `glib` was a long-standing [problem reported in 2010](https://sourceware.org/bugzilla/show_bug.cgi?id=12154) and fixed in `glibc 2.37` in 2022-08-30. Considering the DNS Proxy feature was added in Istio 1.11 back in 2021, it was only possible to validate the DNS Proxy wildcard feature in `musl`, which is also the default on the contaienrs used on the sample.

Now that `glibc` fix has been backported to `glibc 2.34+` and picked up by a few distros (eg: [Debian Bookworm](https://salsa.debian.org/glibc-team/glibc/-/blob/bookworm/debian/patches/git-updates.diff#L111)), it would be important to enable the DNS Proxy wildcard resolution for processes using `glic`.

## Test Scenario before the change

Consider the following `ServiceEntry` object for the tests: Tested on a local Colima k3s cluster, and an EKS staging cluster.

1. Follow the [DNS Proxy documentation](https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/)

```sh
cat <<EOF | istioctl install -y -f -
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  meshConfig:
    defaultConfig:
      proxyMetadata:
        # Enable basic DNS proxying
        ISTIO_META_DNS_CAPTURE: "true"
        # Enable automatic address allocation, optional
        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
EOF
```

```sh
kubectl label namespace default istio-injection=enabled --overwrite
```

2. Introduce a `ServiceEntry` with a wildcard host:

```sh
cat <<EOF | kubectl apply -f -
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: cluster-redirect
  namespace: default
spec:
  addresses:
    - 240.240.0.1
  hosts:
    - '*.mycluster.internal'
  location: MESH_INTERNAL
  ports:
    - name: http
      number: 80
      protocol: http
  resolution: STATIC
EOF
```

3. Run a container and attempt to resolve `foo.mycluster.internal`:

<details>
<summary>Debian (glibc) :x:</summary>

### Result
:x: Lookup does not resolve to the wildcard address.

#### Command used:
```
kubectl run --rm -ti --command \
  --image python:bookworm \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- /bin/sh
```

#### Pod output:


```
(pod) % getent hosts foo.mycluster.internal
(pod) % echo $?
2
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'

Traceback (most recent call last):
  File "<string>", line 1, in <module>
socket.gaierror: [Errno -2] Name or service not known
```

```
(pod) % apt update && apt install -y curl 

(pod) % curl foo.mycluster.internal
curl: (6) Could not resolve host: foo.mycluster.internal
```

</details>

<details>
<summary>Alpine (musl) :white_check_mark:</summary>

### Result
:white_check_mark: Lookup does resolve to the wildcard address.

#### Command used:
```
kubectl run --rm -ti --command \
  --image python:alpine \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- getent hosts foo.mycluster.internal
```
#### Pod output:

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1       foo.mycluster.internal.default.svc.cluster.local  foo.mycluster.internal.default.svc.cluster.local foo.mycluster.internal
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apk add curl

(pod) # curl foo.mycluster.internal
no healthy upstream
```

</details>


## Problem

The DNS query including the search domains appended returns as this format:

```
;; QUESTION SECTION:
;foo.mycluster.internal.default.svc.cluster.local.		IN	A

;; ANSWER SECTION:
*.mycluster.internal.default.svc.cluster.local.	30	IN	CNAME	*.mycluster.internal.
foo.mycluster.internal.default.svc.cluster.local.	30	IN	A	240.240.0.1
```

This works fine for `musl` as it performs a [domain expansion](https://git.musl-libc.org/cgit/musl/tree/src/network/lookup_name.c#n120) for the chained CNAME DNS response, completing the wildcard pointers to their redirects, which finally resolves to the A record as necessary.

Meanwhile, when analyzing the `glibc` issue report and implementation, it expects the chained CNAME DNS response to follow this pattern instead:

```
;; QUESTION SECTION:
;foo.mycluster.internal.default.svc.cluster.local.		IN	A

;; ANSWER SECTION:
foo.mycluster.internal.default.svc.cluster.local. 30 IN	CNAME *.mycluster.internal.
*.mycluster.internal.	30	IN	A	240.240.0.1
```

Notice that the first CNAME response is the fully qualified domain name, including the search domain, and the second entry is an A record with the wildcard `ServiceRegistry` address. Using this response format, both `glibc` and `musl` are able to resolve the wildcard address.

## Solution

This commit changes the CNAME response from this pattern and fixes #47264

```
;; QUESTION SECTION:
;${full_qualified_domain_query_with_search}		IN	A

;; ANSWER SECTION:
${wildcard_service_entry}.${search_domain} 30 IN	CNAME ${wildcard_service_entry}
${full_qualified_domain_query_with_search}	30	IN	A	240.240.0.1
```

Now, the following pattern when a CNAME wildcard is found:
```
;; QUESTION SECTION:
;${full_qualified_domain_query_with_search}		IN	A

;; ANSWER SECTION:
${full_qualified_domain_query_with_search} 30 IN	CNAME ${wildcard_service_entry}
${wildcard_service_entry}	30	IN	A	240.240.0.1

```

The changes kept the bahaviour of expanding the wildcard `ServiceRegistry` when the query is made without the search domain included, resolving directly to an A record:

```
;; QUESTION SECTION:
;foo.mycluster.internal.		IN	A

;; ANSWER SECTION:
foo.mycluster.internal.	30	IN	A	240.240.0.1
```

### Tests performed after the change
After building a local istio image with the change, the following tests were performed:

1. Re
```sh
cat <<EOF | go run ./istioctl/cmd/istioctl install -y -f -
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  hub: 'docker.io/bltavares'
  tag: 'cname3'
  meshConfig:
    defaultConfig:
      proxyMetadata:
        # Enable basic DNS proxying
        ISTIO_META_DNS_CAPTURE: "true"
        # Enable automatic address allocation, optional
        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
EOF
```

```sh
kubectl label namespace default istio-injection=enabled --overwrite
```

2. Introduce a `ServiceEntry` with a wildcard host:

```sh
cat <<EOF | kubectl apply -f -
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: cluster-redirect
  namespace: default
spec:
  addresses:
    - 240.240.0.1
  hosts:
    - '*.mycluster.internal'
  location: MESH_INTERNAL
  ports:
    - name: http
      number: 80
      protocol: http
  resolution: STATIC
EOF
```

3. Run a container and attempt to resolve `foo.mycluster.internal`:

<details>
<summary>Debian (glibc) :white_check_mark:</summary>

### Result
:white_check_mark: Lookup **DOES** resolve to the wildcard address.

#### Command used:
```
kubectl run --rm -ti --command \
  --image python:bookworm \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- /bin/sh
```

#### Pod output:

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1     foo.mycluster.internal.default.svc.cluster.local
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apt update && apt install -y curl 

(pod) % curl foo.mycluster.internal
no healthy upstream
```

</details>

<details>
<summary>Alpine (musl) :white_check_mark:</summary>

### Result
:white_check_mark: Lookup does resolve to the wildcard address.

#### Command used:
```
kubectl run --rm -ti --command \
  --image python:alpine \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- getent hosts foo.mycluster.internal
```
#### Pod output:

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1       foo.mycluster.internal.default.svc.cluster.local  foo.mycluster.internal.default.svc.cluster.local foo.mycluster.internal
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apk add curl

(pod) # curl foo.mycluster.internal
no healthy upstream
```

</details>

---