### PR TITLE
Get rid of a lint warning message

### DIFF
--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -17,7 +17,7 @@ package slices
 import (
 	"cmp"
 	"fmt"
-	"math/rand" // nolint: not used for security purposes
+	"math/rand"
 	"reflect"
 	"testing"
 


### PR DESCRIPTION
**Please provide a description of this PR:**

When running `make lint` I see this annoying warning:

```sh
WARN [runner/nolint] Found unknown linters in //nolint directives: not used for security purposes
```

Removing the root cause.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [X] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
