### PR TITLE
service entry: fix leak in workload addesses

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -35,7 +35,7 @@ type PodCache struct {
 	// podsByIP maintains stable pod IP to name key mapping
 	// this allows us to retrieve the latest status by pod IP.
 	// This should only contain RUNNING or PENDING pods with an allocated IP.
-	podsByIP map[string]types.NamespacedName
+	podsByIP map[string]sets.Set[types.NamespacedName]
 	// IPByPods is a reverse map of podsByIP. This exists to allow us to prune stale entries in the
 	// pod cache if a pod changes IP.
 	IPByPods map[types.NamespacedName]string
@@ -53,7 +53,7 @@ func newPodCache(c *Controller, pods kclient.Client[*v1.Pod], queueEndpointEvent
 	out := &PodCache{
 		pods:               pods,
 		c:                  c,
-		podsByIP:           make(map[string]types.NamespacedName),
+		podsByIP:           make(map[string]sets.Set[types.NamespacedName]),
 		IPByPods:           make(map[types.NamespacedName]string),
 		needResync:         make(map[string]sets.Set[types.NamespacedName]),
 		queueEndpointEvent: queueEndpointEvent,
@@ -219,8 +219,8 @@ func getPortMap(pod *v1.Pod) map[string]uint32 {
 func (pc *PodCache) deleteIP(ip string, podKey types.NamespacedName) bool {
 	pc.Lock()
 	defer pc.Unlock()
-	if pc.podsByIP[ip] == podKey {
-		delete(pc.podsByIP, ip)
+	if pc.podsByIP[ip].Contains(podKey) {
+		sets.DeleteCleanupLast(pc.podsByIP, ip, podKey)
 		delete(pc.IPByPods, podKey)
 		return true
 	}
@@ -230,15 +230,15 @@ func (pc *PodCache) deleteIP(ip string, podKey types.NamespacedName) bool {
 func (pc *PodCache) update(ip string, key types.NamespacedName) {
 	pc.Lock()
 	// if the pod has been cached, return
-	if key == pc.podsByIP[ip] {
+	if pc.podsByIP[ip].Contains(key) {
 		pc.Unlock()
 		return
 	}
 	if current, f := pc.IPByPods[key]; f {
 		// The pod already exists, but with another IP Address. We need to clean up that
-		delete(pc.podsByIP, current)
+		sets.DeleteCleanupLast(pc.podsByIP, current, key)
 	}
-	pc.podsByIP[ip] = key
+	sets.InsertOrNew(pc.podsByIP, ip, key)
 	pc.IPByPods[key] = ip
 
 	if endpointsToUpdate, f := pc.needResync[ip]; f {
@@ -276,20 +276,23 @@ func (pc *PodCache) proxyUpdates(ip string) {
 	}
 }
 
-func (pc *PodCache) getPodKey(addr string) (types.NamespacedName, bool) {
+func (pc *PodCache) getPodKeys(addr string) sets.Set[types.NamespacedName] {
 	pc.RLock()
 	defer pc.RUnlock()
-	key, exists := pc.podsByIP[addr]
-	return key, exists
+	return pc.podsByIP[addr]
 }
 
 // getPodByIp returns the pod or nil if pod not found or an error occurred
-func (pc *PodCache) getPodByIP(addr string) *v1.Pod {
-	key, exists := pc.getPodKey(addr)
-	if !exists {
+func (pc *PodCache) getPodsByIP(addr string) []*v1.Pod {
+	keys := pc.getPodKeys(addr)
+	if keys.IsEmpty() {
 		return nil
 	}
-	return pc.getPodByKey(key)
+	res := make([]*v1.Pod, 0, len(keys))
+	for key := range keys {
+		res = append(res, pc.getPodByKey(key))
+	}
+	return res
 }
 
 // getPodByKey returns the pod by key
@@ -312,5 +315,23 @@ func (pc *PodCache) getPodByProxy(proxy *model.Proxy) *v1.Pod {
 	// because multiple ips belong to the same pod
 	proxyIP := proxy.IPAddresses[0]
 	// just in case the proxy ID is bad formatted
-	return pc.getPodByIP(proxyIP)
+	pods := pc.getPodsByIP(proxyIP)
+	switch len(pods) {
+	case 0:
+		return nil
+	case 1:
+		return pods[0]
+	default:
+		// This should only happen with hostNetwork pods, which cannot be proxy clients...
+		log.Errorf("unexpected: found multiple pods for proxy %v (%v)", proxy.ID, proxyIP)
+		// Try to handle it gracefully
+		for _, p := range pods {
+			// At least filter out wrong namespaces...
+			if proxy.ConfigNamespace != p.Namespace {
+				continue
+			}
+			return p
+		}
+		return nil
+	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -276,20 +276,20 @@ func (pc *PodCache) proxyUpdates(ip string) {
 	}
 }
 
-func (pc *PodCache) getPodKeys(addr string) sets.Set[types.NamespacedName] {
+func (pc *PodCache) getPodKeys(addr string) []types.NamespacedName {
 	pc.RLock()
 	defer pc.RUnlock()
-	return pc.podsByIP[addr]
+	return pc.podsByIP[addr].UnsortedList()
 }
 
 // getPodByIp returns the pod or nil if pod not found or an error occurred
 func (pc *PodCache) getPodsByIP(addr string) []*v1.Pod {
 	keys := pc.getPodKeys(addr)
-	if keys.IsEmpty() {
+	if keys == nil {
 		return nil
 	}
 	res := make([]*v1.Pod, 0, len(keys))
-	for key := range keys {
+	for _, key := range keys {
 		res = append(res, pc.getPodByKey(key))
 	}
 	return res

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -28,8 +29,11 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/util/xdsfake"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Prepare k8s. This can be used in multiple tests, to
@@ -111,30 +115,45 @@ func TestPodCache(t *testing.T) {
 
 func TestHostNetworkPod(t *testing.T) {
 	c, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
+	pods := clienttest.Wrap(t, c.podsClient)
+	events := assert.NewTracker[string](t)
+	c.AppendWorkloadHandler(func(instance *model.WorkloadInstance, event model.Event) {
+		events.Record(fmt.Sprintf("%v/%v", instance.Name, event))
+	})
 	initTestEnv(t, c.client.Kube(), fx)
 	createPod := func(ip, name string) {
 		addPods(t, c, fx, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
 	}
 
 	createPod("128.0.0.1", "pod1")
-	if p, f := c.pods.getPodKey("128.0.0.1"); !f || (p != types.NamespacedName{Name: "pod1", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), sets.New(types.NamespacedName{Name: "pod1", Namespace: "ns"}))
 
 	createPod("128.0.0.1", "pod2")
-	if p, f := c.pods.getPodKey("128.0.0.1"); !f || (p != types.NamespacedName{Name: "pod2", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), sets.New(
+		types.NamespacedName{Name: "pod1", Namespace: "ns"},
+		types.NamespacedName{Name: "pod2", Namespace: "ns"},
+	))
 
 	p := c.pods.getPodByKey(types.NamespacedName{Name: "pod1", Namespace: "ns"})
 	if p == nil || p.Name != "pod1" {
 		t.Fatalf("unexpected pod: %v", p)
 	}
+	pods.Delete("pod1", "ns")
+	pods.Delete("pod2", "ns")
+	events.WaitOrdered(
+		"pod1/add",
+		"pod1/update",
+		"pod2/add",
+		"pod2/update",
+		"pod1/delete",
+		"pod2/delete",
+	)
 }
 
 // Regression test for https://github.com/istio/istio/issues/20676
 func TestIPReuse(t *testing.T) {
 	c, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
+	pods := clienttest.Wrap(t, c.podsClient)
 	initTestEnv(t, c.client.Kube(), fx)
 
 	createPod := func(ip, name string) {
@@ -142,41 +161,30 @@ func TestIPReuse(t *testing.T) {
 	}
 
 	createPod("128.0.0.1", "pod")
-	if p, f := c.pods.getPodKey("128.0.0.1"); !f || (p != types.NamespacedName{Name: "pod", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), sets.New(types.NamespacedName{Name: "pod", Namespace: "ns"}))
 
 	// Change the pod IP. This can happen if the pod moves to another node, for example.
 	createPod("128.0.0.2", "pod")
-	if p, f := c.pods.getPodKey("128.0.0.2"); !f || (p != types.NamespacedName{Name: "pod", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
-	if p, f := c.pods.getPodKey("128.0.0.1"); f {
-		t.Fatalf("expected no pod, got pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.2"), sets.New(types.NamespacedName{Name: "pod", Namespace: "ns"}))
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), nil)
 
 	// A new pod is created with the old IP. We should get new-pod, not pod
 	createPod("128.0.0.1", "new-pod")
-	if p, f := c.pods.getPodKey("128.0.0.1"); !f || (p != types.NamespacedName{Name: "new-pod", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), sets.New(types.NamespacedName{Name: "new-pod", Namespace: "ns"}))
 
-	// A new pod is created with the same IP. In theory this should never happen, but maybe we miss an update somehow.
+	// A new pod is created with the same IP. This happens with hostNetwork, or maybe we miss an update somehow.
 	createPod("128.0.0.1", "another-pod")
-	if p, f := c.pods.getPodKey("128.0.0.1"); !f || (p != types.NamespacedName{Name: "another-pod", Namespace: "ns"}) {
-		t.Fatalf("unexpected pod: %v", p)
-	}
+	assert.Equal(t, c.pods.getPodKeys("128.0.0.1"), sets.New(
+		types.NamespacedName{Name: "new-pod", Namespace: "ns"},
+		types.NamespacedName{Name: "another-pod", Namespace: "ns"},
+	))
 
-	err := c.client.Kube().CoreV1().Pods("ns").Delete(context.TODO(), "another-pod", metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Cannot delete pod: %v", err)
-	}
-	retry.UntilOrFail(t, func() bool {
-		if _, ok := c.pods.getPodKey("128.0.0.1"); ok {
-			return false
-		}
-		return true
-	})
+	fetch := func() sets.Set[types.NamespacedName] { return c.pods.getPodKeys("128.0.0.1") }
+	pods.Delete("another-pod", "ns")
+	assert.EventuallyEqual(t, fetch, sets.New(types.NamespacedName{Name: "new-pod", Namespace: "ns"}))
+
+	pods.Delete("new-pod", "ns")
+	assert.EventuallyEqual(t, fetch, nil)
 }
 
 func waitForPod(t test.Failer, c *FakeController, ip string) {
@@ -219,25 +227,25 @@ func testPodCache(t *testing.T) {
 		"128.0.0.3": {"app": "prod-app-2"},
 	}
 	for addr, wantTag := range wantLabels {
-		pod := c.pods.getPodByIP(addr)
+		pod := c.pods.getPodsByIP(addr)
 		if pod == nil {
 			t.Error("Not found ", addr)
 			continue
 		}
-		if !reflect.DeepEqual(wantTag, labels.Instance(pod.Labels)) {
-			t.Errorf("Expected %v got %v", wantTag, labels.Instance(pod.Labels))
+		if !reflect.DeepEqual(wantTag, labels.Instance(pod[0].Labels)) {
+			t.Errorf("Expected %v got %v", wantTag, labels.Instance(pod[0].Labels))
 		}
 	}
 
 	// This pod exists, but should not be in the cache because it is in a
 	// namespace not watched by the controller.
-	pod := c.pods.getPodByIP("128.0.0.4")
+	pod := c.pods.getPodsByIP("128.0.0.4")
 	if pod != nil {
 		t.Error("Expected not found but was found")
 	}
 
 	// This pod should not be in the cache because it never existed.
-	pod = c.pods.getPodByIP("128.0.0.128")
+	pod = c.pods.getPodsByIP("128.0.0.128")
 	if pod != nil {
 		t.Error("Expected not found but was found")
 	}
@@ -282,9 +290,7 @@ func TestPodCacheEvents(t *testing.T) {
 	if handled != 1 {
 		t.Errorf("notified workload handler %d times, want %d", handled, 1)
 	}
-	if pod, exists := podCache.getPodKey(ip); !exists || (pod != types.NamespacedName{Name: "pod1", Namespace: "default"}) {
-		t.Errorf("getPodKey => got %s, pod1 not found or incorrect", pod)
-	}
+	assert.Equal(t, c.pods.getPodKeys(ip), sets.New(types.NamespacedName{Name: "pod1", Namespace: "default"}))
 
 	if err := f(nil,
 		&v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{Conditions: readyCondition, PodIP: ip, Phase: v1.PodFailed}}, model.EventUpdate); err != nil {
@@ -293,7 +299,7 @@ func TestPodCacheEvents(t *testing.T) {
 	if handled != 2 {
 		t.Errorf("notified workload handler %d times, want %d", handled, 2)
 	}
-	if pod, exists := podCache.getPodKey(ip); exists {
+	if pod := podCache.getPodKeys(ip); pod != nil {
 		t.Errorf("getPodKey => got %s, want none", pod)
 	}
 
@@ -312,9 +318,7 @@ func TestPodCacheEvents(t *testing.T) {
 	if handled != 3 {
 		t.Errorf("notified workload handler %d times, want %d", handled, 3)
 	}
-	if pod, exists := podCache.getPodKey(ip); !exists || (pod != types.NamespacedName{Name: "pod2", Namespace: "default"}) {
-		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
-	}
+	assert.Equal(t, c.pods.getPodKeys(ip), sets.New(types.NamespacedName{Name: "pod2", Namespace: "default"}))
 
 	if err := f(nil, &v1.Pod{ObjectMeta: pod1, Status: v1.PodStatus{PodIP: ip, Phase: v1.PodFailed}}, model.EventDelete); err != nil {
 		t.Error(err)
@@ -322,9 +326,7 @@ func TestPodCacheEvents(t *testing.T) {
 	if handled != 3 {
 		t.Errorf("notified workload handler %d times, want %d", handled, 3)
 	}
-	if pod, exists := podCache.getPodKey(ip); !exists || (pod != types.NamespacedName{Name: "pod2", Namespace: "default"}) {
-		t.Errorf("getPodKey => got %s, pod2 not found or incorrect", pod)
-	}
+	assert.Equal(t, c.pods.getPodKeys(ip), sets.New(types.NamespacedName{Name: "pod2", Namespace: "default"}))
 
 	if err := f(nil, &v1.Pod{ObjectMeta: pod2, Spec: v1.PodSpec{
 		RestartPolicy: v1.RestartPolicyOnFailure,
@@ -334,7 +336,7 @@ func TestPodCacheEvents(t *testing.T) {
 	if handled != 4 {
 		t.Errorf("notified workload handler %d times, want %d", handled, 4)
 	}
-	if pod, exists := podCache.getPodKey(ip); exists {
+	if pod := podCache.getPodKeys(ip); pod != nil {
 		t.Errorf("getPodKey => got %s, want none", pod)
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -306,10 +306,10 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		addConfigs(se, services)
 	}
 
-	s.serviceInstances.deleteInstances(key, instancesDeleted)
+	s.serviceInstances.deleteInstanceKeys(key, instancesDeleted)
 	if event == model.EventDelete {
 		s.workloadInstances.Delete(wi)
-		s.serviceInstances.deleteInstances(key, instancesUpdated)
+		s.serviceInstances.deleteInstanceKeys(key, instancesUpdated)
 	} else {
 		s.workloadInstances.Insert(wi)
 		s.serviceInstances.updateInstances(key, instancesUpdated)
@@ -387,7 +387,7 @@ func (s *Controller) serviceEntryHandler(_, curr config.Config, event model.Even
 	serviceInstancesByConfig, serviceInstances := s.buildServiceInstances(curr, cs)
 	oldInstances := s.serviceInstances.getServiceEntryInstances(key)
 	for configKey, old := range oldInstances {
-		s.serviceInstances.deleteInstances(configKey, old)
+		s.serviceInstances.deleteInstanceKeys(configKey, old)
 	}
 	if event == model.EventDelete {
 		s.serviceInstances.deleteAllServiceEntryInstances(key)
@@ -583,11 +583,11 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 	}
 
 	if len(instancesDeleted) > 0 {
-		s.serviceInstances.deleteInstances(key, instancesDeleted)
+		s.serviceInstances.deleteInstanceKeys(key, instancesDeleted)
 	}
 
 	if event == model.EventDelete {
-		s.serviceInstances.deleteInstances(key, instances)
+		s.serviceInstances.deleteInstanceKeys(key, instances)
 	} else {
 		s.serviceInstances.updateInstances(key, instances)
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/store.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store.go
@@ -58,11 +58,13 @@ func (s *serviceInstancesStore) getByKey(key instancesKey) []*model.ServiceInsta
 	return all
 }
 
-func (s *serviceInstancesStore) deleteInstances(key configKey, instances []*model.ServiceInstance) {
+// deleteInstanceKeys deletes all instances with the given configKey and instanceKey
+// Note: as a convenience, this takes a []ServiceInstance instead of []instanceKey, as most callers have this format
+// However, this function only operates on the instance keys
+func (s *serviceInstancesStore) deleteInstanceKeys(key configKey, instances []*model.ServiceInstance) {
 	for _, i := range instances {
 		ikey := makeInstanceKey(i)
-		hostPort := hostPort{ikey.hostname.String(), i.ServicePort.Port}
-		s.instancesByHostAndPort.Delete(hostPort)
+		s.instancesByHostAndPort.Delete(hostPort{ikey.hostname.String(), i.ServicePort.Port})
 		oldInstances := s.instances[ikey][key]
 		delete(s.instances[ikey], key)
 		if len(s.instances[ikey]) == 0 {
@@ -71,6 +73,7 @@ func (s *serviceInstancesStore) deleteInstances(key configKey, instances []*mode
 		delete(s.ip2instance, i.Endpoint.Address)
 		// Cleanup stale IPs, if the IPs changed
 		for _, oi := range oldInstances {
+			s.instancesByHostAndPort.Delete(hostPort{ikey.hostname.String(), oi.ServicePort.Port})
 			delete(s.ip2instance, oi.Endpoint.Address)
 		}
 	}
@@ -104,7 +107,7 @@ func (s *serviceInstancesStore) addInstances(key configKey, instances []*model.S
 
 func (s *serviceInstancesStore) updateInstances(key configKey, instances []*model.ServiceInstance) {
 	// first delete
-	s.deleteInstances(key, instances)
+	s.deleteInstanceKeys(key, instances)
 
 	// second add
 	s.addInstances(key, instances)

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -96,8 +96,8 @@ func TestServiceInstancesStore(t *testing.T) {
 		t.Errorf("got unexpected instances %v", gotSeInstances)
 	}
 
-	// 7. test deleteInstances
-	store.deleteInstances(cKey, instances)
+	// 7. test deleteInstanceKeys
+	store.deleteInstanceKeys(cKey, instances)
 	gotInstances = store.getAll()
 	if len(gotInstances) != 0 {
 		t.Errorf("got unexpected instances %v", gotSeInstances)

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -246,8 +246,7 @@ func TestClient(t *testing.T) {
 	tester.Delete(obj3.Name, obj3.Namespace)
 	tester.Delete(obj2.Name, obj2.Namespace)
 	tester.Delete(obj1.Name, obj1.Namespace)
-	tracker.WaitOrdered("delete/2")
-	tracker.WaitOrdered("delete/1")
+	tracker.WaitOrdered("delete/2", "delete/1")
 	assert.Equal(t, tester.List(obj1.Namespace, klabels.Everything()), nil)
 
 	// Create some more objects again

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -170,6 +170,9 @@ func (s Set[T]) SupersetOf(s2 Set[T]) bool {
 
 // UnsortedList returns the slice with contents in random order.
 func (s Set[T]) UnsortedList() []T {
+	if len(s) == 0 {
+		return nil
+	}
 	res := make([]T, 0, s.Len())
 	for key := range s {
 		res = append(res, key)

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -170,9 +170,6 @@ func (s Set[T]) SupersetOf(s2 Set[T]) bool {
 
 // UnsortedList returns the slice with contents in random order.
 func (s Set[T]) UnsortedList() []T {
-	if len(s) == 0 {
-		return nil
-	}
 	res := make([]T, 0, s.Len())
 	for key := range s {
 		res = append(res, key)

--- a/releasenotes/notes/we-memory-leaks.yaml
+++ b/releasenotes/notes/we-memory-leaks.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [47893]
+releaseNotes:
+  - |
+    **Fixed** a memory leak when `hostNetwork` pods scale up and down.
+  - |
+    **Fixed** a memory leak when `WorkloadEntries` change their IP address.
+  - |
+    **Fixed** a memory leak when a `ServiceEntry` is removed. 


### PR DESCRIPTION
This fixes three leaks in workload handling:
* Most critical one, found in production: rolling restart of hostNetwork pods leaks an endpoint. 

Sequence that it hits:
In PodCache.onEvent:
* first hostnet pod comes up, all good
* Second hostnet pod comes up, replaces the pod stored for the IP (same IP as first pod)
* first pod is removed. delete() doesn't remove it, since the IP is mapped to second pod. We `return nil`
Result: notifyWorkloadHandlers never gets a delete event

* WorkloadEntry changing IP never removes the old IP
* instancesBySE doesn't remove the key when we remove a SE