### PR TITLE
Fix ExportTo behavior if workload's namespace is included

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1914,7 +1914,7 @@ func (ps *PushContext) setDestinationRules(configs []config.Config) {
 		// We only honor . and *
 		if exportToSet.IsEmpty() && ps.exportToDefaults.destinationRule.Contains(visibility.Private) {
 			isPrivateOnly = true
-		} else if exportToSet.Len() == 1 && exportToSet.Contains(visibility.Private) || exportToSet.Contains(visibility.Instance(configs[i].Namespace)) {
+		} else if exportToSet.Len() == 1 && (exportToSet.Contains(visibility.Private) || exportToSet.Contains(visibility.Instance(configs[i].Namespace))) {
 			isPrivateOnly = true
 		}
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -2133,7 +2133,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		},
 		Spec: &networking.DestinationRule{
 			Host:     testhost,
-			ExportTo: []string{"test2", "ns1", "test1"},
+			ExportTo: []string{"test2", "ns1", "test1", "newNS"},
 			Subsets: []*networking.Subset{
 				{
 					Name: "subset3",
@@ -2317,6 +2317,12 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		{
 			proxyNs:     "test2",
 			serviceNs:   "test1",
+			host:        testhost,
+			wantSubsets: []string{"subset3", "subset4"},
+		},
+		{
+			proxyNs:     "newNS",
+			serviceNs:   "test2",
 			host:        testhost,
 			wantSubsets: []string{"subset3", "subset4"},
 		},

--- a/releasenotes/notes/48312.yaml
+++ b/releasenotes/notes/48312.yaml
@@ -2,7 +2,7 @@ apiVersion: release-notes/v2
 kind: bug-fix
 area: traffic-management
 issue:
-- 48300
+- 48349
 releaseNotes:
 - |
   **Fixed** an issue if DestinationRule's exportTo includes workload's current namespace (not '.'), other namespaces are ignored from ExportTo.

--- a/releasenotes/notes/48312.yaml
+++ b/releasenotes/notes/48312.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 48300
+releaseNotes:
+- |
+  **Fixed** an issue if DestinationRule's exportTo includes workload's current namespace (not '.'), other namespaces are ignored from ExportTo.


### PR DESCRIPTION
resolves https://github.com/istio/istio/issues/48349

**Please provide a description of this PR:**
With the change below, I observed an issue that if exportTo includes workload's current namespace (not '.'), other namespaces are ignored from ExportTo.
 - https://github.com/istio/istio/blob/master/pilot/pkg/model/push_context.go#L1917