### PR TITLE
update zt daemonset to use ISTIO_META_CLUSTER_ID

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -83,7 +83,7 @@ spec:
         {{- end }}
         - name: XDS_ADDRESS
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.istioNamespace }}.svc:15012
-        - name: CLUSTER_ID
+        - name: ISTIO_META_CLUSTER_ID
           value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}
         - name: POD_NAME
           valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ztunnel.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ztunnel.golden.yaml
@@ -30,7 +30,7 @@ spec:
           value: istiod.istio-system.svc:15012
         - name: XDS_ADDRESS
           value: istiod.istio-system.svc:15012
-        - name: ISTIO_META_CLUSTER_ID
+        - name: CLUSTER_ID
           value: Kubernetes
         - name: POD_NAME
           valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ztunnel.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ztunnel.golden.yaml
@@ -30,7 +30,7 @@ spec:
           value: istiod.istio-system.svc:15012
         - name: XDS_ADDRESS
           value: istiod.istio-system.svc:15012
-        - name: CLUSTER_ID
+        - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
**Please provide a description of this PR:**

In https://github.com/istio/ztunnel/pull/563 the decision was made to use `ISTIO_META_CLUSTER_ID` instead of `CLUSTER_ID `. This PR updates our zt daemonset to populate the new env variable name.

Should address #47917