### PR TITLE
Fix internal-debug syncz not working with agent, and add support for debug type `config_dump `

### DIFF
--- a/istioctl/pkg/internaldebug/internal-debug.go
+++ b/istioctl/pkg/internaldebug/internal-debug.go
@@ -125,18 +125,17 @@ By default it will use the default serviceAccount from (istio-system) namespace 
 					Err: fmt.Errorf("debug type is required"),
 				}
 			}
-			var xdsRequest discovery.DiscoveryRequest
+			var xdsRequest *discovery.DiscoveryRequest
 			var namespace, serviceAccount string
 
-			xdsRequest = discovery.DiscoveryRequest{
-				ResourceNames: []string{args[0]},
+			xdsRequest = &discovery.DiscoveryRequest{
 				Node: &core.Node{
 					Id: "debug~0.0.0.0~istioctl~cluster.local",
 				},
-				TypeUrl: v3.DebugType,
+				TypeUrl: v3.DebugType + "/" + args[0],
 			}
 
-			xdsResponses, err := multixds.MultiRequestAndProcessXds(internalDebugAllIstiod, &xdsRequest, centralOpts, ctx.IstioNamespace(),
+			xdsResponses, err := multixds.MultiRequestAndProcessXds(internalDebugAllIstiod, xdsRequest, centralOpts, ctx.IstioNamespace(),
 				namespace, serviceAccount, kubeClient, multixds.DefaultOptions)
 			if err != nil {
 				return err

--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -91,7 +91,8 @@ func TestPiggyback(t *testing.T) {
 					"internal-debug",
 					"syncz",
 					"--plaintext",
-					"--xds-address", pf.Address()}
+					"--xds-address", pf.Address(),
+				}
 				output, _, err := istioCtl.Invoke(args)
 				if err != nil {
 					return err

--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -86,7 +86,12 @@ func TestPiggyback(t *testing.T) {
 				defer pf.Close()
 
 				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Clusters().Default()})
-				args := []string{"x", "proxy-status", "--plaintext", "--xds-address", pf.Address()}
+				args := []string{
+					"x",
+					"internal-debug",
+					"syncz",
+					"--plaintext",
+					"--xds-address", pf.Address()}
 				output, _, err := istioCtl.Invoke(args)
 				if err != nil {
 					return err


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently if I do:
```
istioctl x internal-debug syncz  --xds-address localhost:15004 --plaintext
```
I get no response.

Also, replace `x ps` with `x internal-debug syncz`. This is a prerequisite of https://github.com/istio/istio/pull/47740.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
