### PR TITLE
Fix TestSyncAllWorkloadsFromAmbient flake

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -256,7 +256,6 @@ func TestSyncAllWorkloadsFromAmbient(t *testing.T) {
 					return
 				}
 				t.Logf("skipping namespace %s want %s", n, namespace)
-				continue
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -245,13 +245,9 @@ func TestSyncAllWorkloadsFromAmbient(t *testing.T) {
 
 	waitNamespaceNotify := func(namespace string) {
 		retry.UntilSuccessOrFail(t, func() error {
-			select {
-			case notifiedNamespace := <-namespaceNotifyCh:
-				if notifiedNamespace != namespace {
-					return fmt.Errorf("no namespace notify")
-				}
-			case <-time.After(5 * time.Second):
-				return fmt.Errorf("timeout waiting for namespace notification")
+			notifiedNamespace := <-namespaceNotifyCh
+			if notifiedNamespace != namespace {
+				return fmt.Errorf("no namespace notify")
 			}
 			return nil
 		}, retry.Timeout(5*time.Second), retry.Delay(10*time.Millisecond))


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/48085.

Add a notifier to the test, to make sure the namespace has already be handled by the controller before assert.