### PR TITLE
Re-add PILOT_PARTIAL_FULL_PUSHES

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -563,6 +563,10 @@ var (
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()
 
+	PartialFullPushes = env.Register("PILOT_PARTIAL_FULL_PUSHES", true,
+		"If enabled, pilot will send partial pushes in for child resources (RDS, EDS, etc) when possible. "+
+			"This occurs for EDS in many cases regardless of this setting.").Get()
+
 	SharedMeshConfig = env.Register("SHARED_MESH_CONFIG", "",
 		"Additional config map to load for shared MeshConfig settings. The standard mesh config will take precedence.").Get()
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -191,7 +191,7 @@ func (eds *EdsGenerator) buildEndpoints(proxy *model.Proxy,
 	// ConfigsUpdated=ALL, so in this case we would not enable a partial push.
 	// Despite this code existing on the SotW code path, sending these partial pushes is still allowed;
 	// see https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#grouping-resources-into-responses
-	if !req.Full || canSendPartialFullPushes(req) {
+	if !req.Full || (features.PartialFullPushes && canSendPartialFullPushes(req)) {
 		edsUpdatedServices = model.ConfigNamesOfKind(req.ConfigsUpdated, kind.ServiceEntry)
 	}
 	var resources model.Resources

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -110,7 +110,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#deleting-resources.
 	// This means if there are only removals, we will not respond.
 	var logFiltered string
-	if !req.Delta.IsEmpty() && !con.proxy.IsProxylessGrpc() {
+	if !req.Delta.IsEmpty() && features.PartialFullPushes && !con.proxy.IsProxylessGrpc() {
 		logFiltered = " filtered:" + strconv.Itoa(len(w.ResourceNames)-len(req.Delta.Subscribed))
 		w = &model.WatchedResource{
 			TypeUrl:       w.TypeUrl,
@@ -136,7 +136,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 
 		// If we are sending a request, we must respond or we can get Envoy stuck. Assert we do.
 		// One exception is if Envoy is simply unsubscribing from some resources, in which case we can skip.
-		isUnsubscribe := !req.Delta.IsEmpty() && req.Delta.Subscribed.IsEmpty()
+		isUnsubscribe := features.PartialFullPushes && !req.Delta.IsEmpty() && req.Delta.Subscribed.IsEmpty()
 		if features.EnableUnsafeAssertions && err == nil && res == nil && req.IsRequest() && !isUnsubscribe {
 			log.Fatalf("%s: SKIPPED%s for node:%s%s but expected a response for request", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, info)
 		}


### PR DESCRIPTION
It's related to https://github.com/istio/istio/issues/48135
**Please provide a description of this PR:**
It essentially reverts https://github.com/istio/istio/pull/44590. 
It's for the case when we'd like to update custom envoy bootstrap to add additional envoy static cluster, whose EDS service name is same to the one indicated in envoy clusters generated by istiod. Currently, it would cause envoyproxy startup stuck for this case.

The cause is related to istiod currently skips sending the EDS records if they have been sent before. However, due to that envoy cannot effectively share EDS responses across different envoy clusters, it would cause envoy to wait for additional EDS record.

The PR brings back the flag PILOT_PARTIAL_FULL_PUSHES, and enable it by default. For the case that there's a envoy static cluster having the same EDS service name, developers can disable PILOT_PARTIAL_FULL_PUSHES to mitigate the above issue.
