### PR TITLE
Fix update_crds for istio/api having a beta.0 label

### DIFF
--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -36,7 +36,11 @@ SHA=$(grep "istio.io/api" go.mod | grep "^replace" | awk -F "-" '{print $NF}')
 if [ -n "${SHA}" ]; then
   REPO=$(grep "istio.io/api" go.mod | grep "^replace" | awk '{print $4}')
 else
-  SHA=$(grep "istio.io/api" go.mod | head -n1 | awk -F "-" '{print $NF}')
+  SHA=$(grep "istio.io/api" go.mod | head -n1 | awk '{ print $2 }')
+  if [[ ${SHA} == *"-"* && ! ${SHA} =~ -rc.[0-9]$ && ! ${SHA} =~ -beta.[0-9]$ ]]; then
+    # not an official release or release candidate, so get the commit sha
+    SHA=$(echo "${SHA}" | awk -F '-' '{ print $NF }')
+  fi
 fi
 
 if [ -z "${SHA}" ]; then


### PR DESCRIPTION
**Please provide a description of this PR:**

In the release-1.20 branch, the RMs ran `go get istio/api@release-1.20` as part of the update_deps. This updated the go.mod to have a version like:
```
	istio.io/api v1.20.0-beta.0
```

The update_crds script failed with this trying to checkout the `beta.0` branch (which doesn't exist). The code was updated for rc and beta similar to the istio/istio code later in the script (noting we have a `.` after beta and rc in our labels) to fix the issue in the release-1.20 branch in https://github.com/istio/istio/pull/47625.

This is a manual cherry pick of the script change only to the main branch.