### PR TITLE
self-signed root cert rotate should also trigger istiod server to reload certificate

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -189,7 +189,7 @@ func (s *Server) RotateDNSCertForK8sCA(stop <-chan struct{},
 ) {
 	certUtil := certutil.NewCertUtil(int(defaultCertGracePeriodRatio * 100))
 	for {
-		waitTime, _ := certUtil.GetWaitTime(s.istiodCertBundleWatcher.GetKeyCertBundle().CertPem, time.Now(), time.Duration(0))
+		waitTime, _ := certUtil.GetWaitTime(s.istiodCertBundleWatcher.GetKeyCertBundle().CertPem, time.Now())
 		if !sleep.Until(stop, waitTime) {
 			return
 		}

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -203,8 +203,9 @@ func (s *Server) RotateDNSCertForK8sCA(stop <-chan struct{},
 	}
 }
 
-// updatePluggedinRootCertAndGenKeyCert when intermediate CA is updated, it generates new dns certs and notifies keycertbundle about the changes
-func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
+// updateRootCertAndGenKeyCert when CA certs is updated, it generates new dns certs and notifies keycertbundle about the changes
+func (s *Server) updateRootCertAndGenKeyCert() error {
+	log.Infof("update root cert and generate new dns certs")
 	caBundle := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 	certChain, keyPEM, err := s.CA.GenKeyCert(s.dnsNames, SelfSignedCACertTTL.Get(), false)
 	if err != nil {
@@ -213,7 +214,7 @@ func (s *Server) updatePluggedinRootCertAndGenKeyCert() error {
 
 	if features.MultiRootMesh {
 		// Trigger trust anchor update, this will send PCDS to all sidecars.
-		log.Debugf("Update trust anchor with new root cert")
+		log.Infof("Update trust anchor with new root cert")
 		err = s.workloadTrustBundle.UpdateTrustAnchor(&tb.TrustAnchorUpdate{
 			TrustAnchorConfig: tb.TrustAnchorConfig{Certs: []string{string(caBundle)}},
 			Source:            tb.SourceIstioCA,

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -295,7 +295,6 @@ func (s *Server) loadCACerts(caOpts *caOptions, dir string) error {
 // newly introduced cacerts are intermediate CA which is generated
 // from cuurent root-cert.pem. Then it updates and keycertbundle
 // and generates new dns certs.
-// TODO(rveerama1): Add support for new ROOT-CA rotation also.
 func handleEvent(s *Server) {
 	log.Info("Update Istiod cacerts")
 
@@ -468,6 +467,7 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 
 		s.initCACertsWatcher()
 	}
+	caOpts.OnRootCertUpdate = s.updatePluggedinRootCertAndGenKeyCert
 	istioCA, err := ca.NewIstioCA(caOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an istiod CA: %v", err)

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -343,7 +343,7 @@ func handleEvent(s *Server) {
 		return
 	}
 
-	err = s.updatePluggedinRootCertAndGenKeyCert()
+	err = s.updateRootCertAndGenKeyCert()
 	if err != nil {
 		log.Errorf("Failed generating plugged-in istiod key cert: %v", err)
 		return
@@ -456,6 +456,7 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 		if err != nil {
 			return nil, err
 		}
+		caOpts.OnRootCertUpdate = s.updateRootCertAndGenKeyCert
 	} else {
 		// The secret is mounted and the "istio-generated" key is not used.
 		log.Info("Use local CA certificate")
@@ -467,7 +468,6 @@ func (s *Server) createIstioCA(opts *caOptions) (*ca.IstioCA, error) {
 
 		s.initCACertsWatcher()
 	}
-	caOpts.OnRootCertUpdate = s.updatePluggedinRootCertAndGenKeyCert
 	istioCA, err := ca.NewIstioCA(caOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an istiod CA: %v", err)

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -113,7 +113,12 @@ type IstioCAOptions struct {
 
 	// Config for creating self-signed root cert rotator.
 	RotatorConfig *SelfSignedCARootCertRotatorConfig
+
+	// OnRootCertUpdate is the cb which can only be called by root cert rotator
+	OnRootCertUpdate func() error
 }
+
+type RootCertUpdateFunc func() error
 
 // NewSelfSignedIstioCAOptions returns a new IstioCAOptions instance using self-signed certificate.
 func NewSelfSignedIstioCAOptions(ctx context.Context,
@@ -200,6 +205,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 		}
 		return err
 	})
+	pkiCaLog.Infof("Set secret name for self-signed CA cert rotator to %s", caCertName)
 	caOpts.RotatorConfig.secretName = caCertName
 	return caOpts, err
 }
@@ -216,7 +222,6 @@ func loadSelfSignedCaSecret(client corev1.CoreV1Interface, namespace string, caC
 			caSecret.Data[CAPrivateKeyFile], nil, rootCerts); err != nil {
 			return fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
 		}
-		pkiCaLog.Infof("Set secret name for self-signed CA cert rotator to %s", caCertName)
 		pkiCaLog.Infof("Using existing public key: %v", string(rootCerts))
 	}
 	return err
@@ -344,7 +349,7 @@ func NewIstioCA(opts *IstioCAOptions) (*IstioCA, error) {
 	}
 
 	if opts.CAType == selfSignedCA && opts.RotatorConfig != nil && opts.RotatorConfig.CheckInterval > time.Duration(0) {
-		ca.rootCertRotator = NewSelfSignedCARootCertRotator(opts.RotatorConfig, ca)
+		ca.rootCertRotator = NewSelfSignedCARootCertRotator(opts.RotatorConfig, ca, opts.OnRootCertUpdate)
 	}
 
 	// if CA cert becomes invalid before workload cert it's going to cause workload cert to be invalid too,

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -114,7 +114,7 @@ type IstioCAOptions struct {
 	// Config for creating self-signed root cert rotator.
 	RotatorConfig *SelfSignedCARootCertRotatorConfig
 
-	// OnRootCertUpdate is the cb which can only be called by root cert rotator
+	// OnRootCertUpdate is the cb which can only be called by self-signed root cert rotator
 	OnRootCertUpdate func() error
 }
 

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -163,7 +163,7 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 				rootCertRotatorLog.Info("Successfully reloaded root cert into KeyCertBundle.")
 			}
 			if rotator.onRootCertUpdate != nil {
-				rotator.onRootCertUpdate()
+				_ = rotator.onRootCertUpdate()
 			}
 		}
 		return
@@ -250,7 +250,7 @@ func (rotator *SelfSignedCARootCertRotator) updateRootCertificate(caSecret *v1.S
 	}
 	rootCertRotatorLog.Infof("Root certificate is updated in CA KeyCertBundle: %v", string(cert))
 	if rotator.onRootCertUpdate != nil {
-		rotator.onRootCertUpdate()
+		_ = rotator.onRootCertUpdate()
 	}
 	return false, nil
 }

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -53,6 +53,7 @@ type SelfSignedCARootCertRotator struct {
 	config             *SelfSignedCARootCertRotatorConfig
 	backOffTime        time.Duration
 	ca                 *IstioCA
+	onRootCertUpdate   func() error
 }
 
 // NewSelfSignedCARootCertRotator returns a new root cert rotator instance that
@@ -61,11 +62,13 @@ type SelfSignedCARootCertRotator struct {
 // Not security sensitive code
 func NewSelfSignedCARootCertRotator(config *SelfSignedCARootCertRotatorConfig,
 	ca *IstioCA,
+	onRootCertUpdate func() error,
 ) *SelfSignedCARootCertRotator {
 	rotator := &SelfSignedCARootCertRotator{
 		caSecretController: controller.NewCaSecretController(config.client),
 		config:             config,
 		ca:                 ca,
+		onRootCertUpdate:   onRootCertUpdate,
 	}
 	if config.enableJitter {
 		// Select a back off time in seconds, which is in the range of [0, rotator.config.CheckInterval).
@@ -137,7 +140,7 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 		return
 	}
 	// Check root certificate expiration time in CA secret
-	waitTime, err := rotator.config.certInspector.GetWaitTime(caSecret.Data[CACertFile], time.Now(), time.Duration(0))
+	waitTime, err := rotator.config.certInspector.GetWaitTime(caSecret.Data[CACertFile], time.Now())
 	if err == nil && waitTime > 0 {
 		rootCertRotatorLog.Info("Root cert is not about to expire, skipping root cert rotation.")
 		caCertInMem, _, _, _ := rotator.ca.GetCAKeyCertBundle().GetAllPem()
@@ -152,11 +155,15 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 				rootCertRotatorLog.Errorf("failed to append root certificates from file: %s", err.Error())
 				return
 			}
+
 			if err := rotator.ca.GetCAKeyCertBundle().VerifyAndSetAll(caSecret.Data[CACertFile],
 				caSecret.Data[CAPrivateKeyFile], nil, rootCerts); err != nil {
 				rootCertRotatorLog.Errorf("failed to reload root cert into KeyCertBundle (%v)", err)
 			} else {
 				rootCertRotatorLog.Info("Successfully reloaded root cert into KeyCertBundle.")
+			}
+			if rotator.onRootCertUpdate != nil {
+				rotator.onRootCertUpdate()
 			}
 		}
 		return
@@ -242,6 +249,8 @@ func (rotator *SelfSignedCARootCertRotator) updateRootCertificate(caSecret *v1.S
 		return false, fmt.Errorf("failed to update CA KeyCertBundle (error: %s)", err.Error())
 	}
 	rootCertRotatorLog.Infof("Root certificate is updated in CA KeyCertBundle: %v", string(cert))
-
+	if rotator.onRootCertUpdate != nil {
+		rotator.onRootCertUpdate()
+	}
 	return false, nil
 }

--- a/security/pkg/util/certutil.go
+++ b/security/pkg/util/certutil.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 	"time"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/util"
 )
 
 // CertUtil is an interface for utility functions on certificate.
 type CertUtil interface {
 	// GetWaitTime returns the waiting time before renewing the certificate.
-	GetWaitTime([]byte, time.Time, time.Duration) (time.Duration, error)
+	GetWaitTime([]byte, time.Time) (time.Duration, error)
 }
 
 // CertUtilImpl is the implementation of CertUtil, for production use.
@@ -42,7 +41,7 @@ func NewCertUtil(gracePeriodPercentage int) CertUtilImpl {
 
 // GetWaitTime returns the waiting time before renewing the cert, based on current time, the timestamps in cert and
 // grace period.
-func (cu CertUtilImpl) GetWaitTime(certBytes []byte, now time.Time, minGracePeriod time.Duration) (time.Duration, error) {
+func (cu CertUtilImpl) GetWaitTime(certBytes []byte, now time.Time) (time.Duration, error) {
 	cert, certErr := util.ParsePemEncodedCertificate(certBytes)
 	if certErr != nil {
 		return time.Duration(0), certErr
@@ -55,12 +54,6 @@ func (cu CertUtilImpl) GetWaitTime(certBytes []byte, now time.Time, minGracePeri
 	// Note: multiply time.Duration(int64) by an int (gracePeriodPercentage) will cause overflow (e.g.,
 	// when duration is time.Hour * 90000). So float64 is used instead.
 	gracePeriod := time.Duration(float64(cert.NotAfter.Sub(cert.NotBefore)) * (float64(cu.gracePeriodPercentage) / 100))
-	if gracePeriod < minGracePeriod {
-		log.Warnf("gracePeriod (%v * %f) = %v is less than minGracePeriod %v. Apply minGracePeriod.",
-			cert.NotAfter.Sub(cert.NotBefore), float64(cu.gracePeriodPercentage/100), gracePeriod, minGracePeriod)
-		gracePeriod = minGracePeriod
-	}
-
 	// waitTime is the duration between now and the grace period starts.
 	// It is the time until cert expiration minus the length of grace period.
 	waitTime := timeToExpire - gracePeriod

--- a/security/pkg/util/certutil_test.go
+++ b/security/pkg/util/certutil_test.go
@@ -38,7 +38,6 @@ func TestGetWaitTime(t *testing.T) {
 		now              time.Time
 		expectedWaitTime int
 		expectedErr      string
-		minGracePeriod   time.Duration
 	}{
 		"Success": {
 			// Now = 2017-08-23 21:00:40 +0000 UTC
@@ -48,17 +47,6 @@ func TestGetWaitTime(t *testing.T) {
 			cert:             testCert,
 			now:              time.Date(2017, time.August, 23, 21, 0, 0, 40, time.UTC),
 			expectedWaitTime: 36039,
-			minGracePeriod:   time.Duration(0),
-		},
-		"Success with min grace period": {
-			// Now = 2017-08-23 21:00:40 +0000 UTC
-			// Cert TTL is 24h, and grace period is 50% of TTL, that is 12h.
-			// The cert expires at 2017-08-24 19:00:40 +0000 UTC, so the grace period starts at 2017-08-24 07:00:40 +0000 UTC
-			// The wait time is the duration from fake now to the grace period start time, which is 10h39s (36039s).
-			cert:             testCert,
-			now:              time.Date(2017, time.August, 23, 21, 0, 0, 40, time.UTC),
-			expectedWaitTime: 32439,
-			minGracePeriod:   13 * time.Hour,
 		},
 		"Cert expired": {
 			// Now = 2017-08-25 21:00:40 +0000 UTC.
@@ -67,37 +55,25 @@ func TestGetWaitTime(t *testing.T) {
 			now:  time.Date(2017, time.August, 25, 21, 0, 0, 40, time.UTC),
 			expectedErr: "certificate already expired at 2017-08-24 19:00:40 +0000" +
 				" UTC, but now is 2017-08-25 21:00:00.00000004 +0000 UTC",
-			minGracePeriod: time.Duration(0),
 		},
 		"Renew now": {
 			// Now = 2017-08-24 16:00:40 +0000 UTC
 			// Now is later than the start of grace period 2017-08-24 07:00:40 +0000 UTC, but earlier than
 			// cert expiration 2017-08-24 19:00:40 +0000 UTC.
-			cert:           testCert,
-			now:            time.Date(2017, time.August, 24, 16, 0, 0, 40, time.UTC),
-			expectedErr:    "got a certificate that should be renewed now",
-			minGracePeriod: time.Duration(0),
-		},
-		"Renew now with min grace period": {
-			// Now = 2017-08-24 6:00:40 +0000 UTC
-			// Now is earlier than the start of default grace period 2017-08-24 07:00:40 +0000 UTC, but with min grace period,
-			// the cert is in grace period after 2017-08-24 5:00:40 +0000 UTC.
-			cert:           testCert,
-			now:            time.Date(2017, time.August, 24, 6, 0, 40, 0, time.UTC),
-			expectedErr:    "got a certificate that should be renewed now",
-			minGracePeriod: 14 * time.Hour,
+			cert:        testCert,
+			now:         time.Date(2017, time.August, 24, 16, 0, 0, 40, time.UTC),
+			expectedErr: "got a certificate that should be renewed now",
 		},
 		"Invalid cert pem": {
-			cert:           []byte(`INVALIDCERT`),
-			now:            time.Date(2017, time.August, 23, 21, 0, 0, 40, time.UTC),
-			expectedErr:    "invalid PEM encoded certificate",
-			minGracePeriod: time.Duration(0),
+			cert:        []byte(`INVALIDCERT`),
+			now:         time.Date(2017, time.August, 23, 21, 0, 0, 40, time.UTC),
+			expectedErr: "invalid PEM encoded certificate",
 		},
 	}
 
 	cu := NewCertUtil(50) // Grace period percentage is set to 50
 	for id, c := range testCases {
-		waitTime, err := cu.GetWaitTime(c.cert, c.now, c.minGracePeriod)
+		waitTime, err := cu.GetWaitTime(c.cert, c.now)
 		if c.expectedErr != "" {
 			if err == nil {
 				t.Errorf("%s: no error is returned.", id)

--- a/security/pkg/util/mock/fakecertutil.go
+++ b/security/pkg/util/mock/fakecertutil.go
@@ -23,7 +23,7 @@ type FakeCertUtil struct {
 }
 
 // GetWaitTime returns duration if err is nil, otherwise, it returns err.
-func (f FakeCertUtil) GetWaitTime(certBytes []byte, now time.Time, minGracePeriod time.Duration) (time.Duration, error) {
+func (f FakeCertUtil) GetWaitTime(certBytes []byte, now time.Time) (time.Duration, error) {
 	if f.Err != nil {
 		return time.Duration(0), f.Err
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

Self-signed root cert rotator does not work when it rotates root cert. It should trigger istiod to resign the certs for its grpc server.

And should update the namespace scoped root cert configmap