### PR TITLE
fix uds log timestamp

### DIFF
--- a/cni/pkg/log/uds.go
+++ b/cni/pkg/log/uds.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"istio.io/istio/cni/pkg/constants"
 	"istio.io/istio/pkg/log"
@@ -36,8 +37,9 @@ type UDSLogger struct {
 }
 
 type cniLog struct {
-	Level string `json:"level"`
-	Msg   string `json:"msg"`
+	Level string    `json:"level"`
+	Time  time.Time `json:"time"`
+	Msg   string    `json:"msg"`
 }
 
 func NewUDSLogger() *UDSLogger {
@@ -117,13 +119,13 @@ func (l *UDSLogger) processLog(body []byte) {
 		// There is no fatal log from CNI plugin
 		switch m.Level {
 		case "debug":
-			pluginLog.Debug(m.Msg)
+			pluginLog.LogWithTime(log.DebugLevel, m.Msg, m.Time)
 		case "info":
-			pluginLog.Info(m.Msg)
+			pluginLog.LogWithTime(log.InfoLevel, m.Msg, m.Time)
 		case "warn":
-			pluginLog.Warn(m.Msg)
+			pluginLog.LogWithTime(log.WarnLevel, m.Msg, m.Time)
 		case "error":
-			pluginLog.Error(m.Msg)
+			pluginLog.LogWithTime(log.ErrorLevel, m.Msg, m.Time)
 		}
 	}
 }

--- a/pkg/log/default_test.go
+++ b/pkg/log/default_test.go
@@ -263,7 +263,6 @@ func TestDefaultWithLabel(t *testing.T) {
 }
 
 func TestLogWithTime(t *testing.T) {
-
 	getLogTime := func(t *testing.T, line string) time.Time {
 		type logEntry struct {
 			Time time.Time `json:"time"`

--- a/pkg/log/default_test.go
+++ b/pkg/log/default_test.go
@@ -15,9 +15,11 @@
 package log
 
 import (
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func testOptions() *Options {
@@ -258,4 +260,50 @@ func TestDefaultWithLabel(t *testing.T) {
 	}
 
 	mustRegexMatchString(t, lines[0], `Hello	foo=bar baz=123 qux=0.123`)
+}
+
+func TestLogWithTime(t *testing.T) {
+
+	getLogTime := func(t *testing.T, line string) time.Time {
+		type logEntry struct {
+			Time time.Time `json:"time"`
+		}
+		var e logEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("Failed to unmarshal log entry: %v", err)
+		}
+		return e.Time
+	}
+
+	t.Run("specified time", func(t *testing.T) {
+		yesterday := time.Now().Add(-time.Hour * 24).Truncate(time.Microsecond)
+
+		stdoutLines, _ := captureStdout(func() {
+			o := DefaultOptions()
+			o.JSONEncoding = true
+			_ = Configure(o)
+			defaultScope.LogWithTime(InfoLevel, "Hello", yesterday)
+		})
+
+		gotTime := getLogTime(t, stdoutLines[0])
+		if gotTime.UnixNano() != yesterday.UnixNano() {
+			t.Fatalf("Got time %v, expected %v", gotTime, yesterday)
+		}
+	})
+
+	t.Run("empty time", func(t *testing.T) {
+		stdoutLines, _ := captureStdout(func() {
+			o := DefaultOptions()
+			o.JSONEncoding = true
+			_ = Configure(o)
+
+			var ti time.Time
+			defaultScope.LogWithTime(InfoLevel, "Hello", ti)
+		})
+
+		gotTime := getLogTime(t, stdoutLines[0])
+		if gotTime.IsZero() {
+			t.Fatalf("Got %v, expected non-zero", gotTime)
+		}
+	})
 }

--- a/pkg/log/scope.go
+++ b/pkg/log/scope.go
@@ -218,6 +218,13 @@ func (s *Scope) Debug(msg any) {
 	}
 }
 
+// LogWithTime outputs a message with a given timestamp.
+func (s *Scope) LogWithTime(level Level, msg string, t time.Time) {
+	if s.GetOutputLevel() >= level {
+		s.emitWithTime(levelToZap[level], msg, t)
+	}
+}
+
 // Debugf uses fmt.Sprintf to construct and log a message at debug level.
 func (s *Scope) Debugf(format string, args ...any) {
 	if s.GetOutputLevel() >= DebugLevel {
@@ -302,10 +309,18 @@ func (s *Scope) WithLabels(kvlist ...any) *Scope {
 }
 
 func (s *Scope) emit(level zapcore.Level, msg string) {
+	s.emitWithTime(level, msg, time.Now())
+}
+
+func (s *Scope) emitWithTime(level zapcore.Level, msg string, t time.Time) {
+	if t.IsZero() {
+		t = time.Now()
+	}
+
 	e := zapcore.Entry{
 		Message:    msg,
 		Level:      level,
-		Time:       time.Now(),
+		Time:       t,
 		LoggerName: s.nameToEmit,
 	}
 

--- a/pkg/log/zapcore_handler.go
+++ b/pkg/log/zapcore_handler.go
@@ -28,7 +28,7 @@ var toLevel = map[zapcore.Level]Level{
 
 // callerSkipOffset is how many callers to pop off the stack to determine the caller function locality, used for
 // adding file/line number to log output.
-const callerSkipOffset = 2
+const callerSkipOffset = 3
 
 func dumpStack(level zapcore.Level, scope *Scope) bool {
 	thresh := toLevel[level]


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixing #47965 

Change:

- Add a `LogWithTime` to `log.Scope` to support custom timestamp.