### PR TITLE
update readiness-probe test to use gateway svc ips

### DIFF
--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -624,7 +624,7 @@ func StatusGatewayTest(t framework.TestContext) {
 }
 
 // Verify that the envoy readiness probes are reachable at
-// https://GatewayPodIP:15021/healthz/ready . This is being explicitly done
+// https://GatewaySvcIP:15021/healthz/ready . This is being explicitly done
 // to make sure, in dual-stack scenarios both v4 and v6 probes are reachable.
 func TestGatewayReadinessProbes(t *testing.T) {
 	// nolint: staticcheck
@@ -634,14 +634,15 @@ func TestGatewayReadinessProbes(t *testing.T) {
 		Features("traffic.gateway.readiness").
 		Run(func(t framework.TestContext) {
 			c := t.Clusters().Default()
-			podIPs, err := i.PodIPsFor(c, "app=istio-ingressgateway")
+			var svc *corev1.Service
+			svc, _, err := testKube.WaitUntilServiceEndpointsAreReady(c.Kube(), "istio-system", "istio-ingressgateway")
 			if err != nil {
-				t.Fatalf("error getting ingress gateway pod ips: %v", err)
+				t.Fatalf("error getting ingress gateway svc ips: %v", err)
 			}
-			for _, ip := range podIPs {
-				t.NewSubTest("gateway-readiness-probe-" + ip.IP).Run(func(t framework.TestContext) {
+			for _, ip := range svc.Spec.ClusterIPs {
+				t.NewSubTest("gateway-readiness-probe-" + ip).Run(func(t framework.TestContext) {
 					apps.External.All[0].CallOrFail(t, echo.CallOptions{
-						Address: ip.IP,
+						Address: ip,
 						Port:    echo.Port{ServicePort: 15021},
 						Scheme:  scheme.HTTP,
 						HTTP: echo.HTTP{


### PR DESCRIPTION
Now that gateway is deployed as a dual-stack service, let us use the service ips for readiness probe tests, instead of podIPs 