### PR TITLE
Add separator to two CRD files

### DIFF
--- a/manifests/charts/base/templates/crds.yaml
+++ b/manifests/charts/base/templates/crds.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.base.enableCRDTemplates }}
 {{ .Files.Get "crds/crd-all.gen.yaml" }}
+---
 {{ .Files.Get "crds/crd-operator.yaml" }}
 {{- end }}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix https://github.com/istio/istio/issues/48374.

I think right now we don't need this in the master branch, and can clean up the operator crd as well, but since this needs to be cherry-picked into release-1.20 - which still has the iop file, it's better to do it in another PR.