### PR TITLE
Unskip ambient tests for jwt-claim-route and autopassthrough.

### DIFF
--- a/pkg/test/framework/components/echo/match/matchers.go
+++ b/pkg/test/framework/components/echo/match/matchers.go
@@ -161,6 +161,20 @@ var Waypoint Matcher = func(i echo.Instance) bool {
 
 var NotWaypoint = Not(Waypoint)
 
+// add a "waypointed service" matcher
+func WaypointService() Matcher {
+	return func(i echo.Instance) bool {
+		return Waypoint(i)
+	}
+}
+
+// add a new matcher for "captured service -> service"
+func CapturedService() Matcher {
+	return func(i echo.Instance) bool {
+		return i.Config().ZTunnelCaptured()
+	}
+}
+
 // RegularPod matches echos that don't meet any of the following criteria:
 // - VM
 // - Naked

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3414,7 +3414,7 @@ spec:
       claim: "wrong_claim"
 ---
 `
-	podB := []match.Matcher{match.ServiceName(t.Apps.B.NamespacedName())}
+	matchers := []match.Matcher{match.Or(match.ServiceName(t.Apps.B.NamespacedName()), match.WaypointService(), match.CapturedService())}
 	headersWithToken := map[string][]string{
 		"Host":          {"foo.bar"},
 		"Authorization": {"Bearer " + jwt.TokenIssuer1WithNestedClaims1},
@@ -3449,7 +3449,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched with nested claim using claim to header:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3474,7 +3474,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched with nested claim and single claim using claim to header:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3502,7 +3502,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched with wrong claim and added header:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3532,7 +3532,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched with nested claims:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3557,7 +3557,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched with single claim:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3582,7 +3582,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched multiple claims with regex:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3610,7 +3610,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched multiple claims:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3638,7 +3638,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched without claim:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3663,7 +3663,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched without claim:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3688,7 +3688,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "matched both with and without claims with regex:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3717,7 +3717,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched multiple claims:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3745,7 +3745,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched token:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3770,7 +3770,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched with invalid token:401",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3795,7 +3795,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched with no token:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3820,7 +3820,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched with no token but same header:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3846,7 +3846,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "unmatched with no request authentication:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configRoute,
@@ -3876,7 +3876,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched with nested claims:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3901,7 +3901,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched with single claim:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3926,7 +3926,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched multiple claims with regex:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3954,7 +3954,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched multiple claims:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -3982,7 +3982,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched without claim:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4007,7 +4007,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched without claim:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4032,7 +4032,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched both with and without claims with regex:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4061,7 +4061,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched multiple claims:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4089,7 +4089,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched token:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4114,7 +4114,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with invalid token:401",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4139,7 +4139,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with no token:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4164,7 +4164,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with no token but same header:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4190,7 +4190,7 @@ spec:
 	})
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with no request authentication:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configRoute,
@@ -4216,7 +4216,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched with simple collision-resistant claim name:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4242,7 +4242,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with simple collision-resistant claim name:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4268,7 +4268,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: matched with nested collision-resistant claim name:200",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,
@@ -4294,7 +4294,7 @@ spec:
 
 	t.RunTraffic(TrafficTestCase{
 		name:             "usage2: unmatched with nested collision-resistant claim name:404",
-		targetMatchers:   podB,
+		targetMatchers:   matchers,
 		workloadAgnostic: true,
 		viaIngress:       true,
 		config:           configAll,

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -267,13 +267,13 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 			}
 		})
 	}
-	RunSkipAmbient("jwt-claim-route", jwtClaimRoute, "ingress needed")
+	RunCase("jwt-claim-route", jwtClaimRoute)
 	RunCase("virtualservice", virtualServiceCases)
 	RunCase("sniffing", protocolSniffingCases)
 	RunCase("selfcall", selfCallsCases)
 	RunSkipAmbient("serverfirst", serverFirstTestCases, "Expected success cases time out")
 	RunCase("gateway", gatewayCases)
-	RunSkipAmbient("autopassthrough", autoPassthroughCases, "ingress needed")
+	RunCase("autopassthrough", autoPassthroughCases)
 	RunSkipAmbient("loop", trafficLoopCases, "does not error (waypoint -> waypoint)")
 	RunSkipAmbient("tls-origination", tlsOriginationCases, "not workload agnostic")
 	RunSkipAmbient("instanceip", instanceIPTests, "not supported")


### PR DESCRIPTION
**Please provide a description of this PR:**
I took a look at the existing Traffic test cases to confirm which cases need to skip Ambient still and which don't. I've identified `jwt-claim-route` and `autopassthrough` as not having to skip ambient anymore. Basically, there is no difference when changing to `RunCase` from `RunSkipAmbient` for those particular test cases. Also, added a matcher for a `waypointed service` and a `captured service` to validate these cases actually run through Ambient.

Related to #43698 