### PR TITLE
remove limits.cpu from values.yaml

### DIFF
--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -65,7 +65,7 @@ resources:
     cpu: 100m
     memory: 128Mi
   limits:
-    cpu: 2000m
+    # cpu: 2000m
     memory: 1024Mi
 
 autoscaling:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -369,7 +369,7 @@ global:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 2000m
+        # cpu: 2000m
         memory: 1024Mi
 
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -369,7 +369,7 @@ global:
         cpu: 100m
         memory: 128Mi
       limits:
-        # cpu: 2000m
+        cpu: 2000m
         memory: 1024Mi
 
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.


### PR DESCRIPTION
**Please provide a description of this PR:**

When Istio chart is imported as dependency chart, it is unable to unset `limits.cpu`. The change is really about supporting wider adoption. Keeping original values commented out for referencing and can be restored if desired.

If the change is accepted, feel free to let me know necessary change to increment chart version.