### PR TITLE
uninstall: fix no confirmation when istiod cannot be connected

### DIFF
--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -211,9 +211,6 @@ func preCheckWarnings(cmd *cobra.Command, kubeClient kube.CLIClient, uiArgs *uni
 	rev string, resourcesList []*unstructured.UnstructuredList, objectsList object.K8sObjects, l *clog.ConsoleLogger, dryRun bool,
 ) {
 	pids, err := proxyinfo.GetIDsFromProxyInfo(kubeClient, istioNamespace)
-	if err != nil {
-		l.LogAndError(err.Error())
-	}
 	needConfirmation, message := false, ""
 	if uiArgs.purge {
 		needConfirmation = true
@@ -238,6 +235,10 @@ func preCheckWarnings(cmd *cobra.Command, kubeClient kube.CLIClient, uiArgs *uni
 			}
 			message += "If you proceed with the uninstall, these proxies will become detached from any control plane" +
 				" and will not function correctly.\n"
+		} else if rev != "" && err != nil {
+			needConfirmation = true
+			message += fmt.Sprintf("Unable to find any proxies pointing to the %s control plane. "+
+				"This may be becuase the control plane cannot be connected or there is no %s control plane.\n", rev, rev)
 		}
 		if gwList != "" {
 			needConfirmation = true

--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -238,7 +238,7 @@ func preCheckWarnings(cmd *cobra.Command, kubeClient kube.CLIClient, uiArgs *uni
 		} else if rev != "" && err != nil {
 			needConfirmation = true
 			message += fmt.Sprintf("Unable to find any proxies pointing to the %s control plane. "+
-				"This may be becuase the control plane cannot be connected or there is no %s control plane.\n", rev, rev)
+				"This may be because the control plane cannot be connected or there is no %s control plane.\n", rev, rev)
 		}
 		if gwList != "" {
 			needConfirmation = true

--- a/releasenotes/notes/47617.yaml
+++ b/releasenotes/notes/47617.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where sometimes `uninstall` was performed without confirmation when istiod was not available to be connected.


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently, when istiod cannot be connected, the components will be uninstalled without any confirmation. Not sure if the behavior - skipping confirmation when no proxy info was obtained - was intentional, however I think it doesn't mean there's no proxy so it's better to have a confirmation like other situations do.