### PR TITLE
gcp: drop reliance on metadata server entirely when GCP_METADATA is set

### DIFF
--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -229,8 +229,6 @@ func TestGCPMetadata(t *testing.T) {
 			},
 			map[string]string{
 				GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster",
-				GCEInstance: "instanceName", GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy",
-				GCPClusterURL: "https://container.googleapis.com/v1/projects/env_pid/locations/env_location/clusters/env_cluster",
 			},
 		},
 		{


### PR DESCRIPTION
In the past, we had made it so this will behave correctly if the env var
is set and we cannot reach the metadata server. This could be an outage
or netpol blocking, etc.

however, we have begun to see issues where the metadata server is around
enough to pass the "is alive", but not stable enough to respond quickly.
This results in massive (20s+) startup latencies. This is for
effectively useless information, as the `gce_*` metadata is unused on
GKE where the variable is used anyways.

This PR makes the logic even more robust, and short circuits entirely if
the var is set
