### PR TITLE
Bootstrap fix - move deprecated runtime flag to resource monitors

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -49,7 +49,7 @@ endif
 export VERSION
 
 # Base version of Istio image to use
-BASE_VERSION ?= master-2023-10-12T19-01-47
+BASE_VERSION ?= master-2023-10-22T19-01-47
 ISTIO_BASE_REGISTRY ?= gcr.io/istio-release
 
 export GO111MODULE ?= on

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -55,6 +55,8 @@ const (
 
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
 
+	globalDownstreamMaxConnections = 2147483647
+
 	// required stats are used by readiness checks.
 	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,server,cluster.xds-grpc,wasm"
 
@@ -308,8 +310,7 @@ var StripFragment = env.Register("HTTP_STRIP_FRAGMENT_FROM_PATH_UNSAFE_IF_DISABL
 func extractRuntimeFlags(cfg *model.NodeMetaProxyConfig) map[string]any {
 	// Setup defaults
 	runtimeFlags := map[string]any{
-		"overload.global_downstream_max_connections": "2147483647",
-		"re2.max_program_size.error_level":           "32768",
+		"re2.max_program_size.error_level": "32768",
 		"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
 		"envoy.reloadable_features.http_reject_path_with_fragment":                                             false,
 	}
@@ -458,6 +459,9 @@ func getProxyConfigOptions(metadata *model.BootstrapNodeMetadata) ([]option.Inst
 			option.EnvoyAccessLogServiceTLS(config.EnvoyAccessLogService.TlsSettings, metadata),
 			option.EnvoyAccessLogServiceTCPKeepalive(config.EnvoyAccessLogService.TcpKeepalive))
 	}
+
+	// Add resource monitors
+	opts = append(opts, option.EnvoyResourceMonitorDownstreamConnections(globalDownstreamMaxConnections))
 
 	return opts, nil
 }

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -209,6 +209,10 @@ func EnvoyAccessLogServiceTCPKeepalive(value *networkingAPI.ConnectionPoolSettin
 	return newTCPKeepaliveOption("envoy_accesslog_service_tcp_keepalive", value)
 }
 
+func EnvoyResourceMonitorDownstreamConnections(value int) Instance {
+	return newOption("max_active_downstream_connections", value)
+}
+
 func EnvoyExtraStatTags(value []string) Instance {
 	return newStringArrayOptionOrSkipIfEmpty("extraStatTags", value)
 }

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -15,13 +15,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -15,13 +15,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -10,13 +10,22 @@
       "layers": [
           {
             "name": "global config",
-            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"overload.global_downstream_max_connections":"2147483647","re2.max_program_size.error_level":"32768"}
+            "static_layer": {"envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst":true,"envoy.reloadable_features.http_reject_path_with_fragment":false,"re2.max_program_size.error_level":"32768"}
           },
           {
               "name": "admin",
               "admin_layer": {}
           }
       ]
+  },
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": 2147483647
+      }
+    }]
   },
   "bootstrap_extensions": [
     {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -33,6 +33,17 @@
           }
       ]
   },
+  {{- if .max_active_downstream_connections }}
+  "overload_manager": {
+    "resource_monitors": [{
+      "name": "envoy.resource_monitors.downstream_connections",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig",
+        "max_active_downstream_connections": {{ .max_active_downstream_connections }}
+      }
+    }]
+  },
+  {{- end }}
   "bootstrap_extensions": [
     {{- if .metadata_discovery }}
     {


### PR DESCRIPTION
Runtime flag global_downstream_max_connections has been deprecated.
Envoy recommends moving to Resource monitors.
fixes- https://github.com/istio/istio/issues/47355