### PR TITLE
Optimize model.ParseSubsetKey

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1080,34 +1080,52 @@ func IsDNSSrvSubsetKey(s string) bool {
 	return false
 }
 
+// ParseSubsetKeyHostname is an optimized specialization of ParseSubsetKey that only returns the hostname.
+// This is created as this is used in some hot paths and is about 2x faster than ParseSubsetKey; for typical use ParseSubsetKey is sufficient (and zero-alloc).
+// Warning: this does not support "DNS SRV" form
+func ParseSubsetKeyHostname(s string) (hostname string) {
+	idx := strings.LastIndex(s, "|")
+	if idx == -1 {
+		return ""
+	}
+	return s[idx:]
+}
+
 // ParseSubsetKey is the inverse of the BuildSubsetKey method
 func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, hostname host.Name, port int) {
-	var parts []string
-	dnsSrvMode := false
+	sep := "|"
 	// This could be the DNS srv form of the cluster that uses outbound_.port_.subset_.hostname
 	// Since we do not want every callsite to implement the logic to differentiate between the two forms
 	// we add an alternate parser here.
 	if strings.HasPrefix(s, trafficDirectionOutboundSrvPrefix) ||
 		strings.HasPrefix(s, trafficDirectionInboundSrvPrefix) {
-		parts = strings.SplitN(s, ".", 4)
-		dnsSrvMode = true
-	} else {
-		parts = strings.Split(s, "|")
+		sep = "_."
 	}
 
-	if len(parts) < 4 {
+	// Format: dir|port|subset|hostname
+	dir, s, ok := strings.Cut(s, sep)
+	if !ok {
 		return
 	}
+	direction = TrafficDirection(dir)
 
-	direction = TrafficDirection(strings.TrimSuffix(parts[0], "_"))
-	port, _ = strconv.Atoi(strings.TrimSuffix(parts[1], "_"))
-	subsetName = parts[2]
-
-	if dnsSrvMode {
-		subsetName = strings.TrimSuffix(parts[2], "_")
+	p, s, ok := strings.Cut(s, sep)
+	if !ok {
+		return
 	}
+	port, _ = strconv.Atoi(p)
 
-	hostname = host.Name(parts[3])
+	ss, s, ok := strings.Cut(s, sep)
+	if !ok {
+		return
+	}
+	subsetName = ss
+
+	// last part. No | remains -- verify this
+	if strings.Contains(s, sep) {
+		return
+	}
+	hostname = host.Name(s)
 	return
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1088,7 +1088,7 @@ func ParseSubsetKeyHostname(s string) (hostname string) {
 	if idx == -1 {
 		return ""
 	}
-	return s[idx:]
+	return s[idx+1:]
 }
 
 // ParseSubsetKey is the inverse of the BuildSubsetKey method

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1082,11 +1082,14 @@ func IsDNSSrvSubsetKey(s string) bool {
 
 // ParseSubsetKeyHostname is an optimized specialization of ParseSubsetKey that only returns the hostname.
 // This is created as this is used in some hot paths and is about 2x faster than ParseSubsetKey; for typical use ParseSubsetKey is sufficient (and zero-alloc).
-// Warning: this does not support "DNS SRV" form
 func ParseSubsetKeyHostname(s string) (hostname string) {
 	idx := strings.LastIndex(s, "|")
 	if idx == -1 {
-		return ""
+		// Could be DNS SRV format.
+		// Do not do LastIndex("_."), as those are valid characters in the hostname (unlike |)
+		// Fallback to the full parser.
+		_, _, hostname, _ := ParseSubsetKey(s)
+		return string(hostname)
 	}
 	return s[idx+1:]
 }

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -611,6 +611,7 @@ func TestParseSubsetKeyHostname(t *testing.T) {
 		{"|||", ""},
 		{"||||||", ""},
 		{"", ""},
+		{"outbound_.80_._.test.local", "test.local"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestGetByPort(t *testing.T) {
@@ -598,5 +599,22 @@ func TestFuzzServiceDeepCopy(t *testing.T) {
 	if !cmp.Equal(originalSvc, copied, opts...) {
 		diff := cmp.Diff(originalSvc, copied, opts...)
 		t.Errorf("unexpected diff %v", diff)
+	}
+}
+
+func TestParseSubsetKeyHostname(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{"outbound|80|subset|host.com", "host.com"},
+		{"outbound|80|subset|", ""},
+		{"|||", ""},
+		{"||||||", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, ParseSubsetKeyHostname(tt.in), tt.out)
+		})
 	}
 }

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -200,8 +200,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	regenerated := 0
 	for _, clusterName := range w.ResourceNames {
 		if edsUpdatedServices != nil {
-			_, _, hostname, _ := model.ParseSubsetKey(clusterName)
-			if _, ok := edsUpdatedServices[string(hostname)]; !ok {
+			if _, ok := edsUpdatedServices[model.ParseSubsetKeyHostname(clusterName)]; !ok {
 				// Cluster was not updated, skip recomputing. This happens when we get an incremental update for a
 				// specific Hostname. On connect or for full push edsUpdatedServices will be empty.
 				continue
@@ -258,8 +257,7 @@ func (eds *EdsGenerator) buildDeltaEndpoints(proxy *model.Proxy,
 
 	for _, clusterName := range w.ResourceNames {
 		// filter out eds that are not updated for clusters
-		_, _, hostname, _ := model.ParseSubsetKey(clusterName)
-		if _, ok := edsUpdatedServices[string(hostname)]; !ok {
+		if _, ok := edsUpdatedServices[model.ParseSubsetKeyHostname(clusterName)]; !ok {
 			continue
 		}
 


### PR DESCRIPTION
I wouldn't have thought so, but this is looking like a hotpath for some setups. I don't think its typically this high, but in a high-churn environment I see 12% total CPU here(!): https://pprof.me/726e9dfa265282e0cb2857cdc13e9770/?profileType=profile%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds%3Adelta

```
name \ time/op    /tmp/old     /tmp/new2   /tmp/new
T-8                137µs ±56%   59µs ±15%   28µs ±19%

name \ alloc/op   /tmp/old     /tmp/new2   /tmp/new
T-8               64.0kB ± 0%  0.0kB       0.0kB     

name \ allocs/op  /tmp/old     /tmp/new2   /tmp/new
T-8                1.00k ± 0%  0.00k       0.00k     
```

* Old = master
* New2 = optimized ParseSubsetKey
* New = specialized ParseSubsetKeyHostname