### PR TITLE
Add support for gzip compression in /stats/prometheus endpoint

### DIFF
--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -543,12 +543,27 @@
                       }
                     ]
                   },
-                  "http_filters": [{
-                    "name": "envoy.filters.http.router",
-                    "typed_config": {
-                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                  "http_filters": [
+                    {
+                      "name": "envoy.filters.http.compressor",
+                      "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.compressor.v3.Compressor",
+                        "compressor_library": {
+                          "name": "text_optimized",
+                          "typed_config": {
+                            "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+                          }
+                        },
+                        "remove_accept_encoding_header": true
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
-                  }]
+                  ]
                 }
               }
             ]


### PR DESCRIPTION
This is a change motivated by https://github.com/istio/istio/issues/30987 to support a gzip compressed /stats/prometheus endpoint.

We are currently generating high "Inter-Zone Egress" traffic costs due to the Prometheus scrapes of many pods with many Istio/Envoy metrics and could cut these costs by 1/10th if using gzip compression.

The solution proposed in https://github.com/istio/istio/issues/30987 does work when manually cURL'ing the new/separate 14090 endpoint. However it fails to work when using a `PodMonitor` CRD (from Prometheus Operator), because the targetPort in that PodMonitor *must* be advertised on a container in the scraped pods, or else Prometheus will not add any targets to this PodMonitor and will not scrape pods with this new (but hidden) 14090 port. Yes, I know that for a port to work and be accessible by other pods, it merely must be bound/listening by any process in the pod on the `0.0.0.0` interface and communication would then work. This however fails due to Prometheus and the PodMonitor not registering any pods (when specifying the `targetPort: 14090` in the PodMonitor, because Prometheus will check whether that port is actually advertised in the ports section of any container in the pod.

Also, the solution proposed in https://github.com/istio/istio/issues/30987 *must* use a separate port (and not 15090) because of the way that custom bootstrap configurations are merged with the default/built-in bootstrap configuration. Using the port 15090 in the custom bootstrap override, for example, will not work, because the port 15090 is already used, since `staticResources.listeners` is a list, and new entries will simply be appended to it, as is described by https://github.com/istio/istio/blob/master/samples/custom-bootstrap/README.md#customizing-the-bootstrap .

So, the problem of actually making a gzipped /stats/prometheus endpoint workable, can be solved by either:
- enabling gzip compression on the default 15090 port (as proposed by this Pull Request)
- providing a way to let the istio-proxy container advertize additional ports on the injected pod to make Prometheus/PodMonitor happy (not possible right now)

I'd like to discuss this matter in this Pull Request, thanks!