### PR TITLE
iptables: stop panicing in leaf functions

### DIFF
--- a/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
@@ -122,10 +122,6 @@ type DependenciesStub struct {
 	ExecutedAll      []string
 }
 
-func (s *DependenciesStub) RunOrFail(cmd string, stdin io.ReadSeeker, args ...string) {
-	s.execute(false /*quietly*/, cmd, args...)
-}
-
 func (s *DependenciesStub) Run(cmd string, stdin io.ReadSeeker, args ...string) error {
 	s.execute(false /*quietly*/, cmd, args...)
 	return nil

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -199,7 +199,9 @@ func ProgramIptables(cfg *config.Config) error {
 	iptConfigurator := capture.NewIptablesConfigurator(cfg, ext)
 
 	if !cfg.SkipRuleApply {
-		iptConfigurator.Run()
+		if err := iptConfigurator.Run(); err != nil {
+			return err
+		}
 		if err := capture.ConfigureRoutes(cfg); err != nil {
 			return fmt.Errorf("failed to configure routes: %v", err)
 		}

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -17,14 +17,12 @@ package dependencies
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
@@ -136,20 +134,6 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 	}
 
 	return stderr
-}
-
-// RunOrFail runs a command and exits with an error message, if it fails
-func (r *RealDependencies) RunOrFail(cmd string, stdin io.ReadSeeker, args ...string) {
-	var err error
-	if XTablesCmds.Contains(cmd) {
-		err = r.executeXTables(cmd, false, stdin, args...)
-	} else {
-		err = r.execute(cmd, false, stdin, args...)
-	}
-	if err != nil {
-		log.Errorf("Failed to execute: %s %s, %v", cmd, strings.Join(args, " "), err)
-		os.Exit(-1)
-	}
 }
 
 // Run runs a command

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -18,8 +18,6 @@ import "io"
 
 // Dependencies is used as abstraction for the commands used from the operating system
 type Dependencies interface {
-	// RunOrFail runs a command and panics, if it fails. Stdin may be nil.
-	RunOrFail(cmd string, stdin io.ReadSeeker, args ...string)
 	// Run runs a command
 	Run(cmd string, stdin io.ReadSeeker, args ...string) error
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors


### PR DESCRIPTION
General best practice is for all functions to return `error`, and only
panic or os.Exit at top level command (or panic if invariant is
violated, but it isn't the case here).

This refactors to align with that practice. In particular, this makes it
reasonable to use this code outside of a single one-off CLI.
