### PR TITLE
EnvoyFilter: support matching ApplicationProtocols

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -743,8 +743,13 @@ func filterChainMatch(listener *listener.Listener, fc *listener.FilterChain, lp 
 	}
 
 	if match.ApplicationProtocols != "" {
-		if fc.FilterChainMatch == nil || strings.Join(fc.FilterChainMatch.ApplicationProtocols, ",") != match.ApplicationProtocols {
+		if fc.FilterChainMatch == nil {
 			return false
+		}
+		for _, p := range strings.Split(match.ApplicationProtocols, ",") {
+			if !slices.Contains(fc.FilterChainMatch.ApplicationProtocols, p) {
+				return false
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -16,6 +16,7 @@ package envoyfilter
 
 import (
 	"fmt"
+	"strings"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -737,6 +738,12 @@ func filterChainMatch(listener *listener.Listener, fc *listener.FilterChain, lp 
 
 	if match.TransportProtocol != "" {
 		if fc.FilterChainMatch == nil || fc.FilterChainMatch.TransportProtocol != match.TransportProtocol {
+			return false
+		}
+	}
+
+	if match.ApplicationProtocols != "" {
+		if fc.FilterChainMatch == nil || strings.Join(fc.FilterChainMatch.ApplicationProtocols, ",") != match.ApplicationProtocols {
 			return false
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -903,7 +903,7 @@ func TestApplyListenerPatches(t *testing.T) {
 				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 					Listener: &networking.EnvoyFilter_ListenerMatch{
 						PortNumber:  12345,
-						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{ApplicationProtocols: "http/1.1,h2c"},
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{ApplicationProtocols: "http/1.1"},
 					},
 				},
 			},

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -897,6 +897,21 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 		},
 		{
+			ApplyTo: networking.EnvoyFilter_FILTER_CHAIN,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber:  12345,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{ApplicationProtocols: "http/1.1,h2c"},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_REMOVE,
+			},
+		},
+		{
 			ApplyTo: networking.EnvoyFilter_LISTENER_FILTER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_SIDECAR_OUTBOUND,
@@ -1180,6 +1195,12 @@ func TestApplyListenerPatches(t *testing.T) {
 						},
 					},
 					Filters: []*listener.Filter{{Name: "envoy.transport_sockets.tls"}},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{ApplicationProtocols: []string{"http/1.1", "h2c"}},
+					Filters: []*listener.Filter{
+						{Name: "filter1"},
+					},
 				},
 				{
 					Filters: []*listener.Filter{
@@ -1673,6 +1694,12 @@ func TestApplyListenerPatches(t *testing.T) {
 						},
 					},
 					Filters: []*listener.Filter{{Name: "envoy.transport_sockets.tls"}},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{ApplicationProtocols: []string{"http/1.1", "h2c"}},
+					Filters: []*listener.Filter{
+						{Name: "filter1"},
+					},
 				},
 				{
 					Filters: []*listener.Filter{

--- a/releasenotes/notes/envoyfilter-app-protocals-match.yaml
+++ b/releasenotes/notes/envoyfilter-app-protocals-match.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** support for matching `ApplicationProtocols` in EnvoyFilter.


### PR DESCRIPTION
**Please provide a description of this PR:**
We want to patch filter chains using `EnvoyFilter.ListenerMatch.FilterChainMatch.ApplicationProtocols`, but found it's not working

This field was introduced in https://github.com/istio/api/pull/1026 but not implemented