### PR TITLE
Fix auto san validation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_tls.go
@@ -312,7 +312,7 @@ func (cb *ClusterBuilder) setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls
 	if len(tls.Sni) == 0 {
 		setAutoSni = true
 	}
-	if features.VerifyCertAtClient && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
+	if features.VerifyCertAtClient && setAutoSni && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
 		setAutoSanValidation = true
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_tls_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_tls_test.go
@@ -1402,7 +1402,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				if len(tc.tls.Sni) == 0 {
 					assert.Equal(t, tc.opts.mutable.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni, true)
 				}
-				if tc.enableVerifyCertAtClient && len(tc.tls.SubjectAltNames) == 0 {
+				if tc.enableVerifyCertAtClient && len(tc.tls.Sni) == 0 && len(tc.tls.SubjectAltNames) == 0 {
 					assert.Equal(t, tc.opts.mutable.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSanValidation, true)
 				}
 			}

--- a/releasenotes/notes/auto-san-validation.yaml
+++ b/releasenotes/notes/auto-san-validation.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** an issue where auto-san-validation was enabled even when sni was explicitly set in the DestinationRule.


### PR DESCRIPTION
As per envoy docs, auto-san-validation is supposed to be set with auto-sni, however in our current implementation, the logic sets auto-san-validation, even if the DR has an explicit SNI set, but SAN is not set.
Please see: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-upstreamhttpprotocoloptions-auto-san-validation