### PR TITLE
Fix RBAC permissions for status reporter

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -28,6 +28,11 @@ rules:
     verbs: ["update"]
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]
+
+  # Needed because status reporter sets the config map owner reference to the istiod pod
+  - apiGroups: [""]
+    verbs: ["update"]
+    resources: ["pods/finalizers"]
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -29,6 +29,11 @@ rules:
     verbs: ["update"]
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]
+
+  # Needed because status reporter sets the config map owner reference to the istiod pod
+  - apiGroups: [""]
+    verbs: ["update"]
+    resources: ["pods/finalizers"]
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]


### PR DESCRIPTION
This fixes this error:
```
error	status	configmaps "istiod-767f4ff6db-r789m-distribution" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

When running in a cluster with the
`OwnerReferencesPermissionEnforcement` plugin enabled: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
