### PR TITLE
Strip GW v1 empty infrastructure on x waypoint

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -103,6 +103,9 @@ func Cmd(ctx cli.Context) *cobra.Command {
 `, "")
 			res = strings.ReplaceAll(res, `status: {}
 `, "")
+			// stripping infrastructure introduced in Gateway v1 if empty
+			res = strings.ReplaceAll(res, `  infrastructure: {}
+`, "")
 			fmt.Fprint(cmd.OutOrStdout(), res)
 			return nil
 		},
@@ -130,7 +133,10 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, err = gwc.Patch(context.Background(), gw.Name, types.ApplyPatchType, b, metav1.PatchOptions{
+			// stripping infrastructure introduced in Gateway v1 if empty
+			res := strings.ReplaceAll(string(b), `  infrastructure: {}
+`, "")
+			_, err = gwc.Patch(context.Background(), gw.Name, types.ApplyPatchType, []byte(res), metav1.PatchOptions{
 				Force:        nil,
 				FieldManager: "istioctl",
 			})


### PR DESCRIPTION
**Please provide a description of this PR:**

Following the bump of K8s Gateway API to v1, when running `x waypoint apply` we get:
```
Error: failed to create typed patch object (test/bookinfo-productpage; gateway.networking.k8s.io/v1beta1, Kind=Gateway): .spec.infrastructure: field not declared in schema
```

This happens with any CRDs (`v1.0.0-rc1` and before) as the spec does not include the new `infrastructure` field (yet).
Although this field is marked as don't emit when empty it's being output because it's a struct.

Change in the PR are stripping the field if it's not set to avoid the error above and be backward compatible with earlier versions of the CRDs.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
