### PR TITLE
install: add openshift-ambient profile

### DIFF
--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -1,0 +1,35 @@
+meshConfig:
+  defaultConfig:
+    proxyMetadata:
+      ISTIO_META_ENABLE_HBONE: "true"
+global:
+  platform: openshift
+cni:
+  ambient:
+    enabled: true
+  cniBinDir: /var/lib/cni/bin
+  cniConfDir: /etc/cni/multus/net.d
+  chained: false
+  cniConfFileName: "istio-cni.conf"
+  excludeNamespaces:
+    - kube-system
+  logLevel: info
+  privileged: true
+  provider: "multus"
+istio_cni:
+  enabled: true
+  chained: false
+pilot:
+  variant: distroless
+  env:
+    # Setup more secure default that is off in 'default' only for backwards compatibility
+    VERIFY_CERTIFICATE_AT_CLIENT: "true"
+    ENABLE_AUTO_SNI: "true"
+
+    PILOT_ENABLE_HBONE: "true"
+    CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+ztunnel:
+  variant: distroless
+  seLinuxOptions:
+    type: spc_t

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -29,7 +29,6 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-ztunnel:
-  variant: distroless
-  seLinuxOptions:
-    type: spc_t
+variant: distroless
+seLinuxOptions:
+  type: spc_t

--- a/manifests/profiles/openshift-ambient.yaml
+++ b/manifests/profiles/openshift-ambient.yaml
@@ -23,7 +23,6 @@ spec:
     cni:
       ambient:
         enabled: true
-        redirectMode: "inpod"
       cniBinDir: /var/lib/cni/bin
       cniConfDir: /etc/cni/multus/net.d
       chained: false
@@ -48,6 +47,5 @@ spec:
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     ztunnel:
       variant: distroless
-      redirectMode: "inpod"
       seLinuxOptions:
         type: spc_t

--- a/manifests/profiles/openshift-ambient.yaml
+++ b/manifests/profiles/openshift-ambient.yaml
@@ -23,6 +23,7 @@ spec:
     cni:
       ambient:
         enabled: true
+        redirectMode: "inpod"
       cniBinDir: /var/lib/cni/bin
       cniConfDir: /etc/cni/multus/net.d
       chained: false
@@ -47,3 +48,6 @@ spec:
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     ztunnel:
       variant: distroless
+      redirectMode: "inpod"
+      seLinuxOptions:
+        type: spc_t

--- a/manifests/profiles/openshift-ambient.yaml
+++ b/manifests/profiles/openshift-ambient.yaml
@@ -1,11 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  meshConfig:
-    defaultConfig:
-      proxyMetadata:
-        ISTIO_META_ENABLE_HBONE: "true"
-
   components:
     cni:
       enabled: true
@@ -16,36 +11,5 @@ spec:
     ingressGateways:
     - name: istio-ingressgateway
       enabled: false
-
   values:
-    global:
-      platform: openshift
-    cni:
-      ambient:
-        enabled: true
-      cniBinDir: /var/lib/cni/bin
-      cniConfDir: /etc/cni/multus/net.d
-      chained: false
-      cniConfFileName: "istio-cni.conf"
-      excludeNamespaces:
-      - kube-system
-      logLevel: info
-      privileged: true
-      provider: "multus"
-    istio_cni:
-      enabled: true
-      chained: false
-    pilot:
-      variant: distroless
-      env:
-        # Setup more secure default that is off in 'default' only for backwards compatibility
-        VERIFY_CERTIFICATE_AT_CLIENT: "true"
-        ENABLE_AUTO_SNI: "true"
-
-        PILOT_ENABLE_HBONE: "true"
-        CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-        PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    ztunnel:
-      variant: distroless
-      seLinuxOptions:
-        type: spc_t
+    profile: openshift-ambient

--- a/manifests/profiles/openshift-ambient.yaml
+++ b/manifests/profiles/openshift-ambient.yaml
@@ -1,0 +1,49 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_META_ENABLE_HBONE: "true"
+
+  components:
+    cni:
+      enabled: true
+      namespace: kube-system
+    ztunnel:
+      enabled: true
+      namespace: kube-system
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: false
+
+  values:
+    global:
+      platform: openshift
+    cni:
+      ambient:
+        enabled: true
+      cniBinDir: /var/lib/cni/bin
+      cniConfDir: /etc/cni/multus/net.d
+      chained: false
+      cniConfFileName: "istio-cni.conf"
+      excludeNamespaces:
+      - kube-system
+      logLevel: info
+      privileged: true
+      provider: "multus"
+    istio_cni:
+      enabled: true
+      chained: false
+    pilot:
+      variant: distroless
+      env:
+        # Setup more secure default that is off in 'default' only for backwards compatibility
+        VERIFY_CERTIFICATE_AT_CLIENT: "true"
+        ENABLE_AUTO_SNI: "true"
+
+        PILOT_ENABLE_HBONE: "true"
+        CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
+        PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    ztunnel:
+      variant: distroless

--- a/releasenotes/notes/openshift-ambient-profile.yaml
+++ b/releasenotes/notes/openshift-ambient-profile.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 42341
+releaseNotes:
+  - |
+    **Added** `openshift-ambient` profile.


### PR DESCRIPTION
**Please provide a description of this PR:**

Beside adding new profile, I changed the namespace controller to create istio-ca-root-cert for ztunnel in the kube-system namespace when `global.platform=openshift` is set. This approach simplifies installation, because it does not require to change SCC of the istio-system namespace.