### PR TITLE
Fix wrong socket type for extra addresses in QUIC listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1143,7 +1143,11 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 	}
 	// add extra addresses for the listener
 	if features.EnableDualStack && len(opts.extraBind) > 0 {
-		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port), util.OptionalBuildAddressOptions{Transport: transport})
+		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
+		// Ensure consistent transport protocol with main address
+		for _, additionalAddress := range res.AdditionalAddresses {
+			additionalAddress.Address.GetSocketAddress().Protocol = transport.ToEnvoySocketProtocol()
+		}
 	}
 	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, istionetworking.ListenerClassGateway)
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1146,7 +1146,7 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
 		// Ensure consistent transport protocol with main address
 		for _, additionalAddress := range res.AdditionalAddresses {
-			additionalAddress.Address.GetSocketAddress().Protocol = transport.ToEnvoySocketProtocol()
+			additionalAddress.GetAddress().GetSocketAddress().Protocol = transport.ToEnvoySocketProtocol()
 		}
 	}
 	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, istionetworking.ListenerClassGateway)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1143,7 +1143,7 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 	}
 	// add extra addresses for the listener
 	if features.EnableDualStack && len(opts.extraBind) > 0 {
-		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
+		res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port), util.OptionalBuildAddressOptions{Transport: transport})
 	}
 	accessLogBuilder.setListenerAccessLog(opts.push, opts.proxy, res, istionetworking.ListenerClassGateway)
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -171,9 +171,20 @@ func AddrStrToCidrRange(addr string) (*core.CidrRange, error) {
 	}, nil
 }
 
+// OptionalBuildOptions is a struct to hold optional parameters for BuildAddress.
+type OptionalBuildAddressOptions struct {
+	Transport istionetworking.TransportProtocol
+}
+
 // BuildAddress returns a SocketAddress with the given ip and port or uds.
-func BuildAddress(bind string, port uint32) *core.Address {
-	address := BuildNetworkAddress(bind, port, istionetworking.TransportProtocolTCP)
+func BuildAddress(bind string, port uint32, options ...OptionalBuildAddressOptions) *core.Address {
+	transport := istionetworking.TransportProtocol(istionetworking.TransportProtocolTCP)
+	var buildOptions OptionalBuildAddressOptions
+	if len(options) > 0 {
+		buildOptions = options[0]
+		transport = buildOptions.Transport
+	}
+	address := BuildNetworkAddress(bind, port, transport)
 	if address != nil {
 		return address
 	}
@@ -188,7 +199,7 @@ func BuildAddress(bind string, port uint32) *core.Address {
 }
 
 // BuildAdditionalAddresses can add extra addresses to additional addresses for a listener
-func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32) []*listener.AdditionalAddress {
+func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32, options ...OptionalBuildAddressOptions) []*listener.AdditionalAddress {
 	var additionalAddresses []*listener.AdditionalAddress
 	if len(extrAddresses) > 0 {
 		for _, exbd := range extrAddresses {
@@ -196,7 +207,7 @@ func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32) []*list
 				continue
 			}
 			extraAddress := &listener.AdditionalAddress{
-				Address: BuildAddress(exbd, listenPort),
+				Address: BuildAddress(exbd, listenPort, options...),
 			}
 			additionalAddresses = append(additionalAddresses, extraAddress)
 		}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -171,20 +171,9 @@ func AddrStrToCidrRange(addr string) (*core.CidrRange, error) {
 	}, nil
 }
 
-// OptionalBuildOptions is a struct to hold optional parameters for BuildAddress and BuildAdditionalAddresses.
-type OptionalBuildAddressOptions struct {
-	Transport istionetworking.TransportProtocol
-}
-
 // BuildAddress returns a SocketAddress with the given ip and port or uds.
-func BuildAddress(bind string, port uint32, options ...OptionalBuildAddressOptions) *core.Address {
-	transport := istionetworking.TransportProtocol(istionetworking.TransportProtocolTCP)
-	var buildOptions OptionalBuildAddressOptions
-	if len(options) > 0 {
-		buildOptions = options[0]
-		transport = buildOptions.Transport
-	}
-	address := BuildNetworkAddress(bind, port, transport)
+func BuildAddress(bind string, port uint32) *core.Address {
+	address := BuildNetworkAddress(bind, port, istionetworking.TransportProtocolTCP)
 	if address != nil {
 		return address
 	}
@@ -199,7 +188,7 @@ func BuildAddress(bind string, port uint32, options ...OptionalBuildAddressOptio
 }
 
 // BuildAdditionalAddresses can add extra addresses to additional addresses for a listener
-func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32, options ...OptionalBuildAddressOptions) []*listener.AdditionalAddress {
+func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32) []*listener.AdditionalAddress {
 	var additionalAddresses []*listener.AdditionalAddress
 	if len(extrAddresses) > 0 {
 		for _, exbd := range extrAddresses {
@@ -207,7 +196,7 @@ func BuildAdditionalAddresses(extrAddresses []string, listenPort uint32, options
 				continue
 			}
 			extraAddress := &listener.AdditionalAddress{
-				Address: BuildAddress(exbd, listenPort, options...),
+				Address: BuildAddress(exbd, listenPort),
 			}
 			additionalAddresses = append(additionalAddresses, extraAddress)
 		}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -171,7 +171,7 @@ func AddrStrToCidrRange(addr string) (*core.CidrRange, error) {
 	}, nil
 }
 
-// OptionalBuildOptions is a struct to hold optional parameters for BuildAddress.
+// OptionalBuildOptions is a struct to hold optional parameters for BuildAddress and BuildAdditionalAddresses.
 type OptionalBuildAddressOptions struct {
 	Transport istionetworking.TransportProtocol
 }

--- a/releasenotes/notes/48334.yaml
+++ b/releasenotes/notes/48334.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 48336
+releaseNotes:
+- |
+  **Fixed** an issue where the QUIC listeners were not correctly created when dual-stack is enabled

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -79,12 +79,6 @@ func TestTlsGatewaysWithQUIC(t *testing.T) {
 		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.tls").
 		Run(func(t framework.TestContext) {
-			if t.Settings().EnableDualStack {
-				// Due to https://github.com/istio/istio/issues/46911
-				// currently QUIC tests do not work in dual-stack clusters.
-				// TODO: fix the issue and remove this skip.
-				t.Skip("QUIC tests for TlsGateways are broken for dual-stack")
-			}
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				ingressutil.RunTestMultiTLSGateways(t, inst, namespace.Future(&echo1NS))
 			})

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -98,12 +98,6 @@ func TestMtlsGatewaysWithQUIC(t *testing.T) {
 		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.mtls").
 		Run(func(t framework.TestContext) {
-			if t.Settings().EnableDualStack {
-				// Due to https://github.com/istio/istio/issues/46911
-				// currently QUIC tests do not work in dual-stack clusters.
-				// TODO: fix the issue and remove this skip.
-				t.Skip("QUIC tests for MtlsGateways are broken for dual-stack")
-			}
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				ingressutil.RunTestMultiTLSGateways(t, inst, namespace.Future(&echo1NS))
 			})


### PR DESCRIPTION
**Please provide a description of this PR:**
This will address a DS-exclusive issue: #48336

As I mentioend in the issue, when both DS and QUIC listeners are enabled we end up using different socket type between the address and additional_addresses.
Because we end up with both an UDP and a TCP address in the same listener, Envoy will correctly rejects the configuration.

I have updated the code to ensure a proper listener configuration.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
