### PR TITLE
[release-1.19] Dedupe wildcard routes based on the virtualservice with the most specific match (#48071)

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -684,6 +684,17 @@ var (
 	// Also see https://github.com/istio/istio/issues/46719 why this flag is required
 	EnableAdditionalIpv4OutboundListenerForIpv6Only = env.RegisterBoolVar("ISTIO_ENABLE_IPV4_OUTBOUND_LISTENER_FOR_IPV6_CLUSTERS", false,
 		"If true, pilot will configure an additional IPv4 listener for outbound traffic in IPv6 only clusters, e.g. AWS EKS IPv6 only clusters.").Get()
+
+	UseCacertsForSelfSignedCA = env.Register("USE_CACERTS_FOR_SELF_SIGNED_CA", false,
+		"If enabled, istiod will use a secret named cacerts to store its self-signed istio-"+
+			"generated root certificate.").Get()
+
+	StackdriverAuditLog = env.Register("STACKDRIVER_AUDIT_LOG", false, ""+
+		"If enabled, StackDriver audit logging will be enabled.").Get()
+
+	PersistOldestWinsHeuristicForVirtualServiceHostMatching = env.Register("PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING", false,
+		"If enabled, istiod will persist the oldest first heuristic for subtly conflicting traffic policy selection"+
+			"(such as with overlapping wildcard hosts)").Get()
 )
 
 // UnsafeFeaturesEnabled returns true if any unsafe features are enabled.

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -331,6 +331,44 @@ func mostSpecificHostWildcardMatch[V any](needle string, wildcard map[host.Name]
 	return matchHost, matchValue, found
 }
 
+// OldestMatchingHost returns the oldest matching host for a given needle (whether specific or wildcarded)
+func OldestMatchingHost(needle host.Name, specific map[host.Name]config.Config, wildcard map[host.Name]config.Config) (host.Name, config.Config, bool) {
+	// The algorithm is a bit different than MostSpecificHostMatch. We can't short-circuit on the first
+	// match, regardless of whether it's specific or wildcarded. This is because we have to check the timestamp
+	// of all configs to make sure there's not an older matching one that we should use instead.
+
+	if needle.IsWildCarded() {
+		needle = needle[1:]
+	}
+
+	found := false
+	var matchHost host.Name
+	var matchValue config.Config
+	// exact match first
+	if v, ok := specific[needle]; ok {
+		found = true
+		matchHost = needle
+		matchValue = v
+	}
+
+	// Even if we have a match, we still need to check the wildcard map to see if there's an older match
+	for h, v := range wildcard {
+		if strings.HasSuffix(string(needle), string(h[1:])) {
+			if !found {
+				matchHost = h
+				matchValue = wildcard[h]
+				found = true
+			} else if h.Matches(matchHost) && v.GetCreationTimestamp().Before(matchValue.GetCreationTimestamp()) {
+				// Only replace if the new match is more specific and older than the current match
+				matchHost = h
+				matchValue = v
+			}
+		}
+	}
+
+	return matchHost, matchValue, found
+}
+
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
 func sortConfigByCreationTime(configs []config.Config) []config.Config {
 	sort.Slice(configs, func(i, j int) bool {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
@@ -167,6 +168,11 @@ type IstioEgressListenerWrapper struct {
 	// a private virtual service for serviceA from the local namespace,
 	// with a different path rewrite or no path rewrites.
 	virtualServices []config.Config
+
+	// An index of hostname to the namespaced name of the VirtualService containing the most
+	// relevant host match. Depending on the `PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING`
+	// feature flag, it could be the most specific host match or the oldest host match.
+	mostSpecificWildcardVsIndex map[host.Name]types.NamespacedName
 }
 
 const defaultSidecar = "default-sidecar"
@@ -182,6 +188,8 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	}
 	defaultEgressListener.services = ps.servicesExportedToNamespace(configNamespace)
 	defaultEgressListener.virtualServices = ps.VirtualServicesForGateway(configNamespace, constants.IstioMeshGateway)
+	defaultEgressListener.mostSpecificWildcardVsIndex = computeWildcardHostVirtualServiceIndex(
+		defaultEgressListener.virtualServices, defaultEgressListener.services)
 
 	out := &SidecarScope{
 		Name:                    defaultSidecar,
@@ -466,6 +474,8 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 	out.virtualServices = SelectVirtualServices(ps.virtualServiceIndex, configNamespace, listenerHosts)
 	svces := ps.servicesExportedToNamespace(configNamespace)
 	out.services = out.selectServices(svces, configNamespace, listenerHosts)
+	out.mostSpecificWildcardVsIndex = computeWildcardHostVirtualServiceIndex(out.virtualServices, out.services)
+
 	return out
 }
 
@@ -525,6 +535,12 @@ func (ilw *IstioEgressListenerWrapper) Services() []*Service {
 // egress listener
 func (ilw *IstioEgressListenerWrapper) VirtualServices() []config.Config {
 	return ilw.virtualServices
+}
+
+// WildcardHostVirtualServiceIndex returns the the wildcardHostVirtualServiceIndex for this egress
+// listener.
+func (ilw *IstioEgressListenerWrapper) MostSpecificWildcardServiceIndex() map[host.Name]types.NamespacedName {
+	return ilw.mostSpecificWildcardVsIndex
 }
 
 // DependsOnConfig determines if the proxy depends on the given config.
@@ -752,4 +768,37 @@ func needsPortMatch(ilw *IstioEgressListenerWrapper) bool {
 	//  - If Port's protocol is proxy protocol(HTTP_PROXY) in which case the egress listener is used as generic egress http proxy.
 	return ilw.IstioListener != nil && ilw.IstioListener.Port.GetNumber() != 0 &&
 		protocol.Parse(ilw.IstioListener.Port.Protocol) != protocol.HTTP_PROXY
+}
+
+// computeWildcardHostVirtualServiceIndex computes the wildcardHostVirtualServiceIndex for a given
+// list of virtualServices. This is used to optimize the lookup of the most specific wildcard host
+func computeWildcardHostVirtualServiceIndex(virtualServices []config.Config, services []*Service) map[host.Name]types.NamespacedName {
+	fqdnVirtualServiceHostIndex := make(map[host.Name]config.Config, len(virtualServices))
+	wildcardVirtualServiceHostIndex := make(map[host.Name]config.Config, len(virtualServices))
+	for _, vs := range virtualServices {
+		v := vs.Spec.(*networking.VirtualService)
+		for _, h := range v.Hosts {
+			if host.Name(h).IsWildCarded() {
+				wildcardVirtualServiceHostIndex[host.Name(h)] = vs
+			} else {
+				fqdnVirtualServiceHostIndex[host.Name(h)] = vs
+			}
+		}
+	}
+
+	mostSpecificWildcardVsIndex := make(map[host.Name]types.NamespacedName)
+	comparator := MostSpecificHostMatch[config.Config]
+	if features.PersistOldestWinsHeuristicForVirtualServiceHostMatching {
+		comparator = OldestMatchingHost
+	}
+	for _, svc := range services {
+		_, ref, exists := comparator(svc.Hostname, fqdnVirtualServiceHostIndex, wildcardVirtualServiceHostIndex)
+		if !exists {
+			// This svc doesn't have a virtualService; skip
+			continue
+		}
+		mostSpecificWildcardVsIndex[svc.Hostname] = ref.NamespacedName()
+	}
+
+	return mostSpecificWildcardVsIndex
 }

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -20,13 +20,16 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -34,6 +37,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -2391,7 +2395,7 @@ func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 	}
 
 	meshConfigWithRegistryOnly, err := mesh.ApplyMeshConfigDefaults(`
-outboundTrafficPolicy: 
+outboundTrafficPolicy:
   mode: REGISTRY_ONLY
 `)
 	if err != nil {
@@ -2569,5 +2573,102 @@ func benchmarkConvertIstioListenerToWrapper(b *testing.B, vsNum int, hostNum int
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		convertIstioListenerToWrapper(ps, "default", istioListener)
+	}
+}
+
+func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
+	oldestTime := time.Now().Add(-2 * time.Hour)
+	olderTime := time.Now().Add(-1 * time.Hour)
+	newerTime := time.Now()
+	virtualServices := []config.Config{
+		{
+			Meta: config.Meta{
+				Name:              "foo",
+				Namespace:         "default",
+				CreationTimestamp: newerTime,
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"foo.example.com"},
+			},
+		},
+		{
+			Meta: config.Meta{
+				Name:              "wild",
+				Namespace:         "default",
+				CreationTimestamp: olderTime,
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"*.example.com"},
+			},
+		},
+		{
+			Meta: config.Meta{
+				Name:              "barwild",
+				Namespace:         "default",
+				CreationTimestamp: oldestTime,
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"*.bar.example.com"},
+			},
+		},
+	}
+
+	services := []*Service{
+		{
+			Hostname: "foo.example.com",
+		},
+		{
+			Hostname: "baz.example.com",
+		},
+		{
+			Hostname: "qux.bar.example.com",
+		},
+		{
+			Hostname: "*.bar.example.com",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		virtualServices []config.Config
+		services        []*Service
+		expectedIndex   map[host.Name]types.NamespacedName
+		oldestWins      bool
+	}{
+		{
+			name:            "most specific",
+			virtualServices: virtualServices,
+			services:        services,
+			expectedIndex: map[host.Name]types.NamespacedName{
+				"foo.example.com":     {Name: "foo", Namespace: "default"},
+				"baz.example.com":     {Name: "wild", Namespace: "default"},
+				"qux.bar.example.com": {Name: "barwild", Namespace: "default"},
+				"*.bar.example.com":   {Name: "barwild", Namespace: "default"},
+			},
+		},
+		{
+			name:            "oldest wins",
+			virtualServices: virtualServices,
+			services:        services,
+			expectedIndex: map[host.Name]types.NamespacedName{
+				"foo.example.com":     {Name: "wild", Namespace: "default"},
+				"baz.example.com":     {Name: "wild", Namespace: "default"},
+				"qux.bar.example.com": {Name: "barwild", Namespace: "default"},
+				"*.bar.example.com":   {Name: "barwild", Namespace: "default"},
+			},
+			oldestWins: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.oldestWins {
+				test.SetForTest(t, &features.PersistOldestWinsHeuristicForVirtualServiceHostMatching, true)
+			}
+			index := computeWildcardHostVirtualServiceIndex(tt.virtualServices, tt.services)
+			if !reflect.DeepEqual(tt.expectedIndex, index) {
+				t.Errorf("Expected index %v, got %v", tt.expectedIndex, index)
+			}
+		})
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -451,8 +451,12 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 		// only select virtualServices that matches a service
 		virtualServices = selectVirtualServices(virtualServices, servicesByName)
 	}
+
+	mostSpecificWildcardIndex := egressListener.MostSpecificWildcardServiceIndex()
 	// Get list of virtual services bound to the mesh gateway
-	virtualHostWrappers := istio_route.BuildSidecarVirtualHostWrapper(routeCache, node, push, servicesByName, virtualServices, listenerPort)
+	virtualHostWrappers := istio_route.BuildSidecarVirtualHostWrapper(routeCache, node, push,
+		servicesByName, virtualServices, listenerPort, mostSpecificWildcardIndex,
+	)
 
 	if features.EnableRDSCaching {
 		resource := xdsCache.Get(routeCache)

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -31,6 +31,7 @@ import (
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -94,7 +95,7 @@ type VirtualHostWrapper struct {
 // and a list of Services from the service registry. Services are indexed by FQDN hostnames.
 // The list of Services is also passed to allow maintaining consistent ordering.
 func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *model.PushContext, serviceRegistry map[host.Name]*model.Service,
-	virtualServices []config.Config, listenPort int,
+	virtualServices []config.Config, listenPort int, mostSpecificWildcardIndex map[host.Name]types.NamespacedName,
 ) []VirtualHostWrapper {
 	out := make([]VirtualHostWrapper, 0)
 
@@ -106,7 +107,9 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 	for _, virtualService := range virtualServices {
 		hashByDestination, destinationRules := hashForVirtualService(push, node, virtualService)
 		dependentDestinationRules = append(dependentDestinationRules, destinationRules...)
-		wrappers := buildSidecarVirtualHostsForVirtualService(node, virtualService, serviceRegistry, hashByDestination, listenPort, push.Mesh)
+		wrappers := buildSidecarVirtualHostsForVirtualService(
+			node, virtualService, serviceRegistry, hashByDestination, listenPort, push.Mesh, mostSpecificWildcardIndex,
+		)
 		out = append(out, wrappers...)
 	}
 
@@ -141,7 +144,11 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 // plain non-registry hostnames
 func separateVSHostsAndServices(virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service,
+	mostSpecificWildcardIndex map[host.Name]types.NamespacedName,
 ) ([]string, []*model.Service) {
+	// TODO: A further optimization would be to completely rely on the index and not do the loop below
+	// However, that requires assuming that serviceRegistry never got filtered after the
+	// egressListener was created.
 	rule := virtualService.Spec.(*networking.VirtualService)
 	hosts := make([]string, 0)
 	servicesInVirtualService := make([]*model.Service, 0)
@@ -169,15 +176,23 @@ func separateVSHostsAndServices(virtualService config.Config,
 			hosts = append(hosts, string(hostname))
 			continue
 		}
-		// Say host is *.global
+		// Say this VS's host is *.global and there's another VS with host *.foo.global
 		foundSvcMatch := false
 		// Say we have Services *.foo.global, *.bar.global
 		for svcHost, svc := range serviceRegistry {
-			// *.foo.global matches *.global
-			if svcHost.Matches(hostname) {
-				servicesInVirtualService = append(servicesInVirtualService, svc)
-				foundSvcMatch = true
+			vs, ok := mostSpecificWildcardIndex[svcHost]
+			if !ok {
+				// This service doesn't have a virtualService that matches it.
+				continue
 			}
+			foundSvcMatch = true // we did find a match
+			if vs != virtualService.NamespacedName() {
+				// This virtual service is not the most specific wildcard match for this service.
+				// So we don't add it to the list of services in this virtual service so as
+				// to avoid duplicates
+				continue
+			}
+			servicesInVirtualService = append(servicesInVirtualService, svc)
 		}
 		if !foundSvcMatch {
 			hosts = append(hosts, string(hostname))
@@ -197,6 +212,7 @@ func buildSidecarVirtualHostsForVirtualService(
 	hashByDestination DestinationHashMap,
 	listenPort int,
 	mesh *meshconfig.MeshConfig,
+	mostSpecificWildcardIndex map[host.Name]types.NamespacedName,
 ) []VirtualHostWrapper {
 	meshGateway := sets.New(constants.IstioMeshGateway)
 	opts := RouteOptions{
@@ -212,7 +228,7 @@ func buildSidecarVirtualHostsForVirtualService(
 		return nil
 	}
 
-	hosts, servicesInVirtualService := separateVSHostsAndServices(virtualService, serviceRegistry)
+	hosts, servicesInVirtualService := separateVSHostsAndServices(virtualService, serviceRegistry, mostSpecificWildcardIndex)
 
 	// Gateway allows only routes from the namespace of the proxy, or namespace of the destination.
 	if model.UseGatewaySemantics(virtualService) {
@@ -406,7 +422,7 @@ func translateRoute(
 	opts RouteOptions,
 ) *route.Route {
 	// When building routes, it's okay if the target cluster cannot be
-	// resolved Traffic to such clusters will blackhole.
+	// resolved. Traffic to such clusters will blackhole.
 
 	// Match by the destination port specified in the match condition
 	if match != nil && match.Port != 0 && match.Port != uint32(listenPort) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -15,6 +15,7 @@
 package route_test
 
 import (
+	"log"
 	"reflect"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -1132,7 +1134,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 			Services: exampleService,
 		})
-		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
+			[]config.Config{}, 8080, map[host.Name]types.NamespacedName{},
+		)
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
@@ -1150,7 +1154,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 			Services: exampleService,
 		})
-		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
+			[]config.Config{}, 8080, map[host.Name]types.NamespacedName{},
+		)
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -1160,6 +1166,36 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 		}
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).To(gomega.ConsistOf(hashPolicy))
+	})
+
+	t.Run("for virtualservices and services with overlapping wildcard hosts", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+			Configs:  []config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost},
+			Services: []*model.Service{exampleWildcardService, exampleNestedWildcardService},
+		})
+
+		// Redefine the service registry for this test
+		serviceRegistry := map[host.Name]*model.Service{
+			"*.example.org":             exampleWildcardService,
+			"goodbye.hello.example.org": exampleNestedWildcardService,
+		}
+
+		wildcardIndex := map[host.Name]types.NamespacedName{
+			"*.example.org":       virtualServiceWithWildcardHost.NamespacedName(),
+			"*.hello.example.org": virtualServiceWithNestedWildcardHost.NamespacedName(),
+		}
+
+		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
+			[]config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost}, 8080,
+			wildcardIndex,
+		)
+		log.Printf("%#v", vhosts)
+		g.Expect(vhosts).To(gomega.HaveLen(2))
+		for _, vhost := range vhosts {
+			g.Expect(vhost.Services).To(gomega.HaveLen(1))
+			g.Expect(vhost.Routes).To(gomega.HaveLen(1))
+		}
 	})
 }
 
@@ -1405,6 +1441,66 @@ var virtualServiceWithCatchAllPort = config.Config{
 							Host: "example1.default.svc.cluster.local",
 							Port: &networking.PortSelector{
 								Number: 8484,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithWildcardHost = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "wildcard",
+	},
+	Spec: &networking.VirtualService{
+		Hosts: []string{"*.example.org"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "https",
+						Port: uint32(8080),
+					},
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "*.example.org",
+							Port: &networking.PortSelector{
+								Number: 8080,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithNestedWildcardHost = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "nested-wildcard",
+	},
+	Spec: &networking.VirtualService{
+		Hosts: []string{"*.hello.example.org"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Name: "https",
+						Port: uint32(8080),
+					},
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "*.hello.example.org",
+							Port: &networking.PortSelector{
+								Number: 8080,
 							},
 						},
 					},
@@ -2522,7 +2618,19 @@ var networkingDestinationRule = &networking.DestinationRule{
 	},
 }
 
-var exampleService = []*model.Service{{Hostname: "*.example.org", Attributes: model.ServiceAttributes{Namespace: "istio-system"}}}
+var (
+	exampleService         = []*model.Service{{Hostname: "*.example.org", Attributes: model.ServiceAttributes{Namespace: "istio-system"}}}
+	exampleWildcardService = &model.Service{
+		Hostname:   "*.example.org",
+		Attributes: model.ServiceAttributes{Namespace: "istio-system"},
+		Ports:      []*model.Port{{Port: 8080, Protocol: "HTTP"}},
+	}
+	exampleNestedWildcardService = &model.Service{
+		Hostname:   "goodbye.hello.example.org",
+		Attributes: model.ServiceAttributes{Namespace: "istio-system"},
+		Ports:      []*model.Port{{Port: 8080, Protocol: "HTTP"}},
+	}
+)
 
 var networkingDestinationRuleWithPortLevelTrafficPolicy = &networking.DestinationRule{
 	Host: "*.example.org",

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1763,6 +1763,7 @@ spec:
 		routeName       string
 		expected        map[string][]string
 		expectedGateway map[string][]string
+		oldestWins      bool
 	}{
 		// Port 80 has special cases as there is defaulting logic around this port
 		{
@@ -2055,7 +2056,7 @@ spec:
 			},
 		},
 		{
-			name: "wildcard first then explicit",
+			name: "wildcard first then explicit (oldest wins feature flag)",
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "default",
@@ -2075,6 +2076,40 @@ spec:
 			expected: map[string][]string{
 				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
 				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"}, // oldest wins
+				// Matched an exact service, so we have no route for the wildcard
+				"*.cluster.local": nil,
+			},
+			expectedGateway: map[string][]string{
+				// No overrides, use default
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				// Explicit has precedence
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
+				// Last is our wildcard
+				"*.cluster.local": {"outbound|80||wild.example.com"},
+			},
+			oldestWins: true,
+		},
+		{
+			name: "wildcard first then explicit",
+			cfg: []Configer{
+				vsArgs{
+					Namespace: "default",
+					Match:     "*.cluster.local",
+					Dest:      "wild.example.com",
+					Time:      TimeOlder,
+				},
+				vsArgs{
+					Namespace: "default",
+					Match:     "known.default.svc.cluster.local",
+					Dest:      "explicit.example.com",
+					Time:      TimeNewer,
+				},
+			},
+			proxy:     proxy("default"),
+			routeName: "80",
+			expected: map[string][]string{
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
 				"*.cluster.local": nil,
 			},
@@ -2107,7 +2142,7 @@ spec:
 			routeName: "80",
 			expected: map[string][]string{
 				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
-				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"}, // oldest wins
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
 				"*.cluster.local": nil,
 			},
@@ -2119,6 +2154,46 @@ spec:
 				// Last is our wildcard
 				"*.cluster.local": {"outbound|80||wild.example.com"},
 			},
+		},
+		{
+			name: "wildcard and explicit with sidecar (oldest wins feature flag)",
+			cfg: []Configer{
+				vsArgs{
+					Namespace: "default",
+					Match:     "*.cluster.local",
+					Dest:      "wild.example.com",
+					Time:      TimeOlder,
+				},
+				vsArgs{
+					Namespace: "default",
+					Match:     "known.default.svc.cluster.local",
+					Dest:      "explicit.example.com",
+					Time:      TimeNewer,
+				},
+				scArgs{
+					Namespace: "default",
+					Egress:    []string{"default/known.default.svc.cluster.local", "default/alt-known.default.svc.cluster.local"},
+				},
+			},
+			proxy:     proxy("default"),
+			routeName: "80",
+			expected: map[string][]string{
+				// Even though we did not import `*.cluster.local`, the VS attaches
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				// Oldest wins
+				"known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				// Matched an exact service, so we have no route for the wildcard
+				"*.cluster.local": nil,
+			},
+			expectedGateway: map[string][]string{
+				// No rule imported
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				// Imported rule
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
+				// Not imported
+				"*.cluster.local": nil,
+			},
+			oldestWins: true,
 		},
 		{
 			name: "wildcard and explicit with sidecar",
@@ -2145,7 +2220,8 @@ spec:
 			expected: map[string][]string{
 				// Even though we did not import `*.cluster.local`, the VS attaches
 				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
-				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"},
+				// Most exact match wins
+				"known.default.svc.cluster.local": {"outbound|80||explicit.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
 				"*.cluster.local": nil,
 			},
@@ -2189,7 +2265,7 @@ spec:
 			},
 		},
 		{
-			name: "wildcard and explicit cross namespace",
+			name: "wildcard and explicit cross namespace (oldest wins feature flag)",
 			cfg: []Configer{
 				vsArgs{
 					Namespace: "not-default",
@@ -2210,6 +2286,40 @@ spec:
 				// Wildcard is older, so it wins, even though it is cross namespace
 				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
 				"known.default.svc.cluster.local":     {"outbound|80||wild.example.com"},
+				// Matched an exact service, so we have no route for the wildcard
+				"*.cluster.local": nil,
+			},
+			expectedGateway: map[string][]string{
+				// Exact match wins
+				"alt-known.default.svc.cluster.local": {"outbound|80||alt-known.default.svc.cluster.local"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
+				// Wildcard last
+				"*.cluster.local": {"outbound|80||wild.example.com"},
+			},
+			oldestWins: true,
+		},
+		{
+			name: "wildcard and explicit cross namespace",
+			cfg: []Configer{
+				vsArgs{
+					Namespace: "not-default",
+					Match:     "*.cluster.local",
+					Dest:      "wild.example.com",
+					Time:      TimeOlder,
+				},
+				vsArgs{
+					Namespace: "default",
+					Match:     "known.default.svc.cluster.local",
+					Dest:      "explicit.example.com",
+					Time:      TimeNewer,
+				},
+			},
+			proxy:     proxy("default"),
+			routeName: "80",
+			expected: map[string][]string{
+				// Exact match wins
+				"alt-known.default.svc.cluster.local": {"outbound|80||wild.example.com"},
+				"known.default.svc.cluster.local":     {"outbound|80||explicit.example.com"},
 				// Matched an exact service, so we have no route for the wildcard
 				"*.cluster.local": nil,
 			},
@@ -2445,7 +2555,11 @@ spec:
 			for _, tt := range cases {
 				tt := tt
 				t.Run(tt.name, func(t *testing.T) {
-					t.Parallel()
+					if tt.oldestWins {
+						test.SetForTest(t, &features.PersistOldestWinsHeuristicForVirtualServiceHostMatching, true)
+					} else {
+						t.Parallel() // feature flags and parallel tests don't mix
+					}
 					cfg := knownServices
 					for _, tc := range tt.cfg {
 						cfg = cfg + "\n---\n" + tc.Config(t, variant)

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -365,6 +365,17 @@ func (c Config) GetNamespace() string {
 	return c.Namespace
 }
 
+func (c Config) GetCreationTimestamp() time.Time {
+	return c.CreationTimestamp
+}
+
+func (c Config) NamespacedName() kubetypes.NamespacedName {
+	return kubetypes.NamespacedName{
+		Namespace: c.Namespace,
+		Name:      c.Name,
+	}
+}
+
 var _ fmt.Stringer = GroupVersionKind{}
 
 type GroupVersionKind struct {

--- a/releasenotes/notes/45415-overlapping-wildcards.yaml
+++ b/releasenotes/notes/45415-overlapping-wildcards.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+issue:
+  - 45415
+
+releaseNotes:
+  - |
+    **Fixed** a bug where overlapping wildcard hosts in a VirtualService would produce incorrect routing configuration when wildcard services were selected (e.g. in ServiceEntries).
+
+upgradeNotes:
+  - title: Overlapping Wildcard Conflicts
+    content: |
+      This fix changes the behavior of overlapping wildcard hosts in VirtualService. Previously, the oldest VirtualService would take precedence
+      regardless of whether or not it was the most specific host match. Now, the most specific host match will take precedence. To persist the old behavior,
+      set the `PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING` environment variable to `true` on istiod.


### PR DESCRIPTION
Fixes #48258