### PR TITLE
Fix for #46163 - Make `netns` host node path configurable

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -202,7 +202,9 @@ spec:
             path: /var/run/istio-cni
         - name: cni-netns-dir
           hostPath:
-            path: /var/run/netns
+            path: {{ .Values.cniNetnsDir | default "/var/run/netns" }}
+            type: Directory # this directory must exist on the node, if it does not,
+            # consult your container runtime documentation for the appropriate path
         {{- if eq .Values.cni.ambient.redirectMode "ebpf"}}
         - name: cni-bpffs-dir
           hostPath:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -20,6 +20,10 @@ cni:
   cniBinDir: "" # Auto-detected based on version; defaults to /opt/cni/bin.
   cniConfDir: /etc/cni/net.d
   cniConfFileName: ""
+  # This directory must exist on the node, if it does not, consult your container runtime
+  # documentation for the appropriate path.
+  cniNetnsDir: # Defaults to '/var/run/netns', in minikube/docker/others can be '/var/docker/netns'.
+
 
   excludeNamespaces:
     - istio-system

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -22,7 +22,7 @@ cni:
   cniConfFileName: ""
   # This directory must exist on the node, if it does not, consult your container runtime
   # documentation for the appropriate path.
-  cniNetnsDir: # Defaults to '/var/run/netns', in minikube/docker/others can be '/var/docker/netns'.
+  cniNetnsDir: # Defaults to '/var/run/netns', in minikube/docker/others can be '/run/docker/netns'.
 
 
   excludeNamespaces:

--- a/releasenotes/notes/47444.yaml
+++ b/releasenotes/notes/47444.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47444
+releaseNotes:
+- |
+  **Added** Support alternate network namespace paths (for e.g. minikube) via `values.cni.cniNetnsDir`


### PR DESCRIPTION
When installing istio ambient on `minikube` (e.g. with the `docker driver`):

> minikube start --cni=kindnet --driver=docker                                                                                                                                     

`istio-cni` fails [here](https://github.com/istio/istio/blob/e7bbb971cee5d511a252cce017382055085bf199/cni/pkg/ambient/server.go#L221), because it can't scan `/var/run/netns` to find the right network namespace.

Normally that folder is populated on the node's filesystem with network namespaces of all pods scheduled on that node, and we host-mount that path into `istio-cni` so we can get the file descriptor for the network namespace we want to jump into. But not all container runtimes put it in that spot, apparently - some place them in other locations and do not bind mount them to `/var/run/netns`, some place them in other locations and bind-mount them back into `/var/run/netns`, some bind-mount them into `/var/run/docker/netns`, etc etc.

This just makes that path configurable via Helm so e.g. `minikube` and others can work, getting around #46163.

The only better long-term fix seems to be host-mounting all of `/proc` and walking it on every pod add - every process has an entry in `/proc`, and if it has a netns, it will be in there. This is foolproof (and what e.g. others like `Cilium` do to get around this), but expensive, and sucking all of `/proc` into the CNI pod as a host mount seems a little gross.

This PR is at least a quick fix for some corner cases, but open to discussion on this if we want to improve the UX.