### PR TITLE
Remove runAs from test deployment files

### DIFF
--- a/pkg/test/echo/docker/Dockerfile.app
+++ b/pkg/test/echo/docker/Dockerfile.app
@@ -9,4 +9,8 @@ COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
 COPY certs/cert.crt /cert.crt
 COPY certs/cert.key /cert.key
 
+# Add a user that will run the application. This allows running as this user and capture iptables
+RUN useradd -m --uid 1338 application
+USER 1338
+
 ENTRYPOINT ["/usr/local/bin/server"]

--- a/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
+++ b/pkg/test/framework/components/echo/cmd/echogen/testdata/golden.yaml
@@ -155,9 +155,6 @@ spec:
             port: 8080
           initialDelaySeconds: 1
           periodSeconds: 2
-        securityContext:
-          runAsGroup: 1338
-          runAsUser: 1338
         startupProbe:
           failureThreshold: 10
           periodSeconds: 1

--- a/pkg/test/framework/components/echo/kube/templates/deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/deployment.yaml
@@ -99,9 +99,6 @@ spec:
         image: {{ $.ImageHub }}/app:{{ $.ImageTag }}
 {{- end }}
         imagePullPolicy: {{ $.ImagePullPolicy }}
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
 {{- if $appContainer.FallbackPort }}
           - --forwarding_address=0.0.0.0:{{ $appContainer.FallbackPort }}

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -47,9 +47,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/disable-automount-sa.yaml
@@ -54,9 +54,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -48,9 +48,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions-no-proxy.yaml
@@ -43,9 +43,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0
@@ -118,9 +115,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiple-istio-versions.yaml
@@ -48,9 +48,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0
@@ -128,9 +125,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -50,9 +50,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0
@@ -127,9 +124,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless-custom-image.yaml
@@ -46,9 +46,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0
@@ -96,9 +93,6 @@ spec:
       - name: custom-grpc-app
         image: grpc/echo:cpp
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --forwarding_address=0.0.0.0:17777
           - --metrics=15014

--- a/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/proxyless.yaml
@@ -46,9 +46,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -47,9 +47,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0
@@ -122,9 +119,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1338
-          runAsGroup: 1338
         args:
           - --metrics=15014
           - --cluster=cluster-0

--- a/samples/grpc-echo/grpc-echo.yaml
+++ b/samples/grpc-echo/grpc-echo.yaml
@@ -97,9 +97,6 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
-          securityContext:
-            runAsGroup: 1338
-            runAsUser: 1338
           startupProbe:
             failureThreshold: 10
             periodSeconds: 10
@@ -185,9 +182,6 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
-          securityContext:
-            runAsGroup: 1338
-            runAsUser: 1338
           startupProbe:
             failureThreshold: 10
             periodSeconds: 10


### PR DESCRIPTION
They're not strictly required and do not play well with OpenShift.