### PR TITLE
require linux node for deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
       affinity:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+      os:
+        name: linux
 {{- with .Values.pilot.tolerations }}
       tolerations:
 {{- toYaml . | nindent 8 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -58,8 +58,9 @@ spec:
 {{ toYaml .Values.pilot.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-{{- if .Values.pilot.nodeSelector }}
       nodeSelector:
+        kubernetes.io/os: linux
+{{- if .Values.pilot.nodeSelector }}
 {{ toYaml .Values.pilot.nodeSelector | indent 8 }}
 {{- end }}
 {{- with .Values.pilot.affinity }}


### PR DESCRIPTION
istiod does not run on windows, and as such should specify a linux node for running. to prevent being scheduled to a windows node.

fixes: #47723

Add a `nodeSelector` for istiod in the helm chart to ensure it only gets scheduled to a linux node.