### PR TITLE
Fix iop not being deleted during uninstall when specifying filename

### DIFF
--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -200,6 +200,21 @@ func uninstall(cmd *cobra.Command, ctx cli.Context, rootArgs *RootArgs, uiArgs *
 	if err := h.DeleteControlPlaneByManifests(manifestMap, iop.Spec.Revision, uiArgs.purge); err != nil {
 		return fmt.Errorf("failed to delete control plane by manifests: %v", err)
 	}
+	iopName := savedIOPName(iop)
+	ioplist := h.GetIstioOperatorCR()
+	for _, item := range ioplist.Items {
+		if item.GetName() == iopName {
+			err = h.DeleteObjectsList([]*unstructured.UnstructuredList{
+				{
+					Items: []unstructured.Unstructured{item},
+				},
+			}, "")
+			if err != nil {
+				return fmt.Errorf("failed to delete IstioOperator CR: %v", err)
+			}
+			break
+		}
+	}
 	opts.ProgressLog.SetState(progress.StateUninstallComplete)
 	return nil
 }

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -249,12 +249,12 @@ func (h *HelmReconciler) GetPrunedResources(revision string, includeClusterResou
 	gvkList := append(resources, ClusterCPResources...)
 	if includeClusterResources {
 		gvkList = append(resources, AllClusterResources...)
-		if ioplist := h.getIstioOperatorCR(); ioplist.Items != nil {
+		if ioplist := h.GetIstioOperatorCR(); ioplist.Items != nil {
 			usList = append(usList, ioplist)
 		}
 	} else if componentName == "" {
 		// Remove Istio operator CR with specified revision if it is uninstalled
-		ioplist := h.getIstioOperatorCR()
+		ioplist := h.GetIstioOperatorCR()
 		if ioplist.Items != nil {
 			for _, iop := range ioplist.Items {
 				revisionIop := getIstioOperatorCRName(revision)
@@ -313,10 +313,10 @@ func (h *HelmReconciler) GetPrunedResources(revision string, includeClusterResou
 	return usList, nil
 }
 
-// getIstioOperatorCR is a helper function to get IstioOperator CR during purge,
+// GetIstioOperatorCR is a helper function to get IstioOperator CR during purge,
 // otherwise the resources would be reconciled back later if there is in-cluster operator deployment.
 // And it is needed to remove the IstioOperator CRD.
-func (h *HelmReconciler) getIstioOperatorCR() *unstructured.UnstructuredList {
+func (h *HelmReconciler) GetIstioOperatorCR() *unstructured.UnstructuredList {
 	objects := &unstructured.UnstructuredList{}
 	objects.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "install.istio.io",

--- a/releasenotes/notes/47857.yaml
+++ b/releasenotes/notes/47857.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an issue where custom `IstioOperator` resource was not deleted after uninstallation.


### PR DESCRIPTION
**Please provide a description of this PR:**
Default installation and revisioned installation are fine, but if I have a custom IOP file, it will not be deleted. This currently may lead to other commands that depends on the IOP not working as expected.