### PR TITLE
bug-report: sort events by creation date

### DIFF
--- a/releasenotes/notes/istioctl-sort-events-by-creation.yaml
+++ b/releasenotes/notes/istioctl-sort-events-by-creation.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Improved** `istioctl bug-report` to sort gathered events by creation date.

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -165,7 +165,7 @@ func GetPodInfo(p *Params) (map[string]string, error) {
 
 // GetEvents returns events for all namespaces.
 func GetEvents(p *Params) (map[string]string, error) {
-	out, err := p.Runner.RunCmd("get events --all-namespaces -o wide", "", p.KubeConfig, p.KubeContext, p.DryRun)
+	out, err := p.Runner.RunCmd("get events --all-namespaces -o wide --sort-by=.metadata.creationTimestamp", "", p.KubeConfig, p.KubeContext, p.DryRun)
 	return map[string]string{
 		"events": out,
 	}, err


### PR DESCRIPTION
**Please provide a description of this PR:**

Events gathered by `istio bug-report` are not sorted by date, which makes difficult to correlate data. Sort events by creation timestamp to more easily identify the last generated events.

Tested locally by running:

```
go run tools/bug-report/main.go
```
