### PR TITLE
cni: fix typo at root.go

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -169,7 +169,7 @@ func init() {
 	registerBooleanParameter(constants.RepairDeletePods, false, "Controller will delete pods when detecting pod broken by race condition")
 	registerBooleanParameter(constants.RepairLabelPods, false, "Controller will label pods when detecting pod broken by race condition")
 	registerStringParameter(constants.RepairLabelKey, "cni.istio.io/uninitialized",
-		"The key portion of the label which will be set by the ace repair if label pods is true")
+		"The key portion of the label which will be set by the race repair if label pods is true")
 	registerStringParameter(constants.RepairLabelValue, "true",
 		"The value portion of the label which will be set by the race repair if label pods is true")
 	registerStringParameter(constants.RepairNodeName, "", "The name of the managed node (will manage all nodes if unset)")


### PR DESCRIPTION
**Please provide a description of this PR:**

Correct typo from 'ace' to 'race' at `cni/pkg/cmd/root.go`.