### PR TITLE
Make sure we still take the oldest VS when we have actual duplicate hosts

### DIFF
--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2776,6 +2776,16 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 		},
 		{
 			Meta: config.Meta{
+				Name:              "foo2",
+				Namespace:         "default",
+				CreationTimestamp: olderTime.Add(30 * time.Minute), // Make sure we're newer than wild.default
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"foo.example.com"},
+			},
+		},
+		{
+			Meta: config.Meta{
 				Name:              "wild",
 				Namespace:         "default",
 				CreationTimestamp: olderTime,
@@ -2789,6 +2799,16 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 				Name:              "barwild",
 				Namespace:         "default",
 				CreationTimestamp: oldestTime,
+			},
+			Spec: &networking.VirtualService{
+				Hosts: []string{"*.bar.example.com"},
+			},
+		},
+		{
+			Meta: config.Meta{
+				Name:              "barwild2",
+				Namespace:         "default",
+				CreationTimestamp: olderTime,
 			},
 			Spec: &networking.VirtualService{
 				Hosts: []string{"*.bar.example.com"},
@@ -2823,7 +2843,7 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 			virtualServices: virtualServices,
 			services:        services,
 			expectedIndex: map[host.Name]types.NamespacedName{
-				"foo.example.com":     {Name: "foo", Namespace: "default"},
+				"foo.example.com":     {Name: "foo2", Namespace: "default"},
 				"baz.example.com":     {Name: "wild", Namespace: "default"},
 				"qux.bar.example.com": {Name: "barwild", Namespace: "default"},
 				"*.bar.example.com":   {Name: "barwild", Namespace: "default"},


### PR DESCRIPTION
**Please provide a description of this PR:**
Bugfix #48071; I realized while reading #10464 that I didn't account for the duplicate hostname case. We still must make sure the oldest deployed VS wins for backwards compat purposes. I added a test case to make sure this nuance isn't missed in the future