### PR TITLE
cni: 1.19 cherrypicks

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -26,8 +26,6 @@ import (
 	"istio.io/istio/cni/pkg/plugin"
 	"istio.io/istio/pkg/log"
 	istioversion "istio.io/istio/pkg/version"
-	"istio.io/istio/tools/istio-iptables/pkg/cmd"
-	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 func main() {
@@ -41,24 +39,6 @@ func main() {
 		// to https://github.com/uber-go/zap/issues/328
 		_ = log.Sync()
 	}()
-
-	// configure-routes allows setting up the iproute2 configuration.
-	// This is an old workaround and kept in place to preserve old behavior.
-	// It is called standalone when HostNSEnterExec=true.
-	// Default behavior is to use go netns, which is not in need for this:
-
-	// Older versions of Go < 1.10 cannot change network namespaces safely within a go program
-	// (see https://www.weave.works/blog/linux-namespaces-and-go-don-t-mix).
-	// As a result, the flow is:
-	// * CNI plugin is called with no args, skipping this section.
-	// * CNI code invokes iptables code with CNIMode=true. This in turn runs 'nsenter -- istio-cni configure-routes'
-	if len(os.Args) > 1 && os.Args[1] == constants.CommandConfigureRoutes {
-		if err := cmd.GetRouteCommand().Execute(); err != nil {
-			log.Errorf("failed to configure routes: %v", err)
-			os.Exit(1)
-		}
-		return
-	}
 
 	// TODO: implement plugin version
 	skel.PluginMain(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -76,9 +76,6 @@ type InstallConfig struct {
 
 	// Whether ebpf is enabled
 	EbpfEnabled bool
-
-	// Use the external nsenter command for network namespace switching
-	HostNSEnterExec bool
 }
 
 // RepairConfig struct defines the Istio CNI race repair configuration
@@ -132,7 +129,6 @@ func (c InstallConfig) String() string {
 	b.WriteString("K8sNodeName: " + c.K8sNodeName + "\n")
 	b.WriteString("MonitoringPort: " + fmt.Sprint(c.MonitoringPort) + "\n")
 	b.WriteString("LogUDSAddress: " + fmt.Sprint(c.LogUDSAddress) + "\n")
-	b.WriteString("HostNSEnterExec: " + fmt.Sprint(c.HostNSEnterExec) + "\n")
 
 	b.WriteString("AmbientEnabled: " + fmt.Sprint(c.AmbientEnabled) + "\n")
 

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -35,7 +35,6 @@ var getNs = ns.GetNS
 // provided in Redirect.
 func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.CNIMode, true)
-	viper.Set(constants.HostNSEnterExec, rdrct.hostNSEnterExec)
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -79,11 +79,10 @@ type Config struct {
 	PrevResult    *cniv1.Result   `json:"-"`
 
 	// Add plugin-specific flags here
-	LogLevel        string     `json:"log_level"`
-	LogUDSAddress   string     `json:"log_uds_address"`
-	AmbientEnabled  bool       `json:"ambient_enabled"`
-	Kubernetes      Kubernetes `json:"kubernetes"`
-	HostNSEnterExec bool       `json:"hostNSEnterExec"`
+	LogLevel       string     `json:"log_level"`
+	LogUDSAddress  string     `json:"log_uds_address"`
+	AmbientEnabled bool       `json:"ambient_enabled"`
+	Kubernetes     Kubernetes `json:"kubernetes"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
@@ -323,7 +322,6 @@ func doRun(args *skel.CmdArgs, conf *Config) error {
 		return fmt.Errorf("redirect failed to find InterceptRuleMgr")
 	}
 
-	redirect.hostNSEnterExec = conf.HostNSEnterExec
 	rulesMgr := interceptMgrCtor()
 	if err := rulesMgr.Program(podName, args.Netns, redirect); err != nil {
 		return err

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -90,7 +90,6 @@ type Redirect struct {
 	dnsRedirect          bool
 	dualStack            bool
 	invalidDrop          bool
-	hostNSEnterExec      bool
 }
 
 type annotationValidationFunc func(value string) error

--- a/releasenotes/notes/iptables-lock.yaml
+++ b/releasenotes/notes/iptables-lock.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** `iptables` locking. The new implementation uses `iptables` builtin lock waiting when needed, and disables locking entirely when not needed.

--- a/tools/istio-clean-iptables/pkg/cmd/root.go
+++ b/tools/istio-clean-iptables/pkg/cmd/root.go
@@ -105,46 +105,27 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	viper.AutomaticEnv()
 	// Replace - with _; so that environment variables are looked up correctly.
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	if err := viper.BindPFlag(constants.DryRun, cmd.Flags().Lookup(constants.DryRun)); err != nil {
-		handleError(err)
+	bind := func(name string, def any) {
+		if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
+			handleError(err)
+		}
+		viper.SetDefault(name, def)
 	}
-	viper.SetDefault(constants.DryRun, false)
-
-	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
-		handleError(err)
+	bindEnv := func(name string, def any) {
+		if err := viper.BindEnv(name); err != nil {
+			handleError(err)
+		}
+		viper.SetDefault(name, def)
 	}
-	viper.SetDefault(constants.ProxyUID, "")
 
-	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyGID, "")
-
-	if err := viper.BindPFlag(constants.RedirectDNS, cmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
-
-	if err := viper.BindEnv(constants.OwnerGroupsInclude.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OwnerGroupsInclude.Name, constants.OwnerGroupsInclude.DefaultValue)
-
-	if err := viper.BindEnv(constants.OwnerGroupsExclude.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OwnerGroupsExclude.Name, constants.OwnerGroupsExclude.DefaultValue)
-
-	if err := viper.BindEnv(constants.IstioInboundInterceptionMode.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.IstioInboundInterceptionMode.Name, constants.IstioInboundInterceptionMode.DefaultValue)
-
-	if err := viper.BindEnv(constants.IstioInboundTproxyMark.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.IstioInboundTproxyMark.Name, constants.IstioInboundTproxyMark.DefaultValue)
+	bind(constants.DryRun, false)
+	bind(constants.ProxyUID, "")
+	bind(constants.ProxyGID, "")
+	bind(constants.RedirectDNS, dnsCaptureByAgent)
+	bindEnv(constants.OwnerGroupsInclude.Name, constants.OwnerGroupsInclude.DefaultValue)
+	bindEnv(constants.OwnerGroupsExclude.Name, constants.OwnerGroupsExclude.DefaultValue)
+	bindEnv(constants.IstioInboundInterceptionMode.Name, constants.IstioInboundInterceptionMode.DefaultValue)
+	bindEnv(constants.IstioInboundTproxyMark.Name, constants.IstioInboundTproxyMark.DefaultValue)
 }
 
 // https://github.com/spf13/viper/issues/233.

--- a/tools/istio-iptables/pkg/capture/run_linux.go
+++ b/tools/istio-iptables/pkg/capture/run_linux.go
@@ -16,7 +16,6 @@ package capture
 import (
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -95,11 +94,6 @@ func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
 		return nil
 	}
 	if ext != nil && cfg.CNIMode {
-		if cfg.HostNSEnterExec {
-			command := os.Args[0]
-			return ext.Run(command, nil, constants.CommandConfigureRoutes)
-		}
-
 		nsContainer, err := ns.GetNS(cfg.NetworkNamespace)
 		if err != nil {
 			return err

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -67,9 +67,14 @@ var rootCmd = &cobra.Command{
 		if cfg.DryRun {
 			ext = &dep.StdoutStubDependencies{}
 		} else {
+			ipv, err := dep.DetectIptablesVersion(cfg.IPTablesVersion)
+			if err != nil {
+				handleErrorWithCode(err, 1)
+			}
 			ext = &dep.RealDependencies{
 				CNIMode:          cfg.CNIMode,
 				NetworkNamespace: cfg.NetworkNamespace,
+				IptablesVersion:  ipv,
 			}
 		}
 
@@ -276,6 +281,7 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	bind(constants.CaptureAllDNS, false)
 	bind(constants.NetworkNamespace, "")
 	bind(constants.CNIMode, false)
+	bind(constants.IptablesVersion, "")
 	bind(constants.DualStack, DualStack)
 }
 
@@ -362,6 +368,8 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 
 	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
+
+	rootCmd.Flags().String(constants.IptablesVersion, "", "version of iptables command. If not set, this is automatically detected.")
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -252,169 +252,51 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	// Replace - with _; so that environment variables are looked up correctly.
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	envoyPort := "15001"
-	inboundPort := "15006"
-	inboundTunnelPort := "15008"
-
-	if err := viper.BindPFlag(constants.EnvoyPort, cmd.Flags().Lookup(constants.EnvoyPort)); err != nil {
-		handleError(err)
+	bind := func(name string, def any) {
+		if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
+			handleError(err)
+		}
+		viper.SetDefault(name, def)
 	}
-	viper.SetDefault(constants.EnvoyPort, envoyPort)
-
-	if err := viper.BindPFlag(constants.InboundCapturePort, cmd.Flags().Lookup(constants.InboundCapturePort)); err != nil {
-		handleError(err)
+	bindEnv := func(name string, def any) {
+		if err := viper.BindEnv(name); err != nil {
+			handleError(err)
+		}
+		viper.SetDefault(name, def)
 	}
-	viper.SetDefault(constants.InboundCapturePort, inboundPort)
 
-	if err := viper.BindPFlag(constants.InboundTunnelPort, cmd.Flags().Lookup(constants.InboundTunnelPort)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundTunnelPort, inboundTunnelPort)
-
-	if err := viper.BindPFlag(constants.ProxyUID, cmd.Flags().Lookup(constants.ProxyUID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyUID, "")
-
-	if err := viper.BindPFlag(constants.ProxyGID, cmd.Flags().Lookup(constants.ProxyGID)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProxyGID, "")
-
-	if err := viper.BindPFlag(constants.InboundInterceptionMode, cmd.Flags().Lookup(constants.InboundInterceptionMode)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundInterceptionMode, "")
-
-	if err := viper.BindPFlag(constants.InboundPorts, cmd.Flags().Lookup(constants.InboundPorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundPorts, "")
-
-	if err := viper.BindPFlag(constants.LocalExcludePorts, cmd.Flags().Lookup(constants.LocalExcludePorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.LocalExcludePorts, "")
-
-	if err := viper.BindPFlag(constants.ExcludeInterfaces, cmd.Flags().Lookup(constants.ExcludeInterfaces)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ExcludeInterfaces, "")
-
-	if err := viper.BindPFlag(constants.ServiceCidr, cmd.Flags().Lookup(constants.ServiceCidr)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ServiceCidr, "")
-
-	if err := viper.BindPFlag(constants.ServiceExcludeCidr, cmd.Flags().Lookup(constants.ServiceExcludeCidr)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ServiceExcludeCidr, "")
-
-	if err := viper.BindEnv(constants.OwnerGroupsInclude.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OwnerGroupsInclude.Name, constants.OwnerGroupsInclude.DefaultValue)
-
-	if err := viper.BindEnv(constants.OwnerGroupsExclude.Name); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OwnerGroupsExclude.Name, constants.OwnerGroupsExclude.DefaultValue)
-
-	if err := viper.BindPFlag(constants.OutboundPorts, cmd.Flags().Lookup(constants.OutboundPorts)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OutboundPorts, "")
-
-	if err := viper.BindPFlag(constants.LocalOutboundPortsExclude, cmd.Flags().Lookup(constants.LocalOutboundPortsExclude)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.LocalOutboundPortsExclude, "")
-
-	if err := viper.BindPFlag(constants.KubeVirtInterfaces, cmd.Flags().Lookup(constants.KubeVirtInterfaces)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.KubeVirtInterfaces, "")
-
-	if err := viper.BindPFlag(constants.InboundTProxyMark, cmd.Flags().Lookup(constants.InboundTProxyMark)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundTProxyMark, "1337")
-
-	if err := viper.BindPFlag(constants.InboundTProxyRouteTable, cmd.Flags().Lookup(constants.InboundTProxyRouteTable)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.InboundTProxyRouteTable, "133")
-
-	if err := viper.BindPFlag(constants.DryRun, cmd.Flags().Lookup(constants.DryRun)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.DryRun, false)
-
-	if err := viper.BindPFlag(constants.TraceLogging, cmd.Flags().Lookup(constants.TraceLogging)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.TraceLogging, false)
-
-	if err := viper.BindPFlag(constants.RestoreFormat, cmd.Flags().Lookup(constants.RestoreFormat)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RestoreFormat, true)
-
-	if err := viper.BindPFlag(constants.IptablesProbePort, cmd.Flags().Lookup(constants.IptablesProbePort)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.IptablesProbePort, constants.DefaultIptablesProbePort)
-
-	if err := viper.BindPFlag(constants.ProbeTimeout, cmd.Flags().Lookup(constants.ProbeTimeout)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.ProbeTimeout, constants.DefaultProbeTimeout)
-
-	if err := viper.BindPFlag(constants.SkipRuleApply, cmd.Flags().Lookup(constants.SkipRuleApply)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.SkipRuleApply, false)
-
-	if err := viper.BindPFlag(constants.RunValidation, cmd.Flags().Lookup(constants.RunValidation)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RunValidation, false)
-
-	if err := viper.BindPFlag(constants.RedirectDNS, cmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
-
-	if err := viper.BindPFlag(constants.DropInvalid, cmd.Flags().Lookup(constants.DropInvalid)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.DropInvalid, InvalidDropByIptables)
-
-	if err := viper.BindPFlag(constants.CaptureAllDNS, cmd.Flags().Lookup(constants.CaptureAllDNS)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.CaptureAllDNS, false)
-
-	if err := viper.BindPFlag(constants.NetworkNamespace, cmd.Flags().Lookup(constants.NetworkNamespace)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.NetworkNamespace, "")
-
-	if err := viper.BindPFlag(constants.CNIMode, cmd.Flags().Lookup(constants.CNIMode)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.CNIMode, false)
-
-	if err := viper.BindPFlag(constants.HostNSEnterExec, cmd.Flags().Lookup(constants.HostNSEnterExec)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.HostNSEnterExec, false)
-
-	if err := viper.BindPFlag(constants.DualStack, cmd.Flags().Lookup(constants.DualStack)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.DualStack, DualStack)
+	bind(constants.EnvoyPort, "15001")
+	bind(constants.InboundCapturePort, "15006")
+	bind(constants.InboundTunnelPort, "15008")
+	bind(constants.ProxyUID, "")
+	bind(constants.ProxyGID, "")
+	bind(constants.InboundInterceptionMode, "")
+	bind(constants.InboundPorts, "")
+	bind(constants.LocalExcludePorts, "")
+	bind(constants.ExcludeInterfaces, "")
+	bind(constants.ServiceCidr, "")
+	bind(constants.ServiceExcludeCidr, "")
+	bindEnv(constants.OwnerGroupsInclude.Name, constants.OwnerGroupsInclude.DefaultValue)
+	bindEnv(constants.OwnerGroupsExclude.Name, constants.OwnerGroupsExclude.DefaultValue)
+	bind(constants.OutboundPorts, "")
+	bind(constants.LocalOutboundPortsExclude, "")
+	bind(constants.KubeVirtInterfaces, "")
+	bind(constants.InboundTProxyMark, "1337")
+	bind(constants.InboundTProxyRouteTable, "133")
+	bind(constants.DryRun, false)
+	bind(constants.TraceLogging, false)
+	bind(constants.RestoreFormat, true)
+	bind(constants.IptablesProbePort, constants.DefaultIptablesProbePort)
+	bind(constants.ProbeTimeout, constants.DefaultProbeTimeout)
+	bind(constants.SkipRuleApply, false)
+	bind(constants.RunValidation, false)
+	bind(constants.RedirectDNS, dnsCaptureByAgent)
+	bind(constants.DropInvalid, InvalidDropByIptables)
+	bind(constants.CaptureAllDNS, false)
+	bind(constants.NetworkNamespace, "")
+	bind(constants.CNIMode, false)
+	bind(constants.HostNSEnterExec, false)
+	bind(constants.DualStack, DualStack)
 }
 
 // https://github.com/spf13/viper/issues/233.
@@ -511,10 +393,4 @@ func GetCommand() *cobra.Command {
 
 func GetRouteCommand() *cobra.Command {
 	return configureRoutesCommand
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		handleError(err)
-	}
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -69,7 +69,6 @@ var rootCmd = &cobra.Command{
 		} else {
 			ext = &dep.RealDependencies{
 				CNIMode:          cfg.CNIMode,
-				HostNSEnterExec:  cfg.HostNSEnterExec,
 				NetworkNamespace: cfg.NetworkNamespace,
 			}
 		}
@@ -100,23 +99,6 @@ If installed with 'cni.repair.deletePods=true', this pod should automatically be
 Otherwise, this pod will need to be manually removed so that it is scheduled on a node with istio-cni running, allowing iptables rules to be established.
 `)
 				handleErrorWithCode(msg, constants.ValidationErrorCode)
-			}
-		}
-	},
-}
-
-var configureRoutesCommand = &cobra.Command{
-	Use:    "configure-routes",
-	Short:  "Configures iproute2 rules for the Istio sidecar",
-	PreRun: bindFlags,
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := constructConfig()
-		if err := cfg.Validate(); err != nil {
-			handleErrorWithCode(err, 1)
-		}
-		if !cfg.SkipRuleApply {
-			if err := capture.ConfigureRoutes(cfg, nil); err != nil {
-				handleErrorWithCode(err, 1)
 			}
 		}
 	},
@@ -155,7 +137,6 @@ func constructConfig() *config.Config {
 		NetworkNamespace:        viper.GetString(constants.NetworkNamespace),
 		CNIMode:                 viper.GetBool(constants.CNIMode),
 		DualStack:               viper.GetBool(constants.DualStack),
-		HostNSEnterExec:         viper.GetBool(constants.HostNSEnterExec),
 	}
 
 	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
@@ -295,7 +276,6 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	bind(constants.CaptureAllDNS, false)
 	bind(constants.NetworkNamespace, "")
 	bind(constants.CNIMode, false)
-	bind(constants.HostNSEnterExec, false)
 	bind(constants.DualStack, DualStack)
 }
 
@@ -304,7 +284,6 @@ func bindFlags(cmd *cobra.Command, args []string) {
 // Otherwise, the flag with the same name shared across subcommands will be overwritten by the last.
 func init() {
 	bindCmdlineFlags(rootCmd)
-	bindCmdlineFlags(configureRoutesCommand)
 }
 
 func bindCmdlineFlags(rootCmd *cobra.Command) {
@@ -383,14 +362,8 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 
 	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
-
-	rootCmd.Flags().Bool(constants.HostNSEnterExec, false, "Instead of using the internal go netns, use the nsenter command for switching network namespaces.")
 }
 
 func GetCommand() *cobra.Command {
 	return rootCmd
-}
-
-func GetRouteCommand() *cobra.Command {
-	return configureRoutesCommand
 }

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
+	IPTablesVersion         string        `json:"IPTABLES_VERSION"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 	DualStack               bool          `json:"DUAL_STACK"`
 }
@@ -73,6 +74,7 @@ func (c *Config) String() string {
 
 func (c *Config) Print() {
 	var b strings.Builder
+	b.WriteString(fmt.Sprintf("IPTABLES_VERSION=%s\n", c.IPTablesVersion))
 	b.WriteString(fmt.Sprintf("PROXY_PORT=%s\n", c.ProxyPort))
 	b.WriteString(fmt.Sprintf("PROXY_INBOUND_CAPTURE_PORT=%s\n", c.InboundCapturePort))
 	b.WriteString(fmt.Sprintf("PROXY_TUNNEL_PORT=%s\n", c.InboundTunnelPort))

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -59,7 +59,6 @@ type Config struct {
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
-	HostNSEnterExec         bool          `json:"HOST_NSENTER_EXEC"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
 	DualStack               bool          `json:"DUAL_STACK"`
 }
@@ -99,7 +98,6 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.CNIMode)))
-	b.WriteString(fmt.Sprintf("HOST_NSENTER_EXEC=%s\n", strconv.FormatBool(c.HostNSEnterExec)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))
 	log.Infof("Istio iptables variables:\n%s", b.String())
 }

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -107,6 +107,7 @@ const (
 	CaptureAllDNS             = "capture-all-dns"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
+	IptablesVersion           = "iptables-version"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -96,7 +96,6 @@ const (
 	KubeVirtInterfaces        = "kube-virt-interfaces"
 	DryRun                    = "dry-run"
 	TraceLogging              = "iptables-trace-logging"
-	Clean                     = "clean"
 	RestoreFormat             = "restore-format"
 	SkipRuleApply             = "skip-rule-apply"
 	RunValidation             = "run-validation"
@@ -108,7 +107,6 @@ const (
 	CaptureAllDNS             = "capture-all-dns"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
-	HostNSEnterExec           = "host-nsenter-exec"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.
@@ -140,8 +138,7 @@ const (
 
 // Constants used in environment variables
 const (
-	DisableRedirectionOnLocalLoopback = "DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK"
-	EnvoyUser                         = "ENVOY_USER"
+	EnvoyUser = "ENVOY_USER"
 )
 
 // Constants for iptables commands
@@ -152,7 +149,6 @@ const (
 	IP6TABLES        = "ip6tables"
 	IP6TABLESRESTORE = "ip6tables-restore"
 	IP6TABLESSAVE    = "ip6tables-save"
-	NSENTER          = "nsenter"
 )
 
 // Constants for syscall
@@ -174,8 +170,4 @@ const (
 // DNS ports
 const (
 	IstioAgentDNSListenerPort = "15053"
-)
-
-const (
-	CommandConfigureRoutes = "configure-routes"
 )

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -15,12 +15,14 @@
 package dependencies
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
@@ -61,10 +63,58 @@ var XTablesCmds = sets.New(
 	constants.IP6TABLESSAVE,
 )
 
+// XTablesWriteCmds contains all xtables commands that do write actions (and thus need a lock)
+var XTablesWriteCmds = sets.New(
+	constants.IPTABLES,
+	constants.IP6TABLES,
+	constants.IPTABLESRESTORE,
+	constants.IP6TABLESRESTORE,
+)
+
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
+	IptablesVersion  IptablesVersion
 	NetworkNamespace string
 	CNIMode          bool
+}
+
+const iptablesVersionPattern = `v([0-9]+(\.[0-9]+)+)`
+
+type IptablesVersion struct {
+	// the actual version
+	version *utilversion.Version
+	// true if legacy mode, false if nf_tables
+	legacy bool
+}
+
+// NoLocks returns true if this version does not use or support locks
+func (v IptablesVersion) NoLocks() bool {
+	// nf_tables does not use locks
+	// legacy added locks in 1.6.2
+	return !v.legacy || v.version.LessThan(IptablesRestoreLocking)
+}
+
+func DetectIptablesVersion(ver string) (IptablesVersion, error) {
+	if ver == "" {
+		var err error
+		verb, err := exec.Command("iptables", "--version").CombinedOutput()
+		if err != nil {
+			return IptablesVersion{}, err
+		}
+		ver = string(verb)
+	}
+	// Legacy will have no marking or 'legacy', so just look for nf_tables
+	nft := strings.Contains(ver, "nf_tables")
+	versionMatcher := regexp.MustCompile(iptablesVersionPattern)
+	match := versionMatcher.FindStringSubmatch(ver)
+	if match == nil {
+		return IptablesVersion{}, fmt.Errorf("no iptables version found: %q", ver)
+	}
+	version, err := utilversion.ParseGeneric(match[1])
+	if err != nil {
+		return IptablesVersion{}, fmt.Errorf("iptables version %q is not a valid version string: %v", match[1], err)
+	}
+	return IptablesVersion{version: version, legacy: !nft}, nil
 }
 
 // transformToXTablesErrorMessage returns an updated error message with explicit xtables error hints, if applicable.
@@ -93,37 +143,6 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 	}
 
 	return stderr
-}
-
-func isXTablesLockError(stderr *bytes.Buffer, exitcode int) bool {
-	// xtables lock acquire failure maps to resource problem exit code.
-	// https://git.netfilter.org/iptables/tree/iptables/iptables.c?h=v1.6.0#n1769
-	if exitcode != int(XTablesResourceProblem) {
-		return false
-	}
-
-	// check stderr output and see if there is `xtables lock` in it.
-	// https://git.netfilter.org/iptables/tree/iptables/iptables.c?h=v1.6.0#n1763
-	if strings.Contains(stderr.String(), "xtables lock") {
-		return true
-	}
-
-	return false
-}
-
-func exitCode(err error) (int, bool) {
-	if err == nil {
-		return 0, false
-	}
-
-	ee, ok := err.(*exec.ExitError)
-	if !ok {
-		// Not common, but can happen if file not found error, etc
-		return 0, false
-	}
-
-	exitcode := ee.ExitCode()
-	return exitcode, true
 }
 
 // RunOrFail runs a command and exits with an error message, if it fails

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -64,7 +64,6 @@ var XTablesCmds = sets.New(
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
 	NetworkNamespace string
-	HostNSEnterExec  bool
 	CNIMode          bool
 }
 

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -16,17 +16,17 @@ package dependencies
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"os/exec"
 	"strings"
-	"time"
+	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 
-	"istio.io/istio/pkg/backoff"
 	"istio.io/istio/pkg/log"
 )
 
@@ -49,22 +49,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 		}
 		externalCommand.Env = append(externalCommand.Env, fmt.Sprintf("%s=%v", strings.ToUpper(repl.Replace(k)), v))
 	}
-	var err error
-	var nsContainer ns.NetNS
-	if r.CNIMode {
-		nsContainer, err = ns.GetNS(r.NetworkNamespace)
-		if err != nil {
-			return err
-		}
-
-		err = nsContainer.Do(func(ns.NetNS) error {
-			return externalCommand.Run()
-		})
-		nsContainer.Close()
-	} else {
-		err = externalCommand.Run()
-	}
-
+	err := r.runCommand(externalCommand)
 	if len(stdout.String()) != 0 {
 		log.Infof("Command output: \n%v", stdout.String())
 	}
@@ -76,67 +61,73 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 	return err
 }
 
-func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
-
-	var stdout, stderr *bytes.Buffer
-	var err error
-	var nsContainer ns.NetNS
-
+func (r *RealDependencies) runCommand(c *exec.Cmd) error {
 	if r.CNIMode {
-		nsContainer, err = ns.GetNS(r.NetworkNamespace)
+		n, err := ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
 		}
-		defer nsContainer.Close()
+		defer n.Close()
+
+		return n.Do(func(ns.NetNS) error {
+			return c.Run()
+		})
 	}
-	o := backoff.Option{
-		InitialInterval: 100 * time.Millisecond,
-		MaxInterval:     2 * time.Second,
-	}
-	b := backoff.NewExponentialBackOff(o)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	backoffError := b.RetryWithContext(ctx, func() error {
-		externalCommand := exec.Command(cmd, args...)
-		stdout = &bytes.Buffer{}
-		stderr = &bytes.Buffer{}
-		externalCommand.Stdout = stdout
-		externalCommand.Stderr = stderr
-		externalCommand.Stdin = stdin
-		if stdin != nil {
-			if _, err := stdin.Seek(0, io.SeekStart); err != nil {
-				return err
-			}
-		}
+	return c.Run()
+}
+
+var (
+	// IptablesRestoreLocking is the version where locking and -w is added to iptables-restore
+	IptablesRestoreLocking = utilversion.MustParseGeneric("1.6.2")
+	// IptablesLockfileEnv is the version where XTABLES_LOCKFILE is added to iptables.
+	IptablesLockfileEnv = utilversion.MustParseGeneric("1.8.6")
+)
+
+func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+	mode := "without lock"
+	var c *exec.Cmd
+	_, needLock := XTablesWriteCmds[cmd]
+	if !needLock || r.IptablesVersion.NoLocks() {
+		// No locking supported/needed, just run as is. Nothing special
+		c = exec.Command(cmd, args...)
+	} else {
 		if r.CNIMode {
-			err = nsContainer.Do(func(ns.NetNS) error {
-				return externalCommand.Run()
-			})
+			// In CNI, we are running the pod network namespace, but the host filesystem. Locking the host is both useless and harmful,
+			// as it opens the risk of lock contention with other node actors (such as kube-proxy), and isn't actually needed at all.
+			// In both cases we are setting the lockfile to `r.NetworkNamespace`.
+			// * /dev/null looks like a good option, but actually doesn't work (it will ensure only one actor can access it)
+			// * `mktemp` works, but it is slightly harder to deal with cleanup and in some platforms we may not have write access.
+			if r.IptablesVersion.version.LessThan(IptablesLockfileEnv) {
+				// Older iptables cannot turn off the lock explicitly, so we hack around it...
+				// Overwrite the lock file with /dev/null
+				// cmd is repeated twice as the first 'cmd' instance becomes $0
+				args := append([]string{"-c", fmt.Sprintf("mount --bind %s /run/xtables.lock; exec $@", r.NetworkNamespace), cmd, cmd}, args...)
+				c = exec.Command("sh", args...)
+				// Run in a new mount namespace so our mount doesn't impact any other processes.
+				c.SysProcAttr = &syscall.SysProcAttr{Unshareflags: unix.CLONE_NEWNS}
+				mode = "without lock by mount"
+			} else {
+				// Available since iptables 1.8.6+, just point to a different file directly
+				c = exec.Command(cmd, args...)
+				c.Env = append(c.Env, "XTABLES_LOCKFILE="+r.NetworkNamespace)
+				mode = "without lock by environment"
+			}
 		} else {
-			err = externalCommand.Run()
+			// We want the lock. Wait up to 30s for it.
+			args = append(args, "--wait=30")
+			c = exec.Command(cmd, args...)
+			log.Debugf("running with lock")
+			mode = "with wait lock"
 		}
-		exitCode, ok := exitCode(err)
-		if !ok {
-			// cannot get exit code. consider this as non-retriable.
-			return nil
-		}
-
-		if !isXTablesLockError(stderr, exitCode) {
-			// Command succeeded, or failed not because of xtables lock.
-			return nil
-		}
-
-		// If command failed because xtables was locked, try the command again.
-		// Note we retry invoking iptables command explicitly instead of using the `-w` option of iptables,
-		// because as of iptables 1.6.x (version shipped with bionic), iptables-restore does not support `-w`.
-		log.Debugf("Failed to acquire XTables lock, retry iptables command..")
-		return err
-	})
-	if backoffError != nil {
-		return fmt.Errorf("timed out trying to acquire XTables lock: %v", err)
 	}
 
+	log.Infof("Running command (%s): %s %s", mode, cmd, strings.Join(args, " "))
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	c.Stdout = stdout
+	c.Stderr = stderr
+	c.Stdin = stdin
+	err := r.runCommand(c)
 	if len(stdout.String()) != 0 {
 		log.Infof("Command output: \n%v", stdout.String())
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -28,15 +28,9 @@ import (
 
 	"istio.io/istio/pkg/backoff"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reader, args ...string) error {
-	if r.CNIMode && r.HostNSEnterExec {
-		originalCmd := cmd
-		cmd = constants.NSENTER
-		args = append([]string{fmt.Sprintf("--net=%v", r.NetworkNamespace), "--", originalCmd}, args...)
-	}
 	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 
 	externalCommand := exec.Command(cmd, args...)
@@ -57,7 +51,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 	}
 	var err error
 	var nsContainer ns.NetNS
-	if r.CNIMode && !r.HostNSEnterExec {
+	if r.CNIMode {
 		nsContainer, err = ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
@@ -83,18 +77,13 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 }
 
 func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	if r.CNIMode && r.HostNSEnterExec {
-		originalCmd := cmd
-		cmd = constants.NSENTER
-		args = append([]string{fmt.Sprintf("--net=%v", r.NetworkNamespace), "--", originalCmd}, args...)
-	}
 	log.Infof("Running command: %s %s", cmd, strings.Join(args, " "))
 
 	var stdout, stderr *bytes.Buffer
 	var err error
 	var nsContainer ns.NetNS
 
-	if r.CNIMode && !r.HostNSEnterExec {
+	if r.CNIMode {
 		nsContainer, err = ns.GetNS(r.NetworkNamespace)
 		if err != nil {
 			return err
@@ -120,7 +109,7 @@ func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin i
 				return err
 			}
 		}
-		if r.CNIMode && !r.HostNSEnterExec {
+		if r.CNIMode {
 			err = nsContainer.Do(func(ns.NetNS) error {
 				return externalCommand.Run()
 			})


### PR DESCRIPTION
Cherrypicks of some CNI changes, the most important of which is avoiding taking the host level iptables file lock, which was leading to some significant lock contention and scaling issues. Also includes a couple prior adjacent changes that made the cherrypick cleaner.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ X ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure