### PR TITLE
Improve validate error message

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -233,7 +233,8 @@ func GetTemplateLabels(u *unstructured.Unstructured) (map[string]string, error) 
 	return nil, nil
 }
 
-func (v *validator) validateFile(istioNamespace *string, defaultNamespace string, reader io.Reader, writer io.Writer) (validation.Warning, error) {
+func (v *validator) validateFile(path string, istioNamespace *string, defaultNamespace string, reader io.Reader, writer io.Writer,
+) (validation.Warning, error) {
 	decoder := yaml.NewDecoder(reader)
 	decoder.SetStrict(true)
 	var errs error
@@ -246,7 +247,7 @@ func (v *validator) validateFile(istioNamespace *string, defaultNamespace string
 			return warnings, errs
 		}
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("failed to decode file %s: ", path)))
 			return warnings, errs
 		}
 		if len(raw) == 0 {
@@ -293,7 +294,7 @@ func validateFiles(istioNamespace *string, defaultNamespace string, filenames []
 				return
 			}
 		}
-		warning, err := v.validateFile(istioNamespace, defaultNamespace, reader, writer)
+		warning, err := v.validateFile(path, istioNamespace, defaultNamespace, reader, writer)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
Add a file path prefix to the decode error, to let users know which file has format error.

```
 istioctl validate -f samples/
...
Error: 4 errors occurred:
        * failed to decode file samples/ambient-argo/tag-chart/templates/mutatingwebhooks.yaml:  yaml: did not find expected node content
        * failed to decode file samples/ambient-argo/tag-chart/templates/shimservice.yaml:  yaml: did not find expected node content
        * failed to decode file samples/ambient-argo/tag-chart/templates/validatingwebhook.yaml:  yaml: did not find expected node content
        * failed to decode file samples/bookinfo/src/mongodb/ratings_data.json:  yaml: line 1: did not find expected <document start>

```