### PR TITLE
Surface error when autoscale maximums are not supplied

### DIFF
--- a/manifests/charts/gateway/templates/hpa.yaml
+++ b/manifests/charts/gateway/templates/hpa.yaml
@@ -18,7 +18,7 @@ spec:
     kind: {{ .Values.kind | default "Deployment" }}
     name: {{ include "gateway.name" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  maxReplicas: {{ required "A valid .Values.autoscaling.maxReplicas value is required" .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.pilot.autoscaleEnabled .Values.pilot.autoscaleMin .Values.pilot.autoscaleMax }}
+{{- if and .Values.pilot.autoscaleEnabled }}
 {{- if not .Values.global.autoscalingv2API }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -12,7 +12,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
-  maxReplicas: {{ .Values.pilot.autoscaleMax }}
+  maxReplicas: {{ required "A valid .Values.pilot.autoscaleMax value is required" .Values.pilot.autoscaleMax }}
   minReplicas: {{ .Values.pilot.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
@@ -41,7 +41,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
 spec:
-  maxReplicas: {{ .Values.pilot.autoscaleMax }}
+  maxReplicas: {{ required "A valid .Values.pilot.autoscaleMax value is required" .Values.pilot.autoscaleMax }}
   minReplicas: {{ .Values.pilot.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
**Please provide a description of this PR:**
Require the max replicas helm values when enabling autoscaling in istio-discovery or gateway charts.

Fixes #48115