### PR TITLE
istioctl: fix dashboard namespace flag usage

### DIFF
--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -25,12 +25,9 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 )
@@ -52,10 +49,6 @@ var (
 
 	// label selector
 	labelSelector = ""
-
-	addonNamespace = ""
-
-	envoyDashNs = ""
 
 	proxyAdminPort int
 )
@@ -87,7 +80,7 @@ func promDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app.kubernetes.io/name=prometheus")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app.kubernetes.io/name=prometheus")
 			if err != nil {
 				return fmt.Errorf("not able to locate Prometheus pod: %v", err)
 			}
@@ -97,7 +90,7 @@ func promDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "Prometheus",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Prometheus",
 				"http://%s", bindAddress, promPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -123,7 +116,7 @@ func grafanaDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app.kubernetes.io/name=grafana")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app.kubernetes.io/name=grafana")
 			if err != nil {
 				return fmt.Errorf("not able to locate Grafana pod: %v", err)
 			}
@@ -133,7 +126,7 @@ func grafanaDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "Grafana",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Grafana",
 				"http://%s", bindAddress, grafanaPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -159,7 +152,7 @@ func kialiDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=kiali")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=kiali")
 			if err != nil {
 				return fmt.Errorf("not able to locate Kiali pod: %v", err)
 			}
@@ -169,7 +162,7 @@ func kialiDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "Kiali",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Kiali",
 				"http://%s/kiali", bindAddress, kialiPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -195,7 +188,7 @@ func jaegerDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=jaeger")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=jaeger")
 			if err != nil {
 				return fmt.Errorf("not able to locate Jaeger pod: %v", err)
 			}
@@ -205,7 +198,7 @@ func jaegerDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "Jaeger",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Jaeger",
 				"http://%s", bindAddress, jaegerPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -231,7 +224,7 @@ func zipkinDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=zipkin")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=zipkin")
 			if err != nil {
 				return fmt.Errorf("not able to locate Zipkin pod: %v", err)
 			}
@@ -241,7 +234,7 @@ func zipkinDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "Zipkin",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Zipkin",
 				"http://%s", bindAddress, zipkinPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -283,7 +276,7 @@ func createDashCmd(ctx cli.Context, config CreateProxyDashCmdConfig) *cobra.Comm
 
 			var podName, ns string
 			if labelSelector != "" {
-				pl, err := kubeClient.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(envoyDashNs), labelSelector)
+				pl, err := kubeClient.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.Namespace()), labelSelector)
 				if err != nil {
 					return fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 				}
@@ -300,7 +293,7 @@ func createDashCmd(ctx cli.Context, config CreateProxyDashCmdConfig) *cobra.Comm
 				podName = pl.Items[0].Name
 				ns = pl.Items[0].Namespace
 			} else {
-				podName, ns, err = ctx.InferPodInfoFromTypedResource(args[0], envoyDashNs)
+				podName, ns, err = ctx.InferPodInfoFromTypedResource(args[0], ctx.NamespaceOrDefault(ctx.Namespace()))
 				if err != nil {
 					return err
 				}
@@ -395,7 +388,7 @@ func controlZDashCmd(ctx cli.Context) *cobra.Command {
 
 			var podName, ns string
 			if labelSelector != "" {
-				pl, err := client.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(addonNamespace), labelSelector)
+				pl, err := client.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.IstioNamespace()), labelSelector)
 				if err != nil {
 					return fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
 				}
@@ -412,7 +405,7 @@ func controlZDashCmd(ctx cli.Context) *cobra.Command {
 				podName = pl.Items[0].Name
 				ns = pl.Items[0].Namespace
 			} else {
-				podName, ns, err = ctx.InferPodInfoFromTypedResource(args[0], addonNamespace)
+				podName, ns, err = ctx.InferPodInfoFromTypedResource(args[0], ctx.IstioNamespace())
 				if err != nil {
 					return err
 				}
@@ -444,7 +437,7 @@ func skywalkingDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), addonNamespace, "app=skywalking-ui")
+			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=skywalking-ui")
 			if err != nil {
 				return fmt.Errorf("not able to locate SkyWalking UI pod: %v", err)
 			}
@@ -454,7 +447,7 @@ func skywalkingDashCmd(ctx cli.Context) *cobra.Command {
 			}
 
 			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, addonNamespace, "SkyWalking",
+			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "SkyWalking",
 				"http://%s", bindAddress, skywalkingPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -566,8 +559,6 @@ func Dashboard(cliContext cli.Context) *cobra.Command {
 	dashboardCmd.PersistentFlags().BoolVar(&browser, "browser", true,
 		"When --browser is supplied as false, istioctl dashboard will not open the browser. "+
 			"Default is true which means istioctl dashboard will always open a browser to view the dashboard.")
-	dashboardCmd.PersistentFlags().StringVarP(&addonNamespace, "namespace", "n", "istio-system",
-		"Namespace where the addon is running, if not specified, istio-system would be used")
 
 	kiali := kialiDashCmd(cliContext)
 	kiali.PersistentFlags().IntVar(&kialiPort, "ui-port", defaultKialiPort, "The component dashboard UI port.")
@@ -597,23 +588,17 @@ func Dashboard(cliContext cli.Context) *cobra.Command {
 	envoy.Long += fmt.Sprintf("\n\n%s\n", "Note: envoy command is deprecated and can be replaced with proxy command, "+
 		"e.g. `istioctl dashboard proxy --help`")
 	envoy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
-	envoy.PersistentFlags().StringVarP(&envoyDashNs, "namespace", "n", metav1.NamespaceDefault,
-		"Namespace where the addon is running, if not specified, istio-system would be used")
 	envoy.PersistentFlags().IntVar(&proxyAdminPort, "ui-port", util.DefaultProxyAdminPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(envoy)
 
 	proxy := proxyDashCmd(cliContext)
 	proxy.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
-	proxy.PersistentFlags().StringVarP(&envoyDashNs, "namespace", "n", constants.IstioSystemNamespace,
-		"Namespace where the addon is running, if not specified, istio-system would be used")
 	proxy.PersistentFlags().IntVar(&proxyAdminPort, "ui-port", util.DefaultProxyAdminPort, "The component dashboard UI port.")
 	dashboardCmd.AddCommand(proxy)
 
 	controlz := controlZDashCmd(cliContext)
 	controlz.PersistentFlags().IntVar(&controlZport, "ctrlz_port", 9876, "ControlZ port")
 	controlz.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
-	controlz.PersistentFlags().StringVarP(&addonNamespace, "namespace", "n", "istio-system",
-		"Namespace where the addon is running, if not specified, istio-system would be used")
 	dashboardCmd.AddCommand(controlz)
 
 	return dashboardCmd

--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util"

--- a/istioctl/pkg/dashboard/dashboard_test.go
+++ b/istioctl/pkg/dashboard/dashboard_test.go
@@ -100,17 +100,13 @@ func TestDashboard(t *testing.T) {
 			ExpectedRegexp: regexp.MustCompile(".*Error: name cannot be provided when a selector is specified"),
 			WantException:  true,
 		},
-		{ // case 15
-			Args:           strings.Split("-n istio-system", " "),
-			ExpectedRegexp: regexp.MustCompile("Access to Istio web UIs"),
-		},
 		{ // case 16
-			Args:           strings.Split("controlz --browser=false pod-123456-7890 -n istio-system", " "),
+			Args:           strings.Split("controlz --browser=false pod-123456-7890", " "),
 			ExpectedRegexp: regexp.MustCompile(".*http://localhost:3456"),
 			WantException:  false,
 		},
 		{ // case 17
-			Args:           strings.Split("envoy --browser=false pod-123456-7890 -n istio-system", " "),
+			Args:           strings.Split("envoy --browser=false pod-123456-7890", " "),
 			ExpectedRegexp: regexp.MustCompile("http://localhost:3456"),
 			WantException:  false,
 		},

--- a/releasenotes/notes/47877.yaml
+++ b/releasenotes/notes/47877.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where the default namespace of envoy and proxy dashboard command was not set to the actual default namespace.


### PR DESCRIPTION
**Please provide a description of this PR:**
There are several sub-namespace flags in the dashboard command, which may lead to the incorrect usage of the default namespace or other namespaces. 

This PR fixes a regression where the envoy dashboard command defaulted to the `default` namespace, but it has since changed to `istio-system` - I suspect it's a result of refactoring. 

Additionally, the PR removes all the namespace flags from the dashboard and its sub-commands, and updates the addonNamespace (formerly istio-system) to ctx.IstioNamespace(), and sets the envoyDashNs to the default namespace. This will not change the previous behavior.