### PR TITLE
Remove spurious log message from istioctl output

### DIFF
--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -88,7 +88,7 @@ func (f *forwarder) Start() error {
 				f.errCh <- fmt.Errorf("port forward: %v", err)
 				return
 			}
-			log.Infof("port forward completed without error")
+			log.Debugf("port forward completed without error")
 			f.errCh <- nil
 			// At this point, either the stopCh has been closed, or port forwarder connection is broken.
 			// the port forwarder should have already been ready before.


### PR DESCRIPTION
**Please provide a description of this PR:**
Spurious log output from istioctl is causing integrations to fail.
Fixes #48073