### PR TITLE
Update spire-agent image to match spire-server

### DIFF
--- a/samples/security/spire/spire-quickstart.yaml
+++ b/samples/security/spire/spire-quickstart.yaml
@@ -886,7 +886,7 @@ spec:
       serviceAccountName: spire-agent
       containers:
         - name: spire-agent
-          image: ghcr.io/spiffe/spire-agent:1.2.3
+          image: ghcr.io/spiffe/spire-agent:1.5.4
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:


### PR DESCRIPTION
**Please provide a description of this PR:**
The image used for spire-agent is old and using that https://github.com/istio/istio/blob/9efde960c9150864cda1c5384a111cca510fb5f0/samples/security/spire/spire-quickstart.yaml#L848-L853 is not working as expected. This PR matches the image of spire-agent with that of spire-server. 