### PR TITLE
istioctl: subcommand tag support set tags for config validation

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags-validating.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags-validating.yaml
@@ -1,0 +1,59 @@
+{{- if $.Values.global.configValidation }}
+# Adapted from istio-discovery/templates/validatingwebhookconfiguration.yaml
+{{- range $tagName := $.Values.revisionTags }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+{{- if eq $.Release.Namespace "istio-system"}}
+  name: istio-revision-tag-{{ $tagName }}
+{{- else }}
+  name: istio-revision-tag-{{ $tagName }}-{{ $.Release.Namespace }}
+{{- end }}
+  labels:
+    app: istiod
+    release: {{ $.Release.Name }}
+    istio: istiod
+    istio.io/rev: {{ $.Values.revision | default "default" }}
+    istio.io/tag: {{ $tagName }}
+webhooks:
+  - name: rev.validation.istio.io
+    clientConfig:
+      {{- if $.Values.base.validationURL }}
+      url: {{ $.Values.base.validationURL }}
+      {{- else }}
+      service:
+        name: istiod{{- if not (eq $.Values.revision "") }}-{{ $.Values.revision }}{{- end }}
+        namespace: {{ $.Values.global.istioNamespace }}
+        path: "/validate"
+      {{- end }}
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+          {{- if $.Values.base.validateGateway }}
+          - gateway.networking.k8s.io
+          {{- end }}
+        apiVersions:
+          - "*"
+        resources:
+          - "*"
+    # Fail open until the validation webhook is ready. The webhook controller
+    # will update this to `Fail` and patch in the `caBundle` when the webhook
+    # endpoint is ready.
+    failurePolicy: Ignore
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
+    objectSelector:
+      matchExpressions:
+        - key: istio.io/rev
+          operator: In
+          values:
+          - "{{ $tagName }}"
+---
+{{- end }}
+{{- end }}


### PR DESCRIPTION
**Please provide a description of this PR:**

The `istioctl tag` does not currently support `ValidatingWebhook`, this pr tries to add support for it.





Add the "--disable-config-validation" flag to the "istioctl tag set/generate" command. Use this tag to satisfy the "values.global.configValidation=false" setting during installation.