### PR TITLE
Fix daemonset inaccurate wait status during upgrade

### DIFF
--- a/operator/pkg/helmreconciler/wait.go
+++ b/operator/pkg/helmreconciler/wait.go
@@ -322,6 +322,11 @@ func daemonsetsReady(daemonsets []*appsv1.DaemonSet) (bool, []string) {
 					scope.Infof("DaemonSet is not ready: %s/%s. %d out of %d expected pods are ready",
 						ds.Namespace, ds.Name, ds.Status.NumberReady, ds.Status.UpdatedNumberScheduled)
 					notReady = append(notReady, "DaemonSet/"+ds.Namespace+"/"+ds.Name)
+				} else if ds.Status.UpdatedNumberScheduled != ds.Status.DesiredNumberScheduled {
+					// Make sure all the updated pods have been scheduled
+					scope.Infof("DaemonSet is not ready: %s/%s. %d out of %d expected pods have been scheduled",
+						ds.Namespace, ds.Name, ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled)
+					notReady = append(notReady, "DaemonSet/"+ds.Namespace+"/"+ds.Name)
 				}
 			}
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
When a cni/ztunnel is upgraded to a new image, it is immediately reported as successfully installed. However, the updated version has not yet been scheduled on the node.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
