### PR TITLE
Move default tests over to k8s 1.28

### DIFF
--- a/prow/config/ambient-sc.yaml
+++ b/prow/config/ambient-sc.yaml
@@ -1,8 +1,6 @@
 # similar to default, but multi-node
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  MixedProtocolLBService: true
 nodes:
 - role: control-plane
 - role: worker

--- a/prow/config/ambient-sc.yaml
+++ b/prow/config/ambient-sc.yaml
@@ -3,7 +3,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   MixedProtocolLBService: true
-  GRPCContainerProbe: true
 nodes:
 - role: control-plane
 - role: worker

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -2,8 +2,6 @@
 # This should be used to create K8s clusters with versions >= 1.23
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  MixedProtocolLBService: true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -4,7 +4,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   MixedProtocolLBService: true
-  GRPCContainerProbe: true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -37,7 +37,7 @@ setup_and_export_git_sha
 source "${ROOT}/common/scripts/kind_provisioner.sh"
 
 TOPOLOGY=SINGLE_CLUSTER
-NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.27.3"
+NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.28.4"
 KIND_CONFIG=""
 CLUSTER_TOPOLOGY_CONFIG_FILE="${ROOT}/prow/config/topology/multicluster.json"
 


### PR DESCRIPTION
Will pair with a test-infra PR with +1.27,-1.28,+1.29.
