### PR TITLE
reduce fallback scope

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -67,8 +67,15 @@ func (hc hostClassification) Matches(h host.Name) bool {
 	if hc.exactHosts.Contains(h) {
 		return true
 	}
+
 	// exactHosts not found, fallback to loop allHosts
+	hIsWildCarded := h.IsWildCarded()
 	for _, importedHost := range hc.allHosts {
+		// If both are exact hosts, then fallback is not needed.
+		// In this scenario it should be determined by exact lookup.
+		if !hIsWildCarded && !importedHost.IsWildCarded() {
+			continue
+		}
 		// Check if the hostnames match per usual hostname matching rules
 		if h.SubsetOf(importedHost) {
 			return true

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -52,7 +52,13 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 			}
 
 			// exactHosts not found, fallback to loop allHosts
+			vhIsWildCard := host.Name(vh).IsWildCarded()
 			for _, ah := range hosts.allHosts {
+				// If both are exact hosts, then fallback is not needed.
+				// In this scenario it should be determined by exact lookup.
+				if !vhIsWildCard && !ah.IsWildCarded() {
+					continue
+				}
 				if vsHostMatches(vh, ah, vs) {
 					importedVirtualServices = append(importedVirtualServices, vs)
 					vsset.Insert(key)


### PR DESCRIPTION
Benchmark test results show that the performance of exact host matching has been significantly improved.
```
$ benchstat old.txt new.txt
goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/model
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                                                  │   old.txt    │               new.txt               │
                                                  │    sec/op    │    sec/op     vs base               │
ConvertIstioListenerToWrapper/small-exact-12         3.204µ ± 1%   2.737µ ±  1%  -14.56% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-12      1.827µ ± 1%   1.887µ ±  1%   +3.31% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-match-all-12     5.413µ ± 2%   5.447µ ± 19%        ~ (p=0.240 n=6)
ConvertIstioListenerToWrapper/middle-exact-12        32.62µ ± 2%   17.08µ ± 25%  -47.64% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-12     32.66µ ± 2%   33.11µ ±  0%   +1.39% (p=0.041 n=6)
ConvertIstioListenerToWrapper/middle-match-all-12    49.66µ ± 1%   50.38µ ±  2%   +1.45% (p=0.015 n=6)
ConvertIstioListenerToWrapper/big-exact-12          125.13µ ± 8%   46.57µ ±  2%  -62.78% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-12        127.4µ ± 1%   131.8µ ±  1%   +3.46% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-match-all-12       149.2µ ± 2%   148.2µ ±  2%        ~ (p=0.394 n=6)
geomean                                              25.12µ        20.80µ        -17.20%

                                                  │   old.txt    │               new.txt                │
                                                  │     B/op     │     B/op      vs base                │
ConvertIstioListenerToWrapper/small-exact-12        2.289Ki ± 0%   2.289Ki ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-wildcard-12       400.0 ± 0%     400.0 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-match-all-12    9.316Ki ± 0%   9.316Ki ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-exact-12       11.29Ki ± 0%   11.29Ki ± 0%       ~ (p=1.000 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-12    1.781Ki ± 0%   1.781Ki ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-match-all-12   94.83Ki ± 0%   94.83Ki ± 0%       ~ (p=0.857 n=6)
ConvertIstioListenerToWrapper/big-exact-12          15.50Ki ± 0%   15.50Ki ± 0%       ~ (p=0.574 n=6)
ConvertIstioListenerToWrapper/big-wildcard-12       3.688Ki ± 0%   3.688Ki ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-match-all-12      323.4Ki ± 0%   323.4Ki ± 0%       ~ (p=0.667 n=6)
geomean                                             8.727Ki        8.727Ki       +0.00%
¹ all samples are equal

                                                  │  old.txt   │              new.txt               │
                                                  │ allocs/op  │ allocs/op   vs base                │
ConvertIstioListenerToWrapper/small-exact-12        16.00 ± 0%   16.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-wildcard-12     9.000 ± 0%   9.000 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/small-match-all-12    17.00 ± 0%   17.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-exact-12       32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-wildcard-12    18.00 ± 0%   18.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/middle-match-all-12   32.00 ± 0%   32.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-exact-12          39.00 ± 0%   39.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-wildcard-12       23.00 ± 0%   23.00 ± 0%       ~ (p=1.000 n=6) ¹
ConvertIstioListenerToWrapper/big-match-all-12      39.00 ± 0%   39.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                             22.67        22.67       +0.00%
¹ all samples are equal
```