### PR TITLE
fix inconsistent clusterid

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -544,7 +544,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
 
-		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(kubeRestConfig), args.RegistryOptions.KubeOptions.ClusterID)
+		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(kubeRestConfig), s.clusterID)
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}


### PR DESCRIPTION
`s.clusterID` has been processed by the `getClusterID` function. `kubelib.NewClient` should not use the `ClusterID` of the original `args`, but should use the processed one, otherwise the two may be inconsistent.


https://github.com/istio/istio/blob/3902626360adab4b712a4391809dc7b6913a609c/pilot/pkg/bootstrap/server.go#L219

https://github.com/istio/istio/blob/3902626360adab4b712a4391809dc7b6913a609c/pilot/pkg/bootstrap/server.go#L547