### PR TITLE
iptables: refactor to avoid global variables

### DIFF
--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -158,7 +158,7 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 			input: &PodInfo{
 				Containers:        sets.New("test", "istio-proxy", "istio-validate"),
 				Annotations:       map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables.Name: "true"},
+				ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables: "true"},
 			},
 			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/invalid-drop.txt.golden"),
 		},

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -292,7 +292,7 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			log.Warnf("cannot parse dual stack environment variable %v", valErr)
 		}
 	}
-	if v, found := pi.ProxyEnvironments[cmd.InvalidDropByIptables.Name]; found {
+	if v, found := pi.ProxyEnvironments[cmd.InvalidDropByIptables]; found {
 		// parse and set the bool value of invalidDrop
 		redir.invalidDrop, valErr = strconv.ParseBool(v)
 		if valErr != nil {

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package flag
 
 import (

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -1,0 +1,53 @@
+package flag
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Flaggable defines the set of types that can be flags.
+// This is not exhaustive; add more as needed
+type Flaggable interface {
+	string | bool | uint16 | time.Duration
+}
+
+var replacer = strings.NewReplacer("-", "_")
+
+// Bind registers a flag to the FlagSet. When parsed, the value will be set via pointer.
+// Usage:
+//
+//	cfg := Config{Foo: "default-foo"}
+//	flag.Bind(fs, "foo", "f", "the foo value", &cfg.Foo)
+func Bind[T Flaggable](fs *pflag.FlagSet, name, shorthand, usage string, val *T) {
+	switch d := any(val).(type) {
+	case *string:
+		fs.StringVarP(d, name, shorthand, *d, usage)
+	case *bool:
+		fs.BoolVarP(d, name, shorthand, *d, usage)
+	case *time.Duration:
+		fs.DurationVarP(d, name, shorthand, *d, usage)
+	case *uint16:
+		fs.Uint16VarP(d, name, shorthand, *d, usage)
+	}
+}
+
+// BindEnv behaves like Bind, but additionally allows an environment variable to override.
+// This will transform to name field: foo-bar becomes FOO_BAR.
+func BindEnv[T Flaggable](fs *pflag.FlagSet, name, shorthand, usage string, val *T) {
+	Bind(fs, name, shorthand, usage, val)
+	en := strings.ToUpper(replacer.Replace(name))
+	if v, f := os.LookupEnv(en); f {
+		_ = fs.Set(name, v)
+	}
+}
+
+// AdditionalEnv allows additional env vars to set the flag value as well.
+// Unlike BindEnv, this does not do any transformations.
+func AdditionalEnv(fs *pflag.FlagSet, flagName, envName string) {
+	if v, f := os.LookupEnv(envName); f {
+		_ = fs.Set(flagName, v)
+	}
+}

--- a/pkg/flag/flag_test.go
+++ b/pkg/flag/flag_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package flag
 
 import (

--- a/pkg/flag/flag_test.go
+++ b/pkg/flag/flag_test.go
@@ -1,0 +1,34 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestBind(t *testing.T) {
+	type Options struct {
+		A, B, C string
+		Env     string
+		Bool    bool
+	}
+	opts := Options{
+		B: "b-def",
+	}
+	test.SetEnvForTest(t, "TEST_ENV", "from-env")
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	Bind(fs, "a", "", "desc", &opts.A)
+	Bind(fs, "bool", "", "desc", &opts.Bool)
+	BindEnv(fs, "test-env", "", "desc", &opts.Env)
+	fs.Set("a", "a-set")
+	fs.Set("bool", "true")
+	assert.Equal(t, opts, Options{
+		A:    "a-set",
+		B:    "b-def",
+		Env:  "from-env",
+		Bool: true,
+	})
+}

--- a/tools/istio-iptables/pkg/capture/run_linux.go
+++ b/tools/istio-iptables/pkg/capture/run_linux.go
@@ -18,14 +18,12 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
-	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
 // configureTProxyRoutes configures ip firewall rules to enable TPROXY support.
@@ -88,29 +86,11 @@ func configureTProxyRoutes(cfg *config.Config) error {
 	return nil
 }
 
-func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
+func ConfigureRoutes(cfg *config.Config) error {
 	if cfg.DryRun {
 		log.Infof("skipping configuring routes due to dry run mode")
 		return nil
 	}
-	if ext != nil && cfg.CNIMode {
-		nsContainer, err := ns.GetNS(cfg.NetworkNamespace)
-		if err != nil {
-			return err
-		}
-		defer nsContainer.Close()
-
-		return nsContainer.Do(func(ns.NetNS) error {
-			if err := configureIPv6Addresses(cfg); err != nil {
-				return err
-			}
-			if err := configureTProxyRoutes(cfg); err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	// called through 'nsenter -- istio-cni configure-routes'
 	if err := configureIPv6Addresses(cfg); err != nil {
 		return err
 	}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -16,19 +16,12 @@ package cmd
 
 import (
 	"fmt"
-	"net"
-	"net/netip"
 	"os"
-	"os/user"
-	"strings"
 
-	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
-	"istio.io/istio/pkg/env"
+	"istio.io/istio/pkg/flag"
 	"istio.io/istio/pkg/log"
-	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/tools/istio-iptables/pkg/capture"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
@@ -36,342 +29,180 @@ import (
 	"istio.io/istio/tools/istio-iptables/pkg/validation"
 )
 
-var (
-	envoyUserVar = env.Register(constants.EnvoyUser, "istio-proxy", "Envoy proxy username")
-	// Enable interception of DNS.
-	dnsCaptureByAgent = env.Register("ISTIO_META_DNS_CAPTURE", false,
-		"If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053").Get()
-	// InvalidDropByIptables is the flag to enable invalid drop iptables rule to drop the out of window packets
-	InvalidDropByIptables = env.Register("INVALID_DROP", false,
-		"If set to true, enable the invalid drop iptables rule, default false will cause iptables reset out of window packets")
-	DualStack = env.Register("ISTIO_DUAL_STACK", false,
-		"If true, Istio will enable the Dual Stack feature.").Get()
-)
-
-// mock net.InterfaceAddrs to make its unit test become available
-var (
-	LocalIPAddrs = net.InterfaceAddrs
-)
-
-var rootCmd = &cobra.Command{
-	Use:    "istio-iptables",
-	Short:  "Set up iptables rules for Istio Sidecar",
-	Long:   "istio-iptables is responsible for setting up port forwarding for Istio Sidecar.",
-	PreRun: bindFlags,
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := constructConfig()
-		if err := cfg.Validate(); err != nil {
-			handleErrorWithCode(err, 1)
-		}
-		var ext dep.Dependencies
-		if cfg.DryRun {
-			ext = &dep.StdoutStubDependencies{}
-		} else {
-			ipv, err := dep.DetectIptablesVersion(cfg.IPTablesVersion)
-			if err != nil {
-				handleErrorWithCode(err, 1)
-			}
-			ext = &dep.RealDependencies{
-				CNIMode:          cfg.CNIMode,
-				NetworkNamespace: cfg.NetworkNamespace,
-				IptablesVersion:  ipv,
-			}
-		}
-
-		iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
-
-		if !cfg.SkipRuleApply {
-			iptConfigurator.Run()
-			if err := capture.ConfigureRoutes(cfg, ext); err != nil {
-				log.Errorf("failed to configure routes: ")
-				handleErrorWithCode(err, 1)
-			}
-		}
-		if cfg.RunValidation {
-			hostIP, _, err := getLocalIP(cfg.DualStack)
-			if err != nil {
-				// Assume it is not handled by istio-cni and won't reuse the ValidationErrorCode
-				panic(err)
-			}
-			validator := validation.NewValidator(cfg, hostIP)
-
-			if err := validator.Run(); err != nil {
-				// nolint: revive, stylecheck
-				msg := fmt.Errorf(`iptables validation failed; workload is not ready for Istio.
-When using Istio CNI, this can occur if a pod is scheduled before the node is ready.
-
-If installed with 'cni.repair.deletePods=true', this pod should automatically be deleted and retry.
-Otherwise, this pod will need to be manually removed so that it is scheduled on a node with istio-cni running, allowing iptables rules to be established.
-`)
-				handleErrorWithCode(msg, constants.ValidationErrorCode)
-			}
-		}
-	},
-}
-
-func constructConfig() *config.Config {
-	cfg := &config.Config{
-		DryRun:                  viper.GetBool(constants.DryRun),
-		TraceLogging:            viper.GetBool(constants.TraceLogging),
-		RestoreFormat:           viper.GetBool(constants.RestoreFormat),
-		ProxyPort:               viper.GetString(constants.EnvoyPort),
-		InboundCapturePort:      viper.GetString(constants.InboundCapturePort),
-		InboundTunnelPort:       viper.GetString(constants.InboundTunnelPort),
-		ProxyUID:                viper.GetString(constants.ProxyUID),
-		ProxyGID:                viper.GetString(constants.ProxyGID),
-		InboundInterceptionMode: viper.GetString(constants.InboundInterceptionMode),
-		InboundTProxyMark:       viper.GetString(constants.InboundTProxyMark),
-		InboundTProxyRouteTable: viper.GetString(constants.InboundTProxyRouteTable),
-		InboundPortsInclude:     viper.GetString(constants.InboundPorts),
-		InboundPortsExclude:     viper.GetString(constants.LocalExcludePorts),
-		OwnerGroupsInclude:      viper.GetString(constants.OwnerGroupsInclude.Name),
-		OwnerGroupsExclude:      viper.GetString(constants.OwnerGroupsExclude.Name),
-		OutboundPortsInclude:    viper.GetString(constants.OutboundPorts),
-		OutboundPortsExclude:    viper.GetString(constants.LocalOutboundPortsExclude),
-		OutboundIPRangesInclude: viper.GetString(constants.ServiceCidr),
-		OutboundIPRangesExclude: viper.GetString(constants.ServiceExcludeCidr),
-		KubeVirtInterfaces:      viper.GetString(constants.KubeVirtInterfaces),
-		ExcludeInterfaces:       viper.GetString(constants.ExcludeInterfaces),
-		IptablesProbePort:       uint16(viper.GetUint(constants.IptablesProbePort)),
-		ProbeTimeout:            viper.GetDuration(constants.ProbeTimeout),
-		SkipRuleApply:           viper.GetBool(constants.SkipRuleApply),
-		RunValidation:           viper.GetBool(constants.RunValidation),
-		RedirectDNS:             viper.GetBool(constants.RedirectDNS),
-		DropInvalid:             viper.GetBool(constants.DropInvalid),
-		CaptureAllDNS:           viper.GetBool(constants.CaptureAllDNS),
-		NetworkNamespace:        viper.GetString(constants.NetworkNamespace),
-		CNIMode:                 viper.GetBool(constants.CNIMode),
-		DualStack:               viper.GetBool(constants.DualStack),
-	}
-
-	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
-	if cfg.ProxyUID == "" {
-		usr, err := user.Lookup(envoyUserVar.Get())
-		var userID string
-		// Default to the UID of ENVOY_USER
-		if err != nil {
-			userID = constants.DefaultProxyUID
-		} else {
-			userID = usr.Uid
-		}
-		cfg.ProxyUID = userID
-	}
-	// For TPROXY as its uid and gid are same.
-	if cfg.ProxyGID == "" {
-		cfg.ProxyGID = cfg.ProxyUID
-	}
-
-	// Detect whether IPv6 is enabled by checking if the pod's IP address is IPv4 or IPv6.
-	_, isIPv6, err := getLocalIP(cfg.DualStack)
-	if err != nil {
-		panic(err)
-	}
-
-	cfg.EnableInboundIPv6 = isIPv6
-
-	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
-	// case where reading /etc/resolv.conf could fail.
-	// If capture all DNS option is enabled, we don't need to read from the dns resolve conf. All
-	// traffic to port 53 will be captured.
-	if cfg.RedirectDNS && !cfg.CaptureAllDNS {
-		dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
-		if err != nil {
-			panic(fmt.Sprintf("failed to load /etc/resolv.conf: %v", err))
-		}
-		cfg.DNSServersV4, cfg.DNSServersV6 = netutil.IPsSplitV4V6(dnsConfig.Servers)
-	}
-	return cfg
-}
-
-// getLocalIP returns one of the local IP address and it should support IPv6 or not
-func getLocalIP(dualStack bool) (netip.Addr, bool, error) {
-	var isIPv6 bool
-	var ipAddrs []netip.Addr
-	addrs, err := LocalIPAddrs()
-	if err != nil {
-		return netip.Addr{}, isIPv6, err
-	}
-
-	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok {
-			ip := ipnet.IP
-			ipAddr, ok := netip.AddrFromSlice(ip)
-			if !ok {
-				continue
-			}
-			// unwrap the IPv4-mapped IPv6 address
-			unwrapAddr := ipAddr.Unmap()
-			if !unwrapAddr.IsLoopback() && !unwrapAddr.IsLinkLocalUnicast() && !unwrapAddr.IsLinkLocalMulticast() {
-				isIPv6 = unwrapAddr.Is6()
-				ipAddrs = append(ipAddrs, unwrapAddr)
-				if !dualStack {
-					return unwrapAddr, isIPv6, nil
-				}
-				if isIPv6 {
-					break
-				}
-			}
-		}
-	}
-
-	if len(ipAddrs) > 0 {
-		return ipAddrs[0], isIPv6, nil
-	}
-
-	return netip.Addr{}, isIPv6, fmt.Errorf("no valid local IP address found")
-}
-
-func handleError(err error) {
-	handleErrorWithCode(err, 1)
-}
+const InvalidDropByIptables = "INVALID_DROP"
 
 func handleErrorWithCode(err error, code int) {
 	log.Error(err)
 	os.Exit(code)
 }
 
-// https://github.com/spf13/viper/issues/233.
-// Any viper mutation and binding should be placed in `PreRun` since they should be dynamically bound to the subcommand being executed.
-func bindFlags(cmd *cobra.Command, args []string) {
-	// Read in all environment variables
-	viper.AutomaticEnv()
-	// Replace - with _; so that environment variables are looked up correctly.
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
+	fs := cmd.Flags()
+	flag.Bind(fs, constants.EnvoyPort, "p", "Specify the envoy port to which redirect all TCP traffic.", &cfg.ProxyPort)
 
-	bind := func(name string, def any) {
-		if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
-			handleError(err)
-		}
-		viper.SetDefault(name, def)
-	}
-	bindEnv := func(name string, def any) {
-		if err := viper.BindEnv(name); err != nil {
-			handleError(err)
-		}
-		viper.SetDefault(name, def)
-	}
+	flag.BindEnv(fs, constants.InboundCapturePort, "z",
+		"Port to which all inbound TCP traffic to the pod/VM should be redirected to.",
+		&cfg.InboundCapturePort)
 
-	bind(constants.EnvoyPort, "15001")
-	bind(constants.InboundCapturePort, "15006")
-	bind(constants.InboundTunnelPort, "15008")
-	bind(constants.ProxyUID, "")
-	bind(constants.ProxyGID, "")
-	bind(constants.InboundInterceptionMode, "")
-	bind(constants.InboundPorts, "")
-	bind(constants.LocalExcludePorts, "")
-	bind(constants.ExcludeInterfaces, "")
-	bind(constants.ServiceCidr, "")
-	bind(constants.ServiceExcludeCidr, "")
-	bindEnv(constants.OwnerGroupsInclude.Name, constants.OwnerGroupsInclude.DefaultValue)
-	bindEnv(constants.OwnerGroupsExclude.Name, constants.OwnerGroupsExclude.DefaultValue)
-	bind(constants.OutboundPorts, "")
-	bind(constants.LocalOutboundPortsExclude, "")
-	bind(constants.KubeVirtInterfaces, "")
-	bind(constants.InboundTProxyMark, "1337")
-	bind(constants.InboundTProxyRouteTable, "133")
-	bind(constants.DryRun, false)
-	bind(constants.TraceLogging, false)
-	bind(constants.RestoreFormat, true)
-	bind(constants.IptablesProbePort, constants.DefaultIptablesProbePort)
-	bind(constants.ProbeTimeout, constants.DefaultProbeTimeout)
-	bind(constants.SkipRuleApply, false)
-	bind(constants.RunValidation, false)
-	bind(constants.RedirectDNS, dnsCaptureByAgent)
-	bind(constants.DropInvalid, InvalidDropByIptables)
-	bind(constants.CaptureAllDNS, false)
-	bind(constants.NetworkNamespace, "")
-	bind(constants.CNIMode, false)
-	bind(constants.IptablesVersion, "")
-	bind(constants.DualStack, DualStack)
-}
+	flag.BindEnv(fs, constants.InboundTunnelPort, "e",
+		"Specify the istio tunnel port for inbound tcp traffic.",
+		&cfg.InboundTunnelPort)
 
-// https://github.com/spf13/viper/issues/233.
-// Only adding flags in `init()` while moving its binding to Viper and value defaulting as part of the command execution.
-// Otherwise, the flag with the same name shared across subcommands will be overwritten by the last.
-func init() {
-	bindCmdlineFlags(rootCmd)
-}
+	flag.BindEnv(fs, constants.ProxyUID, "u",
+		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container.",
+		&cfg.ProxyUID)
 
-func bindCmdlineFlags(rootCmd *cobra.Command) {
-	rootCmd.Flags().StringP(constants.EnvoyPort, "p", "", "Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001).")
+	flag.BindEnv(fs, constants.ProxyGID, "g",
+		"Specify the GID of the user for which the redirection is not applied (same default value as -u param).",
+		&cfg.ProxyGID)
 
-	rootCmd.Flags().StringP(constants.InboundCapturePort, "z", "",
-		"Port to which all inbound TCP traffic to the pod/VM should be redirected to (default $INBOUND_CAPTURE_PORT = 15006).")
+	flag.BindEnv(fs, constants.InboundInterceptionMode, "m",
+		"The mode used to redirect inbound connections to Envoy, either \"REDIRECT\" or \"TPROXY\".",
+		&cfg.InboundInterceptionMode)
 
-	rootCmd.Flags().StringP(constants.InboundTunnelPort, "e", "",
-		"Specify the istio tunnel port for inbound tcp traffic (default $INBOUND_TUNNEL_PORT = 15008).")
-
-	rootCmd.Flags().StringP(constants.ProxyUID, "u", "",
-		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container.")
-
-	rootCmd.Flags().StringP(constants.ProxyGID, "g", "",
-		"Specify the GID of the user for which the redirection is not applied (same default value as -u param).")
-
-	rootCmd.Flags().StringP(constants.InboundInterceptionMode, "m", "",
-		"The mode used to redirect inbound connections to Envoy, either \"REDIRECT\" or \"TPROXY\".")
-
-	rootCmd.Flags().StringP(constants.InboundPorts, "b", "",
+	flag.BindEnv(fs, constants.InboundPorts, "b",
 		"Comma separated list of inbound ports for which traffic is to be redirected to Envoy (optional). "+
-			"The wildcard character \"*\" can be used to configure redirection for all ports. An empty list will disable.")
+			"The wildcard character \"*\" can be used to configure redirection for all ports. An empty list will disable.",
+		&cfg.InboundPortsInclude)
 
-	rootCmd.Flags().StringP(constants.LocalExcludePorts, "d", "",
+	flag.BindEnv(fs, constants.LocalExcludePorts, "d",
 		"Comma separated list of inbound ports to be excluded from redirection to Envoy (optional). "+
-			"Only applies when all inbound traffic (i.e. \"*\") is being redirected (default to $ISTIO_LOCAL_EXCLUDE_PORTS).")
+			"Only applies when all inbound traffic (i.e. \"*\") is being redirected.",
+		&cfg.InboundPortsExclude)
 
-	rootCmd.Flags().StringP(constants.ExcludeInterfaces, "c", "",
-		"Comma separated list of NIC (optional). Neither inbound nor outbound traffic will be captured.")
+	flag.BindEnv(fs, constants.ExcludeInterfaces, "c",
+		"Comma separated list of NIC (optional). Neither inbound nor outbound traffic will be captured.",
+		&cfg.ExcludeInterfaces)
 
-	rootCmd.Flags().StringP(constants.ServiceCidr, "i", "",
+	flag.BindEnv(fs, constants.ServiceCidr, "i",
 		"Comma separated list of IP ranges in CIDR form to redirect to envoy (optional). "+
-			"The wildcard character \"*\" can be used to redirect all outbound traffic. An empty list will disable all outbound.")
+			"The wildcard character \"*\" can be used to redirect all outbound traffic. An empty list will disable all outbound.",
+		&cfg.OutboundIPRangesInclude)
 
-	rootCmd.Flags().StringP(constants.ServiceExcludeCidr, "x", "",
+	flag.BindEnv(fs, constants.ServiceExcludeCidr, "x",
 		"Comma separated list of IP ranges in CIDR form to be excluded from redirection. "+
-			"Only applies when all  outbound traffic (i.e. \"*\") is being redirected (default to $ISTIO_SERVICE_EXCLUDE_CIDR).")
+			"Only applies when all  outbound traffic (i.e. \"*\") is being redirected.",
+		&cfg.OutboundIPRangesExclude)
 
-	rootCmd.Flags().StringP(constants.OutboundPorts, "q", "",
-		"Comma separated list of outbound ports to be explicitly included for redirection to Envoy.")
+	flag.BindEnv(fs, constants.OutboundPorts, "q",
+		"Comma separated list of outbound ports to be explicitly included for redirection to Envoy.",
+		&cfg.OutboundPortsInclude)
 
-	rootCmd.Flags().StringP(constants.LocalOutboundPortsExclude, "o", "",
-		"Comma separated list of outbound ports to be excluded from redirection to Envoy.")
+	flag.BindEnv(fs, constants.LocalOutboundPortsExclude, "o",
+		"Comma separated list of outbound ports to be excluded from redirection to Envoy.",
+		&cfg.OutboundPortsExclude)
 
-	rootCmd.Flags().StringP(constants.KubeVirtInterfaces, "k", "",
-		"Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound.")
+	flag.BindEnv(fs, constants.KubeVirtInterfaces, "k",
+		"Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound.",
+		&cfg.KubeVirtInterfaces)
 
-	rootCmd.Flags().StringP(constants.InboundTProxyMark, "t", "", "")
+	flag.BindEnv(fs, constants.InboundTProxyMark, "t", "", &cfg.InboundTProxyMark)
 
-	rootCmd.Flags().StringP(constants.InboundTProxyRouteTable, "r", "", "")
+	flag.BindEnv(fs, constants.InboundTProxyRouteTable, "r", "", &cfg.InboundTProxyRouteTable)
 
-	rootCmd.Flags().BoolP(constants.DryRun, "n", false, "Do not call any external dependencies like iptables.")
+	flag.BindEnv(fs, constants.DryRun, "n", "Do not call any external dependencies like iptables.",
+		&cfg.DryRun)
 
-	rootCmd.Flags().Bool(constants.TraceLogging, false, "Insert tracing logs for each iptables rules, using the LOG chain.")
+	flag.BindEnv(fs, constants.TraceLogging, "", "Insert tracing logs for each iptables rules, using the LOG chain.", &cfg.TraceLogging)
 
-	rootCmd.Flags().BoolP(constants.RestoreFormat, "f", true, "Print iptables rules in iptables-restore interpretable format.")
+	flag.BindEnv(fs, constants.RestoreFormat, "f", "Print iptables rules in iptables-restore interpretable format.",
+		&cfg.RestoreFormat)
 
-	rootCmd.Flags().String(constants.IptablesProbePort, constants.DefaultIptablesProbePort, "Set listen port for failure detection.")
+	flag.BindEnv(fs, constants.IptablesProbePort, "", "Set listen port for failure detection.", &cfg.IptablesProbePort)
 
-	rootCmd.Flags().Duration(constants.ProbeTimeout, constants.DefaultProbeTimeout, "Failure detection timeout.")
+	flag.BindEnv(fs, constants.ProbeTimeout, "", "Failure detection timeout.", &cfg.ProbeTimeout)
 
-	rootCmd.Flags().Bool(constants.SkipRuleApply, false, "Skip iptables apply.")
+	flag.BindEnv(fs, constants.SkipRuleApply, "", "Skip iptables apply.", &cfg.SkipRuleApply)
 
-	rootCmd.Flags().Bool(constants.RunValidation, false, "Validate iptables.")
+	flag.BindEnv(fs, constants.RunValidation, "", "Validate iptables.", &cfg.RunValidation)
 
-	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "Enable capture of dns traffic by istio-agent.")
+	flag.BindEnv(fs, constants.RedirectDNS, "", "Enable capture of dns traffic by istio-agent.", &cfg.RedirectDNS)
+	// Allow binding to a different var, for consistency with other components
+	flag.AdditionalEnv(fs, constants.RedirectDNS, "ISTIO_META_DNS_CAPTURE")
 
-	rootCmd.Flags().Bool(constants.DropInvalid, InvalidDropByIptables.Get(), "Enable invalid drop in the iptables rules.")
+	flag.BindEnv(fs, constants.DropInvalid, "", "Enable invalid drop in the iptables rules.", &cfg.DropInvalid)
+	// This could have just used the default but for backwards compat we support the old env.
+	flag.AdditionalEnv(fs, constants.DropInvalid, InvalidDropByIptables)
 
-	rootCmd.Flags().Bool(constants.DualStack, DualStack, "Enable ipv4/ipv6 redirects for dual-stack.")
+	flag.BindEnv(fs, constants.DualStack, "", "Enable ipv4/ipv6 redirects for dual-stack.", &cfg.DualStack)
+	// Allow binding to a different var, for consistency with other components
+	flag.AdditionalEnv(fs, constants.DualStack, "ISTIO_DUAL_STACK")
 
-	rootCmd.Flags().Bool(constants.CaptureAllDNS, false,
-		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.")
+	flag.BindEnv(fs, constants.CaptureAllDNS, "",
+		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.",
+		&cfg.CaptureAllDNS)
 
-	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
+	flag.BindEnv(fs, constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.",
+		&cfg.NetworkNamespace)
 
-	rootCmd.Flags().Bool(constants.CNIMode, false, "Whether to run as CNI plugin.")
+	flag.BindEnv(fs, constants.CNIMode, "", "Whether to run as CNI plugin.", &cfg.CNIMode)
 
-	rootCmd.Flags().String(constants.IptablesVersion, "", "version of iptables command. If not set, this is automatically detected.")
+	flag.BindEnv(fs, constants.IptablesVersion, "", "version of iptables command. If not set, this is automatically detected.", &cfg.IPTablesVersion)
 }
 
 func GetCommand() *cobra.Command {
-	return rootCmd
+	cfg := config.DefaultConfig()
+	cmd := &cobra.Command{
+		Use:   "istio-iptables",
+		Short: "Set up iptables rules for Istio Sidecar",
+		Long:  "istio-iptables is responsible for setting up port forwarding for Istio Sidecar.",
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg.FillConfigFromEnvironment()
+			if err := cfg.Validate(); err != nil {
+				handleErrorWithCode(err, 1)
+			}
+			if err := ProgramIptables(cfg); err != nil {
+				handleErrorWithCode(err, 1)
+			}
+
+			if cfg.RunValidation {
+				validator := validation.NewValidator(cfg)
+
+				if err := validator.Run(); err != nil {
+					// nolint: revive, stylecheck
+					msg := fmt.Errorf(`iptables validation failed; workload is not ready for Istio.
+When using Istio CNI, this can occur if a pod is scheduled before the node is ready.
+
+If installed with 'cni.repair.deletePods=true', this pod should automatically be deleted and retry.
+Otherwise, this pod will need to be manually removed so that it is scheduled on a node with istio-cni running, allowing iptables rules to be established.
+`)
+					handleErrorWithCode(msg, constants.ValidationErrorCode)
+				}
+			}
+		},
+	}
+	bindCmdlineFlags(cfg, cmd)
+	return cmd
+}
+
+type IptablesError struct {
+	Error    error
+	ExitCode int
+}
+
+func ProgramIptables(cfg *config.Config) error {
+	var ext dep.Dependencies
+	if cfg.DryRun {
+		ext = &dep.StdoutStubDependencies{}
+	} else {
+		ipv, err := dep.DetectIptablesVersion(cfg.IPTablesVersion)
+		if err != nil {
+			return err
+		}
+		ext = &dep.RealDependencies{
+			CNIMode:          cfg.CNIMode,
+			NetworkNamespace: cfg.NetworkNamespace,
+			IptablesVersion:  ipv,
+		}
+	}
+
+	iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
+
+	if !cfg.SkipRuleApply {
+		iptConfigurator.Run()
+		if err := capture.ConfigureRoutes(cfg); err != nil {
+			return fmt.Errorf("failed to configure routes: %v", err)
+		}
+	}
+	return nil
 }

--- a/tools/istio-iptables/pkg/config/config_test.go
+++ b/tools/istio-iptables/pkg/config/config_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/tools/istio-iptables/pkg/config/config_test.go
+++ b/tools/istio-iptables/pkg/config/config_test.go
@@ -1,18 +1,4 @@
-// Copyright Istio Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-package cmd
+package config
 
 import (
 	"net"

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -160,8 +160,9 @@ const (
 )
 
 const (
-	DefaultIptablesProbePort = "15002"
-	DefaultProbeTimeout      = 5 * time.Second
+	DefaultIptablesProbePort     = "15002"
+	DefaultIptablesProbePortUint = 15002
+	DefaultProbeTimeout          = 5 * time.Second
 )
 
 const (

--- a/tools/istio-iptables/pkg/validation/validator.go
+++ b/tools/istio-iptables/pkg/validation/validator.go
@@ -100,11 +100,11 @@ func genListenerAddress(ip netip.Addr, ports []string) []string {
 	return addresses
 }
 
-func NewValidator(config *config.Config, hostIP netip.Addr) *Validator {
+func NewValidator(config *config.Config) *Validator {
 	// It's tricky here:
 	// Connect to 127.0.0.6 will redirect to 127.0.0.1
 	// Connect to ::6       will redirect to ::1
-	isIPv6 := hostIP.Is6()
+	isIPv6 := config.HostIP.Is6()
 	listenIP, _ := netip.AddrFromSlice([]byte{127, 0, 0, 1})
 	serverIP, _ := netip.AddrFromSlice([]byte{127, 0, 0, 6})
 	if isIPv6 {


### PR DESCRIPTION
Currently, we have a complete mess of configuration for the iptables commands. This is driven a few issues:

* It was designed to be *byte for byte* compatible with the original Bash script years ago, so it has a ton of weird bash-isms.
* It is designed exclusively as a command line, but now its used beyond that (in CNI, etc)
* Uses lots of globals, and each config item ends up in 3-4 places.

This PR refactors this to simplify the configuration surface. The actual goal of this is to make it safe to run the iptables setup multiple times in a long running fashion; due to global variable usage this was extremely hard to do so safely previously.

As part of this, a new package `pkg/flag` is introduced. This replaces our minimal usage of viper with ~3 lines of code to allow setting a flag's default value from an environment variable.

There should be no behavioral differences, except some of the `--help` output is more clear (defaults shown)

**Please provide a description of this PR:**