### PR TITLE
Drop gateway api ignore log to debug

### DIFF
--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -52,7 +52,7 @@ func getPolicyMatcher(kind config.GroupVersionKind, policyName string, opts Work
 	targetRef := policy.GetTargetRef()
 	if isGatewayAPI && targetRef == nil && policy.GetSelector() != nil {
 		if opts.IsWaypoint || !features.EnableSelectorBasedK8sGatewayPolicy {
-			log.Warnf("Ignoring workload-scoped %s/%s %s.%s for gateway %s because it has no targetRef", kind.Group, kind.Kind, opts.Namespace, policyName, gatewayName)
+			log.Debugf("Ignoring workload-scoped %s/%s %s.%s for gateway %s because it has no targetRef", kind.Group, kind.Kind, opts.Namespace, policyName, gatewayName)
 			return policyMatchIgnore
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
There are too many warning logs for a single gateway-api resource in istiod's log. Maybe the alternative is to move it to a more appropriate location.