### PR TITLE
Always send new healthy endpoints

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -321,7 +321,6 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 				// new endpoint. Always send new healthy endpoints.
 				// Also send new unhealthy endpoints when SendUnhealthyEndpoints is enabled.
 				// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
-				// For headless services, the Kubernetes controller will trigger the push .
 				if nie.HealthStatus != UnHealthy || features.SendUnhealthyEndpoints.Load() {
 					needPush = true
 				}

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -318,10 +318,11 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 				newIstioEndpoints = append(newIstioEndpoints, nie)
 			} else {
 				// If the endpoint does not exist in shards that means it is a
-				// new endpoint. Always send new endpoints even if they are not healthy.
+				// new endpoint. Always send new healthy endpoints.
+				// Also send new unhealthy endpoints when SendUnhealthyEndpoints is enabled.
 				// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
-				// Without SendUnhealthyEndpoints we do not need this; headless services will trigger the push in the Kubernetes controller.
-				if features.SendUnhealthyEndpoints.Load() {
+				// For headless services, the Kubernetes controller will trigger the push .
+				if nie.HealthStatus != UnHealthy || features.SendUnhealthyEndpoints.Load() {
 					needPush = true
 				}
 				newIstioEndpoints = append(newIstioEndpoints, nie)

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -528,7 +528,27 @@ func TestEDSUnhealthyEndpoints(t *testing.T) {
 
 			validateEndpoints(true, []string{"10.0.0.53:53"}, nil)
 
-			// Remove last healthy endpoint
+			// Add another healthy endpoint and validate Eds is pushed.
+			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.0.0.53",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+					{
+						Address:         "10.0.0.54",
+						EndpointPort:    53,
+						ServicePortName: "tcp-dns",
+						HealthStatus:    model.Healthy,
+					},
+				})
+
+			// Validate that endpoints are pushed.
+			validateEndpoints(true, []string{"10.0.0.53:53", "10.0.0.54:53"}, nil)
+
+			// Remove last healthy endpoints
 			s.MemRegistry.SetEndpoints("unhealthy.svc.cluster.local", "", []*model.IstioEndpoint{})
 			validateEndpoints(true, nil, nil)
 		})

--- a/releasenotes/notes/endpoints-false-negative.yaml
+++ b/releasenotes/notes/endpoints-false-negative.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: 
+  - 48373
+releaseNotes:
+  - |
+    **Fixed** an issue where new endpoints may not be sent to proxies.


### PR DESCRIPTION
**Please provide a description of this PR:**
We should always send new healthy endpoints. This typically happens when EndpointSlices are manually managed or pods are selected by a ServiceEntry
Fixes https://github.com/istio/istio/issues/48373


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
