### PR TITLE
[release-1.19] Fix wrong socket type for extra addresses in QUIC listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1138,6 +1138,10 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		// add extra addresses for the listener
 		if features.EnableDualStack && len(opts.extraBind) > 0 {
 			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port.Port))
+			// Ensure consistent transport protocol with main address
+			for _, additionalAddress := range res.AdditionalAddresses {
+				additionalAddress.GetAddress().GetSocketAddress().Protocol = transport.ToEnvoySocketProtocol()
+			}
 		}
 	}
 

--- a/releasenotes/notes/48334.yaml
+++ b/releasenotes/notes/48334.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 48336
+releaseNotes:
+- |
+  **Fixed** an issue where the QUIC listeners were not correctly created when dual-stack is enabled


### PR DESCRIPTION
Manual cherry-pick of #48334