### PR TITLE
Check if proxy.image is an image url in `ProxyImage`: fixes #47911

### DIFF
--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -1074,7 +1074,7 @@ func TestProxyImage(t *testing.T) {
 			want: "private-repo/istio/odd_name:1.12",
 		},
 		{
-			desc: "proxy.image is the image url if it contains '/'",
+			desc: "proxy.image is directly returned as the image url if it contains '/'",
 			v:    val("private-repo/istio", "docker.io/istio/proxyv2:1.12-distroless", "1.12"),
 			want: "docker.io/istio/proxyv2:1.12-distroless",
 		},

--- a/releasenotes/notes/47911.yaml
+++ b/releasenotes/notes/47911.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: istioctl
+area: traffic-management
 issue:
   - 47911
 releaseNotes:

--- a/releasenotes/notes/47911.yaml
+++ b/releasenotes/notes/47911.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 47911
+releaseNotes:
+  - |
+    **Fixed** when proxy.image is an image URL and proxy_init.image is unset
+    sidecar injection no longer creates an invalid URL for the istio-init image,
+    but falls back to proxy.image


### PR DESCRIPTION
If `proxy.image` is a URL, and `proxy_init.image` is not set, then the image URL created by `.ProxyImage` would be wrong. To handle this, we check if `proxy.image` passes the test for a URL (it includes a `/`), and if so, we just use the value of proxy.image as is, without prefixing hub or postfixing tag (reported in #47911)

An alternative approach would be to add more logic to the template to check `proxy.image` as well as `proxy_init.image` before falling through to `.ProxyImage`. I preferred this approach as it doesn't require modifying multiple templates.