### PR TITLE
Add support for rolling update deployment strategy in istio/gateway chart.

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingMaxSurge }}
+      maxUnavailable: {{ .Values.rollingMaxUnavailable }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -290,6 +290,12 @@
         },
         "priorityClassName": {
           "type": "string"
+        },
+        "rollingMaxSurge": {
+          "type": ["integer", "string"]
+        },
+        "rollingMaxUnavailable": {
+          "type": ["integer", "string"]
         }
       }
     }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -150,3 +150,11 @@ defaults:
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   # for more detail.
   priorityClassName: ""
+
+  # Maximum number of Pods that can be created over the desired number of Pods.
+  # The value can be an absolute number (for example, 5) or a percentage of desired Pods (for example, 10%).
+  rollingMaxSurge: "25%"
+
+  # Maximum number of Pods that can be unavailable during the update process.
+  # The value can be an absolute number (for example, 5) or a percentage of desired Pods (for example, 10%).
+  rollingMaxUnavailable: "25%"

--- a/releasenotes/notes/48218.yaml
+++ b/releasenotes/notes/48218.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Added** istio/gateway helm chart support for specifying the rolling update deployment strategy.


### PR DESCRIPTION
Adds istio/gateway helm chart support for specifying the rolling update deployment strategy. By [k8s defaults](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment) we end up with a `maxUnavailable` of `25%`, which might be undesirable because you might end up with fewer than the desired pods running during deployments.


- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure