### PR TITLE
allow configuration of outbound IPv4 loopback CIDR 

### DIFF
--- a/releasenotes/notes/47211.yaml
+++ b/releasenotes/notes/47211.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+issue:
+  - 47211
+
+releaseNotes:
+- |
+  **Added** Ability to configure the IPv4 loopback CIDR used by istio-iptables in various firewall rules.

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -142,7 +142,7 @@ func (cfg *IptablesConfigurator) handleInboundPortsInclude() {
 			// port.
 			// In the ISTIOINBOUND chain, '-j RETURN' bypasses Envoy and
 			// '-j ISTIOTPROXY' redirects to Envoy.
-			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand,
+			cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand,
 				constants.ISTIOTPROXY, constants.MANGLE, "!", "-d", constants.IPVersionSpecific,
 				"-p", constants.TCP, "-j", constants.TPROXY,
 				"--tproxy-mark", cfg.cfg.InboundTProxyMark+"/0xffffffff", "--on-port", cfg.cfg.InboundCapturePort)
@@ -362,7 +362,7 @@ func (cfg *IptablesConfigurator) Run() error {
 			// app => istio-agent => Envoy inbound => dns server
 			// Instead, we just have:
 			// app => istio-agent => dns server
-			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+			cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 				"-o", "lo",
 				"!", "-d", constants.IPVersionSpecific,
 				"-p", "tcp",
@@ -370,7 +370,7 @@ func (cfg *IptablesConfigurator) Run() error {
 				"!", "--dports", "53,"+cfg.cfg.InboundTunnelPort,
 				"-m", "owner", "--uid-owner", uid, "-j", constants.ISTIOINREDIRECT)
 		} else {
-			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+			cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 				"-o", "lo",
 				"!", "-d", constants.IPVersionSpecific,
 				"-p", "tcp",
@@ -405,7 +405,7 @@ func (cfg *IptablesConfigurator) Run() error {
 	for _, gid := range split(cfg.cfg.ProxyGID) {
 		// Redirect app calls back to itself via Envoy when using the service VIP
 		// e.g. appN => Envoy (client) => Envoy (server) => appN.
-		cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+		cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 			"-o", "lo",
 			"!", "-d", constants.IPVersionSpecific,
 			"-p", "tcp",
@@ -483,7 +483,7 @@ func (cfg *IptablesConfigurator) Run() error {
 	// Skip redirection for Envoy-aware applications and
 	// container-to-container traffic both of which explicitly use
 	// localhost.
-	cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
+	cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.ISTIOOUTPUT, constants.NAT,
 		"-d", constants.IPVersionSpecific, "-j", constants.RETURN)
 	// Apply outbound IPv4 exclusions. Must be applied before inclusions.
 	for _, cidr := range ipv4RangesExclude.CIDRs {
@@ -516,14 +516,14 @@ func (cfg *IptablesConfigurator) Run() error {
 		for _, uid := range split(cfg.cfg.ProxyUID) {
 			// mark outgoing packets from envoy to workload by pod ip
 			// app call VIP --> envoy outbound -(mark 1338)-> envoy inbound --> app
-			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
+			cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
 				"!", "-d", constants.IPVersionSpecific, "-p", constants.TCP, "-o", "lo",
 				"-m", "owner", "--uid-owner", uid, "-j", constants.MARK, "--set-mark", outboundMark)
 		}
 		for _, gid := range split(cfg.cfg.ProxyGID) {
 			// mark outgoing packets from envoy to workload by pod ip
 			// app call VIP --> envoy outbound -(mark 1338)-> envoy inbound --> app
-			cfg.iptables.AppendVersionedRule("127.0.0.1/32", "::1/128", iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
+			cfg.iptables.AppendVersionedRule(cfg.cfg.HostIPv4LoopbackCidr, "::1/128", iptableslog.UndefinedCommand, constants.OUTPUT, constants.MANGLE,
 				"!", "-d", constants.IPVersionSpecific, "-p", constants.TCP, "-o", "lo",
 				"-m", "owner", "--gid-owner", gid, "-j", constants.MARK, "--set-mark", outboundMark)
 		}

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -37,6 +37,7 @@ func constructTestConfig() *config.Config {
 		InboundTProxyMark:       "1337",
 		InboundTProxyRouteTable: "133",
 		OwnerGroupsInclude:      constants.OwnerGroupsInclude.DefaultValue,
+		HostIPv4LoopbackCidr:    constants.HostIPv4LoopbackCidr.DefaultValue,
 		RestoreFormat:           true,
 	}
 }
@@ -261,6 +262,12 @@ func TestIptables(t *testing.T) {
 			"drop-invalid",
 			func(cfg *config.Config) {
 				cfg.DropInvalid = true
+			},
+		},
+		{
+			"host-ipv4-loopback-cidr",
+			func(cfg *config.Config) {
+				cfg.HostIPv4LoopbackCidr = "127.0.0.1/8"
 			},
 		},
 	}

--- a/tools/istio-iptables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
@@ -1,0 +1,16 @@
+iptables -t nat -N ISTIO_INBOUND
+iptables -t nat -N ISTIO_REDIRECT
+iptables -t nat -N ISTIO_IN_REDIRECT
+iptables -t nat -N ISTIO_OUTPUT
+iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN
+iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
+iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
+iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/8 -p tcp ! --dport 15008 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/8 -p tcp ! --dport 15008 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
+iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
+iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/8 -j RETURN

--- a/tools/istio-iptables/pkg/config/validation.go
+++ b/tools/istio-iptables/pkg/config/validation.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 )
 
 const (
@@ -38,6 +39,23 @@ func ValidateOwnerGroups(include, exclude string) error {
 		return fmt.Errorf("number of owner groups whose outgoing traffic "+
 			"should be redirected to Envoy cannot exceed %d, got %d: %v",
 			maxOwnerGroupsInclude, len(filter.Values), filter.Values)
+	}
+	return nil
+}
+
+func ValidateIPv4LoopbackCidr(cidr string) error {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	if ip.To4() == nil || !ip.To4().IsLoopback() {
+		return fmt.Errorf("expected valid ipv4 loopback address; found %v", ip)
+	}
+
+	ones, _ := ipNet.Mask.Size()
+	if ones < 8 || ones > 32 {
+		return fmt.Errorf("expected mask in range [8, 32]; found %v", ones)
 	}
 	return nil
 }

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -116,6 +116,9 @@ const (
 //
 // Use viper to resolve the value of the environment variable.
 var (
+	HostIPv4LoopbackCidr = env.Register("ISTIO_OUTBOUND_IPV4_LOOPBACK_CIDR", "127.0.0.1/32",
+		`IPv4 CIDR range used to identify outbound traffic on loopback interface intended for application container`)
+
 	OwnerGroupsInclude = env.Register("ISTIO_OUTBOUND_OWNER_GROUPS", "*",
 		`Comma separated list of groups whose outgoing traffic is to be redirected to Envoy.
 A group can be specified either by name or by a numeric GID.


### PR DESCRIPTION
**Please provide a description of this PR:** implements support for https://github.com/istio/istio/issues/47211

Currently, this PR applies the configuration in a blanket fashion for consistency purposes. If this is not desirable, perhaps the changes can be trimmed down to just this rule: https://github.com/istio/istio/blob/master/tools/istio-iptables/pkg/capture/run.go#L373-L378.