### PR TITLE
Fix ambient profile installation

### DIFF
--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -24,10 +24,9 @@ spec:
       enabled: false
 
   values:
-    ztunnel:
+    global:
       variant: distroless
     pilot:
-      variant: distroless
       env:
         # Setup more secure default that is off in 'default' only for backwards compatibility
         VERIFY_CERTIFICATE_AT_CLIENT: "true"
@@ -37,6 +36,7 @@ spec:
         CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     cni:
+      variant: "" # CNI distroless doesn't work yet.
       logLevel: info
       privileged: true
       ambient:


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently the ambient profile installation defaults to distroless. When I use my own built images, which are not distroless, and apply an overlay file:
```
hub: somehub
tag: sometag
values:
  global:
    variant: ""
```
I expect all the components to follow my default global settings, which should not have distroless. However the current behavior is that pilot and ztunnel still have the distroless suffix.