### PR TITLE
ambient: fix veth lookup for ztunnel pod on OpenShift

### DIFF
--- a/cni/pkg/ambient/constants/constants.go
+++ b/cni/pkg/ambient/constants/constants.go
@@ -77,4 +77,5 @@ const (
 
 const (
 	AmbientConfigFilepath = "/etc/ambient-config/config.json"
+	NetNsPath             = "/var/run/netns"
 )

--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -250,11 +250,11 @@ func findVethLinkForPeerIP(peerIP net.IP) (*netlink.Veth, error) {
 		veth := l.(*netlink.Veth)
 		peerIndex, err := getPeerIndex(veth)
 		if err != nil {
-			log.Warnf("failed to get peer index for veth interface %s: %v", veth.Name, err)
+			continue
 		}
 		peerNs, err := getNsNameFromNsID(veth.Attrs().NetNsID)
 		if err != nil {
-			log.Warnf("failed to get network namespace name from namespace id '%d' for veth interface %s: %v", veth.Attrs().NetNsID, veth.Name, err)
+			continue
 		}
 		var peerVethFound bool
 		if err := netns.WithNetNSPath(filepath.Join(constants.NetNsPath, filepath.Base(peerNs)), func(netns.NetNS) error {

--- a/cni/pkg/ambient/net_linux.go
+++ b/cni/pkg/ambient/net_linux.go
@@ -257,7 +257,7 @@ func findVethLinkForPeerIP(peerIP net.IP) (*netlink.Veth, error) {
 			log.Warnf("failed to get network namespace name from namespace id '%d' for veth interface %s: %v", veth.Attrs().NetNsID, veth.Name, err)
 		}
 		var peerVethFound bool
-		if err := netns.WithNetNSPath(fmt.Sprintf("%s/%s", constants.NetNsPath, filepath.Base(peerNs)), func(netns.NetNS) error {
+		if err := netns.WithNetNSPath(filepath.Join(constants.NetNsPath, filepath.Base(peerNs)), func(netns.NetNS) error {
 			peerLink, err := netlink.LinkByIndex(peerIndex)
 			if err != nil {
 				return fmt.Errorf("failed to get veth interface '%s' by peer index: %v", veth.Name, err)
@@ -321,7 +321,7 @@ func GetIndexAndPeerMac(podIfName, nspath string) (int, net.HardwareAddr, error)
 
 func getMacFromNsIdx(nsName string, ifIndex int) (net.HardwareAddr, error) {
 	var hwAddr net.HardwareAddr
-	err := netns.WithNetNSPath(fmt.Sprintf("%s/%s", constants.NetNsPath, nsName), func(netns.NetNS) error {
+	err := netns.WithNetNSPath(filepath.Join(constants.NetNsPath, nsName), func(netns.NetNS) error {
 		link, err := netlink.LinkByIndex(ifIndex)
 		if err != nil {
 			return fmt.Errorf("failed to get link(%d) in ns(%s): %v", ifIndex, nsName, err)
@@ -891,7 +891,7 @@ func determineDstPortForGeneveLink(remoteIP net.IP, vnis ...uint32) uint16 {
 func (s *Server) CreateEBPFRulesWithinNodeProxyNS(proxyNsVethIdx int, ztunnelIP, ztunnelNetNS string) error {
 	ns := filepath.Base(ztunnelNetNS)
 	log.Debugf("CreateEBPFRulesWithinNodeProxyNS: proxyNsVethIdx=%d, ztunnelIP=%s, from within netns=%s", proxyNsVethIdx, ztunnelIP, ztunnelNetNS)
-	err := netns.WithNetNSPath(fmt.Sprintf("%s/%s", constants.NetNsPath, ns), func(netns.NetNS) error {
+	err := netns.WithNetNSPath(filepath.Join(constants.NetNsPath, ns), func(netns.NetNS) error {
 		// Make sure we flush table 100 before continuing - it should be empty in a new namespace
 		// but better to ensure that.
 		if err := routeFlushTable(constants.RouteTableInbound); err != nil {
@@ -1038,7 +1038,7 @@ func (s *Server) createTProxyRulesForLegacyEBPF(ztunnelIP, ifName string) error 
 func (s *Server) CreateRulesWithinNodeProxyNS(proxyNsVethIdx int, ztunnelIP, ztunnelNetNS, hostIP string, geneveDstPort uint16) error {
 	ns := filepath.Base(ztunnelNetNS)
 	log.Debugf("CreateRulesWithinNodeProxyNS: proxyNsVethIdx=%d, ztunnelIP=%s, hostIP=%s, from within netns=%s", proxyNsVethIdx, ztunnelIP, hostIP, ztunnelNetNS)
-	err := netns.WithNetNSPath(fmt.Sprintf("%s/%s", constants.NetNsPath, ns), func(netns.NetNS) error {
+	err := netns.WithNetNSPath(filepath.Join(constants.NetNsPath, ns), func(netns.NetNS) error {
 		//"p" is just to visually distinguish from the host-side tunnel links in logs
 		inboundGeneveLinkName := "p" + constants.InboundTun
 		outboundGeneveLinkName := "p" + constants.OutboundTun

--- a/cni/pkg/ebpf/server/redirectionServer_linux.go
+++ b/cni/pkg/ebpf/server/redirectionServer_linux.go
@@ -47,6 +47,7 @@ import (
 	"github.com/josharian/native"
 	"golang.org/x/sys/unix"
 
+	"istio.io/istio/cni/pkg/ambient/constants"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/istio/pkg/util/sets"
@@ -533,7 +534,7 @@ func (r *RedirectServer) attachTCForWorkLoad(ifindex uint32) error {
 func (r *RedirectServer) attachTC(namespace string, ifindex uint32, direction string, fd uint32, name string) error {
 	config := &tc.Config{}
 	if namespace != "" {
-		nsHdlr, err := ns.GetNS(fmt.Sprintf("/var/run/netns/%s", namespace))
+		nsHdlr, err := ns.GetNS(fmt.Sprintf("%s/%s", constants.NetNsPath, namespace))
 		if err != nil {
 			return err
 		}
@@ -627,7 +628,7 @@ func (r *RedirectServer) attachTC(namespace string, ifindex uint32, direction st
 func (r *RedirectServer) delClsactQdisc(namespace string, ifindex uint32) error {
 	config := &tc.Config{}
 	if namespace != "" {
-		nsHdlr, err := ns.GetNS(fmt.Sprintf("/var/run/netns/%s", namespace))
+		nsHdlr, err := ns.GetNS(fmt.Sprintf("%s/%s", constants.NetNsPath, namespace))
 		if err != nil {
 			return err
 		}

--- a/cni/pkg/ebpf/server/redirectionServer_linux.go
+++ b/cni/pkg/ebpf/server/redirectionServer_linux.go
@@ -36,6 +36,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -534,7 +535,7 @@ func (r *RedirectServer) attachTCForWorkLoad(ifindex uint32) error {
 func (r *RedirectServer) attachTC(namespace string, ifindex uint32, direction string, fd uint32, name string) error {
 	config := &tc.Config{}
 	if namespace != "" {
-		nsHdlr, err := ns.GetNS(fmt.Sprintf("%s/%s", constants.NetNsPath, namespace))
+		nsHdlr, err := ns.GetNS(filepath.Join(constants.NetNsPath, namespace))
 		if err != nil {
 			return err
 		}
@@ -628,7 +629,7 @@ func (r *RedirectServer) attachTC(namespace string, ifindex uint32, direction st
 func (r *RedirectServer) delClsactQdisc(namespace string, ifindex uint32) error {
 	config := &tc.Config{}
 	if namespace != "" {
-		nsHdlr, err := ns.GetNS(fmt.Sprintf("%s/%s", constants.NetNsPath, namespace))
+		nsHdlr, err := ns.GetNS(filepath.Join(constants.NetNsPath, namespace))
 		if err != nil {
 			return err
 		}

--- a/releasenotes/notes/fix-peer-veth-lookup-on-openshift.yaml
+++ b/releasenotes/notes/fix-peer-veth-lookup-on-openshift.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** veth lookup for ztunnel pod on OpenShift where default CNIs do not create routes for each veth interface.


### PR DESCRIPTION
**Please provide a description of this PR:**

Istio CNI fails to apply ip and iptables rules on OpenShift with OVN-Kubernetes and OpenShift-SDN, because these CNIs do not create routes for veth interfaces.

On KinD cluster I see the following routes:
```
kubectl exec istio-cni-node -n istio-system -- ip route   
default via 172.18.0.1 dev eth0 
10.244.0.0/24 via 172.18.0.2 dev eth0 
10.244.1.0/24 via 172.18.0.3 dev eth0 
10.244.2.2 dev vethb80b7ad6 scope host 
10.244.2.3 dev veth3af6af4b scope host 
172.18.0.0/16 dev eth0 proto kernel scope link src 172.18.0.4 
192.168.126.0/30 dev istioin proto kernel scope link src 192.168.126.1 
192.168.127.0/30 dev istioout proto kernel scope link src 192.168.127.1
```
and function [getLinkWithDestinationOf](https://github.com/istio/istio/blob/master/cni/pkg/ambient/net_linux.go#L212) expects to get this route:
```
10.244.2.3 dev veth3af6af4b scope host
```
but OpenShift CNIs are built on top of OVS and all veth interfaces are connected to a bridge, so there are no routes for veth interfaces. Instead, there are routes to other special bridges, like `br-ex` and `ovn-k8s-mp0`, but these are irrelevant for Istio CNI.

To fix this problem, I added a function which iterates over veth interfaces on the host, enters their net namespaces, and looks for veth interface with the expected IP.