### PR TITLE
autoregistration: fix marking entries as connected after disconnect

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -376,7 +376,7 @@ func (c *Controller) changeWorkloadEntryStateToConnected(entryName string, proxy
 	if conTime.Before(lastConTime) {
 		return false, nil
 	}
-	// Try to patch, if it fails then try to create
+	// Try to update, if it fails we retry all the above logic since the WLE changed
 	updated := wle.DeepCopy()
 	setConnectMeta(&updated, c.instanceID, conTime)
 	_, err := c.store.Update(updated)

--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -174,6 +174,7 @@ func (c *Controller) setupAutoRecreate() {
 	}
 	c.lateRegistrationQueue = controllers.NewQueue("auto-register existing connections",
 		controllers.WithReconciler(func(key kubetypes.NamespacedName) error {
+			log.Debugf("(%s) processing WorkloadGroup add for %s/%s", c.instanceID, key.Namespace, key.Name)
 			// WorkloadGroup doesn't exist anymore, skip this.
 			if c.store.Get(gvk.WorkloadGroup, key.Name, key.Namespace) == nil {
 				return nil
@@ -185,10 +186,10 @@ func (c *Controller) setupAutoRecreate() {
 				if entryName == "" {
 					continue
 				}
-				proxy.SetWorkloadEntry(entryName, true)
 				if err := c.registerWorkload(entryName, proxy, conn.ConnectedAt()); err != nil {
 					log.Error(err)
 				}
+				proxy.SetWorkloadEntry(entryName, true)
 			}
 			return nil
 		}))
@@ -321,7 +322,7 @@ func (c *Controller) registerWorkload(entryName string, proxy *model.Proxy, conT
 			return nil
 		}
 		autoRegistrationUpdates.Increment()
-		log.Infof("updated auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
+		log.Infof("updated auto-registered WorkloadEntry %s/%s as connected", proxy.Metadata.Namespace, entryName)
 		return nil
 	}
 
@@ -358,16 +359,27 @@ func (c *Controller) changeWorkloadEntryStateToConnected(entryName string, proxy
 	if wle == nil {
 		return false, fmt.Errorf("failed updating WorkloadEntry %s/%s: WorkloadEntry not found", proxy.Metadata.Namespace, entryName)
 	}
+
+	// check if this was actually disconnected AFTER this connTime
+	// this check can miss, but when it does the `Update` will fail due to versioning
+	// and retry. The retry includes this check and passes the next time.
+	if timestamp, ok := wle.Annotations[annotation.IoIstioDisconnectedAt.Name]; ok {
+		disconnTime, _ := time.Parse(timeFormat, timestamp)
+		if conTime.Before(disconnTime) {
+			// we slowly processed a connect and disconnected before getting to this point
+			return false, nil
+		}
+	}
+
 	lastConTime, _ := time.Parse(timeFormat, wle.Annotations[annotation.IoIstioConnectedAt.Name])
 	// the proxy has reconnected to another pilot, not belong to this one.
 	if conTime.Before(lastConTime) {
 		return false, nil
 	}
 	// Try to patch, if it fails then try to create
-	_, err := c.store.Patch(*wle, func(cfg config.Config) (config.Config, kubetypes.PatchType) {
-		setConnectMeta(&cfg, c.instanceID, conTime)
-		return cfg, kubetypes.MergePatchType
-	})
+	updated := wle.DeepCopy()
+	setConnectMeta(&updated, c.instanceID, conTime)
+	_, err := c.store.Update(updated)
 	if err != nil {
 		return false, fmt.Errorf("failed updating WorkloadEntry %s/%s err: %v", proxy.Metadata.Namespace, entryName, err)
 	}
@@ -475,6 +487,7 @@ func (c *Controller) unregisterWorkload(item any) error {
 	if !changed {
 		return nil
 	}
+	log.Infof("updated auto-registered WorkloadEntry %s/%s as disconnected", workItem.proxy.Metadata.Namespace, workItem.entryName)
 
 	if workItem.autoCreated {
 		autoRegistrationUnregistrations.Increment()

--- a/releasenotes/notes/48089.yaml
+++ b/releasenotes/notes/48089.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 44640
+releaseNotes:
+- |
+  **Fixed** slow cleanup of auto-registered `WorkloadEntry` resources
+  when auto-registration and cleanup should occur shortly after the
+  initial `WorkloadGroup` creation.


### PR DESCRIPTION
fixes #44640

The race:
* Start processing a WorkloadGroup Add
* Start processing a proxy disconnect
* If the disconnect update is written first, the WG Add event overwrites it

User impact:

If a user connects their VM, has a WorkloadEntry created then quickly disconnects their VM shortly after the initial WorkloadGroup is created, they will wait for the "periodic" cleanup (based on maxConnectionAge) rather than getting quick cleanup. 

The fix:
* Check that the connection timestamp is newer than the disconnect
* Use `Update` instead of `Patch` to make sure we knew about the timestamps before writing

We're relying on timestamps from different controllers which isn't great, but I don't see a better option. For the case where we have one controller, we could hold locks for longer or lock changes for individual connections/proxies but we will still hit issues with  >  1 istiod. 



```
5s: 48 runs so far, 0 failures
10s: 96 runs so far, 0 failures
15s: 144 runs so far, 0 failures
20s: 216 runs so far, 0 failures
25s: 264 runs so far, 0 failures
30s: 312 runs so far, 0 failures
35s: 384 runs so far, 0 failures
40s: 432 runs so far, 0 failures
45s: 480 runs so far, 0 failures
50s: 531 runs so far, 0 failures
55s: 600 runs so far, 0 failures
1m0s: 648 runs so far, 0 failures
1m5s: 696 runs so far, 0 failures
1m10s: 768 runs so far, 0 failures
1m15s: 816 runs so far, 0 failures
1m20s: 865 runs so far, 0 failures
1m25s: 936 runs so far, 0 failures
1m30s: 984 runs so far, 0 failures
```