### PR TITLE
Fix header present match

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1022,7 +1022,7 @@ func translateQueryParamMatch(name string, in *networking.StringMatch) *route.Qu
 // isCatchAllStringMatch determines if the given matcher is matched with all strings or not.
 // Currently, if the regex has "*" value, it returns true
 func isCatchAllStringMatch(in *networking.StringMatch) bool {
-	if in == nil {
+	if in == nil || in.MatchType == nil {
 		return true
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -21,6 +21,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -312,6 +313,15 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal("FOO-HEADER"))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(Equal(true))
 		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(false))
+
+		routes, err = route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithPresentMatchingOnHeader2,
+			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		xdstest.ValidateRoutes(t, routes)
+		g.Expect(len(routes)).To(gomega.Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(gomega.Equal("FOO-HEADER"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(gomega.Equal(true))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(false))
 	})
 
 	t.Run("for virtual service with presence matching on header and without_header", func(t *testing.T) {
@@ -2204,6 +2214,34 @@ var virtualServiceWithPresentMatchingOnHeader = config.Config{
 						Name: "presence",
 						Headers: map[string]*networking.StringMatch{
 							"FOO-HEADER": nil,
+						},
+					},
+				},
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithPresentMatchingOnHeader2 = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "presence",
+						Headers: map[string]*networking.StringMatch{
+							"FOO-HEADER": {},
 						},
 					},
 				},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -21,7 +21,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -316,12 +315,12 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		routes, err = route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithPresentMatchingOnHeader2,
 			serviceRegistry, nil, 8080, gatewayNames, route.RouteOptions{})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		xdstest.ValidateRoutes(t, routes)
-		g.Expect(len(routes)).To(gomega.Equal(1))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(gomega.Equal("FOO-HEADER"))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(gomega.Equal(true))
-		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(gomega.Equal(false))
+		g.Expect(len(routes)).To(Equal(1))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetName()).To(Equal("FOO-HEADER"))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetPresentMatch()).To(Equal(true))
+		g.Expect(routes[0].GetMatch().GetHeaders()[0].GetInvertMatch()).To(Equal(false))
 	})
 
 	t.Run("for virtual service with presence matching on header and without_header", func(t *testing.T) {

--- a/releasenotes/notes/header-present.yaml
+++ b/releasenotes/notes/header-present.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47341
+releaseNotes:
+- |
+  **Fixed** VirtualService http header present match does not work with `header-name: {}` set.


### PR DESCRIPTION
**Please provide a description of this PR:**



According to https://istio.io/latest/docs/reference/config/networking/virtual-service/

```
The header keys must be lowercase and use hyphen as the separator, e.g. x-request-id.

Header values are case-sensitive and formatted as follows:

exact: "value" for exact string match

prefix: "value" for prefix-based match

regex: "value" for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).

If the value is empty and only the name of header is specified, presence of the header is checked. To provide an empty value, use {}, for example:

 - match:
   - headers:
       myheader: {}
```



Without this, the generated route match does not contain ` presentMatch: true` .
```
 - match:
   - headers:
       myheader: {}
```

```
    routes:
    - decorator:
        operation: sleep.default.svc.cluster.local:80/ratings/v2/*
      match:
        caseSensitive: false
        headers:
        - name: myheader
          presentMatch: true

```