### PR TITLE
cni/install: Handle fs permission issues during binary copy

### DIFF
--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -78,12 +78,3 @@ func TestExists(t *testing.T) {
 	unExist := Exists("unExist")
 	assert.Equal(t, unExist, false)
 }
-
-func TestIsDirWriteable(t *testing.T) {
-	d := t.TempDir()
-	err := IsDirWriteable(d)
-	assert.NoError(t, err)
-
-	err = IsDirWriteable("unWriteAble")
-	assert.Error(t, err)
-}


### PR DESCRIPTION
Checking directory permissions by writing a file can have race conditions or side-effects depending on the underlying filesystem. This patch avoids those types of issues entirely by simply handling permissions errors at the time the operations are performed.

Also, the `Exists()` function did not specifically check for file existence and could give incorrect results if there are permissions issues. We now explicitly check for permissions errors and report the result.

- [ ] Ambient
- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
