### PR TITLE
Add validationIgnorer to crd validator to ignore resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,8 +108,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.12.3
-	istio.io/api v1.19.0-alpha.1.0.20231005164637-4881de7246ff
-	istio.io/client-go v1.19.0-alpha.1.0.20231005165138-e8a971be23eb
+	istio.io/api v1.19.0-alpha.1.0.20231016212338-60a1b113da9e
+	istio.io/client-go v1.19.0-alpha.1.0.20231016212638-60083ed631c6
 	k8s.io/api v0.28.2
 	k8s.io/apiextensions-apiserver v0.28.2
 	k8s.io/apimachinery v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -1379,10 +1379,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v1.19.0-alpha.1.0.20231005164637-4881de7246ff h1:D7RWLJ045Bb6MryDt2HTCWG22YXRAYR3hfdcvoZwH84=
-istio.io/api v1.19.0-alpha.1.0.20231005164637-4881de7246ff/go.mod h1:hFqNwCBpXIy5jboW4geFoz3io9ZR3nVJ4oLI7udf6Vo=
-istio.io/client-go v1.19.0-alpha.1.0.20231005165138-e8a971be23eb h1:EtrpYxQrejldv0s40Aawskb8uQHHwMBwaNYaPGysG2Q=
-istio.io/client-go v1.19.0-alpha.1.0.20231005165138-e8a971be23eb/go.mod h1:NpSpbrMKVT2N1k54mdix1iPEHBiWGq6/+cA21jWZ2XA=
+istio.io/api v1.19.0-alpha.1.0.20231016212338-60a1b113da9e h1:j/VwqNDTet36P5zg52z4lvI3EDIf61biZf0o7ybHF4w=
+istio.io/api v1.19.0-alpha.1.0.20231016212338-60a1b113da9e/go.mod h1:hm1PE/mGdIAsjCDkTIAplP53H7TjO5LUQCiVvF26SVg=
+istio.io/client-go v1.19.0-alpha.1.0.20231016212638-60083ed631c6 h1:27o4dS/6wq3952pl/lwxxjC2VSt5vCMD9GJrZ2inx08=
+istio.io/client-go v1.19.0-alpha.1.0.20231016212638-60083ed631c6/go.mod h1:tDfreMY8/hEe80RDxR3UTTSYdnp6zR7++FyMRfcYXxo=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
 k8s.io/api v0.18.4/go.mod h1:lOIQAKYgai1+vz9J7YcDZwC26Z0zQewYOGWdyIPUUQ4=
 k8s.io/api v0.28.2 h1:9mpl5mOb6vXZvqbQmankOfPIGiudghwCoLl1EYfUZbw=

--- a/manifests/charts/base/crds/crd-all.gen.yaml
+++ b/manifests/charts/base/crds/crd-all.gen.yaml
@@ -56,6 +56,8 @@ spec:
                 type: string
               imagePullSecret:
                 description: Credentials to use for OCI image pulling.
+                maxLength: 253
+                minLength: 1
                 type: string
               match:
                 description: Specifies the criteria to determine which traffic is
@@ -76,9 +78,16 @@ spec:
                       items:
                         properties:
                           number:
+                            maximum: 65535
+                            minimum: 1
                             type: integer
+                        required:
+                        - number
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - number
+                      x-kubernetes-list-type: map
                   type: object
                 type: array
               phase:
@@ -97,6 +106,8 @@ spec:
               pluginName:
                 description: The plugin name to be used in the Envoy configuration
                   (used to be called `rootID`).
+                maxLength: 256
+                minLength: 1
                 type: string
               priority:
                 description: Determines ordering of `WasmPlugins` in the same `phase`.
@@ -116,6 +127,7 @@ spec:
               sha256:
                 description: SHA256 checksum that will be used to verify Wasm module
                   or OCI container.
+                pattern: (^$|^[a-f0-9]{64}$)
                 type: string
               targetRef:
                 properties:
@@ -137,7 +149,14 @@ spec:
                 type: string
               url:
                 description: URL of a Wasm module or OCI container.
+                minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: url must have schema one of [http, https, file, oci]
+                  rule: 'isURL(self) ? (url(self).getScheme() in ['''', ''http'',
+                    ''https'', ''oci'', ''file'']) : (isURL(''http://'' + self) &&
+                    url(''http://'' +self).getScheme() in ['''', ''http'', ''https'',
+                    ''oci'', ''file''])'
               verificationKey:
                 type: string
               vmConfig:
@@ -149,31 +168,46 @@ spec:
                     items:
                       properties:
                         name:
-                          description: Required Name of the environment variable.
+                          description: Name of the environment variable.
+                          maxLength: 256
+                          minLength: 1
                           type: string
                         value:
                           description: Value for the environment variable.
+                          maxLength: 2048
                           type: string
                         valueFrom:
-                          description: Required Source for the environment variable's
-                            value.
+                          description: Source for the environment variable's value.
                           enum:
                           - INLINE
                           - HOST
                           type: string
+                      required:
+                      - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: value may only be set when valueFrom is INLINE
+                        rule: '(has(self.valueFrom) ? self.valueFrom : '''') != ''HOST''
+                          || !has(self.value)'
+                    maxItems: 256
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 type: object
+            required:
+            - url
             type: object
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -334,84 +368,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -425,6 +420,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -654,84 +651,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -745,6 +703,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -1004,8 +964,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -1096,84 +1061,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -1187,6 +1113,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -1410,84 +1338,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1501,6 +1390,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -1751,6 +1642,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -1764,6 +1658,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -1907,84 +1803,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1998,6 +1855,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -2227,84 +2086,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -2318,6 +2138,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -2577,8 +2399,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -2669,84 +2496,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -2760,6 +2548,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -2983,84 +2773,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -3074,6 +2825,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -3324,6 +3077,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -3337,6 +3093,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -3346,7 +3104,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3618,7 +3375,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3693,6 +3449,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3771,6 +3531,9 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -3830,6 +3593,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3908,6 +3675,9 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -3919,7 +3689,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3987,7 +3756,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4117,6 +3885,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4143,6 +3914,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4255,6 +4028,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4281,6 +4057,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4290,7 +4068,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4363,8 +4140,85 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
                 description: Ingress specifies the configuration of the sidecar for
                   processing inbound traffic to the attached workload instance.
@@ -4382,6 +4236,86 @@ spec:
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
                       description: The IP endpoint or Unix domain socket to which
                         traffic should be forwarded to.
@@ -4479,6 +4413,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4499,6 +4435,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4574,8 +4512,85 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
                 description: Ingress specifies the configuration of the sidecar for
                   processing inbound traffic to the attached workload instance.
@@ -4593,6 +4608,86 @@ spec:
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
                       description: The IP endpoint or Unix domain socket to which
                         traffic should be forwarded to.
@@ -4690,6 +4785,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4710,6 +4807,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4737,7 +4836,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4913,6 +5011,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -5285,6 +5385,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -5323,6 +5425,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -5332,6 +5436,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -5451,6 +5557,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -5490,6 +5598,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -5560,12 +5670,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -5611,6 +5725,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -5637,14 +5753,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -5805,6 +5927,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -6177,6 +6301,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -6215,6 +6341,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -6224,6 +6352,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -6343,6 +6473,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -6382,6 +6514,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -6452,12 +6586,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -6503,6 +6641,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -6529,14 +6669,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -6548,7 +6694,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6691,7 +6836,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6805,6 +6949,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6827,6 +6973,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -6866,6 +7014,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -6966,6 +7116,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6988,6 +7140,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -7027,6 +7181,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -7036,7 +7192,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7223,6 +7378,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7418,6 +7575,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7452,7 +7611,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7498,8 +7656,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or
-              not) to the sidecar.
+            description: 'Peer authentication configuration for workloads. See more
+              details at: https://istio.io/docs/reference/config/security/peer_authentication.html'
             properties:
               mtls:
                 description: Mutual TLS settings for workload.
@@ -7547,7 +7705,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7580,8 +7737,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7609,6 +7766,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7648,6 +7807,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7685,8 +7846,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7714,6 +7875,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7753,6 +7916,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7785,7 +7950,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7867,6 +8031,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                   type: object
@@ -7951,6 +8117,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     reportingInterval:
@@ -8060,6 +8228,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     randomSamplingPercentage:
@@ -8081,5 +8251,3 @@ spec:
     storage: true
     subresources:
       status: {}
-
----

--- a/manifests/charts/istiod-remote/templates/crd-all.gen.yaml
+++ b/manifests/charts/istiod-remote/templates/crd-all.gen.yaml
@@ -57,6 +57,8 @@ spec:
                 type: string
               imagePullSecret:
                 description: Credentials to use for OCI image pulling.
+                maxLength: 253
+                minLength: 1
                 type: string
               match:
                 description: Specifies the criteria to determine which traffic is
@@ -77,9 +79,16 @@ spec:
                       items:
                         properties:
                           number:
+                            maximum: 65535
+                            minimum: 1
                             type: integer
+                        required:
+                        - number
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - number
+                      x-kubernetes-list-type: map
                   type: object
                 type: array
               phase:
@@ -98,6 +107,8 @@ spec:
               pluginName:
                 description: The plugin name to be used in the Envoy configuration
                   (used to be called `rootID`).
+                maxLength: 256
+                minLength: 1
                 type: string
               priority:
                 description: Determines ordering of `WasmPlugins` in the same `phase`.
@@ -117,6 +128,7 @@ spec:
               sha256:
                 description: SHA256 checksum that will be used to verify Wasm module
                   or OCI container.
+                pattern: (^$|^[a-f0-9]{64}$)
                 type: string
               targetRef:
                 properties:
@@ -138,7 +150,14 @@ spec:
                 type: string
               url:
                 description: URL of a Wasm module or OCI container.
+                minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: url must have schema one of [http, https, file, oci]
+                  rule: 'isURL(self) ? (url(self).getScheme() in ['''', ''http'',
+                    ''https'', ''oci'', ''file'']) : (isURL(''http://'' + self) &&
+                    url(''http://'' +self).getScheme() in ['''', ''http'', ''https'',
+                    ''oci'', ''file''])'
               verificationKey:
                 type: string
               vmConfig:
@@ -150,31 +169,46 @@ spec:
                     items:
                       properties:
                         name:
-                          description: Required Name of the environment variable.
+                          description: Name of the environment variable.
+                          maxLength: 256
+                          minLength: 1
                           type: string
                         value:
                           description: Value for the environment variable.
+                          maxLength: 2048
                           type: string
                         valueFrom:
-                          description: Required Source for the environment variable's
-                            value.
+                          description: Source for the environment variable's value.
                           enum:
                           - INLINE
                           - HOST
                           type: string
+                      required:
+                      - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: value may only be set when valueFrom is INLINE
+                        rule: '(has(self.valueFrom) ? self.valueFrom : '''') != ''HOST''
+                          || !has(self.value)'
+                    maxItems: 256
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 type: object
+            required:
+            - url
             type: object
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -335,84 +369,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -426,6 +421,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -655,84 +652,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -746,6 +704,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -1005,8 +965,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -1097,84 +1062,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -1188,6 +1114,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -1411,84 +1339,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1502,6 +1391,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -1752,6 +1643,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -1765,6 +1659,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -1908,84 +1804,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -1999,6 +1856,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -2228,84 +2087,45 @@ spec:
                                     anyOf:
                                     - required:
                                       - simple
-                                    - properties:
-                                        consistentHash:
-                                          allOf:
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - httpHeaderName
-                                                - required:
-                                                  - httpCookie
-                                                - required:
-                                                  - useSourceIp
-                                                - required:
-                                                  - httpQueryParameterName
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                          - oneOf:
-                                            - not:
-                                                anyOf:
-                                                - required:
-                                                  - ringHash
-                                                - required:
-                                                  - maglev
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                          properties:
-                                            minimumRingSize: {}
-                                      required:
+                                    - required:
                                       - consistentHash
                                 - required:
                                   - simple
-                                - properties:
-                                    consistentHash:
-                                      allOf:
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                      - oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - ringHash
-                                            - required:
-                                              - maglev
-                                        - required:
-                                          - ringHash
-                                        - required:
-                                          - maglev
-                                      properties:
-                                        minimumRingSize: {}
-                                  required:
+                                - required:
                                   - consistentHash
                                 properties:
                                   consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
                                     properties:
                                       httpCookie:
                                         description: Hash based on HTTP cookie.
@@ -2319,6 +2139,8 @@ spec:
                                           ttl:
                                             description: Lifetime of the cookie.
                                             type: string
+                                        required:
+                                        - name
                                         type: object
                                       httpHeaderName:
                                         description: Hash based on a specific HTTP
@@ -2578,8 +2400,13 @@ spec:
                               description: Specifies a port to which the downstream
                                 connection is tunneled.
                               type: integer
+                          required:
+                          - targetHost
+                          - targetPort
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               trafficPolicy:
@@ -2670,84 +2497,45 @@ spec:
                         anyOf:
                         - required:
                           - simple
-                        - properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                minimumRingSize: {}
-                          required:
+                        - required:
                           - consistentHash
                     - required:
                       - simple
-                    - properties:
-                        consistentHash:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                            - required:
-                              - ringHash
-                            - required:
-                              - maglev
-                          properties:
-                            minimumRingSize: {}
-                      required:
+                    - required:
                       - consistentHash
                     properties:
                       consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
                         properties:
                           httpCookie:
                             description: Hash based on HTTP cookie.
@@ -2761,6 +2549,8 @@ spec:
                               ttl:
                                 description: Lifetime of the cookie.
                                 type: string
+                            required:
+                            - name
                             type: object
                           httpHeaderName:
                             description: Hash based on a specific HTTP header.
@@ -2984,84 +2774,45 @@ spec:
                               anyOf:
                               - required:
                                 - simple
-                              - properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      minimumRingSize: {}
-                                required:
+                              - required:
                                 - consistentHash
                           - required:
                             - simple
-                          - properties:
-                              consistentHash:
-                                allOf:
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                                - oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                  - required:
-                                    - ringHash
-                                  - required:
-                                    - maglev
-                                properties:
-                                  minimumRingSize: {}
-                            required:
+                          - required:
                             - consistentHash
                           properties:
                             consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
                               properties:
                                 httpCookie:
                                   description: Hash based on HTTP cookie.
@@ -3075,6 +2826,8 @@ spec:
                                     ttl:
                                       description: Lifetime of the cookie.
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                                 httpHeaderName:
                                   description: Hash based on a specific HTTP header.
@@ -3325,6 +3078,9 @@ spec:
                         description: Specifies a port to which the downstream connection
                           is tunneled.
                         type: integer
+                    required:
+                    - targetHost
+                    - targetPort
                     type: object
                 type: object
               workloadSelector:
@@ -3338,6 +3094,8 @@ spec:
                       pods/VMs on which a policy should be applied.
                     type: object
                 type: object
+            required:
+            - host
             type: object
           status:
             type: object
@@ -3347,7 +3105,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3619,7 +3376,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3694,6 +3450,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3772,6 +3532,9 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -3831,6 +3594,10 @@ spec:
                           type: string
                         targetPort:
                           type: integer
+                      required:
+                      - number
+                      - protocol
+                      - name
                       type: object
                     tls:
                       description: Set of TLS related options that govern the server's
@@ -3909,6 +3676,9 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
+                  - hosts
                   type: object
                 type: array
             type: object
@@ -3920,7 +3690,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3988,7 +3757,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4118,6 +3886,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4144,6 +3915,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4256,6 +4029,9 @@ spec:
                       description: The port number on the endpoint where the traffic
                         will be received.
                       type: integer
+                  required:
+                  - number
+                  - name
                   type: object
                 type: array
               resolution:
@@ -4282,6 +4058,8 @@ spec:
                       pods/VMs on which the configuration should be applied.
                     type: object
                 type: object
+            required:
+            - hosts
             type: object
           status:
             type: object
@@ -4291,7 +4069,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4364,8 +4141,85 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
                 description: Ingress specifies the configuration of the sidecar for
                   processing inbound traffic to the attached workload instance.
@@ -4383,6 +4237,86 @@ spec:
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
                       description: The IP endpoint or Unix domain socket to which
                         traffic should be forwarded to.
@@ -4480,6 +4414,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4500,6 +4436,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4575,8 +4513,85 @@ spec:
                         targetPort:
                           type: integer
                       type: object
+                  required:
+                  - hosts
                   type: object
                 type: array
+              inboundConnectionPool:
+                description: Settings controlling the volume of connections Envoy
+                  will accept from the network.
+                properties:
+                  http:
+                    description: HTTP connection pool settings.
+                    properties:
+                      h2UpgradePolicy:
+                        description: Specify if http1.1 connection should be upgraded
+                          to http2 for the associated destination.
+                        enum:
+                        - DEFAULT
+                        - DO_NOT_UPGRADE
+                        - UPGRADE
+                        type: string
+                      http1MaxPendingRequests:
+                        description: Maximum number of requests that will be queued
+                          while waiting for a ready connection pool connection.
+                        format: int32
+                        type: integer
+                      http2MaxRequests:
+                        description: Maximum number of active requests to a destination.
+                        format: int32
+                        type: integer
+                      idleTimeout:
+                        description: The idle timeout for upstream connection pool
+                          connections.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: Maximum number of requests per connection to
+                          a backend.
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: Maximum number of retries that can be outstanding
+                          to all hosts in a cluster at a given time.
+                        format: int32
+                        type: integer
+                      useClientProtocol:
+                        description: If set to true, client protocol will be preserved
+                          while initiating connection to backend.
+                        type: boolean
+                    type: object
+                  tcp:
+                    description: Settings common to both HTTP and TCP upstream connections.
+                    properties:
+                      connectTimeout:
+                        description: TCP connection timeout.
+                        type: string
+                      maxConnectionDuration:
+                        description: The maximum duration of a connection.
+                        type: string
+                      maxConnections:
+                        description: Maximum number of HTTP1 /TCP connections to a
+                          destination host.
+                        format: int32
+                        type: integer
+                      tcpKeepalive:
+                        description: If set then set SO_KEEPALIVE on the socket to
+                          enable TCP Keepalives.
+                        properties:
+                          interval:
+                            description: The time duration between keep-alive probes.
+                            type: string
+                          probes:
+                            description: Maximum number of keepalive probes to send
+                              without response before deciding the connection is dead.
+                            type: integer
+                          time:
+                            description: The time duration a connection needs to be
+                              idle before keep-alive probes start being sent.
+                            type: string
+                        type: object
+                    type: object
+                type: object
               ingress:
                 description: Ingress specifies the configuration of the sidecar for
                   processing inbound traffic to the attached workload instance.
@@ -4594,6 +4609,86 @@ spec:
                       - IPTABLES
                       - NONE
                       type: string
+                    connectionPool:
+                      description: Settings controlling the volume of connections
+                        Envoy will accept from the network.
+                      properties:
+                        http:
+                          description: HTTP connection pool settings.
+                          properties:
+                            h2UpgradePolicy:
+                              description: Specify if http1.1 connection should be
+                                upgraded to http2 for the associated destination.
+                              enum:
+                              - DEFAULT
+                              - DO_NOT_UPGRADE
+                              - UPGRADE
+                              type: string
+                            http1MaxPendingRequests:
+                              description: Maximum number of requests that will be
+                                queued while waiting for a ready connection pool connection.
+                              format: int32
+                              type: integer
+                            http2MaxRequests:
+                              description: Maximum number of active requests to a
+                                destination.
+                              format: int32
+                              type: integer
+                            idleTimeout:
+                              description: The idle timeout for upstream connection
+                                pool connections.
+                              type: string
+                            maxRequestsPerConnection:
+                              description: Maximum number of requests per connection
+                                to a backend.
+                              format: int32
+                              type: integer
+                            maxRetries:
+                              description: Maximum number of retries that can be outstanding
+                                to all hosts in a cluster at a given time.
+                              format: int32
+                              type: integer
+                            useClientProtocol:
+                              description: If set to true, client protocol will be
+                                preserved while initiating connection to backend.
+                              type: boolean
+                          type: object
+                        tcp:
+                          description: Settings common to both HTTP and TCP upstream
+                            connections.
+                          properties:
+                            connectTimeout:
+                              description: TCP connection timeout.
+                              type: string
+                            maxConnectionDuration:
+                              description: The maximum duration of a connection.
+                              type: string
+                            maxConnections:
+                              description: Maximum number of HTTP1 /TCP connections
+                                to a destination host.
+                              format: int32
+                              type: integer
+                            tcpKeepalive:
+                              description: If set then set SO_KEEPALIVE on the socket
+                                to enable TCP Keepalives.
+                              properties:
+                                interval:
+                                  description: The time duration between keep-alive
+                                    probes.
+                                  type: string
+                                probes:
+                                  description: Maximum number of keepalive probes
+                                    to send without response before deciding the connection
+                                    is dead.
+                                  type: integer
+                                time:
+                                  description: The time duration a connection needs
+                                    to be idle before keep-alive probes start being
+                                    sent.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
                     defaultEndpoint:
                       description: The IP endpoint or Unix domain socket to which
                         traffic should be forwarded to.
@@ -4691,6 +4786,8 @@ spec:
                             type: string
                           type: array
                       type: object
+                  required:
+                  - port
                   type: object
                 type: array
               outboundTrafficPolicy:
@@ -4711,6 +4808,8 @@ spec:
                       subset:
                         description: The name of a subset within the service.
                         type: string
+                    required:
+                    - host
                     type: object
                   mode:
                     enum:
@@ -4738,7 +4837,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4914,6 +5012,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -5286,6 +5386,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -5324,6 +5426,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -5333,6 +5437,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -5452,6 +5558,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -5491,6 +5599,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -5561,12 +5671,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -5612,6 +5726,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -5638,14 +5754,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -5806,6 +5928,8 @@ spec:
                         status:
                           description: Specifies the HTTP response status to be returned.
                           type: integer
+                      required:
+                      - status
                       type: object
                     fault:
                       description: Fault injection policy to apply on HTTP traffic
@@ -6178,6 +6302,8 @@ spec:
                         subset:
                           description: The name of a subset within the service.
                           type: string
+                      required:
+                      - host
                       type: object
                     mirror_percent:
                       nullable: true
@@ -6216,6 +6342,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           percentage:
                             description: Percentage of the traffic to be mirrored
@@ -6225,6 +6353,8 @@ spec:
                                 format: double
                                 type: number
                             type: object
+                        required:
+                        - destination
                         type: object
                       type: array
                     name:
@@ -6344,6 +6474,8 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           headers:
                             properties:
@@ -6383,6 +6515,8 @@ spec:
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                     timeout:
@@ -6453,12 +6587,16 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
                   type: object
@@ -6504,6 +6642,8 @@ spec:
                             description: Source namespace constraining the applicability
                               of a rule to workloads in that namespace.
                             type: string
+                        required:
+                        - sniHosts
                         type: object
                       type: array
                     route:
@@ -6530,14 +6670,20 @@ spec:
                               subset:
                                 description: The name of a subset within the service.
                                 type: string
+                            required:
+                            - host
                             type: object
                           weight:
                             description: Weight specifies the relative proportion
                               of traffic to be forwarded to the destination.
                             format: int32
                             type: integer
+                        required:
+                        - destination
                         type: object
                       type: array
+                  required:
+                  - match
                   type: object
                 type: array
             type: object
@@ -6549,7 +6695,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6692,7 +6837,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -6806,6 +6950,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6828,6 +6974,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -6867,6 +7015,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -6967,6 +7117,8 @@ spec:
                         type: integer
                       scheme:
                         type: string
+                    required:
+                    - port
                     type: object
                   initialDelaySeconds:
                     description: Number of seconds after the container has started
@@ -6989,6 +7141,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                    - port
                     type: object
                   timeoutSeconds:
                     description: Number of seconds after which the probe times out.
@@ -7028,6 +7182,8 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
+            required:
+            - template
             type: object
           status:
             type: object
@@ -7037,7 +7193,6 @@ spec:
     storage: false
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7224,6 +7379,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7419,6 +7576,8 @@ spec:
                             items:
                               type: string
                             type: array
+                        required:
+                        - key
                         type: object
                       type: array
                   type: object
@@ -7453,7 +7612,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7499,8 +7657,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or
-              not) to the sidecar.
+            description: 'Peer authentication configuration for workloads. See more
+              details at: https://istio.io/docs/reference/config/security/peer_authentication.html'
             properties:
               mtls:
                 description: Mutual TLS settings for workload.
@@ -7548,7 +7706,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7581,8 +7738,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7610,6 +7767,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7649,6 +7808,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7686,8 +7847,8 @@ spec:
       openAPIV3Schema:
         properties:
           spec:
-            description: RequestAuthentication defines what request authentication
-              methods are supported by a workload.
+            description: 'Request authentication configuration for workloads. See
+              more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
                 description: Define the list of JWTs that can be validated at the
@@ -7715,6 +7876,8 @@ spec:
                             description: The prefix that should be stripped before
                               decoding the token.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     fromParams:
@@ -7754,6 +7917,8 @@ spec:
                       description: This field specifies the header name to output
                         a successfully verified JWT payload to the backend.
                       type: string
+                  required:
+                  - issuer
                   type: object
                 type: array
               selector:
@@ -7786,7 +7951,6 @@ spec:
     storage: true
     subresources:
       status: {}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7868,6 +8032,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                   type: object
@@ -7952,6 +8118,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     reportingInterval:
@@ -8061,6 +8229,8 @@ spec:
                           name:
                             description: Required.
                             type: string
+                        required:
+                        - name
                         type: object
                       type: array
                     randomSamplingPercentage:
@@ -8082,6 +8252,4 @@ spec:
     storage: true
     subresources:
       status: {}
-
----
 {{- end }}

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -368,35 +368,54 @@ func TestConvertResources(t *testing.T) {
 	validator := crdvalidation.NewIstioValidator(t)
 	cases := []struct {
 		name string
+		// Some configs are intended to be generated with invalid configs, and since they will be validated
+		// by the validator, we need to ignore the validation errors to prevent the test from failing.
+		validationIgnorer *crdvalidation.ValidationIgnorer
 	}{
-		{"http"},
-		{"tcp"},
-		{"tls"},
-		{"grpc"},
-		{"mismatch"},
-		{"weighted"},
-		{"zero"},
-		{"mesh"},
-		{"invalid"},
-		{"multi-gateway"},
-		{"delegated"},
-		{"route-binding"},
-		{"reference-policy-tls"},
-		{"reference-policy-service"},
-		{"reference-policy-tcp"},
-		{"serviceentry"},
-		{"eastwest"},
-		{"eastwest-tlsoption"},
-		{"eastwest-labelport"},
-		{"eastwest-remote"},
-		{"alias"},
-		{"mcs"},
-		{"route-precedence"},
-		{"waypoint"},
+		{name: "http"},
+		{name: "tcp"},
+		{name: "tls"},
+		{name: "grpc"},
+		{name: "mismatch"},
+		{name: "weighted"},
+		{name: "zero"},
+		{name: "mesh"},
+		{
+			name: "invalid",
+			validationIgnorer: crdvalidation.NewValidationIgnorer(
+				"default/^invalid-backendRef-kind-",
+				"default/^invalid-backendRef-mixed-",
+			),
+		},
+		{name: "multi-gateway"},
+		{name: "delegated"},
+		{name: "route-binding"},
+		{name: "reference-policy-tls"},
+		{
+			name: "reference-policy-service",
+			validationIgnorer: crdvalidation.NewValidationIgnorer(
+				"istio-system/^backend-not-allowed-",
+			),
+		},
+		{
+			name: "reference-policy-tcp",
+			validationIgnorer: crdvalidation.NewValidationIgnorer(
+				"istio-system/^not-allowed-echo-",
+			),
+		},
+		{name: "serviceentry"},
+		{name: "eastwest"},
+		{name: "eastwest-tlsoption"},
+		{name: "eastwest-labelport"},
+		{name: "eastwest-remote"},
+		{name: "alias"},
+		{name: "mcs"},
+		{name: "route-precedence"},
+		{name: "waypoint"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			input := readConfig(t, fmt.Sprintf("testdata/%s.yaml", tt.name), validator)
+			input := readConfig(t, fmt.Sprintf("testdata/%s.yaml", tt.name), validator, nil)
 			// Setup a few preconfigured services
 			instances := []*model.ServiceInstance{}
 			for _, svc := range services {
@@ -432,7 +451,7 @@ func TestConvertResources(t *testing.T) {
 			goldenFile := fmt.Sprintf("testdata/%s.yaml.golden", tt.name)
 			res := append(output.Gateway, output.VirtualService...)
 			util.CompareContent(t, marshalYaml(t, res), goldenFile)
-			golden := splitOutput(readConfig(t, goldenFile, validator))
+			golden := splitOutput(readConfig(t, goldenFile, validator, tt.validationIgnorer))
 
 			// sort virtual services to make the order deterministic
 			sort.Slice(golden.VirtualService, func(i, j int) bool {
@@ -1091,7 +1110,7 @@ spec:
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			input := readConfigString(t, tt.config, validator)
+			input := readConfigString(t, tt.config, validator, nil)
 			cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 			kr := splitInput(t, input)
 			kr.Context = NewGatewayContext(cg.PushContext())
@@ -1190,18 +1209,19 @@ func splitInput(t test.Failer, configs []config.Config) GatewayResources {
 	return out
 }
 
-func readConfig(t testing.TB, filename string, validator *crdvalidation.Validator) []config.Config {
+func readConfig(t testing.TB, filename string, validator *crdvalidation.Validator, ignorer *crdvalidation.ValidationIgnorer) []config.Config {
 	t.Helper()
 
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("failed to read input yaml file: %v", err)
 	}
-	return readConfigString(t, string(data), validator)
+	return readConfigString(t, string(data), validator, ignorer)
 }
 
-func readConfigString(t testing.TB, data string, validator *crdvalidation.Validator) []config.Config {
-	if err := validator.ValidateCustomResourceYAML(data); err != nil {
+func readConfigString(t testing.TB, data string, validator *crdvalidation.Validator, ignorer *crdvalidation.ValidationIgnorer,
+) []config.Config {
+	if err := validator.ValidateCustomResourceYAML(data, ignorer); err != nil {
 		t.Error(err)
 	}
 	c, _, err := crd.ParseInputs(data)
@@ -1317,7 +1337,7 @@ func BenchmarkBuildHTTPVirtualServices(b *testing.B) {
 	})
 
 	validator := crdvalidation.NewIstioValidator(b)
-	input := readConfig(b, "testdata/benchmark-httproute.yaml", validator)
+	input := readConfig(b, "testdata/benchmark-httproute.yaml", validator, nil)
 	kr := splitInput(b, input)
 	kr.Context = NewGatewayContext(cg.PushContext())
 	ctx := configContext{

--- a/pkg/config/crd/validator_test.go
+++ b/pkg/config/crd/validator_test.go
@@ -29,7 +29,7 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-`); err != nil {
+`, nil); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -42,7 +42,7 @@ metadata:
 spec:
   mtls:
     mode: BAD
-`); err == nil {
+`, nil); err == nil {
 			t.Fatal("expected error but got none")
 		}
 	})


### PR DESCRIPTION
**Please provide a description of this PR:**
Some resources are intended to be created/generated with invalid configs, and this PR adds the ability to ignore these invalid configs. 
Also bumping the client-go version, and fixes the gateway conversion test. Fix https://github.com/istio/istio/pull/47383