### PR TITLE
release-1.20] Run  update_deps and fix make update-crds (api has beta label)

### DIFF
--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -e
-
 fail() {
   echo "$@" 1>&2
   exit 1
@@ -36,7 +35,11 @@ SHA=$(grep "istio.io/api" go.mod | grep "^replace" | awk -F "-" '{print $NF}')
 if [ -n "${SHA}" ]; then
   REPO=$(grep "istio.io/api" go.mod | grep "^replace" | awk '{print $4}')
 else
-  SHA=$(grep "istio.io/api" go.mod | head -n1 | awk -F "-" '{print $NF}')
+  SHA=$(grep "istio.io/api" go.mod | awk '{ print $2 }')
+  if [[ ${SHA} == *"-"* && ! ${SHA} =~ -rc.[0-9]$ && ! ${SHA} =~ -beta.[0-9]$ ]]; then
+    # not an official release or release candidate, so get the commit sha
+    SHA=$(echo "${SHA}" | awk -F '-' '{ print $NF }')
+  fi
 fi
 
 if [ -z "${SHA}" ]; then

--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -35,7 +35,7 @@ SHA=$(grep "istio.io/api" go.mod | grep "^replace" | awk -F "-" '{print $NF}')
 if [ -n "${SHA}" ]; then
   REPO=$(grep "istio.io/api" go.mod | grep "^replace" | awk '{print $4}')
 else
-  SHA=$(grep "istio.io/api" go.mod | awk '{ print $2 }')
+  SHA=$(grep "istio.io/api" go.mod | head -n1 | awk '{ print $2 }')
   if [[ ${SHA} == *"-"* && ! ${SHA} =~ -rc.[0-9]$ && ! ${SHA} =~ -beta.[0-9]$ ]]; then
     # not an official release or release candidate, so get the commit sha
     SHA=$(echo "${SHA}" | awk -F '-' '{ print $NF }')

--- a/go.mod
+++ b/go.mod
@@ -108,8 +108,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.12.3
-	istio.io/api v1.19.0-alpha.1.0.20231020014103-f04dabe883d3
-	istio.io/client-go v1.19.0-alpha.1.0.20231020015056-c529c054a39d
+	istio.io/api v1.20.0-beta.0
+	istio.io/client-go v1.20.0-beta.0
 	k8s.io/api v0.28.2
 	k8s.io/apiextensions-apiserver v0.28.2
 	k8s.io/apimachinery v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -1379,10 +1379,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v1.19.0-alpha.1.0.20231020014103-f04dabe883d3 h1:rTT2/lUSay8+bRMjtMXZtX0Am+A1MPLBXVBjwcaSrJw=
-istio.io/api v1.19.0-alpha.1.0.20231020014103-f04dabe883d3/go.mod h1:hm1PE/mGdIAsjCDkTIAplP53H7TjO5LUQCiVvF26SVg=
-istio.io/client-go v1.19.0-alpha.1.0.20231020015056-c529c054a39d h1:apK1I3YbjsWy/G33uTpHznNeXhM3sCZ3ebONDtxAh/Q=
-istio.io/client-go v1.19.0-alpha.1.0.20231020015056-c529c054a39d/go.mod h1:oIxBb0bKB6J+sibL0oiWEJq7AQEjmJyqGlAmzYqEimE=
+istio.io/api v1.20.0-beta.0 h1:PqBd8IS3xAWo7Sss1pMfuiYAidaaIfUifxnI6fjVY5M=
+istio.io/api v1.20.0-beta.0/go.mod h1:hm1PE/mGdIAsjCDkTIAplP53H7TjO5LUQCiVvF26SVg=
+istio.io/client-go v1.20.0-beta.0 h1:44imNMp+O70gOhVCQgQQnCsBVJHHjbDHAMjTt1BJjrY=
+istio.io/client-go v1.20.0-beta.0/go.mod h1:oIxBb0bKB6J+sibL0oiWEJq7AQEjmJyqGlAmzYqEimE=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
 k8s.io/api v0.18.4/go.mod h1:lOIQAKYgai1+vz9J7YcDZwC26Z0zQewYOGWdyIPUUQ4=
 k8s.io/api v0.28.2 h1:9mpl5mOb6vXZvqbQmankOfPIGiudghwCoLl1EYfUZbw=

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -36,7 +36,7 @@ docker run --rm --privileged "${DOCKER_HUB}/qemu-user-static" --reset -p yes
 export ISTIO_DOCKER_QEMU=true
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=68d2667b22291b998d045ddf9d48d193544afb1c
+BUILDER_SHA=d6a1f04f9d86db2e7713c76d8d2b0a7b4fd3d653
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
**Please provide a description of this PR:**

If https://github.com/istio/istio/pull/47633 is merged, the separate update_deps PR could be merged as well instead of this PR which combines the two PRs. The benefit of this PR is that it only requires a single RM approval, where using https://github.com/istio/istio/pull/47614 would require and RM besides @hanxiaop.

The 1.20 RMs opened a PR running update_deps and it failed in a `make gen`
```
error: pathspec 'beta.0' did not match any file(s) known to git
```
This failure is because the update_crds.sh doesn't not understand istio/api on the go.mod with a rc or beta label without a sha.

I updated the code to calculate the correct label. We should copy the script update to the main branch as well.