### PR TITLE
[release-1.20] Fix wrong socket type for extra addresses in QUIC listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1162,6 +1162,10 @@ func buildGatewayListener(opts gatewayListenerOpts, transport istionetworking.Tr
 		// add extra addresses for the listener
 		if features.EnableDualStack && len(opts.extraBind) > 0 {
 			res.AdditionalAddresses = util.BuildAdditionalAddresses(opts.extraBind, uint32(opts.port))
+			// Ensure consistent transport protocol with main address
+			for _, additionalAddress := range res.AdditionalAddresses {
+				additionalAddress.GetAddress().GetSocketAddress().Protocol = transport.ToEnvoySocketProtocol()
+			}
 		}
 	}
 

--- a/releasenotes/notes/48334.yaml
+++ b/releasenotes/notes/48334.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 48336
+releaseNotes:
+- |
+  **Fixed** an issue where the QUIC listeners were not correctly created when dual-stack is enabled

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -79,12 +79,6 @@ func TestTlsGatewaysWithQUIC(t *testing.T) {
 		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.tls").
 		Run(func(t framework.TestContext) {
-			if t.Settings().EnableDualStack {
-				// Due to https://github.com/istio/istio/issues/46911
-				// currently QUIC tests do not work in dual-stack clusters.
-				// TODO: fix the issue and remove this skip.
-				t.Skip("QUIC tests for TlsGateways are broken for dual-stack")
-			}
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				ingressutil.RunTestMultiTLSGateways(t, inst, namespace.Future(&echo1NS))
 			})
@@ -104,12 +98,6 @@ func TestMtlsGatewaysWithQUIC(t *testing.T) {
 		RequiresSingleCluster().
 		Features("security.ingress.quic.sds.mtls").
 		Run(func(t framework.TestContext) {
-			if t.Settings().EnableDualStack {
-				// Due to https://github.com/istio/istio/issues/46911
-				// currently QUIC tests do not work in dual-stack clusters.
-				// TODO: fix the issue and remove this skip.
-				t.Skip("QUIC tests for MtlsGateways are broken for dual-stack")
-			}
 			t.NewSubTest("tcp").Run(func(t framework.TestContext) {
 				ingressutil.RunTestMultiTLSGateways(t, inst, namespace.Future(&echo1NS))
 			})


### PR DESCRIPTION
Manual cherry-pick of https://github.com/istio/istio/pull/48334