### PR TITLE
[release-1.18] Adjust DNS Proxy CNAME wildcard response to be compatible with glibc and musl 

### DIFF
--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -509,12 +509,10 @@ func generateAltHosts(hostname string, nameinfo *dnsProto.NameTable_NameInfo, pr
 // If it is not part of the registry, return nil so that caller queries upstream. If it is part
 // of registry, we will look it up in one of our tables, failing which we will return NXDOMAIN.
 func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, bool) {
-	var hostFound bool
-
-	question := host.Name(hostname)
+	question := string(host.Name(hostname))
 	wildcard := false
 	// First check if host exists in all hosts.
-	_, hostFound = table.allHosts[hostname]
+	_, hostFound := table.allHosts[hostname]
 	// If it is not found, check if a wildcard host exists for it.
 	// For example for "*.example.com", with the question "svc.svcns.example.com",
 	// we check if we have entries for "*.svcns.example.com", "*.example.com" etc.
@@ -535,16 +533,21 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 	}
 
 	var out []dns.RR
+	var ipAnswers []dns.RR
+	var wcAnswers []dns.RR
+	var cnAnswers []dns.RR
+
 	// Odds are, the first query will always be an expanded hostname
 	// (productpage.ns1.svc.cluster.local.ns1.svc.cluster.local)
 	// So lookup the cname table first
-	cn := table.cname[hostname]
-	if len(cn) > 0 {
+	for _, cn := range table.cname[hostname] {
 		// this was a cname match
-		hostname = cn[0].(*dns.CNAME).Target
+		copied := dns.Copy(cn).(*dns.CNAME)
+		copied.Header().Name = question
+		cnAnswers = append(cnAnswers, copied)
+		hostname = copied.Target
 	}
-	var ipAnswers []dns.RR
-	var wcAnswers []dns.RR
+
 	switch qtype {
 	case dns.TypeA:
 		ipAnswers = table.name4[hostname]
@@ -560,16 +563,23 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 		if wildcard {
 			for _, answer := range ipAnswers {
 				copied := dns.Copy(answer)
-				copied.Header().Name = string(question)
+				/// If there is a CNAME record for the wildcard host, we will sent a chained response of CNAME + A/AAAA pointer
+				/// Otherwhise we expand the wildcard to the original question domain
+				if len(cnAnswers) > 0 {
+					copied.Header().Name = hostname
+				} else {
+					copied.Header().Name = question
+				}
 				wcAnswers = append(wcAnswers, copied)
 			}
 		}
+
 		// We will return a chained response. In a chained response, the first entry is the cname record,
 		// and the second one is the A/AAAA record itself. Some clients do not follow cname redirects
 		// with additional DNS queries. Instead, they expect all the resolved records to be in the same
 		// big DNS response (presumably assuming that a recursive DNS query should do the deed, resolve
 		// cname et al and return the composite response).
-		out = append(out, cn...)
+		out = append(out, cnAnswers...)
 		if wildcard {
 			out = append(out, wcAnswers...)
 		} else {

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -182,6 +182,12 @@ func testDNS(t *testing.T, d *LocalDNSServer) {
 			expected: a("a.b.wildcard.", []netip.Addr{netip.MustParseAddr("11.11.11.11")}),
 		},
 		{
+			name: "success: wild card with with search namespace chained pointer correctly",
+			host: "foo.wildcard.ns1.svc.cluster.local.",
+			expected: append(cname("foo.wildcard.ns1.svc.cluster.local.", "*.wildcard."),
+				a("*.wildcard.", []netip.Addr{netip.MustParseAddr("10.10.10.10")})...),
+		},
+		{
 			name:     "success: wild card with domain returns A record correctly",
 			host:     "foo.svc.mesh.company.net.",
 			expected: a("foo.svc.mesh.company.net.", []netip.Addr{netip.MustParseAddr("10.1.2.3")}),
@@ -194,8 +200,8 @@ func testDNS(t *testing.T, d *LocalDNSServer) {
 		{
 			name: "success: wild card with search domain returns A record correctly",
 			host: "foo.svc.mesh.company.net.ns1.svc.cluster.local.",
-			expected: append(cname("*.svc.mesh.company.net.ns1.svc.cluster.local.", "*.svc.mesh.company.net."),
-				a("foo.svc.mesh.company.net.ns1.svc.cluster.local.", []netip.Addr{netip.MustParseAddr("10.1.2.3")})...),
+			expected: append(cname("foo.svc.mesh.company.net.ns1.svc.cluster.local.", "*.svc.mesh.company.net."),
+				a("*.svc.mesh.company.net.", []netip.Addr{netip.MustParseAddr("10.1.2.3")})...),
 		},
 		{
 			name:      "success: TypeAAAA query returns AAAA records only",

--- a/releasenotes/notes/47290.yaml
+++ b/releasenotes/notes/47290.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47290
+  - 47264
+  - 31250
+  - 33360
+  - 30531
+  - 38484
+releaseNotes:
+- |
+  **Fixed** DNS Proxy resolution for wildcard ServiceEntry with the search domain suffix for glibc based containers.


### PR DESCRIPTION
**cherry-pick https://github.com/istio/istio/pull/47290**


As reported on #47264, the DNS Proxy component is capable of returnin……g a CNAME chained response for wildcard `ServiceEntry` objects.

Unfortunately, this only worked for `musl` based DNS resolution leading to a few inconsistent reports of DNS resolution issues, likely on `glibc` based systems.

The issue on `glib` was a long-standing [problem reported in 2010](https://sourceware.org/bugzilla/show_bug.cgi?id=12154) and fixed in `glibc 2.37` in 2022-08-30. Considering the DNS Proxy feature was added in Istio 1.11 back in 2021, it was only possible to validate the DNS Proxy wildcard feature in `musl`, which is also the default on the contaienrs used on the sample.

Now that `glibc` fix has been backported to `glibc 2.34+` and picked up by a few distros (eg: [Debian Bookworm](https://salsa.debian.org/glibc-team/glibc/-/blob/bookworm/debian/patches/git-updates.diff#L111)), it would be important to enable the DNS Proxy wildcard resolution for processes using `glic`.

Consider the following `ServiceEntry` object for the tests: Tested on a local Colima k3s cluster, and an EKS staging cluster.

1. Follow the [DNS Proxy documentation](https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/)

```sh
cat <<EOF | istioctl install -y -f -
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  meshConfig:
    defaultConfig:
      proxyMetadata:
        # Enable basic DNS proxying
        ISTIO_META_DNS_CAPTURE: "true"
        # Enable automatic address allocation, optional
        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
EOF
```

```sh
kubectl label namespace default istio-injection=enabled --overwrite
```

2. Introduce a `ServiceEntry` with a wildcard host:

```sh
cat <<EOF | kubectl apply -f -
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: cluster-redirect
  namespace: default
spec:
  addresses:
    - 240.240.0.1
  hosts:
    - '*.mycluster.internal'
  location: MESH_INTERNAL
  ports:
    - name: http
      number: 80
      protocol: http
  resolution: STATIC
EOF
```

3. Run a container and attempt to resolve `foo.mycluster.internal`:

<details>
<summary>Debian (glibc) ❌</summary>

❌ Lookup does not resolve to the wildcard address.

```
kubectl run --rm -ti --command \
  --image python:bookworm \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- /bin/sh
```

```
(pod) % getent hosts foo.mycluster.internal
(pod) % echo $?
2
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'

Traceback (most recent call last):
  File "<string>", line 1, in <module>
socket.gaierror: [Errno -2] Name or service not known
```

```
(pod) % apt update && apt install -y curl

(pod) % curl foo.mycluster.internal
curl: (6) Could not resolve host: foo.mycluster.internal
```

</details>

<details>
<summary>Alpine (musl) ✅</summary>

✅ Lookup does resolve to the wildcard address.

```
kubectl run --rm -ti --command \
  --image python:alpine \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- getent hosts foo.mycluster.internal
```

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1       foo.mycluster.internal.default.svc.cluster.local  foo.mycluster.internal.default.svc.cluster.local foo.mycluster.internal
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apk add curl

(pod) # curl foo.mycluster.internal
no healthy upstream
```

</details>

The DNS query including the search domains appended returns as this format:

```
;; QUESTION SECTION:
;foo.mycluster.internal.default.svc.cluster.local.		IN	A

;; ANSWER SECTION:
*.mycluster.internal.default.svc.cluster.local.	30	IN	CNAME	*.mycluster.internal.
foo.mycluster.internal.default.svc.cluster.local.	30	IN	A	240.240.0.1
```

This works fine for `musl` as it performs a [domain expansion](https://git.musl-libc.org/cgit/musl/tree/src/network/lookup_name.c#n120) for the chained CNAME DNS response, completing the wildcard pointers to their redirects, which finally resolves to the A record as necessary.

Meanwhile, when analyzing the `glibc` issue report and implementation, it expects the chained CNAME DNS response to follow this pattern instead:

```
;; QUESTION SECTION:
;foo.mycluster.internal.default.svc.cluster.local.		IN	A

;; ANSWER SECTION:
foo.mycluster.internal.default.svc.cluster.local. 30 IN	CNAME *.mycluster.internal.
*.mycluster.internal.	30	IN	A	240.240.0.1
```

Notice that the first CNAME response is the fully qualified domain name, including the search domain, and the second entry is an A record with the wildcard `ServiceRegistry` address. Using this response format, both `glibc` and `musl` are able to resolve the wildcard address.

This commit changes the CNAME response from this pattern:

```
;; QUESTION SECTION:
;${full_qualified_domain_query_with_search}		IN	A

;; ANSWER SECTION:
${wildcard_service_entry}.${search_domain} 30 IN	CNAME ${wildcard_service_entry}
${full_qualified_domain_query_with_search}	30	IN	A	240.240.0.1
```

Now, the following pattern when a CNAME wildcard is found:
```
;; QUESTION SECTION:
;${full_qualified_domain_query_with_search}		IN	A

;; ANSWER SECTION:
${full_qualified_domain_query_with_search} 30 IN	CNAME ${wildcard_service_entry}
${wildcard_service_entry}	30	IN	A	240.240.0.1

```

The changes kept the bahaviour of expanding the wildcard `ServiceRegistry` when the query is made without the search domain included, resolving directly to an A record:

```
;; QUESTION SECTION:
;foo.mycluster.internal.		IN	A

;; ANSWER SECTION:
foo.mycluster.internal.	30	IN	A	240.240.0.1
```

After building a local istio image with the change, the following tests were performed:

1. Re
```sh
cat <<EOF | go run ./istioctl/cmd/istioctl install -y -f -
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  hub: 'docker.io/bltavares'
  tag: 'cname3'
  meshConfig:
    defaultConfig:
      proxyMetadata:
        # Enable basic DNS proxying
        ISTIO_META_DNS_CAPTURE: "true"
        # Enable automatic address allocation, optional
        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
EOF
```

```sh
kubectl label namespace default istio-injection=enabled --overwrite
```

2. Introduce a `ServiceEntry` with a wildcard host:

```sh
cat <<EOF | kubectl apply -f -
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: cluster-redirect
  namespace: default
spec:
  addresses:
    - 240.240.0.1
  hosts:
    - '*.mycluster.internal'
  location: MESH_INTERNAL
  ports:
    - name: http
      number: 80
      protocol: http
  resolution: STATIC
EOF
```

3. Run a container and attempt to resolve `foo.mycluster.internal`:

<details>
<summary>Debian (glibc) ✅</summary>

✅ Lookup **DOES** resolve to the wildcard address.

```
kubectl run --rm -ti --command \
  --image python:bookworm \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- /bin/sh
```

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1     foo.mycluster.internal.default.svc.cluster.local
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apt update && apt install -y curl

(pod) % curl foo.mycluster.internal
no healthy upstream
```

</details>

<details>
<summary>Alpine (musl) ✅</summary>

✅ Lookup does resolve to the wildcard address.

```
kubectl run --rm -ti --command \
  --image python:alpine \
  --namespace default \
  --annotations sidecar.istio.io/agentLogLevel=dns:debug \
  $(whoami|tr '.' '-')-dns-test -- getent hosts foo.mycluster.internal
```

```
(pod) % getent hosts foo.mycluster.internal
240.240.0.1       foo.mycluster.internal.default.svc.cluster.local  foo.mycluster.internal.default.svc.cluster.local foo.mycluster.internal
```

```
(pod) % python3 -c 'import socket; print(socket.gethostbyname("foo.mycluster.internal"))'
240.240.0.1
```

```
(pod) % apk add curl

(pod) # curl foo.mycluster.internal
no healthy upstream
```

</details>

**Please provide a description of this PR:**