### PR TITLE
Fix experimental version has no proxy info shown

### DIFF
--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -157,7 +157,7 @@ func XdsVersionCommand(ctx cli.Context) *cobra.Command {
 func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptions, centralOpts *clioptions.CentralControlPlaneOptions, outXDS **discovery.DiscoveryResponse) func() (*istioVersion.MeshInfo, error) {
 	return func() (*istioVersion.MeshInfo, error) {
 		xdsRequest := discovery.DiscoveryRequest{
-			TypeUrl: "istio.io/connections",
+			TypeUrl: xds.TypeURLConnect,
 		}
 		kubeClient, err := ctx.CLIClientWithRevision(opts.Revision)
 		if err != nil {

--- a/releasenotes/notes/48021.yaml
+++ b/releasenotes/notes/48021.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where `istioctl experimental version` has no proxy info shown.


### PR DESCRIPTION
**Please provide a description of this PR:**
Pilot generate response with

https://github.com/istio/istio/blob/141104caec71593378094d789a47e1da7979b57b/pilot/pkg/xds/statusgen.go#L76-L81

where TypeURLConnect is `istio.io/connect`