### PR TITLE
Bump prometheus

### DIFF
--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -87,7 +87,7 @@ func promDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=prometheus")
+			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app.kubernetes.io/name=prometheus")
 			if err != nil {
 				return fmt.Errorf("not able to locate Prometheus pod: %v", err)
 			}

--- a/istioctl/pkg/metrics/metrics.go
+++ b/istioctl/pkg/metrics/metrics.go
@@ -107,7 +107,7 @@ func run(c *cobra.Command, ctx cli.Context, args []string) error {
 		return fmt.Errorf("failed to create k8s client: %v", err)
 	}
 
-	pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=prometheus")
+	pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app.kubernetes.io/name=prometheus")
 	if err != nil {
 		return fmt.Errorf("not able to locate Prometheus pod: %v", err)
 	}

--- a/istioctl/pkg/metrics/metrics_test.go
+++ b/istioctl/pkg/metrics/metrics_test.go
@@ -80,7 +80,7 @@ func TestMetrics(t *testing.T) {
 			Name:      "prometheus",
 			Namespace: "istio-system",
 			Labels: map[string]string{
-				"app": "prometheus",
+				"app.kubernetes.io/name": "prometheus",
 			},
 		},
 	}, metav1.CreateOptions{})

--- a/manifests/addons/gen.sh
+++ b/manifests/addons/gen.sh
@@ -46,7 +46,7 @@ helm3 template kiali-server \
 # Set up prometheus
 helm3 template prometheus prometheus \
   --namespace istio-system \
-  --version 19.6.1 \
+  --version 25.2.0 \
   --repo https://prometheus-community.github.io/helm-charts \
   -f "${WD}/values-prometheus.yaml" \
   > "${ADDONS}/prometheus.yaml"

--- a/manifests/addons/values-prometheus.yaml
+++ b/manifests/addons/values-prometheus.yaml
@@ -26,3 +26,5 @@ server:
   # use dockerhub
   image:
     repository: prom/prometheus
+
+  securityContext: null

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -103,7 +103,7 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 	for _, cls := range ctx.Clusters().Kube() {
 		scopes.Framework.Debugf("Installing Prometheus on cluster: %s", cls.Name())
 		// Find the Prometheus pod and service, and start forwarding a local port.
-		fetchFn := testKube.NewSinglePodFetch(cls, cfg.TelemetryNamespace, fmt.Sprintf("app=%s", appName))
+		fetchFn := testKube.NewSinglePodFetch(cls, cfg.TelemetryNamespace, fmt.Sprintf("app.kubernetes.io/name=%s", appName))
 		pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
 		if err != nil {
 			return nil, err

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -4,11 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
   annotations:
@@ -19,11 +21,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
 data:
@@ -282,6 +286,10 @@ data:
         regex: Pending|Succeeded|Failed|Completed
         source_labels:
         - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
     - honor_labels: true
       job_name: kubernetes-pods-slow
       kubernetes_sd_configs:
@@ -332,6 +340,10 @@ data:
         regex: Pending|Succeeded|Failed|Completed
         source_labels:
         - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
       scrape_interval: 5m
       scrape_timeout: 30s
   recording_rules.yml: |
@@ -344,11 +356,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
 rules:
   - apiGroups:
@@ -376,6 +390,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - "/metrics"
     verbs:
@@ -386,11 +408,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
 subjects:
   - kind: ServiceAccount
@@ -406,11 +430,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
 spec:
@@ -420,9 +446,9 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    component: "server"
-    app: prometheus
-    release: prometheus
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
   sessionAffinity: None
   type: "ClusterIP"
 ---
@@ -431,31 +457,36 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-19.6.1
-    heritage: Helm
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.47.0
+    helm.sh/chart: prometheus-25.2.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
   name: prometheus
   namespace: istio-system
 spec:
   selector:
     matchLabels:
-      component: "server"
-      app: prometheus
-      release: prometheus
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: prometheus
   replicas: 1
+  revisionHistoryLimit: 10
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
       labels:
-        component: "server"
-        app: prometheus
-        release: prometheus
-        chart: prometheus-19.6.1
-        heritage: Helm
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: prometheus
+        app.kubernetes.io/version: v2.47.0
+        helm.sh/chart: prometheus-25.2.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
         
         sidecar.istio.io/inject: "false"
     spec:
@@ -463,11 +494,11 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.8.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0"
           imagePullPolicy: "IfNotPresent"
           args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090/-/reload
+            - --watched-dir=/etc/config
+            - --reload-url=http://127.0.0.1:9090/-/reload
           resources:
             {}
           volumeMounts:
@@ -476,7 +507,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "prom/prometheus:v2.41.0"
+          image: "prom/prometheus:v2.47.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d
@@ -516,11 +547,6 @@ spec:
               mountPath: /data
               subPath: ""
       dnsPolicy: ClusterFirst
-      securityContext:
-        fsGroup: 65534
-        runAsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
       terminationGracePeriodSeconds: 300
       volumes:
         - name: config-volume


### PR DESCRIPTION
And override securityContext values so that it is not set in the pod. Not setting it makes it work on both Kubernetes and OpenShift, as expected. The container does not run as root, it runs as the user `nobody` in Kubernetes and with a random UID on OpenShift.
