### PR TITLE
tools/bug-report: Reduce k8s API calls via "get" not "describe"

### DIFF
--- a/releasenotes/notes/bug-report-perf.yaml
+++ b/releasenotes/notes/bug-report-perf.yaml
@@ -1,0 +1,29 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: istioctl
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Improved** bug-report performance by reducing the amount of calls to the k8s API. The pod/node details included in the report will look different, but contain the same information.

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -317,7 +317,7 @@ func gatherInfo(runner *kubectlcmd.Runner, config *config.BugReportConfig, resou
 	getFromCluster(content.GetClusterInfo, params, clusterDir, &mandatoryWg)
 	getFromCluster(content.GetNodeInfo, params, clusterDir, &mandatoryWg)
 	getFromCluster(content.GetSecrets, params.SetVerbose(config.FullSecrets), clusterDir, &mandatoryWg)
-	getFromCluster(content.GetDescribePods, params.SetIstioNamespace(config.IstioNamespace), clusterDir, &mandatoryWg)
+	getFromCluster(content.GetPodInfo, params.SetIstioNamespace(config.IstioNamespace), clusterDir, &mandatoryWg)
 
 	common.LogAndPrintf("\nFetching CNI logs from cluster.\n\n")
 	for _, cniPod := range resources.CniPod {

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -87,22 +87,15 @@ func (p *Params) SetContainer(container string) *Params {
 	return &out
 }
 
-func retMap(filename, text string, err error) (map[string]string, error) {
-	if err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		filename: text,
-	}, nil
-}
-
 // GetK8sResources returns all k8s cluster resources.
 func GetK8sResources(p *Params) (map[string]string, error) {
 	out, err := p.Runner.RunCmd("get --all-namespaces "+
 		"all,namespaces,jobs,ingresses,endpoints,endpointslices,customresourcedefinitions,configmaps,events,"+
 		"mutatingwebhookconfigurations,validatingwebhookconfigurations,networkpolicies "+
 		"-o yaml", "", p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("k8s-resources", out, err)
+	return map[string]string{
+		"k8s-resources": out,
+	}, err
 }
 
 // GetSecrets returns all k8s secrets. If full is set, the secret contents are also returned.
@@ -112,7 +105,9 @@ func GetSecrets(p *Params) (map[string]string, error) {
 		cmdStr += " -o yaml"
 	}
 	out, err := p.Runner.RunCmd(cmdStr, "", p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("secrets", out, err)
+	return map[string]string{
+		"secrets": out,
+	}, err
 }
 
 // GetCRs returns CR contents for all CRDs in the cluster.
@@ -122,7 +117,9 @@ func GetCRs(p *Params) (map[string]string, error) {
 		return nil, err
 	}
 	out, err := p.Runner.RunCmd("get --all-namespaces "+strings.Join(crds, ",")+" -o yaml", "", p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("crs", out, err)
+	return map[string]string{
+		"crs": out,
+	}, err
 }
 
 // GetClusterInfo returns the cluster info.
@@ -149,23 +146,29 @@ func GetClusterContext(runner *kubectlcmd.Runner, kubeConfig string) (string, er
 
 // GetNodeInfo returns node information.
 func GetNodeInfo(p *Params) (map[string]string, error) {
-	out, err := p.Runner.RunCmd("describe nodes", "", p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("nodes", out, err)
+	out, err := p.Runner.RunCmd("get nodes -o yaml", "", p.KubeConfig, p.KubeContext, p.DryRun)
+	return map[string]string{
+		"nodes": out,
+	}, err
 }
 
-// GetDescribePods returns describe pods for istioNamespace.
-func GetDescribePods(p *Params) (map[string]string, error) {
+// GetPodInfo returns pod details for istioNamespace.
+func GetPodInfo(p *Params) (map[string]string, error) {
 	if p.IstioNamespace == "" {
-		return nil, fmt.Errorf("getDescribePods requires the Istio namespace")
+		return nil, fmt.Errorf("getPodInfo requires the Istio namespace")
 	}
-	out, err := p.Runner.RunCmd("describe pods", p.IstioNamespace, p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("describe-pods", out, err)
+	out, err := p.Runner.RunCmd("get pods -o yaml", p.IstioNamespace, p.KubeConfig, p.KubeContext, p.DryRun)
+	return map[string]string{
+		"pods": out,
+	}, err
 }
 
 // GetEvents returns events for all namespaces.
 func GetEvents(p *Params) (map[string]string, error) {
 	out, err := p.Runner.RunCmd("get events --all-namespaces -o wide", "", p.KubeConfig, p.KubeContext, p.DryRun)
-	return retMap("events", out, err)
+	return map[string]string{
+		"events": out,
+	}, err
 }
 
 // GetIstiodInfo returns internal Istiod debug info.
@@ -240,7 +243,9 @@ func GetNetstat(p *Params) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return retMap("netstat", out, err)
+	return map[string]string{
+		"netstat": out,
+	}, err
 }
 
 // GetAnalyze returns the output of istioctl analyze.
@@ -289,20 +294,6 @@ func GetAnalyze(p *Params, timeout time.Duration) (map[string]string, error) {
 	}
 	return out, nil
 }
-
-// GetNetfilter returns netfilter for the given container.
-/*func GetNetfilter(p *Params) (map[string]string, error) {
-	if p.Namespace == "" || p.Pod == "" {
-		return nil, fmt.Errorf("getNetfilter requires namespace and pod")
-	}
-
-	out, err := kubectlcmd.RunCmd("exec -it -n "+p.Namespace+" "+p.Pod+
-		" -- bash -c for fl in $(ls -1 /proc/sys/net/netfilter/*); do echo $fl: $(cat $fl); done", "", p.DryRun)
-	if err != nil {
-		return nil, err
-	}
-	return retMap("netfilter", out, err)
-}*/
 
 // GetCoredumps returns coredumps for the given namespace/pod/container.
 func GetCoredumps(p *Params) (map[string]string, error) {


### PR DESCRIPTION
The `istioctl bug-report` will use the `get pods` and `get nodes` commands for the report instead of `describe ...`. This reduces the amount of calls made to the k8s API and speeds up the generation of the bug report tool.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
