### PR TITLE
ambient: cleanup profile

### DIFF
--- a/manifests/profiles/ambient.yaml
+++ b/manifests/profiles/ambient.yaml
@@ -6,13 +6,6 @@ spec:
     defaultConfig:
       proxyMetadata:
         ISTIO_META_ENABLE_HBONE: "true"
-    # Telemetry API is used with ambient instead of EnvoyFilters
-    defaultProviders:
-      metrics:
-      - prometheus
-    extensionProviders:
-    - name: prometheus
-      prometheus: {}
 
   components:
     cni:
@@ -45,9 +38,3 @@ spec:
       # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
       excludeNamespaces:
       - kube-system
-
-    telemetry:
-      # Telemetry handled with Telemetry API only
-      enabled: false
-      v2:
-        enabled: false


### PR DESCRIPTION
This is already the default now

This makes no changes to the resulting behavior or install at all, just
cleanup
