### PR TITLE
optimize performance

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -714,14 +715,16 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 				continue
 			}
 		}
-		if wnsFound { // Check if there is an import of form */host or */*
+
+		// Check if there is an import of form */host or */*
+		if wnsFound {
 			if svc := matchingAliasService(wildcardHosts, matchingService(wildcardHosts, s, ilw)); svc != nil {
 				importedServices = append(importedServices, svc)
 			}
 		}
 	}
 
-	validServices := make(map[host.Name]string)
+	validServices := make(map[host.Name]string, len(importedServices))
 	for _, svc := range importedServices {
 		_, f := validServices[svc.Hostname]
 		// Select a single namespace for a given hostname.
@@ -732,14 +735,10 @@ func (ilw *IstioEgressListenerWrapper) selectServices(services []*Service, confi
 		}
 	}
 
-	filteredServices := make([]*Service, 0)
 	// Filter down to just instances in scope for the service
-	for _, svc := range importedServices {
-		if validServices[svc.Hostname] == svc.Attributes.Namespace {
-			filteredServices = append(filteredServices, svc)
-		}
-	}
-	return filteredServices
+	return slices.FilterInPlace(importedServices, func(svc *Service) bool {
+		return validServices[svc.Hostname] == svc.Attributes.Namespace
+	})
 }
 
 // Return the original service or a trimmed service which has a subset of the ports in original service.

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -38,7 +38,6 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 
 	addVirtualService := func(vs config.Config, hosts hostClassification) {
 		key := vs.NamespacedName()
-
 		if vsset.Contains(key) {
 			return
 		}
@@ -64,6 +63,7 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 		}
 	}
 
+	wnsImportedHosts, wnsFound := hostsByNamespace[wildcardNamespace]
 	loopAndAdd := func(vses []config.Config) {
 		for _, c := range vses {
 			configNamespace := c.Namespace
@@ -78,8 +78,8 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 			}
 
 			// Check if there is an import of form */host or */*
-			if importedHosts, wnsFound := hostsByNamespace[wildcardNamespace]; wnsFound {
-				addVirtualService(c, importedHosts)
+			if wnsFound {
+				addVirtualService(c, wnsImportedHosts)
 			}
 		}
 	}


### PR DESCRIPTION
Improve some usages to optimize `ConvertToSidecarScope`'s performance.

```code
$ benchstat old.txt new.txt
goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/model
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                                                  │   old.txt   │              new.txt               │
                                                  │   sec/op    │   sec/op     vs base               │
ConvertIstioListenerToWrapper/small-exact-12        3.353µ ± 0%   3.200µ ± 1%   -4.55% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-12     1.827µ ± 2%   1.785µ ± 1%   -2.30% (p=0.009 n=6)
ConvertIstioListenerToWrapper/small-match-all-12    5.760µ ± 1%   5.272µ ± 1%   -8.46% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-exact-12       33.00µ ± 1%   32.35µ ± 1%   -1.98% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-12    30.70µ ± 2%   30.18µ ± 1%   -1.70% (p=0.015 n=6)
ConvertIstioListenerToWrapper/middle-match-all-12   57.83µ ± 2%   48.18µ ± 1%  -16.68% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-exact-12          123.0µ ± 1%   120.6µ ± 1%   -1.95% (p=0.026 n=6)
ConvertIstioListenerToWrapper/big-wildcard-12       121.7µ ± 1%   120.9µ ± 1%        ~ (p=0.180 n=6)
ConvertIstioListenerToWrapper/big-match-all-12      166.8µ ± 1%   144.8µ ± 1%  -13.18% (p=0.002 n=6)
geomean                                             25.85µ        24.33µ        -5.88%

                                                  │    old.txt    │                new.txt                │
                                                  │     B/op      │     B/op      vs base                 │
ConvertIstioListenerToWrapper/small-exact-12         2.344Ki ± 0%   2.289Ki ± 0%   -2.33% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-12        400.0 ± 0%     400.0 ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-match-all-12     9.559Ki ± 0%   9.316Ki ± 0%   -2.53% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-exact-12        11.53Ki ± 0%   11.29Ki ± 0%   -2.10% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-12     1.781Ki ± 0%   1.781Ki ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-match-all-12   106.39Ki ± 0%   94.83Ki ± 0%  -10.86% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-exact-12           16.35Ki ± 0%   15.50Ki ± 0%   -5.16% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-12        3.688Ki ± 0%   3.688Ki ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-match-all-12       351.0Ki ± 0%   323.4Ki ± 0%   -7.86% (p=0.002 n=6)
geomean                                              9.043Ki        8.727Ki        -3.50%
¹ all samples are equal

                                                  │  old.txt   │               new.txt               │
                                                  │ allocs/op  │ allocs/op   vs base                 │
ConvertIstioListenerToWrapper/small-exact-12        19.00 ± 0%   16.00 ± 0%  -15.79% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-12     9.000 ± 0%   9.000 ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-match-all-12    22.00 ± 0%   17.00 ± 0%  -22.73% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-exact-12       37.00 ± 0%   32.00 ± 0%  -13.51% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-12    18.00 ± 0%   18.00 ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-match-all-12   47.00 ± 0%   32.00 ± 0%  -31.91% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-exact-12          45.00 ± 0%   39.00 ± 0%  -13.33% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-12       23.00 ± 0%   23.00 ± 0%        ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-match-all-12      60.00 ± 0%   39.00 ± 0%  -35.00% (p=0.002 n=6)
geomean                                             26.87        22.67       -15.66%
¹ all samples are equal
```