### PR TITLE
Assume virtualService map is already sorted by the precedence order desired with respect to duplicates

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -866,7 +866,6 @@ func computeWildcardHostVirtualServiceIndex(virtualServices []config.Config, ser
 				_, exists := fqdnVirtualServiceHostIndex[host.Name(h)]
 				if !exists {
 					fqdnVirtualServiceHostIndex[host.Name(h)] = vs
-					continue
 				}
 			}
 		}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -845,33 +845,28 @@ func serviceMatchingVirtualServicePorts(service *Service, vsDestPorts sets.Set[i
 }
 
 // computeWildcardHostVirtualServiceIndex computes the wildcardHostVirtualServiceIndex for a given
-// list of virtualServices. This is used to optimize the lookup of the most specific wildcard host
+// (sorted) list of virtualServices. This is used to optimize the lookup of the most specific wildcard host.
+//
+// N.B the caller MUST presort virtualServices based on the desired precedence for duplicate hostnames.
+// This function will persist that order and not overwrite any previous entries for a given hostname.
 func computeWildcardHostVirtualServiceIndex(virtualServices []config.Config, services []*Service) map[host.Name]types.NamespacedName {
 	fqdnVirtualServiceHostIndex := make(map[host.Name]config.Config, len(virtualServices))
 	wildcardVirtualServiceHostIndex := make(map[host.Name]config.Config, len(virtualServices))
 	for _, vs := range virtualServices {
 		v := vs.Spec.(*networking.VirtualService)
 		for _, h := range v.Hosts {
-			// We may have duplicate (not just overlapping) hosts; in the case of exact duplicates, take the oldest one first
+			// We may have duplicate (not just overlapping) hosts; assume the list of VS is sorted already
+			// and never overwrite existing entries
 			if host.Name(h).IsWildCarded() {
-				existingVs, exists := wildcardVirtualServiceHostIndex[host.Name(h)]
+				_, exists := wildcardVirtualServiceHostIndex[host.Name(h)]
 				if !exists {
-					wildcardVirtualServiceHostIndex[host.Name(h)] = vs
-					continue
-				}
-				// Only replace if this VS is older than the existing one for this hostname
-				if vs.GetCreationTimestamp().Before(existingVs.GetCreationTimestamp()) {
 					wildcardVirtualServiceHostIndex[host.Name(h)] = vs
 				}
 			} else {
-				existingVs, exists := fqdnVirtualServiceHostIndex[host.Name(h)]
+				_, exists := fqdnVirtualServiceHostIndex[host.Name(h)]
 				if !exists {
 					fqdnVirtualServiceHostIndex[host.Name(h)] = vs
 					continue
-				}
-				// Only replace if this VS is older than the existing one for this hostname
-				if vs.GetCreationTimestamp().Before(existingVs.GetCreationTimestamp()) {
-					fqdnVirtualServiceHostIndex[host.Name(h)] = vs
 				}
 			}
 		}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2778,7 +2778,7 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 			Meta: config.Meta{
 				Name:              "foo2",
 				Namespace:         "default",
-				CreationTimestamp: olderTime.Add(30 * time.Minute), // Make sure we're newer than wild.default
+				CreationTimestamp: olderTime.Add(30 * time.Minute), // This should not be used despite being older than foo
 			},
 			Spec: &networking.VirtualService{
 				Hosts: []string{"foo.example.com"},
@@ -2843,7 +2843,7 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 			virtualServices: virtualServices,
 			services:        services,
 			expectedIndex: map[host.Name]types.NamespacedName{
-				"foo.example.com":     {Name: "foo2", Namespace: "default"},
+				"foo.example.com":     {Name: "foo", Namespace: "default"},
 				"baz.example.com":     {Name: "wild", Namespace: "default"},
 				"qux.bar.example.com": {Name: "barwild", Namespace: "default"},
 				"*.bar.example.com":   {Name: "barwild", Namespace: "default"},


### PR DESCRIPTION
**Please provide a description of this PR:**
Third time's the charm? @hzxuzhonghu correctly points out that the previous patch in #48330 [changes the precedence order
](https://github.com/istio/istio/pull/48330#discussion_r1426120302) because the list is presorted. We should maintain that ordering when handling duplicate hostnames before dealing with overlapping wildcards