### PR TITLE
Remove the log being called in init phase

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -58,7 +58,6 @@ var GCPStaticMetadata = func() map[string]string {
 		return map[string]string{}
 	}
 	md := map[string]string{}
-	log.Infof("Extract GCP metadata from env variable GCP_METADATA: %v", gcpm)
 	parts := strings.Split(gcpm, "|")
 	if len(parts) == 4 {
 		md[GCPProject] = parts[0]


### PR DESCRIPTION
To get the info of GCPMetadata, we are logging it in a global variable initialization.
But, since it happen in the global variable initialization, `--log_target` option is not working because the log is running before configuring the flag.

This causes some output mixing up in stdout(e.g., pilot-agent request GET), which is not desired.

This PR simply delete the log because the logging in init is not prefereable.

Change-Id: I9e207e058d6842e021523b6d473670d80c2d114e