### PR TITLE
Setting priority of the ztunnel daemonset

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -125,6 +125,7 @@ spec:
         {{- with .Values.volumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      priorityClassName: system-node-critical
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
       - name: istio-token

--- a/releasenotes/notes/ztunnel-chart-priorityclassname.yaml
+++ b/releasenotes/notes/ztunnel-chart-priorityclassname.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 47867
+
+releaseNotes:
+  - |
+    **Added** Set the ztunnel Daemonset priorityClassName to system-node-critical to ensure it is running on all nodes


### PR DESCRIPTION
**Please provide a description of this PR:**
This is to set the priorityClass of the ztunnel Daemonset so that the Kubernetes scheduler when ensure it runs on all nodes (unless there are affinity rules that prohibit ztunnel on certain nodes).   This change matches the existing configuration of the Daemonset for istio-cni-node Daemonset.  That configuration can be found here: https://github.com/ali-research/istio/blob/a2fc718683e7660b51ba336cdb4df46e084277bd/manifests/charts/istio-cni/templates/daemonset.yaml#L62

I have brought up this idea in https://github.com/istio/istio/issues/47867 and no one has objected to the idea.

I updated the helm chart but I also found a manifest at `operator/cmd/mesh/testdata/manifest-generate/output/ztunnel.golden.yaml` that should probably be updated, too.