### PR TITLE
istioctl bug-report: Speed improvement from concurrency limiting

### DIFF
--- a/releasenotes/notes/bug-report-speedup.yaml
+++ b/releasenotes/notes/bug-report-speedup.yaml
@@ -1,0 +1,31 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: telemetry
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Removed** `--rps-limit` flag for `istioctl bug-report` and **added** `--rq-concurrency` flag.
+    The bug reporter will now limit request concurrency instead of limiting request rate to the kube
+    API.

--- a/releasenotes/notes/bug-report-speedup.yaml
+++ b/releasenotes/notes/bug-report-speedup.yaml
@@ -20,7 +20,7 @@ kind: feature
 # - installation
 # - istioctl
 # - documentation
-area: telemetry
+area: istioctl
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -52,6 +52,7 @@ import (
 
 const (
 	bugReportDefaultTimeout = 30 * time.Minute
+	defaultRPSLimit         = 100
 )
 
 var (
@@ -101,7 +102,7 @@ var (
 )
 
 func runBugReportCommand(ctx cli.Context, _ *cobra.Command, logOpts *log.Options) error {
-	runner := kubectlcmd.NewRunner(gConfig.RequestsPerSecondLimit)
+	runner := kubectlcmd.NewRunner(gConfig.RequestConcurrency)
 	runner.ReportRunningTasks()
 	if err := configLogs(logOpts); err != nil {
 		return err
@@ -124,7 +125,7 @@ func runBugReportCommand(ctx cli.Context, _ *cobra.Command, logOpts *log.Options
 	common.LogAndPrintf("\nTarget cluster context: %s\n", clusterCtxStr)
 	common.LogAndPrintf("Running with the following config: \n\n%s\n\n", config)
 
-	restConfig, clientset, err := kubeclient.New(config.KubeConfigPath, config.Context, gConfig.RequestsPerSecondLimit)
+	restConfig, clientset, err := kubeclient.New(config.KubeConfigPath, config.Context)
 	if err != nil {
 		return fmt.Errorf("could not initialize k8s client: %s ", err)
 	}

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -52,7 +52,6 @@ import (
 
 const (
 	bugReportDefaultTimeout = 30 * time.Minute
-	defaultRPSLimit         = 100
 )
 
 var (

--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -96,10 +96,9 @@ func addFlags(cmd *cobra.Command, args *config2.BugReportConfig) {
 	cmd.PersistentFlags().StringVar(&outputDir, "output-dir", "",
 		"Set a specific directory for output archive file.")
 
-	// requests per second limit
-	cmd.PersistentFlags().IntVar(&args.RequestsPerSecondLimit, "rps-limit", 0,
-		"Requests per second limit to the Kubernetes API server, defaults to 10."+
-			"A higher limit can make bug report collection much faster.")
+	// in-flight request limit
+	cmd.PersistentFlags().IntVar(&args.RequestConcurrency, "rq-concurrency", 0,
+		"Set the concurrency limit of requests to the Kubernetes API server, defaults to 32.")
 }
 
 func parseConfig() (*config2.BugReportConfig, error) {

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -174,8 +174,8 @@ type BugReportConfig struct {
 	// calculating the error heuristic for a log.
 	IgnoredErrors []string `json:"ignoredErrors,omitempty"`
 
-	// RequestsPerSecondLimit controls the RPS limit to the API server.
-	RequestsPerSecondLimit int `json:"requestsPerSecondLimit,omitempty"`
+	// RequestConcurrency controls the request concurrency limit to the API server.
+	RequestConcurrency int `json:"requestConcurrency,omitempty"`
 }
 
 func (b *BugReportConfig) String() string {

--- a/tools/bug-report/pkg/kubeclient/kubeclient.go
+++ b/tools/bug-report/pkg/kubeclient/kubeclient.go
@@ -29,17 +29,13 @@ const (
 )
 
 // New creates a rest.Config and Clientset from the given kubeconfig path and Context.
-func New(kubeconfig, kubeContext string, qpsLimit int) (*rest.Config, *kubernetes.Clientset, error) {
+func New(kubeconfig, kubeContext string) (*rest.Config, *kubernetes.Clientset, error) {
 	clientConfig := kube.BuildClientCmd(kubeconfig, kubeContext, func(co *clientcmd.ConfigOverrides) {
 		co.Timeout = defaultTimeoutDurationStr
 	})
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err
-	}
-	if qpsLimit > 0 {
-		restConfig.QPS = float32(qpsLimit)
-		restConfig.Burst = qpsLimit * 2
 	}
 
 	clientset, err := kubernetes.NewForConfig(kube.SetRestDefaults(restConfig))

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
@@ -33,8 +31,8 @@ import (
 )
 
 const (
-	// maxRequestsPerSecond is the max rate of requests to the API server.
-	defaultMaxRequestsPerSecond = 10
+	// The default number of in-flight requests allowed for the runner.
+	defaultActiveRequestLimit = 32
 
 	// reportInterval controls how frequently to output progress reports on running tasks.
 	reportInterval = 30 * time.Second
@@ -43,10 +41,8 @@ const (
 type Runner struct {
 	Client kube.CLIClient
 
-	requestLimiter *rate.Limiter
-	// logFetchLimitCh limits the number of concurrent requests to fetch pod logs, this is separate
-	// to requestLimiter as these can be very large.
-	logFetchLimitCh chan struct{}
+	// Used to limit the number of concurrent tasks.
+	taskSem chan struct{}
 
 	// runningTasks tracks the in-flight fetch operations for user feedback.
 	runningTasks   sets.Set[string]
@@ -56,13 +52,12 @@ type Runner struct {
 	runningTasksTicker *time.Ticker
 }
 
-func NewRunner(rpsLimit int) *Runner {
-	if rpsLimit <= 0 {
-		rpsLimit = defaultMaxRequestsPerSecond
+func NewRunner(activeRqLimit int) *Runner {
+	if activeRqLimit <= 0 {
+		activeRqLimit = defaultActiveRequestLimit
 	}
 	return &Runner{
-		requestLimiter:     rate.NewLimiter(rate.Limit(rpsLimit), rpsLimit),
-		logFetchLimitCh:    make(chan struct{}, rpsLimit),
+		taskSem:            make(chan struct{}, activeRqLimit),
 		runningTasks:       sets.New[string](),
 		runningTasksMu:     sync.RWMutex{},
 		runningTasksTicker: time.NewTicker(reportInterval),
@@ -111,11 +106,6 @@ func (r *Runner) Logs(namespace, pod, container string, previous, dryRun bool) (
 		return fmt.Sprintf("Dry run: would be running client.PodLogs(%s, %s, %s)", pod, namespace, container), nil
 	}
 	// ignore cancellation errors since this is subject to global timeout.
-	_ = r.requestLimiter.Wait(context.TODO())
-	r.logFetchLimitCh <- struct{}{}
-	defer func() {
-		<-r.logFetchLimitCh
-	}()
 	task := fmt.Sprintf("PodLogs %s/%s/%s", namespace, pod, container)
 	r.addRunningTask(task)
 	defer r.removeRunningTask(task)
@@ -127,7 +117,6 @@ func (r *Runner) EnvoyGet(namespace, pod, url string, dryRun bool) (string, erro
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running client.EnvoyDo(%s, %s, %s)", pod, namespace, url), nil
 	}
-	_ = r.requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("ProxyGet %s/%s:%s", namespace, pod, url)
 	r.addRunningTask(task)
 	defer r.removeRunningTask(task)
@@ -141,11 +130,6 @@ func (r *Runner) Cat(namespace, pod, container, path string, dryRun bool) (strin
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	_ = r.requestLimiter.Wait(context.TODO())
-	r.logFetchLimitCh <- struct{}{}
-	defer func() {
-		<-r.logFetchLimitCh
-	}()
 	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
 	r.addRunningTask(task)
 	defer r.removeRunningTask(task)
@@ -162,7 +146,6 @@ func (r *Runner) Exec(namespace, pod, container, cmdStr string, dryRun bool) (st
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	_ = r.requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
 	r.addRunningTask(task)
 	defer r.removeRunningTask(task)
@@ -214,7 +197,6 @@ func (r *Runner) Run(subcmds []string, opts *Options) (string, error) {
 		return "", nil
 	}
 
-	_ = r.requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("kubectl %s", cmdStr)
 	r.addRunningTask(task)
 	defer r.removeRunningTask(task)
@@ -240,6 +222,9 @@ func (r *Runner) printRunningTasks() {
 }
 
 func (r *Runner) addRunningTask(task string) {
+	// Limit the concurrency of running tasks.
+	r.taskSem <- struct{}{}
+
 	r.runningTasksMu.Lock()
 	defer r.runningTasksMu.Unlock()
 	log.Infof("STARTING %s", task)
@@ -247,6 +232,11 @@ func (r *Runner) addRunningTask(task string) {
 }
 
 func (r *Runner) removeRunningTask(task string) {
+	defer func() {
+		// Free up a slot for another running task.
+		<-r.taskSem
+	}()
+
 	r.runningTasksMu.Lock()
 	defer r.runningTasksMu.Unlock()
 	log.Infof("COMPLETED %s", task)


### PR DESCRIPTION
The `istioctl bug-report` currently limits the request rate to the kube API to 10 RPS. This is rather conservative and causes the bug report generation to take an unreasonable amount of time in some cases. This patch speeds things up by limiting request **concurrency** instead of request **rate**. It results in dramatic speed increases in my local testing (1:12 -> 0:15).

To protect the api server from overload in cases where request concurrency is low and the rate is high, the bug-report will rely on server-side rate limiting to mitigate the overload risk.

Before:
```
istioctl bug-report  9.38s user 3.41s system 17% cpu 1:12.19 total
```

After:
```
out/linux_amd64/istioctl bug-report  10.54s user 3.70s system 97% cpu 14.566 total
```