### PR TITLE
probe return body as well as statuscode

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -793,7 +793,6 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	// Return the body from probe as well
 	b, _ := utilio.ReadAtMost(response.Body, maxRespBodyLength)
 	_, _ = w.Write(b)
-
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -788,6 +788,8 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
+	body, _ := io.ReadAll(response.Body)
+	w.Write(body)
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -71,7 +71,6 @@ const (
 	// indicates that httpbin container liveness prober port is 8080 and probing path is /hello.
 	// This environment variable should never be set manually.
 	KubeAppProberEnvName = "ISTIO_KUBE_APP_PROBERS"
-
 	localHostIPv4 = "127.0.0.1"
 	localHostIPv6 = "::1"
 	maxRespBodyLength = 10 * 1 << 10

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -74,7 +74,7 @@ const (
 
 	localHostIPv4 = "127.0.0.1"
 	localHostIPv6 = "::1"
-	maxRespBodyLength = 10 * 1 << 10 // 10KB
+	maxRespBodyLength = 10 * 1 << 10
 )
 
 var (
@@ -792,7 +792,8 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	w.WriteHeader(response.StatusCode)
 	// Return the body from probe as well
 	b, _ := utilio.ReadAtMost(response.Body, maxRespBodyLength)
-	w.Write(b)
+	_, _ = w.Write(b)
+
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -788,8 +788,7 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
-	body, _ := io.ReadAll(response.Body)
-	w.Write(body)
+	io.Copy(w, response.Body)
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -71,6 +71,7 @@ const (
 	// indicates that httpbin container liveness prober port is 8080 and probing path is /hello.
 	// This environment variable should never be set manually.
 	KubeAppProberEnvName = "ISTIO_KUBE_APP_PROBERS"
+
 	localHostIPv4 = "127.0.0.1"
 	localHostIPv6 = "::1"
 	maxRespBodyLength = 10 * 1 << 10

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -788,7 +788,7 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	}
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
-	io.Copy(w, response.Body)
+	_, _ = io.Copy(w, response.Body)
 }
 
 func (s *Server) handleAppProbeTCPSocket(w http.ResponseWriter, prober *Prober) {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -72,8 +72,8 @@ const (
 	// This environment variable should never be set manually.
 	KubeAppProberEnvName = "ISTIO_KUBE_APP_PROBERS"
 
-	localHostIPv4 = "127.0.0.1"
-	localHostIPv6 = "::1"
+	localHostIPv4     = "127.0.0.1"
+	localHostIPv6     = "::1"
 	maxRespBodyLength = 10 * 1 << 10
 )
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -43,7 +43,7 @@ import (
 	grpcHealth "google.golang.org/grpc/health/grpc_health_v1"
 	grpcStatus "google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilio "k8s.io/utils/io"
+	k8sUtilIo "k8s.io/utils/io"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/grpcready"
@@ -791,7 +791,7 @@ func (s *Server) handleAppProbeHTTPGet(w http.ResponseWriter, req *http.Request,
 	// We only write the status code to the response.
 	w.WriteHeader(response.StatusCode)
 	// Return the body from probe as well
-	b, _ := utilio.ReadAtMost(response.Body, maxRespBodyLength)
+	b, _ := k8sUtilIo.ReadAtMost(response.Body, maxRespBodyLength)
 	_, _ = w.Write(b)
 }
 

--- a/releasenotes/notes/48047-probe-return-body.yaml
+++ b/releasenotes/notes/48047-probe-return-body.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+releaseNotes:
+  - |
+    **Improved** pilot-agent will return the return of http probe body from the original probe API setting in the container as well as statuscode.

--- a/releasenotes/notes/48047-probe-return-body.yaml
+++ b/releasenotes/notes/48047-probe-return-body.yaml
@@ -1,7 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
-issue:
 releaseNotes:
   - |
     **Improved** pilot-agent will return the return of http probe body from the original probe API setting in the container as well as statuscode.


### PR DESCRIPTION
**Please provide a description of this PR:**
Some times the app probe return failed, and the user want to get some error information from the probe return body, so I think istio-pilot agent shout return the probe body as well as the statuscode.