### PR TITLE
remove error message in istioctl operator

### DIFF
--- a/operator/cmd/operator/main.go
+++ b/operator/cmd/operator/main.go
@@ -18,10 +18,15 @@ import (
 	"os"
 
 	"istio.io/istio/pkg/log"
+	controllruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func main() {
 	log.EnableKlogWithCobra()
+	// adding to remove message about the controller-runtime logs not getting displayed
+	scope := log.RegisterScope("controlleruntime", "scope for controller runtime")
+	controllruntimelog.SetLogger(log.NewLogrAdapter(scope))
+
 	rootCmd := getRootCmd(os.Args[1:])
 
 	if err := rootCmd.Execute(); err != nil {

--- a/operator/cmd/operator/main.go
+++ b/operator/cmd/operator/main.go
@@ -17,8 +17,9 @@ package main
 import (
 	"os"
 
-	"istio.io/istio/pkg/log"
 	controllruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"istio.io/istio/pkg/log"
 )
 
 func main() {


### PR DESCRIPTION
Looks like when using the operator to install Istio the following message is getting spit out:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 364 [running]:
	>  runtime/debug.Stack()
	>  	runtime/debug/stack.go:24 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithValues(0xc000854a00, {0xc0014c52c0, 0x6, 0x6})
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/deleg.go:168 +0x49
	>  github.com/go-logr/logr.Logger.WithValues(...)
	>  	github.com/go-logr/logr@v1.2.4/logr.go:323
	>  sigs.k8s.io/controller-runtime/pkg/controller.NewUnmanaged.func1(0xc00011e3e0)
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/controller/controller.go:121 +0x1d7
	>  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000af54a0, {0x3614f68, 0xc000985d10}, {0x2bf6780?, 0xc00011e3c0?})
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:306 +0x16a
	>  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000af54a0, {0x3614f68, 0xc000985d10})
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266 +0x1c9
	>  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227 +0x79
	>  created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 100
	>  	sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:223 +0x565
```

It doesn't look like there is any issue with the operator it just seems to be an issue with the logging.

Using this PR to remove that message.  With the changes in the PR now see the following added to the logs
```
2023-11-09T17:55:51.162265Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *v1alpha1.IstioOperator
2023-11-09T17:55:51.162414Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162443Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162466Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162503Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162527Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162550Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162577Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162621Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162649Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162688Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162712Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162747Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162792Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162815Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162867Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162900Z	info	controlleruntime	Starting EventSource	controller=istiocontrolplane-controller source=kind source: *unstructured.Unstructured
2023-11-09T17:55:51.162940Z	info	controlleruntime	Starting Controller	controller=istiocontrolplane-controller
2023-11-09T17:55:52.987736Z	info	controlleruntime	Starting workers	controller=istiocontrolplane-controller worker count=1
```