### PR TITLE
Fix netns path invoking from cni plugin

### DIFF
--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -245,12 +245,11 @@ func getDeviceWithDestinationOf(ip string) (string, error) {
 	return link.Attrs().Name, nil
 }
 
-func GetIndexAndPeerMac(podIfName, ns string) (int, net.HardwareAddr, error) {
+func GetIndexAndPeerMac(podIfName, nspath string) (int, net.HardwareAddr, error) {
 	var hostIfIndex int
 	var hwAddr net.HardwareAddr
 
-	ns = filepath.Base(ns)
-	err := netns.WithNetNSPath(fmt.Sprintf("/var/run/netns/%s", ns), func(netns.NetNS) error {
+	err := netns.WithNetNSPath(nspath, func(netns.NetNS) error {
 		link, err := netlink.LinkByName(podIfName)
 		if err != nil {
 			return err
@@ -271,18 +270,18 @@ func GetIndexAndPeerMac(podIfName, ns string) (int, net.HardwareAddr, error) {
 		return nil
 	})
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get info for if(%s) in ns(%s): %v", podIfName, ns, err)
+		return 0, nil, fmt.Errorf("failed to get info for if(%s) in ns(%s): %v", podIfName, nspath, err)
 	}
 
 	return hostIfIndex, hwAddr, nil
 }
 
-func getMacFromNsIdx(ns string, ifIndex int) (net.HardwareAddr, error) {
+func getMacFromNsIdx(nsName string, ifIndex int) (net.HardwareAddr, error) {
 	var hwAddr net.HardwareAddr
-	err := netns.WithNetNSPath(fmt.Sprintf("/var/run/netns/%s", ns), func(netns.NetNS) error {
+	err := netns.WithNetNSPath(fmt.Sprintf("/var/run/netns/%s", nsName), func(netns.NetNS) error {
 		link, err := netlink.LinkByIndex(ifIndex)
 		if err != nil {
-			return fmt.Errorf("failed to get link(%d) in ns(%s): %v", ifIndex, ns, err)
+			return fmt.Errorf("failed to get link(%d) in ns(%s): %v", ifIndex, nsName, err)
 		}
 		hwAddr = link.Attrs().HardwareAddr
 		return nil

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -202,7 +202,7 @@ spec:
             path: /var/run/istio-cni
         - name: cni-netns-dir
           hostPath:
-            path: {{ .Values.cniNetnsDir | default "/var/run/netns" }}
+            path: {{ .Values.cni.cniNetnsDir | default "/var/run/netns" }}
             type: Directory # this directory must exist on the node, if it does not,
             # consult your container runtime documentation for the appropriate path
         {{- if eq .Values.cni.ambient.redirectMode "ebpf"}}


### PR DESCRIPTION
**Please provide a description of this PR:**

#47876

The invoke path from kubelet->cri->cni_plugin passes the absolute netns path to cni  cmdAdd command, and for  `cri-dockerd` alike cri implementation, it may input the netns directly with /proc such as `/proc/[pid]/net` rather than `/var/run/netns/[ns_name]`

In addition, correct the yaml values quote for netns path mount.