### PR TITLE
operator: cleanup default profile

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -3,169 +3,27 @@ kind: IstioOperator
 metadata:
   namespace: istio-system
 spec:
-  hub: gcr.io/istio-testing
-  tag: latest
-
-  # You may override parts of meshconfig by uncommenting the following lines.
-  meshConfig:
-    defaultConfig:
-      proxyMetadata: {}
-    enablePrometheusMerge: true
-    # Opt-out of global http2 upgrades.
-    # Destination rule is used to opt-in.
-    # h2_upgrade_policy: DO_NOT_UPGRADE
-
-  # Traffic management feature
+  # Turn on default components: base, pilot, and ingress gateway
   components:
     base:
       enabled: true
     pilot:
       enabled: true
-
     # Istio Gateway feature
     ingressGateways:
-    - name: istio-ingressgateway
-      enabled: true
+      - name: istio-ingressgateway
+        enabled: true
     egressGateways:
-    - name: istio-egressgateway
-      enabled: false
+      - name: istio-egressgateway
+        enabled: false
 
-    # Istio CNI feature
-    cni:
-      enabled: false
-    
-    # Remote and config cluster configuration for an external istiod
-    istiodRemote:
-      enabled: false
-
-  # Global values passed through to helm global.yaml.
-  # Please keep this in sync with manifests/charts/global.yaml
+  # Most default values come from the helm chart's values.yaml
+  # Below are the things that differ
   values:
     defaultRevision: ""
     global:
       istioNamespace: istio-system
-      istiod:
-        enableAnalysis: false
-      logging:
-        level: "default:info"
-      logAsJson: false
-      pilotCertProvider: istiod
-      jwtPolicy: third-party-jwt
-      proxy:
-        image: proxyv2
-        clusterDomain: "cluster.local"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-        logLevel: warning
-        componentLogLevel: "misc:error"
-        privileged: false
-        enableCoreDump: false
-        statusPort: 15020
-        readinessInitialDelaySeconds: 0
-        readinessPeriodSeconds: 15
-        readinessFailureThreshold: 4
-        startupProbe:
-          enabled: true
-          failureThreshold: 600
-        includeIPRanges: "*"
-        excludeIPRanges: ""
-        excludeOutboundPorts: ""
-        excludeInboundPorts: ""
-        autoInject: enabled
-        tracer: "zipkin"
-      proxy_init:
-        image: proxyv2
-      # Specify image pull policy if default behavior isn't desired.
-      # Default behavior: latest images will be Always else IfNotPresent.
-      imagePullPolicy: ""
-      operatorManageWebhooks: false
-      tracer:
-        lightstep: {}
-        zipkin: {}
-        datadog: {}
-        stackdriver: {}
-      imagePullSecrets: []
-      oneNamespace: false
-      defaultNodeSelector: {}
       configValidation: true
-      multiCluster:
-        enabled: false
-        clusterName: ""
-      omitSidecarInjectorConfigMap: false
-      network: ""
-      defaultResources:
-        requests:
-          cpu: 10m
-      defaultPodDisruptionBudget:
-        enabled: true
-      priorityClassName: ""
-      useMCP: false
-      sds:
-        token:
-          aud: istio-ca
-      sts:
-        servicePort: 0
-      meshNetworks: {}
-      mountMtlsCerts: false
-    base:
-      enableCRDTemplates: false
-      validationURL: ""
-    pilot:
-      autoscaleEnabled: true
-      autoscaleMin: 1
-      autoscaleMax: 5
-      replicaCount: 1
-      image: pilot
-      traceSampling: 1.0
-      env: {}
-      cpu:
-        targetAverageUtilization: 80
-      nodeSelector: {}
-      keepaliveMaxServerConnectionAge: 30m
-      deploymentLabels:
-      podLabels: {}
-      configMap: true
-
-    telemetry:
-      enabled: true
-      v2:
-        enabled: true
-        prometheus:
-          enabled: true
-        stackdriver:
-          enabled: false
-
-    istiodRemote:
-      injectionURL: ""
-      
     gateways:
-      istio-egressgateway:
-        env: {}
-        autoscaleEnabled: true
-        type: ClusterIP
-        name: istio-egressgateway
-        secretVolumes:
-          - name: egressgateway-certs
-            secretName: istio-egressgateway-certs
-            mountPath: /etc/istio/egressgateway-certs
-          - name: egressgateway-ca-certs
-            secretName: istio-egressgateway-ca-certs
-            mountPath: /etc/istio/egressgateway-ca-certs
-
-      istio-ingressgateway:
-        autoscaleEnabled: true
-        type: LoadBalancer
-        name: istio-ingressgateway
-        env: {}
-        secretVolumes:
-          - name: ingressgateway-certs
-            secretName: istio-ingressgateway-certs
-            mountPath: /etc/istio/ingressgateway-certs
-          - name: ingressgateway-ca-certs
-            secretName: istio-ingressgateway-ca-certs
-            mountPath: /etc/istio/ingressgateway-ca-certs
+      istio-ingressgateway: {}
+      istio-egressgateway: {}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -14,11 +14,11 @@ spec:
       enabled: true
     # Istio Gateway feature
     ingressGateways:
-      - name: istio-ingressgateway
-        enabled: true
+    - name: istio-ingressgateway
+      enabled: true
     egressGateways:
-      - name: istio-egressgateway
-        enabled: false
+    - name: istio-egressgateway
+      enabled: false
 
   # Most default values come from the helm chart's values.yaml
   # Below are the things that differ

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -3,6 +3,9 @@ kind: IstioOperator
 metadata:
   namespace: istio-system
 spec:
+  hub: gcr.io/istio-testing
+  tag: latest
+
   # Turn on default components: base, pilot, and ingress gateway
   components:
     base:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/default.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -92,13 +91,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -91,13 +90,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -91,13 +90,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -92,13 +91,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -94,13 +93,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -91,13 +90,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -91,13 +90,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.mesh.gen.yaml
@@ -1,6 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  proxyMetadata: {}
   tracing:
     zipkin:
       address: zipkin.istio-system:9411

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -6,7 +6,6 @@
     "certSigners": [],
     "configCluster": false,
     "configValidation": true,
-    "defaultNodeSelector": {},
     "defaultPodDisruptionBudget": {
       "enabled": true
     },
@@ -90,13 +89,6 @@
       "servicePort": 0
     },
     "tag": "latest",
-    "tracer": {
-      "datadog": {},
-      "lightstep": {},
-      "stackdriver": {},
-      "zipkin": {}
-    },
-    "useMCP": false,
     "variant": ""
   },
   "istio_cni": {


### PR DESCRIPTION
No need to have all this junk in there, as its already defaulted in helm.

Diff of the output:

```diff
8879d8878
<       proxyMetadata: {}
10746d10744
<         "defaultNodeSelector": {},
10830,10836d10827
<         "tracer": {
<           "datadog": {},
<           "lightstep": {},
<           "stackdriver": {},
<           "zipkin": {}
<         },
<         "useMCP": false,
```

These are all NOP