### PR TITLE
Fix dry-run deactivating default webhook

### DIFF
--- a/istioctl/pkg/tag/generate_test.go
+++ b/istioctl/pkg/tag/generate_test.go
@@ -15,6 +15,7 @@
 package tag
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"istio.io/api/label"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 var (
@@ -348,4 +350,38 @@ func TestGenerateMutatingWebhook(t *testing.T) {
 			}
 		}
 	}
+}
+
+func testGenerateOption(t *testing.T, generate bool, assertFunc func(*testing.T, []admitv1.MutatingWebhook, []admitv1.MutatingWebhook)) {
+	defaultWh := defaultRevisionCanonicalWebhook.DeepCopy()
+	fakeClient := kube.NewFakeClient(defaultWh)
+
+	opts := &GenerateOptions{
+		Generate: generate,
+		Tag:      "default",
+		Revision: "default",
+	}
+
+	_, err := Generate(context.TODO(), fakeClient, opts, "istio-system")
+	assert.NoError(t, err)
+
+	wh, err := fakeClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().
+		Get(context.Background(), "istio-sidecar-injector", metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	assertFunc(t, wh.Webhooks, defaultWh.Webhooks)
+}
+
+func TestGenerateOptions(t *testing.T) {
+	// Test generate option 'true', should not modify webhooks
+	testGenerateOption(t, true, func(t *testing.T, actual, expected []admitv1.MutatingWebhook) {
+		assert.Equal(t, actual, expected)
+	})
+
+	// Test generate option 'false', should modify webhooks
+	testGenerateOption(t, false, func(t *testing.T, actual, expected []admitv1.MutatingWebhook) {
+		if err := assert.Compare(actual, expected); err == nil {
+			t.Errorf("expected diff between webhooks, got none")
+		}
+	})
 }

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -640,6 +640,7 @@ func ProcessDefaultWebhook(client kube.Client, iop *istioV1Alpha1.IstioOperator,
 			Overwrite:            true,
 			AutoInjectNamespaces: autoInjectNamespaces,
 			CustomLabels:         ignorePruneLabel,
+			Generate:             opt.DryRun,
 		}
 		// If tag cannot be created could be remote cluster install, don't fail out.
 		tagManifests, err := revtag.Generate(context.Background(), client, o, opt.Namespace)

--- a/releasenotes/notes/48266.yaml
+++ b/releasenotes/notes/48266.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 48241
+releaseNotes:
+- |
+  **Fixed** an issue where the Istio injection webhook may be modified in dry-run mode.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/48241.

See:

https://github.com/istio/istio/blob/ed790066c418cda0f9a258af2981dffeba0a6546/istioctl/pkg/tag/generate.go#L77-L79

And:

https://github.com/istio/istio/blob/ed790066c418cda0f9a258af2981dffeba0a6546/istioctl/pkg/tag/generate.go#L133-L144