### PR TITLE
Fix the command `ipilot-agent istio-clean-iptables` cannot clean up the iptables rules generated for istio dns proxy

### DIFF
--- a/releasenotes/notes/47957.yaml
+++ b/releasenotes/notes/47957.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: 
+  - 47957
+releaseNotes:
+  - |
+    **Fixed** the command ipilot-agent istio-clean-iptables cannot clean up the iptables rules generated for istio dns proxy.

--- a/releasenotes/notes/47957.yaml
+++ b/releasenotes/notes/47957.yaml
@@ -5,4 +5,4 @@ issue:
   - 47957
 releaseNotes:
   - |
-    **Fixed** the command ipilot-agent istio-clean-iptables cannot clean up the iptables rules generated for istio dns proxy.
+    **Fixed** an issue where the `pilot-agent istio-clean-iptables` command cannot clean up the iptables rules generated for istio dns proxy.

--- a/tools/istio-clean-iptables/pkg/cmd/root.go
+++ b/tools/istio-clean-iptables/pkg/cmd/root.go
@@ -39,6 +39,10 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 	// Allow binding to a different var, for consistency with other components
 	flag.AdditionalEnv(fs, constants.RedirectDNS, "ISTIO_META_DNS_CAPTURE")
 
+	flag.BindEnv(fs, constants.CaptureAllDNS, "",
+		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.",
+		&cfg.CaptureAllDNS)
+
 	flag.BindEnv(fs, constants.InboundInterceptionMode, "m",
 		"The mode used to redirect inbound connections to Envoy, either \"REDIRECT\" or \"TPROXY\".",
 		&cfg.InboundInterceptionMode)


### PR DESCRIPTION
Fix #47957

I added the `--capture-all-dns` parameter to `pilot-agent istio-clean-iptables`. In the parameter description and usage, make it consistent with the `--capture-all-dns` parameter of `pilot-agent istio-iptables`.