### PR TITLE
Skip graceful termination if Envoy ended prematurely

### DIFF
--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -174,7 +174,7 @@ func (a *Agent) terminate() {
 			ac, err := a.activeProxyConnections()
 			select {
 			case status := <-a.statusCh:
-				log.Warnf("Envoy exited with status %v", status.err)
+				log.Infof("Envoy exited with status %v", status.err)
 				log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
 				return
 			default:

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -129,12 +129,6 @@ func (a *Agent) Run(ctx context.Context) {
 
 	case <-ctx.Done():
 		a.terminate()
-		status := <-a.statusCh
-		if status.err == errAbort {
-			log.Infof("Envoy aborted normally")
-		} else {
-			log.Warnf("Envoy aborted abnormally")
-		}
 		log.Info("Agent has successfully terminated")
 	}
 }
@@ -175,31 +169,51 @@ func (a *Agent) terminate() {
 		log.Infof("Checking for active connections...")
 		ticker := time.NewTicker(activeConnectionCheckDelay)
 		defer ticker.Stop()
+	graceful_loop:
 		for range ticker.C {
-			ac, err := a.activeProxyConnections()
-			if err != nil {
-				log.Errorf(err.Error())
-				a.abortCh <- errAbort
+			select {
+			case status := <-a.statusCh:
+				log.Warnf("Envoy exited with error %v", status.err)
+				log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
 				return
+			default:
+				ac, err := a.activeProxyConnections()
+				if err != nil {
+					log.Errorf(err.Error())
+					a.abortCh <- errAbort
+					break graceful_loop
+				}
+				if ac == -1 {
+					log.Info("downstream_cx_active are not available. This either means there are no downstream connection established yet" +
+						" or the stats are not enabled. Skipping active connections check...")
+					a.abortCh <- errAbort
+					break graceful_loop
+				}
+				if ac == 0 {
+					log.Info("There are no more active connections. terminating proxy...")
+					a.abortCh <- errAbort
+					break graceful_loop
+				}
+				log.Infof("There are still %d active connections", ac)
 			}
-			if ac == -1 {
-				log.Info("downstream_cx_active are not available. This either means there are no downstream connection established yet" +
-					" or the stats are not enabled. Skipping active connections check...")
-				a.abortCh <- errAbort
-				return
-			}
-			if ac == 0 {
-				log.Info("There are no more active connections. terminating proxy...")
-				a.abortCh <- errAbort
-				return
-			}
-			log.Infof("There are still %d active connections", ac)
 		}
 	} else {
 		log.Infof("Graceful termination period is %v, starting...", a.terminationDrainDuration)
-		time.Sleep(a.terminationDrainDuration)
-		log.Infof("Graceful termination period complete, terminating remaining proxies.")
-		a.abortCh <- errAbort
+		select {
+		case status := <-a.statusCh:
+			log.Warnf("Envoy exited with error %v", status.err)
+			log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
+			return
+		case <-time.After(a.terminationDrainDuration):
+			log.Infof("Graceful termination period complete, terminating remaining proxies.")
+			a.abortCh <- errAbort
+		}
+	}
+	status := <-a.statusCh
+	if status.err == errAbort {
+		log.Infof("Envoy aborted normally")
+	} else {
+		log.Warnf("Envoy aborted abnormally")
 	}
 	log.Warnf("Aborted proxy instance")
 }

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -171,16 +171,17 @@ func (a *Agent) terminate() {
 		defer ticker.Stop()
 	graceful_loop:
 		for range ticker.C {
+			ac, err := a.activeProxyConnections()
 			select {
 			case status := <-a.statusCh:
 				log.Warnf("Envoy exited with error %v", status.err)
 				log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
 				return
 			default:
-				ac, err := a.activeProxyConnections()
 				if err != nil {
 					log.Errorf(err.Error())
 					a.abortCh <- errAbort
+					log.Infof("Graceful termination logic ended prematurely, error while obtaining downstream_cx_active stat")
 					break graceful_loop
 				}
 				if ac == -1 {

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -174,7 +174,7 @@ func (a *Agent) terminate() {
 			ac, err := a.activeProxyConnections()
 			select {
 			case status := <-a.statusCh:
-				log.Warnf("Envoy exited with error %v", status.err)
+				log.Warnf("Envoy exited with status %v", status.err)
 				log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
 				return
 			default:
@@ -202,7 +202,7 @@ func (a *Agent) terminate() {
 		log.Infof("Graceful termination period is %v, starting...", a.terminationDrainDuration)
 		select {
 		case status := <-a.statusCh:
-			log.Warnf("Envoy exited with error %v", status.err)
+			log.Infof("Envoy exited with status %v", status.err)
 			log.Infof("Graceful termination logic ended prematurely, envoy process terminated early")
 			return
 		case <-time.After(a.terminationDrainDuration):

--- a/releasenotes/notes/skip-graceful-termination.yaml
+++ b/releasenotes/notes/skip-graceful-termination.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: [36686]
+releaseNotes:
+- |
+  **Improved** Abort graceful termination logic if the Envoy process terminates early


### PR DESCRIPTION
Currently, there is ambiguity in the behavior when both the pilot-agent and Envoy receive a SIGTERM signal "at around the same time". If the pilot-agent detects the SIGTERM before detecting the termination of the Envoy process, it initiates a graceful termination logic, waiting for X seconds. On the other, if it identifies the termination of the Envoy process before initiating the graceful logic, it terminates immediately.

This pull request change the behavior by skipping the remaining graceful waiting time in case Envoy terminates prematurely.
It's important to note that if the exitOnZeroActiveConnections flag is in use, this PR will not alter the behavior (but it will alter the logging messages). When exitOnZeroActiveConnections=true, the graceful termination logic already aborts prematurely as part of the error handling process.