### PR TITLE
Revert "Fix internal-debug syncz not working with agent, and add support for debug type `config_dump `"

### DIFF
--- a/tests/integration/pilot/piggyback_test.go
+++ b/tests/integration/pilot/piggyback_test.go
@@ -86,13 +86,7 @@ func TestPiggyback(t *testing.T) {
 				defer pf.Close()
 
 				istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{Cluster: t.Clusters().Default()})
-				args := []string{
-					"x",
-					"internal-debug",
-					"syncz",
-					"--plaintext",
-					"--xds-address", pf.Address(),
-				}
+				args := []string{"x", "proxy-status", "--plaintext", "--xds-address", pf.Address()}
 				output, _, err := istioCtl.Invoke(args)
 				if err != nil {
 					return err


### PR DESCRIPTION
Reverts istio/istio#47801

See https://github.com/istio/istio/issues/48109

I am not sure I fully understand the original PR. Maybe some context I am missing that can forward-fix instead of revert, LMK @hanxiaop
 The config_dump already worked before the PR, and seems to not work with the PR (along with everything else; the command now does not work at all). `~/istio/istio-1.20.0-rc.0/bin/istioctl x internal-debug config_dump?proxyID=echo-istio-6c4d855455-6xn55` works for example.