### PR TITLE
Refactor a little in HelmReconciler.ApplyManifest

### DIFF
--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -268,7 +268,7 @@ func applyWithReconciler(reconciler *helmreconciler.HelmReconciler, manifest str
 		Name:    name.IstioOperatorComponentName,
 		Content: manifest,
 	}
-	_, _, err := reconciler.ApplyManifest(m, false)
+	_, err := reconciler.ApplyManifest(m, false)
 	return err
 }
 

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -146,7 +146,7 @@ func applyManifest(kubeClient kube.Client, client client.Client, manifestStr str
 		Name:    componentName,
 		Content: manifestStr,
 	}
-	_, _, err = reconciler.ApplyManifest(ms, reconciler.CheckSSAEnabled())
+	_, err = reconciler.ApplyManifest(ms, reconciler.CheckSSAEnabled())
 	return err
 }
 

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -46,7 +46,7 @@ type AppliedResult struct {
 
 // Succeed returns true if the apply operation succeeded.
 func (r AppliedResult) Succeed() bool {
-	return len(r.processedObjects) > 0 && r.deployed > 0
+	return len(r.processedObjects) > 0 || r.deployed > 0
 }
 
 // ApplyManifest applies the manifest to create or update resources. It returns the processed (created or updated)

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -35,21 +35,33 @@ import (
 
 const fieldOwnerOperator = "istio-operator"
 
+// AppliedResult is the result of applying a Manifest.
+type AppliedResult struct {
+	// processedObjects is the list of objects that were processed in this apply operation.
+	processedObjects object.K8sObjects
+	// deployed is the number of objects have been deployed which means
+	// it's in the cache and it's not changed from the cache.
+	deployed int
+}
+
+// Succeed returns true if the apply operation succeeded.
+func (r AppliedResult) Succeed() bool {
+	return len(r.processedObjects) > 0 && r.deployed > 0
+}
+
 // ApplyManifest applies the manifest to create or update resources. It returns the processed (created or updated)
 // objects and the number of objects in the manifests.
-func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply bool) (object.K8sObjects, int, error) {
-	var processedObjects object.K8sObjects
-	var deployedObjects int
+func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply bool) (result AppliedResult, _ error) {
 	cname := string(manifest.Name)
 	crHash, err := h.getCRHash(cname)
 	if err != nil {
-		return nil, 0, err
+		return result, err
 	}
 
 	scope.Infof("Processing resources from manifest: %s for CR %s", cname, crHash)
 	allObjects, err := object.ParseK8sObjectsFromYAMLManifest(manifest.Content)
 	if err != nil {
-		return nil, 0, err
+		return result, err
 	}
 
 	objectCache := cache.GetCache(crHash)
@@ -71,7 +83,7 @@ func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply b
 		if co, ok := objectCache.Cache[oh]; ok && obj.Equal(co) {
 			// Object is in the cache and unchanged.
 			metrics.AddResource(obj.FullName(), obj.GroupVersionKind().GroupKind())
-			deployedObjects++
+			result.deployed++
 			continue
 		}
 		changedObjects = append(changedObjects, obj)
@@ -96,15 +108,15 @@ func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply b
 		for _, obj := range objList {
 			obju := obj.UnstructuredObject()
 			if err := h.applyLabelsAndAnnotations(obju, cname); err != nil {
-				return nil, 0, err
+				return result, err
 			}
 			if err := h.ApplyObject(obj.UnstructuredObject(), serverSideApply); err != nil {
 				plog.ReportError(err.Error())
-				return processedObjects, 0, err
+				return result, err
 			}
 			plog.ReportProgress()
 			metrics.AddResource(obj.FullName(), obj.GroupVersionKind().GroupKind())
-			processedObjects = append(processedObjects, obj)
+			result.processedObjects = append(result.processedObjects, obj)
 			// Update the cache with the latest object.
 			objectCache.Cache[obj.Hash()] = obj
 		}
@@ -123,17 +135,17 @@ func (h *HelmReconciler) ApplyManifest(manifest name.Manifest, serverSideApply b
 	}
 
 	if len(changedObjectKeys) > 0 {
-		err := WaitForResources(processedObjects, h.kubeClient,
+		err := WaitForResources(result.processedObjects, h.kubeClient,
 			h.opts.WaitTimeout, h.opts.DryRun, plog)
 		if err != nil {
 			werr := fmt.Errorf("failed to wait for resource: %v", err)
 			plog.ReportError(werr.Error())
-			return processedObjects, 0, werr
+			return result, werr
 		}
 		plog.ReportFinished()
 
 	}
-	return processedObjects, deployedObjects, nil
+	return result, nil
 }
 
 // ApplyObject creates or updates an object in the API server depending on whether it already exists.

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -198,8 +198,7 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 		c, ms := c, ms
 		wg.Add(1)
 		go func() {
-			var processedObjs object.K8sObjects
-			var deployedObjects int
+			var appliedResult AppliedResult
 			defer wg.Done()
 			if s := h.dependencyWaitCh[c]; s != nil {
 				scope.Infof("%s is waiting on dependency...", c)
@@ -220,10 +219,10 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 					Name:    c,
 					Content: name.MergeManifestSlices(ms),
 				}
-				processedObjs, deployedObjects, err = h.ApplyManifest(m, serverSideApply)
+				appliedResult, err = h.ApplyManifest(m, serverSideApply)
 				if err != nil {
 					status = v1alpha1.InstallStatus_ERROR
-				} else if len(processedObjs) != 0 || deployedObjects > 0 {
+				} else if appliedResult.Succeed() {
 					status = v1alpha1.InstallStatus_HEALTHY
 				}
 			}

--- a/tests/fuzz/helm_reconciler_fuzzer.go
+++ b/tests/fuzz/helm_reconciler_fuzzer.go
@@ -58,6 +58,6 @@ func FuzzHelmReconciler(data []byte) int {
 	}
 	_ = h.ApplyObject(obj, false)
 	_, _ = h.Reconcile()
-	_, _, _ = h.ApplyManifest(m, false)
+	_, _ = h.ApplyManifest(m, false)
 	return 1
 }


### PR DESCRIPTION
In current implementation of `HelmReconciler.ApplyManifest`, it returns 3 args and they dont be used in most of cases.
So in this PR, we define `AppliedResult` to make it more understandable.

Nothing changed in change anything in functional.

**Please provide a description of this PR:**