### PR TITLE
move cors policy to typed per filter config

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_waypoint.go
@@ -528,9 +528,14 @@ func (lb *ListenerBuilder) translateRoute(
 	out.Decorator = &route.Decorator{
 		Operation: istio_route.GetRouteOperation(out, virtualService.Name, listenPort),
 	}
-	if in.Fault != nil {
+	if in.Fault != nil || in.CorsPolicy != nil {
 		out.TypedPerFilterConfig = make(map[string]*any.Any)
+	}
+	if in.Fault != nil {
 		out.TypedPerFilterConfig[wellknown.Fault] = protoconv.MessageToAny(istio_route.TranslateFault(in.Fault))
+	}
+	if in.CorsPolicy != nil {
+		out.TypedPerFilterConfig[wellknown.CORS] = protoconv.MessageToAny(istio_route.TranslateCORSPolicy(in.CorsPolicy))
 	}
 
 	return out
@@ -543,7 +548,6 @@ func (lb *ListenerBuilder) routeDestination(out *route.Route, in *networking.HTT
 		policy = lb.push.Mesh.GetDefaultHttpRetryPolicy()
 	}
 	action := &route.RouteAction{
-		Cors:        istio_route.TranslateCORSPolicy(in.CorsPolicy),
 		RetryPolicy: retry.ConvertPolicy(policy),
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -453,9 +453,14 @@ func translateRoute(
 	out.Decorator = &route.Decorator{
 		Operation: GetRouteOperation(out, virtualService.Name, listenPort),
 	}
-	if in.Fault != nil {
+	if in.Fault != nil || in.CorsPolicy != nil {
 		out.TypedPerFilterConfig = make(map[string]*anypb.Any)
+	}
+	if in.Fault != nil {
 		out.TypedPerFilterConfig[wellknown.Fault] = protoconv.MessageToAny(TranslateFault(in.Fault))
+	}
+	if in.CorsPolicy != nil {
+		out.TypedPerFilterConfig[wellknown.CORS] = protoconv.MessageToAny(TranslateCORSPolicy(in.CorsPolicy))
 	}
 
 	if opts.IsHTTP3AltSvcHeaderNeeded {
@@ -486,7 +491,6 @@ func applyHTTPRouteDestination(
 		policy = mesh.GetDefaultHttpRetryPolicy()
 	}
 	action := &route.RouteAction{
-		Cors:        TranslateCORSPolicy(in.CorsPolicy),
 		RetryPolicy: retry.ConvertPolicy(policy),
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -23,6 +23,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xdsfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/fault/v3"
+	cors "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -1059,13 +1060,13 @@ func translateHeaderMatch(name string, in *networking.StringMatch) *route.Header
 }
 
 // TranslateCORSPolicy translates CORS policy
-func TranslateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
+func TranslateCORSPolicy(in *networking.CorsPolicy) *cors.CorsPolicy {
 	if in == nil {
 		return nil
 	}
 
 	// CORS filter is enabled by default
-	out := route.CorsPolicy{}
+	out := cors.CorsPolicy{}
 	// nolint: staticcheck
 	if in.AllowOrigins != nil {
 		out.AllowOriginStringMatch = util.ConvertToEnvoyMatches(in.AllowOrigins)
@@ -1073,12 +1074,10 @@ func TranslateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 		out.AllowOriginStringMatch = util.StringToExactMatch(in.AllowOrigin)
 	}
 
-	out.EnabledSpecifier = &route.CorsPolicy_FilterEnabled{
-		FilterEnabled: &core.RuntimeFractionalPercent{
-			DefaultValue: &xdstype.FractionalPercent{
-				Numerator:   100,
-				Denominator: xdstype.FractionalPercent_HUNDRED,
-			},
+	out.FilterEnabled = &core.RuntimeFractionalPercent{
+		DefaultValue: &xdstype.FractionalPercent{
+			Numerator:   100,
+			Denominator: xdstype.FractionalPercent_HUNDRED,
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -21,6 +21,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xdsfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/fault/v3"
+	cors "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -323,7 +324,7 @@ func TestTranslateCORSPolicy(t *testing.T) {
 			{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
 		},
 	}
-	expectedCorsPolicy := &route.CorsPolicy{
+	expectedCorsPolicy := &cors.CorsPolicy{
 		AllowOriginStringMatch: []*matcher.StringMatcher{
 			{MatchPattern: &matcher.StringMatcher_Exact{Exact: "exact"}},
 			{MatchPattern: &matcher.StringMatcher_Prefix{Prefix: "prefix"}},
@@ -335,12 +336,10 @@ func TestTranslateCORSPolicy(t *testing.T) {
 				},
 			},
 		},
-		EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
-			FilterEnabled: &core.RuntimeFractionalPercent{
-				DefaultValue: &xdstype.FractionalPercent{
-					Numerator:   100,
-					Denominator: xdstype.FractionalPercent_HUNDRED,
-				},
+		FilterEnabled: &core.RuntimeFractionalPercent{
+			DefaultValue: &xdstype.FractionalPercent{
+				Numerator:   100,
+				Denominator: xdstype.FractionalPercent_HUNDRED,
 			},
 		},
 	}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -784,13 +784,13 @@ spec:
       abort:
         percentage:
           value: 100
-        httpStatus: 404`,
+        httpStatus: 418`,
 		opts: echo.CallOptions{
 			Port: echo.Port{
 				Name: "http",
 			},
 			Count: 1,
-			Check: check.OK(),
+			Check: check.Status(http.StatusTeapot),
 		},
 		workloadAgnostic: true,
 	})
@@ -820,7 +820,7 @@ spec:
 			},
 			Scheme: scheme.GRPC,
 			Count:  1,
-			Check:  check.GRPCStatus(codes.Aborted),
+			Check:  check.GRPCStatus(codes.Unavailable),
 		},
 		workloadAgnostic: true,
 		sourceMatchers:   includeProxyless,

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -790,7 +790,7 @@ spec:
 				Name: "http",
 			},
 			Count: 1,
-			Check: check.Status(http.StatusTeapot),
+			Check: check.Status(http.StatusOK),
 		},
 		workloadAgnostic: true,
 	})

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -784,7 +784,7 @@ spec:
       abort:
         percentage:
           value: 100
-        httpStatus: 418`,
+        httpStatus: 404`,
 		opts: echo.CallOptions{
 			Port: echo.Port{
 				Name: "http",

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -790,7 +790,7 @@ spec:
 				Name: "http",
 			},
 			Count: 1,
-			Check: check.Status(http.StatusOK),
+			Check: check.OK(),
 		},
 		workloadAgnostic: true,
 	})
@@ -820,7 +820,7 @@ spec:
 			},
 			Scheme: scheme.GRPC,
 			Count:  1,
-			Check:  check.GRPCStatus(codes.Unavailable),
+			Check:  check.GRPCStatus(codes.Aborted),
 		},
 		workloadAgnostic: true,
 		sourceMatchers:   includeProxyless,


### PR DESCRIPTION
[RouterAction.Cors](https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/route/v3/route_components.proto#L154) is deprecated. This PR moves is to Routes' perFilterConfig similar to Fault

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure