### PR TITLE
WIP: Add manifest translate command

### DIFF
--- a/operator/cmd/mesh/manifest-translate.go
+++ b/operator/cmd/mesh/manifest-translate.go
@@ -1,0 +1,253 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"io/fs"
+	"reflect"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"istio.io/istio/istioctl/pkg/cli"
+	"istio.io/istio/manifests"
+	"istio.io/istio/operator/pkg/component"
+	"istio.io/istio/operator/pkg/controlplane"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/tpath"
+	"istio.io/istio/operator/pkg/translate"
+	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/log"
+)
+
+type ManifestTranslateArgs struct {
+	// InFilenames is an array of paths to the input IstioOperator CR files.
+	InFilenames []string
+
+	// Set is a string with element format "path=value" where path is an IstioOperator path and the value is a
+	// value to set the node at that path to.
+	Set []string
+	// ManifestsPath is a path to a charts and profiles directory in the local filesystem with a release tgz.
+	ManifestsPath string
+	// Revision is the Istio control plane revision the command targets.
+	Revision string
+}
+
+func addManifestTranslateFlags(cmd *cobra.Command, args *ManifestTranslateArgs) {
+	cmd.PersistentFlags().StringSliceVarP(&args.InFilenames, "filename", "f", nil, filenameFlagHelpStr)
+	cmd.PersistentFlags().StringArrayVarP(&args.Set, "set", "s", nil, setFlagHelpStr)
+	cmd.PersistentFlags().StringVarP(&args.ManifestsPath, "manifests", "d", "", ManifestsFlagHelpStr)
+	cmd.PersistentFlags().StringVarP(&args.Revision, "revision", "r", "", revisionFlagHelpStr)
+}
+
+func ManifestTranslateCmd(ctx cli.Context, rootArgs *RootArgs, mgArgs *ManifestTranslateArgs, logOpts *log.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "translate",
+		Short: "Translates an Istio install manifest to Helm values",
+		Long:  "The translate subcommand translates an Istio install manifest and outputs to the console by default.",
+		// nolint: lll
+		Example: `  # Translate an IstioOperator yaml file into helm values
+  istioctl manifest translate -f istio.yaml
+
+  # Translate a default Istio installation
+  istioctl manifest translate
+
+  # Enable Tracing
+  istioctl manifest translate --set meshConfig.enableTracing=true
+
+  # Translate the demo profile
+  istioctl manifest translate --set profile=demo
+
+  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
+  istioctl manifest translate --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
+`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("translate accepts no positional arguments, got %#v", args)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if kubeClientFunc == nil {
+				kubeClientFunc = ctx.CLIClient
+			}
+			var kubeClient kube.CLIClient
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
+			return ManifestTranslate(kubeClient, rootArgs, mgArgs, logOpts, l)
+		},
+	}
+}
+
+func ManifestTranslate(kubeClient kube.CLIClient, args *RootArgs, mgArgs *ManifestTranslateArgs, logopts *log.Options, l clog.Logger) error {
+	if err := configLogs(logopts); err != nil {
+		return fmt.Errorf("could not configure logs: %s", err)
+	}
+
+	_, iop, err := manifest.GenerateConfig(mgArgs.InFilenames, applyFlagAliases(mgArgs.Set, mgArgs.ManifestsPath, mgArgs.Revision),
+		true, kubeClient, l)
+	if err != nil {
+		return err
+	}
+	t := translate.NewTranslator()
+	valuesMap := map[string]any{}
+	debugMap := map[string]any{}
+	opts := &component.Options{
+		InstallSpec: iop.Spec,
+		Translator:  t,
+		Filter:      nil,
+		Version:     nil,
+	}
+	comps, err := controlplane.BuildComponents(*opts)
+	if err != nil {
+		return err
+	}
+	for _, c := range comps {
+		k := c.ComponentName()
+		l.LogAndPrint(k)
+		compYAML, err := t.TranslateHelmValues(iop.Spec, c.ComponentSpec(), k)
+		if err != nil {
+			return err
+		}
+		compmap := map[string]any{}
+		err = yaml.Unmarshal([]byte(compYAML), &compmap)
+		if err != nil {
+			return err
+		}
+		debugMap[string(c.ComponentName())] = compmap
+		mergeMaps(compmap, valuesMap, util.Path{})
+	}
+	defaults := loadDefaults(mgArgs.ManifestsPath)
+
+	// remove any values that are already defaults
+	subtractMaps(defaults, valuesMap)
+	// remove any empty parts of the map
+	removeEmptyYaml(valuesMap)
+
+	out, err := yaml.Marshal(valuesMap)
+	l.Print(string(out))
+
+	return nil
+}
+
+func subtractMaps(src, dst map[string]any) {
+	if util.IsValueNil(src) {
+		return
+	}
+	for k, v := range src {
+		if _, ok := dst[k]; ok {
+			if reflect.DeepEqual(v, dst[k]) {
+				delete(dst, k)
+			} else if reflect.TypeOf(v).Kind() == reflect.Map {
+				subtractMaps(v.(map[string]any), dst[k].(map[string]any))
+				if dst[k] == nil || len(dst[k].(map[string]any)) == 0 {
+					delete(dst, k)
+				}
+			}
+		}
+	}
+}
+
+func removeEmptyYaml(src map[string]any) {
+	if len(src) == 0 {
+		return
+	}
+	for k, v := range src {
+		if src[k] == nil {
+			delete(src, k)
+		} else if reflect.TypeOf(v).Kind() == reflect.Map {
+			removeEmptyYaml(v.(map[string]any))
+			if len(v.(map[string]any)) == 0 {
+				delete(src, k)
+			}
+		} else if reflect.TypeOf(v).Kind() == reflect.Slice && len(v.([]any)) == 0 {
+			delete(src, k)
+		}
+	}
+}
+
+func mergeMaps(src any, dst map[string]any, path util.Path) (errs util.Errors) {
+	if util.IsValueNil(src) {
+		return nil
+	}
+
+	vv := reflect.ValueOf(src)
+	vt := reflect.TypeOf(src)
+	switch vt.Kind() {
+	case reflect.Ptr:
+		if !util.IsNilOrInvalidValue(vv.Elem()) {
+			errs = util.AppendErrs(errs, mergeMaps(vv.Elem().Interface(), dst, path))
+		}
+	case reflect.Struct:
+		for i := 0; i < vv.NumField(); i++ {
+			fieldName := vv.Type().Field(i).Name
+			fieldValue := vv.Field(i)
+			if a, ok := vv.Type().Field(i).Tag.Lookup("json"); ok && a == "-" {
+				continue
+			}
+			if !fieldValue.CanInterface() {
+				continue
+			}
+			errs = util.AppendErrs(errs, mergeMaps(fieldValue.Interface(), dst, append(path, fieldName)))
+		}
+	case reflect.Map:
+		for _, key := range vv.MapKeys() {
+			nnp := append(path, key.String())
+			errs = util.AppendErr(errs, mergeLeaf(dst, nnp, vv.MapIndex(key)))
+		}
+	case reflect.Slice:
+		for i := 0; i < vv.Len(); i++ {
+			errs = util.AppendErrs(errs, mergeMaps(vv.Index(i).Interface(), dst, path))
+		}
+	default:
+		// Must be a leaf
+		if vv.CanInterface() {
+			errs = util.AppendErr(errs, mergeLeaf(dst, path, vv))
+		}
+	}
+
+	return errs
+}
+
+func mergeLeaf(out map[string]any, path util.Path, value reflect.Value) error {
+	return tpath.WriteNode(out, path, value.Interface())
+}
+
+// load all values.yaml files, representing defaults, and merge into single default map
+func loadDefaults(manifestsPath string) map[string]any {
+	f := manifests.BuiltinOrDir(manifestsPath)
+	filenames, err := fs.Glob(f, "charts/**/values.yaml")
+	// files, err := os.ReadDir(manifestsPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	result := map[string]any{}
+	for _, filename := range filenames {
+		fs.ReadFile(f, filename)
+		valuesFile, err := fs.ReadFile(f, filename)
+		if err != nil {
+			continue
+		}
+		var values map[string]any
+		err = yaml.Unmarshal(valuesFile, &values)
+		if err != nil {
+			log.Fatal(err)
+		}
+		mergeMaps(values, result, util.Path{})
+	}
+	return result
+}

--- a/operator/cmd/mesh/manifest-translate_test.go
+++ b/operator/cmd/mesh/manifest-translate_test.go
@@ -1,0 +1,52 @@
+package mesh
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSubtractMaps(t *testing.T) {
+	// Test case 1: src is nil, dst should remain unchanged
+	dst := map[string]any{"key1": "value1", "key2": "value2"}
+	subtractMaps(nil, dst)
+	expected := map[string]any{"key1": "value1", "key2": "value2"}
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("Expected dst to be %v, but got %v", expected, dst)
+	}
+
+	// Test case 2: src and dst have no common keys, dst should remain unchanged
+	src := map[string]any{"key3": "value3", "key4": "value4"}
+	dst = map[string]any{"key1": "value1", "key2": "value2"}
+	subtractMaps(src, dst)
+	expected = map[string]any{"key1": "value1", "key2": "value2"}
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("Expected dst to be %v, but got %v", expected, dst)
+	}
+
+	// Test case 3: src and dst have common keys with equal values, common keys should be deleted from dst
+	src = map[string]any{"key1": "value1", "key2": "value2"}
+	dst = map[string]any{"key1": "value1", "key2": "value2", "key3": "value3"}
+	subtractMaps(src, dst)
+	expected = map[string]any{"key3": "value3"}
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("Expected dst to be %v, but got %v", expected, dst)
+	}
+
+	// Test case 4: src and dst have common keys with different values, common keys should not be deleted from dst
+	src = map[string]any{"key1": "value1", "key2": "value2"}
+	dst = map[string]any{"key1": "value1", "key2": "value3", "key3": "value3"}
+	subtractMaps(src, dst)
+	expected = map[string]any{"key2": "value3", "key3": "value3"}
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("Expected dst to be %v, but got %v", expected, dst)
+	}
+
+	// Test case 5: src and dst have common keys with nested maps, nested maps should be subtracted recursively
+	src = map[string]any{"key1": map[string]any{"nestedKey1": "nestedValue1"}}
+	dst = map[string]any{"key1": map[string]any{"nestedKey1": "nestedValue1", "nestedKey2": "nestedValue2"}}
+	subtractMaps(src, dst)
+	expected = map[string]any{"key1": map[string]any{"nestedKey2": "nestedValue2"}}
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("Expected dst to be %v, but got %v", expected, dst)
+	}
+}

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -31,23 +31,28 @@ func ManifestCmd(ctx cli.Context, logOpts *log.Options) *cobra.Command {
 
 	mgcArgs := &ManifestGenerateArgs{}
 	mdcArgs := &manifestDiffArgs{}
+	mtcArgs := &ManifestTranslateArgs{}
 
 	args := &RootArgs{}
 
 	mgc := ManifestGenerateCmd(ctx, args, mgcArgs, logOpts)
+	mtc := ManifestTranslateCmd(ctx, args, mtcArgs, logOpts)
 	mdc := manifestDiffCmd(args, mdcArgs)
 	ic := InstallCmd(ctx, logOpts)
 
 	addFlags(mc, args)
 	addFlags(mgc, args)
 	addFlags(mdc, args)
+	addFlags(mtc, args)
 
 	addManifestGenerateFlags(mgc, mgcArgs)
 	addManifestDiffFlags(mdc, mdcArgs)
+	addManifestTranslateFlags(mtc, mtcArgs)
 
 	mc.AddCommand(mgc)
 	mc.AddCommand(mdc)
 	mc.AddCommand(ic)
+	mc.AddCommand(mtc)
 
 	return mc
 }

--- a/operator/pkg/component/component.go
+++ b/operator/pkg/component/component.go
@@ -72,6 +72,8 @@ type IstioComponent interface {
 	Run() error
 	// RenderManifest returns a string with the rendered manifest for the component.
 	RenderManifest() (string, error)
+	// ComponentSpec returns the component spec for the component.
+	ComponentSpec() any
 }
 
 // CommonComponentFields is a struct common to all components.
@@ -119,6 +121,10 @@ func (c *IstioComponentBase) Run() error {
 
 func (c *IstioComponentBase) RenderManifest() (string, error) {
 	return renderManifest(c)
+}
+
+func (c *IstioComponentBase) ComponentSpec() any {
+	return c.componentSpec
 }
 
 // NewCoreComponent creates a new IstioComponent with the given componentName and options.


### PR DESCRIPTION
**Please provide a description of this PR:**
The manifest translate command takes similar arguments to manifest generate, but outputs the Helm values.yaml file needed to perform the equivalent installations with helm.  Critically, helm cannot perform any K8s overlay tasks associated with the IstioOperator input, so those inputs are ignored.  A separate command could be created to postRended k8s overlays in helm, but that will be a separate PR.

At the moment, the output includes a lot of values which appear to be defaults, but are not included in the respective chart values.yaml, which is where defaults are specified.  I will need to add logic to identify implicit defaults and scrub them from the output to keep the output as clean as possible.