### PR TITLE
Prevent Externalname service dns floods

### DIFF
--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -114,7 +114,7 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 				}
 			}
 
-			// external name service, we should return the address of the referenced service address if exists
+			// Handle external name service, we should return the address of the referenced service address if exists.
 			if svc.Attributes.ExternalName != "" {
 				if referredSvc := cfg.Node.SidecarScope.GetService(host.Name(svc.Attributes.ExternalName)); referredSvc != nil {
 					svcAddress := referredSvc.GetAddressForProxy(cfg.Node)


### PR DESCRIPTION
**Please provide a description of this PR:**

This help when the referenced service has an address, 
like it is a k8s service with clusterIP, to it is a ServiceEntry with address previously allocated by istio