### PR TITLE
Update BASE_VERSION to point to master image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -49,7 +49,7 @@ endif
 export VERSION
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.20-2023-10-25T19-02-31
+BASE_VERSION ?= master-2023-10-25T19-05-49
 ISTIO_BASE_REGISTRY ?= gcr.io/istio-release
 
 export GO111MODULE ?= on


### PR DESCRIPTION
**Please provide a description of this PR:**
Supersedes https://github.com/istio/istio/pull/47588.

New BASE_VERSION images were created across the board yesterday. Unfortunately, the pipeline tried updating the master branch with the 1.20 (https://github.com/istio/istio/pull/47585)  and master (https://github.com/istio/istio/pull/47588) BASE_VERSION images. The 1.20 PR merged first causing a rebase issue with the master PR.

I fixed the pipeline so this own't happen again, and for now the pipeline will find a "good" image (since it was created yesterday) in the master branch although it happens to have a release-1.20 in the name. This will fix itself when the next set of base image are built.

However, since we have the master image already, I just recreated the PR since I can't rebase the other one easily.