### PR TITLE
Wrap IsPodEnrolledInDp for iptables and ebpf mode

### DIFF
--- a/cni/pkg/ambient/informers.go
+++ b/cni/pkg/ambient/informers.go
@@ -115,7 +115,7 @@ func (s *Server) Reconcile(input any) error {
 		}
 		// Typically, a pod Add is handled by the CNI plugin.
 		// But if CNI restarts, we clear the rules, so this can happen due to CNI restart as well
-		if PodRedirectionEnabled(ns, pod) && !s.IsPodEnrolledInDp(pod) {
+		if PodRedirectionEnabled(ns, pod) && !s.IsPodEnrolledInAmbient(pod) {
 			log.Debugf("Pod added not in ipset, adding")
 			s.AddPodToMesh(pod)
 		}
@@ -135,7 +135,7 @@ func (s *Server) Reconcile(input any) error {
 		} else if !wasEnabled && nowEnabled {
 			log.Debugf("Pod now matches, adding to mesh")
 			s.AddPodToMesh(pod)
-		} else if nowEnabled && !s.IsPodEnrolledInDp(pod) {
+		} else if nowEnabled && !s.IsPodEnrolledInAmbient(pod) {
 			// This can happen if a node cleanup happens as part of a ztunnel recycle,
 			// cleaning up the node-level ipset with all the pod IPs
 			// If this happens we re-queue everything for reconciliation, and need to

--- a/cni/pkg/ambient/informers.go
+++ b/cni/pkg/ambient/informers.go
@@ -115,7 +115,7 @@ func (s *Server) Reconcile(input any) error {
 		}
 		// Typically, a pod Add is handled by the CNI plugin.
 		// But if CNI restarts, we clear the rules, so this can happen due to CNI restart as well
-		if PodRedirectionEnabled(ns, pod) && !IsPodInIpset(pod) {
+		if PodRedirectionEnabled(ns, pod) && !s.IsPodEnrolledInDp(pod) {
 			log.Debugf("Pod added not in ipset, adding")
 			s.AddPodToMesh(pod)
 		}
@@ -135,7 +135,7 @@ func (s *Server) Reconcile(input any) error {
 		} else if !wasEnabled && nowEnabled {
 			log.Debugf("Pod now matches, adding to mesh")
 			s.AddPodToMesh(pod)
-		} else if nowEnabled && !IsPodInIpset(pod) {
+		} else if nowEnabled && !s.IsPodEnrolledInDp(pod) {
 			// This can happen if a node cleanup happens as part of a ztunnel recycle,
 			// cleaning up the node-level ipset with all the pod IPs
 			// If this happens we re-queue everything for reconciliation, and need to

--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -1326,6 +1326,16 @@ func (s *Server) getEnrolledIPSets() sets.String {
 	return pods
 }
 
+func (s *Server) IsPodEnrolledInDp(pod *corev1.Pod) bool {
+	switch s.redirectMode {
+	case IptablesMode:
+		return IsPodInIpset(pod)
+	case EbpfMode:
+		return s.ebpfServer.IsPodIPEnrolled(pod.Status.PodIP)
+	}
+	return false
+}
+
 func addTProxyMarkRule() error {
 	// Set up tproxy marks
 	var rules []*netlink.Rule

--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -1326,7 +1326,7 @@ func (s *Server) getEnrolledIPSets() sets.String {
 	return pods
 }
 
-func (s *Server) IsPodEnrolledInDp(pod *corev1.Pod) bool {
+func (s *Server) IsPodEnrolledInAmbient(pod *corev1.Pod) bool {
 	switch s.redirectMode {
 	case IptablesMode:
 		return IsPodInIpset(pod)

--- a/cni/pkg/ebpf/server/redirectionServer_linux.go
+++ b/cni/pkg/ebpf/server/redirectionServer_linux.go
@@ -692,7 +692,9 @@ func (r *RedirectServer) IsPodIPEnrolled(ip string) bool {
 	if err != nil {
 		return false
 	}
-	err = r.obj.AppInfo.Lookup(ipAddr.As4(), &valueOut)
+	if err = r.obj.AppInfo.Lookup(ipAddr.As4(), &valueOut); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		log.Errorf("failed to look up AppInfo: %w", err)
+	}
 
 	return err == nil
 }

--- a/cni/pkg/ebpf/server/redirectionServer_linux.go
+++ b/cni/pkg/ebpf/server/redirectionServer_linux.go
@@ -131,7 +131,7 @@ func EBPFTProxySupport() bool {
 		return true
 	}
 	if errors.Is(err, ebpf.ErrNotSupported) {
-		log.Infof("FnSkAssign (Linux 5.7 or later) is not supported in current kernel")
+		log.Debugf("FnSkAssign (Linux 5.7 or later) is not supported in current kernel")
 	} else {
 		log.Errorf("failed to query ebpf helper availability: %v", err)
 	}
@@ -263,7 +263,7 @@ func (r *RedirectServer) initBpfObjects() error {
 	}
 	r.ztunnelIngressProgName = ztunnelIngressInfo.Name
 
-	log.Infof("ztunnelIngressProgName: %s", r.ztunnelIngressProgName)
+	log.Debugf("ztunnelIngressProgName: %s", r.ztunnelIngressProgName)
 
 	r.inboundFd = uint32(r.obj.AppInbound.FD())
 	inboundInfo, err := r.obj.AppInbound.Info()
@@ -684,6 +684,17 @@ func (r *RedirectServer) DumpAppIPs() sets.String {
 		m.Insert(ipAddr.String())
 	}
 	return m
+}
+
+func (r *RedirectServer) IsPodIPEnrolled(ip string) bool {
+	var valueOut mapInfo
+	ipAddr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false
+	}
+	err = r.obj.AppInfo.Lookup(ipAddr.As4(), &valueOut)
+
+	return err == nil
 }
 
 func htons(a uint16) uint16 {


### PR DESCRIPTION
**Please provide a description of this PR:**

massive unexpected error log in istio-cni while using eBPF redirect mode
```
│ 2023-11-17T06:54:58.937501Z    error    ambient    Failed to list ipset entries: failed to list ipset ztunnel-pods-ips: no such file or directory                                                                                                                                 │
│ 2023-11-17T06:55:00.951899Z    error    ambient    Failed to list ipset entries: failed to list ipset ztunnel-pods-ips: no such file or directory
```
In eBPF mode, ipset is not involved, thus wraps to `IsPodEnrolledInDp` for both mode instead of `IsPodInIpset`