### PR TITLE
Fix telemetry templates

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/_helpers.tpl
+++ b/manifests/charts/istio-control/istio-discovery/templates/_helpers.tpl
@@ -1,5 +1,5 @@
-{{/* Prometheus is enabled if its enabled and there are no config overrides set */}}
-{{ define "prometheus" }}
+{{/* Default Prometheus is enabled if its enabled and there are no config overrides set */}}
+{{ define "default-prometheus" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.prometheus.enabled
@@ -10,8 +10,8 @@
   )) }}
 {{- end }}
 
-{{/* SD has metrics and logging split. Metrics are enabled if SD is enabled and there are no config overrides set */}}
-{{ define "sd-metrics" }}
+{{/* SD has metrics and logging split. Default metrics are enabled if SD is enabled and there are no config overrides set */}}
+{{ define "default-sd-metrics" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.stackdriver.enabled
@@ -22,14 +22,14 @@
 {{- end }}
 
 {{/* SD has metrics and logging split. */}}
-{{ define "sd-logs" }}
+{{ define "default-sd-logs" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.stackdriver.enabled
   (not (or
     .Values.telemetry.v2.stackdriver.configOverride
     (has .Values.telemetry.v2.stackdriver.outboundAccessLogging (list "" "ERRORS_ONLY"))
-    (has .Values.telemetry.v2.stackdriver.inboundAccessLogging (list "" "ALL"))
+    (has .Values.telemetry.v2.stackdriver.inboundAccessLogging (list "" "FULL"))
     .Values.telemetry.v2.stackdriver.disableOutbound ))
 }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -9,17 +9,17 @@
     # is processed as if it were declared in the leaf namespace.
     rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
 
-  {{ $prom := include "prometheus" . | eq "true" }}
-  {{ $sdMetrics := include "sd-metrics" . | eq "true" }}
-  {{ $sdLogs := include "sd-logs" . | eq "true" }}
+  {{ $prom := include "default-prometheus" . | eq "true" }}
+  {{ $sdMetrics := include "default-sd-metrics" . | eq "true" }}
+  {{ $sdLogs := include "default-sd-logs" . | eq "true" }}
   {{- if or $prom $sdMetrics $sdLogs }}
     defaultProviders:
     {{- if or $prom $sdMetrics }}
       metrics:
       {{ if $prom }}- prometheus{{ end }}
-      {{ if $sdMetrics }}- stackdriver{{ end }}
+      {{ if and $sdMetrics $sdLogs }}- stackdriver{{ end }}
     {{- end }}
-    {{- if $sdLogs }}
+    {{- if and $sdMetrics $sdLogs }}
       accessLogging:
       - stackdriver
     {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.18.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.18.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.19.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.19.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.20.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.20.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.21.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istiod-remote/templates/_helpers.tpl
+++ b/manifests/charts/istiod-remote/templates/_helpers.tpl
@@ -1,5 +1,5 @@
-{{/* Prometheus is enabled if its enabled and there are no config overrides set */}}
-{{ define "prometheus" }}
+{{/* Default Prometheus is enabled if its enabled and there are no config overrides set */}}
+{{ define "default-prometheus" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.prometheus.enabled
@@ -10,8 +10,8 @@
   )) }}
 {{- end }}
 
-{{/* SD has metrics and logging split. Metrics are enabled if SD is enabled and there are no config overrides set */}}
-{{ define "sd-metrics" }}
+{{/* SD has metrics and logging split. Default metrics are enabled if SD is enabled and there are no config overrides set */}}
+{{ define "default-sd-metrics" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.stackdriver.enabled
@@ -22,14 +22,14 @@
 {{- end }}
 
 {{/* SD has metrics and logging split. */}}
-{{ define "sd-logs" }}
+{{ define "default-sd-logs" }}
 {{- and
   (not .Values.meshConfig.defaultProviders)
   .Values.telemetry.enabled .Values.telemetry.v2.enabled .Values.telemetry.v2.stackdriver.enabled
   (not (or
     .Values.telemetry.v2.stackdriver.configOverride
     (has .Values.telemetry.v2.stackdriver.outboundAccessLogging (list "" "ERRORS_ONLY"))
-    (has .Values.telemetry.v2.stackdriver.inboundAccessLogging (list "" "ALL"))
+    (has .Values.telemetry.v2.stackdriver.inboundAccessLogging (list "" "FULL"))
     .Values.telemetry.v2.stackdriver.disableOutbound ))
 }}
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -9,17 +9,17 @@
     # is processed as if it were declared in the leaf namespace.
     rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
 
-  {{ $prom := include "prometheus" . | eq "true" }}
-  {{ $sdMetrics := include "sd-metrics" . | eq "true" }}
-  {{ $sdLogs := include "sd-logs" . | eq "true" }}
+  {{ $prom := include "default-prometheus" . | eq "true" }}
+  {{ $sdMetrics := include "default-sd-metrics" . | eq "true" }}
+  {{ $sdLogs := include "default-sd-logs" . | eq "true" }}
   {{- if or $prom $sdMetrics $sdLogs }}
     defaultProviders:
     {{- if or $prom $sdMetrics }}
       metrics:
       {{ if $prom }}- prometheus{{ end }}
-      {{ if $sdMetrics }}- stackdriver{{ end }}
+      {{ if and $sdMetrics $sdLogs }}- stackdriver{{ end }}
     {{- end }}
-    {{- if $sdLogs }}
+    {{- if and $sdMetrics $sdLogs }}
       accessLogging:
       - stackdriver
     {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.18.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.18.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.19.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.19.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.20.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.20.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.21.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.21.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-{{ $prom := not (include "prometheus" . | eq "true") }}
-{{ $sdMetrics := not (include "sd-metrics" . | eq "true") }}
-{{ $sdLogs := not (include "sd-logs" . | eq "true") }}
+{{ $customProm := not (include "default-prometheus" . | eq "true") }}
+{{ $customSdMetrics := not (include "default-sd-metrics" . | eq "true") }}
+{{ $customSdLogs := not (include "default-sd-logs" . | eq "true") }}
 ---
 # Note: http stats filter is wasm enabled only in sidecars.
-{{- if and .Values.telemetry.v2.prometheus.enabled $prom }}
+{{- if and .Values.telemetry.v2.prometheus.enabled $customProm }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -180,7 +180,7 @@ spec:
 ---
 {{- end }}
 {{/*TODO: this is broken, we do not handle the split quite right! */}}
-{{- if and .Values.telemetry.v2.stackdriver.enabled $sdLogs $sdMetrics }}
+{{- if and .Values.telemetry.v2.stackdriver.enabled (or $customSdLogs $customSdMetrics) }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/releasenotes/notes/fix-stackdriver-install.yaml
+++ b/releasenotes/notes/fix-stackdriver-install.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** an issue where installing with Stackdriver and having custom configs would lead to Stackdriver not being enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**

- Rename the variables.
- Fix an issue that: If there's config set for SD logs but no for SD metrics, neither defaultProvider nor Envoyfilter is created.

If both SD metrics & SD logs are default, set in defaultProvider.
If any of SD metrics or logs has custom config set, use EnvoyFilter.