### PR TITLE
Fix user created tag webhook being deleted by installer

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -45,6 +45,8 @@ const (
 	istioInjectionWebhookSuffix = "sidecar-injector.istio.io"
 
 	vwhBaseTemplateName = "istiod-default-validator"
+
+	operatorNamespace = "operator.istio.io"
 )
 
 // tagWebhookConfig holds config needed to render a tag webhook.
@@ -81,6 +83,9 @@ type GenerateOptions struct {
 	AutoInjectNamespaces bool
 	// CustomLabels are labels to add to the generated webhook.
 	CustomLabels map[string]string
+	// UserManaged indicates whether the revision tag is user managed.
+	// If true, the revision tag will not be affected by the installer.
+	UserManaged bool
 }
 
 // Generate generates the manifests for a revision tag pointed the given revision.
@@ -146,7 +151,7 @@ func Generate(ctx context.Context, client kube.Client, opts *GenerateOptions, is
 			return "", fmt.Errorf("failed to create validating webhook config: %w", err)
 		}
 
-		vwhYAML, err := generateValidatingWebhook(validationWhConfig, opts.ManifestsPath, opts.CustomLabels)
+		vwhYAML, err := generateValidatingWebhook(validationWhConfig, opts)
 		if err != nil {
 			return "", fmt.Errorf("failed to create validating webhook: %w", err)
 		}
@@ -199,8 +204,8 @@ func Create(client kube.CLIClient, manifests, ns string) error {
 }
 
 // generateValidatingWebhook renders a validating webhook configuration from the given tagWebhookConfig.
-func generateValidatingWebhook(config *tagWebhookConfig, chartPath string, customLabels map[string]string) (string, error) {
-	r := helm.NewHelmRenderer(chartPath, defaultChart, "Pilot", config.IstioNamespace, nil)
+func generateValidatingWebhook(config *tagWebhookConfig, opts *GenerateOptions) (string, error) {
+	r := helm.NewHelmRenderer(opts.ManifestsPath, defaultChart, "Pilot", config.IstioNamespace, nil)
 
 	if err := r.Run(); err != nil {
 		return "", fmt.Errorf("failed running Helm renderer: %v", err)
@@ -239,8 +244,7 @@ base:
 	for i := range decodedWh.Webhooks {
 		decodedWh.Webhooks[i].ClientConfig.CABundle = []byte(config.CABundle)
 	}
-	decodedWh.Labels = maps.MergeCopy(decodedWh.Labels, config.Labels)
-	decodedWh.Labels = maps.MergeCopy(decodedWh.Labels, customLabels)
+	decodedWh.Labels = generateLabels(decodedWh.Labels, config.Labels, opts.CustomLabels, opts.UserManaged)
 	decodedWh.Annotations = maps.MergeCopy(decodedWh.Annotations, config.Annotations)
 	for i := range decodedWh.Webhooks {
 		if failurePolicy, ok := config.FailurePolicy[decodedWh.Webhooks[i].Name]; ok {
@@ -254,6 +258,19 @@ base:
 	}
 
 	return whBuf.String(), nil
+}
+
+func generateLabels(whLabels, curLabels, customLabels map[string]string, userManaged bool) map[string]string {
+	whLabels = maps.MergeCopy(whLabels, curLabels)
+	whLabels = maps.MergeCopy(whLabels, customLabels)
+	if userManaged {
+		for _, label := range whLabels {
+			if strings.Contains(label, operatorNamespace) {
+				delete(whLabels, label)
+			}
+		}
+	}
+	return whLabels
 }
 
 // generateMutatingWebhook renders a mutating webhook configuration from the given tagWebhookConfig.
@@ -310,8 +327,7 @@ istiodRemote:
 	if opts.WebhookName != "" {
 		decodedWh.Name = opts.WebhookName
 	}
-	decodedWh.Labels = maps.MergeCopy(decodedWh.Labels, config.Labels)
-	decodedWh.Labels = maps.MergeCopy(decodedWh.Labels, opts.CustomLabels)
+	decodedWh.Labels = generateLabels(decodedWh.Labels, config.Labels, opts.CustomLabels, opts.UserManaged)
 	decodedWh.Annotations = maps.MergeCopy(decodedWh.Annotations, config.Annotations)
 	whBuf := new(bytes.Buffer)
 	if err = serializer.Encode(decodedWh, whBuf); err != nil {

--- a/istioctl/pkg/tag/generate_test.go
+++ b/istioctl/pkg/tag/generate_test.go
@@ -186,7 +186,10 @@ func TestGenerateValidatingWebhook(t *testing.T) {
 			if err != nil {
 				t.Fatalf("webhook fixing failed with error: %v", err)
 			}
-			webhookYAML, err := generateValidatingWebhook(webhookConfig, filepath.Join(env.IstioSrc, "manifests"), nil)
+			opts := &GenerateOptions{
+				ManifestsPath: filepath.Join(env.IstioSrc, "manifests"),
+			}
+			webhookYAML, err := generateValidatingWebhook(webhookConfig, opts)
 			if err != nil {
 				t.Fatalf("tag webhook YAML generation failed with error: %v", err)
 			}

--- a/istioctl/pkg/tag/tag.go
+++ b/istioctl/pkg/tag/tag.go
@@ -277,6 +277,7 @@ func setTag(ctx context.Context, kubeClient kube.CLIClient, tagName, revision, i
 		Generate:             generate,
 		Overwrite:            overwrite,
 		AutoInjectNamespaces: autoInjectNamespaces,
+		UserManaged:          true,
 	}
 	tagWhYAML, err := Generate(ctx, kubeClient, opts, istioNS)
 	if err != nil {

--- a/releasenotes/notes/47538.yaml
+++ b/releasenotes/notes/47538.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 47423
+releaseNotes:
+- |
+  **Fixed** an issue where the webhook generated with `istioctl tag set` is unexpectedly being removed by the installer.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/47423.

This is a regression introduced following https://github.com/istio/istio/pull/43897. Now user-generated labels will be identical to the installer created labels. As a result, a generated tag webhook will be managed by the installer as well.
However, they should be added/removed by using `istioctl tag set/remove`.

My approach is to remove the operator managed labels, since it was introduced by `MergeCopy` - this reverts to the previous behavior.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
