### PR TITLE
Sidecar resources using defaultEndpoint can use ::1 in all cases

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -610,18 +610,12 @@ func buildInboundClustersFromSidecar(cb *ClusterBuilder, proxy *model.Proxy,
 						break
 					}
 				}
-				if endpointAddress == "" {
-					endpointAddress = actualLocalHosts[0]
-				}
 			} else if hostIP == model.LocalhostIPv6AddressPrefix {
 				for _, host := range actualLocalHosts {
 					if netutil.IsIPv6Address(host) {
 						endpointAddress = host
 						break
 					}
-				}
-				if endpointAddress == "" {
-					endpointAddress = actualLocalHosts[0]
 				}
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -604,18 +604,34 @@ func buildInboundClustersFromSidecar(cb *ClusterBuilder, proxy *model.Proxy,
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
 			} else if hostIP == model.LocalhostAddressPrefix {
+				// prefer 127.0.0.1 to :;1, but if given no option choose ::1
+				ipV6EndpointAddress := ""
 				for _, host := range actualLocalHosts {
 					if netutil.IsIPv4Address(host) {
 						endpointAddress = host
 						break
 					}
+					if netutil.IsIPv6Address(host) {
+						ipV6EndpointAddress = host
+					}
+				}
+				if endpointAddress == "" {
+					endpointAddress = ipV6EndpointAddress
 				}
 			} else if hostIP == model.LocalhostIPv6AddressPrefix {
+				// prefer ::1 to 127.0.0.1, but if given no option choose 127.0.0.1
+				ipV4EndpointAddress := ""
 				for _, host := range actualLocalHosts {
 					if netutil.IsIPv6Address(host) {
 						endpointAddress = host
 						break
 					}
+					if netutil.IsIPv4Address(host) {
+						ipV4EndpointAddress = host
+					}
+				}
+				if endpointAddress == "" {
+					endpointAddress = ipV4EndpointAddress
 				}
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -603,6 +603,22 @@ func buildInboundClustersFromSidecar(cb *ClusterBuilder, proxy *model.Proxy,
 				if endpointAddress == "" {
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
+			} else if features.EnableDualStack {
+				if hostIP == model.LocalhostAddressPrefix {
+					for _, host := range actualLocalHosts {
+						if netutil.IsIPv4Address(host) {
+							endpointAddress = host
+							break
+						}
+					}
+				} else if hostIP == model.LocalhostIPv6AddressPrefix {
+					for _, host := range actualLocalHosts {
+						if netutil.IsIPv6Address(host) {
+							endpointAddress = host
+							break
+						}
+					}
+				}
 			} else if hostIP == model.LocalhostAddressPrefix || hostIP == model.LocalhostIPv6AddressPrefix {
 				endpointAddress = actualLocalHosts[0]
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -604,7 +604,7 @@ func buildInboundClustersFromSidecar(cb *ClusterBuilder, proxy *model.Proxy,
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
 			} else if hostIP == model.LocalhostAddressPrefix {
-				// prefer 127.0.0.1 to :;1, but if given no option choose ::1
+				// prefer 127.0.0.1 to ::1, but if given no option choose ::1
 				ipV6EndpointAddress := ""
 				for _, host := range actualLocalHosts {
 					if netutil.IsIPv4Address(host) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -603,24 +603,26 @@ func buildInboundClustersFromSidecar(cb *ClusterBuilder, proxy *model.Proxy,
 				if endpointAddress == "" {
 					endpointAddress = model.LocalhostIPv6AddressPrefix
 				}
-			} else if features.EnableDualStack {
-				if hostIP == model.LocalhostAddressPrefix {
-					for _, host := range actualLocalHosts {
-						if netutil.IsIPv4Address(host) {
-							endpointAddress = host
-							break
-						}
-					}
-				} else if hostIP == model.LocalhostIPv6AddressPrefix {
-					for _, host := range actualLocalHosts {
-						if netutil.IsIPv6Address(host) {
-							endpointAddress = host
-							break
-						}
+			} else if hostIP == model.LocalhostAddressPrefix {
+				for _, host := range actualLocalHosts {
+					if netutil.IsIPv4Address(host) {
+						endpointAddress = host
+						break
 					}
 				}
-			} else if hostIP == model.LocalhostAddressPrefix || hostIP == model.LocalhostIPv6AddressPrefix {
-				endpointAddress = actualLocalHosts[0]
+				if endpointAddress == "" {
+					endpointAddress = actualLocalHosts[0]
+				}
+			} else if hostIP == model.LocalhostIPv6AddressPrefix {
+				for _, host := range actualLocalHosts {
+					if netutil.IsIPv6Address(host) {
+						endpointAddress = host
+						break
+					}
+				}
+				if endpointAddress == "" {
+					endpointAddress = actualLocalHosts[0]
+				}
 			}
 		}
 		// Find the service instance that corresponds to this ingress listener by looking

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1971,7 +1971,16 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 }
 
 func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
-	dsProxy := &dualStackProxy
+	dsProxy := model.Proxy{
+		Type:        model.SidecarProxy,
+		IPAddresses: []string{"1.1.1.1", "1111:2222::1"},
+		ID:          "v0.default",
+		DNSDomain:   "default.example.org",
+		Metadata: &model.NodeMetadata{
+			Namespace: "not-default",
+		},
+		ConfigNamespace: "not-default",
+	}
 
 	inboundFilter := func(c *cluster.Cluster) bool {
 		return strings.HasPrefix(c.Name, "inbound|")
@@ -1988,7 +1997,7 @@ func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
 		{
 			name:            "dual stack disabled, defaultEndpoint set to [::1]:7073",
 			isDual:          false,
-			proxy:           dsProxy,
+			proxy:           &dsProxy,
 			defaultEndpoint: "[::1]:7073",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7073,
@@ -1996,7 +2005,7 @@ func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
 		{
 			name:            "dual stack enabled, defaultEndpoint set to 127.0.0.1:7072",
 			isDual:          true,
-			proxy:           dsProxy,
+			proxy:           &dsProxy,
 			defaultEndpoint: "127.0.0.1:7072",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7072,
@@ -2004,7 +2013,7 @@ func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
 		{
 			name:            "dual stack enabled, defaultEndpoint set to [::1]:7073",
 			isDual:          true,
-			proxy:           dsProxy,
+			proxy:           &dsProxy,
 			defaultEndpoint: "[::1]:7073",
 			expectedAddr:    "::1",
 			expectedPort:    7073,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1970,7 +1970,7 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 	}
 }
 
-func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
+func TestInboundClustersDefaultEndpoint(t *testing.T) {
 	dsProxy := model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1", "1111:2222::1"},
@@ -1988,31 +1988,34 @@ func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
 
 	cases := []struct {
 		name            string
-		isDual          bool
 		proxy           *model.Proxy
 		defaultEndpoint string
 		expectedAddr    string
 		expectedPort    uint32
 	}{
 		{
-			name:            "dual stack disabled, defaultEndpoint set to [::1]:7073",
-			isDual:          false,
+			name:            "defaultEndpoint set to 127.0.0.1:7073",
 			proxy:           &dsProxy,
-			defaultEndpoint: "[::1]:7073",
+			defaultEndpoint: "127.0.0.1:7073",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7073,
 		},
 		{
-			name:            "dual stack enabled, defaultEndpoint set to 127.0.0.1:7072",
-			isDual:          true,
+			name:            "defaultEndpoint set to [::1]:7073",
+			proxy:           &dsProxy,
+			defaultEndpoint: "[::1]:7073",
+			expectedAddr:    "::1",
+			expectedPort:    7073,
+		},
+		{
+			name:            "defaultEndpoint set to 127.0.0.1:7072",
 			proxy:           &dsProxy,
 			defaultEndpoint: "127.0.0.1:7072",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7072,
 		},
 		{
-			name:            "dual stack enabled, defaultEndpoint set to [::1]:7073",
-			isDual:          true,
+			name:            "defaultEndpoint set to [::1]:7073",
 			proxy:           &dsProxy,
 			defaultEndpoint: "[::1]:7073",
 			expectedAddr:    "::1",
@@ -2022,7 +2025,6 @@ func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			test.SetForTest(t, &features.EnableDualStack, c.isDual)
 			g := NewWithT(t)
 			cg := NewConfigGenTest(t, TestOptions{})
 			proxy := cg.SetupProxy(c.proxy)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1970,7 +1970,7 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 	}
 }
 
-func TestInboundClustersDefaultEndpoint(t *testing.T) {
+func TestInboundClustersLocalhostDefaultEndpoint(t *testing.T) {
 	dsProxy := model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1", "1111:2222::1"},
@@ -1999,20 +1999,6 @@ func TestInboundClustersDefaultEndpoint(t *testing.T) {
 			defaultEndpoint: "127.0.0.1:7073",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7073,
-		},
-		{
-			name:            "defaultEndpoint set to [::1]:7073",
-			proxy:           &dsProxy,
-			defaultEndpoint: "[::1]:7073",
-			expectedAddr:    "::1",
-			expectedPort:    7073,
-		},
-		{
-			name:            "defaultEndpoint set to 127.0.0.1:7072",
-			proxy:           &dsProxy,
-			defaultEndpoint: "127.0.0.1:7072",
-			expectedAddr:    "127.0.0.1",
-			expectedPort:    7072,
 		},
 		{
 			name:            "defaultEndpoint set to [::1]:7073",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1970,6 +1970,85 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 	}
 }
 
+func TestDualStackInboundClustersDefaultEndpoint(t *testing.T) {
+	dsProxy := &dualStackProxy
+
+	inboundFilter := func(c *cluster.Cluster) bool {
+		return strings.HasPrefix(c.Name, "inbound|")
+	}
+
+	cases := []struct {
+		name            string
+		isDual          bool
+		proxy           *model.Proxy
+		defaultEndpoint string
+		expectedAddr    string
+		expectedPort    uint32
+	}{
+		{
+			name:            "dual stack disabled, defaultEndpoint set to [::1]:7073",
+			isDual:          false,
+			proxy:           dsProxy,
+			defaultEndpoint: "[::1]:7073",
+			expectedAddr:    "127.0.0.1",
+			expectedPort:    7073,
+		},
+		{
+			name:            "dual stack enabled, defaultEndpoint set to 127.0.0.1:7072",
+			isDual:          true,
+			proxy:           dsProxy,
+			defaultEndpoint: "127.0.0.1:7072",
+			expectedAddr:    "127.0.0.1",
+			expectedPort:    7072,
+		},
+		{
+			name:            "dual stack enabled, defaultEndpoint set to [::1]:7073",
+			isDual:          true,
+			proxy:           dsProxy,
+			defaultEndpoint: "[::1]:7073",
+			expectedAddr:    "::1",
+			expectedPort:    7073,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			test.SetForTest(t, &features.EnableDualStack, c.isDual)
+			g := NewWithT(t)
+			cg := NewConfigGenTest(t, TestOptions{})
+			proxy := cg.SetupProxy(c.proxy)
+			proxy.Metadata.InterceptionMode = model.InterceptionNone
+			proxy.SidecarScope = &model.SidecarScope{
+				Sidecar: &networking.Sidecar{
+					Ingress: []*networking.IstioIngressListener{
+						{
+							CaptureMode:     networking.CaptureMode_NONE,
+							DefaultEndpoint: c.defaultEndpoint,
+							Port: &networking.SidecarPort{
+								Number:   7443,
+								Name:     "http",
+								Protocol: "HTTP",
+							},
+						},
+					},
+				},
+			}
+
+			clusters := cg.Clusters(proxy)
+			xdstest.ValidateClusters(t, clusters)
+
+			clusters = xdstest.FilterClusters(clusters, inboundFilter)
+			g.Expect(len(clusters)).ShouldNot(Equal(0))
+
+			for _, cluster := range clusters {
+				socket := cluster.GetLoadAssignment().GetEndpoints()[0].LbEndpoints[0].GetEndpoint().GetAddress().GetSocketAddress()
+				g.Expect(socket.GetAddress()).To(Equal(c.expectedAddr))
+				g.Expect(socket.GetPortValue()).To(Equal(c.expectedPort))
+			}
+		})
+	}
+}
+
 func TestRedisProtocolWithPassThroughResolutionAtGateway(t *testing.T) {
 	servicePort := &model.Port{
 		Name:     "redis-port",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2006,7 +2006,7 @@ func TestInboundClustersLocalhostDefaultEndpoint(t *testing.T) {
 		{
 			name:            "ipv4 host: defaultEndpoint set to [::1]:7073",
 			proxy:           ipv4Proxy,
-			defaultEndpoint: "127.0.0.1:7073",
+			defaultEndpoint: "[::1]:7073",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7073,
 		},

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -1971,6 +1971,8 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 }
 
 func TestInboundClustersLocalhostDefaultEndpoint(t *testing.T) {
+	ipv4Proxy := getProxy()
+	ipv6Proxy := getIPv6Proxy()
 	dsProxy := model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1", "1111:2222::1"},
@@ -1993,15 +1995,45 @@ func TestInboundClustersLocalhostDefaultEndpoint(t *testing.T) {
 		expectedAddr    string
 		expectedPort    uint32
 	}{
+		// ipv4 use cases
 		{
-			name:            "defaultEndpoint set to 127.0.0.1:7073",
+			name:            "ipv4 host: defaultEndpoint set to 127.0.0.1:7073",
+			proxy:           ipv4Proxy,
+			defaultEndpoint: "127.0.0.1:7073",
+			expectedAddr:    "127.0.0.1",
+			expectedPort:    7073,
+		},
+		{
+			name:            "ipv4 host: defaultEndpoint set to [::1]:7073",
+			proxy:           ipv4Proxy,
+			defaultEndpoint: "127.0.0.1:7073",
+			expectedAddr:    "127.0.0.1",
+			expectedPort:    7073,
+		},
+		// ipv6 use cases
+		{
+			name:            "ipv6 host: defaultEndpoint set to 127.0.0.1:7073",
+			proxy:           ipv6Proxy,
+			defaultEndpoint: "127.0.0.1:7073",
+			expectedAddr:    "::1",
+			expectedPort:    7073,
+		},
+		{
+			name:            "ipv6 host: defaultEndpoint set to [::1]:7073",
+			proxy:           ipv6Proxy,
+			defaultEndpoint: "[::1]:7073",
+			expectedAddr:    "::1",
+			expectedPort:    7073,
+		}, // dual-stack use cases
+		{
+			name:            "dual-stack host: defaultEndpoint set to 127.0.0.1:7073",
 			proxy:           &dsProxy,
 			defaultEndpoint: "127.0.0.1:7073",
 			expectedAddr:    "127.0.0.1",
 			expectedPort:    7073,
 		},
 		{
-			name:            "defaultEndpoint set to [::1]:7073",
+			name:            "dual-stack host: defaultEndpoint set to [::1]:7073",
 			proxy:           &dsProxy,
 			defaultEndpoint: "[::1]:7073",
 			expectedAddr:    "::1",

--- a/releasenotes/notes/47412.yaml
+++ b/releasenotes/notes/47412.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47412
+releaseNotes:
+  - |
+    **Fixed** an issue where using a Sidecar resource using IstioIngressListener.defaultEndpoint cannot use [::1]:PORT.
+

--- a/releasenotes/notes/47412.yaml
+++ b/releasenotes/notes/47412.yaml
@@ -5,5 +5,5 @@ issue:
   - 47412
 releaseNotes:
   - |
-    **Fixed** an issue where using a Sidecar resource using IstioIngressListener.defaultEndpoint cannot use [::1]:PORT.
+    **Fixed** an issue where using a Sidecar resource using IstioIngressListener.defaultEndpoint cannot use [::1]:PORT if the default IP addressing is not IPv6.
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes https://github.com/istio/istio/issues/47412