### PR TITLE
Fix build failure on mac

### DIFF
--- a/tools/istio-iptables/pkg/capture/run_unspecified.go
+++ b/tools/istio-iptables/pkg/capture/run_unspecified.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 
 	"istio.io/istio/tools/istio-iptables/pkg/config"
-	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
 // ErrNotImplemented is returned when a requested feature is not implemented.
@@ -32,6 +31,6 @@ func configureTProxyRoutes(cfg *config.Config) error {
 	return ErrNotImplemented
 }
 
-func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
+func ConfigureRoutes(cfg *config.Config) error {
 	return ErrNotImplemented
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
```
common/scripts/gobuild.sh /Users/xiaopenghan/go/src/istio.io/istio/out/darwin_arm64/ -tags=agent ./pilot/cmd/pilot-agent
# istio.io/istio/tools/istio-iptables/pkg/cmd
tools/istio-iptables/pkg/cmd/root.go:203:37: not enough arguments in call to capture.ConfigureRoutes
        have (*config.Config)
        want (*config.Config, dependencies.Dependencies)
make: *** [build] Error 1
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
