### PR TITLE
Revert gomega to using dots

### DIFF
--- a/istioctl/pkg/analyze/analyze_test.go
+++ b/istioctl/pkg/analyze/analyze_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/util/testutil"
@@ -26,7 +26,7 @@ import (
 )
 
 func TestErrorOnIssuesFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	msgs := []diag.Message{
 		diag.NewMessage(
@@ -43,11 +43,11 @@ func TestErrorOnIssuesFound(t *testing.T) {
 
 	err := errorIfMessagesExceedThreshold(msgs)
 
-	g.Expect(err).To(gomega.BeIdenticalTo(AnalyzerFoundIssuesError{}))
+	g.Expect(err).To(BeIdenticalTo(AnalyzerFoundIssuesError{}))
 }
 
 func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	msgs := []diag.Message{
 		diag.NewMessage(
@@ -64,7 +64,7 @@ func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
 
 	err := errorIfMessagesExceedThreshold(msgs)
 
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 }
 
 func TestSkipPodsInFiles(t *testing.T) {

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -733,7 +733,7 @@ users:
 }
 
 func TestRemoteSecretOptions(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	ctx := cli.NewFakeContext(nil)
 	o := RemoteSecretOptions{}
@@ -742,8 +742,8 @@ func TestRemoteSecretOptions(t *testing.T) {
 	g.Expect(flags.Parse([]string{
 		"--name",
 		"valid-name",
-	})).Should(gomega.Succeed())
-	g.Expect(o.prepare(ctx)).Should(gomega.Succeed())
+	})).Should(Succeed())
+	g.Expect(o.prepare(ctx)).Should(Succeed())
 
 	o = RemoteSecretOptions{}
 	flags = pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -751,6 +751,6 @@ func TestRemoteSecretOptions(t *testing.T) {
 	g.Expect(flags.Parse([]string{
 		"--name",
 		"?-invalid-name",
-	})).Should(gomega.Succeed())
-	g.Expect(o.prepare(ctx)).Should(gomega.Not(gomega.Succeed()))
+	})).Should(Succeed())
+	g.Expect(o.prepare(ctx)).Should(Not(Succeed()))
 }

--- a/istioctl/pkg/util/formatting/formatter_test.go
+++ b/istioctl/pkg/util/formatting/formatter_test.go
@@ -17,14 +17,14 @@ package formatting
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/config/analysis/diag"
 	"istio.io/istio/pkg/url"
 )
 
 func TestFormatter_PrintLog(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := diag.NewMessage(
 		diag.NewMessageType(diag.Error, "B1", "Explosion accident: %v"),
@@ -40,14 +40,14 @@ func TestFormatter_PrintLog(t *testing.T) {
 	msgs := diag.Messages{firstMsg, secondMsg}
 	output, _ := Print(msgs, LogFormat, false)
 
-	g.Expect(output).To(gomega.Equal(
+	g.Expect(output).To(Equal(
 		"Error [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
 			"Warning [C1] (GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 
 func TestFormatter_PrintLogWithColor(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := diag.NewMessage(
 		diag.NewMessageType(diag.Error, "B1", "Explosion accident: %v"),
@@ -63,14 +63,14 @@ func TestFormatter_PrintLogWithColor(t *testing.T) {
 	msgs := diag.Messages{firstMsg, secondMsg}
 	output, _ := Print(msgs, LogFormat, true)
 
-	g.Expect(output).To(gomega.Equal(
+	g.Expect(output).To(Equal(
 		"\033[1;31mError\033[0m [B1] (SoapBubble) Explosion accident: the bubble is too big\n" +
 			"\033[33mWarning\033[0m [C1] (GrandCastle) Collapse danger: the castle is too old",
 	))
 }
 
 func TestFormatter_PrintJSON(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := diag.NewMessage(
 		diag.NewMessageType(diag.Error, "B1", "Explosion accident: %v"),
@@ -103,11 +103,11 @@ func TestFormatter_PrintJSON(t *testing.T) {
 	}
 ]`
 
-	g.Expect(output).To(gomega.Equal(expectedOutput))
+	g.Expect(output).To(Equal(expectedOutput))
 }
 
 func TestFormatter_PrintYAML(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := diag.NewMessage(
 		diag.NewMessageType(diag.Error, "B1", "Explosion accident: %v"),
@@ -135,20 +135,20 @@ func TestFormatter_PrintYAML(t *testing.T) {
   origin: GrandCastle
 `
 
-	g.Expect(output).To(gomega.Equal(expectedOutput))
+	g.Expect(output).To(Equal(expectedOutput))
 }
 
 func TestFormatter_PrintEmpty(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	msgs := diag.Messages{}
 
 	logOutput, _ := Print(msgs, LogFormat, false)
-	g.Expect(logOutput).To(gomega.Equal(""))
+	g.Expect(logOutput).To(Equal(""))
 
 	jsonOutput, _ := Print(msgs, JSONFormat, false)
-	g.Expect(jsonOutput).To(gomega.Equal("[]"))
+	g.Expect(jsonOutput).To(Equal("[]"))
 
 	yamlOutput, _ := Print(msgs, YAMLFormat, false)
-	g.Expect(yamlOutput).To(gomega.Equal("[]\n"))
+	g.Expect(yamlOutput).To(Equal("[]\n"))
 }

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -186,7 +186,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestManifestGenerateComponentHubTag(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	objs, err := runManifestCommands("component_hub_tag", "", liveCharts, []string{"templates/deployment.yaml"})
 	if err != nil {
@@ -223,7 +223,7 @@ func TestManifestGenerateComponentHubTag(t *testing.T) {
 }
 
 func TestManifestGenerateGateways(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	flags := "-s components.ingressGateways.[0].k8s.resources.requests.memory=999Mi " +
 		"-s components.ingressGateways.[name:user-ingressgateway].k8s.resources.requests.cpu=555m"
@@ -234,12 +234,12 @@ func TestManifestGenerateGateways(t *testing.T) {
 	}
 
 	for _, objs := range objss {
-		g.Expect(objs.kind(name.HPAStr).size()).Should(gomega.Equal(3))
-		g.Expect(objs.kind(name.PDBStr).size()).Should(gomega.Equal(3))
-		g.Expect(objs.kind(name.ServiceStr).labels("istio=ingressgateway").size()).Should(gomega.Equal(3))
-		g.Expect(objs.kind(name.RoleStr).nameMatches(".*gateway.*").size()).Should(gomega.Equal(3))
-		g.Expect(objs.kind(name.RoleBindingStr).nameMatches(".*gateway.*").size()).Should(gomega.Equal(3))
-		g.Expect(objs.kind(name.SAStr).nameMatches(".*gateway.*").size()).Should(gomega.Equal(3))
+		g.Expect(objs.kind(name.HPAStr).size()).Should(Equal(3))
+		g.Expect(objs.kind(name.PDBStr).size()).Should(Equal(3))
+		g.Expect(objs.kind(name.ServiceStr).labels("istio=ingressgateway").size()).Should(Equal(3))
+		g.Expect(objs.kind(name.RoleStr).nameMatches(".*gateway.*").size()).Should(Equal(3))
+		g.Expect(objs.kind(name.RoleBindingStr).nameMatches(".*gateway.*").size()).Should(Equal(3))
+		g.Expect(objs.kind(name.SAStr).nameMatches(".*gateway.*").size()).Should(Equal(3))
 
 		dobj := mustGetDeployment(g, objs, "istio-ingressgateway")
 		d := dobj.Unstructured()
@@ -283,22 +283,22 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 	testCases := []struct {
 		name       string
 		force      bool
-		assertFunc func(g *gomega.WithT, objs *ObjectSet, err error)
+		assertFunc func(g *WithT, objs *ObjectSet, err error)
 	}{
 		{
 			name:  "Duplicate MutatingWebhookConfiguration should be allowed when --force is enabled",
 			force: true,
-			assertFunc: func(g *gomega.WithT, objs *ObjectSet, err error) {
-				g.Expect(err).Should(gomega.BeNil())
-				g.Expect(objs.kind(name.MutatingWebhookConfigurationStr).size()).Should(gomega.Equal(2))
+			assertFunc: func(g *WithT, objs *ObjectSet, err error) {
+				g.Expect(err).Should(BeNil())
+				g.Expect(objs.kind(name.MutatingWebhookConfigurationStr).size()).Should(Equal(2))
 			},
 		},
 		{
 			name:  "Duplicate MutatingWebhookConfiguration should not be allowed when --force is disabled",
 			force: false,
-			assertFunc: func(g *gomega.WithT, objs *ObjectSet, err error) {
-				g.Expect(err.Error()).To(gomega.ContainSubstring("Webhook overlaps with others"))
-				g.Expect(objs).Should(gomega.BeNil())
+			assertFunc: func(g *WithT, objs *ObjectSet, err error) {
+				g.Expect(err.Error()).To(ContainSubstring("Webhook overlaps with others"))
+				g.Expect(objs).Should(BeNil())
 			},
 		},
 	}
@@ -324,7 +324,7 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			objs, err := fakeControllerReconcile(testResourceFile, tmpCharts, &helmreconciler.Options{Force: tc.force, SkipPrune: true})
 			tc.assertFunc(g, objs, err)
 		})
@@ -332,7 +332,7 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 }
 
 func TestManifestGenerateIstiodRemote(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	objss, err := runManifestCommands("istiod_remote", "", liveCharts, nil)
 	if err != nil {
@@ -341,16 +341,16 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 
 	for _, objs := range objss {
 		// check core CRDs exists
-		g.Expect(objs.kind(name.CRDStr).nameEquals("destinationrules.networking.istio.io")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.CRDStr).nameEquals("gateways.networking.istio.io")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.CRDStr).nameEquals("sidecars.networking.istio.io")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.CRDStr).nameEquals("virtualservices.networking.istio.io")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.CRDStr).nameEquals("adapters.config.istio.io")).Should(gomega.BeNil())
-		g.Expect(objs.kind(name.CRDStr).nameEquals("authorizationpolicies.security.istio.io")).Should(gomega.Not(gomega.BeNil()))
+		g.Expect(objs.kind(name.CRDStr).nameEquals("destinationrules.networking.istio.io")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.CRDStr).nameEquals("gateways.networking.istio.io")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.CRDStr).nameEquals("sidecars.networking.istio.io")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.CRDStr).nameEquals("virtualservices.networking.istio.io")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.CRDStr).nameEquals("adapters.config.istio.io")).Should(BeNil())
+		g.Expect(objs.kind(name.CRDStr).nameEquals("authorizationpolicies.security.istio.io")).Should(Not(BeNil()))
 
-		g.Expect(objs.kind(name.CMStr).nameEquals("istio-sidecar-injector")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.ServiceStr).nameEquals("istiod")).Should(gomega.Not(gomega.BeNil()))
-		g.Expect(objs.kind(name.SAStr).nameEquals("istio-reader-service-account")).Should(gomega.Not(gomega.BeNil()))
+		g.Expect(objs.kind(name.CMStr).nameEquals("istio-sidecar-injector")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.ServiceStr).nameEquals("istiod")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.SAStr).nameEquals("istio-reader-service-account")).Should(Not(BeNil()))
 
 		mwc := mustGetMutatingWebhookConfiguration(g, objs, "istio-sidecar-injector").Unstructured()
 		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.url", "https://xxx:15017/inject"}))
@@ -364,7 +364,7 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 }
 
 func TestManifestGenerateAllOff(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("all_off", "", liveCharts, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -373,11 +373,11 @@ func TestManifestGenerateAllOff(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	g.Expect(objs.size()).Should(gomega.Equal(0))
+	g.Expect(objs.size()).Should(Equal(0))
 }
 
 func TestManifestGenerateFlagsMinimalProfile(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	// Change profile from empty to minimal using flag.
 	m, _, err := generateManifest("empty", "-s profile=minimal", liveCharts, []string{"templates/deployment.yaml"})
 	if err != nil {
@@ -392,7 +392,7 @@ func TestManifestGenerateFlagsMinimalProfile(t *testing.T) {
 }
 
 func TestManifestGenerateFlagsSetHubTag(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("minimal", "-s hub=foo -s tag=bar", liveCharts, []string{"templates/deployment.yaml"})
 	if err != nil {
 		t.Fatal(err)
@@ -409,7 +409,7 @@ func TestManifestGenerateFlagsSetHubTag(t *testing.T) {
 }
 
 func TestManifestGenerateFlagsSetValues(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("default", "-s values.global.proxy.image=myproxy -s values.global.proxy.includeIPRanges=172.30.0.0/16,172.21.0.0/16", liveCharts,
 		[]string{"templates/deployment.yaml", "templates/istiod-injector-configmap.yaml"})
 	if err != nil {

--- a/operator/cmd/mesh/profile-list_test.go
+++ b/operator/cmd/mesh/profile-list_test.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/pkg/kube"
@@ -27,7 +27,7 @@ import (
 )
 
 func TestProfileList(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	args := []string{"profile", "list", "--dry-run", "--manifests", filepath.Join(env.IstioSrc, "manifests")}
 
 	kubeClientFunc = func() (kube.CLIClient, error) {
@@ -47,6 +47,6 @@ func TestProfileList(t *testing.T) {
 	output := out.String()
 	expectedProfiles := []string{"default", "demo", "empty", "minimal", "openshift", "preview", "remote", "external"}
 	for _, prof := range expectedProfiles {
-		g.Expect(output).To(gomega.ContainSubstring(prof))
+		g.Expect(output).To(ContainSubstring(prof))
 	}
 }

--- a/operator/cmd/mesh/test-util_test.go
+++ b/operator/cmd/mesh/test-util_test.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	labels2 "k8s.io/apimachinery/pkg/labels"
 
@@ -157,55 +157,55 @@ func hasLabel(o *object.K8sObject, label, value string) bool {
 }
 
 // mustGetService returns the service with the given name or fails if it's not found in objs.
-func mustGetService(g *gomega.WithT, objs *ObjectSet, name string) *object.K8sObject {
+func mustGetService(g *WithT, objs *ObjectSet, name string) *object.K8sObject {
 	obj := objs.kind(name2.ServiceStr).nameEquals(name)
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
 // mustGetDeployment returns the deployment with the given name or fails if it's not found in objs.
-func mustGetDeployment(g *gomega.WithT, objs *ObjectSet, deploymentName string) *object.K8sObject {
+func mustGetDeployment(g *WithT, objs *ObjectSet, deploymentName string) *object.K8sObject {
 	obj := objs.kind(name2.DeploymentStr).nameEquals(deploymentName)
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
 // mustGetClusterRole returns the clusterRole with the given name or fails if it's not found in objs.
-func mustGetClusterRole(g *gomega.WithT, objs *ObjectSet, name string) *object.K8sObject {
+func mustGetClusterRole(g *WithT, objs *ObjectSet, name string) *object.K8sObject {
 	obj := objs.kind(name2.ClusterRoleStr).nameEquals(name)
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
 // mustGetRole returns the role with the given name or fails if it's not found in objs.
-func mustGetRole(g *gomega.WithT, objs *ObjectSet, name string) *object.K8sObject {
+func mustGetRole(g *WithT, objs *ObjectSet, name string) *object.K8sObject {
 	obj := objs.kind(name2.RoleStr).nameEquals(name)
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
 // mustGetContainer returns the container tree with the given name in the deployment with the given name.
-func mustGetContainer(g *gomega.WithT, objs *ObjectSet, deploymentName, containerName string) map[string]any {
+func mustGetContainer(g *WithT, objs *ObjectSet, deploymentName, containerName string) map[string]any {
 	obj := mustGetDeployment(g, objs, deploymentName)
 	container := obj.Container(containerName)
-	g.Expect(container).Should(gomega.Not(gomega.BeNil()), fmt.Sprintf("Expected to get container %s in deployment %s", containerName, deploymentName))
+	g.Expect(container).Should(Not(BeNil()), fmt.Sprintf("Expected to get container %s in deployment %s", containerName, deploymentName))
 	return container
 }
 
 // mustGetEndpoint returns the endpoint tree with the given name in the deployment with the given name.
-func mustGetEndpoint(g *gomega.WithT, objs *ObjectSet, endpointName string) *object.K8sObject {
+func mustGetEndpoint(g *WithT, objs *ObjectSet, endpointName string) *object.K8sObject {
 	obj := objs.kind(name2.EndpointStr).nameEquals(endpointName)
 	if obj == nil {
 		return nil
 	}
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
 // mustGetMutatingWebhookConfiguration returns the mutatingWebhookConfiguration with the given name or fails if it's not found in objs.
-func mustGetMutatingWebhookConfiguration(g *gomega.WithT, objs *ObjectSet, mutatingWebhookConfigurationName string) *object.K8sObject {
+func mustGetMutatingWebhookConfiguration(g *WithT, objs *ObjectSet, mutatingWebhookConfigurationName string) *object.K8sObject {
 	obj := objs.kind(name2.MutatingWebhookConfigurationStr).nameEquals(mutatingWebhookConfigurationName)
-	g.Expect(obj).Should(gomega.Not(gomega.BeNil()))
+	g.Expect(obj).Should(Not(BeNil()))
 	return obj
 }
 
@@ -417,10 +417,10 @@ func findObject(objs object.K8sObjects, name, kind string) *object.K8sObject {
 
 // mustGetValueAtPath returns the value at the given path in the unstructured tree t. Fails if the path is not found
 // in the tree.
-func mustGetValueAtPath(g *gomega.WithT, t map[string]any, path string) any {
+func mustGetValueAtPath(g *WithT, t map[string]any, path string) any {
 	got, f, err := tpath.GetPathContext(t, util.PathFromString(path), false)
-	g.Expect(err).Should(gomega.BeNil(), "path %s should exist (%s)", path, err)
-	g.Expect(f).Should(gomega.BeTrue(), "path %s should exist", path)
+	g.Expect(err).Should(BeNil(), "path %s should exist (%s)", path, err)
+	g.Expect(f).Should(BeTrue(), "path %s should exist", path)
 	return got.Node
 }
 
@@ -472,7 +472,7 @@ func portVal(name string, port, targetPort int64) map[string]any {
 }
 
 // checkRoleBindingsReferenceRoles fails if any RoleBinding in objs references a Role that isn't found in objs.
-func checkRoleBindingsReferenceRoles(g *gomega.WithT, objs *ObjectSet) {
+func checkRoleBindingsReferenceRoles(g *WithT, objs *ObjectSet) {
 	for _, o := range objs.kind(name2.RoleBindingStr).objSlice {
 		ou := o.Unstructured()
 		rrname := mustGetValueAtPath(g, ou, "roleRef.name")
@@ -481,7 +481,7 @@ func checkRoleBindingsReferenceRoles(g *gomega.WithT, objs *ObjectSet) {
 }
 
 // checkClusterRoleBindingsReferenceRoles fails if any RoleBinding in objs references a Role that isn't found in objs.
-func checkClusterRoleBindingsReferenceRoles(g *gomega.WithT, objs *ObjectSet) {
+func checkClusterRoleBindingsReferenceRoles(g *WithT, objs *ObjectSet) {
 	for _, o := range objs.kind(name2.ClusterRoleBindingStr).objSlice {
 		ou := o.Unstructured()
 		rrname := mustGetValueAtPath(g, ou, "roleRef.name")

--- a/pilot/cmd/pilot-agent/app/cmd_test.go
+++ b/pilot/cmd/pilot-agent/app/cmd_test.go
@@ -17,17 +17,17 @@ package app
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/pkg/model"
 )
 
 func TestPilotDefaultDomainKubernetes(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	role := &model.Proxy{}
 	role.DNSDomain = ""
 
 	domain := getDNSDomain("default", role.DNSDomain)
 
-	g.Expect(domain).To(gomega.Equal("default.svc.cluster.local"))
+	g.Expect(domain).To(Equal("default.svc.cluster.local"))
 }

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/status/testserver"
 )
@@ -32,7 +32,7 @@ var (
 )
 
 func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(liveServerStats)
 	defer server.Close()
@@ -43,11 +43,11 @@ func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 
 	err := probe.Check()
 
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 }
 
 func TestEnvoyDraining(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(liveServerStats)
 	defer server.Close()
@@ -57,7 +57,7 @@ func TestEnvoyDraining(t *testing.T) {
 
 	err := probe.isEnvoyReady()
 
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEnvoyStats(t *testing.T) {
@@ -133,7 +133,7 @@ server.state: 0`,
 }
 
 func TestEnvoyInitializing(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(initServerStats)
 	defer server.Close()
@@ -143,11 +143,11 @@ func TestEnvoyInitializing(t *testing.T) {
 	probe.Context = ctx
 	err := probe.Check()
 
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEnvoyNoClusterManagerStats(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(onlyServerStats)
 	defer server.Close()
@@ -157,11 +157,11 @@ func TestEnvoyNoClusterManagerStats(t *testing.T) {
 	probe.Context = ctx
 	err := probe.Check()
 
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEnvoyNoServerStats(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(noServerStats)
 	defer server.Close()
@@ -171,11 +171,11 @@ func TestEnvoyNoServerStats(t *testing.T) {
 	probe.Context = ctx
 	err := probe.Check()
 
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEnvoyReadinessCache(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	server := testserver.CreateAndStartServer(noServerStats)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -183,28 +183,28 @@ func TestEnvoyReadinessCache(t *testing.T) {
 	probe := Probe{AdminPort: uint16(server.Listener.Addr().(*net.TCPAddr).Port)}
 	probe.Context = ctx
 	err := probe.Check()
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(gomega.BeFalse())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeFalse())
 	err = probe.Check()
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(gomega.BeFalse())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeFalse())
 	server.Close()
 
 	server = testserver.CreateAndStartServer(liveServerStats)
 	probe.AdminPort = uint16(server.Listener.Addr().(*net.TCPAddr).Port)
 	err = probe.Check()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(gomega.BeTrue())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeTrue())
 	server.Close()
 
 	server = testserver.CreateAndStartServer(noServerStats)
 	probe.AdminPort = uint16(server.Listener.Addr().(*net.TCPAddr).Port)
 	err = probe.Check()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(gomega.BeTrue())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeTrue())
 	server.Close()
 
 	err = probe.Check()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(gomega.BeTrue())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeTrue())
 }

--- a/pilot/pkg/bootstrap/istio_ca_test.go
+++ b/pilot/pkg/bootstrap/istio_ca_test.go
@@ -19,7 +19,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -33,7 +33,7 @@ import (
 const testNamespace = "istio-system"
 
 func TestRemoteCerts(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	dir := t.TempDir()
 
@@ -47,29 +47,29 @@ func TestRemoteCerts(t *testing.T) {
 
 	// Should do nothing because cacerts doesn't exist.
 	err := s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
 	_, err = os.Stat(path.Join(dir, "root-cert.pem"))
-	g.Expect(os.IsNotExist(err)).Should(gomega.Equal(true))
+	g.Expect(os.IsNotExist(err)).Should(Equal(true))
 
 	// Should load remote cacerts successfully.
 	createCASecret(t, s.kubeClient)
 
 	err = s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
 	expectedRoot, err := readSampleCertFromFile("root-cert.pem")
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
-	g.Expect(os.ReadFile(path.Join(dir, "root-cert.pem"))).Should(gomega.Equal(expectedRoot))
+	g.Expect(os.ReadFile(path.Join(dir, "root-cert.pem"))).Should(Equal(expectedRoot))
 
 	// Should do nothing because certs already exist locally.
 	err = s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 }
 
 func TestRemoteTLSCerts(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	dir := t.TempDir()
 
@@ -83,25 +83,25 @@ func TestRemoteTLSCerts(t *testing.T) {
 
 	// Should do nothing because cacerts doesn't exist.
 	err := s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
 	_, err = os.Stat(path.Join(dir, "ca.crt"))
-	g.Expect(os.IsNotExist(err)).Should(gomega.Equal(true))
+	g.Expect(os.IsNotExist(err)).Should(Equal(true))
 
 	// Should load remote cacerts successfully.
 	createCATLSSecret(t, s.kubeClient)
 
 	err = s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
 	expectedRoot, err := readSampleCertFromFile("root-cert.pem")
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 
-	g.Expect(os.ReadFile(path.Join(dir, "ca.crt"))).Should(gomega.Equal(expectedRoot))
+	g.Expect(os.ReadFile(path.Join(dir, "ca.crt"))).Should(Equal(expectedRoot))
 
 	// Should do nothing because certs already exist locally.
 	err = s.loadCACerts(caOpts, dir)
-	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(err).Should(BeNil())
 }
 
 func createCATLSSecret(t test.Failer, client kube.Client) {

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	cert "k8s.io/api/certificates/v1"
@@ -228,13 +228,13 @@ func TestNewServerCertInit(t *testing.T) {
 
 				p.ShutdownDuration = 1 * time.Millisecond
 			})
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			s, err := NewServer(args, func(s *Server) {
 				s.kubeClient = kube.NewFakeClient()
 			})
-			g.Expect(err).To(gomega.Succeed())
+			g.Expect(err).To(Succeed())
 			stop := make(chan struct{})
-			g.Expect(s.Start(stop)).To(gomega.Succeed())
+			g.Expect(s.Start(stop)).To(Succeed())
 			defer func() {
 				close(stop)
 				s.WaitUntilCompletion()
@@ -327,12 +327,12 @@ func TestReloadIstiodCert(t *testing.T) {
 		t.Fatalf("WriteFile(%v) failed: %v", tlsOptions.KeyFile, err)
 	}
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	// Validate that istiod cert is updated.
 	g.Eventually(func() bool {
 		return checkCert(t, s, testcerts.RotatedCert, testcerts.RotatedKey)
-	}, "10s", "100ms").Should(gomega.BeTrue())
+	}, "10s", "100ms").Should(BeTrue())
 }
 
 func TestNewServer(t *testing.T) {
@@ -399,19 +399,19 @@ func TestNewServer(t *testing.T) {
 				p.JwtRule = c.jwtRule
 			})
 
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			s, err := NewServer(args, func(s *Server) {
 				s.kubeClient = kube.NewFakeClient()
 			})
-			g.Expect(err).To(gomega.Succeed())
+			g.Expect(err).To(Succeed())
 			stop := make(chan struct{})
-			g.Expect(s.Start(stop)).To(gomega.Succeed())
+			g.Expect(s.Start(stop)).To(Succeed())
 			defer func() {
 				close(stop)
 				s.WaitUntilCompletion()
 			}()
 
-			g.Expect(s.environment.DomainSuffix).To(gomega.Equal(c.expectedDomain))
+			g.Expect(s.environment.DomainSuffix).To(Equal(c.expectedDomain))
 
 			assert.Equal(t, s.secureGrpcServer != nil, c.enableSecureGRPC)
 		})
@@ -440,13 +440,13 @@ func TestMultiplex(t *testing.T) {
 		p.ShutdownDuration = 1 * time.Millisecond
 	})
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	s, err := NewServer(args, func(s *Server) {
 		s.kubeClient = kube.NewFakeClient()
 	})
-	g.Expect(err).To(gomega.Succeed())
+	g.Expect(err).To(Succeed())
 	stop := make(chan struct{})
-	g.Expect(s.Start(stop)).To(gomega.Succeed())
+	g.Expect(s.Start(stop)).To(Succeed())
 	defer func() {
 		close(stop)
 		s.WaitUntilCompletion()
@@ -532,14 +532,14 @@ func TestIstiodCipherSuites(t *testing.T) {
 				p.ShutdownDuration = 1 * time.Millisecond
 			})
 
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			s, err := NewServer(args, func(s *Server) {
 				s.kubeClient = kube.NewFakeClient()
 			})
-			g.Expect(err).To(gomega.Succeed())
+			g.Expect(err).To(Succeed())
 
 			stop := make(chan struct{})
-			g.Expect(s.Start(stop)).To(gomega.Succeed())
+			g.Expect(s.Start(stop)).To(Succeed())
 			defer func() {
 				close(stop)
 				s.WaitUntilCompletion()

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"go.uber.org/atomic"
 
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -34,7 +34,7 @@ import (
 )
 
 func TestAggregateStoreBasicMake(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	schema1 := collections.HTTPRoute
 	schema2 := collections.GatewayClass
@@ -44,27 +44,27 @@ func TestAggregateStoreBasicMake(t *testing.T) {
 	stores := []model.ConfigStore{store1, store2}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	schemas := store.Schemas()
-	g.Expect(schemas.All()).To(gomega.HaveLen(2))
+	g.Expect(schemas.All()).To(HaveLen(2))
 	fixtures.ExpectEqual(t, schemas, collection.SchemasFor(schema1, schema2))
 }
 
 func TestAggregateStoreMakeValidationFailure(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(schemaFor("SomeConfig", "broken message name")))
 
 	stores := []model.ConfigStore{store1}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("not found: broken message name")))
-	g.Expect(store).To(gomega.BeNil())
+	g.Expect(err).To(MatchError(ContainSubstring("not found: broken message name")))
+	g.Expect(store).To(BeNil())
 }
 
 func TestAggregateStoreGet(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.GatewayClass))
 	store2 := memory.Make(collection.SchemasFor(collections.GatewayClass))
@@ -77,19 +77,19 @@ func TestAggregateStoreGet(t *testing.T) {
 	}
 
 	_, err := store1.Create(*configReturn)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	stores := []model.ConfigStore{store1, store2}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	c := store.Get(gvk.GatewayClass, "other", "")
-	g.Expect(c.Name).To(gomega.Equal(configReturn.Name))
+	g.Expect(c.Name).To(Equal(configReturn.Name))
 }
 
 func TestAggregateStoreList(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
 	store2 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
@@ -114,14 +114,14 @@ func TestAggregateStoreList(t *testing.T) {
 	stores := []model.ConfigStore{store1, store2}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	l := store.List(gvk.HTTPRoute, "")
-	g.Expect(l).To(gomega.HaveLen(2))
+	g.Expect(l).To(HaveLen(2))
 }
 
 func TestAggregateStoreWrite(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
 	store2 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
@@ -129,7 +129,7 @@ func TestAggregateStoreWrite(t *testing.T) {
 	stores := []model.ConfigStore{store1, store2}
 
 	store, err := makeStore(stores, store1)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	if _, err := store.Create(config.Config{
 		Meta: config.Meta{
@@ -141,22 +141,22 @@ func TestAggregateStoreWrite(t *testing.T) {
 	}
 
 	la := store.List(gvk.HTTPRoute, "")
-	g.Expect(la).To(gomega.HaveLen(1))
-	g.Expect(la[0].Name).To(gomega.Equal("other"))
+	g.Expect(la).To(HaveLen(1))
+	g.Expect(la[0].Name).To(Equal("other"))
 
 	l := store1.List(gvk.HTTPRoute, "")
-	g.Expect(l).To(gomega.HaveLen(1))
-	g.Expect(l[0].Name).To(gomega.Equal("other"))
+	g.Expect(l).To(HaveLen(1))
+	g.Expect(l[0].Name).To(Equal("other"))
 
 	// Check the aggregated and individual store return identical response
-	g.Expect(la).To(gomega.BeEquivalentTo(l))
+	g.Expect(la).To(BeEquivalentTo(l))
 
 	l = store2.List(gvk.HTTPRoute, "")
-	g.Expect(l).To(gomega.HaveLen(0))
+	g.Expect(l).To(HaveLen(0))
 }
 
 func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
 	store2 := memory.Make(collection.SchemasFor(collections.HTTPRoute))
@@ -164,7 +164,7 @@ func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
 	stores := []model.ConfigStore{store1, store2}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	if _, err := store.Create(config.Config{
 		Meta: config.Meta{
@@ -177,36 +177,36 @@ func TestAggregateStoreWriteWithoutWriter(t *testing.T) {
 }
 
 func TestAggregateStoreFails(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(schemaFor("OtherConfig", "istio.networking.v1alpha3.Gateway")))
 
 	stores := []model.ConfigStore{store1}
 
 	store, err := makeStore(stores, nil)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	t.Run("Fails to Delete", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		err = store.Delete(config.GroupVersionKind{Kind: "not"}, "gonna", "work", nil)
-		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported operation")))
 	})
 
 	t.Run("Fails to Create", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		c, err := store.Create(config.Config{})
-		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
-		g.Expect(c).To(gomega.BeEmpty())
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported operation")))
+		g.Expect(c).To(BeEmpty())
 	})
 
 	t.Run("Fails to Update", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		c, err := store.Update(config.Config{})
-		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
-		g.Expect(c).To(gomega.BeEmpty())
+		g.Expect(err).To(MatchError(ContainSubstring("unsupported operation")))
+		g.Expect(c).To(BeEmpty())
 	})
 }
 

--- a/pilot/pkg/config/file/util/kubeyaml/kubeyaml_test.go
+++ b/pilot/pkg/config/file/util/kubeyaml/kubeyaml_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var joinCases = []struct {
@@ -83,7 +83,7 @@ yaml: foo`,
 func TestJoinBytes(t *testing.T) {
 	for i, c := range joinCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			var by [][]byte
 			for _, s := range c.split {
@@ -91,7 +91,7 @@ func TestJoinBytes(t *testing.T) {
 			}
 			actual := Join(by...)
 
-			g.Expect(actual).To(gomega.Equal([]byte(c.merged)))
+			g.Expect(actual).To(Equal([]byte(c.merged)))
 		})
 	}
 }
@@ -99,11 +99,11 @@ func TestJoinBytes(t *testing.T) {
 func TestJoinString(t *testing.T) {
 	for i, c := range joinCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			actual := JoinString(c.split...)
 
-			g.Expect(actual).To(gomega.Equal(c.merged))
+			g.Expect(actual).To(Equal(c.merged))
 		})
 	}
 }
@@ -128,7 +128,7 @@ func TestLineNumber(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			reader := bufio.NewReader(strings.NewReader(tc.input))
 			decoder := NewYAMLReader(reader)
@@ -140,7 +140,7 @@ func TestLineNumber(t *testing.T) {
 				}
 				expectedLineNumbers = append(expectedLineNumbers, line)
 			}
-			g.Expect(expectedLineNumbers).To(gomega.Equal(tc.lineNumbers))
+			g.Expect(expectedLineNumbers).To(Equal(tc.lineNumbers))
 		})
 	}
 }

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -82,7 +82,7 @@ var AlwaysReady = func(class schema.GroupVersionResource, stop <-chan struct{}) 
 }
 
 func TestListInvalidGroupVersionKind(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	clientSet := kube.NewFakeClient()
 	clientSet.RunAndWait(test.NewStop(t))
 	store := memory.NewController(memory.Make(collections.All))
@@ -90,11 +90,11 @@ func TestListInvalidGroupVersionKind(t *testing.T) {
 
 	typ := config.GroupVersionKind{Kind: "wrong-kind"}
 	c := controller.List(typ, "ns1")
-	g.Expect(c).To(gomega.HaveLen(0))
+	g.Expect(c).To(HaveLen(0))
 }
 
 func TestListGatewayResourceType(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	clientSet := kube.NewFakeClient()
 	clientSet.RunAndWait(test.NewStop(t))
@@ -129,14 +129,14 @@ func TestListGatewayResourceType(t *testing.T) {
 	})
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
-	g.Expect(controller.Reconcile(cg.PushContext())).ToNot(gomega.HaveOccurred())
+	g.Expect(controller.Reconcile(cg.PushContext())).ToNot(HaveOccurred())
 	cfg := controller.List(gvk.Gateway, "ns1")
-	g.Expect(cfg).To(gomega.HaveLen(1))
+	g.Expect(cfg).To(HaveLen(1))
 	for _, c := range cfg {
-		g.Expect(c.GroupVersionKind).To(gomega.Equal(gvk.Gateway))
-		g.Expect(c.Name).To(gomega.Equal("gwspec" + "-" + constants.KubernetesGatewayName + "-default"))
-		g.Expect(c.Namespace).To(gomega.Equal("ns1"))
-		g.Expect(c.Spec).To(gomega.Equal(expectedgw))
+		g.Expect(c.GroupVersionKind).To(Equal(gvk.Gateway))
+		g.Expect(c.Name).To(Equal("gwspec" + "-" + constants.KubernetesGatewayName + "-default"))
+		g.Expect(c.Namespace).To(Equal("ns1"))
+		g.Expect(c.Spec).To(Equal(expectedgw))
 	}
 }
 

--- a/pilot/pkg/config/monitor/file_snapshot_test.go
+++ b/pilot/pkg/config/monitor/file_snapshot_test.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/schema/collection"
@@ -76,7 +76,7 @@ spec:
 `
 
 func TestFileSnapshotNoFilter(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{"gateway.yml": []byte(gatewayYAML)},
@@ -86,18 +86,18 @@ func TestFileSnapshotNoFilter(t *testing.T) {
 
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "foo")
 	configs, err := fileWatcher.ReadConfigFiles()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(configs).To(gomega.HaveLen(1))
-	g.Expect(configs[0].Domain).To(gomega.Equal("foo"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(configs).To(HaveLen(1))
+	g.Expect(configs[0].Domain).To(Equal("foo"))
 
 	gateway := configs[0].Spec.(*networking.Gateway)
-	g.Expect(gateway.Servers[0].Port.Number).To(gomega.Equal(uint32(80)))
-	g.Expect(gateway.Servers[0].Port.Protocol).To(gomega.Equal("http"))
-	g.Expect(gateway.Servers[0].Hosts).To(gomega.Equal([]string{"*.example.com"}))
+	g.Expect(gateway.Servers[0].Port.Number).To(Equal(uint32(80)))
+	g.Expect(gateway.Servers[0].Port.Protocol).To(Equal("http"))
+	g.Expect(gateway.Servers[0].Hosts).To(Equal([]string{"*.example.com"}))
 }
 
 func TestFileSnapshotWithFilter(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{
@@ -110,15 +110,15 @@ func TestFileSnapshotWithFilter(t *testing.T) {
 
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(collections.VirtualService), "")
 	configs, err := fileWatcher.ReadConfigFiles()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(configs).To(gomega.HaveLen(1))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(configs).To(HaveLen(1))
 
 	virtualService := configs[0].Spec.(*networking.VirtualService)
-	g.Expect(virtualService.Hosts).To(gomega.Equal([]string{"some.example.com"}))
+	g.Expect(virtualService.Hosts).To(Equal([]string{"some.example.com"}))
 }
 
 func TestFileSnapshotSorting(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{
@@ -132,11 +132,11 @@ func TestFileSnapshotSorting(t *testing.T) {
 	fileWatcher := NewFileSnapshot(ts.rootPath, collection.SchemasFor(), "")
 
 	configs, err := fileWatcher.ReadConfigFiles()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(configs).To(gomega.HaveLen(2))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(configs).To(HaveLen(2))
 
-	g.Expect(configs[0].Spec).To(gomega.BeAssignableToTypeOf(&networking.Gateway{}))
-	g.Expect(configs[1].Spec).To(gomega.BeAssignableToTypeOf(&networking.VirtualService{}))
+	g.Expect(configs[0].Spec).To(BeAssignableToTypeOf(&networking.Gateway{}))
+	g.Expect(configs[1].Spec).To(BeAssignableToTypeOf(&networking.VirtualService{}))
 }
 
 type testState struct {

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -73,7 +73,7 @@ var updateConfigSet = []*config.Config{
 }
 
 func TestMonitorForChange(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store := memory.Make(collection.SchemasFor(collections.Gateway))
 
@@ -124,7 +124,7 @@ func TestMonitorForChange(t *testing.T) {
 		}
 
 		return nil
-	}).Should(gomega.Succeed())
+	}).Should(Succeed())
 
 	g.Eventually(func() error {
 		c := store.List(gvk.Gateway, "")
@@ -138,11 +138,11 @@ func TestMonitorForChange(t *testing.T) {
 		}
 
 		return nil
-	}).Should(gomega.Succeed())
+	}).Should(Succeed())
 
 	g.Eventually(func() []config.Config {
 		return store.List(gvk.Gateway, "")
-	}).Should(gomega.HaveLen(0))
+	}).Should(HaveLen(0))
 }
 
 func TestMonitorFileSnapshot(t *testing.T) {
@@ -163,7 +163,7 @@ func TestMonitorFileSnapshot(t *testing.T) {
 }
 
 func TestMonitorForError(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	store := memory.Make(collection.SchemasFor(collections.Gateway))
 
@@ -223,5 +223,5 @@ func TestMonitorForError(t *testing.T) {
 		}
 
 		return nil
-	}).Should(gomega.Succeed())
+	}).Should(Succeed())
 }

--- a/pilot/pkg/model/addressmap_test.go
+++ b/pilot/pkg/model/addressmap_test.go
@@ -17,7 +17,7 @@ package model_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
@@ -68,14 +68,14 @@ func TestAddressMapLen(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-			g.Expect(c.newMap().Len()).To(gomega.Equal(c.expected))
+			g := NewWithT(t)
+			g.Expect(c.newMap().Len()).To(Equal(c.expected))
 		})
 	}
 }
 
 func TestAddressMapGetAddressesFor(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := model.AddressMap{
 		Addresses: map[cluster.ID][]string{
@@ -84,33 +84,33 @@ func TestAddressMapGetAddressesFor(t *testing.T) {
 		},
 	}
 
-	g.Expect(m.GetAddressesFor(c1ID)).To(gomega.Equal(c1Addresses))
-	g.Expect(m.GetAddressesFor(c2ID)).To(gomega.Equal(c2Addresses))
+	g.Expect(m.GetAddressesFor(c1ID)).To(Equal(c1Addresses))
+	g.Expect(m.GetAddressesFor(c2ID)).To(Equal(c2Addresses))
 }
 
 func TestAddressMapSetAddressesFor(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := model.AddressMap{}
 	m.SetAddressesFor(c1ID, c1Addresses)
 	m.SetAddressesFor(c2ID, c2Addresses)
 
-	g.Expect(m.GetAddressesFor(c1ID)).To(gomega.Equal(c1Addresses))
-	g.Expect(m.GetAddressesFor(c2ID)).To(gomega.Equal(c2Addresses))
+	g.Expect(m.GetAddressesFor(c1ID)).To(Equal(c1Addresses))
+	g.Expect(m.GetAddressesFor(c2ID)).To(Equal(c2Addresses))
 }
 
 func TestAddressMapAddAddressesFor(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := model.AddressMap{}
 	m.SetAddressesFor(c1ID, c1Addresses)
 	m.AddAddressesFor(c1ID, []string{"1.1.1.3", "1.1.1.4"})
 
-	g.Expect(m.GetAddressesFor(c1ID)).To(gomega.Equal([]string{"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4"}))
+	g.Expect(m.GetAddressesFor(c1ID)).To(Equal([]string{"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4"}))
 }
 
 func TestAddressMapForEach(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := model.AddressMap{
 		Addresses: map[cluster.ID][]string{
@@ -124,6 +124,6 @@ func TestAddressMapForEach(t *testing.T) {
 		found[id] = addrs
 	})
 
-	g.Expect(found[c1ID]).To(gomega.Equal(c1Addresses))
-	g.Expect(found[c2ID]).To(gomega.Equal(c2Addresses))
+	g.Expect(found[c1ID]).To(Equal(c1Addresses))
+	g.Expect(found[c2ID]).To(Equal(c2Addresses))
 }

--- a/pilot/pkg/model/cluster_local_test.go
+++ b/pilot/pkg/model/cluster_local_test.go
@@ -17,7 +17,7 @@ package model_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -146,13 +146,13 @@ func TestIsClusterLocal(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			env := &model.Environment{Watcher: mesh.NewFixedWatcher(c.m)}
 			env.Init()
 
 			clusterLocal := env.ClusterLocal().GetClusterLocalHosts().IsClusterLocal(host.Name(c.host))
-			g.Expect(clusterLocal).To(gomega.Equal(c.expected))
+			g.Expect(clusterLocal).To(Equal(c.expected))
 		})
 	}
 }

--- a/pilot/pkg/model/proxy_view_test.go
+++ b/pilot/pkg/model/proxy_view_test.go
@@ -17,7 +17,7 @@ package model_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/network"
@@ -58,7 +58,7 @@ func TestProxyView(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			view := (&model.Proxy{
 				Metadata: &model.NodeMetadata{
@@ -70,7 +70,7 @@ func TestProxyView(t *testing.T) {
 				Network: network.ID(c.network),
 			})
 
-			g.Expect(actual).To(gomega.Equal(c.visible))
+			g.Expect(actual).To(Equal(c.visible))
 		})
 	}
 }

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1213,7 +1213,7 @@ func TestWasmPlugins(t *testing.T) {
 }
 
 func TestServiceIndex(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	env := NewEnvironment()
 	env.ConfigStore = NewFakeStore()
 	env.ServiceDiscovery = &localServiceDiscovery{
@@ -1278,18 +1278,18 @@ func TestServiceIndex(t *testing.T) {
 	si := pc.ServiceIndex
 
 	// Should have all 5 services
-	g.Expect(si.instancesByPort).To(gomega.HaveLen(5))
-	g.Expect(si.HostnameAndNamespace).To(gomega.HaveLen(5))
+	g.Expect(si.instancesByPort).To(HaveLen(5))
+	g.Expect(si.HostnameAndNamespace).To(HaveLen(5))
 
 	// Should just have "namespace"
-	g.Expect(si.exportedToNamespace).To(gomega.HaveLen(1))
-	g.Expect(serviceNames(si.exportedToNamespace["namespace"])).To(gomega.Equal([]string{"svc-namespace"}))
+	g.Expect(si.exportedToNamespace).To(HaveLen(1))
+	g.Expect(serviceNames(si.exportedToNamespace["namespace"])).To(Equal([]string{"svc-namespace"}))
 
-	g.Expect(serviceNames(si.public)).To(gomega.Equal([]string{"svc-public", "svc-unset"}))
+	g.Expect(serviceNames(si.public)).To(Equal([]string{"svc-public", "svc-unset"}))
 
 	// Should just have "test1"
-	g.Expect(si.privateByNamespace).To(gomega.HaveLen(1))
-	g.Expect(serviceNames(si.privateByNamespace["test1"])).To(gomega.Equal([]string{"svc-private"}))
+	g.Expect(si.privateByNamespace).To(HaveLen(1))
+	g.Expect(serviceNames(si.privateByNamespace["test1"])).To(Equal([]string{"svc-private"}))
 }
 
 func TestIsServiceVisible(t *testing.T) {
@@ -1442,8 +1442,8 @@ func TestIsServiceVisible(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			isVisible := c.pushContext.IsServiceVisible(c.service, targetNamespace)
 
-			g := gomega.NewWithT(t)
-			g.Expect(isVisible).To(gomega.Equal(c.expect))
+			g := NewWithT(t)
+			g.Expect(isVisible).To(Equal(c.expect))
 		})
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -28,7 +28,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -238,7 +238,7 @@ func TestConnectionPoolSettings(t *testing.T) {
 	}
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			clusters := xdstest.ExtractClusters(buildTestClusters(clusterTest{
 				t:               t,
@@ -258,39 +258,39 @@ func TestConnectionPoolSettings(t *testing.T) {
 					}
 					t.Fatalf("cluster %v not found; have: %s", c, strings.Join(names, ", "))
 				}
-				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(gomega.Equal(1))
+				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(Equal(1))
 				thresholds := cluster.CircuitBreakers.Thresholds[0]
 
 				if expected == nil {
-					g.Expect(thresholds).To(gomega.Equal(getDefaultCircuitBreakerThresholds()))
+					g.Expect(thresholds).To(Equal(getDefaultCircuitBreakerThresholds()))
 				} else {
 					// verify TCP settings
-					g.Expect(cluster.UpstreamConnectionOptions.TcpKeepalive).NotTo(gomega.BeNil())
+					g.Expect(cluster.UpstreamConnectionOptions.TcpKeepalive).NotTo(BeNil())
 					g.Expect(cluster.UpstreamConnectionOptions.TcpKeepalive.KeepaliveProbes.Value).
-						To(gomega.Equal(expected.Tcp.TcpKeepalive.Probes))
+						To(Equal(expected.Tcp.TcpKeepalive.Probes))
 					g.Expect(cluster.UpstreamConnectionOptions.TcpKeepalive.KeepaliveTime.Value).
-						To(gomega.Equal(uint32(expected.Tcp.TcpKeepalive.Time.Seconds)))
+						To(Equal(uint32(expected.Tcp.TcpKeepalive.Time.Seconds)))
 					g.Expect(cluster.UpstreamConnectionOptions.TcpKeepalive.KeepaliveInterval.Value).
-						To(gomega.Equal(uint32(expected.Tcp.TcpKeepalive.Interval.Seconds)))
-					g.Expect(cluster.ConnectTimeout).NotTo(gomega.BeNil())
-					g.Expect(cluster.ConnectTimeout.Seconds).To(gomega.Equal(expected.Tcp.ConnectTimeout.Seconds))
+						To(Equal(uint32(expected.Tcp.TcpKeepalive.Interval.Seconds)))
+					g.Expect(cluster.ConnectTimeout).NotTo(BeNil())
+					g.Expect(cluster.ConnectTimeout.Seconds).To(Equal(expected.Tcp.ConnectTimeout.Seconds))
 
-					g.Expect(thresholds.MaxConnections).NotTo(gomega.BeNil())
-					g.Expect(thresholds.MaxConnections.Value).To(gomega.Equal(uint32(expected.Tcp.MaxConnections)))
+					g.Expect(thresholds.MaxConnections).NotTo(BeNil())
+					g.Expect(thresholds.MaxConnections.Value).To(Equal(uint32(expected.Tcp.MaxConnections)))
 
 					// and HTTP settings
-					g.Expect(thresholds.MaxPendingRequests.Value).To(gomega.Equal(uint32(expected.Http.Http1MaxPendingRequests)))
-					g.Expect(thresholds.MaxRequests).NotTo(gomega.BeNil())
-					g.Expect(thresholds.MaxRequests.Value).To(gomega.Equal(uint32(expected.Http.Http2MaxRequests)))
-					g.Expect(cluster.TypedExtensionProtocolOptions).NotTo(gomega.BeNil())
+					g.Expect(thresholds.MaxPendingRequests.Value).To(Equal(uint32(expected.Http.Http1MaxPendingRequests)))
+					g.Expect(thresholds.MaxRequests).NotTo(BeNil())
+					g.Expect(thresholds.MaxRequests.Value).To(Equal(uint32(expected.Http.Http2MaxRequests)))
+					g.Expect(cluster.TypedExtensionProtocolOptions).NotTo(BeNil())
 					anyOptions := cluster.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType]
-					g.Expect(anyOptions).NotTo(gomega.BeNil())
+					g.Expect(anyOptions).NotTo(BeNil())
 					httpProtocolOptions := &http.HttpProtocolOptions{}
 					anyOptions.UnmarshalTo(httpProtocolOptions)
 					g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.GetValue()).
-						To(gomega.Equal(uint32(expected.Http.MaxRequestsPerConnection)))
-					g.Expect(thresholds.MaxRetries).NotTo(gomega.BeNil())
-					g.Expect(thresholds.MaxRetries.Value).To(gomega.Equal(uint32(expected.Http.MaxRetries)))
+						To(Equal(uint32(expected.Http.MaxRequestsPerConnection)))
+					g.Expect(thresholds.MaxRetries).NotTo(BeNil())
+					g.Expect(thresholds.MaxRetries.Value).To(Equal(uint32(expected.Http.MaxRetries)))
 				}
 			}
 		})
@@ -350,7 +350,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 		}
 		testName := fmt.Sprintf("%s-%s-%s", tc.clusterName, settingsName, tc.proxyType)
 		t.Run(testName, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			clusters := xdstest.ExtractClusters(buildTestClusters(clusterTest{
 				t: t, serviceHostname: "*.example.org", nodeType: tc.proxyType, mesh: testMesh(),
 				destRule: &networking.DestinationRule{
@@ -360,7 +360,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 					},
 				},
 			}))
-			g.Expect(len(clusters)).To(gomega.Equal(tc.clusters))
+			g.Expect(len(clusters)).To(Equal(tc.clusters))
 			c := clusters[tc.clusterName]
 
 			anyOptions := c.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType]
@@ -380,8 +380,8 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			}
 
 			// Verify that the values were set correctly.
-			g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.IdleTimeout).To(gomega.Not(gomega.BeNil()))
-			g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.IdleTimeout).To(gomega.Equal(durationpb.New(time.Duration(15000000000))))
+			g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.IdleTimeout).To(Not(BeNil()))
+			g.Expect(httpProtocolOptions.CommonHttpProtocolOptions.IdleTimeout).To(Equal(durationpb.New(time.Duration(15000000000))))
 		})
 	}
 }
@@ -603,7 +603,7 @@ func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			test.SetForTest(t, &features.FilterGatewayClusterConfig, false)
 
@@ -630,9 +630,9 @@ func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
 					},
 				}))
 
-			g.Expect(c.LbPolicy).To(gomega.Equal(cluster.Cluster_RING_HASH))
-			g.Expect(c.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(gomega.Equal(uint64(tt.expectedRingSize)))
-			g.Expect(c.ConnectTimeout).To(gomega.Equal(durationpb.New(time.Duration(10000000001))))
+			g.Expect(c.LbPolicy).To(Equal(cluster.Cluster_RING_HASH))
+			g.Expect(c.GetRingHashLbConfig().GetMinimumRingSize().GetValue()).To(Equal(uint64(tt.expectedRingSize)))
+			g.Expect(c.ConnectTimeout).To(Equal(durationpb.New(time.Duration(10000000001))))
 		})
 	}
 }
@@ -824,10 +824,10 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.sni, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			c := xdstest.ExtractCluster("outbound|8080|foobar|foo.example.org", buildSniTestClustersForSidecar(t, tt.sni))
-			g.Expect(getTLSContext(t, c).GetSni()).To(gomega.Equal(tt.expected))
+			g.Expect(getTLSContext(t, c).GetSni()).To(Equal(tt.expected))
 		})
 	}
 }
@@ -837,7 +837,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	expectedClientCertPath := "/clientCertFromNodeMetadata.pem"
 	expectedRootCertPath := "/clientRootCertFromNodeMetadata.pem"
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	envoyMetadata := &model.NodeMetadata{
 		TLSClientCertChain: expectedClientCertPath,
@@ -885,7 +885,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 
 	// per the docs: default values will be applied to fields omitted in port-level traffic policies rather than inheriting
 	// settings specified at the destination level
-	g.Expect(getTLSContext(t, xdstest.ExtractCluster("outbound|8080|foobar|foo.example.org", clusters))).To(gomega.BeNil())
+	g.Expect(getTLSContext(t, xdstest.ExtractCluster("outbound|8080|foobar|foo.example.org", clusters))).To(BeNil())
 
 	expected := []string{
 		"outbound|8080||foo.example.org",
@@ -895,14 +895,14 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	for _, e := range expected {
 		c := xdstest.ExtractCluster(e, clusters)
 		tlsContext := getTLSContext(t, c)
-		g.Expect(tlsContext).NotTo(gomega.BeNil())
+		g.Expect(tlsContext).NotTo(BeNil())
 
 		rootSdsConfig := tlsContext.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig()
-		g.Expect(rootSdsConfig.GetName()).To(gomega.Equal("file-root:/clientRootCertFromNodeMetadata.pem"))
+		g.Expect(rootSdsConfig.GetName()).To(Equal("file-root:/clientRootCertFromNodeMetadata.pem"))
 
 		certSdsConfig := tlsContext.CommonTlsContext.GetTlsCertificateSdsSecretConfigs()
-		g.Expect(certSdsConfig).To(gomega.HaveLen(1))
-		g.Expect(certSdsConfig[0].GetName()).To(gomega.Equal("file-cert:/clientCertFromNodeMetadata.pem~/clientKeyFromNodeMetadata.pem"))
+		g.Expect(certSdsConfig).To(HaveLen(1))
+		g.Expect(certSdsConfig[0].GetName()).To(Equal("file-cert:/clientCertFromNodeMetadata.pem~/clientKeyFromNodeMetadata.pem"))
 	}
 }
 
@@ -1042,7 +1042,7 @@ func buildTestClustersWithTCPKeepalive(t testing.TB, configType ConfigType) []*c
 }
 
 func TestClusterMetadata(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: "*.example.org",
@@ -1067,59 +1067,59 @@ func TestClusterMetadata(t *testing.T) {
 	for _, cluster := range clusters {
 		if strings.HasPrefix(cluster.Name, "outbound") || strings.HasPrefix(cluster.Name, "inbound") {
 			clustersWithMetadata++
-			g.Expect(cluster.Metadata).NotTo(gomega.BeNil())
+			g.Expect(cluster.Metadata).NotTo(BeNil())
 			md := cluster.Metadata
-			g.Expect(md.FilterMetadata[util.IstioMetadataKey]).NotTo(gomega.BeNil())
+			g.Expect(md.FilterMetadata[util.IstioMetadataKey]).NotTo(BeNil())
 			istio := md.FilterMetadata[util.IstioMetadataKey]
-			g.Expect(istio.Fields["config"]).NotTo(gomega.BeNil())
+			g.Expect(istio.Fields["config"]).NotTo(BeNil())
 			dr := istio.Fields["config"]
-			g.Expect(dr.GetStringValue()).To(gomega.Equal("/apis/networking.istio.io/v1alpha3/namespaces//destination-rule/acme"))
+			g.Expect(dr.GetStringValue()).To(Equal("/apis/networking.istio.io/v1alpha3/namespaces//destination-rule/acme"))
 			if strings.Contains(cluster.Name, "Subset") {
 				foundSubset = true
 				sub := istio.Fields["subset"]
-				g.Expect(sub.GetStringValue()).To(gomega.HavePrefix("Subset "))
+				g.Expect(sub.GetStringValue()).To(HavePrefix("Subset "))
 			} else {
 				_, ok := istio.Fields["subset"]
-				g.Expect(ok).To(gomega.Equal(false))
+				g.Expect(ok).To(Equal(false))
 			}
 		} else {
-			g.Expect(cluster.Metadata).To(gomega.BeNil())
+			g.Expect(cluster.Metadata).To(BeNil())
 		}
 	}
 
-	g.Expect(foundSubset).To(gomega.Equal(true))
-	g.Expect(clustersWithMetadata).To(gomega.Equal(len(destRule.Subsets) + 6)) // outbound  outbound subsets  inbound
+	g.Expect(foundSubset).To(Equal(true))
+	g.Expect(clustersWithMetadata).To(Equal(len(destRule.Subsets) + 6)) // outbound  outbound subsets  inbound
 
 	sniClusters := buildSniDnatTestClustersForGateway(t, "test-sni")
 
 	foundSNISubset := false
 	for _, cluster := range sniClusters {
 		if strings.HasPrefix(cluster.Name, "outbound") {
-			g.Expect(cluster.Metadata).NotTo(gomega.BeNil())
+			g.Expect(cluster.Metadata).NotTo(BeNil())
 			md := cluster.Metadata
-			g.Expect(md.FilterMetadata[util.IstioMetadataKey]).NotTo(gomega.BeNil())
+			g.Expect(md.FilterMetadata[util.IstioMetadataKey]).NotTo(BeNil())
 			istio := md.FilterMetadata[util.IstioMetadataKey]
-			g.Expect(istio.Fields["config"]).NotTo(gomega.BeNil())
+			g.Expect(istio.Fields["config"]).NotTo(BeNil())
 			dr := istio.Fields["config"]
-			g.Expect(dr.GetStringValue()).To(gomega.Equal("/apis/networking.istio.io/v1alpha3/namespaces//destination-rule/acme"))
+			g.Expect(dr.GetStringValue()).To(Equal("/apis/networking.istio.io/v1alpha3/namespaces//destination-rule/acme"))
 			if strings.Contains(cluster.Name, "foobar") {
 				foundSNISubset = true
 				sub := istio.Fields["subset"]
-				g.Expect(sub.GetStringValue()).To(gomega.Equal("foobar"))
+				g.Expect(sub.GetStringValue()).To(Equal("foobar"))
 			} else {
 				_, ok := istio.Fields["subset"]
-				g.Expect(ok).To(gomega.Equal(false))
+				g.Expect(ok).To(Equal(false))
 			}
 		} else {
-			g.Expect(cluster.Metadata).To(gomega.BeNil())
+			g.Expect(cluster.Metadata).To(BeNil())
 		}
 	}
 
-	g.Expect(foundSNISubset).To(gomega.Equal(true))
+	g.Expect(foundSNISubset).To(Equal(true))
 }
 
 func TestDisablePanicThresholdAsDefault(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	outliers := []*networking.OutlierDetection{
 		// Unset MinHealthPercent
@@ -1142,13 +1142,13 @@ func TestDisablePanicThresholdAsDefault(t *testing.T) {
 					},
 				},
 			}))
-		g.Expect(c.CommonLbConfig.HealthyPanicThreshold).To(gomega.Not(gomega.BeNil()))
-		g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(0)))
+		g.Expect(c.CommonLbConfig.HealthyPanicThreshold).To(Not(BeNil()))
+		g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(0)))
 	}
 }
 
 func TestApplyOutlierDetection(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	tests := []struct {
 		name string
@@ -1254,13 +1254,13 @@ func TestApplyOutlierDetection(t *testing.T) {
 						},
 					},
 				}))
-			g.Expect(c.OutlierDetection).To(gomega.Equal(tt.o))
+			g.Expect(c.OutlierDetection).To(Equal(tt.o))
 		})
 	}
 }
 
 func TestStatNamePattern(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	statConfigMesh := &meshconfig.MeshConfig{
 		ConnectTimeout: &durationpb.Duration{
@@ -1281,8 +1281,8 @@ func TestStatNamePattern(t *testing.T) {
 			Host: "*.example.org",
 		},
 	})
-	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(gomega.Equal("*.example.org_default_8080"))
-	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(gomega.Equal("LocalService_*.example.org"))
+	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080"))
+	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestDuplicateClusters(t *testing.T) {
@@ -1296,7 +1296,7 @@ func TestDuplicateClusters(t *testing.T) {
 }
 
 func TestSidecarLocalityLB(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	// Distribute locality loadbalancing setting
 	mesh := testMesh()
 	mesh.LocalityLbSetting = &networking.LocalityLoadBalancerSetting{
@@ -1332,21 +1332,21 @@ func TestSidecarLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
 
-	g.Expect(len(c.LoadAssignment.Endpoints)).To(gomega.Equal(3))
+	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
 		if locality.Region == "region1" && locality.SubZone == "subzone1" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(34)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(34)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		} else if locality.Region == "region1" && locality.SubZone == "subzone2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(17)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(20)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(17)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(20)))
 		} else if locality.Region == "region2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(50)))
-			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(gomega.Equal(1))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(50)))
+			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(Equal(1))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		}
 	}
 
@@ -1375,23 +1375,23 @@ func TestSidecarLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
 
-	g.Expect(len(c.LoadAssignment.Endpoints)).To(gomega.Equal(3))
+	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
 		if locality.Region == "region1" && locality.Zone == "zone1" && locality.SubZone == "subzone1" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(0)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(0)))
 		} else if locality.Region == "region1" && locality.Zone == "zone1" && locality.SubZone == "subzone2" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(1)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(1)))
 		} else if locality.Region == "region2" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(2)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(2)))
 		}
 	}
 }
 
 func TestLocalityLBDestinationRuleOverride(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mesh := testMesh()
 	// Distribute locality loadbalancing setting
 	mesh.LocalityLbSetting = &networking.LocalityLoadBalancerSetting{
@@ -1438,27 +1438,27 @@ func TestLocalityLBDestinationRuleOverride(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
 
-	g.Expect(len(c.LoadAssignment.Endpoints)).To(gomega.Equal(3))
+	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
 		if locality.Region == "region1" && locality.SubZone == "subzone1" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		} else if locality.Region == "region1" && locality.SubZone == "subzone2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(20)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(20)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(20)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(20)))
 		} else if locality.Region == "region2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
-			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(gomega.Equal(1))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
+			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(Equal(1))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		}
 	}
 }
 
 func TestGatewayLocalityLB(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	// Test distribute
 	// Distribute locality loadbalancing setting
@@ -1499,20 +1499,20 @@ func TestGatewayLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Errorf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(10)))
-	g.Expect(len(c.LoadAssignment.Endpoints)).To(gomega.Equal(3))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
+	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
 		if locality.Region == "region1" && locality.SubZone == "subzone1" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(34)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(34)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		} else if locality.Region == "region1" && locality.SubZone == "subzone2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(17)))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(20)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(17)))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(20)))
 		} else if locality.Region == "region2" {
-			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(50)))
-			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(gomega.Equal(1))
-			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(gomega.Equal(uint32(40)))
+			g.Expect(localityLbEndpoint.LoadBalancingWeight.GetValue()).To(Equal(uint32(50)))
+			g.Expect(len(localityLbEndpoint.LbEndpoints)).To(Equal(1))
+			g.Expect(localityLbEndpoint.LbEndpoints[0].LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
 		}
 	}
 
@@ -1542,17 +1542,17 @@ func TestGatewayLocalityLB(t *testing.T) {
 	if c.CommonLbConfig == nil {
 		t.Fatalf("CommonLbConfig should be set for cluster %+v", c)
 	}
-	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(gomega.Equal(float64(10)))
+	g.Expect(c.CommonLbConfig.HealthyPanicThreshold.GetValue()).To(Equal(float64(10)))
 
-	g.Expect(len(c.LoadAssignment.Endpoints)).To(gomega.Equal(3))
+	g.Expect(len(c.LoadAssignment.Endpoints)).To(Equal(3))
 	for _, localityLbEndpoint := range c.LoadAssignment.Endpoints {
 		locality := localityLbEndpoint.Locality
 		if locality.Region == "region1" && locality.Zone == "zone1" && locality.SubZone == "subzone1" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(0)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(0)))
 		} else if locality.Region == "region1" && locality.Zone == "zone1" && locality.SubZone == "subzone2" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(1)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(1)))
 		} else if locality.Region == "region2" {
-			g.Expect(localityLbEndpoint.Priority).To(gomega.Equal(uint32(2)))
+			g.Expect(localityLbEndpoint.Priority).To(Equal(uint32(2)))
 		}
 	}
 }
@@ -1598,7 +1598,7 @@ func TestFindServiceInstanceForIngressListener(t *testing.T) {
 }
 
 func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	clusters := buildTestClusters(clusterTest{
 		t:                 t,
@@ -1620,12 +1620,12 @@ func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
 
 	c := xdstest.ExtractCluster("outbound|8080||*.example.org",
 		clusters)
-	g.Expect(c.LbPolicy).To(gomega.Equal(cluster.Cluster_CLUSTER_PROVIDED))
-	g.Expect(c.GetClusterDiscoveryType()).To(gomega.Equal(&cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}))
+	g.Expect(c.LbPolicy).To(Equal(cluster.Cluster_CLUSTER_PROVIDED))
+	g.Expect(c.GetClusterDiscoveryType()).To(Equal(&cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}))
 }
 
 func TestSlowStartConfig(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	testcases := []struct {
 		name                string
 		lbType              networking.LoadBalancerSettings_SimpleLB
@@ -1656,15 +1656,15 @@ func TestSlowStartConfig(t *testing.T) {
 				clusters)
 
 			if !test.enableSlowStartMode {
-				g.Expect(c.GetLbConfig()).To(gomega.BeNil())
+				g.Expect(c.GetLbConfig()).To(BeNil())
 			} else {
 				switch c.LbPolicy {
 				case cluster.Cluster_ROUND_ROBIN:
-					g.Expect(c.GetRoundRobinLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(gomega.Equal(int64(15)))
+					g.Expect(c.GetRoundRobinLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(Equal(int64(15)))
 				case cluster.Cluster_LEAST_REQUEST:
-					g.Expect(c.GetLeastRequestLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(gomega.Equal(int64(15)))
+					g.Expect(c.GetLeastRequestLbConfig().GetSlowStartConfig().GetSlowStartWindow().Seconds).To(Equal(int64(15)))
 				default:
-					g.Expect(c.GetLbConfig()).To(gomega.BeNil())
+					g.Expect(c.GetLbConfig()).To(BeNil())
 				}
 			}
 		})
@@ -1687,7 +1687,7 @@ func getSlowStartTrafficPolicy(slowStartEnabled bool, lbType networking.LoadBala
 }
 
 func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	clusters := buildTestClusters(clusterTest{
 		t:                 t,
@@ -1708,9 +1708,9 @@ func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
 	})
 
 	c := xdstest.ExtractCluster("outbound|8080||*.example.org", clusters)
-	g.Expect(c.LbPolicy).To(gomega.Equal(cluster.Cluster_CLUSTER_PROVIDED))
-	g.Expect(c.GetClusterDiscoveryType()).To(gomega.Equal(&cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}))
-	g.Expect(c.EdsClusterConfig).To(gomega.BeNil())
+	g.Expect(c.LbPolicy).To(Equal(cluster.Cluster_CLUSTER_PROVIDED))
+	g.Expect(c.GetClusterDiscoveryType()).To(Equal(&cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST}))
+	g.Expect(c.EdsClusterConfig).To(BeNil())
 }
 
 func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
@@ -1824,7 +1824,7 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			cfgs := []config.Config{}
 			if c.destRule != nil {
 				cfgs = append(cfgs, config.Config{
@@ -1846,11 +1846,11 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 			if c.filter != nil {
 				clusters = xdstest.FilterClusters(clusters, c.filter)
 			}
-			g.Expect(len(clusters)).ShouldNot(gomega.Equal(0))
+			g.Expect(len(clusters)).ShouldNot(Equal(0))
 
 			for _, cluster := range clusters {
-				g.Expect(cluster.CircuitBreakers).NotTo(gomega.BeNil())
-				g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(gomega.Equal(c.expected))
+				g.Expect(cluster.CircuitBreakers).NotTo(BeNil())
+				g.Expect(cluster.CircuitBreakers.Thresholds[0]).To(Equal(c.expected))
 			}
 		})
 	}
@@ -1944,7 +1944,7 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			test.SetForTest(t, &features.EnableDualStack, c.dualStack)
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			cg := NewConfigGenTest(t, TestOptions{
 				Services:  []*model.Service{service},
 				Instances: instances,
@@ -1954,15 +1954,15 @@ func TestInboundClustersPassThroughBindIPs(t *testing.T) {
 			xdstest.ValidateClusters(t, clusters)
 
 			clusters = xdstest.FilterClusters(clusters, inboundFilter)
-			g.Expect(len(clusters)).ShouldNot(gomega.Equal(0))
+			g.Expect(len(clusters)).ShouldNot(Equal(0))
 
 			for _, cluster := range clusters {
-				g.Expect(cluster.UpstreamBindConfig.SourceAddress.Address).To(gomega.Equal(c.expectedSrcAddr))
+				g.Expect(cluster.UpstreamBindConfig.SourceAddress.Address).To(Equal(c.expectedSrcAddr))
 				if c.expectedExtraSrcAddr != "" {
-					g.Expect(len(cluster.UpstreamBindConfig.ExtraSourceAddresses)).To(gomega.Equal(1))
-					g.Expect(cluster.UpstreamBindConfig.ExtraSourceAddresses[0].Address.Address).To(gomega.Equal(c.expectedExtraSrcAddr))
+					g.Expect(len(cluster.UpstreamBindConfig.ExtraSourceAddresses)).To(Equal(1))
+					g.Expect(cluster.UpstreamBindConfig.ExtraSourceAddresses[0].Address.Address).To(Equal(c.expectedExtraSrcAddr))
 				} else {
-					g.Expect(len(cluster.UpstreamBindConfig.ExtraSourceAddresses)).To(gomega.Equal(0))
+					g.Expect(len(cluster.UpstreamBindConfig.ExtraSourceAddresses)).To(Equal(0))
 				}
 
 			}
@@ -2020,7 +2020,7 @@ func TestRedisProtocolWithPassThroughResolutionAtGateway(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			test.SetForTest(t, &features.FilterGatewayClusterConfig, false)
 			test.SetForTest(t, &features.EnableRedisFilter, tt.redisEnabled)
 			cg := NewConfigGenTest(t, TestOptions{Services: []*model.Service{service}})
@@ -2028,14 +2028,14 @@ func TestRedisProtocolWithPassThroughResolutionAtGateway(t *testing.T) {
 			xdstest.ValidateClusters(t, clusters)
 
 			c := xdstest.ExtractCluster("outbound|6379||redis.com", clusters)
-			g.Expect(c.LbPolicy).To(gomega.Equal(tt.lbType))
-			g.Expect(c.GetClusterDiscoveryType()).To(gomega.Equal(&cluster.Cluster_Type{Type: tt.discoveryType}))
+			g.Expect(c.LbPolicy).To(Equal(tt.lbType))
+			g.Expect(c.GetClusterDiscoveryType()).To(Equal(&cluster.Cluster_Type{Type: tt.discoveryType}))
 		})
 	}
 }
 
 func TestAutoMTLSClusterSubsets(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: TestServiceNHostname,
@@ -2070,18 +2070,18 @@ func TestAutoMTLSClusterSubsets(t *testing.T) {
 	clusters := buildTestClusters(clusterTest{t: t, serviceHostname: TestServiceNHostname, nodeType: model.SidecarProxy, mesh: mesh, destRule: destRule})
 
 	tlsContext := getTLSContext(t, clusters[1])
-	g.Expect(tlsContext).ToNot(gomega.BeNil())
-	g.Expect(tlsContext.GetSni()).To(gomega.Equal("custom.sni.com"))
-	g.Expect(clusters[1].TransportSocketMatches).To(gomega.HaveLen(0))
+	g.Expect(tlsContext).ToNot(BeNil())
+	g.Expect(tlsContext.GetSni()).To(Equal("custom.sni.com"))
+	g.Expect(clusters[1].TransportSocketMatches).To(HaveLen(0))
 
 	for _, i := range []int{0, 2, 3} {
-		g.Expect(getTLSContext(t, clusters[i])).To(gomega.BeNil())
-		g.Expect(clusters[i].TransportSocketMatches).To(gomega.HaveLen(2))
+		g.Expect(getTLSContext(t, clusters[i])).To(BeNil())
+		g.Expect(clusters[i].TransportSocketMatches).To(HaveLen(2))
 	}
 }
 
 func TestAutoMTLSClusterIgnoreWorkloadLevelPeerAuthn(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: TestServiceNHostname,
@@ -2131,16 +2131,16 @@ func TestAutoMTLSClusterIgnoreWorkloadLevelPeerAuthn(t *testing.T) {
 	// No policy visible, auto-mTLS should set to PERMISSIVE.
 	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
 	// TlsContext is nil because we use socket match instead
-	g.Expect(getTLSContext(t, clusters[0])).To(gomega.BeNil())
-	g.Expect(clusters[0].TransportSocketMatches).To(gomega.HaveLen(2))
+	g.Expect(getTLSContext(t, clusters[0])).To(BeNil())
+	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
 
 	// For 9090, use the TLS settings are explicitly specified in DR (which disable TLS)
-	g.Expect(getTLSContext(t, clusters[1])).To(gomega.BeNil())
+	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
 
 	// Sanity check: make sure TLS is not accidentally added to other clusters.
 	for i := 2; i < len(clusters); i++ {
 		cluster := clusters[i]
-		g.Expect(getTLSContext(t, cluster)).To(gomega.BeNil())
+		g.Expect(getTLSContext(t, cluster)).To(BeNil())
 	}
 }
 
@@ -2250,7 +2250,7 @@ func TestApplyLoadBalancer(t *testing.T) {
 }
 
 func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	service := &model.Service{
 		Hostname: host.Name("static.test"),
@@ -2275,7 +2275,7 @@ func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
 
 	// Expect to ignore STRICT_DNS cluster without endpoints.
 	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).
-		To(gomega.Equal([]string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster"}))
+		To(Equal([]string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster"}))
 }
 
 func TestEnvoyFilterPatching(t *testing.T) {
@@ -2938,7 +2938,7 @@ func TestVerifyCertAtClient(t *testing.T) {
 }
 
 func TestBuildDeltaClusters(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	testService1 := &model.Service{
 		Hostname: host.Name("test.com"),
@@ -3385,14 +3385,14 @@ func TestBuildDeltaClusters(t *testing.T) {
 			if delta != tc.usedDelta {
 				t.Errorf("un expected delta, want %v got %v", tc.usedDelta, delta)
 			}
-			g.Expect(removed).To(gomega.Equal(tc.removedClusters))
-			g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(gomega.Equal(tc.expectedClusters))
+			g.Expect(removed).To(Equal(tc.removedClusters))
+			g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal(tc.expectedClusters))
 		})
 	}
 }
 
 func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	service := &model.Service{
 		Hostname: host.Name("static.test"),
@@ -3419,7 +3419,7 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 	// Expect sds_external cluster be added if credentialSocket exists
 	clusters := cg.Clusters(proxy)
 	xdstest.ValidateClusters(t, clusters)
-	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(gomega.Equal([]string{
+	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
 		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", security.SDSExternalClusterName,
 	}))
 
@@ -3427,7 +3427,7 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 	proxy = cg.SetupProxy(nil)
 	clusters = cg.Clusters(proxy)
 	xdstest.ValidateClusters(t, clusters)
-	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(gomega.Equal([]string{
+	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
 		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
 	}))
 }

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -21,7 +21,7 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -82,7 +82,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: all priorities", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildFakeCluster()
 		ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, nil, env.Mesh().LocalityLbSetting, true)
@@ -90,25 +90,25 @@ func TestApplyLocalitySetting(t *testing.T) {
 			if localityEndpoint.Locality.Region == locality.Region {
 				if localityEndpoint.Locality.Zone == locality.Zone {
 					if localityEndpoint.Locality.SubZone == locality.SubZone {
-						g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(0)))
+						g.Expect(localityEndpoint.Priority).To(Equal(uint32(0)))
 						continue
 					}
-					g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(1)))
+					g.Expect(localityEndpoint.Priority).To(Equal(uint32(1)))
 					continue
 				}
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(2)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(2)))
 				continue
 			}
 			if localityEndpoint.Locality.Region == "region2" {
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(3)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(3)))
 			} else {
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(4)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(4)))
 			}
 		}
 	})
 
 	t.Run("Failover: priorities with gaps", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildSmallCluster()
 		ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, nil, env.Mesh().LocalityLbSetting, true)
@@ -119,14 +119,14 @@ func TestApplyLocalitySetting(t *testing.T) {
 						t.Errorf("Should not exist")
 						continue
 					}
-					g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(0)))
+					g.Expect(localityEndpoint.Priority).To(Equal(uint32(0)))
 					continue
 				}
 				t.Errorf("Should not exist")
 				continue
 			}
 			if localityEndpoint.Locality.Region == "region2" {
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(1)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(1)))
 			} else {
 				t.Errorf("Should not exist")
 			}
@@ -134,26 +134,26 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: priorities with some nil localities", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildSmallClusterWithNilLocalities()
 		ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, nil, env.Mesh().LocalityLbSetting, true)
 		for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
 			if localityEndpoint.Locality == nil {
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(2)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(2)))
 			} else if localityEndpoint.Locality.Region == locality.Region {
 				if localityEndpoint.Locality.Zone == locality.Zone {
 					if localityEndpoint.Locality.SubZone == locality.SubZone {
 						t.Errorf("Should not exist")
 						continue
 					}
-					g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(0)))
+					g.Expect(localityEndpoint.Priority).To(Equal(uint32(0)))
 					continue
 				}
 				t.Errorf("Should not exist")
 				continue
 			} else if localityEndpoint.Locality.Region == "region2" {
-				g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(1)))
+				g.Expect(localityEndpoint.Priority).To(Equal(uint32(1)))
 			} else {
 				t.Errorf("Should not exist")
 			}
@@ -161,14 +161,14 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: with locality lb disabled", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cluster := buildSmallClusterWithNilLocalities()
 		lbsetting := &networking.LocalityLoadBalancerSetting{
 			Enabled: &wrappers.BoolValue{Value: false},
 		}
 		ApplyLocalityLBSetting(cluster.LoadAssignment, nil, locality, nil, lbsetting, true)
 		for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
-			g.Expect(localityEndpoint.Priority).To(gomega.Equal(uint32(0)))
+			g.Expect(localityEndpoint.Priority).To(Equal(uint32(0)))
 		}
 	})
 

--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
@@ -21,7 +21,7 @@ import (
 
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	previouspriorities "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/priority/previous_priorities/v3"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -34,15 +34,15 @@ func TestRetry(t *testing.T) {
 	testCases := []struct {
 		name       string
 		route      *networking.HTTPRoute
-		assertFunc func(g *gomega.WithT, policy *envoyroute.RetryPolicy)
+		assertFunc func(g *WithT, policy *envoyroute.RetryPolicy)
 	}{
 		{
 			name: "TestNilRetryShouldReturnDefault",
 			// Create a route where no retry policy has been explicitly set.
 			route: &networking.HTTPRoute{},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy).To(gomega.Equal(retry.DefaultPolicy()))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy).To(Equal(retry.DefaultPolicy()))
 			},
 		},
 		{
@@ -54,8 +54,8 @@ func TestRetry(t *testing.T) {
 					Attempts: 0,
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.BeNil())
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(BeNil())
 			},
 		},
 		{
@@ -68,15 +68,15 @@ func TestRetry(t *testing.T) {
 					PerTryTimeout: durationpb.New(time.Second * 3),
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("some,fake,conditions"))
-				g.Expect(policy.PerTryTimeout).To(gomega.Equal(durationpb.New(time.Second * 3)))
-				g.Expect(policy.NumRetries.Value).To(gomega.Equal(uint32(2)))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal(make([]uint32, 0)))
-				g.Expect(policy.RetryPriority).To(gomega.BeNil())
-				g.Expect(policy.HostSelectionRetryMaxAttempts).To(gomega.Equal(retry.DefaultPolicy().HostSelectionRetryMaxAttempts))
-				g.Expect(policy.RetryHostPredicate).To(gomega.Equal(retry.DefaultPolicy().RetryHostPredicate))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("some,fake,conditions"))
+				g.Expect(policy.PerTryTimeout).To(Equal(durationpb.New(time.Second * 3)))
+				g.Expect(policy.NumRetries.Value).To(Equal(uint32(2)))
+				g.Expect(policy.RetriableStatusCodes).To(Equal(make([]uint32, 0)))
+				g.Expect(policy.RetryPriority).To(BeNil())
+				g.Expect(policy.HostSelectionRetryMaxAttempts).To(Equal(retry.DefaultPolicy().HostSelectionRetryMaxAttempts))
+				g.Expect(policy.RetryHostPredicate).To(Equal(retry.DefaultPolicy().RetryHostPredicate))
 			},
 		},
 		{
@@ -89,10 +89,10 @@ func TestRetry(t *testing.T) {
 					RetryOn:  "some,fake,conditions,,,",
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("some,fake,conditions"))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal([]uint32{}))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("some,fake,conditions"))
+				g.Expect(policy.RetriableStatusCodes).To(Equal([]uint32{}))
 			},
 		},
 		{
@@ -105,10 +105,10 @@ func TestRetry(t *testing.T) {
 					RetryOn:  "gateway-error,retriable-status-codes,503",
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("gateway-error,retriable-status-codes"))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal([]uint32{503}))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("gateway-error,retriable-status-codes"))
+				g.Expect(policy.RetriableStatusCodes).To(Equal([]uint32{503}))
 			},
 		},
 		{
@@ -121,10 +121,10 @@ func TestRetry(t *testing.T) {
 					RetryOn:  " some,	,fake ,	conditions, ,",
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("some,fake,conditions"))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal([]uint32{}))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("some,fake,conditions"))
+				g.Expect(policy.RetriableStatusCodes).To(Equal([]uint32{}))
 			},
 		},
 		{
@@ -136,10 +136,10 @@ func TestRetry(t *testing.T) {
 					RetryOn:  "some,fake,5xx,404,conditions,503",
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("some,fake,5xx,conditions,retriable-status-codes"))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal([]uint32{404, 503}))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("some,fake,5xx,conditions,retriable-status-codes"))
+				g.Expect(policy.RetriableStatusCodes).To(Equal([]uint32{404, 503}))
 			},
 		},
 		{
@@ -151,10 +151,10 @@ func TestRetry(t *testing.T) {
 					RetryOn:  "some,fake,conditions,1000",
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal("some,fake,conditions,1000"))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal([]uint32{}))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal("some,fake,conditions,1000"))
+				g.Expect(policy.RetriableStatusCodes).To(Equal([]uint32{}))
 			},
 		},
 		{
@@ -165,10 +165,10 @@ func TestRetry(t *testing.T) {
 					Attempts: 2,
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal(retry.DefaultPolicy().RetryOn))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal(retry.DefaultPolicy().RetriableStatusCodes))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal(retry.DefaultPolicy().RetryOn))
+				g.Expect(policy.RetriableStatusCodes).To(Equal(retry.DefaultPolicy().RetriableStatusCodes))
 			},
 		},
 		{
@@ -179,9 +179,9 @@ func TestRetry(t *testing.T) {
 					Attempts: 2,
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.PerTryTimeout).To(gomega.BeNil())
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.PerTryTimeout).To(BeNil())
 			},
 		},
 		{
@@ -195,10 +195,10 @@ func TestRetry(t *testing.T) {
 					},
 				},
 			},
-			assertFunc: func(g *gomega.WithT, policy *envoyroute.RetryPolicy) {
-				g.Expect(policy).To(gomega.Not(gomega.BeNil()))
-				g.Expect(policy.RetryOn).To(gomega.Equal(retry.DefaultPolicy().RetryOn))
-				g.Expect(policy.RetriableStatusCodes).To(gomega.Equal(retry.DefaultPolicy().RetriableStatusCodes))
+			assertFunc: func(g *WithT, policy *envoyroute.RetryPolicy) {
+				g.Expect(policy).To(Not(BeNil()))
+				g.Expect(policy.RetryOn).To(Equal(retry.DefaultPolicy().RetryOn))
+				g.Expect(policy.RetriableStatusCodes).To(Equal(retry.DefaultPolicy().RetriableStatusCodes))
 
 				previousPrioritiesConfig := &previouspriorities.PreviousPrioritiesConfig{
 					UpdateFrequency: int32(2),
@@ -217,7 +217,7 @@ func TestRetry(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			policy := retry.ConvertPolicy(tc.route.Retries)
 			if tc.assertFunc != nil {
 				tc.assertFunc(g, policy)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -21,7 +21,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -65,7 +65,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	gatewayNames := sets.New("some-gateway")
 
 	t.Run("for virtual service", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		t.Setenv("ISTIO_DEFAULT_REQUEST_TIMEOUT", "0ms")
@@ -73,23 +73,23 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServicePlain, serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 		// Validate that when timeout is not specified, we disable it based on default value of flag.
-		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(Equal(int64(0)))
 		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with HTTP/3 discovery enabled", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServicePlain, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{IsHTTP3AltSvcHeaderNeeded: true})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(routes[0].GetResponseHeadersToAdd()).To(gomega.Equal([]*core.HeaderValueOption{
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(routes[0].GetResponseHeadersToAdd()).To(Equal([]*core.HeaderValueOption{
 			{
 				Header: &core.HeaderValue{
 					Key:   util.AltSvcHeader,
@@ -101,63 +101,63 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with timeout", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithTimeout, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 		// Validate that when timeout specified, we send the configured timeout to Envoys.
-		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(10)))
+		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(Equal(int64(10)))
 		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(10)))
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(Equal(int64(10)))
 	})
 
 	t.Run("for virtual service with disabled timeout", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithTimeoutDisabled, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetRoute().Timeout.Seconds).To(Equal(int64(0)))
 		// nolint: staticcheck
-		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(gomega.Equal(int64(0)))
+		g.Expect(routes[0].GetRoute().MaxGrpcTimeout.Seconds).To(Equal(int64(0)))
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithCatchAllRoute,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(2))
-		g.Expect(routes[0].Name).To(gomega.Equal("route.non-catch-all"))
-		g.Expect(routes[1].Name).To(gomega.Equal("route.catch-all"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(2))
+		g.Expect(routes[0].Name).To(Equal("route.non-catch-all"))
+		g.Expect(routes[1].Name).To(Equal("route.catch-all"))
 	})
 
 	t.Run("for virtual service with catch all route：port match", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithCatchAllPort,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].Name).To(gomega.Equal("route 1.catch-all for 8080"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].Name).To(Equal("route 1.catch-all for 8080"))
 	})
 
 	t.Run("for internally generated virtual service with ingress semantics", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		vs := virtualServiceWithCatchAllRoute
@@ -170,17 +170,17 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(routes[0].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_PathSeparatedPrefix{
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(routes[0].Match.PathSpecifier).To(Equal(&envoyroute.RouteMatch_PathSeparatedPrefix{
 			PathSeparatedPrefix: "/route/v1",
 		}))
-		g.Expect(routes[1].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_Prefix{
+		g.Expect(routes[1].Match.PathSpecifier).To(Equal(&envoyroute.RouteMatch_Prefix{
 			Prefix: "/",
 		}))
 	})
 
 	t.Run("for internally generated virtual service with gateway semantics", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		vs := virtualServiceWithCatchAllRoute
@@ -193,212 +193,212 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(routes[0].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_PathSeparatedPrefix{
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(routes[0].Match.PathSpecifier).To(Equal(&envoyroute.RouteMatch_PathSeparatedPrefix{
 			PathSeparatedPrefix: "/route/v1",
 		}))
 		g.Expect(routes[0].Action.(*envoyroute.Route_Route).Route.ClusterNotFoundResponseCode).
-			To(gomega.Equal(envoyroute.RouteAction_INTERNAL_SERVER_ERROR))
-		g.Expect(routes[1].Match.PathSpecifier).To(gomega.Equal(&envoyroute.RouteMatch_Prefix{
+			To(Equal(envoyroute.RouteAction_INTERNAL_SERVER_ERROR))
+		g.Expect(routes[1].Match.PathSpecifier).To(Equal(&envoyroute.RouteMatch_Prefix{
 			Prefix: "/",
 		}))
 		g.Expect(routes[1].Action.(*envoyroute.Route_Route).Route.ClusterNotFoundResponseCode).
-			To(gomega.Equal(envoyroute.RouteAction_INTERNAL_SERVER_ERROR))
+			To(Equal(envoyroute.RouteAction_INTERNAL_SERVER_ERROR))
 	})
 
 	t.Run("for virtual service with top level catch all route", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithCatchAllRouteWeightedDestination,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 	})
 
 	t.Run("for virtual service with multi prefix catch all route", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithCatchAllMultiPrefixRoute,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
 
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 	})
 
 	t.Run("for virtual service with regex matching on URI", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRegexMatchingOnURI,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("\\/(.?)\\/status"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetSafeRegex().GetRegex()).To(Equal("\\/(.?)\\/status"))
 	})
 
 	t.Run("for virtual service with stat_prefix set for a match on URI", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithStatPrefix,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(3))
-		g.Expect(routes[0].GetMatch().GetPrefix()).To(gomega.Equal("/foo"))
-		g.Expect(routes[0].StatPrefix).To(gomega.Equal("foo"))
-		g.Expect(routes[1].GetMatch().GetPrefix()).To(gomega.Equal("/baz"))
-		g.Expect(routes[1].StatPrefix).To(gomega.Equal(""))
-		g.Expect(routes[2].GetMatch().GetPrefix()).To(gomega.Equal("/bar"))
-		g.Expect(routes[2].StatPrefix).To(gomega.Equal(""))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(3))
+		g.Expect(routes[0].GetMatch().GetPrefix()).To(Equal("/foo"))
+		g.Expect(routes[0].StatPrefix).To(Equal("foo"))
+		g.Expect(routes[1].GetMatch().GetPrefix()).To(Equal("/baz"))
+		g.Expect(routes[1].StatPrefix).To(Equal(""))
+		g.Expect(routes[2].GetMatch().GetPrefix()).To(Equal("/bar"))
+		g.Expect(routes[2].StatPrefix).To(Equal(""))
 	})
 
 	t.Run("for virtual service with exact matching on JWT claims", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithExactMatchingOnHeaderForJWTClaims,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(len(routes[0].GetMatch().GetHeaders())).To(gomega.Equal(0))
-		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[0].GetFilter()).To(gomega.Equal("istio_authn"))
-		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[0].GetInvert()).To(gomega.BeFalse())
-		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[1].GetFilter()).To(gomega.Equal("istio_authn"))
-		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[1].GetInvert()).To(gomega.BeTrue())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(len(routes[0].GetMatch().GetHeaders())).To(Equal(0))
+		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[0].GetFilter()).To(Equal("istio_authn"))
+		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[0].GetInvert()).To(BeFalse())
+		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[1].GetFilter()).To(Equal("istio_authn"))
+		g.Expect(routes[0].GetMatch().GetDynamicMetadata()[1].GetInvert()).To(BeTrue())
 	})
 
 	t.Run("for virtual service with regex matching on header", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRegexMatchingOnHeader,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("Bearer .+?\\..+?\\..+?"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(Equal("Bearer .+?\\..+?\\..+?"))
 	})
 
 	t.Run("for virtual service with regex matching on without_header", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRegexMatchingOnWithoutHeader,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("BAR .+?\\..+?\\..+?"))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(true))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(Equal("BAR .+?\\..+?\\..+?"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(true))
 	})
 
 	t.Run("for virtual service with presence matching on header", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithPresentMatchingOnHeader,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(gomega.Equal("FOO-HEADER"))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(gomega.Equal(true))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(false))
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal("FOO-HEADER"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(Equal(true))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(false))
 	})
 
 	t.Run("for virtual service with presence matching on header and without_header", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithPresentMatchingOnWithoutHeader,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(gomega.Equal("FOO-HEADER"))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(gomega.Equal(true))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(true))
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal("FOO-HEADER"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(Equal(true))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(true))
 	})
 
 	t.Run("for virtual service with regex matching for all cases on header", func(t *testing.T) {
 		cset := createVirtualServiceWithRegexMatchingForAllCasesOnHeader()
 
 		for _, c := range cset {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 			routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), *c, serviceRegistry, nil,
 				8080, gatewayNames, route.RouteOptions{})
 			xdstest.ValidateRoutes(t, routes)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(len(routes)).To(gomega.Equal(1))
-			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(gomega.Equal("FOO-HEADER"))
-			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(gomega.Equal(true))
-			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(false))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(routes)).To(Equal(1))
+			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal("FOO-HEADER"))
+			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(Equal(true))
+			g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(false))
 		}
 	})
 
 	t.Run("for virtual service with exact matching on query parameter", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithExactMatchingOnQueryParameter,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetExact()).To(gomega.Equal("foo"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetExact()).To(Equal("foo"))
 	})
 
 	t.Run("for virtual service with prefix matching on query parameter", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithPrefixMatchingOnQueryParameter,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetPrefix()).To(gomega.Equal("foo-"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetPrefix()).To(Equal("foo-"))
 	})
 
 	t.Run("for virtual service with regex matching on query parameter", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRegexMatchingOnQueryParameter,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(gomega.Equal("BAR .+?\\..+?\\..+?"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetStringMatch().GetSafeRegex().GetRegex()).To(Equal("BAR .+?\\..+?\\..+?"))
 	})
 
 	t.Run("for virtual service with regex matching for all cases on query parameter", func(t *testing.T) {
 		cset := createVirtualServiceWithRegexMatchingForAllCasesOnQueryParameter()
 
 		for _, c := range cset {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 			routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), *c, serviceRegistry, nil,
 				8080, gatewayNames, route.RouteOptions{})
 			xdstest.ValidateRoutes(t, routes)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			g.Expect(len(routes)).To(gomega.Equal(1))
-			g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetName()).To(gomega.Equal("token"))
-			g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetPresentMatch()).To(gomega.Equal(true))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(routes)).To(Equal(1))
+			g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetName()).To(Equal("token"))
+			g.Expect(routes[0].GetMatch().GetQueryParameters()[0].GetPresentMatch()).To(Equal(true))
 		}
 	})
 
 	t.Run("for virtual service with source namespace matching", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		fooNode := cg.SetupProxy(&model.Proxy{
@@ -408,9 +408,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(fooNode, virtualServiceMatchingOnSourceNamespace,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetName()).To(gomega.Equal("foo"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetName()).To(Equal("foo"))
 
 		barNode := cg.SetupProxy(&model.Proxy{
 			ConfigNamespace: "bar",
@@ -418,13 +418,13 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		routes, err = route.BuildHTTPRoutesForVirtualService(barNode, virtualServiceMatchingOnSourceNamespace,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetName()).To(gomega.Equal("bar"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetName()).To(Equal("bar"))
 	})
 
 	t.Run("for virtual service with ring hash", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		ttl := durationpb.Duration{Nanos: 100}
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
 			Services: exampleService,
@@ -461,8 +461,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -472,11 +472,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("for virtual service with query param based ring hash", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
 			Services: exampleService,
 			Configs: []config.Config{
@@ -509,8 +509,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_QueryParameter_{
@@ -519,11 +519,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("for virtual service with subsets with ring hash", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		virtualService := config.Config{
 			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
@@ -554,8 +554,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -565,11 +565,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("for virtual service with subsets with port level settings with ring hash", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		virtualService := config.Config{
 			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
@@ -597,8 +597,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -608,11 +608,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("for virtual service with subsets and top level traffic policy with ring hash", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		virtualService := config.Config{
 			Meta: config.Meta{
@@ -643,8 +643,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualService, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -654,11 +654,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("port selector based traffic policy", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
 			Services: exampleService,
@@ -678,8 +678,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		routes, err := route.BuildHTTPRoutesForVirtualService(proxy, virtualServicePlain, serviceRegistry,
 			hashByDestination, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -689,26 +689,26 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(routes[0].GetRoute().GetHashPolicy()).To(ConsistOf(hashPolicy))
 	})
 
 	t.Run("for header operations for single cluster", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithHeaderOperationsForSingleCluster,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		r := routes[0]
-		g.Expect(len(r.RequestHeadersToAdd)).To(gomega.Equal(4))
-		g.Expect(len(r.ResponseHeadersToAdd)).To(gomega.Equal(4))
-		g.Expect(len(r.RequestHeadersToRemove)).To(gomega.Equal(2))
-		g.Expect(len(r.ResponseHeadersToRemove)).To(gomega.Equal(2))
+		g.Expect(len(r.RequestHeadersToAdd)).To(Equal(4))
+		g.Expect(len(r.ResponseHeadersToAdd)).To(Equal(4))
+		g.Expect(len(r.RequestHeadersToRemove)).To(Equal(2))
+		g.Expect(len(r.ResponseHeadersToRemove)).To(Equal(2))
 
-		g.Expect(r.RequestHeadersToAdd).To(gomega.Equal([]*core.HeaderValueOption{
+		g.Expect(r.RequestHeadersToAdd).To(Equal([]*core.HeaderValueOption{
 			{
 				Header: &core.HeaderValue{
 					Key:   "x-req-set",
@@ -738,9 +738,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				AppendAction: core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
 			},
 		}))
-		g.Expect(r.RequestHeadersToRemove).To(gomega.Equal([]string{"x-req-remove", "x-route-req-remove"}))
+		g.Expect(r.RequestHeadersToRemove).To(Equal([]string{"x-req-remove", "x-route-req-remove"}))
 
-		g.Expect(r.ResponseHeadersToAdd).To(gomega.Equal([]*core.HeaderValueOption{
+		g.Expect(r.ResponseHeadersToAdd).To(Equal([]*core.HeaderValueOption{
 			{
 				Header: &core.HeaderValue{
 					Key:   "x-resp-set",
@@ -770,30 +770,30 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				AppendAction: core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
 			},
 		}))
-		g.Expect(r.ResponseHeadersToRemove).To(gomega.Equal([]string{"x-resp-remove", "x-route-resp-remove"}))
+		g.Expect(r.ResponseHeadersToRemove).To(Equal([]string{"x-resp-remove", "x-route-resp-remove"}))
 
 		routeAction, ok := r.GetAction().(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.GetHostRewriteLiteral()).To(gomega.Equal("foo.extsvc.com"))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.GetHostRewriteLiteral()).To(Equal("foo.extsvc.com"))
 	})
 
 	t.Run("for header operations for weighted cluster", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithHeaderOperationsForWeightedCluster,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		r := routes[0]
 		routeAction, ok := r.GetAction().(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
+		g.Expect(ok).NotTo(BeFalse())
 
 		weightedCluster := routeAction.Route.GetWeightedClusters()
-		g.Expect(weightedCluster).NotTo(gomega.BeNil())
-		g.Expect(len(weightedCluster.GetClusters())).To(gomega.Equal(2))
+		g.Expect(weightedCluster).NotTo(BeNil())
+		g.Expect(len(weightedCluster.GetClusters())).To(Equal(2))
 
 		expectResults := []struct {
 			reqAdd     []*core.HeaderValueOption
@@ -880,77 +880,77 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		for i, expectResult := range expectResults {
 			cluster := weightedCluster.GetClusters()[i]
-			g.Expect(cluster.RequestHeadersToAdd).To(gomega.Equal(expectResult.reqAdd))
-			g.Expect(cluster.RequestHeadersToRemove).To(gomega.Equal(expectResult.reqRemove))
-			g.Expect(cluster.ResponseHeadersToAdd).To(gomega.Equal(expectResult.respAdd))
-			g.Expect(cluster.RequestHeadersToRemove).To(gomega.Equal(expectResult.reqRemove))
-			g.Expect(cluster.GetHostRewriteLiteral()).To(gomega.Equal(expectResult.authority))
+			g.Expect(cluster.RequestHeadersToAdd).To(Equal(expectResult.reqAdd))
+			g.Expect(cluster.RequestHeadersToRemove).To(Equal(expectResult.reqRemove))
+			g.Expect(cluster.ResponseHeadersToAdd).To(Equal(expectResult.respAdd))
+			g.Expect(cluster.RequestHeadersToRemove).To(Equal(expectResult.reqRemove))
+			g.Expect(cluster.GetHostRewriteLiteral()).To(Equal(expectResult.authority))
 		}
 	})
 
 	t.Run("for redirect code", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirect, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(redirectAction.Redirect.ResponseCode).To(gomega.Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.ResponseCode).To(Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
 	})
 
 	t.Run("for path prefix redirect", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirectPathPrefix, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(gomega.Equal(&envoyroute.RedirectAction_PrefixRewrite{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PrefixRewrite{
 			PrefixRewrite: "/replace-prefix",
 		}))
 	})
 
 	t.Run("for host rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRewriteHost, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.HostRewriteSpecifier).To(gomega.Equal(&envoyroute.RouteAction_HostRewriteLiteral{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.HostRewriteSpecifier).To(Equal(&envoyroute.RouteAction_HostRewriteLiteral{
 			HostRewriteLiteral: "bar.example.org",
 		}))
 	})
 
 	t.Run("for full path rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRewriteFullPath, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
+		g.Expect(ok).NotTo(BeFalse())
 
-		g.Expect(routeAction.Route.RegexRewrite).To(gomega.Equal(&matcher.RegexMatchAndSubstitute{
+		g.Expect(routeAction.Route.RegexRewrite).To(Equal(&matcher.RegexMatchAndSubstitute{
 			Pattern: &matcher.RegexMatcher{
 				Regex: "/.*",
 			},
@@ -959,33 +959,33 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for prefix path rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRewritePrefixPath, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.PrefixRewrite).To(gomega.Equal("/replace-prefix"))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.PrefixRewrite).To(Equal("/replace-prefix"))
 	})
 
 	t.Run("for empty prefix path rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithEmptyRewritePrefixPath, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.RegexRewrite).To(gomega.Equal(&matcher.RegexMatchAndSubstitute{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.RegexRewrite).To(Equal(&matcher.RegexMatchAndSubstitute{
 			Pattern: &matcher.RegexMatcher{
 				Regex: `^/prefix-to-be-removed(/?)(.*)`,
 			},
@@ -994,22 +994,22 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for path and host rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
 			virtualServiceWithRewriteFullPathAndHost,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.HostRewriteSpecifier).To(gomega.Equal(&envoyroute.RouteAction_HostRewriteLiteral{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.HostRewriteSpecifier).To(Equal(&envoyroute.RouteAction_HostRewriteLiteral{
 			HostRewriteLiteral: "bar.example.org",
 		}))
-		g.Expect(routeAction.Route.RegexRewrite).To(gomega.Equal(&matcher.RegexMatchAndSubstitute{
+		g.Expect(routeAction.Route.RegexRewrite).To(Equal(&matcher.RegexMatchAndSubstitute{
 			Pattern: &matcher.RegexMatcher{
 				Regex: "/.*",
 			},
@@ -1018,19 +1018,19 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for path regex match with regex rewrite", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
 			virtualServiceWithPathRegexMatchRegexRewrite,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		routeAction, ok := routes[0].Action.(*envoyroute.Route_Route)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(routeAction.Route.RegexRewrite).To(gomega.Equal(&matcher.RegexMatchAndSubstitute{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(routeAction.Route.RegexRewrite).To(Equal(&matcher.RegexMatchAndSubstitute{
 			Pattern: &matcher.RegexMatcher{
 				Regex: "^/service/([^/]+)(/.*)$",
 			},
@@ -1039,97 +1039,97 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for redirect uri prefix '%PREFIX()%' that is without gateway semantics", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg),
 			virtualServiceWithRedirectPathPrefixNoGatewaySematics,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(gomega.Equal(&envoyroute.RedirectAction_PathRedirect{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PathRedirect{
 			PathRedirect: "%PREFIX()%/replace-full",
 		}))
 	})
 
 	t.Run("for full path redirect", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirectFullPath, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(gomega.Equal(&envoyroute.RedirectAction_PathRedirect{
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.PathRewriteSpecifier).To(Equal(&envoyroute.RedirectAction_PathRedirect{
 			PathRedirect: "/replace-full-path",
 		}))
 	})
 
 	t.Run("for redirect and header manipulation", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithRedirectAndSetHeader, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		redirectAction, ok := routes[0].Action.(*envoyroute.Route_Redirect)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(redirectAction.Redirect.ResponseCode).To(gomega.Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
-		g.Expect(len(routes[0].ResponseHeadersToAdd)).To(gomega.Equal(1))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].AppendAction).To(gomega.Equal(core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Key).To(gomega.Equal("Strict-Transport-Security"))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Value).To(gomega.Equal("max-age=31536000; includeSubDomains; preload"))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(redirectAction.Redirect.ResponseCode).To(Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
+		g.Expect(len(routes[0].ResponseHeadersToAdd)).To(Equal(1))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].AppendAction).To(Equal(core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Key).To(Equal("Strict-Transport-Security"))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Value).To(Equal("max-age=31536000; includeSubDomains; preload"))
 	})
 
 	t.Run("for direct response code", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithDirectResponse, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		directResponseAction, ok := routes[0].Action.(*envoyroute.Route_DirectResponse)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(directResponseAction.DirectResponse.Status).To(gomega.Equal(uint32(200)))
-		g.Expect(directResponseAction.DirectResponse.Body.Specifier.(*core.DataSource_InlineString).InlineString).To(gomega.Equal("hello"))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(directResponseAction.DirectResponse.Status).To(Equal(uint32(200)))
+		g.Expect(directResponseAction.DirectResponse.Body.Specifier.(*core.DataSource_InlineString).InlineString).To(Equal("hello"))
 	})
 
 	t.Run("for direct response code and header manipulation", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithDirectResponseAndSetHeader, serviceRegistry,
 			nil, 8080, gatewayNames, route.RouteOptions{})
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
 
 		directResponseAction, ok := routes[0].Action.(*envoyroute.Route_DirectResponse)
-		g.Expect(ok).NotTo(gomega.BeFalse())
-		g.Expect(directResponseAction.DirectResponse.Status).To(gomega.Equal(uint32(200)))
-		g.Expect(directResponseAction.DirectResponse.Body.Specifier.(*core.DataSource_InlineString).InlineString).To(gomega.Equal("hello"))
-		g.Expect(len(routes[0].ResponseHeadersToAdd)).To(gomega.Equal(1))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].AppendAction).To(gomega.Equal(core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Key).To(gomega.Equal("Strict-Transport-Security"))
-		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Value).To(gomega.Equal("max-age=31536000; includeSubDomains; preload"))
+		g.Expect(ok).NotTo(BeFalse())
+		g.Expect(directResponseAction.DirectResponse.Status).To(Equal(uint32(200)))
+		g.Expect(directResponseAction.DirectResponse.Body.Specifier.(*core.DataSource_InlineString).InlineString).To(Equal("hello"))
+		g.Expect(len(routes[0].ResponseHeadersToAdd)).To(Equal(1))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].AppendAction).To(Equal(core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Key).To(Equal("Strict-Transport-Security"))
+		g.Expect(routes[0].ResponseHeadersToAdd[0].Header.Value).To(Equal("max-age=31536000; includeSubDomains; preload"))
 	})
 
 	t.Run("for no virtualservice but has destinationrule with consistentHash loadbalancer", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
 			Configs: []config.Config{
 				{
@@ -1144,10 +1144,10 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Services: exampleService,
 		})
 		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry, []config.Config{}, 8080)
-		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
+		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
 			Configs: []config.Config{
 				{
@@ -1170,7 +1170,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).To(gomega.ConsistOf(hashPolicy))
+		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).To(ConsistOf(hashPolicy))
 	})
 }
 

--- a/pilot/pkg/server/instance_test.go
+++ b/pilot/pkg/server/instance_test.go
@@ -19,14 +19,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"go.uber.org/atomic"
 
 	"istio.io/istio/pilot/pkg/server"
 )
 
 func TestStartWithError(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	inst := server.New()
 	expected := errors.New("fake")
@@ -36,11 +36,11 @@ func TestStartWithError(t *testing.T) {
 
 	stop := newReclosableChannel()
 	t.Cleanup(stop.Close)
-	g.Expect(inst.Start(stop.c)).To(gomega.Equal(expected))
+	g.Expect(inst.Start(stop.c)).To(Equal(expected))
 }
 
 func TestStartWithNoError(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	inst := server.New()
 	c := newFakeComponent(0)
@@ -48,8 +48,8 @@ func TestStartWithNoError(t *testing.T) {
 
 	stop := newReclosableChannel()
 	t.Cleanup(stop.Close)
-	g.Expect(inst.Start(stop.c)).To(gomega.BeNil())
-	g.Expect(c.started.Load()).To(gomega.BeTrue())
+	g.Expect(inst.Start(stop.c)).To(BeNil())
+	g.Expect(c.started.Load()).To(BeTrue())
 }
 
 func TestRunComponentsAfterStart(t *testing.T) {
@@ -87,12 +87,12 @@ func TestRunComponentsAfterStart(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			stop := newReclosableChannel()
 			t.Cleanup(stop.Close)
 			inst := server.New()
-			g.Expect(inst.Start(stop.c)).To(gomega.BeNil())
+			g.Expect(inst.Start(stop.c)).To(BeNil())
 
 			go func() {
 				component := c.c.Run
@@ -110,7 +110,7 @@ func TestRunComponentsAfterStart(t *testing.T) {
 			// Ensure that the component is started.
 			g.Eventually(func() bool {
 				return c.c.started.Load()
-			}).Should(gomega.BeTrue())
+			}).Should(BeTrue())
 
 			// Stop before the tasks end.
 			stop.Close()
@@ -119,9 +119,9 @@ func TestRunComponentsAfterStart(t *testing.T) {
 				totalWaitTime := shortDuration + (1 * time.Second)
 				g.Eventually(func() bool {
 					return c.c.completed.Load()
-				}, totalWaitTime).Should(gomega.BeTrue())
+				}, totalWaitTime).Should(BeTrue())
 			} else {
-				g.Expect(c.c.completed.Load()).Should(gomega.BeFalse())
+				g.Expect(c.c.completed.Load()).Should(BeFalse())
 			}
 		})
 	}

--- a/pilot/pkg/status/distribution/report_test.go
+++ b/pilot/pkg/status/distribution/report_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 
 	"istio.io/istio/pilot/pkg/status"
@@ -36,11 +36,11 @@ func TestReportSerialization(t *testing.T) {
 		},
 	}
 	outbytes, err := yaml.Marshal(in)
-	gomega.RegisterTestingT(t)
-	gomega.Expect(err).To(gomega.BeNil())
+	RegisterTestingT(t)
+	Expect(err).To(BeNil())
 	out := Report{}
 	err = yaml.Unmarshal(outbytes, &out)
-	gomega.Expect(err).To(gomega.BeNil())
+	Expect(err).To(BeNil())
 	if !reflect.DeepEqual(out, in) {
 		t.Errorf("Report Serialization mutated the Report. got = %v, want %v", out, in)
 	}

--- a/pilot/pkg/status/distribution/reporter_test.go
+++ b/pilot/pkg/status/distribution/reporter_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/clock"
 
 	"istio.io/istio/pilot/pkg/status"
@@ -36,16 +36,16 @@ func TestStatusMaps(t *testing.T) {
 	r.processEvent("conB", typ, "a")
 	r.processEvent("conC", typ, "c")
 	r.processEvent("conD", typ, "d")
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 	x := struct{}{}
-	gomega.Expect(r.status).To(gomega.Equal(map[string]string{"conA~": "a", "conB~": "a", "conC~": "c", "conD~": "d"}))
-	gomega.Expect(r.reverseStatus).To(gomega.Equal(map[string]sets.String{"a": {"conA~": x, "conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conA~": "a", "conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]sets.String{"a": {"conA~": x, "conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
 	r.processEvent("conA", typ, "d")
-	gomega.Expect(r.status).To(gomega.Equal(map[string]string{"conA~": "d", "conB~": "a", "conC~": "c", "conD~": "d"}))
-	gomega.Expect(r.reverseStatus).To(gomega.Equal(map[string]sets.String{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x, "conA~": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conA~": "d", "conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]sets.String{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x, "conA~": x}}))
 	r.RegisterDisconnect("conA", []xds.EventType{typ})
-	gomega.Expect(r.status).To(gomega.Equal(map[string]string{"conB~": "a", "conC~": "c", "conD~": "d"}))
-	gomega.Expect(r.reverseStatus).To(gomega.Equal(map[string]sets.String{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
+	Expect(r.status).To(Equal(map[string]string{"conB~": "a", "conC~": "c", "conD~": "d"}))
+	Expect(r.reverseStatus).To(Equal(map[string]sets.String{"a": {"conB~": x}, "c": {"conC~": x}, "d": {"conD~": x}}))
 }
 
 func initReporterWithoutStarting() (out Reporter) {
@@ -61,7 +61,7 @@ func initReporterWithoutStarting() (out Reporter) {
 }
 
 func TestBuildReport(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	RegisterTestingT(t)
 	r := initReporterWithoutStarting()
 	r.ledger = ledger.Make(time.Minute)
 	resources := []*config.Config{
@@ -118,11 +118,11 @@ func TestBuildReport(t *testing.T) {
 	// build a report, which should have only two dataplanes, with 50% acking v2 of config
 	rpt, prunes := r.buildReport()
 	r.removeCompletedResource(prunes)
-	gomega.Expect(rpt.DataPlaneCount).To(gomega.Equal(2))
-	gomega.Expect(rpt.InProgressResources).To(gomega.Equal(map[string]int{
+	Expect(rpt.DataPlaneCount).To(Equal(2))
+	Expect(rpt.InProgressResources).To(Equal(map[string]int{
 		myResources[0].String(): 2,
 		myResources[1].String(): 1,
 		myResources[2].String(): 2,
 	}))
-	gomega.Expect(r.inProgressResources).NotTo(gomega.ContainElement(resources[0]))
+	Expect(r.inProgressResources).NotTo(ContainElement(resources[0]))
 }

--- a/pilot/pkg/status/resourcelock_test.go
+++ b/pilot/pkg/status/resourcelock_test.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"istio.io/api/meta/v1alpha1"
@@ -27,7 +27,7 @@ import (
 )
 
 func TestResourceLock_Lock(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 	r1 := Resource{
 		GroupVersionResource: schema.GroupVersionResource{
 			Group:   "r1",
@@ -83,6 +83,6 @@ func TestResourceLock_Lock(t *testing.T) {
 	}
 	<-y
 	result := atomic.LoadInt32(&runCount)
-	g.Expect(result).To(gomega.Equal(int32(3)))
+	g.Expect(result).To(Equal(int32(3)))
 	cancel()
 }

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/kubectl/pkg/util/fieldpath"
 
 	"istio.io/api/mesh/v1alpha1"
@@ -108,14 +108,14 @@ func TestGetNodeMetaData(t *testing.T) {
 		ExitOnZeroActiveConnections: true,
 	})
 
-	g := gomega.NewWithT(t)
-	g.Expect(err).Should(gomega.BeNil())
-	g.Expect(node.Metadata.Owner).To(gomega.Equal(expectOwner))
-	g.Expect(node.Metadata.WorkloadName).To(gomega.Equal(expectWorkloadName))
-	g.Expect(node.Metadata.ExitOnZeroActiveConnections).To(gomega.Equal(expectExitOnZeroActiveConnections))
-	g.Expect(node.RawMetadata["OWNER"]).To(gomega.Equal(expectOwner))
-	g.Expect(node.RawMetadata["WORKLOAD_NAME"]).To(gomega.Equal(expectWorkloadName))
-	g.Expect(node.Metadata.Labels[model.LocalityLabel]).To(gomega.Equal("region/zone/subzone"))
+	g := NewWithT(t)
+	g.Expect(err).Should(BeNil())
+	g.Expect(node.Metadata.Owner).To(Equal(expectOwner))
+	g.Expect(node.Metadata.WorkloadName).To(Equal(expectWorkloadName))
+	g.Expect(node.Metadata.ExitOnZeroActiveConnections).To(Equal(expectExitOnZeroActiveConnections))
+	g.Expect(node.RawMetadata["OWNER"]).To(Equal(expectOwner))
+	g.Expect(node.RawMetadata["WORKLOAD_NAME"]).To(Equal(expectWorkloadName))
+	g.Expect(node.Metadata.Labels[model.LocalityLabel]).To(Equal("region/zone/subzone"))
 }
 
 func TestSetIstioVersion(t *testing.T) {

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	meshAPI "istio.io/api/mesh/v1alpha1"
@@ -677,19 +677,19 @@ func TestOptions(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			params, err := option.NewTemplateParams(c.option)
 			if c.expectError {
-				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(err).ToNot(BeNil())
 			} else {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 				actual, ok := params[c.key]
 				if c.expected == nil {
-					g.Expect(ok).To(gomega.BeFalse())
+					g.Expect(ok).To(BeFalse())
 				} else {
-					g.Expect(ok).To(gomega.BeTrue())
-					g.Expect(actual).To(gomega.Equal(c.expected))
+					g.Expect(ok).To(BeTrue())
+					g.Expect(actual).To(Equal(c.expected))
 				}
 			}
 		})

--- a/pkg/config/analysis/analyzer_test.go
+++ b/pkg/config/analysis/analyzer_test.go
@@ -17,7 +17,7 @@ package analysis
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis/diag"
@@ -55,7 +55,7 @@ func (ctx *context) Canceled() bool                                             
 func (ctx *context) SetAnalyzer(_ string)                                               {}
 
 func TestCombinedAnalyzer(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	col1 := newSchema("col1")
 	col2 := newSchema("col2")
@@ -68,19 +68,19 @@ func TestCombinedAnalyzer(t *testing.T) {
 	a4 := &analyzer{name: "a4", inputs: []config.GroupVersionKind{col4.GroupVersionKind()}}
 
 	a := Combine("combined", a1, a2, a3, a4)
-	g.Expect(a.Metadata().Inputs).To(gomega.ConsistOf(col1.GroupVersionKind(), col2.GroupVersionKind(), col3.GroupVersionKind(), col4.GroupVersionKind()))
+	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1.GroupVersionKind(), col2.GroupVersionKind(), col3.GroupVersionKind(), col4.GroupVersionKind()))
 
 	removed := a.RemoveSkipped(collection.NewSchemasBuilder().MustAdd(col1).MustAdd(col2).Build())
 
-	g.Expect(removed).To(gomega.ConsistOf(a3.Metadata().Name, a4.Metadata().Name))
-	g.Expect(a.Metadata().Inputs).To(gomega.ConsistOf(col1.GroupVersionKind(), col2.GroupVersionKind()))
+	g.Expect(removed).To(ConsistOf(a3.Metadata().Name, a4.Metadata().Name))
+	g.Expect(a.Metadata().Inputs).To(ConsistOf(col1.GroupVersionKind(), col2.GroupVersionKind()))
 
 	a.Analyze(&context{})
 
-	g.Expect(a1.ran).To(gomega.BeTrue())
-	g.Expect(a2.ran).To(gomega.BeTrue())
-	g.Expect(a3.ran).To(gomega.BeFalse())
-	g.Expect(a4.ran).To(gomega.BeFalse())
+	g.Expect(a1.ran).To(BeTrue())
+	g.Expect(a2.ran).To(BeTrue())
+	g.Expect(a3.ran).To(BeFalse())
+	g.Expect(a4.ran).To(BeFalse())
 }
 
 func newSchema(name string) resource2.Schema {

--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
@@ -868,7 +868,7 @@ func TestAnalyzers(t *testing.T) {
 	for _, tc := range testGrid {
 		tc := tc // Capture range variable so subtests work correctly
 		t.Run(tc.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			// Set up a hook to record which collections are accessed by each analyzer
 			analyzerName := tc.analyzer.Metadata().Name
@@ -891,14 +891,14 @@ func TestAnalyzers(t *testing.T) {
 				t.Fatalf("Error running analysis on testcase %s: %v", tc.name, err)
 			}
 
-			g.Expect(extractFields(result.Messages)).To(gomega.ConsistOf(tc.expected), "%v", prettyPrintMessages(result.Messages))
+			g.Expect(extractFields(result.Messages)).To(ConsistOf(tc.expected), "%v", prettyPrintMessages(result.Messages))
 		})
 	}
 
 	// Verify that the collections actually accessed during testing actually match
 	// the collections declared as inputs for each of the analyzers
 	t.Run("CheckMetadataInputs", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 	outer:
 		for _, a := range All() {
 			analyzerName := a.Metadata().Name
@@ -919,7 +919,7 @@ func TestAnalyzers(t *testing.T) {
 				requestedInputs = append(requestedInputs, col)
 			}
 
-			g.Expect(a.Metadata().Inputs).To(gomega.ConsistOf(requestedInputs), fmt.Sprintf(
+			g.Expect(a.Metadata().Inputs).To(ConsistOf(requestedInputs), fmt.Sprintf(
 				"Metadata inputs for analyzer %q don't match actual collections accessed during testing. "+
 					"Either the metadata is wrong or the test cases for the analyzer are insufficient.", analyzerName))
 		}
@@ -928,7 +928,7 @@ func TestAnalyzers(t *testing.T) {
 
 // Verify that all of the analyzers tested here are also registered in All()
 func TestAnalyzersInAll(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var allNames []string
 	for _, a := range All() {
@@ -937,13 +937,13 @@ func TestAnalyzersInAll(t *testing.T) {
 
 	for _, tc := range testGrid {
 		if !tc.skipAll {
-			g.Expect(allNames).To(gomega.ContainElement(tc.analyzer.Metadata().Name))
+			g.Expect(allNames).To(ContainElement(tc.analyzer.Metadata().Name))
 		}
 	}
 }
 
 func TestAnalyzersHaveUniqueNames(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	existingNames := sets.New[string]()
 	for _, a := range All() {
@@ -952,7 +952,7 @@ func TestAnalyzersHaveUniqueNames(t *testing.T) {
 		if existingNames.Contains(n) && n == "schema.ValidationAnalyzer.ServiceEntry" {
 			continue
 		}
-		g.Expect(existingNames.Contains(n)).To(gomega.BeFalse(), fmt.Sprintf("Analyzer name %q is used more than once. "+
+		g.Expect(existingNames.Contains(n)).To(BeFalse(), fmt.Sprintf("Analyzer name %q is used more than once. "+
 			"Analyzers should be registered in All() exactly once and have a unique name.", n))
 
 		existingNames.Insert(n)
@@ -960,10 +960,10 @@ func TestAnalyzersHaveUniqueNames(t *testing.T) {
 }
 
 func TestAnalyzersHaveDescription(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	for _, a := range All() {
-		g.Expect(a.Metadata().Description).ToNot(gomega.Equal(""))
+		g.Expect(a.Metadata().Description).ToNot(Equal(""))
 	}
 }
 

--- a/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
@@ -32,14 +32,14 @@ import (
 )
 
 func TestCorrectArgs(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m1 := &v1alpha3.VirtualService{}
 
 	testSchema := schemaWithValidateFn(func(cfg config.Config) (warnings validation.Warning, errs error) {
-		g.Expect(cfg.Name).To(gomega.Equal("name"))
-		g.Expect(cfg.Namespace).To(gomega.Equal("ns"))
-		g.Expect(cfg.Spec).To(gomega.Equal(m1))
+		g.Expect(cfg.Name).To(Equal("name"))
+		g.Expect(cfg.Namespace).To(Equal("ns"))
+		g.Expect(cfg.Spec).To(Equal(m1))
 		return nil, nil
 	})
 	ctx := &fixtures.Context{
@@ -80,12 +80,12 @@ func TestSchemaValidationWrapper(t *testing.T) {
 	a := ValidationAnalyzer{s: testSchema}
 
 	t.Run("CheckMetadataInputs", func(t *testing.T) {
-		g := gomega.NewWithT(t)
-		g.Expect(a.Metadata().Inputs).To(gomega.ConsistOf(testCol))
+		g := NewWithT(t)
+		g.Expect(a.Metadata().Inputs).To(ConsistOf(testCol))
 	})
 
 	t.Run("NoErrors", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
 				{
@@ -94,11 +94,11 @@ func TestSchemaValidationWrapper(t *testing.T) {
 			},
 		}
 		a.Analyze(ctx)
-		g.Expect(ctx.Reports).To(gomega.BeEmpty())
+		g.Expect(ctx.Reports).To(BeEmpty())
 	})
 
 	t.Run("SingleError", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
@@ -109,12 +109,12 @@ func TestSchemaValidationWrapper(t *testing.T) {
 			},
 		}
 		a.Analyze(ctx)
-		g.Expect(ctx.Reports).To(gomega.HaveLen(1))
-		g.Expect(ctx.Reports[0].Type).To(gomega.Equal(msg.SchemaValidationError))
+		g.Expect(ctx.Reports).To(HaveLen(1))
+		g.Expect(ctx.Reports[0].Type).To(Equal(msg.SchemaValidationError))
 	})
 
 	t.Run("MultiError", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
 				{
@@ -124,9 +124,9 @@ func TestSchemaValidationWrapper(t *testing.T) {
 			},
 		}
 		a.Analyze(ctx)
-		g.Expect(ctx.Reports).To(gomega.HaveLen(2))
-		g.Expect(ctx.Reports[0].Type).To(gomega.Equal(msg.SchemaValidationError))
-		g.Expect(ctx.Reports[1].Type).To(gomega.Equal(msg.SchemaValidationError))
+		g.Expect(ctx.Reports).To(HaveLen(2))
+		g.Expect(ctx.Reports[0].Type).To(Equal(msg.SchemaValidationError))
+		g.Expect(ctx.Reports[1].Type).To(Equal(msg.SchemaValidationError))
 	})
 }
 

--- a/pkg/config/analysis/analyzers/util/exportto_test.go
+++ b/pkg/config/analysis/analyzers/util/exportto_test.go
@@ -17,24 +17,24 @@ package util
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestIsExportToAllNamespaces(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	// Empty array
-	g.Expect(IsExportToAllNamespaces(nil)).To(gomega.Equal(true))
+	g.Expect(IsExportToAllNamespaces(nil)).To(Equal(true))
 
 	// Array with "*"
-	g.Expect(IsExportToAllNamespaces([]string{"*"})).To(gomega.Equal(true))
+	g.Expect(IsExportToAllNamespaces([]string{"*"})).To(Equal(true))
 
 	// Array with "."
-	g.Expect(IsExportToAllNamespaces([]string{"."})).To(gomega.Equal(false))
+	g.Expect(IsExportToAllNamespaces([]string{"."})).To(Equal(false))
 
 	// Array with "." & "*"
-	g.Expect(IsExportToAllNamespaces([]string{".", "*"})).To(gomega.Equal(true))
+	g.Expect(IsExportToAllNamespaces([]string{".", "*"})).To(Equal(true))
 
 	// Array with "bogus"
-	g.Expect(IsExportToAllNamespaces([]string{"bogus"})).To(gomega.Equal(false))
+	g.Expect(IsExportToAllNamespaces([]string{"bogus"})).To(Equal(false))
 }

--- a/pkg/config/analysis/analyzers/util/find_errorline_utils_test.go
+++ b/pkg/config/analysis/analyzers/util/find_errorline_utils_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	kube2 "istio.io/istio/pkg/config/legacy/source/kube"
 	"istio.io/istio/pkg/config/resource"
@@ -47,24 +47,24 @@ var fieldMap = map[string]int{
 }
 
 func TestExtractLabelFromSelectorString(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	s := "label=test"
-	g.Expect(ExtractLabelFromSelectorString(s)).To(gomega.Equal("label"))
+	g.Expect(ExtractLabelFromSelectorString(s)).To(Equal("label"))
 }
 
 func TestErrorLine(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	r := &resource.Instance{Origin: &kube2.Origin{FieldsMap: fieldMap}}
 	test1, err1 := ErrorLine(r, "{.metadata.name}")
 	test2, err2 := ErrorLine(r, "{.metadata.fake}")
-	g.Expect(test1).To(gomega.Equal(1))
-	g.Expect(err1).To(gomega.Equal(true))
-	g.Expect(test2).To(gomega.Equal(0))
-	g.Expect(err2).To(gomega.Equal(false))
+	g.Expect(test1).To(Equal(1))
+	g.Expect(err1).To(Equal(true))
+	g.Expect(test2).To(Equal(0))
+	g.Expect(err2).To(Equal(false))
 }
 
 func TestConstants(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	constantsPath := []string{
 		fmt.Sprintf(DestinationHost, "test", 0, 0),
@@ -89,6 +89,6 @@ func TestConstants(t *testing.T) {
 	}
 
 	for _, v := range constantsPath {
-		g.Expect(fieldMap[v]).To(gomega.Equal(1))
+		g.Expect(fieldMap[v]).To(Equal(1))
 	}
 }

--- a/pkg/config/analysis/analyzers/util/hosts_test.go
+++ b/pkg/config/analysis/analyzers/util/hosts_test.go
@@ -17,70 +17,70 @@ package util
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/config/resource"
 )
 
 func TestGetResourceNameFromHost(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	// FQDN, same namespace
-	g.Expect(GetResourceNameFromHost("default", "foo.default.svc.cluster.local")).To(gomega.Equal(resource.NewFullName("default", "foo")))
+	g.Expect(GetResourceNameFromHost("default", "foo.default.svc.cluster.local")).To(Equal(resource.NewFullName("default", "foo")))
 	// FQDN, cross namespace
-	g.Expect(GetResourceNameFromHost("default", "foo.other.svc.cluster.local")).To(gomega.Equal(resource.NewFullName("other", "foo")))
+	g.Expect(GetResourceNameFromHost("default", "foo.other.svc.cluster.local")).To(Equal(resource.NewFullName("other", "foo")))
 	// short name
-	g.Expect(GetResourceNameFromHost("default", "foo")).To(gomega.Equal(resource.NewFullName("default", "foo")))
+	g.Expect(GetResourceNameFromHost("default", "foo")).To(Equal(resource.NewFullName("default", "foo")))
 	// bogus FQDN (gets treated like a short name)
-	g.Expect(GetResourceNameFromHost("default", "foo.svc.cluster.local")).To(gomega.Equal(resource.NewFullName("default", "foo.svc.cluster.local")))
+	g.Expect(GetResourceNameFromHost("default", "foo.svc.cluster.local")).To(Equal(resource.NewFullName("default", "foo.svc.cluster.local")))
 }
 
 func TestGetScopedFqdnHostname(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	// FQDN, same namespace, local scope
-	g.Expect(NewScopedFqdn("default", "default", "foo.default.svc.cluster.local")).To(gomega.Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// FQDN, cross namespace, local scope
-	g.Expect(NewScopedFqdn("default", "other", "foo.default.svc.cluster.local")).To(gomega.Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// FQDN, same namespace, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "default", "foo.default.svc.cluster.local")).To(gomega.Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 	// FQDN, cross namespace, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "other", "foo.default.svc.cluster.local")).To(gomega.Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "other", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 
 	// short name, same namespace, local scope
-	g.Expect(NewScopedFqdn("default", "default", "foo")).To(gomega.Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("default", "default", "foo")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
 	// short name, same namespace, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "default", "foo")).To(gomega.Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
+	g.Expect(NewScopedFqdn("*", "default", "foo")).To(Equal(ScopedFqdn("*/foo.default.svc.cluster.local")))
 
 	// wildcard, local scope
-	g.Expect(NewScopedFqdn("foo", "foo", "*")).To(gomega.Equal(ScopedFqdn("foo/*")))
+	g.Expect(NewScopedFqdn("foo", "foo", "*")).To(Equal(ScopedFqdn("foo/*")))
 	// wildcard sub domain, local scope
-	g.Expect(NewScopedFqdn("foo", "foo", "*.xyz.abc")).To(gomega.Equal(ScopedFqdn("foo/*.xyz.abc")))
+	g.Expect(NewScopedFqdn("foo", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("foo/*.xyz.abc")))
 	// wildcard, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "foo", "*")).To(gomega.Equal(ScopedFqdn("*/*")))
+	g.Expect(NewScopedFqdn("*", "foo", "*")).To(Equal(ScopedFqdn("*/*")))
 	// wildcard sub domain, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "foo", "*.xyz.abc")).To(gomega.Equal(ScopedFqdn("*/*.xyz.abc")))
+	g.Expect(NewScopedFqdn("*", "foo", "*.xyz.abc")).To(Equal(ScopedFqdn("*/*.xyz.abc")))
 
 	// external host, local scope
-	g.Expect(NewScopedFqdn("foo", "foo", "xyz.abc")).To(gomega.Equal(ScopedFqdn("foo/xyz.abc")))
+	g.Expect(NewScopedFqdn("foo", "foo", "xyz.abc")).To(Equal(ScopedFqdn("foo/xyz.abc")))
 	// external host, all namespaces scope
-	g.Expect(NewScopedFqdn("*", "foo", "xyz.abc")).To(gomega.Equal(ScopedFqdn("*/xyz.abc")))
+	g.Expect(NewScopedFqdn("*", "foo", "xyz.abc")).To(Equal(ScopedFqdn("*/xyz.abc")))
 }
 
 func TestScopedFqdn_GetScopeAndFqdn(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	ns, fqdn := ScopedFqdn("default/reviews.default.svc.cluster.local").GetScopeAndFqdn()
-	g.Expect(ns).To(gomega.Equal("default"))
-	g.Expect(fqdn).To(gomega.Equal("reviews.default.svc.cluster.local"))
+	g.Expect(ns).To(Equal("default"))
+	g.Expect(fqdn).To(Equal("reviews.default.svc.cluster.local"))
 
 	ns, fqdn = ScopedFqdn("*/reviews.default.svc.cluster.local").GetScopeAndFqdn()
-	g.Expect(ns).To(gomega.Equal("*"))
-	g.Expect(fqdn).To(gomega.Equal("reviews.default.svc.cluster.local"))
+	g.Expect(ns).To(Equal("*"))
+	g.Expect(fqdn).To(Equal("reviews.default.svc.cluster.local"))
 
 	ns, fqdn = ScopedFqdn("foo/*.xyz.abc").GetScopeAndFqdn()
-	g.Expect(ns).To(gomega.Equal("foo"))
-	g.Expect(fqdn).To(gomega.Equal("*.xyz.abc"))
+	g.Expect(ns).To(Equal("foo"))
+	g.Expect(fqdn).To(Equal("*.xyz.abc"))
 }
 
 func TestScopedFqdn_InScopeOf(t *testing.T) {

--- a/pkg/config/analysis/diag/message_test.go
+++ b/pkg/config/analysis/diag/message_test.go
@@ -19,81 +19,81 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/url"
 )
 
 func TestMessage_String(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 
-	g.Expect(m.String()).To(gomega.Equal(`Error [IST-0042] Cheese type not found: "Feta"`))
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] Cheese type not found: "Feta"`))
 }
 
 func TestMessageWithResource_String(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 
-	g.Expect(m.String()).To(gomega.Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
 }
 
 func TestMessage_Unstructured(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 
-	g.Expect(m.Unstructured(true)).To(gomega.Not(gomega.HaveKey("origin")))
-	g.Expect(m.Unstructured(false)).To(gomega.Not(gomega.HaveKey("origin")))
+	g.Expect(m.Unstructured(true)).To(Not(HaveKey("origin")))
+	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 
 	m = NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese"}}, "Feta")
 
-	g.Expect(m.Unstructured(true)).To((gomega.HaveKey("origin")))
-	g.Expect(m.Unstructured(false)).To(gomega.Not(gomega.HaveKey("origin")))
+	g.Expect(m.Unstructured(true)).To((HaveKey("origin")))
+	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 }
 
 func TestMessageWithDocRef(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 	m.DocRef = "test-ref"
-	g.Expect(m.Unstructured(false)["documentationUrl"]).To(gomega.Equal(url.ConfigAnalysis + "/ist0042/?ref=test-ref"))
+	g.Expect(m.Unstructured(false)["documentationUrl"]).To(Equal(url.ConfigAnalysis + "/ist0042/?ref=test-ref"))
 }
 
 func TestMessage_JSON(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 
 	j, _ := json.Marshal(&m)
-	g.Expect(string(j)).To(gomega.Equal(`{"code":"IST0042","documentationUrl":"` + url.ConfigAnalysis + `/ist0042/"` +
+	g.Expect(string(j)).To(Equal(`{"code":"IST0042","documentationUrl":"` + url.ConfigAnalysis + `/ist0042/"` +
 		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese","reference":"path/to/file"}`))
 }
 
 func TestMessage_ReplaceLine(t *testing.T) {
 	testCases := []string{"test.yaml", "test.yaml:1", "test.yaml:10", "test.yaml: 10", "test", "test:10", "123:10", "123"}
 	result := make([]string, 0)
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 	m := &Message{Line: 321}
 	for _, v := range testCases {
 		result = append(result, m.ReplaceLine(v))
 	}
-	g.Expect(result).To(gomega.Equal([]string{"test.yaml", "test.yaml:321", "test.yaml:321", "test.yaml:321", "test", "test:321", "123:321", "123"}))
+	g.Expect(result).To(Equal([]string{"test.yaml", "test.yaml:321", "test.yaml:321", "test.yaml:321", "test", "test:321", "123:321", "123"}))
 }
 
 func TestMessage_UnstructuredAnalysisMessageBase(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 	m.DocRef = "test-ref"
 
 	mb := m.UnstructuredAnalysisMessageBase()
-	g.Expect(mb["documentationUrl"]).To(gomega.Equal(fmt.Sprintf("%s/%s/%s", url.ConfigAnalysis, "ist0042", "?ref=test-ref")))
-	g.Expect(mb["level"]).To(gomega.Equal("ERROR"))
-	g.Expect(mb["type"]).To(gomega.Equal(
+	g.Expect(mb["documentationUrl"]).To(Equal(fmt.Sprintf("%s/%s/%s", url.ConfigAnalysis, "ist0042", "?ref=test-ref")))
+	g.Expect(mb["level"]).To(Equal("ERROR"))
+	g.Expect(mb["type"]).To(Equal(
 		map[string]any{
 			"code": "IST0042",
 		},

--- a/pkg/config/analysis/diag/messages_test.go
+++ b/pkg/config/analysis/diag/messages_test.go
@@ -17,13 +17,13 @@ package diag
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/url"
 )
 
 func TestMessages_Sort(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -56,11 +56,11 @@ func TestMessages_Sort(t *testing.T) {
 
 	msgs.Sort()
 
-	g.Expect(msgs).To(gomega.Equal(expectedMsgs))
+	g.Expect(msgs).To(Equal(expectedMsgs))
 }
 
 func TestMessages_SortWithNilOrigin(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -83,11 +83,11 @@ func TestMessages_SortWithNilOrigin(t *testing.T) {
 
 	msgs.Sort()
 
-	g.Expect(msgs).To(gomega.Equal(expectedMsgs))
+	g.Expect(msgs).To(Equal(expectedMsgs))
 }
 
 func TestMessages_SortedCopy(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -111,11 +111,11 @@ func TestMessages_SortedCopy(t *testing.T) {
 
 	newMsgs := msgs.SortedDedupedCopy()
 
-	g.Expect(newMsgs).To(gomega.Equal(expectedMsgs))
+	g.Expect(newMsgs).To(Equal(expectedMsgs))
 }
 
 func TestMessages_SetRefDoc(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -135,12 +135,12 @@ func TestMessages_SetRefDoc(t *testing.T) {
 		return msg.Unstructured(false)["documentationUrl"].(string)
 	}
 
-	g.Expect(getDocURL(msgs[0])).To(gomega.Equal(url.ConfigAnalysis + "/b1/?ref=istioctl-awesome"))
-	g.Expect(getDocURL(msgs[1])).To(gomega.Equal(url.ConfigAnalysis + "/c1/?ref=istioctl-awesome"))
+	g.Expect(getDocURL(msgs[0])).To(Equal(url.ConfigAnalysis + "/b1/?ref=istioctl-awesome"))
+	g.Expect(getDocURL(msgs[1])).To(Equal(url.ConfigAnalysis + "/c1/?ref=istioctl-awesome"))
 }
 
 func TestMessages_Filter(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -162,11 +162,11 @@ func TestMessages_Filter(t *testing.T) {
 	filteredMsgs := msgs.FilterOutLowerThan(Warning)
 	expectedMsgs := Messages{firstMsg, thirdMsg}
 
-	g.Expect(filteredMsgs).To(gomega.Equal(expectedMsgs))
+	g.Expect(filteredMsgs).To(Equal(expectedMsgs))
 }
 
 func TestMessages_FilterOutAll(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Info, "A1", "Template: %q"),
@@ -183,5 +183,5 @@ func TestMessages_FilterOutAll(t *testing.T) {
 	filteredMsgs := msgs.FilterOutLowerThan(Error)
 	expectedMsgs := Messages{}
 
-	g.Expect(filteredMsgs).To(gomega.Equal(expectedMsgs))
+	g.Expect(filteredMsgs).To(Equal(expectedMsgs))
 }

--- a/pkg/config/analysis/local/analyze_test.go
+++ b/pkg/config/analysis/local/analyze_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,17 +73,17 @@ func (a *testAnalyzer) Analyze(ctx analysis.Context) {
 }
 
 func TestAbortWithNoSources(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 	_, err := sa.Analyze(cancel)
-	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+	g.Expect(err).To(Not(BeNil()))
 }
 
 func TestAnalyzersRun(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
@@ -103,17 +103,17 @@ func TestAnalyzersRun(t *testing.T) {
 
 	sa := NewSourceAnalyzer(analysis.Combine("a", a), "", "", cr)
 	err := sa.AddReaderKubeSource(nil)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	result, err := sa.Analyze(cancel)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(result.Messages).To(gomega.ConsistOf(m))
-	g.Expect(collectionAccessed).To(gomega.Equal(K8SCollection1.GroupVersionKind()))
-	g.Expect(result.ExecutedAnalyzers).To(gomega.ConsistOf(a.Metadata().Name))
+	g.Expect(err).To(BeNil())
+	g.Expect(result.Messages).To(ConsistOf(m))
+	g.Expect(collectionAccessed).To(Equal(K8SCollection1.GroupVersionKind()))
+	g.Expect(result.ExecutedAnalyzers).To(ConsistOf(a.Metadata().Name))
 }
 
 func TestFilterOutputByNamespace(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
@@ -130,27 +130,27 @@ func TestFilterOutputByNamespace(t *testing.T) {
 
 	sa := NewSourceAnalyzer(analysis.Combine("a", a), "ns1", "", nil)
 	err := sa.AddReaderKubeSource(nil)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	result, err := sa.Analyze(cancel)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(result.Messages).To(gomega.ConsistOf(msg1))
+	g.Expect(err).To(BeNil())
+	g.Expect(result.Messages).To(ConsistOf(msg1))
 }
 
 func TestAddInMemorySource(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 
 	src := model.NewFakeStore()
 	sa.AddSource(dfCache{ConfigStore: src})
 	assert.Equal(t, sa.meshCfg, mesh.DefaultMeshConfig()) // Base default meshcfg
-	g.Expect(sa.meshNetworks.Networks).To(gomega.HaveLen(0))
-	g.Expect(sa.stores).To(gomega.HaveLen(1))
+	g.Expect(sa.meshNetworks.Networks).To(HaveLen(0))
+	g.Expect(sa.stores).To(HaveLen(1))
 }
 
 func TestAddRunningKubeSource(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	mk := kube.NewFakeClient()
 
@@ -158,13 +158,13 @@ func TestAddRunningKubeSource(t *testing.T) {
 
 	sa.AddRunningKubeSource(mk)
 	assert.Equal(t, sa.meshCfg, mesh.DefaultMeshConfig()) // Base default meshcfg
-	g.Expect(sa.meshNetworks.Networks).To(gomega.HaveLen(0))
+	g.Expect(sa.meshNetworks.Networks).To(HaveLen(0))
 	// We have a store for Istio configs and one for service discovery K8S resources.
-	g.Expect(sa.stores).To(gomega.HaveLen(2))
+	g.Expect(sa.stores).To(HaveLen(2))
 }
 
 func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	istioNamespace := resource.Namespace("istio-system")
 
@@ -188,14 +188,14 @@ func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", istioNamespace, nil)
 
 	sa.AddRunningKubeSource(mk)
-	g.Expect(sa.meshCfg.RootNamespace).To(gomega.Equal(testRootNamespace))
-	g.Expect(sa.meshNetworks.Networks).To(gomega.HaveLen(2))
+	g.Expect(sa.meshCfg.RootNamespace).To(Equal(testRootNamespace))
+	g.Expect(sa.meshNetworks.Networks).To(HaveLen(2))
 	// We have a store for Istio configs and one for service discovery K8S resources.
-	g.Expect(sa.stores).To(gomega.HaveLen(2))
+	g.Expect(sa.stores).To(HaveLen(2))
 }
 
 func TestAddReaderKubeSource(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 
@@ -203,9 +203,9 @@ func TestAddReaderKubeSource(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	err := sa.AddReaderKubeSource([]ReaderSource{{Reader: tmpfile}})
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	assert.Equal(t, sa.meshCfg, mesh.DefaultMeshConfig()) // Base default meshcfg
-	g.Expect(sa.stores).To(gomega.HaveLen(0))
+	g.Expect(sa.stores).To(HaveLen(0))
 
 	// Note that a blank file for mesh cfg is equivalent to specifying all the defaults
 	testRootNamespace := "testNamespace"
@@ -213,12 +213,12 @@ func TestAddReaderKubeSource(t *testing.T) {
 	defer func() { _ = os.Remove(tmpMeshFile.Name()) }()
 
 	err = sa.AddFileKubeMeshConfig(tmpMeshFile.Name())
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(sa.meshCfg.RootNamespace).To(gomega.Equal(testRootNamespace)) // Should be mesh config from the file now
+	g.Expect(err).To(BeNil())
+	g.Expect(sa.meshCfg.RootNamespace).To(Equal(testRootNamespace)) // Should be mesh config from the file now
 }
 
 func TestAddReaderKubeSourceSkipsBadEntries(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 
@@ -226,7 +226,7 @@ func TestAddReaderKubeSourceSkipsBadEntries(t *testing.T) {
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	err := sa.AddReaderKubeSource([]ReaderSource{{Reader: tmpfile}})
-	g.Expect(err).To(gomega.Not(gomega.BeNil()))
+	g.Expect(err).To(Not(BeNil()))
 }
 
 const (
@@ -256,7 +256,7 @@ func JoinString(parts ...string) string {
 }
 
 func TestDefaultResourcesRespectsMeshConfig(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(blankCombinedAnalyzer, "", "", nil)
 
@@ -265,18 +265,18 @@ func TestDefaultResourcesRespectsMeshConfig(t *testing.T) {
 	defer func() { _ = os.Remove(ingressOffMeshCfg.Name()) }()
 
 	err := sa.AddFileKubeMeshConfig(ingressOffMeshCfg.Name())
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	sa.AddDefaultResources()
-	g.Expect(sa.stores).To(gomega.BeEmpty())
+	g.Expect(sa.stores).To(BeEmpty())
 
 	// With ingress on, though, we should.
 	ingressStrictMeshCfg := tempFileFromString(t, "ingressControllerMode: 'STRICT'")
 	defer func() { _ = os.Remove(ingressStrictMeshCfg.Name()) }()
 
 	err = sa.AddFileKubeMeshConfig(ingressStrictMeshCfg.Name())
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	sa.AddDefaultResources()
-	g.Expect(sa.stores).To(gomega.HaveLen(0))
+	g.Expect(sa.stores).To(HaveLen(0))
 }
 
 func TestEmptyContext(t *testing.T) {

--- a/pkg/config/mesh/kubemesh/watcher_test.go
+++ b/pkg/config/mesh/kubemesh/watcher_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/testing/protocmp"
 	v1 "k8s.io/api/core/v1"
@@ -235,18 +235,18 @@ func TestNewConfigMapWatcher(t *testing.T) {
 
 	for i, step := range steps {
 		t.Run(fmt.Sprintf("[%v]", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			switch {
 			case step.added != nil:
 				_, err := cms.Create(context.TODO(), step.added, metav1.CreateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.updated != nil:
 				_, err := cms.Update(context.TODO(), step.updated, metav1.UpdateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.deleted != nil:
 				g.Expect(cms.Delete(context.TODO(), step.deleted.Name, metav1.DeleteOptions{})).
-					Should(gomega.Succeed())
+					Should(Succeed())
 			}
 
 			retry.UntilOrFail(t, func() bool { return cmp.Equal(w.Mesh(), step.expect, protocmp.Transform()) })

--- a/pkg/config/mesh/networks_watcher_test.go
+++ b/pkg/config/mesh/networks_watcher_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/config/mesh"
@@ -26,13 +26,13 @@ import (
 )
 
 func TestNewNetworksWatcherWithBadInputShouldFail(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	_, err := mesh.NewNetworksWatcher(filewatcher.NewWatcher(), "")
-	g.Expect(err).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(BeNil())
 }
 
 func TestNetworksWatcherShouldNotifyHandlers(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	path := newTempFile(t)
 	defer removeSilent(path)
@@ -43,7 +43,7 @@ func TestNetworksWatcherShouldNotifyHandlers(t *testing.T) {
 	writeMessage(t, path, &n)
 
 	w := newNetworksWatcher(t, path)
-	g.Expect(w.Networks()).To(gomega.Equal(&n))
+	g.Expect(w.Networks()).To(Equal(&n))
 
 	doneCh := make(chan struct{}, 1)
 
@@ -59,8 +59,8 @@ func TestNetworksWatcherShouldNotifyHandlers(t *testing.T) {
 
 	select {
 	case <-doneCh:
-		g.Expect(newN).To(gomega.Equal(&n))
-		g.Expect(w.Networks()).To(gomega.Equal(newN))
+		g.Expect(newN).To(Equal(&n))
+		g.Expect(w.Networks()).To(Equal(newN))
 		break
 	case <-time.After(time.Second * 5):
 		t.Fatal("timed out waiting for update")

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -31,9 +31,9 @@ import (
 )
 
 func TestNewWatcherWithBadInputShouldFail(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	_, err := mesh.NewFileWatcher(filewatcher.NewWatcher(), "", false)
-	g.Expect(err).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(BeNil())
 }
 
 func TestWatcherShouldNotifyHandlers(t *testing.T) {

--- a/pkg/config/resource/instance_test.go
+++ b/pkg/config/resource/instance_test.go
@@ -17,42 +17,42 @@ package resource
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestInstance_IsEmpty_False(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	e := Instance{
 		Message: &emptypb.Empty{},
 	}
 
-	g.Expect(e.IsEmpty()).To(gomega.BeFalse())
+	g.Expect(e.IsEmpty()).To(BeFalse())
 }
 
 func TestInstance_IsEmpty_True(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	e := Instance{}
 
-	g.Expect(e.IsEmpty()).To(gomega.BeTrue())
+	g.Expect(e.IsEmpty()).To(BeTrue())
 }
 
 func TestInstance_Clone_Empty(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	e := &Instance{}
 
 	c := e.Clone()
-	g.Expect(c).To(gomega.Equal(e))
+	g.Expect(c).To(Equal(e))
 }
 
 func TestInstance_Clone_NonEmpty(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	e := &Instance{
 		Message: &emptypb.Empty{},
 	}
 
 	c := e.Clone()
-	g.Expect(c).To(gomega.Equal(e))
+	g.Expect(c).To(Equal(e))
 }

--- a/pkg/config/resource/metadata_test.go
+++ b/pkg/config/resource/metadata_test.go
@@ -17,11 +17,11 @@ package resource
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestMetadata_Clone_NilMaps(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := Metadata{
 		FullName: NewFullName("ns1", "rs1"),
@@ -29,11 +29,11 @@ func TestMetadata_Clone_NilMaps(t *testing.T) {
 	}
 
 	c := m.Clone()
-	g.Expect(m).To(gomega.Equal(c))
+	g.Expect(m).To(Equal(c))
 }
 
 func TestMetadata_Clone_NonNilMaps(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := Metadata{
 		FullName:    NewFullName("ns1", "rs1"),
@@ -43,5 +43,5 @@ func TestMetadata_Clone_NonNilMaps(t *testing.T) {
 	}
 
 	c := m.Clone()
-	g.Expect(m).To(gomega.Equal(c))
+	g.Expect(m).To(Equal(c))
 }

--- a/pkg/config/schema/ast/ast_test.go
+++ b/pkg/config/schema/ast/ast_test.go
@@ -17,7 +17,7 @@ package ast
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestParse(t *testing.T) {
@@ -56,10 +56,10 @@ resources:
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			actual, err := Parse(c.input)
-			g.Expect(err).To(gomega.BeNil())
-			g.Expect(actual).To(gomega.Equal(c.expected))
+			g.Expect(err).To(BeNil())
+			g.Expect(actual).To(Equal(c.expected))
 		})
 	}
 }

--- a/pkg/config/schema/collection/schemas_test.go
+++ b/pkg/config/schema/collection/schemas_test.go
@@ -17,7 +17,7 @@ package collection_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	_ "google.golang.org/protobuf/types/known/emptypb"
 	_ "google.golang.org/protobuf/types/known/structpb"
 
@@ -43,18 +43,18 @@ var (
 )
 
 func TestSchemas_Basic(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	schemas := collection.SchemasFor(emptyResource)
-	g.Expect(schemas.All()).To(gomega.HaveLen(1))
-	g.Expect(schemas.All()[0]).To(gomega.Equal(emptyResource))
+	g.Expect(schemas.All()).To(HaveLen(1))
+	g.Expect(schemas.All()[0]).To(Equal(emptyResource))
 }
 
 func TestSchemas_MustAdd(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
-		g.Expect(r).To(gomega.BeNil())
+		g.Expect(r).To(BeNil())
 	}()
 	b := collection.NewSchemasBuilder()
 
@@ -62,10 +62,10 @@ func TestSchemas_MustAdd(t *testing.T) {
 }
 
 func TestSchemas_MustRegister_Panic(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
-		g.Expect(r).NotTo(gomega.BeNil())
+		g.Expect(r).NotTo(BeNil())
 	}()
 	b := collection.NewSchemasBuilder()
 
@@ -74,7 +74,7 @@ func TestSchemas_MustRegister_Panic(t *testing.T) {
 }
 
 func TestSchema_FindByGroupVersionKind(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	s := resource.Builder{
 		ProtoPackage: "github.com/gogo/protobuf/types",
@@ -92,25 +92,25 @@ func TestSchema_FindByGroupVersionKind(t *testing.T) {
 		Version: "v1",
 		Kind:    "Empty",
 	})
-	g.Expect(found).To(gomega.BeTrue())
-	g.Expect(s2).To(gomega.Equal(s))
+	g.Expect(found).To(BeTrue())
+	g.Expect(s2).To(Equal(s))
 
 	_, found = schemas.FindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "fake",
 		Version: "v1",
 		Kind:    "Empty",
 	})
-	g.Expect(found).To(gomega.BeFalse())
+	g.Expect(found).To(BeFalse())
 }
 
 func TestSchemas_Kinds(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	s := collection.SchemasFor(emptyResource, structResource)
 
 	actual := s.Kinds()
 	expected := []string{emptyResource.Kind(), structResource.Kind()}
-	g.Expect(actual).To(gomega.Equal(expected))
+	g.Expect(actual).To(Equal(expected))
 }
 
 func TestSchemas_Validate(t *testing.T) {
@@ -139,23 +139,23 @@ func TestSchemas_Validate(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			b := collection.NewSchemasBuilder()
 			for _, s := range c.schemas {
 				b.MustAdd(s)
 			}
 			err := b.Build().Validate()
 			if c.expectError {
-				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(err).ToNot(BeNil())
 			} else {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 			}
 		})
 	}
 }
 
 func TestSchemas_Validate_Error(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	b := collection.NewSchemasBuilder()
 
 	s1 := resource.Builder{
@@ -166,7 +166,7 @@ func TestSchemas_Validate_Error(t *testing.T) {
 	b.MustAdd(s1)
 
 	err := b.Build().Validate()
-	g.Expect(err).NotTo(gomega.BeNil())
+	g.Expect(err).NotTo(BeNil())
 }
 
 func TestSchemas_ForEach(t *testing.T) {
@@ -205,26 +205,26 @@ func TestSchemas_ForEach(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			actual := c.actual()
-			g.Expect(actual).To(gomega.Equal(c.expected))
+			g.Expect(actual).To(Equal(c.expected))
 		})
 	}
 }
 
 func TestSchemas_Remove(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	schemas := collection.SchemasFor(emptyResource, structResource)
-	g.Expect(schemas.Remove(structResource)).To(gomega.Equal(collection.SchemasFor(emptyResource)))
-	g.Expect(schemas.Remove(emptyResource, structResource)).To(gomega.Equal(collection.SchemasFor()))
-	g.Expect(schemas).To(gomega.Equal(collection.SchemasFor(emptyResource, structResource)))
+	g.Expect(schemas.Remove(structResource)).To(Equal(collection.SchemasFor(emptyResource)))
+	g.Expect(schemas.Remove(emptyResource, structResource)).To(Equal(collection.SchemasFor()))
+	g.Expect(schemas).To(Equal(collection.SchemasFor(emptyResource, structResource)))
 }
 
 func TestSchemas_Add(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	schemas := collection.SchemasFor(emptyResource)
-	g.Expect(schemas.Add(structResource)).To(gomega.Equal(collection.SchemasFor(emptyResource, structResource)))
-	g.Expect(schemas).To(gomega.Equal(collection.SchemasFor(emptyResource)))
+	g.Expect(schemas.Add(structResource)).To(Equal(collection.SchemasFor(emptyResource, structResource)))
+	g.Expect(schemas).To(Equal(collection.SchemasFor(emptyResource)))
 }

--- a/pkg/config/schema/resource/schema_test.go
+++ b/pkg/config/schema/resource/schema_test.go
@@ -17,7 +17,7 @@ package resource
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -75,13 +75,13 @@ func TestValidate(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			err := c.b.BuildNoValidate().Validate()
 			if c.expectError {
-				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(err).ToNot(BeNil())
 			} else {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 			}
 		})
 	}
@@ -137,13 +137,13 @@ func TestBuild(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			_, err := c.b.Build()
 			if c.expectError {
-				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(err).ToNot(BeNil())
 			} else {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 			}
 		})
 	}
@@ -183,8 +183,8 @@ func TestCanonicalName(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-			g.Expect(c.s.GroupVersionKind().String()).To(gomega.Equal(c.expected))
+			g := NewWithT(t)
+			g.Expect(c.s.GroupVersionKind().String()).To(Equal(c.expected))
 		})
 	}
 }
@@ -203,10 +203,10 @@ func TestNewProtoInstance(t *testing.T) {
 }
 
 func TestMustNewProtoInstance_Panic_Nil(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
-		g.Expect(r).NotTo(gomega.BeNil())
+		g.Expect(r).NotTo(BeNil())
 	}()
 	old := protoMessageType
 	defer func() {
@@ -226,7 +226,7 @@ func TestMustNewProtoInstance_Panic_Nil(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	s := Builder{
 		Kind:         "Empty",
@@ -235,5 +235,5 @@ func TestString(t *testing.T) {
 		Proto:        "google.protobuf.Empty",
 	}.MustBuild()
 
-	g.Expect(s.String()).To(gomega.Equal(`[Schema](Empty, "github.com/gogo/protobuf/types", google.protobuf.Empty)`))
+	g.Expect(s.String()).To(Equal(`[Schema](Empty, "github.com/gogo/protobuf/types", google.protobuf.Empty)`))
 }

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -25,16 +25,16 @@ import (
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func newWatchFile(t *testing.T) string {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	watchDir := t.TempDir()
 	watchFile := path.Join(watchDir, "test.conf")
 	err := os.WriteFile(watchFile, []byte("foo: bar\n"), 0o640)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	return watchFile
 }
@@ -49,17 +49,17 @@ func newWatchFileThatDoesNotExist(t *testing.T) string {
 
 // newTwoWatchFile returns with two watch files that exist in the same base dir.
 func newTwoWatchFile(t *testing.T) (string, string) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	watchDir := t.TempDir()
 
 	watchFile1 := path.Join(watchDir, "test1.conf")
 	err := os.WriteFile(watchFile1, []byte("foo: bar\n"), 0o640)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	watchFile2 := path.Join(watchDir, "test2.conf")
 	err = os.WriteFile(watchFile2, []byte("foo: baz\n"), 0o640)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	return watchFile1, watchFile2
 }
@@ -78,18 +78,18 @@ func newTwoWatchFile(t *testing.T) (string, string) {
 //
 // <watchDir>/data1/test.conf
 func newSymlinkedWatchFile(t *testing.T) (string, string) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	watchDir := t.TempDir()
 
 	dataDir1 := path.Join(watchDir, "data1")
 	err := os.Mkdir(dataDir1, 0o777)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	realTestFile := path.Join(dataDir1, "test.conf")
 	t.Logf("Real test file location: %s\n", realTestFile)
 	err = os.WriteFile(realTestFile, []byte("foo: bar\n"), 0o640)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	// Now, symlink the tmp `data1` dir to `data` in the baseDir
 	os.Symlink(dataDir1, path.Join(watchDir, "data"))
@@ -102,12 +102,12 @@ func newSymlinkedWatchFile(t *testing.T) (string, string) {
 
 func TestWatchFile(t *testing.T) {
 	t.Run("file content changed", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := NewGomegaWithT(t)
 
 		// Given a file being watched
 		watchFile := newWatchFile(t)
 		_, err := os.Stat(watchFile)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 
 		w := NewWatcher()
 		w.Add(watchFile)
@@ -122,7 +122,7 @@ func TestWatchFile(t *testing.T) {
 
 		// Overwriting the file and waiting its event to be received.
 		err = os.WriteFile(watchFile, []byte("foo: baz\n"), 0o640)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		wg.Wait()
 
 		_ = w.Close()
@@ -133,7 +133,7 @@ func TestWatchFile(t *testing.T) {
 		if runtime.GOOS != "linux" {
 			t.Skipf("Skipping test as symlink replacements don't work on non-linux environment...")
 		}
-		g := gomega.NewGomegaWithT(t)
+		g := NewGomegaWithT(t)
 
 		watchDir, watchFile := newSymlinkedWatchFile(t)
 
@@ -151,15 +151,15 @@ func TestWatchFile(t *testing.T) {
 		// Link to another `test.conf` file
 		dataDir2 := path.Join(watchDir, "data2")
 		err := os.Mkdir(dataDir2, 0o777)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 
 		watchFile2 := path.Join(dataDir2, "test.conf")
 		err = os.WriteFile(watchFile2, []byte("foo: baz\n"), 0o640)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 
 		// change the symlink using the `ln -sfn` command
 		err = exec.Command("ln", "-sfn", dataDir2, path.Join(watchDir, "data")).Run()
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 
 		// Wait its event to be received.
 		wg.Wait()
@@ -168,7 +168,7 @@ func TestWatchFile(t *testing.T) {
 	})
 
 	t.Run("file added later", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := NewGomegaWithT(t)
 
 		// Given a file being watched
 		watchFile := newWatchFileThatDoesNotExist(t)
@@ -186,7 +186,7 @@ func TestWatchFile(t *testing.T) {
 
 		// Overwriting the file and waiting its event to be received.
 		err := os.WriteFile(watchFile, []byte("foo: baz\n"), 0o640)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		wg.Wait()
 
 		_ = w.Close()
@@ -194,7 +194,7 @@ func TestWatchFile(t *testing.T) {
 }
 
 func TestWatcherLifecycle(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	watchFile1, watchFile2 := newTwoWatchFile(t)
 
@@ -202,45 +202,45 @@ func TestWatcherLifecycle(t *testing.T) {
 
 	// Validate Add behavior
 	err := w.Add(watchFile1)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	err = w.Add(watchFile2)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	// Validate events and errors channel are fulfilled.
 	events1 := w.Events(watchFile1)
-	g.Expect(events1).NotTo(gomega.BeNil())
+	g.Expect(events1).NotTo(BeNil())
 	events2 := w.Events(watchFile2)
-	g.Expect(events2).NotTo(gomega.BeNil())
+	g.Expect(events2).NotTo(BeNil())
 
 	errors1 := w.Errors(watchFile1)
-	g.Expect(errors1).NotTo(gomega.BeNil())
+	g.Expect(errors1).NotTo(BeNil())
 	errors2 := w.Errors(watchFile2)
-	g.Expect(errors2).NotTo(gomega.BeNil())
+	g.Expect(errors2).NotTo(BeNil())
 
 	// Validate Remove behavior
 	err = w.Remove(watchFile1)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	events1 = w.Events(watchFile1)
-	g.Expect(events1).To(gomega.BeNil())
+	g.Expect(events1).To(BeNil())
 	errors1 = w.Errors(watchFile1)
-	g.Expect(errors1).To(gomega.BeNil())
+	g.Expect(errors1).To(BeNil())
 	events2 = w.Events(watchFile2)
-	g.Expect(events2).NotTo(gomega.BeNil())
+	g.Expect(events2).NotTo(BeNil())
 	errors2 = w.Errors(watchFile2)
-	g.Expect(errors2).NotTo(gomega.BeNil())
+	g.Expect(errors2).NotTo(BeNil())
 
 	fmt.Printf("2\n")
 	// Validate Close behavior
 	err = w.Close()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	events1 = w.Events(watchFile1)
-	g.Expect(events1).To(gomega.BeNil())
+	g.Expect(events1).To(BeNil())
 	errors1 = w.Errors(watchFile1)
-	g.Expect(errors1).To(gomega.BeNil())
+	g.Expect(errors1).To(BeNil())
 	events2 = w.Events(watchFile2)
-	g.Expect(events2).To(gomega.BeNil())
+	g.Expect(events2).To(BeNil())
 	errors2 = w.Errors(watchFile2)
-	g.Expect(errors2).To(gomega.BeNil())
+	g.Expect(errors2).To(BeNil())
 }
 
 func TestErrors(t *testing.T) {

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -112,30 +112,30 @@ func TestNewConfigMapWatcher(t *testing.T) {
 
 	for i, step := range steps {
 		t.Run(fmt.Sprintf("[%v]", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			switch {
 			case step.added != nil:
 				_, err := cms.Create(context.TODO(), step.added, metav1.CreateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.updated != nil:
 				_, err := cms.Update(context.TODO(), step.updated, metav1.UpdateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.deleted != nil:
 				g.Expect(cms.Delete(context.TODO(), step.deleted.Name, metav1.DeleteOptions{})).
-					Should(gomega.Succeed())
+					Should(Succeed())
 			}
 
 			g.Eventually(func() *Config {
 				mu.Lock()
 				defer mu.Unlock()
 				return newConfig
-			}, time.Second).Should(gomega.Equal(&c))
+			}, time.Second).Should(Equal(&c))
 			g.Eventually(func() string {
 				mu.Lock()
 				defer mu.Unlock()
 				return newValues
-			}, time.Second).Should(gomega.Equal(valuesConfig))
+			}, time.Second).Should(Equal(valuesConfig))
 		})
 	}
 }

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -209,18 +209,18 @@ func Test_SecretController(t *testing.T) {
 		resetCallbackData()
 
 		t.Run(step.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			switch {
 			case step.add != nil:
 				_, err := clientset.Kube().CoreV1().Secrets(step.add.Namespace).Create(context.TODO(), step.add, metav1.CreateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.update != nil:
 				_, err := clientset.Kube().CoreV1().Secrets(step.update.Namespace).Update(context.TODO(), step.update, metav1.UpdateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.delete != nil:
 				g.Expect(clientset.Kube().CoreV1().Secrets(step.delete.Namespace).Delete(context.TODO(), step.delete.Name, metav1.DeleteOptions{})).
-					Should(gomega.Succeed())
+					Should(Succeed())
 			}
 
 			switch {
@@ -229,25 +229,25 @@ func Test_SecretController(t *testing.T) {
 					mu.Lock()
 					defer mu.Unlock()
 					return added
-				}, 10*time.Second).Should(gomega.Equal(step.wantAdded))
+				}, 10*time.Second).Should(Equal(step.wantAdded))
 			case step.wantUpdated != "":
 				g.Eventually(func() cluster.ID {
 					mu.Lock()
 					defer mu.Unlock()
 					return updated
-				}, 10*time.Second).Should(gomega.Equal(step.wantUpdated))
+				}, 10*time.Second).Should(Equal(step.wantUpdated))
 			case step.wantDeleted != "":
 				g.Eventually(func() cluster.ID {
 					mu.Lock()
 					defer mu.Unlock()
 					return deleted
-				}, 10*time.Second).Should(gomega.Equal(step.wantDeleted))
+				}, 10*time.Second).Should(Equal(step.wantDeleted))
 			default:
 				g.Consistently(func() bool {
 					mu.Lock()
 					defer mu.Unlock()
 					return added == "" && updated == "" && deleted == ""
-				}).Should(gomega.Equal(true))
+				}).Should(Equal(true))
 			}
 		})
 	}

--- a/pkg/kube/watcher/configmapwatcher/configmapwatcher_test.go
+++ b/pkg/kube/watcher/configmapwatcher/configmapwatcher_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -106,25 +106,25 @@ func Test_ConfigMapWatcher(t *testing.T) {
 		resetCalled()
 
 		t.Run(fmt.Sprintf("[%v]", i), func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			switch {
 			case step.added != nil:
 				_, err := cms.Create(context.TODO(), step.added, metav1.CreateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.updated != nil:
 				_, err := cms.Update(context.TODO(), step.updated, metav1.UpdateOptions{})
-				g.Expect(err).Should(gomega.BeNil())
+				g.Expect(err).Should(BeNil())
 			case step.deleted != nil:
 				g.Expect(cms.Delete(context.TODO(), step.deleted.Name, metav1.DeleteOptions{})).
-					Should(gomega.Succeed())
+					Should(Succeed())
 			}
 
 			if step.expectCalled {
-				g.Eventually(getCalled, time.Second).Should(gomega.Equal(true))
-				g.Eventually(getCM, time.Second).Should(gomega.Equal(newCM))
+				g.Eventually(getCalled, time.Second).Should(Equal(true))
+				g.Eventually(getCM, time.Second).Should(Equal(newCM))
 			} else {
-				g.Consistently(getCalled).Should(gomega.Equal(false))
+				g.Consistently(getCalled).Should(Equal(false))
 			}
 		})
 	}

--- a/pkg/test/framework/components/echo/config/param/template_test.go
+++ b/pkg/test/framework/components/echo/config/param/template_test.go
@@ -17,7 +17,7 @@ package param_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/test/framework/components/echo/config/param"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -66,8 +66,8 @@ func TestContains(t *testing.T) {
 			tpl := param.Parse(tmpl.ParseOrFail(t, c.template))
 			actual := tpl.ContainsWellKnown(param.To)
 
-			g := gomega.NewWithT(t)
-			g.Expect(actual).To(gomega.Equal(c.expectFound))
+			g := NewWithT(t)
+			g.Expect(actual).To(Equal(c.expectFound))
 		})
 	}
 }

--- a/pkg/test/framework/components/namespace/namespace_test.go
+++ b/pkg/test/framework/components/namespace/namespace_test.go
@@ -17,7 +17,7 @@ package namespace
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestConfigRevisionOverwrite(t *testing.T) {
@@ -63,8 +63,8 @@ func TestConfigRevisionOverwrite(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.cfg.overwriteRevisionIfEmpty(tc.revision)
-			g := gomega.NewWithT(t)
-			g.Expect(tc.cfg.Revision).Should(gomega.Equal(tc.wantRevision))
+			g := NewWithT(t)
+			g.Expect(tc.cfg.Revision).Should(Equal(tc.wantRevision))
 		})
 	}
 }

--- a/pkg/test/framework/scope_test.go
+++ b/pkg/test/framework/scope_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -55,15 +55,15 @@ func TestGet_Struct(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			scope := tt.setup()
 			var got OtherInterface
 			err := scope.get(&got)
 			if tt.expError == nil {
-				g.Expect(err).To(gomega.BeNil())
-				g.Expect(got).To(gomega.Equal(res))
+				g.Expect(err).To(BeNil())
+				g.Expect(got).To(Equal(res))
 			} else {
-				g.Expect(err).To(gomega.Equal(tt.expError))
+				g.Expect(err).To(Equal(tt.expError))
 			}
 		})
 	}
@@ -81,16 +81,16 @@ func TestGet_Slice(t *testing.T) {
 		},
 	}
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	parent := newScope("parent", nil)
 	parent.add(exp[1], &resourceID{id: exp[1].IDValue})
 	child := newScope("child", parent)
 	child.add(exp[0], &resourceID{id: exp[0].IDValue})
 	var got []OtherInterface
 	err := child.get(&got)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(got).To(gomega.HaveLen(len(exp)))
+	g.Expect(err).To(BeNil())
+	g.Expect(got).To(HaveLen(len(exp)))
 	for i, res := range exp {
-		g.Expect(got[i]).To(gomega.Equal(res))
+		g.Expect(got[i]).To(Equal(res))
 	}
 }

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/label"
@@ -62,7 +62,7 @@ func newTestSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getS
 
 func TestSuite_Basic(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -79,14 +79,14 @@ func TestSuite_Basic(t *testing.T) {
 	s := newTestSuite("tid", runFn, exitFn, defaultSettingsFn)
 	s.Run()
 
-	g.Expect(runCalled).To(gomega.BeTrue())
-	g.Expect(runSkipped).To(gomega.BeFalse())
-	g.Expect(exitCode).To(gomega.Equal(-1))
+	g.Expect(runCalled).To(BeTrue())
+	g.Expect(runSkipped).To(BeFalse())
+	g.Expect(exitCode).To(Equal(-1))
 }
 
 func TestSuite_Label_SuiteFilter(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runSkipped bool
 	runFn := func(ctx *suiteContext) int {
@@ -95,7 +95,7 @@ func TestSuite_Label_SuiteFilter(t *testing.T) {
 	}
 
 	sel, err := label.ParseSelector("-customsetup")
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	settings := resource.DefaultSettings()
 	settings.Selector = sel
 
@@ -103,12 +103,12 @@ func TestSuite_Label_SuiteFilter(t *testing.T) {
 	s.Label(label.CustomSetup)
 	s.Run()
 
-	g.Expect(runSkipped).To(gomega.BeTrue())
+	g.Expect(runSkipped).To(BeTrue())
 }
 
 func TestSuite_Label_SuiteAllow(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -119,7 +119,7 @@ func TestSuite_Label_SuiteAllow(t *testing.T) {
 	}
 
 	sel, err := label.ParseSelector("+postsubmit")
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	settings := resource.DefaultSettings()
 	settings.Selector = sel
 
@@ -127,8 +127,8 @@ func TestSuite_Label_SuiteAllow(t *testing.T) {
 	s.Label(label.CustomSetup)
 	s.Run()
 
-	g.Expect(runCalled).To(gomega.BeTrue())
-	g.Expect(runSkipped).To(gomega.BeFalse())
+	g.Expect(runCalled).To(BeTrue())
+	g.Expect(runSkipped).To(BeFalse())
 }
 
 func TestSuite_RequireMinMaxClusters(t *testing.T) {
@@ -200,7 +200,7 @@ func TestSuite_RequireMinMaxClusters(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			defer cleanupRT()
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			var runCalled bool
 			var runSkipped bool
@@ -224,11 +224,11 @@ func TestSuite_RequireMinMaxClusters(t *testing.T) {
 			s.RequireMaxClusters(c.max)
 			s.Run()
 
-			g.Expect(runCalled).To(gomega.BeTrue())
+			g.Expect(runCalled).To(BeTrue())
 			if c.expectSkip {
-				g.Expect(runSkipped).To(gomega.BeTrue())
+				g.Expect(runSkipped).To(BeTrue())
 			} else {
-				g.Expect(runSkipped).To(gomega.BeFalse())
+				g.Expect(runSkipped).To(BeFalse())
 			}
 		})
 	}
@@ -236,7 +236,7 @@ func TestSuite_RequireMinMaxClusters(t *testing.T) {
 
 func TestSuite_Setup(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -255,14 +255,14 @@ func TestSuite_Setup(t *testing.T) {
 	})
 	s.Run()
 
-	g.Expect(setupCalled).To(gomega.BeTrue())
-	g.Expect(runCalled).To(gomega.BeTrue())
-	g.Expect(runSkipped).To(gomega.BeFalse())
+	g.Expect(setupCalled).To(BeTrue())
+	g.Expect(runCalled).To(BeTrue())
+	g.Expect(runSkipped).To(BeFalse())
 }
 
 func TestSuite_SetupFail(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	runFn := func(ctx *suiteContext) int {
@@ -279,13 +279,13 @@ func TestSuite_SetupFail(t *testing.T) {
 	})
 	s.Run()
 
-	g.Expect(setupCalled).To(gomega.BeTrue())
-	g.Expect(runCalled).To(gomega.BeFalse())
+	g.Expect(setupCalled).To(BeTrue())
+	g.Expect(runCalled).To(BeFalse())
 }
 
 func TestSuite_SetupFail_Dump(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	runFn := func(_ *suiteContext) int {
@@ -305,14 +305,14 @@ func TestSuite_SetupFail_Dump(t *testing.T) {
 	})
 	s.Run()
 
-	g.Expect(setupCalled).To(gomega.BeTrue())
-	g.Expect(runCalled).To(gomega.BeFalse())
+	g.Expect(setupCalled).To(BeTrue())
+	g.Expect(runCalled).To(BeFalse())
 }
 
 func TestSuite_Cleanup(t *testing.T) {
 	t.Run("cleanup", func(t *testing.T) {
 		defer cleanupRT()
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		var cleanupCalled bool
 		var conditionalCleanupCalled bool
@@ -338,12 +338,12 @@ func TestSuite_Cleanup(t *testing.T) {
 		s.Run()
 		waitForRun1.Wait()
 
-		g.Expect(cleanupCalled).To(gomega.BeTrue())
-		g.Expect(conditionalCleanupCalled).To(gomega.BeTrue())
+		g.Expect(cleanupCalled).To(BeTrue())
+		g.Expect(conditionalCleanupCalled).To(BeTrue())
 	})
 	t.Run("nocleanup", func(t *testing.T) {
 		defer cleanupRT()
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		var cleanupCalled bool
 		var conditionalCleanupCalled bool
@@ -369,14 +369,14 @@ func TestSuite_Cleanup(t *testing.T) {
 		s.Run()
 		waitForRun1.Wait()
 
-		g.Expect(cleanupCalled).To(gomega.BeTrue())
-		g.Expect(conditionalCleanupCalled).To(gomega.BeFalse())
+		g.Expect(cleanupCalled).To(BeTrue())
+		g.Expect(conditionalCleanupCalled).To(BeFalse())
 	})
 }
 
 func TestSuite_DoubleInit_Error(t *testing.T) {
 	defer cleanupRT()
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	var waitForRun1 sync.WaitGroup
 	waitForRun1.Add(1)
@@ -418,9 +418,9 @@ func TestSuite_DoubleInit_Error(t *testing.T) {
 	waitForTestCompletion.Done()
 	waitForExit1Call.Wait()
 
-	g.Expect(exit2Called).To(gomega.Equal(true))
-	g.Expect(errCode1).To(gomega.Equal(0))
-	g.Expect(errCode2).NotTo(gomega.Equal(0))
+	g.Expect(exit2Called).To(Equal(true))
+	g.Expect(errCode1).To(Equal(0))
+	g.Expect(errCode2).NotTo(Equal(0))
 }
 
 func TestSuite_GetResource(t *testing.T) {
@@ -442,39 +442,39 @@ func TestSuite_GetResource(t *testing.T) {
 	}
 
 	t.Run("struct reference", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		var ref *resource.FakeResource
 		tracked := &resource.FakeResource{IDValue: "1"}
 		// notice that we pass **fakeCluster:
 		// GetResource requires *T where T implements resource.Resource.
 		// *fakeCluster implements it but fakeCluster does not.
 		err := act(&ref, tracked)
-		g.Expect(err).To(gomega.BeNil())
-		g.Expect(tracked).To(gomega.Equal(ref))
+		g.Expect(err).To(BeNil())
+		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("interface reference", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		var ref OtherInterface
 		tracked := &resource.FakeResource{IDValue: "1"}
 		err := act(&ref, tracked)
-		g.Expect(err).To(gomega.BeNil())
-		g.Expect(tracked).To(gomega.Equal(ref))
+		g.Expect(err).To(BeNil())
+		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("slice reference", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		existing := &resource.FakeResource{IDValue: "1"}
 		tracked := &resource.FakeResource{IDValue: "2"}
 		ref := []OtherInterface{existing}
 		err := act(&ref, tracked)
-		g.Expect(err).To(gomega.BeNil())
-		g.Expect(ref).To(gomega.HaveLen(2))
-		g.Expect(existing).To(gomega.Equal(ref[0]))
-		g.Expect(tracked).To(gomega.Equal(ref[1]))
+		g.Expect(err).To(BeNil())
+		g.Expect(ref).To(HaveLen(2))
+		g.Expect(existing).To(Equal(ref[0]))
+		g.Expect(tracked).To(Equal(ref[1]))
 	})
 	t.Run("non pointer ref", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		err := act(resource.FakeResource{}, &resource.FakeResource{})
-		g.Expect(err).NotTo(gomega.BeNil())
+		g.Expect(err).NotTo(BeNil())
 	})
 }
 
@@ -507,9 +507,9 @@ func TestDeriveSuiteName(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.caller, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			actual := deriveSuiteName(c.caller)
-			g.Expect(actual).To(gomega.Equal(c.expected))
+			g.Expect(actual).To(Equal(c.expected))
 		})
 	}
 }

--- a/pkg/test/util/yml/cache_test.go
+++ b/pkg/test/util/yml/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var (
@@ -72,78 +72,78 @@ spec:
 )
 
 func TestCache_Apply_Basic(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	keys, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(keys).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(keys).To(HaveLen(1))
 	expected := CacheKey{
 		group:     "networking.istio.io",
 		kind:      "Gateway",
 		namespace: "",
 		name:      "some-ingress",
 	}
-	g.Expect(keys[0]).To(gomega.Equal(expected))
+	g.Expect(keys[0]).To(Equal(expected))
 	key1 := keys[0]
 
 	file := c.GetFileFor(keys[0])
 	by, err := os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(gateway)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(gateway)))
 
 	keys, err = c.Apply(virtualService)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(keys).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(keys).To(HaveLen(1))
 	expected = CacheKey{
 		group:     "networking.istio.io",
 		kind:      "VirtualService",
 		namespace: "",
 		name:      "route-for-myapp",
 	}
-	g.Expect(keys[0]).To(gomega.Equal(expected))
+	g.Expect(keys[0]).To(Equal(expected))
 	key2 := keys[0]
 
 	file = c.GetFileFor(keys[0])
 	by, err = os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(virtualService)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(virtualService)))
 
 	keys = c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(2))
-	g.Expect(keys).To(gomega.ContainElement(key1))
-	g.Expect(keys).To(gomega.ContainElement(key2))
+	g.Expect(keys).To(HaveLen(2))
+	g.Expect(keys).To(ContainElement(key1))
+	g.Expect(keys).To(ContainElement(key2))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(2))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(2))
 }
 
 func TestCache_Apply_MultiPart(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	keys, err := c.Apply(JoinString(gateway, virtualService))
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(keys).To(gomega.HaveLen(2))
+	g.Expect(err).To(BeNil())
+	g.Expect(keys).To(HaveLen(2))
 	expected := CacheKey{
 		group:     "networking.istio.io",
 		kind:      "Gateway",
 		namespace: "",
 		name:      "some-ingress",
 	}
-	g.Expect(keys[0]).To(gomega.Equal(expected))
+	g.Expect(keys[0]).To(Equal(expected))
 
 	file := c.GetFileFor(keys[0])
 	by, err := os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(gateway)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(gateway)))
 
 	expected = CacheKey{
 		group:     "networking.istio.io",
@@ -151,164 +151,164 @@ func TestCache_Apply_MultiPart(t *testing.T) {
 		namespace: "",
 		name:      "route-for-myapp",
 	}
-	g.Expect(keys[1]).To(gomega.Equal(expected))
+	g.Expect(keys[1]).To(Equal(expected))
 
 	file = c.GetFileFor(keys[1])
 	by, err = os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(virtualService)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(virtualService)))
 
 	applyKeys := keys
 	keys = c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(2))
-	g.Expect(keys).To(gomega.ContainElement(applyKeys[0]))
-	g.Expect(keys).To(gomega.ContainElement(applyKeys[1]))
+	g.Expect(keys).To(HaveLen(2))
+	g.Expect(keys).To(ContainElement(applyKeys[0]))
+	g.Expect(keys).To(ContainElement(applyKeys[1]))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(2))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(2))
 }
 
 func TestCache_Apply_Add_Update(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	keys, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	file := c.GetFileFor(keys[0])
 	by, err := os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(gateway)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(gateway)))
 
 	keys, err = c.Apply(updatedGateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	file = c.GetFileFor(keys[0])
 	by, err = os.ReadFile(file)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(updatedGateway)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(updatedGateway)))
 
 	applyKeys := keys
 	keys = c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(1))
-	g.Expect(keys).To(gomega.ContainElement(applyKeys[0]))
+	g.Expect(keys).To(HaveLen(1))
+	g.Expect(keys).To(ContainElement(applyKeys[0]))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(1))
 }
 
 func TestCache_Apply_SameContent(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	keys1, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	keys2, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	keys := c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(1))
-	g.Expect(keys1).To(gomega.HaveLen(1))
-	g.Expect(keys2).To(gomega.HaveLen(1))
-	g.Expect(keys).To(gomega.ContainElement(keys1[0]))
-	g.Expect(keys).To(gomega.ContainElement(keys2[0]))
+	g.Expect(keys).To(HaveLen(1))
+	g.Expect(keys1).To(HaveLen(1))
+	g.Expect(keys2).To(HaveLen(1))
+	g.Expect(keys).To(ContainElement(keys1[0]))
+	g.Expect(keys).To(ContainElement(keys2[0]))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(1))
 }
 
 func TestCache_Clear(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	_, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	_, err = c.Apply(virtualService)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	err = c.Clear()
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	keys := c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(0))
+	g.Expect(keys).To(HaveLen(0))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(0))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(0))
 }
 
 func TestCache_GetFileFor_Empty(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	f := c.GetFileFor(CacheKey{})
-	g.Expect(f).To(gomega.BeEmpty())
+	g.Expect(f).To(BeEmpty())
 }
 
 func TestCache_Delete(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	_, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	keys1, err := c.Apply(virtualService)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	err = c.Delete(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	keys := c.AllKeys()
-	g.Expect(keys).To(gomega.HaveLen(1))
-	g.Expect(keys1).To(gomega.HaveLen(1))
-	g.Expect(keys).To(gomega.ContainElement(keys1[0]))
+	g.Expect(keys).To(HaveLen(1))
+	g.Expect(keys1).To(HaveLen(1))
+	g.Expect(keys).To(ContainElement(keys1[0]))
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(1))
 
 	by, err := os.ReadFile(path.Join(d, items[0].Name()))
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(virtualService)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(virtualService)))
 }
 
 func TestCache_Delete_Missing(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	d := t.TempDir()
 	t.Logf("Test Dir: %q", d)
 
 	c := NewCache(d)
 
 	_, err := c.Apply(gateway)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	err = c.Delete(virtualService)
-	g.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	items, err := os.ReadDir(d)
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(items).To(gomega.HaveLen(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(items).To(HaveLen(1))
 
 	by, err := os.ReadFile(path.Join(d, items[0].Name()))
-	g.Expect(err).To(gomega.BeNil())
-	g.Expect(strings.TrimSpace(string(by))).To(gomega.Equal(strings.TrimSpace(gateway)))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.TrimSpace(string(by))).To(Equal(strings.TrimSpace(gateway)))
 }

--- a/pkg/test/util/yml/parts_test.go
+++ b/pkg/test/util/yml/parts_test.go
@@ -17,21 +17,21 @@ package yml_test
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/test/util/yml"
 )
 
 func TestEmptyDoc(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	yaml := `
 `
 	parts := yml.SplitString(yaml)
-	g.Expect(len(parts)).To(gomega.Equal(0))
+	g.Expect(len(parts)).To(Equal(0))
 
 	yaml = yml.JoinString(parts...)
-	g.Expect(yaml).To(gomega.Equal(""))
+	g.Expect(yaml).To(Equal(""))
 }
 
 func TestSplitWithEmptyPart(t *testing.T) {
@@ -83,8 +83,8 @@ b
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			parts := yml.SplitString(c.doc)
-			g := gomega.NewWithT(t)
-			g.Expect(parts).To(gomega.Equal(expected))
+			g := NewWithT(t)
+			g.Expect(parts).To(Equal(expected))
 		})
 	}
 }
@@ -103,9 +103,9 @@ b
     b2`,
 	}
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	parts := yml.SplitString(doc)
-	g.Expect(parts).To(gomega.Equal(expected))
+	g.Expect(parts).To(Equal(expected))
 }
 
 func TestJoinRemovesEmptyParts(t *testing.T) {
@@ -129,7 +129,7 @@ b
 ---
 b`
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	doc := yml.JoinString(parts...)
-	g.Expect(doc).To(gomega.Equal(expected))
+	g.Expect(doc).To(Equal(expected))
 }

--- a/pkg/util/strcase/camelcase_test.go
+++ b/pkg/util/strcase/camelcase_test.go
@@ -17,7 +17,7 @@ package strcase
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestCamelCase(t *testing.T) {
@@ -40,10 +40,10 @@ func TestCamelCase(t *testing.T) {
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			a := CamelCase(k)
-			g.Expect(a).To(gomega.Equal(v))
+			g.Expect(a).To(Equal(v))
 		})
 	}
 }
@@ -60,10 +60,10 @@ func TestCamelCaseToKebabCase(t *testing.T) {
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			a := CamelCaseToKebabCase(k)
-			g.Expect(a).To(gomega.Equal(v))
+			g.Expect(a).To(Equal(v))
 		})
 	}
 }

--- a/tests/integration/pilot/analyze_test.go
+++ b/tests/integration/pilot/analyze_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/istioctl/pkg/analyze"
 	"istio.io/istio/pkg/config/analysis/diag"
@@ -53,7 +53,7 @@ func TestEmptyCluster(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -65,7 +65,7 @@ func TestEmptyCluster(t *testing.T) {
 			// For a clean istio install with injection enabled, expect no validation errors
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
 			expectNoMessages(t, g, output)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).To(BeNil())
 		})
 }
 
@@ -75,7 +75,7 @@ func TestFileOnly(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -87,12 +87,12 @@ func TestFileOnly(t *testing.T) {
 			// Validation error if we have a virtual service with subset not defined.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, virtualServiceFile)
 			expectMessages(t, g, output, msg.ReferencedResourceNotFound)
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 
 			// Error goes away if we define the subset in the destination rule.
 			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, destinationRuleFile)
 			expectNoMessages(t, g, output)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).To(BeNil())
 		})
 }
 
@@ -102,7 +102,7 @@ func TestDirectoryWithoutRecursion(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -117,7 +117,7 @@ func TestDirectoryWithoutRecursion(t *testing.T) {
 			// UnknownAnnotation as well).
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, "--recursive=false", dirWithConfig)
 			expectMessages(t, g, output, msg.SchemaValidationError)
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
 
@@ -127,7 +127,7 @@ func TestDirectoryWithRecursion(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -139,7 +139,7 @@ func TestDirectoryWithRecursion(t *testing.T) {
 			// Recursive is true, so we should see one error (SchemaValidationError).
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, "--recursive=true", dirWithConfig)
 			expectMessages(t, g, output, msg.SchemaValidationError)
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
 
@@ -149,7 +149,7 @@ func TestInvalidFileError(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -160,22 +160,22 @@ func TestInvalidFileError(t *testing.T) {
 
 			// Skip the file with invalid extension and produce no errors.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, invalidExtensionFile)
-			g.Expect(output[0]).To(gomega.ContainSubstring(fmt.Sprintf("Skipping file %v, recognized file extensions are: [.json .yaml .yml]", invalidExtensionFile)))
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(output[0]).To(ContainSubstring(fmt.Sprintf("Skipping file %v, recognized file extensions are: [.json .yaml .yml]", invalidExtensionFile)))
+			g.Expect(err).To(BeNil())
 
 			// Parse error as the yaml file itself is not valid yaml.
 			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile)
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring("Error(s) adding files"))
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring("Error(s) adding files"))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
 
-			g.Expect(err).To(gomega.MatchError(analyze.FileParseError{}))
+			g.Expect(err).To(MatchError(analyze.FileParseError{}))
 
 			// Parse error as the yaml file itself is not valid yaml, but ignore.
 			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile, "--ignore-unknown=true")
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring("Error(s) adding files"))
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring("Error(s) adding files"))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
 
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).To(BeNil())
 		})
 }
 
@@ -185,7 +185,7 @@ func TestJsonInputFile(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -198,7 +198,7 @@ func TestJsonInputFile(t *testing.T) {
 			applyFileOrFail(t, ns.Name(), jsonGatewayFile)
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
 			expectMessages(t, g, output, msg.ReferencedResourceNotFound)
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
 
@@ -208,7 +208,7 @@ func TestJsonOutput(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -221,13 +221,13 @@ func TestJsonOutput(t *testing.T) {
 				applyFileOrFail(t, ns.Name(), jsonGatewayFile)
 				stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), true, jsonOutput)
 				expectJSONMessages(t, g, stdout, msg.ReferencedResourceNotFound)
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 			})
 
 			t.NewSubTest("invalid file does not output error in stdout").Run(func(t framework.TestContext) {
 				stdout, _, err := istioctlWithStderr(t, istioCtl, ns.Name(), false, invalidExtensionFile, jsonOutput)
 				expectJSONMessages(t, g, stdout)
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).To(BeNil())
 			})
 		})
 }
@@ -238,7 +238,7 @@ func TestKubeOnly(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -252,7 +252,7 @@ func TestKubeOnly(t *testing.T) {
 			// Validation error if we have a gateway with invalid selector.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true)
 			expectMessages(t, g, output, msg.ReferencedResourceNotFound)
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
 
@@ -262,7 +262,7 @@ func TestFileAndKubeCombined(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -277,7 +277,7 @@ func TestFileAndKubeCombined(t *testing.T) {
 			// fix the error and thus see no message
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true, destinationRuleFile)
 			expectNoMessages(t, g, output)
-			g.Expect(err).To(gomega.BeNil())
+			g.Expect(err).To(BeNil())
 		})
 }
 
@@ -287,7 +287,7 @@ func TestAllNamespaces(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns1 := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze-1",
@@ -314,28 +314,28 @@ func TestAllNamespaces(t *testing.T) {
 			for _, line := range output {
 				if strings.Contains(line, ns1.Name()) {
 					if strings.Contains(line, msg.ReferencedResourceNotFound.Code()) {
-						g.Expect(line).To(gomega.ContainSubstring(msg.ReferencedResourceNotFound.Code()))
+						g.Expect(line).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
 						foundCount++
 					}
 					// There are 2 conflictings can be detected, A to B and B to A
 					if strings.Contains(line, msg.ConflictingGateways.Code()) {
-						g.Expect(line).To(gomega.ContainSubstring(msg.ConflictingGateways.Code()))
+						g.Expect(line).To(ContainSubstring(msg.ConflictingGateways.Code()))
 						foundCount++
 					}
 				}
 				if strings.Contains(line, ns2.Name()) {
 					if strings.Contains(line, msg.ReferencedResourceNotFound.Code()) {
-						g.Expect(line).To(gomega.ContainSubstring(msg.ReferencedResourceNotFound.Code()))
+						g.Expect(line).To(ContainSubstring(msg.ReferencedResourceNotFound.Code()))
 						foundCount++
 					}
 					// There are 2 conflictings can be detected, B to A and A to B
 					if strings.Contains(line, msg.ConflictingGateways.Code()) {
-						g.Expect(line).To(gomega.ContainSubstring(msg.ConflictingGateways.Code()))
+						g.Expect(line).To(ContainSubstring(msg.ConflictingGateways.Code()))
 						foundCount++
 					}
 				}
 			}
-			g.Expect(foundCount).To(gomega.Equal(6))
+			g.Expect(foundCount).To(Equal(6))
 		})
 }
 
@@ -346,7 +346,7 @@ func TestTimeout(t *testing.T) {
 		NewTest(t).
 		RequiresSingleCluster().
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -357,7 +357,7 @@ func TestTimeout(t *testing.T) {
 
 			// We should time out immediately.
 			_, err := istioctlSafe(t, istioCtl, ns.Name(), true, "--timeout=0s")
-			g.Expect(err.Error()).To(gomega.ContainSubstring("timed out"))
+			g.Expect(err.Error()).To(ContainSubstring("timed out"))
 		})
 }
 
@@ -369,7 +369,7 @@ func TestErrorLine(t *testing.T) {
 		RequiresSingleCluster().
 		Features("usability.observability.analysis.line-numbers").
 		Run(func(t framework.TestContext) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, t, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -381,37 +381,37 @@ func TestErrorLine(t *testing.T) {
 			// Validation error if we have a gateway with invalid selector.
 			output, err := istioctlSafe(t, istioCtl, ns.Name(), true, gatewayFile, virtualServiceFile)
 
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring("testdata/gateway.yaml:9"))
-			g.Expect(strings.Join(output, "\n")).To(gomega.ContainSubstring("testdata/virtualservice.yaml:11"))
-			g.Expect(err).To(gomega.BeIdenticalTo(analyzerFoundIssuesError))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring("testdata/gateway.yaml:9"))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring("testdata/virtualservice.yaml:11"))
+			g.Expect(err).To(BeIdenticalTo(analyzerFoundIssuesError))
 		})
 }
 
 // Verify the output contains messages of the expected type, in order, followed by boilerplate lines
-func expectMessages(t test.Failer, g *gomega.GomegaWithT, outputLines []string, expected ...*diag.MessageType) {
+func expectMessages(t test.Failer, g *GomegaWithT, outputLines []string, expected ...*diag.MessageType) {
 	t.Helper()
 
 	// The boilerplate lines that appear if any issues are found
 	boilerplateLines := strings.Split(analyzerFoundIssuesError.Error(), "\n")
 
-	g.Expect(outputLines).To(gomega.HaveLen(len(expected) + len(boilerplateLines)))
+	g.Expect(outputLines).To(HaveLen(len(expected) + len(boilerplateLines)))
 
 	for i, line := range outputLines {
 		if i < len(expected) {
-			g.Expect(line).To(gomega.ContainSubstring(expected[i].Code()))
+			g.Expect(line).To(ContainSubstring(expected[i].Code()))
 		} else {
-			g.Expect(line).To(gomega.ContainSubstring(boilerplateLines[i-len(expected)]))
+			g.Expect(line).To(ContainSubstring(boilerplateLines[i-len(expected)]))
 		}
 	}
 }
 
-func expectNoMessages(t test.Failer, g *gomega.GomegaWithT, output []string) {
+func expectNoMessages(t test.Failer, g *GomegaWithT, output []string) {
 	t.Helper()
-	g.Expect(output).To(gomega.HaveLen(1))
-	g.Expect(output[0]).To(gomega.ContainSubstring("No validation issues found when analyzing"))
+	g.Expect(output).To(HaveLen(1))
+	g.Expect(output[0]).To(ContainSubstring("No validation issues found when analyzing"))
 }
 
-func expectJSONMessages(t test.Failer, g *gomega.GomegaWithT, output string, expected ...*diag.MessageType) {
+func expectJSONMessages(t test.Failer, g *GomegaWithT, output string, expected ...*diag.MessageType) {
 	t.Helper()
 
 	var j []map[string]any
@@ -419,11 +419,11 @@ func expectJSONMessages(t test.Failer, g *gomega.GomegaWithT, output string, exp
 		t.Fatal(err, output)
 	}
 
-	g.Expect(j).To(gomega.HaveLen(len(expected)))
+	g.Expect(j).To(HaveLen(len(expected)))
 
 	for i, m := range j {
-		g.Expect(m["level"]).To(gomega.Equal(expected[i].Level().String()))
-		g.Expect(m["code"]).To(gomega.Equal(expected[i].Code()))
+		g.Expect(m["level"]).To(Equal(expected[i].Level().String()))
+		g.Expect(m["code"]).To(Equal(expected[i].Code()))
 	}
 }
 

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
@@ -213,7 +213,7 @@ func TestProxyConfig(t *testing.T) {
 
 			var output string
 			var args []string
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			args = []string{
 				"--namespace=dummy",
@@ -221,7 +221,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput := jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.HaveKey("bootstrap"))
+			g.Expect(jsonOutput).To(HaveKey("bootstrap"))
 
 			args = []string{
 				"--namespace=dummy",
@@ -229,7 +229,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
+			g.Expect(jsonOutput).To(Not(BeEmpty()))
 
 			args = []string{
 				"--namespace=dummy",
@@ -237,7 +237,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
+			g.Expect(jsonOutput).To(Not(BeEmpty()))
 
 			args = []string{
 				"--namespace=dummy",
@@ -245,7 +245,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
+			g.Expect(jsonOutput).To(Not(BeEmpty()))
 
 			args = []string{
 				"--namespace=dummy",
@@ -253,7 +253,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
+			g.Expect(jsonOutput).To(Not(BeEmpty()))
 
 			args = []string{
 				"--namespace=dummy",
@@ -281,7 +281,7 @@ func TestProxyConfig(t *testing.T) {
 				}
 			}
 
-			g.Expect(hasEndpoints).To(gomega.BeTrue())
+			g.Expect(hasEndpoints).To(BeTrue())
 
 			args = []string{
 				"--namespace=dummy",
@@ -289,7 +289,7 @@ func TestProxyConfig(t *testing.T) {
 			}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
-			g.Expect(jsonOutput).To(gomega.HaveKey("dynamicActiveSecrets"))
+			g.Expect(jsonOutput).To(HaveKey("dynamicActiveSecrets"))
 			dump := &admin.SecretsConfigDump{}
 			if err := protomarshal.Unmarshal([]byte(output), dump); err != nil {
 				t.Fatal(err)
@@ -404,7 +404,7 @@ func TestXdsProxyStatus(t *testing.T) {
 				t.Fatalf("Could not get Pod ID: %v", err)
 			}
 
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			expectSubstrings := func(have string, wants ...string) error {
 				for _, want := range wants {
@@ -443,9 +443,9 @@ func TestXdsProxyStatus(t *testing.T) {
 				filename := filepath.Join(d, "ps-configdump.json")
 				cs := t.Clusters().Default()
 				dump, err := cs.EnvoyDo(context.TODO(), podID, apps.Namespace.Name(), "GET", "config_dump")
-				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(err).ShouldNot(HaveOccurred())
 				err = os.WriteFile(filename, dump, os.ModePerm)
-				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(err).ShouldNot(HaveOccurred())
 				args := []string{
 					"x", "proxy-status", fmt.Sprintf("%s.%s", podID, apps.Namespace.Name()), "--file", filename, timeoutFlag,
 				}

--- a/tools/bug-report/pkg/filter/filter_test.go
+++ b/tools/bug-report/pkg/filter/filter_test.go
@@ -17,7 +17,7 @@ package filter
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
 	cluster2 "istio.io/istio/tools/bug-report/pkg/cluster"
@@ -107,7 +107,7 @@ func init() {
 }
 
 func TestGetMatchingPaths(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	tests := []struct {
 		name    string
@@ -240,13 +240,13 @@ include:
 			if err != nil {
 				t.Fatal(err)
 			}
-			g.Expect(paths).Should(gomega.ConsistOf(tt.want))
+			g.Expect(paths).Should(ConsistOf(tt.want))
 		})
 	}
 }
 
 func TestGetMatchingPathsMultiple(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	tests := []struct {
 		name    string
@@ -316,13 +316,13 @@ include:
 			if err != nil {
 				t.Fatal(err)
 			}
-			g.Expect(paths).Should(gomega.ConsistOf(tt.want))
+			g.Expect(paths).Should(ConsistOf(tt.want))
 		})
 	}
 }
 
 func TestGetMatchingPathsExclude(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	tests := []struct {
 		name    string
@@ -458,7 +458,7 @@ exclude:
 			if err != nil {
 				t.Fatal(err)
 			}
-			g.Expect(paths).Should(gomega.ConsistOf(tt.want))
+			g.Expect(paths).Should(ConsistOf(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
Using dots gives tests a smoother read.

This reverts part of #47556 given we waived this rule in golintci configuration.