### PR TITLE
Fix typos that do not affect logical with crate-ci/typos.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -93,7 +93,7 @@ endif
 -include .istiorc.mk
 
 # Environment for tests, the directory containing istio and deps binaries.
-# Typically same as GOPATH/bin, so tests work seemlessly with IDEs.
+# Typically same as GOPATH/bin, so tests work seamlessly with IDEs.
 
 export ISTIO_BIN=$(GOBIN)
 
@@ -126,7 +126,7 @@ ifeq ($(HUB),)
   $(error "HUB cannot be empty")
 endif
 
-# For dockerx builds, allow HUBS which is a space seperated list of hubs. Default to HUB.
+# For dockerx builds, allow HUBS which is a space separated list of hubs. Default to HUB.
 HUBS ?= $(HUB)
 
 # If tag not explicitly set in users' .istiorc.mk or command line, default to the git sha.

--- a/cni/pkg/ebpf/app/ambient_redirect.bpf.c
+++ b/cni/pkg/ebpf/app/ambient_redirect.bpf.c
@@ -304,7 +304,7 @@ int ztunnel_ingress(struct __sk_buff *skb)
 
     if (skb->cb[4] == OUTBOUND_CB) {
         // We mark all app egress pkt as outbound and redirect here.
-        // We need identify if it's a actual *outbound* or just a reponse to
+        // We need identify if it's a actual *outbound* or just a response to
         // the proxy
         sk = bpf_skc_lookup_tcp(skb, tuple, tuple_len, BPF_F_CURRENT_NETNS, 0);
         if (sk) {
@@ -382,7 +382,7 @@ int ztunnel_tproxy(struct __sk_buff *skb)
         sk = NULL;
     }
     if (!sk) {
-        // No exisiting connection, try to find listner
+        // No existing connection, try to find listner
         __builtin_memset(&proxy_tup, 0, sizeof(proxy_tup));
 
         if (skb->cb[4] == OUTBOUND_CB) {

--- a/cni/pkg/ebpf/server/redirectionServer_linux.go
+++ b/cni/pkg/ebpf/server/redirectionServer_linux.go
@@ -149,7 +149,7 @@ func (r *RedirectServer) SetLogLevel(level string) {
 
 func (r *RedirectServer) UpdateHostIP(ips []string) error {
 	if len(ips) > 2 {
-		return fmt.Errorf("too may ips inputed: %d", len(ips))
+		return fmt.Errorf("too may ips inputted: %d", len(ips))
 	}
 	for _, v := range ips {
 		ip, err := netip.ParseAddr(v)
@@ -199,7 +199,7 @@ func AddPodToMesh(ifIndex uint32, macAddr net.HardwareAddr, ips []netip.Addr) er
 	copy(mapInfo.MacAddr[:], macAddr)
 
 	if len(ips) == 0 {
-		return fmt.Errorf("nil ips inputed")
+		return fmt.Errorf("nil ips inputted")
 	}
 	// TODO: support multiple IPs and IPv6
 	ipAddr := ips[0]
@@ -367,7 +367,7 @@ func (r *RedirectServer) Start(stop <-chan struct{}) {
 
 func (r *RedirectServer) parseIPs(ipAddrs []netip.Addr) ([][]byte, error) {
 	if len(ipAddrs) == 0 {
-		return nil, fmt.Errorf("nil ipAddrs inputed")
+		return nil, fmt.Errorf("nil ipAddrs inputted")
 	}
 	// TODO: support multiple IPs and IPv6
 	ipAddr := ipAddrs[0]
@@ -660,7 +660,7 @@ func (r *RedirectServer) delClsactQdisc(namespace string, ifindex uint32) error 
 	}
 	err = rtnl.Qdisc().Delete(&info)
 	if errors.Is(err, os.ErrNotExist) {
-		log.Debugf("No qdisc configed for Ifindex: %d, %v", ifindex, err)
+		log.Debugf("No qdisc configured for Ifindex: %d, %v", ifindex, err)
 		return nil
 	}
 

--- a/istioctl/pkg/checkinject/checkinject.go
+++ b/istioctl/pkg/checkinject/checkinject.go
@@ -241,15 +241,15 @@ func analyzeWebhooksMatchStatus(whs []admitv1.MutatingWebhook, podLabels, nsLabe
 			return labels
 		}
 
-		var isDeactived bool
+		var isDeactivated bool
 		for _, wh := range whs {
 			if reflect.DeepEqual(wh.NamespaceSelector, util.NeverMatch) && reflect.DeepEqual(wh.ObjectSelector, util.NeverMatch) {
-				isDeactived = true
+				isDeactivated = true
 			}
 			nsMatchedLabels = append(nsMatchedLabels, extractMatchLabels(wh.NamespaceSelector)...)
 			podMatchedLabels = append(podMatchedLabels, extractMatchLabels(wh.ObjectSelector)...)
 		}
-		if isDeactived {
+		if isDeactivated {
 			return "The injection webhook is deactivated, and will never match labels."
 		}
 		return fmt.Sprintf("No matching namespace labels (%s) "+

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -210,7 +210,7 @@ func queryDebugSynczViaAgents(all bool, dr *discovery.DiscoveryRequest, istioNam
 				}
 				namespacedName := pod.Name + "." + pod.Namespace
 				if visited[namespacedName] {
-					// If we alredy have information about the pod, skip it.
+					// If we already have information about the pod, skip it.
 					continue
 				}
 				resp, err := queryToOnePod(&pod)

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -50,15 +50,15 @@ type XdsStatusWriter struct {
 }
 
 type xdsWriterStatus struct {
-	proxyID              string
-	clusterID            string
-	istiodID             string
-	istiodVersion        string
-	clusterStatus        string
-	listenerStatus       string
-	routeStatus          string
-	endpointStatus       string
-	extensionconfigStaus string
+	proxyID               string
+	clusterID             string
+	istiodID              string
+	istiodVersion         string
+	clusterStatus         string
+	listenerStatus        string
+	routeStatus           string
+	endpointStatus        string
+	extensionconfigStatus string
 }
 
 // PrintAll takes a slice of Pilot syncz responses and outputs them using a tabwriter
@@ -196,15 +196,15 @@ func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*discovery.DiscoveryRe
 				cds, lds, eds, rds, ecds := getSyncStatus(&clientConfig)
 				cp := multixds.CpInfo(dr)
 				fullStatus = append(fullStatus, &xdsWriterStatus{
-					proxyID:              clientConfig.GetNode().GetId(),
-					clusterID:            meta.ClusterID.String(),
-					istiodID:             cp.ID,
-					istiodVersion:        meta.IstioVersion,
-					clusterStatus:        cds,
-					listenerStatus:       lds,
-					routeStatus:          rds,
-					endpointStatus:       eds,
-					extensionconfigStaus: ecds,
+					proxyID:               clientConfig.GetNode().GetId(),
+					clusterID:             meta.ClusterID.String(),
+					istiodID:              cp.ID,
+					istiodVersion:         meta.IstioVersion,
+					clusterStatus:         cds,
+					listenerStatus:        lds,
+					routeStatus:           rds,
+					endpointStatus:        eds,
+					extensionconfigStatus: ecds,
 				})
 				if len(fullStatus) == 0 {
 					return nil, nil, fmt.Errorf("no proxies found (checked %d istiods)", len(drs))
@@ -245,7 +245,7 @@ func xdsStatusPrintln(w io.Writer, status *xdsWriterStatus) error {
 	_, err := fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 		status.proxyID, status.clusterID,
 		status.clusterStatus, status.listenerStatus, status.endpointStatus, status.routeStatus,
-		status.extensionconfigStaus,
+		status.extensionconfigStatus,
 		status.istiodID, status.istiodVersion)
 	return err
 }

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -182,7 +182,7 @@ func Namespace(componentName ComponentName, controlPlaneSpec *v1alpha1.IstioOper
 
 	componentNodeI, found, err := tpath.GetFromStructPath(controlPlaneSpec, "Components."+string(componentName)+".Namespace")
 	if err != nil {
-		return "", fmt.Errorf("error in Namepsace GetFromStructPath componentNamespace for component=%s: %s", componentName, err)
+		return "", fmt.Errorf("error in Namespace GetFromStructPath componentNamespace for component=%s: %s", componentName, err)
 	}
 	if !found {
 		return defaultNamespace, nil

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -225,7 +225,7 @@ var (
 		"The group to be used for the Kubernetes Multi-Cluster Services (MCS) API.").Get()
 
 	MCSAPIVersion = env.Register("MCS_API_VERSION", "v1alpha1",
-		"The version to be used for the Kubernets Multi-Cluster Services (MCS) API.").Get()
+		"The version to be used for the Kubernetes Multi-Cluster Services (MCS) API.").Get()
 
 	EnableMCSAutoExport = env.Register(
 		"ENABLE_MCS_AUTO_EXPORT",
@@ -686,8 +686,8 @@ var (
 		"If enabled, istiod will skip verifying the certificate of the JWKS server.").Get()
 
 	// User should not rely on builtin resource labels, this flag will be removed in future releases(1.20).
-	EnableOTELBuiltinResourceLables = env.Register("ENABLE_OTEL_BUILTIN_RESOURCE_LABELS", false,
-		"If enabled, envoy will send builtin lables(e.g. node_name) via OTel sink.").Get()
+	EnableOTELBuiltinResourceLabels = env.Register("ENABLE_OTEL_BUILTIN_RESOURCE_LABELS", false,
+		"If enabled, envoy will send builtin labels(e.g. node_name) via OTel sink.").Get()
 
 	EnableSelectorBasedK8sGatewayPolicy = env.Register("ENABLE_SELECTOR_BASED_K8S_GATEWAY_POLICY", true,
 		"If disabled, Gateway API gateways will ignore workloadSelector policies, only"+

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1020,11 +1020,11 @@ func ParseMetadata(metadata *structpb.Struct) (*NodeMetadata, error) {
 		return &NodeMetadata{}, nil
 	}
 
-	boostrapNodeMeta, err := ParseBootstrapNodeMetadata(metadata)
+	bootstrapNodeMeta, err := ParseBootstrapNodeMetadata(metadata)
 	if err != nil {
 		return nil, err
 	}
-	return &boostrapNodeMeta.NodeMetadata, nil
+	return &bootstrapNodeMeta.NodeMetadata, nil
 }
 
 // ParseBootstrapNodeMetadata parses the opaque Metadata from an Envoy Node into string key-value pairs.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -858,7 +858,7 @@ func (ps *PushContext) ServiceAttachedToGateway(hostname string, proxy *Proxy) b
 	return ps.extraGatewayServices(proxy).Contains(hostname)
 }
 
-// wellknownProviders is a lsit of all known providers.
+// wellknownProviders is a list of all known providers.
 // This exists
 var wellknownProviders = sets.New(
 	"envoy_ext_authz_http",

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -487,7 +487,7 @@ func buildOpenTelemetryAccessLogConfig(logName, hostname, clusterName, format st
 			TransportApiVersion:     core.ApiVersion_V3,
 			FilterStateObjectsToLog: envoyWasmStateToLog,
 		},
-		DisableBuiltinLabels: !features.EnableOTELBuiltinResourceLables,
+		DisableBuiltinLabels: !features.EnableOTELBuiltinResourceLabels,
 	}
 
 	if format != "" {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -117,7 +117,7 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 	}
 	clusters, log := configgen.buildClusters(proxy, updates, services)
 	// DeletedClusters contains list of all subset clusters for the deleted DR or updated DR.
-	// When clusters are rebuilt, it rebuilts the subset clusters as well. So, we know what
+	// When clusters are rebuilt, it rebuilt the subset clusters as well. So, we know what
 	// subset clusters are really needed. So if deleted cluster is not rebuilt, then it is really deleted.
 	builtClusters := sets.New[string]()
 	for _, c := range clusters {
@@ -721,7 +721,7 @@ type buildClusterOpts struct {
 	serviceMTLSMode model.MutualTLSMode
 	// Indicates the service registry of the cluster being built.
 	serviceRegistry provider.ID
-	// Indicates if the destionationRule has a workloadSelector
+	// Indicates if the destinationRule has a workloadSelector
 	isDrWithSelector bool
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -237,7 +237,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 		*meshconfig.MeshConfig_ExtensionProvider_EnvoyFileAccessLog,
 		*meshconfig.MeshConfig_ExtensionProvider_Prometheus:
 		return nil, false, fmt.Errorf("provider %T does not support tracing", provider)
-		// Should enver happen, but just in case we forget to add one
+		// Should never happen, but just in case we forget to add one
 	default:
 		return nil, false, fmt.Errorf("provider %T does not support tracing", provider)
 	}

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -227,7 +227,7 @@ func PodTLSMode(pod *corev1.Pod) string {
 // A user who wishes to expose multi-network connectivity should create a listener named "tls-passthrough"
 // with TLS.Mode Passthrough.
 // For some backwards compatibility, we assume any listener with TLS specified and a port matching
-// 15443 (or the label-override for gateway port) is auto-passtrough as well.
+// 15443 (or the label-override for gateway port) is auto-passthrough as well.
 func IsAutoPassthrough(gwLabels map[string]string, l v1beta1.Listener) bool {
 	if l.TLS == nil {
 		return false

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -800,15 +800,15 @@ func (s *DiscoveryServer) connectionConfigDump(conn *Connection, includeEds bool
 		return nil, err
 	}
 
-	extentionsConfig := make([]*admin.EcdsConfigDump_EcdsFilterConfig, 0)
+	extensionsConfig := make([]*admin.EcdsConfigDump_EcdsFilterConfig, 0)
 	for _, ext := range dump[v3.ExtensionConfigurationType] {
-		extentionsConfig = append(extentionsConfig, &admin.EcdsConfigDump_EcdsFilterConfig{
+		extensionsConfig = append(extensionsConfig, &admin.EcdsConfigDump_EcdsFilterConfig{
 			VersionInfo: version,
 			EcdsFilter:  ext.Resource,
 		})
 	}
-	extentionsAny, err := protoconv.MessageToAnyWithError(&admin.EcdsConfigDump{
-		EcdsFilters: extentionsConfig,
+	extensionsAny, err := protoconv.MessageToAnyWithError(&admin.EcdsConfigDump{
+		EcdsFilters: extensionsConfig,
 	})
 	if err != nil {
 		return nil, err
@@ -848,7 +848,7 @@ func (s *DiscoveryServer) connectionConfigDump(conn *Connection, includeEds bool
 		scopedRoutesAny,
 		routesAny,
 		secretsAny,
-		extentionsAny,
+		extensionsAny,
 	)
 	configDump := &admin.ConfigDump{
 		Configs: configs,

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -397,16 +397,16 @@ var (
 var routers = func() map[RouterFilterContext]*hcm.HttpFilter {
 	res := map[RouterFilterContext]*hcm.HttpFilter{}
 	for _, startSpan := range []bool{true, false} {
-		for _, supressHeaders := range []bool{true, false} {
+		for _, suppressHeaders := range []bool{true, false} {
 			res[RouterFilterContext{
 				StartChildSpan:       startSpan,
-				SuppressDebugHeaders: supressHeaders,
+				SuppressDebugHeaders: suppressHeaders,
 			}] = &hcm.HttpFilter{
 				Name: wellknown.Router,
 				ConfigType: &hcm.HttpFilter_TypedConfig{
 					TypedConfig: protoconv.MessageToAny(&router.Router{
 						StartChildSpan:       startSpan,
-						SuppressEnvoyHeaders: supressHeaders,
+						SuppressEnvoyHeaders: suppressHeaders,
 					}),
 				},
 			}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1827,14 +1827,14 @@ func validateServiceSettings(config *meshconfig.MeshConfig) (errs error) {
 func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 	var errs error
 	if pkpConf.GetProvider() == nil {
-		errs = multierror.Append(errs, errors.New("private key provider confguration is required"))
+		errs = multierror.Append(errs, errors.New("private key provider configuration is required"))
 	}
 
 	switch pkpConf.GetProvider().(type) {
 	case *meshconfig.PrivateKeyProvider_Cryptomb:
 		cryptomb := pkpConf.GetCryptomb()
 		if cryptomb == nil {
-			errs = multierror.Append(errs, errors.New("cryptomb confguration is required"))
+			errs = multierror.Append(errs, errors.New("cryptomb configuration is required"))
 		} else {
 			pollDelay := cryptomb.GetPollDelay()
 			if pollDelay == nil {
@@ -1846,7 +1846,7 @@ func validatePrivateKeyProvider(pkpConf *meshconfig.PrivateKeyProvider) error {
 	case *meshconfig.PrivateKeyProvider_Qat:
 		qatConf := pkpConf.GetQat()
 		if qatConf == nil {
-			errs = multierror.Append(errs, errors.New("qat confguration is required"))
+			errs = multierror.Append(errs, errors.New("qat configuration is required"))
 		} else {
 			pollDelay := qatConf.GetPollDelay()
 			if pollDelay == nil {
@@ -1967,7 +1967,7 @@ func ValidateMeshConfigProxyConfig(config *meshconfig.ProxyConfig) (errs error) 
 
 	if pkpConf := config.GetPrivateKeyProvider(); pkpConf != nil {
 		if err := validatePrivateKeyProvider(pkpConf); err != nil {
-			errs = multierror.Append(errs, multierror.Prefix(err, "invalid private key provider confguration:"))
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid private key provider configuration:"))
 		}
 	}
 

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -562,7 +562,7 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 			for _, answer := range ipAnswers {
 				copied := dns.Copy(answer)
 				/// If there is a CNAME record for the wildcard host, we will sent a chained response of CNAME + A/AAAA pointer
-				/// Otherwhise we expand the wildcard to the original question domain
+				/// Otherwise we expand the wildcard to the original question domain
 				if len(cnAnswers) > 0 {
 					copied.Header().Name = hostname
 				} else {

--- a/pkg/errdict/errdict.go
+++ b/pkg/errdict/errdict.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	LikelyCauseFirstPrefix = "The likely cause is "
-	LikeyCauseSecondPrefix = "Another possible cause could be "
+	LikelyCauseFirstPrefix  = "The likely cause is "
+	LikelyCauseSecondPrefix = "Another possible cause could be "
 )
 
 // General boilerplate.
@@ -98,7 +98,7 @@ var (
 			"because of incompatible Kubernetes settings",
 		Impact:      OperatorImpactNoUpdates,
 		LikelyCause: formatCauses(LikelyCauseConfiguration),
-		Action: "Esnure that IstioOperator config is compatible with current Kubernetes version." +
+		Action: "Ensure that IstioOperator config is compatible with current Kubernetes version." +
 			ActionIfErrSureCorrectConfigContactSupport,
 	}
 )
@@ -114,7 +114,7 @@ func formatCauses(causes ...string) string {
 	}
 	out := LikelyCauseFirstPrefix + fixFormat(causes[0]) + "."
 	for _, c := range causes[1:] {
-		out += LikeyCauseSecondPrefix + fixFormat(c) + "."
+		out += LikelyCauseSecondPrefix + fixFormat(c) + "."
 	}
 	return out
 }

--- a/pkg/workloadapi/workload.pb.go
+++ b/pkg/workloadapi/workload.pb.go
@@ -315,7 +315,7 @@ type Service struct {
 	// The target_port may be overridden on a per-workload basis.
 	Ports []*Port `protobuf:"bytes,5,rep,name=ports,proto3" json:"ports,omitempty"`
 	// Optional; if set, the SAN to verify for TLS connections.
-	// Typically, this is not set and per-workload identity is used to verfiy
+	// Typically, this is not set and per-workload identity is used to verify
 	// TODO: support this field
 	SubjectAltNames []string `protobuf:"bytes,6,rep,name=subject_alt_names,json=subjectAltNames,proto3" json:"subject_alt_names,omitempty"`
 }

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -70,7 +70,7 @@ message Service {
   // The target_port may be overridden on a per-workload basis.
   repeated Port ports = 5;
   // Optional; if set, the SAN to verify for TLS connections.
-  // Typically, this is not set and per-workload identity is used to verfiy
+  // Typically, this is not set and per-workload identity is used to verify
   // TODO: support this field
   repeated string subject_alt_names = 6;
 }

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -65,8 +65,8 @@ func shouldSkipPod(pod *corev1.Pod, config *config2.BugReportConfig) bool {
 		}
 		if len(eld.Labels) > 0 {
 			for key, val := range eld.Labels {
-				if evLablel, exists := pod.Labels[key]; exists {
-					if isExactMatchedOrPatternMatched(val, evLablel) {
+				if evLabel, exists := pod.Labels[key]; exists {
+					if isExactMatchedOrPatternMatched(val, evLabel) {
 						return true
 					}
 				}
@@ -110,8 +110,8 @@ func shouldSkipPod(pod *corev1.Pod, config *config2.BugReportConfig) bool {
 		if len(ild.Labels) > 0 {
 			isLabelsMatch := false
 			for key, val := range ild.Labels {
-				if evLablel, exists := pod.Labels[key]; exists {
-					if isExactMatchedOrPatternMatched(val, evLablel) {
+				if evLabel, exists := pod.Labels[key]; exists {
+					if isExactMatchedOrPatternMatched(val, evLabel) {
 						isLabelsMatch = true
 						break
 					}


### PR DESCRIPTION
**Please provide a description of this PR:**

Find and fix typos via github.com/crate-ci/typos.

I limited the scope of influence to avoid any modifications that might affect the logic of the code
The configuration I use locally:
```toml
[default]
extend-ignore-identifiers-re = [
    "ANDed",
    "O_WRONLY",
    "Failer",
    "failer",
    "IST",
    "ist",
    "ba",
    "ALS",
    "Als",
    "als",
    "Octect",
    "clik",
    "mis",
    "Ser",
    "unmarshaling",
    "wil",
    "Syncronization",
]

[default.extend-words]
wil = "will"
lsit = "list"
rebuilts = "rebuilt"

[type.log]
extend-glob = ["*.log"]
check-file = false

[type.gotest]
extend-glob = ["*_test.go"]
check-file = false

[type.svg]
extend-glob = ["*.svg"]
check-file = false

[files]
extend-exclude = [
  "go.mod",
  "licenses/**",
  "security/**",
  "tests/**",
  "pkg/test/**",
  "pkg/testcerts/**",
  "pkg/ctrlz/assets/static/**",
  "releasenotes/**",
  "samples/**",
  "pkg/config/analysis/analyzers/testdata/**",
  "pilot/pkg/config/kube/gateway/testdata/**",
]

```