### PR TITLE
Fix tag list output command not working

### DIFF
--- a/istioctl/pkg/tag/tag.go
+++ b/istioctl/pkg/tag/tag.go
@@ -227,6 +227,8 @@ func tagListCommand(ctx cli.Context) *cobra.Command {
 		},
 	}
 
+	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", util.TableFormat, "Output format for tag description "+
+		"(available formats: table,json)")
 	return cmd
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/47696

The old `x revision tag list` command has been removed and graduated to the new `tag` command. So I've fixed the `tag` command to accepet output format as a flag input.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
