### PR TITLE
redirect support rewrite the path by match prefix

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1591,7 +1591,11 @@ func createRedirectFilter(filter *k8s.HTTPRequestRedirectFilter) *istio.HTTPRedi
 		case k8sv1.FullPathHTTPPathModifier:
 			resp.Uri = *filter.Path.ReplaceFullPath
 		case k8sv1.PrefixMatchHTTPPathModifier:
-			resp.Uri = fmt.Sprintf("%%PREFIX()%%%s", *filter.Path.ReplacePrefixMatch)
+			resp.Uri = strings.TrimSuffix(*filter.Path.ReplacePrefixMatch, "/")
+			if resp.Uri == "" {
+				// `/` means removing the prefix
+				resp.Uri = "/"
+			}
 		}
 	}
 	return resp

--- a/releasenotes/notes/47773.yaml
+++ b/releasenotes/notes/47773.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** Issue redirect supports uri being replaced by prefix.


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently VirtualService's redirect does not support path prefix replacement, but this feature is supported in rewrite. If I want to redirect to implement prefix replacement, I need to implement it through EnvoyFilter, which makes the problem more complicated.