### PR TITLE
Publish the raw commit SHA as a tag to gcr.io/istio-testing

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -108,5 +108,5 @@ release-builder validate --release "${WORK_DIR}/out"
 if [[ -z "${DRY_RUN:-}" ]]; then
   release-builder publish --release "${WORK_DIR}/out" \
     --gcsbucket "${GCS_BUCKET}" --gcsaliases "${NEXT_VERSION}-dev,latest" \
-    --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION},${NEXT_VERSION}-dev,latest"
+    --dockerhub "${DOCKER_HUB}" --dockertags "${TAG},${VERSION},${NEXT_VERSION}-dev,latest"
 fi


### PR DESCRIPTION
So that given a commit SHA we can reference an image without having to know which version that commit belongs to.