### PR TITLE
[release-1.18] test framework: detect and reconnect if port-forward is terminated

### DIFF
--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -64,6 +64,10 @@ func (m MockPortForwarder) Address() string {
 func (m MockPortForwarder) Close() {
 }
 
+func (m MockPortForwarder) ErrChan() <-chan error {
+	return make(chan error)
+}
+
 func (m MockPortForwarder) WaitForStop() {
 }
 

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -48,6 +48,7 @@ type workloadConfig struct {
 	grpcPort   uint16
 	cluster    cluster.Cluster
 	tls        *common.TLSSettings
+	stop       chan struct{}
 }
 
 type workload struct {
@@ -72,7 +73,46 @@ func newWorkload(cfg workloadConfig, ctx resource.Context) (*workload, error) {
 		return nil, err
 	}
 
+	go watchPortForward(cfg, w)
+
 	return w, nil
+}
+
+// watchPortForward wait watch the health of a port-forward connection. If a disconnect is detected, the workload is reconnected.
+// TODO: this isn't structured very nicely. We have a port forwarder that can notify us when it fails (ErrChan) and we are competing with
+// the pod informer which is sequenced via mutex. This could probably be cleaned up to be more event driven, but would require larger refactoring.
+func watchPortForward(cfg workloadConfig, w *workload) {
+	t := time.NewTicker(time.Millisecond * 500)
+	handler := func() {
+		w.mutex.Lock()
+		defer w.mutex.Unlock()
+		if w.forwarder == nil {
+			// We only want to do reconnects here, if we never connected let the main flow handle it.
+			return
+		}
+		// Only reconnect if the pod is ready
+		if !isPodReady(w.pod) {
+			return
+		}
+		con := !w.isConnected()
+		if con {
+			scopes.Framework.Warnf("pod: %s/%s port forward terminated", w.pod.Namespace, w.pod.Name)
+			err := w.connect(w.pod)
+			if err != nil {
+				scopes.Framework.Warnf("pod: %s/%s port forward reconnect failed: %v", w.pod.Namespace, w.pod.Name, err)
+			} else {
+				scopes.Framework.Warnf("pod: %s/%s port forward reconnect success", w.pod.Namespace, w.pod.Name)
+			}
+		}
+	}
+	for {
+		select {
+		case <-cfg.stop:
+			return
+		case <-t.C:
+			handler()
+		}
+	}
 }
 
 func (w *workload) IsReady() bool {
@@ -180,7 +220,17 @@ func isPodReady(pod corev1.Pod) bool {
 }
 
 func (w *workload) isConnected() bool {
-	return w.forwarder != nil
+	if w.forwarder == nil {
+		return false
+	}
+	select {
+	case <-w.forwarder.ErrChan():
+		// If an error is available, we got disconnected
+		return false
+	default:
+		// Otherwise we are connected
+		return true
+	}
 }
 
 func (w *workload) connect(pod corev1.Pod) (err error) {

--- a/pkg/test/framework/components/echo/kube/workload_manager.go
+++ b/pkg/test/framework/components/echo/kube/workload_manager.go
@@ -192,6 +192,7 @@ func (m *workloadManager) onPodAddOrUpdate(pod *corev1.Pod) error {
 		cluster:    m.cfg.Cluster,
 		grpcPort:   m.grpcPort,
 		tls:        m.tls,
+		stop:       m.stopCh,
 	}, m.ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Port forward is not 100% reliable and actually fails a decent amount. When this happens, we just break forever.
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/46400/integ-pilot-multicluster_istio/1689018314652651520 is an example.

In this PR, we have a (somewhat crude) mechanism to detect the port-forward was terminated and reconnect.

I also considered making the port-forwarder do this transparently, but its too complex because that means the Address() can change dynamically which makes it harder to consume - best to do it explicitly.

(cherry picked from commit c4c004270ee24e66c52dd6bdc9b2ebfba3eaf471)

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
