### PR TITLE
istioctl: fix dashboard namespace

### DIFF
--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -572,7 +572,7 @@ func inferPodMeta(ctx cli.Context, client kube.CLIClient, labelSelector string) 
 	for _, ns := range []string{ctx.IstioNamespace(), ctx.NamespaceOrDefault(ctx.Namespace())} {
 		pl, err := client.PodsForSelector(context.TODO(), ns, labelSelector)
 		if err != nil {
-			return "", "", fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
+			continue
 		}
 		if len(pl.Items) > 0 {
 			return pl.Items[0].Name, pl.Items[0].Namespace, nil

--- a/istioctl/pkg/dashboard/dashboard.go
+++ b/istioctl/pkg/dashboard/dashboard.go
@@ -81,21 +81,14 @@ func promDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app.kubernetes.io/name=prometheus")
+			name, namespace, err := inferPodMeta(ctx, client, "app.kubernetes.io/name=prometheus")
 			if err != nil {
-				return fmt.Errorf("not able to locate Prometheus pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no Prometheus pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Prometheus",
+			return portForward(name, namespace, "Prometheus",
 				"http://%s", bindAddress, promPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
-
 	return cmd
 }
 
@@ -117,17 +110,11 @@ func grafanaDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app.kubernetes.io/name=grafana")
+			name, namespace, err := inferPodMeta(ctx, client, "app.kubernetes.io/name=grafana")
 			if err != nil {
-				return fmt.Errorf("not able to locate Grafana pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no Grafana pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Grafana",
+			return portForward(name, namespace, "Grafana",
 				"http://%s", bindAddress, grafanaPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -153,17 +140,11 @@ func kialiDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=kiali")
+			name, namespace, err := inferPodMeta(ctx, client, "app=kiali")
 			if err != nil {
-				return fmt.Errorf("not able to locate Kiali pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no Kiali pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Kiali",
+			return portForward(name, namespace, "Kiali",
 				"http://%s/kiali", bindAddress, kialiPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -189,17 +170,11 @@ func jaegerDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=jaeger")
+			name, namespace, err := inferPodMeta(ctx, client, "app=jaeger")
 			if err != nil {
-				return fmt.Errorf("not able to locate Jaeger pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no Jaeger pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Jaeger",
+			return portForward(name, namespace, "Jaeger",
 				"http://%s", bindAddress, jaegerPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -225,17 +200,11 @@ func zipkinDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=zipkin")
+			name, namespace, err := inferPodMeta(ctx, client, "app=zipkin")
 			if err != nil {
-				return fmt.Errorf("not able to locate Zipkin pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no Zipkin pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "Zipkin",
+			return portForward(name, namespace, "Zipkin",
 				"http://%s", bindAddress, zipkinPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -438,17 +407,11 @@ func skywalkingDashCmd(ctx cli.Context) *cobra.Command {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
 
-			pl, err := client.PodsForSelector(context.TODO(), ctx.IstioNamespace(), "app=skywalking-ui")
+			name, namespace, err := inferPodMeta(ctx, client, "app=skywalking-ui")
 			if err != nil {
-				return fmt.Errorf("not able to locate SkyWalking UI pod: %v", err)
+				return err
 			}
-
-			if len(pl.Items) < 1 {
-				return errors.New("no SkyWalking UI pods found")
-			}
-
-			// only use the first pod in the list
-			return portForward(pl.Items[0].Name, ctx.IstioNamespace(), "SkyWalking",
+			return portForward(name, namespace, "SkyWalking",
 				"http://%s", bindAddress, skywalkingPort, client, cmd.OutOrStdout(), browser)
 		},
 	}
@@ -603,4 +566,17 @@ func Dashboard(cliContext cli.Context) *cobra.Command {
 	dashboardCmd.AddCommand(controlz)
 
 	return dashboardCmd
+}
+
+func inferPodMeta(ctx cli.Context, client kube.CLIClient, labelSelector string) (name, namespace string, err error) {
+	for _, ns := range []string{ctx.IstioNamespace(), ctx.NamespaceOrDefault(ctx.Namespace())} {
+		pl, err := client.PodsForSelector(context.TODO(), ns, labelSelector)
+		if err != nil {
+			return "", "", fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
+		}
+		if len(pl.Items) > 0 {
+			return pl.Items[0].Name, pl.Items[0].Namespace, nil
+		}
+	}
+	return "", "", fmt.Errorf("no pods found with selector %s", labelSelector)
 }

--- a/istioctl/pkg/dashboard/dashboard_test.go
+++ b/istioctl/pkg/dashboard/dashboard_test.go
@@ -57,27 +57,27 @@ func TestDashboard(t *testing.T) {
 		},
 		{ // case 6
 			Args:           strings.Split("grafana --browser=false", " "),
-			ExpectedOutput: "Error: no Grafana pods found\n",
+			ExpectedOutput: "Error: no pods found with selector app.kubernetes.io/name=grafana\n",
 			WantException:  true,
 		},
 		{ // case 7
 			Args:           strings.Split("jaeger --browser=false", " "),
-			ExpectedOutput: "Error: no Jaeger pods found\n",
+			ExpectedOutput: "Error: no pods found with selector app=jaeger\n",
 			WantException:  true,
 		},
 		{ // case 8
 			Args:           strings.Split("kiali --browser=false", " "),
-			ExpectedOutput: "Error: no Kiali pods found\n",
+			ExpectedOutput: "Error: no pods found with selector app=kiali\n",
 			WantException:  true,
 		},
 		{ // case 9
 			Args:           strings.Split("prometheus --browser=false", " "),
-			ExpectedOutput: "Error: no Prometheus pods found\n",
+			ExpectedOutput: "Error: no pods found with selector app.kubernetes.io/name=prometheus\n",
 			WantException:  true,
 		},
 		{ // case 10
 			Args:           strings.Split("zipkin --browser=false", " "),
-			ExpectedOutput: "Error: no Zipkin pods found\n",
+			ExpectedOutput: "Error: no pods found with selector app=zipkin\n",
 			WantException:  true,
 		},
 		{ // case 11


### PR DESCRIPTION
**Please provide a description of this PR:**
/cc @GregHanson 
The command should accept the `--namespace` flag instead of the `--istioNamespace` flag like before. In this approach, if we find a pod in the `istio-system` namespace, which is the typical namespace for applying addons in samples/addons/*.yaml, then we use it. Otherwise, we use the namespace specified by the `--namespace` flag.