### PR TITLE
Fix the custom injection on OpenShift

### DIFF
--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml
@@ -49,6 +49,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: true
             readOnlyRootFilesystem: false
+            # These should not be removed or ignored, should be honored
+            runAsUser: 1234
+            runAsGroup: 1234
       volumes:
         - name: certs
           secret:

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -17,7 +17,7 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","resources":{"limits":{"cpu":"3"},"requests":{"cpu":"123m"}},"volumeMounts":[{"name":"certs","mountPath":"/etc/certs"}],"livenessProbe":{"httpGet":{"path":"/healthz/ready","port":15021},"initialDelaySeconds":10,"timeoutSeconds":3,"periodSeconds":2,"failureThreshold":30},"lifecycle":{"preStop":{"exec":{"command":["sleep","10"]}}},"terminationMessagePath":"/foo/bar","securityContext":{"readOnlyRootFilesystem":false,"allowPrivilegeEscalation":true},"tty":true}],"initContainers":[{"name":"istio-init","image":"fake/custom-image","args":["my","custom","args"],"resources":{}}]}'
+        proxy.istio.io/overrides: '{"containers":[{"name":"istio-proxy","resources":{"limits":{"cpu":"3"},"requests":{"cpu":"123m"}},"volumeMounts":[{"name":"certs","mountPath":"/etc/certs"}],"livenessProbe":{"httpGet":{"path":"/healthz/ready","port":15021},"initialDelaySeconds":10,"timeoutSeconds":3,"periodSeconds":2,"failureThreshold":30},"lifecycle":{"preStop":{"exec":{"command":["sleep","10"]}}},"terminationMessagePath":"/foo/bar","securityContext":{"runAsUser":1234,"runAsGroup":1234,"readOnlyRootFilesystem":false,"allowPrivilegeEscalation":true},"tty":true}],"initContainers":[{"name":"istio-init","image":"fake/custom-image","args":["my","custom","args"],"resources":{}}]}'
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
       creationTimestamp: null
       labels:
@@ -146,9 +146,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsGroup: 1337
+          runAsGroup: 1234
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: 1234
         startupProbe:
           failureThreshold: 600
           httpGet:

--- a/releasenotes/notes/fix-custom-injection-openshift.yaml
+++ b/releasenotes/notes/fix-custom-injection-openshift.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+docs:
+- 'https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection'
+releaseNotes:
+- |
+    **Fixed** Custom injection of the `istio-proxy` container was not working on OpenShift because of the way OpenShift sets pod's `SecurityContext.RunAs` field.


### PR DESCRIPTION
Use of custom injection (i.e., providing a custom `istio-proxy` container) is broken on OpenShift.

This is because OpenShift sets the `RunAs` field to be the a pseudo-random value that varies by namespace. We rely on the `RunAs` field to be a well-known value, and it's calculated upon injection. We should stick with that value. `iptables` rules were created based on that value.

Even if the user provides another value (i.e., it's not set by OpenShift, but b the user), that's wrong. We should ignore what's in the original pod and use the calculated one, for these two fields only.
