### PR TITLE
kubeconfig/minor cleanup

### DIFF
--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -93,7 +93,7 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 	// Istiod is running on the external cluster. Use the inCluster credentials to
 	// create a kubeclientset
 	if features.LocalClusterSecretWatcher && features.ExternalIstiod {
-		config, err := kube.InClusterConfig()
+		config, err := kube.InClusterConfig(configOverrides...)
 		if err != nil {
 			log.Errorf("Could not get istiod incluster configuration: %v", err)
 			return nil
@@ -203,7 +203,7 @@ func (c *Controller) processItem(key types.NamespacedName) error {
 
 // BuildClientsFromConfig creates kube.Clients from the provided kubeconfig. This is overridden for testing only
 var BuildClientsFromConfig = func(kubeConfig []byte, clusterId cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
-	restConfig, err := kube.NewRemoteRestConfig(kubeConfig, configOverrides...)
+	restConfig, err := kube.NewUntrustedRestConfig(kubeConfig, configOverrides...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -93,16 +93,12 @@ func NewController(kubeclientset kube.Client, namespace string, clusterID cluste
 	// Istiod is running on the external cluster. Use the inCluster credentials to
 	// create a kubeclientset
 	if features.LocalClusterSecretWatcher && features.ExternalIstiod {
-		config, err := rest.InClusterConfig()
+		config, err := kube.InClusterConfig()
 		if err != nil {
 			log.Errorf("Could not get istiod incluster configuration: %v", err)
 			return nil
 		}
 		log.Info("Successfully retrieved incluster config.")
-
-		for _, overwrite := range configOverrides {
-			overwrite(config)
-		}
 
 		localKubeClient, err := kube.NewClient(kube.NewClientConfigForRestConfig(config), clusterID)
 		if err != nil {
@@ -207,7 +203,7 @@ func (c *Controller) processItem(key types.NamespacedName) error {
 
 // BuildClientsFromConfig creates kube.Clients from the provided kubeconfig. This is overridden for testing only
 var BuildClientsFromConfig = func(kubeConfig []byte, clusterId cluster.ID, configOverrides ...func(*rest.Config)) (kube.Client, error) {
-	restConfig, err := kube.NewRestConfigFromContext(kubeConfig, configOverrides...)
+	restConfig, err := kube.NewRemoteRestConfig(kubeConfig, configOverrides...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" //  allow out of cluster authentication
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -91,21 +90,10 @@ func BuildClientCmd(kubeconfig, context string, overrides ...func(*clientcmd.Con
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 }
 
-// CreateClientset is a helper function that builds a kubernetes Clienset from a kubeconfig
-// filepath. See `BuildClientConfig` for kubeconfig loading rules.
-func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*kubernetes.Clientset, error) {
-	c, err := BuildClientConfig(kubeconfig, context)
-	if err != nil {
-		return nil, fmt.Errorf("build client config: %v", err)
-	}
-	for _, fn := range fns {
-		fn(c)
-	}
-	return kubernetes.NewForConfig(c)
-}
-
-// NewRestConfigFromContext returns the rest.Config for the given kube config context.
-func NewRestConfigFromContext(kubeConfig []byte, configOverrides ...func(*rest.Config)) (*rest.Config, error) {
+// NewRemoteRestConfig returns the rest.Config for the given kube config context.
+// This is suitable for access to remote clusters from untrusted kubeConfig inputs.
+// The kubeconfig is sanitized and unsafe auth methods are denied.
+func NewRemoteRestConfig(kubeConfig []byte, configOverrides ...func(*rest.Config)) (*rest.Config, error) {
 	if len(kubeConfig) == 0 {
 		return nil, fmt.Errorf("kubeconfig is empty")
 	}
@@ -127,7 +115,23 @@ func NewRestConfigFromContext(kubeConfig []byte, configOverrides ...func(*rest.C
 	for _, co := range configOverrides {
 		co(restConfig)
 	}
-	return restConfig, nil
+
+	return SetRestDefaults(restConfig), nil
+}
+
+// InClusterConfig returns the rest.Config for in cluster usage.
+// Typically, DefaultRestConfig is used and this is auto detected; usage directly allows explicitly overriding to use in-cluster.
+func InClusterConfig(fns ...func(*rest.Config)) (*rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, fn := range fns {
+		fn(config)
+	}
+
+	return SetRestDefaults(config), nil
 }
 
 // DefaultRestConfig returns the rest.Config for the given kube config file and context.

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -90,10 +90,10 @@ func BuildClientCmd(kubeconfig, context string, overrides ...func(*clientcmd.Con
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 }
 
-// NewRemoteRestConfig returns the rest.Config for the given kube config context.
+// NewUntrustedRestConfig returns the rest.Config for the given kube config context.
 // This is suitable for access to remote clusters from untrusted kubeConfig inputs.
 // The kubeconfig is sanitized and unsafe auth methods are denied.
-func NewRemoteRestConfig(kubeConfig []byte, configOverrides ...func(*rest.Config)) (*rest.Config, error) {
+func NewUntrustedRestConfig(kubeConfig []byte, configOverrides ...func(*rest.Config)) (*rest.Config, error) {
 	if len(kubeConfig) == 0 {
 		return nil, fmt.Errorf("kubeconfig is empty")
 	}


### PR DESCRIPTION
- fix(limit): keep the qps of kubeclient consistent with features.RequestLimit
- use the server kube args to configure the remote clusters
- modify the source rest.config
- apply kube options before invoke lib function
- fix lint
- add uint test
- remove Underline
- move the kubeconfig operator to kube lib
- Cleanup kubeconfig setup a bit
