### PR TITLE
envoy: always use json as as Envoy custom bootstrap config

### DIFF
--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -64,11 +64,22 @@ func TestEnvoyArgs(t *testing.T) {
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
-		"--config-yaml", `{"key": "value"}`,
+		"--config-yaml", `{"key":"value"}`,
 		"--concurrency", "8",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("envoyArgs() => got:\n%v,\nwant:\n%v", got, want)
+	}
+}
+
+func TestReadToJSON(t *testing.T) {
+	got, err := readToJSON("testdata/bootstrap.yaml")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	want := `{"key":"value"}`
+	if got != want {
+		t.Errorf("readToJSON() => got:\n%v,\nwant:\n%v", got, want)
 	}
 }
 

--- a/pkg/envoy/testdata/bootstrap.yaml
+++ b/pkg/envoy/testdata/bootstrap.yaml
@@ -1,0 +1,3 @@
+---
+# Sample custom bootstrap in YAML
+key: value


### PR DESCRIPTION

**Please provide a description of this PR:**

Envoy accepts both JSON and YAML string as `--config-yaml` command line parameter. In operation, When ISTIO_BOOTSTRAP_OVERRIDE used together with a YAML config for overriding, it will lead to long process command difficult to read or parse. What makes it worse is comment strings within YAML file.

This PR standardizes custom bootstrap config on JSON string for Envoy, while continue to allow ISTIO_BOOTSTRAP_OVERRIDE file with either YAML or JSON.

Ref: https://www.envoyproxy.io/docs/envoy/latest/operations/cli.html#command-line-options