### PR TITLE
Fix traffic to terminating headless services

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -286,7 +286,7 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 	ep.Lock()
 	defer ep.Unlock()
 	newIstioEndpoints := istioEndpoints
-	if features.SendUnhealthyEndpoints.Load() {
+	if true {
 		oldIstioEndpoints := ep.Shards[shard]
 		needPush := false
 		if oldIstioEndpoints == nil {
@@ -320,7 +320,10 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 					// If the endpoint does not exist in shards that means it is a
 					// new endpoint. Always send new endpoints even if they are not healthy.
 					// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
-					needPush = true
+					// Without SendUnhealthyEndpoints we do not need this; headless services will trigger the push in the Kubernetes controller.
+					if features.SendUnhealthyEndpoints.Load() {
+						needPush = true
+					}
 					newIstioEndpoints = append(newIstioEndpoints, nie)
 				}
 			}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -447,8 +447,6 @@ type Locality struct {
 type HealthStatus int32
 
 const (
-	// UnknownHealthStatus is set when we do not know the health status.
-	UnknownHealthStatus HealthStatus = 0
 	// Healthy.
 	Healthy HealthStatus = 1
 	// Unhealthy.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -447,6 +447,8 @@ type Locality struct {
 type HealthStatus int32
 
 const (
+	// UnknownHealthStatus is set when we do not know the health status.
+	UnknownHealthStatus HealthStatus = 0
 	// Healthy.
 	Healthy HealthStatus = 1
 	// Unhealthy.

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -187,13 +187,6 @@ func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Na
 		// Draining tracking is only enabled if persistent sessions is enabled.
 		// If we start using them for other features, this can be adjusted.
 		healthStatus := endpointHealthStatus(svc, e)
-		if !features.SendUnhealthyEndpoints.Load() {
-			if healthStatus == model.UnHealthy {
-				// Ignore not ready endpoints. Draining endpoints are tracked, but not returned
-				// except for persistent-session clusters.
-				continue
-			}
-		}
 		for _, a := range e.Addresses {
 			pod, expectedPod := getPod(esc.c, a, &metav1.ObjectMeta{Name: slice.Name, Namespace: slice.Namespace}, e.TargetRef, hostName)
 			if pod == nil && expectedPod {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -409,7 +409,6 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 			}
 			adscon.WaitClear()
 
-			t.Log("blah")
 			// Set additional unhealthy endpoint and validate Eds update is not triggered.
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
 				[]*model.IstioEndpoint{

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -352,171 +352,188 @@ func TestEDSOverlapping(t *testing.T) {
 }
 
 func TestEDSUnhealthyEndpoints(t *testing.T) {
-	test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, true)
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-	addUnhealthyCluster(s)
-	s.EnsureSynced(t)
-	adscon := s.Connect(nil, nil, watchEds)
-	_, err := adscon.Wait(5 * time.Second)
-	if err != nil {
-		t.Fatalf("Error in push %v", err)
-	}
-
-	validateEndpoints := func(expectPush bool, healthy []string, unhealthy []string) {
-		t.Helper()
-		// Normalize lists to make comparison easier
-		if healthy == nil {
-			healthy = []string{}
-		}
-		if unhealthy == nil {
-			unhealthy = []string{}
-		}
-		sort.Strings(healthy)
-		sort.Strings(unhealthy)
-		if expectPush {
-			upd, _ := adscon.Wait(5*time.Second, v3.EndpointType)
-
-			if len(upd) > 0 && !slices.Contains(upd, v3.EndpointType) {
-				t.Fatalf("Expecting EDS push as endpoint health is changed. But received %v", upd)
+	for _, sendUnhealthy := range []bool{true, false} {
+		t.Run(fmt.Sprint(sendUnhealthy), func(t *testing.T) {
+			test.SetAtomicBoolForTest(t, features.SendUnhealthyEndpoints, sendUnhealthy)
+			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+			addUnhealthyCluster(s)
+			s.EnsureSynced(t)
+			adscon := s.Connect(nil, nil, watchEds)
+			_, err := adscon.Wait(5 * time.Second)
+			if err != nil {
+				t.Fatalf("Error in push %v", err)
 			}
-		} else {
-			upd, _ := adscon.Wait(50*time.Millisecond, v3.EndpointType)
-			if slices.Contains(upd, v3.EndpointType) {
-				t.Fatalf("Expected no EDS push, got %v", upd)
+
+			validateEndpoints := func(expectPush bool, healthy []string, unhealthy []string) {
+				t.Helper()
+				// Normalize lists to make comparison easier
+				if healthy == nil {
+					healthy = []string{}
+				}
+				if unhealthy == nil {
+					unhealthy = []string{}
+				}
+				sort.Strings(healthy)
+				sort.Strings(unhealthy)
+				if expectPush {
+					upd, _ := adscon.Wait(5*time.Second, v3.EndpointType)
+
+					if len(upd) > 0 && !slices.Contains(upd, v3.EndpointType) {
+						t.Fatalf("Expecting EDS push as endpoint health is changed. But received %v", upd)
+					}
+				} else {
+					upd, _ := adscon.Wait(50*time.Millisecond, v3.EndpointType)
+					if slices.Contains(upd, v3.EndpointType) {
+						t.Fatalf("Expected no EDS push, got %v", upd)
+					}
+				}
+
+				// Validate that endpoints are pushed.
+				lbe := adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
+				eh, euh := xdstest.ExtractHealthEndpoints(lbe)
+				gotHealthy := sets.SortedList(sets.New(eh...))
+				gotUnhealthy := sets.SortedList(sets.New(euh...))
+				if !reflect.DeepEqual(gotHealthy, healthy) {
+					t.Fatalf("did not get expected endpoints: got %v, want %v", gotHealthy, healthy)
+				}
+				if !reflect.DeepEqual(gotUnhealthy, unhealthy) {
+					t.Fatalf("did not get expected unhealthy endpoints: got %v, want %v", gotUnhealthy, unhealthy)
+				}
 			}
-		}
 
-		// Validate that endpoints are pushed.
-		lbe := adscon.GetEndpoints()["outbound|53||unhealthy.svc.cluster.local"]
-		eh, euh := xdstest.ExtractHealthEndpoints(lbe)
-		gotHealthy := sets.SortedList(sets.New(eh...))
-		gotUnhealthy := sets.SortedList(sets.New(euh...))
-		if !reflect.DeepEqual(gotHealthy, healthy) {
-			t.Fatalf("did not get expected endpoints: got %v, want %v", gotHealthy, healthy)
-		}
-		if !reflect.DeepEqual(gotUnhealthy, unhealthy) {
-			t.Fatalf("did not get expected unhealthy endpoints: got %v, want %v", gotUnhealthy, unhealthy)
-		}
+			// Validate that we do send initial unhealthy endpoints.
+			if sendUnhealthy {
+				validateEndpoints(true, nil, []string{"10.0.0.53:53"})
+			} else {
+				validateEndpoints(true, nil, nil)
+			}
+			adscon.WaitClear()
+
+			t.Log("blah")
+			// Set additional unhealthy endpoint and validate Eds update is not triggered.
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.UnHealthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.UnHealthy,
+					},
+				})
+
+			// Validate that endpoint is pushed.
+			if sendUnhealthy {
+				validateEndpoints(true, nil, []string{"10.0.0.53:53", "10.0.0.54:53"})
+			} else {
+				validateEndpoints(false, nil, nil)
+			}
+
+			// Change the status of endpoint to Healthy and validate Eds is pushed.
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+
+			// Validate that endpoints are pushed.
+			validateEndpoints(true, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
+
+			// Set to exact same endpoints
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+			// Validate that endpoint is not pushed.
+			validateEndpoints(false, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
+
+			// Now change the status of endpoint to UnHealthy and validate Eds is pushed.
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.UnHealthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+
+			// Validate that endpoints are pushed.
+			if sendUnhealthy {
+				validateEndpoints(true, []string{"10.0.0.54:53"}, []string{"10.0.0.53:53"})
+			} else {
+				validateEndpoints(true, []string{"10.0.0.54:53"}, nil)
+			}
+
+			// Change the status of endpoint to Healthy and validate Eds is pushed.
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+
+			validateEndpoints(true, []string{"10.0.0.54:53", "10.0.0.53:53"}, nil)
+
+			// Remove a healthy endpoint
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+
+			validateEndpoints(true, []string{"10.0.0.53:53"}, nil)
+
+			// Remove last healthy endpoint
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "", []*model.IstioEndpoint{})
+			validateEndpoints(true, nil, nil)
+		})
 	}
-
-	// Validate that we do  send initial unhealthy endpoints.
-	validateEndpoints(true, nil, []string{"10.0.0.53:53"})
-	adscon.WaitClear()
-
-	// Set additional unhealthy endpoint and validate Eds update is not triggered.
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.UnHealthy,
-			},
-			{
-				Address:         "10.0.0.54",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.UnHealthy,
-			},
-		})
-
-	// Validate that endpoint is pushed.
-	validateEndpoints(true, nil, []string{"10.0.0.53:53", "10.0.0.54:53"})
-
-	// Change the status of endpoint to Healthy and validate Eds is pushed.
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-			{
-				Address:         "10.0.0.54",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-		})
-
-	// Validate that endpoints are pushed.
-	validateEndpoints(true, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
-
-	// Set to exact same endpoints
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-			{
-				Address:         "10.0.0.54",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-		})
-	// Validate that endpoint is not pushed.
-	validateEndpoints(false, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
-
-	// Now change the status of endpoint to UnHealthy and validate Eds is pushed.
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.UnHealthy,
-			},
-			{
-				Address:         "10.0.0.54",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-		})
-
-	// Validate that endpoints are pushed.
-	validateEndpoints(true, []string{"10.0.0.54:53"}, []string{"10.0.0.53:53"})
-
-	// Change the status of endpoint to Healthy and validate Eds is pushed.
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-			{
-				Address:         "10.0.0.54",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-		})
-
-	validateEndpoints(true, []string{"10.0.0.54:53", "10.0.0.53:53"}, nil)
-
-	// Remove a healthy endpoint
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.0.0.53",
-				EndpointPort:    53,
-				ServicePortName: "tcp-dns",
-				HealthStatus:    model.Healthy,
-			},
-		})
-
-	validateEndpoints(true, []string{"10.0.0.53:53"}, nil)
-
-	// Remove last healthy endpoint
-	s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "", []*model.IstioEndpoint{})
-	validateEndpoints(true, nil, nil)
 }
 
 // Validates the behavior when Service resolution type is updated after initial EDS push.

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -493,7 +493,7 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint, svcPort *
 		return false
 	}
 	// Filter out unhealthy endpoints
-	if !features.SendUnhealthyEndpoints.Load() && !(ep.HealthStatus == model.Healthy || ep.HealthStatus == model.UnknownHealthStatus) {
+	if !features.SendUnhealthyEndpoints.Load() && ep.HealthStatus == model.UnHealthy {
 		return false
 	}
 	// Draining endpoints are only sent to 'persistent session' clusters.

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -492,6 +492,10 @@ func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint, svcPort *
 	if ep.Address == "" && (!b.gateways().IsMultiNetworkEnabled() || b.proxy.InNetwork(ep.Network)) {
 		return false
 	}
+	// Filter out unhealthy endpoints
+	if !features.SendUnhealthyEndpoints.Load() && !(ep.HealthStatus == model.Healthy || ep.HealthStatus == model.UnknownHealthStatus) {
+		return false
+	}
 	// Draining endpoints are only sent to 'persistent session' clusters.
 	draining := ep.HealthStatus == model.Draining ||
 		features.DrainingLabel != "" && ep.Labels[features.DrainingLabel] != ""

--- a/releasenotes/notes/terminating-headless.yaml
+++ b/releasenotes/notes/terminating-headless.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47348
+releaseNotes:
+  - |
+    **Fixed** an issue causing traffic to terminating headless service instances to not function correctly.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/47348.

In previous versions, we used a different mechanism to get service instances that didn't filter unhealthy endpoints. We then switched to use the unified EDS source.

This fixes this by passing unhealthy endpoints through far enough to include them in SA computation, and filtering later.

This probably needs to be backported.
