### PR TITLE
Drop redundant test case in `TestServicesDiff`

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1549,16 +1549,6 @@ func TestServicesDiff(t *testing.T) {
 			unchanged: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 		{
-			name:    "same config with different name",
-			current: updatedHTTPDNS,
-			new: func() *config.Config {
-				c := updatedHTTPDNS.DeepCopy()
-				c.Name = "httpDNS1"
-				return &c
-			}(),
-			unchanged: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
-		},
-		{
 			name:    "different resolution",
 			current: updatedHTTPDNS,
 			new: func() *config.Config {


### PR DESCRIPTION
**Please provide a description of this PR:**

A config name cannot change. Droping redundant `same config with different name` case