### PR TITLE
Actually run through TestServicesDiff cases and fix regression

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1241,7 +1241,8 @@ func (s *Service) Equals(other *Service) bool {
 	}
 
 	return s.DefaultAddress == other.DefaultAddress && s.AutoAllocatedIPv4Address == other.AutoAllocatedIPv4Address &&
-		s.AutoAllocatedIPv6Address == other.AutoAllocatedIPv6Address && s.Hostname == other.Hostname && s.MeshExternal == other.MeshExternal
+		s.AutoAllocatedIPv6Address == other.AutoAllocatedIPv6Address && s.Hostname == other.Hostname &&
+		s.Resolution == other.Resolution && s.MeshExternal == other.MeshExternal
 }
 
 // DeepCopy creates a clone of IstioEndpoint.

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -22,6 +22,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/visibility"
@@ -514,6 +515,42 @@ func TestServicesEqual(t *testing.T) {
 			},
 			shouldEq: false,
 			name:     "different internal traffic policies",
+		},
+		{
+			first:    &Service{Hostname: host.Name("foo.com")},
+			other:    &Service{Hostname: host.Name("foo1.com")},
+			shouldEq: false,
+			name:     "different hostname",
+		},
+		{
+			first:    &Service{DefaultAddress: constants.UnspecifiedIPv6},
+			other:    &Service{DefaultAddress: constants.UnspecifiedIP},
+			shouldEq: false,
+			name:     "different default address",
+		},
+		{
+			first:    &Service{AutoAllocatedIPv4Address: "240.240.0.100"},
+			other:    &Service{AutoAllocatedIPv4Address: "240.240.0.101"},
+			shouldEq: false,
+			name:     "different auto allocated IPv4 addresses",
+		},
+		{
+			first:    &Service{AutoAllocatedIPv6Address: "2001:2::f0f0:e351"},
+			other:    &Service{AutoAllocatedIPv6Address: "2001:2::f0f1:e351"},
+			shouldEq: false,
+			name:     "different auto allocated IPv6 addresses",
+		},
+		{
+			first:    &Service{Resolution: ClientSideLB},
+			other:    &Service{Resolution: Passthrough},
+			shouldEq: false,
+			name:     "different resolution",
+		},
+		{
+			first:    &Service{MeshExternal: true},
+			other:    &Service{MeshExternal: false},
+			shouldEq: false,
+			name:     "different mesh external setting",
 		},
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1607,9 +1607,6 @@ func TestServicesDiff(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		if tt.name != "same config with additional endpoint" {
-			continue
-		}
 		t.Run(tt.name, func(t *testing.T) {
 			as := convertServices(*tt.current)
 			bs := convertServices(*tt.new)


### PR DESCRIPTION
This PR to actually run through service comparison test cases, and ensure model.Service.Resolution is taken into account when comparing model.Services, which is a regression introduced in https://github.com/istio/istio/commit/81ad7b8fcae

**Please provide a description of this PR:**