### PR TITLE
Modify SE with inlined WE auth policy support

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -52,7 +52,10 @@ type AmbientIndex interface {
 	All() []*model.AddressInfo
 	WorkloadsForWaypoint(scope model.WaypointScope) []*model.WorkloadInfo
 	Waypoint(scope model.WaypointScope) []netip.Addr
-	CalculateUpdatedWorkloads(pods map[string]*v1.Pod, workloadEntries map[networkAddress]*apiv1alpha3.WorkloadEntry, c *Controller) map[model.ConfigKey]struct{}
+	CalculateUpdatedWorkloads(pods map[string]*v1.Pod,
+		workloadEntries map[networkAddress]*apiv1alpha3.WorkloadEntry,
+		serviceEntries []*apiv1alpha3.ServiceEntry,
+		c *Controller) map[model.ConfigKey]struct{}
 	HandleSelectedNamespace(ns string, pods []*v1.Pod, c *Controller)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex.go
@@ -54,7 +54,7 @@ type AmbientIndex interface {
 	Waypoint(scope model.WaypointScope) []netip.Addr
 	CalculateUpdatedWorkloads(pods map[string]*v1.Pod,
 		workloadEntries map[networkAddress]*apiv1alpha3.WorkloadEntry,
-		serviceEntries []*apiv1alpha3.ServiceEntry,
+		seEndpoints map[*apiv1alpha3.ServiceEntry]*v1alpha3.WorkloadEntry,
 		c *Controller) map[model.ConfigKey]struct{}
 	HandleSelectedNamespace(ns string, pods []*v1.Pod, c *Controller)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -205,7 +205,22 @@ func (c *Controller) getWorkloadEntriesInPolicy(ns string, sel map[string]string
 		ns = metav1.NamespaceAll
 	}
 
-	return c.getSelectedWorkloadEntries(ns, sel)
+	workloadEntries := c.getSelectedWorkloadEntries(ns, sel)
+
+	// Include workload entries inlined in service entries (endpoints)
+	allServiceEntries := c.configController.List(gvk.ServiceEntry, ns)
+	for _, se := range allServiceEntries {
+		for _, wl := range serviceentry.ConvertServiceEntry(se).Endpoints {
+			if labels.Instance(sel).SubsetOf(wl.Labels) || (len(wl.Labels) == 0 && labels.Instance(sel).SubsetOf(se.Labels)) {
+				workloadEntries = append(workloadEntries, &apiv1alpha3.WorkloadEntry{
+					ObjectMeta: se.ToObjectMeta(),
+					Spec:       *wl.DeepCopy(),
+				})
+			}
+		}
+	}
+
+	return workloadEntries
 }
 
 // NOTE: Mutex is locked prior to being called.
@@ -501,20 +516,6 @@ func (c *Controller) getSelectedWorkloadEntries(ns string, selector map[string]s
 			workloadEntries = append(workloadEntries, wl)
 		}
 	}
-
-	// Include workload entries inlined in service entries (endpoints)
-	allServiceEntries := c.configController.List(gvk.ServiceEntry, ns)
-	for _, se := range allServiceEntries {
-		for _, wl := range serviceentry.ConvertServiceEntry(se).Endpoints {
-			if labels.Instance(selector).SubsetOf(wl.Labels) || (len(wl.Labels) == 0 && labels.Instance(selector).SubsetOf(se.Labels)) {
-				workloadEntries = append(workloadEntries, &apiv1alpha3.WorkloadEntry{
-					ObjectMeta: se.ToObjectMeta(),
-					Spec:       *wl.DeepCopy(),
-				})
-			}
-		}
-	}
-
 	return workloadEntries
 }
 
@@ -568,8 +569,7 @@ func (a *AmbientIndexImpl) cleanupOldWorkloadEntriesInlinedOnServiceEntry(svcEnt
 					delete(a.byWorkloadEntry, networkAddr)
 				}
 				delete(a.byUID, oldUID)
-				weUID := c.generateWorkloadEntryUID(nsName.Namespace, nsName.Name)
-				delete(a.byUID, weUID)
+				delete(a.byUID, c.generateWorkloadEntryUID(oldServiceEntry.GetNamespace(), oldServiceEntry.GetName()))
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_external.go
@@ -562,13 +562,14 @@ func (a *AmbientIndexImpl) cleanupOldWorkloadEntriesInlinedOnServiceEntry(svcEnt
 	if oldServiceEntry, f := a.servicesMap[nsName]; f {
 		for _, oldWe := range oldServiceEntry.Spec.Endpoints {
 			oldUID := c.generateServiceEntryUID(nsName.Namespace, nsName.Name, oldWe.Address)
-			we, found := a.byUID[oldUID]
-			if found {
+			if we, found := a.byUID[oldUID]; found {
 				updates.Insert(model.ConfigKey{Kind: kind.Address, Name: we.ResourceName()})
 				for _, networkAddr := range networkAddressFromWorkload(we) {
 					delete(a.byWorkloadEntry, networkAddr)
 				}
 				delete(a.byUID, oldUID)
+				weUID := c.generateWorkloadEntryUID(nsName.Namespace, nsName.Name)
+				delete(a.byUID, weUID)
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_serviceentry_test.go
@@ -32,7 +32,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 
 	// test code path where service entry creates a workload entry via `ServiceEntry.endpoints`
 	// and the inlined WE has a port override
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, nil, true)
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, nil, "127.0.0.1")
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "name1")
 	s.assertEvent(t, s.seIPXdsName("name1", "127.0.0.1"), "ns1/se.istio.io")
 	s.controller.ambientIndex.(*AmbientIndexImpl).mu.RLock()
@@ -141,7 +141,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
 
 	// a service entry should not be able to select across namespaces
-	s.addServiceEntry(t, "mismatched.istio.io", []string{"240.240.23.45"}, "name1", "mismatched-ns", map[string]string{"app": "a"}, false)
+	s.addServiceEntry(t, "mismatched.istio.io", []string{"240.240.23.45"}, "name1", "mismatched-ns", map[string]string{"app": "a"}, "")
 	s.assertEvent(t, "mismatched-ns/mismatched.istio.io")
 	assert.Equal(t, s.lookup(s.addrXdsName("140.140.0.10")), []*model.AddressInfo{{
 		Address: &workloadapi.Address{
@@ -186,7 +186,7 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 		},
 	}})
 
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, false)
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, "")
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "pod1", "pod2", "name1", "name2")
 	// we should see an update for the workloads selected by the service entry
 	// do not expect event for pod2 since it is not selected by the service entry
@@ -335,7 +335,7 @@ func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *tes
 	s.addPods(t, "140.140.0.11", "pod2", "sa1", map[string]string{"app": "other"}, nil, true, corev1.PodRunning)
 	s.addWorkloadEntries(t, "240.240.34.56", "name1", "sa1", map[string]string{"app": "a"})
 	s.addWorkloadEntries(t, "240.240.34.57", "name2", "sa1", map[string]string{"app": "other"})
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, false)
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "name1", testNS, map[string]string{"app": "a"}, "")
 	s.clearEvents()
 
 	// Setting the PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES to false shouldn't affect the workloads selected by the service

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -1141,14 +1141,14 @@ func (s *ambientTestServer) deleteWorkloadEntry(t *testing.T, name string) {
 	_ = s.cfg.Delete(gvk.WorkloadEntry, name, "ns1", nil)
 }
 
-func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addresses []string, name, ns string, labels map[string]string, inlined bool) {
+func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addresses []string, name, ns string, labels map[string]string, epAddress string) {
 	t.Helper()
 
 	_, _ = s.controller.client.Kube().CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{"istio.io/dataplane-mode": "ambient"}},
 	}, metav1.CreateOptions{})
 
-	serviceEntry := generateServiceEntry(hostStr, addresses, labels, inlined)
+	serviceEntry := generateServiceEntry(hostStr, addresses, labels, epAddress)
 	w := config.Config{
 		Meta: config.Meta{
 			GroupVersionKind: gvk.ServiceEntry,
@@ -1167,18 +1167,18 @@ func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addres
 	}
 }
 
-func generateServiceEntry(host string, addresses []string, labels map[string]string, inlined bool) *v1alpha3.ServiceEntry {
+func generateServiceEntry(host string, addresses []string, labels map[string]string, epAddress string) *v1alpha3.ServiceEntry {
 	var endpoints []*v1alpha3.WorkloadEntry
 	var workloadSelector *v1alpha3.WorkloadSelector
 
-	if !inlined {
+	if epAddress == "" {
 		workloadSelector = &v1alpha3.WorkloadSelector{
 			Labels: labels,
 		}
 	} else {
 		endpoints = []*v1alpha3.WorkloadEntry{
 			{
-				Address: "127.0.0.1",
+				Address: epAddress,
 				Labels:  labels,
 				Ports: map[string]uint32{
 					"http": 8081, // we will override the SE http port

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -309,18 +309,18 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
-	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, true)
+	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, "127.0.0.2")
 	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY, "se1")
-	s.assertEvent(t, s.seIPXdsName("se1", "127.0.0.1"), "ns1/se.istio.io")
+	s.assertEvent(t, s.seIPXdsName("se1", "127.0.0.2"), "ns1/se.istio.io")
 
 	s.addPolicy(t, "selector", "ns1", map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
 	assert.Equal(t,
-		s.lookup(s.seIPXdsName("se1", "127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		s.lookup(s.seIPXdsName("se1", "127.0.0.2"))[0].GetWorkload().GetAuthorizationPolicies(),
 		[]string{"ns1/selector"})
 
 	_ = s.cfg.Delete(gvk.AuthorizationPolicy, "selector", "ns1", nil)
 	assert.Equal(t,
-		s.lookup(s.seIPXdsName("se1", "127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		s.lookup(s.seIPXdsName("se1", "127.0.0.2"))[0].GetWorkload().GetAuthorizationPolicies(),
 		nil)
 
 	s.deleteServiceEntry(t, "se1", testNS)

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -323,6 +323,9 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
 		nil)
+
+	s.deleteServiceEntry(t, "se1", testNS)
+	s.assertWorkloads(t, "", workloadapi.WorkloadStatus_HEALTHY) // Asserting no WE residual
 }
 
 func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_workloadentry_test.go
@@ -315,13 +315,12 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 
 	s.addPolicy(t, "selector", "ns1", map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
 	assert.Equal(t,
-		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		s.lookup(s.seIPXdsName("se1", "127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
 		[]string{"ns1/selector"})
 
 	_ = s.cfg.Delete(gvk.AuthorizationPolicy, "selector", "ns1", nil)
-	s.assertEvent(t, s.wleXdsName("se1"))
 	assert.Equal(t,
-		s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
+		s.lookup(s.seIPXdsName("se1", "127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies(),
 		nil)
 
 	s.deleteServiceEntry(t, "se1", testNS)


### PR DESCRIPTION
**Please provide a description of this PR:**

Rewrote the implementation for the SE with endpoints auth policy support.
Previous implementation added an additional WE with the name of the SE to the index. 
This was unnecessary because in the new implementation it is taking into account that there is already a SE entry for each endpoint address and it just makes sure that auth policy for those entries are updated when the SE is selected by an auth policy.

Previous implementation was also incorrect as if there are multiple endpoints defined in the SE it still added only a single WE.