### PR TITLE
pilot: gateway-api: gateway: Add SANS validation

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2317,9 +2317,12 @@ func buildTLS(ctx configContext, tls *k8s.GatewayTLSConfig, gw config.Config, is
 		return nil, nil
 	}
 	// Explicitly not supported: file mounted
-	// Not yet implemented: TLS mode, https redirect, max protocol version, SANs, CipherSuites, VerifyCertificate
+	// Not yet implemented: TLS mode, https redirect, max protocol version, CipherSuites, VerifyCertificate
 	out := &istio.ServerTLSSettings{
 		HttpsRedirect: false,
+	}
+	if sans, ok := tls.Options[gatewaySubjectAltNamesKey]; ok {
+		out.SubjectAltNames = strings.Split(string(sans), ",")
 	}
 	mode := k8sv1.TLSModeTerminate
 	if tls.Mode != nil {

--- a/pilot/pkg/config/kube/gateway/model.go
+++ b/pilot/pkg/config/kube/gateway/model.go
@@ -33,6 +33,8 @@ const (
 	gatewayNameOverride          = "gateway.istio.io/name-override"
 	gatewaySAOverride            = "gateway.istio.io/service-account"
 	serviceTypeOverride          = "networking.istio.io/service-type"
+	// A comma-separated list of alternate names to verify the subject identity in the certificate presented by the client
+	gatewaySubjectAltNamesKey = "gateway.istio.io/subject-alt-names"
 )
 
 // GatewayResources stores all gateway resources used for our conversion.


### PR DESCRIPTION
**Please provide a description of this PR:**
Adds a Gateway API option to enable [`Gateway.ServerTLSSettings.subjectAltNames`](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings). 

This Istio-specific `Gateway` option (`gateway.istio.io/subject-alt-names`) accepts a comma-separated list of alternate names for client certificate verification with mutual TLS.