### PR TITLE
remove checking ztunnel

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -110,7 +110,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 
 	builder.patchListeners()
 	l := builder.getListeners()
-	if builder.node.EnableHBONE() && !builder.node.IsAmbient() {
+	if builder.node.EnableHBONE() && !builder.node.IsWaypointProxy() {
 		l = append(l, buildConnectOriginateListener())
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -437,7 +437,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 }
 
 func appendMxFilter(httpOpts *httpListenerOpts, node *model.Proxy, filters []*hcm.HttpFilter) []*hcm.HttpFilter {
-	if !features.MetadataExchange || httpOpts.hbone || node.IsAmbient() {
+	if !features.MetadataExchange || httpOpts.hbone {
 		return filters
 	}
 	if !features.NativeMetadataExchange || !util.IsIstioVersionGE119(node.IstioVersion) {

--- a/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_inbound.go
@@ -729,7 +729,7 @@ func buildInboundPassthroughChains(lb *ListenerBuilder) []*listener.FilterChain 
 // This avoids a possible loop where traffic sent to this port would continually call itself indefinitely.
 func buildInboundBlackhole(lb *ListenerBuilder) *listener.FilterChain {
 	var filters []*listener.Filter
-	if !lb.node.IsAmbient() {
+	if !lb.node.IsWaypointProxy() {
 		filters = append(filters, buildMetadataExchangeNetworkFilters()...)
 	}
 	filters = append(filters, buildMetricsNetworkFilters(lb.push, lb.node, istionetworking.ListenerClassSidecarInbound)...)

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -701,7 +701,7 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		}
 	} else if supportsTunnel {
 		// Support connecting to server side waypoint proxy, if the destination has one. This is for sidecars and ingress.
-		if b.dir == model.TrafficDirectionOutbound && !b.proxy.IsWaypointProxy() && !b.proxy.IsAmbient() {
+		if b.dir == model.TrafficDirectionOutbound && !b.proxy.IsWaypointProxy() {
 			workloads := findWaypoints(b.push, e)
 			if len(workloads) > 0 {
 				// TODO: load balance


### PR DESCRIPTION
**Please provide a description of this PR:**

These are called by listener and endpoint builder, which is deemed to be not for ztunnel. So we can only check waypoint.