### PR TITLE
Add topology.istio.io/network label to waypoint if exists

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -35,13 +35,20 @@ spec:
             "prometheus.io/scrape" "true"
           ) | nindent 8 }}
       labels:
+        {{- $requiredLabels := .Labels }}
+        {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+        {{- if $network }}
+        {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+            "topology.istio.io/network" $network
+        )}}
+        {{- end }}
         {{- toJsonMap
           (strdict
             "sidecar.istio.io/inject" "false"
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
            )
-          .Labels
+          $requiredLabels
           (strdict
             "istio.io/gateway-name" .Name
             "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -1,0 +1,238 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    gateway.istio.io/controller-version: "5"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+  name: namespace-istio-waypoint
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+  name: namespace-istio-waypoint
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  selector:
+    matchLabels:
+      istio.io/gateway-name: namespace
+  template:
+    metadata:
+      annotations:
+        ambient.istio.io/redirection: disabled
+        istio.io/rev: default
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      labels:
+        gateway.istio.io/managed: istio.io-mesh-controller
+        istio.io/gateway-name: namespace
+        service.istio.io/canonical-name: namespace-istio-waypoint
+        service.istio.io/canonical-revision: latest
+        sidecar.istio.io/inject: "false"
+        topology.istio.io/network: network-1
+    spec:
+      containers:
+      - args:
+        - proxy
+        - waypoint
+        - --domain
+        - $(POD_NAMESPACE).svc.<no value>
+        - --serviceCluster
+        - namespace-istio-waypoint.$(POD_NAMESPACE)
+        - --proxyLogLevel
+        - <nil>
+        - --proxyComponentLogLevel
+        - <nil>
+        - --log_output_level
+        - <nil>
+        env:
+        - name: ISTIO_META_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: JWT_POLICY
+          value: <no value>
+        - name: PILOT_CERT_PROVIDER
+          value: <no value>
+        - name: CA_ADDR
+          value: istiod-<no value>.<no value>.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {}
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: ISTIO_META_NETWORK
+          value: network-1
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: namespace-istio-waypoint
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace-istio-waypoint
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        image: test/proxyv2:test
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 0
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: true
+          runAsGroup: 1337
+          runAsUser: 0
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      serviceAccountName: namespace-istio-waypoint
+      terminationGracePeriodSeconds: 2
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir:
+          medium: Memory
+        name: go-proxy-envoy
+      - emptyDir: {}
+        name: istio-data
+      - emptyDir: {}
+        name: go-proxy-data
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+  name: namespace-istio-waypoint
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    kind: Gateway
+    name: namespace
+    uid: ""
+spec:
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+  - appProtocol: all
+    name: mesh
+    port: 15008
+    protocol: TCP
+  selector:
+    istio.io/gateway-name: namespace
+  type: ClusterIP
+---

--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -62,6 +62,7 @@ func createInjectionFuncmap() template.FuncMap {
 		"omit":                omit,
 		"strdict":             strdict,
 		"toJsonMap":           toJSONMap,
+		"mergeMaps":           mergeMaps,
 	}
 }
 

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1219,13 +1219,20 @@ templates:
                 "prometheus.io/scrape" "true"
               ) | nindent 8 }}
           labels:
+            {{- $requiredLabels := .Labels }}
+            {{- $network := valueOrDefault (index .Labels `topology.istio.io/network`) .Values.global.network }}
+            {{- if $network }}
+            {{- $requiredLabels = mergeMaps $requiredLabels (strdict
+                "topology.istio.io/network" $network
+            )}}
+            {{- end }}
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )
-              .Labels
+              $requiredLabels
               (strdict
                 "istio.io/gateway-name" .Name
                 "gateway.istio.io/managed" "istio.io-mesh-controller"

--- a/releasenotes/notes/47681.yaml
+++ b/releasenotes/notes/47681.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** an issue where sometimes the network of waypoint was not properly configured.


### PR DESCRIPTION
**Please provide a description of this PR:**
This is likely a follow-up to https://github.com/istio/istio/pull/46725. Setting the `ISTIO_META_` is not enough,

https://github.com/istio/istio/blob/9852844f311e27b55ffaa0ac71b8968b44b453eb/pilot/pkg/serviceregistry/kube/controller/controller.go#L346-L355

as we first check the label then the system namespace. This makes the behavior of the sidecar network and the waypoint network consistent - we do network label modification in injection.