### PR TITLE
crds: understand Gateway API v1, and allow version alias GVK/GVR

### DIFF
--- a/pkg/config/schema/codegen/templates/gvk.go.tmpl
+++ b/pkg/config/schema/codegen/templates/gvk.go.tmpl
@@ -9,17 +9,24 @@ import (
 )
 
 var (
-{{- range .Entries }}
-	{{.Resource.Identifier}} = config.GroupVersionKind{Group: "{{.Resource.Group}}", Version: "{{.Resource.Version}}", Kind: "{{.Resource.Kind}}"}
+{{- range $entry := .Entries }}
+	{{$entry.Resource.Identifier}} = config.GroupVersionKind{Group: "{{$entry.Resource.Group}}", Version: "{{$entry.Resource.Version}}", Kind: "{{$entry.Resource.Kind}}"}
+	{{- range $alias := .Resource.VersionAliases }}
+	{{$entry.Resource.Identifier}}_{{$alias}} = config.GroupVersionKind{Group: "{{$entry.Resource.Group}}", Version: "{{$alias}}", Kind: "{{$entry.Resource.Kind}}"}
+    {{- end }}
 {{- end }}
 )
 
 // ToGVR converts a GVK to a GVR.
 func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 	switch g {
-{{- range .Entries }}
-		case {{.Resource.Identifier}}:
-			return gvr.{{.Resource.Identifier}}, true
+{{- range $entry := .Entries }}
+		case {{$entry.Resource.Identifier}}:
+			return gvr.{{$entry.Resource.Identifier}}, true
+	{{- range $alias := .Resource.VersionAliases }}
+		case {{$entry.Resource.Identifier}}_{{$alias}}:
+			return gvr.{{$entry.Resource.Identifier}}_{{$alias}}, true
+    {{- end }}
 {{- end }}
 	}
 

--- a/pkg/config/schema/codegen/templates/gvr.go.tmpl
+++ b/pkg/config/schema/codegen/templates/gvr.go.tmpl
@@ -6,18 +6,25 @@ import (
 )
 
 var (
-{{- range .Entries }}
-	{{.Resource.Identifier}} = schema.GroupVersionResource{Group: "{{.Resource.Group}}", Version: "{{.Resource.Version}}", Resource: "{{.Resource.Plural}}"}
+{{- range $entry := .Entries }}
+	{{$entry.Resource.Identifier}} = schema.GroupVersionResource{Group: "{{$entry.Resource.Group}}", Version: "{{$entry.Resource.Version}}", Resource: "{{$entry.Resource.Plural}}"}
+	{{- range $alias := .Resource.VersionAliases }}
+	{{$entry.Resource.Identifier}}_{{$alias}} = schema.GroupVersionResource{Group: "{{$entry.Resource.Group}}", Version: "{{$alias}}", Resource: "{{$entry.Resource.Plural}}"}
+    {{- end }}
 {{- end }}
 )
 
 func IsClusterScoped(g schema.GroupVersionResource) bool {
 	switch g {
-{{- range .Entries }}
-	{{- if not .Resource.Synthetic }}
-	case {{.Resource.Identifier}}:
-		return {{.Resource.ClusterScoped}}
+{{- range $entry := .Entries }}
+	{{- if not $entry.Resource.Synthetic }}
+	case {{$entry.Resource.Identifier}}:
+		return {{$entry.Resource.ClusterScoped}}
+	{{- range $alias := .Resource.VersionAliases }}
+    case {{$entry.Resource.Identifier}}_{{$alias}}:
+        return {{$entry.Resource.ClusterScoped}}
 	{{- end }}
+    {{- end }}
 {{- end }}
 	}
 	// shouldn't happen

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -214,6 +214,7 @@ var (
 		Version:    "v1beta1",
 		VersionAliases: []string{
 			"v1alpha2",
+			"v1",
 		},
 		Proto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassStatus",
 		ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayClassSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayClassStatus{}).Elem(),
@@ -232,6 +233,7 @@ var (
 		Version:    "v1beta1",
 		VersionAliases: []string{
 			"v1alpha2",
+			"v1",
 		},
 		Proto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteSpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteStatus",
 		ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.HTTPRouteSpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.HTTPRouteStatus{}).Elem(),
@@ -280,6 +282,7 @@ var (
 		Version:    "v1beta1",
 		VersionAliases: []string{
 			"v1alpha2",
+			"v1",
 		},
 		Proto: "k8s.io.gateway_api.api.v1alpha1.GatewaySpec", StatusProto: "k8s.io.gateway_api.api.v1alpha1.GatewayStatus",
 		ReflectType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewaySpec{}).Elem(), StatusType: reflect.TypeOf(&sigsk8siogatewayapiapisv1beta1.GatewayStatus{}).Elem(),

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -11,21 +11,30 @@ import (
 
 var (
 	AuthorizationPolicy            = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "AuthorizationPolicy"}
+	AuthorizationPolicy_v1         = config.GroupVersionKind{Group: "security.istio.io", Version: "v1", Kind: "AuthorizationPolicy"}
 	CertificateSigningRequest      = config.GroupVersionKind{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"}
 	ConfigMap                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 	CustomResourceDefinition       = config.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
 	Deployment                     = config.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
 	DestinationRule                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"}
+	DestinationRule_v1beta1        = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "DestinationRule"}
 	EndpointSlice                  = config.GroupVersionKind{Group: "", Version: "v1", Kind: "EndpointSlice"}
 	Endpoints                      = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
 	EnvoyFilter                    = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"}
 	GRPCRoute                      = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GRPCRoute"}
 	Gateway                        = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"}
+	Gateway_v1beta1                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "Gateway"}
 	GatewayClass                   = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "GatewayClass"}
+	GatewayClass_v1alpha2          = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "GatewayClass"}
+	GatewayClass_v1                = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "GatewayClass"}
 	HTTPRoute                      = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "HTTPRoute"}
+	HTTPRoute_v1alpha2             = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "HTTPRoute"}
+	HTTPRoute_v1                   = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"}
 	Ingress                        = config.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"}
 	IngressClass                   = config.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "IngressClass"}
 	KubernetesGateway              = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "Gateway"}
+	KubernetesGateway_v1alpha2     = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "Gateway"}
+	KubernetesGateway_v1           = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"}
 	Lease                          = config.GroupVersionKind{Group: "coordination.k8s.io", Version: "v1", Kind: "Lease"}
 	MeshConfig                     = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshConfig"}
 	MeshNetworks                   = config.GroupVersionKind{Group: "", Version: "v1alpha1", Kind: "MeshNetworks"}
@@ -36,21 +45,28 @@ var (
 	Pod                            = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	ProxyConfig                    = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ProxyConfig"}
 	ReferenceGrant                 = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1beta1", Kind: "ReferenceGrant"}
+	ReferenceGrant_v1alpha2        = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "ReferenceGrant"}
 	RequestAuthentication          = config.GroupVersionKind{Group: "security.istio.io", Version: "v1beta1", Kind: "RequestAuthentication"}
+	RequestAuthentication_v1       = config.GroupVersionKind{Group: "security.istio.io", Version: "v1", Kind: "RequestAuthentication"}
 	Secret                         = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 	Service                        = config.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
 	ServiceAccount                 = config.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 	ServiceEntry                   = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "ServiceEntry"}
+	ServiceEntry_v1beta1           = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "ServiceEntry"}
 	Sidecar                        = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Sidecar"}
+	Sidecar_v1beta1                = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "Sidecar"}
 	TCPRoute                       = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
 	TLSRoute                       = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TLSRoute"}
 	Telemetry                      = config.GroupVersionKind{Group: "telemetry.istio.io", Version: "v1alpha1", Kind: "Telemetry"}
 	UDPRoute                       = config.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "UDPRoute"}
 	ValidatingWebhookConfiguration = config.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration"}
 	VirtualService                 = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"}
+	VirtualService_v1beta1         = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "VirtualService"}
 	WasmPlugin                     = config.GroupVersionKind{Group: "extensions.istio.io", Version: "v1alpha1", Kind: "WasmPlugin"}
 	WorkloadEntry                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadEntry"}
+	WorkloadEntry_v1beta1          = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "WorkloadEntry"}
 	WorkloadGroup                  = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1alpha3", Kind: "WorkloadGroup"}
+	WorkloadGroup_v1beta1          = config.GroupVersionKind{Group: "networking.istio.io", Version: "v1beta1", Kind: "WorkloadGroup"}
 )
 
 // ToGVR converts a GVK to a GVR.
@@ -58,6 +74,8 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 	switch g {
 	case AuthorizationPolicy:
 		return gvr.AuthorizationPolicy, true
+	case AuthorizationPolicy_v1:
+		return gvr.AuthorizationPolicy_v1, true
 	case CertificateSigningRequest:
 		return gvr.CertificateSigningRequest, true
 	case ConfigMap:
@@ -68,6 +86,8 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.Deployment, true
 	case DestinationRule:
 		return gvr.DestinationRule, true
+	case DestinationRule_v1beta1:
+		return gvr.DestinationRule_v1beta1, true
 	case EndpointSlice:
 		return gvr.EndpointSlice, true
 	case Endpoints:
@@ -78,16 +98,30 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.GRPCRoute, true
 	case Gateway:
 		return gvr.Gateway, true
+	case Gateway_v1beta1:
+		return gvr.Gateway_v1beta1, true
 	case GatewayClass:
 		return gvr.GatewayClass, true
+	case GatewayClass_v1alpha2:
+		return gvr.GatewayClass_v1alpha2, true
+	case GatewayClass_v1:
+		return gvr.GatewayClass_v1, true
 	case HTTPRoute:
 		return gvr.HTTPRoute, true
+	case HTTPRoute_v1alpha2:
+		return gvr.HTTPRoute_v1alpha2, true
+	case HTTPRoute_v1:
+		return gvr.HTTPRoute_v1, true
 	case Ingress:
 		return gvr.Ingress, true
 	case IngressClass:
 		return gvr.IngressClass, true
 	case KubernetesGateway:
 		return gvr.KubernetesGateway, true
+	case KubernetesGateway_v1alpha2:
+		return gvr.KubernetesGateway_v1alpha2, true
+	case KubernetesGateway_v1:
+		return gvr.KubernetesGateway_v1, true
 	case Lease:
 		return gvr.Lease, true
 	case MeshConfig:
@@ -108,8 +142,12 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.ProxyConfig, true
 	case ReferenceGrant:
 		return gvr.ReferenceGrant, true
+	case ReferenceGrant_v1alpha2:
+		return gvr.ReferenceGrant_v1alpha2, true
 	case RequestAuthentication:
 		return gvr.RequestAuthentication, true
+	case RequestAuthentication_v1:
+		return gvr.RequestAuthentication_v1, true
 	case Secret:
 		return gvr.Secret, true
 	case Service:
@@ -118,8 +156,12 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.ServiceAccount, true
 	case ServiceEntry:
 		return gvr.ServiceEntry, true
+	case ServiceEntry_v1beta1:
+		return gvr.ServiceEntry_v1beta1, true
 	case Sidecar:
 		return gvr.Sidecar, true
+	case Sidecar_v1beta1:
+		return gvr.Sidecar_v1beta1, true
 	case TCPRoute:
 		return gvr.TCPRoute, true
 	case TLSRoute:
@@ -132,12 +174,18 @@ func ToGVR(g config.GroupVersionKind) (schema.GroupVersionResource, bool) {
 		return gvr.ValidatingWebhookConfiguration, true
 	case VirtualService:
 		return gvr.VirtualService, true
+	case VirtualService_v1beta1:
+		return gvr.VirtualService_v1beta1, true
 	case WasmPlugin:
 		return gvr.WasmPlugin, true
 	case WorkloadEntry:
 		return gvr.WorkloadEntry, true
+	case WorkloadEntry_v1beta1:
+		return gvr.WorkloadEntry_v1beta1, true
 	case WorkloadGroup:
 		return gvr.WorkloadGroup, true
+	case WorkloadGroup_v1beta1:
+		return gvr.WorkloadGroup_v1beta1, true
 	}
 
 	return schema.GroupVersionResource{}, false

--- a/pkg/config/schema/gvr/resources.gen.go
+++ b/pkg/config/schema/gvr/resources.gen.go
@@ -8,21 +8,30 @@ var (
 	ServiceExport                  = schema.GroupVersionResource{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceexports"}
 	ServiceImport                  = schema.GroupVersionResource{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceimports"}
 	AuthorizationPolicy            = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1beta1", Resource: "authorizationpolicies"}
+	AuthorizationPolicy_v1         = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1", Resource: "authorizationpolicies"}
 	CertificateSigningRequest      = schema.GroupVersionResource{Group: "certificates.k8s.io", Version: "v1", Resource: "certificatesigningrequests"}
 	ConfigMap                      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	CustomResourceDefinition       = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
 	Deployment                     = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	DestinationRule                = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "destinationrules"}
+	DestinationRule_v1beta1        = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "destinationrules"}
 	EndpointSlice                  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpointslices"}
 	Endpoints                      = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}
 	EnvoyFilter                    = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "envoyfilters"}
 	GRPCRoute                      = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "grpcroutes"}
 	Gateway                        = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "gateways"}
+	Gateway_v1beta1                = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "gateways"}
 	GatewayClass                   = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "gatewayclasses"}
+	GatewayClass_v1alpha2          = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "gatewayclasses"}
+	GatewayClass_v1                = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
 	HTTPRoute                      = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "httproutes"}
+	HTTPRoute_v1alpha2             = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "httproutes"}
+	HTTPRoute_v1                   = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
 	Ingress                        = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
 	IngressClass                   = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"}
 	KubernetesGateway              = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "gateways"}
+	KubernetesGateway_v1alpha2     = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "gateways"}
+	KubernetesGateway_v1           = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
 	Lease                          = schema.GroupVersionResource{Group: "coordination.k8s.io", Version: "v1", Resource: "leases"}
 	MeshConfig                     = schema.GroupVersionResource{Group: "", Version: "v1alpha1", Resource: "meshconfigs"}
 	MeshNetworks                   = schema.GroupVersionResource{Group: "", Version: "v1alpha1", Resource: "meshnetworks"}
@@ -33,21 +42,28 @@ var (
 	Pod                            = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	ProxyConfig                    = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "proxyconfigs"}
 	ReferenceGrant                 = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "referencegrants"}
+	ReferenceGrant_v1alpha2        = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "referencegrants"}
 	RequestAuthentication          = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1beta1", Resource: "requestauthentications"}
+	RequestAuthentication_v1       = schema.GroupVersionResource{Group: "security.istio.io", Version: "v1", Resource: "requestauthentications"}
 	Secret                         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	Service                        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 	ServiceAccount                 = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
 	ServiceEntry                   = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "serviceentries"}
+	ServiceEntry_v1beta1           = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "serviceentries"}
 	Sidecar                        = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "sidecars"}
+	Sidecar_v1beta1                = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "sidecars"}
 	TCPRoute                       = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tcproutes"}
 	TLSRoute                       = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tlsroutes"}
 	Telemetry                      = schema.GroupVersionResource{Group: "telemetry.istio.io", Version: "v1alpha1", Resource: "telemetries"}
 	UDPRoute                       = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "udproutes"}
 	ValidatingWebhookConfiguration = schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}
 	VirtualService                 = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "virtualservices"}
+	VirtualService_v1beta1         = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "virtualservices"}
 	WasmPlugin                     = schema.GroupVersionResource{Group: "extensions.istio.io", Version: "v1alpha1", Resource: "wasmplugins"}
 	WorkloadEntry                  = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "workloadentries"}
+	WorkloadEntry_v1beta1          = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "workloadentries"}
 	WorkloadGroup                  = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "workloadgroups"}
+	WorkloadGroup_v1beta1          = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "workloadgroups"}
 )
 
 func IsClusterScoped(g schema.GroupVersionResource) bool {
@@ -57,6 +73,8 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 	case ServiceImport:
 		return false
 	case AuthorizationPolicy:
+		return false
+	case AuthorizationPolicy_v1:
 		return false
 	case CertificateSigningRequest:
 		return true
@@ -68,6 +86,8 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 		return false
 	case DestinationRule:
 		return false
+	case DestinationRule_v1beta1:
+		return false
 	case EndpointSlice:
 		return false
 	case Endpoints:
@@ -78,15 +98,29 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 		return false
 	case Gateway:
 		return false
+	case Gateway_v1beta1:
+		return false
 	case GatewayClass:
 		return true
+	case GatewayClass_v1alpha2:
+		return true
+	case GatewayClass_v1:
+		return true
 	case HTTPRoute:
+		return false
+	case HTTPRoute_v1alpha2:
+		return false
+	case HTTPRoute_v1:
 		return false
 	case Ingress:
 		return false
 	case IngressClass:
 		return true
 	case KubernetesGateway:
+		return false
+	case KubernetesGateway_v1alpha2:
+		return false
+	case KubernetesGateway_v1:
 		return false
 	case Lease:
 		return false
@@ -104,7 +138,11 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 		return false
 	case ReferenceGrant:
 		return false
+	case ReferenceGrant_v1alpha2:
+		return false
 	case RequestAuthentication:
+		return false
+	case RequestAuthentication_v1:
 		return false
 	case Secret:
 		return false
@@ -114,7 +152,11 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 		return false
 	case ServiceEntry:
 		return false
+	case ServiceEntry_v1beta1:
+		return false
 	case Sidecar:
+		return false
+	case Sidecar_v1beta1:
 		return false
 	case TCPRoute:
 		return false
@@ -128,11 +170,17 @@ func IsClusterScoped(g schema.GroupVersionResource) bool {
 		return true
 	case VirtualService:
 		return false
+	case VirtualService_v1beta1:
+		return false
 	case WasmPlugin:
 		return false
 	case WorkloadEntry:
 		return false
+	case WorkloadEntry_v1beta1:
+		return false
 	case WorkloadGroup:
+		return false
+	case WorkloadGroup_v1beta1:
 		return false
 	}
 	// shouldn't happen

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -166,6 +166,7 @@ resources:
     version: "v1beta1"
     versionAliases:
     - "v1alpha2"
+    - "v1"
     clusterScoped: true
     protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.GatewayClassSpec"
@@ -179,6 +180,7 @@ resources:
     version: "v1beta1"
     versionAliases:
     - "v1alpha2"
+    - "v1"
     protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.GatewaySpec"
     validate: "ValidateKubernetesGateway"
@@ -191,6 +193,7 @@ resources:
     version: "v1beta1"
     versionAliases:
     - "v1alpha2"
+    - "v1"
     protoPackage: "sigs.k8s.io/gateway-api/apis/v1beta1"
     proto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteSpec"
     statusProto: "k8s.io.gateway_api.api.v1alpha1.HTTPRouteStatus"


### PR DESCRIPTION
This allows our tooling that reads yaml, etc to support these versions
