### PR TITLE
Install ztunnel after istio-cni

### DIFF
--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -80,6 +80,9 @@ var (
 		name.IstioBaseComponentName: {
 			name.PilotComponentName,
 		},
+		name.CNIComponentName: {
+			name.ZtunnelComponentName,
+		},
 	}
 
 	// InstallTree is a top down hierarchy tree of dependencies where children must wait for the parent to complete


### PR DESCRIPTION
**Please provide a description of this PR:**
Right now ztunnel is installed without any order, and maybe the first one. However, it actually becomes ready when istiod and istio-cni are ready. 