### PR TITLE
Update min k8s version to 1.26

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 25
+	MinK8SVersion               = 26
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.\n"

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -74,6 +74,11 @@ var (
 		Minor:      "25",
 		GitVersion: "v1.25",
 	}
+	version1_26 = &version.Info{
+		Major:      "1",
+		Minor:      "26",
+		GitVersion: "v1.26",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -234,6 +239,11 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_25,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_25.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_26,
 			isValid: true,
 		},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
This will be needed once we transition to the new supported window for the next release.