### PR TITLE
move tcp and udp specific configs in gateway listener

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1099,68 +1099,51 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		})
 	}
 
-	var res *listener.Listener
+	res := &listener.Listener{
+		// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy doesn't like
+		Address:          util.BuildAddress(opts.bind, uint32(opts.port)),
+		TrafficDirection: core.TrafficDirection_OUTBOUND,
+		ListenerFilters:  listenerFilters,
+		FilterChains:     filterChains,
+		// For Gateways, we want no timeout. We should wait indefinitely for the TLS if we are sniffing.
+		// The timeout is useful for sidecars, where we may operate on server first traffic; for gateways if we have listener filters
+		// we know those filters are required.
+		ContinueOnListenerFiltersTimeout: false,
+		ListenerFiltersTimeout:           durationpb.New(0),
+	}
 	switch transport {
 	case istionetworking.TransportProtocolTCP:
-		var connectionBalance *listener.Listener_ConnectionBalanceConfig
+		// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy doesn't like
+		res.Name = getListenerName(opts.bind, opts.port, istionetworking.TransportProtocolTCP)
+		log.Debugf("buildGatewayListener: building TCP listener %s", res.Name)
 		// only use to exact_balance for tcp outbound listeners; virtualOutbound listener should
 		// not have this set per Envoy docs for redirected listeners
 		if opts.proxy.Metadata.OutboundListenerExactBalance {
-			connectionBalance = &listener.Listener_ConnectionBalanceConfig{
+			res.ConnectionBalanceConfig = &listener.Listener_ConnectionBalanceConfig{
 				BalanceType: &listener.Listener_ConnectionBalanceConfig_ExactBalance_{
 					ExactBalance: &listener.Listener_ConnectionBalanceConfig_ExactBalance{},
 				},
 			}
 		}
-
-		res = &listener.Listener{
-			// TODO: need to sanitize the opts.bind if its a UDS socket, as it could have colons, that envoy doesn't like
-			Name:                    getListenerName(opts.bind, opts.port, istionetworking.TransportProtocolTCP),
-			Address:                 util.BuildAddress(opts.bind, uint32(opts.port)),
-			TrafficDirection:        core.TrafficDirection_OUTBOUND,
-			ListenerFilters:         listenerFilters,
-			FilterChains:            filterChains,
-			ConnectionBalanceConfig: connectionBalance,
-			// For Gateways, we want no timeout. We should wait indefinitely for the TLS if we are sniffing.
-			// The timeout is useful for sidecars, where we may operate on server first traffic; for gateways if we have listener filters
-			// we know those filters are required.
-			ContinueOnListenerFiltersTimeout: false,
-			ListenerFiltersTimeout:           durationpb.New(0),
-		}
-		// add extra addresses for the listener
-		if features.EnableDualStack && len(opts.extraBind) > 0 {
-			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
-		}
 	case istionetworking.TransportProtocolQUIC:
 		// TODO: switch on TransportProtocolQUIC is in too many places now. Once this is a bit
 		//       mature, refactor some of these to an interface so that they kick off the process
 		//       of building listener, filter chains, serializing etc based on transport protocol
-		listenerName := getListenerName(opts.bind, opts.port, istionetworking.TransportProtocolQUIC)
-		log.Debugf("buildGatewayListener: building UDP/QUIC listener %s", listenerName)
-		res = &listener.Listener{
-			Name:             listenerName,
-			Address:          util.BuildNetworkAddress(opts.bind, uint32(opts.port), istionetworking.TransportProtocolQUIC),
-			TrafficDirection: core.TrafficDirection_OUTBOUND,
-			FilterChains:     filterChains,
-			UdpListenerConfig: &listener.UdpListenerConfig{
-				// TODO: Maybe we should add options in MeshConfig to
-				//       configure QUIC options - it should look similar
-				//       to the H2 protocol options.
-				QuicOptions:            &listener.QuicProtocolOptions{},
-				DownstreamSocketConfig: &core.UdpSocketConfig{},
-			},
-			// For Gateways, we want no timeout. We should wait indefinitely for the TLS if we are sniffing.
-			// The timeout is useful for sidecars, where we may operate on server first traffic; for gateways if we have listener filters
-			// we know those filters are required.
-			ContinueOnListenerFiltersTimeout: false,
-			ListenerFiltersTimeout:           durationpb.New(0),
+		res.Name = getListenerName(opts.bind, opts.port, istionetworking.TransportProtocolQUIC)
+		log.Debugf("buildGatewayListener: building UDP/QUIC listener %s", res.Name)
+		res.UdpListenerConfig = &listener.UdpListenerConfig{
+			// TODO: Maybe we should add options in MeshConfig to
+			//       configure QUIC options - it should look similar
+			//       to the H2 protocol options.
+			QuicOptions:            &listener.QuicProtocolOptions{},
+			DownstreamSocketConfig: &core.UdpSocketConfig{},
 		}
-		// add extra addresses for the listener
-		if features.EnableDualStack && len(opts.extraBind) > 0 {
-			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
-		}
-	}
 
+	}
+	// add extra addresses for the listener
+	if features.EnableDualStack && len(opts.extraBind) > 0 {
+		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
+	}
 	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, istionetworking.ListenerClassGateway)
 
 	return res


### PR DESCRIPTION
Build TCP/UDP specific configs inside switch and build the generic listener outside to avoid specifying the same flags twice

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
