### PR TITLE
ambient: fix inconsistencies in indexes

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -945,10 +945,20 @@ func serviceResourceName(s *workloadapi.Service) string {
 	return s.Namespace + "/" + s.Hostname
 }
 
+type WorkloadSource string
+
+const (
+	WorkloadSourcePod           WorkloadSource = "pod"
+	WorkloadSourceServiceEntry  WorkloadSource = "serviceentry"
+	WorkloadSourceWorkloadEntry WorkloadSource = "workloadentry"
+)
+
 type WorkloadInfo struct {
 	*workloadapi.Workload
 	// Labels for the workload. Note these are only used internally, not sent over XDS
 	Labels map[string]string
+	// Source of the workload. Note this is used internally only.
+	Source WorkloadSource
 }
 
 func workloadResourceName(w *workloadapi.Workload) string {
@@ -959,6 +969,7 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 	return &WorkloadInfo{
 		Workload: proto.Clone(i).(*workloadapi.Workload),
 		Labels:   maps.Clone(i.Labels),
+		Source:   i.Source,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -981,8 +981,9 @@ func TestPolicyAfterPod(t *testing.T) {
 		map[string]string{},
 		map[string]string{},
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
+	s.assertEvent(t, s.svcXdsName("svc1"))
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
-	s.assertEvent(t, s.podXdsName("pod1"), s.svcXdsName("svc1"))
+	s.assertEvent(t, s.podXdsName("pod1"))
 	s.addPolicy(t, "selector", testNS, map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
 	s.assertEvent(t, s.podXdsName("pod1"))
 	assert.Equal(t, s.lookup(s.svcXdsName("svc1"))[1].GetWorkload().GetAuthorizationPolicies(), []string{"ns1/selector"})

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -1394,11 +1394,10 @@ func (s *ambientTestServer) assertIndexConsistency(t test.Failer) {
 }
 
 func (s *ambientTestServer) lookup(key string) []*model.AddressInfo {
+	s.assertIndexConsistency(s.t)
 	if key == "" {
-		s.assertIndexConsistency(s.t)
 		return s.controller.ambientIndex.All()
 	}
-	s.assertIndexConsistency(s.t)
 	return s.controller.ambientIndex.Lookup(key)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambientindex_test.go
@@ -971,6 +971,23 @@ func TestEmptyVIPsExcluded(t *testing.T) {
 	assert.Equal(t, 0, len(vips), "optional IP fields should be ignored if empty")
 }
 
+// This is a regression test for a case where policies added after pods were not applied when
+// querying by service
+func TestPolicyAfterPod(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	s := newAmbientTestServer(t, testC, testNW)
+
+	s.addService(t, "svc1",
+		map[string]string{},
+		map[string]string{},
+		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
+	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
+	s.assertEvent(t, s.podXdsName("pod1"), s.svcXdsName("svc1"))
+	s.addPolicy(t, "selector", testNS, map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
+	s.assertEvent(t, s.podXdsName("pod1"))
+	assert.Equal(t, s.lookup(s.svcXdsName("svc1"))[1].GetWorkload().GetAuthorizationPolicies(), []string{"ns1/selector"})
+}
+
 type ambientTestServer struct {
 	cfg        *memory.Controller
 	controller *FakeController
@@ -978,6 +995,7 @@ type ambientTestServer struct {
 	pc         clienttest.TestClient[*corev1.Pod]
 	sc         clienttest.TestClient[*corev1.Service]
 	grc        clienttest.TestClient[*k8sbeta.Gateway]
+	t          *testing.T
 }
 
 func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.ID) *ambientTestServer {
@@ -1001,6 +1019,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	go cfg.Run(test.NewStop(t))
 
 	return &ambientTestServer{
+		t:          t,
 		cfg:        cfg,
 		controller: controller,
 		fx:         fx,
@@ -1324,10 +1343,61 @@ func (s *ambientTestServer) addService(t *testing.T, name string, labels, annota
 	s.sc.CreateOrUpdate(service)
 }
 
+// assertIndexConsistency ensures that all indexes store the same data across the different indexes.
+func (s *ambientTestServer) assertIndexConsistency(t test.Failer) {
+	a := s.controller.ambientIndex.(*AmbientIndexImpl)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	// UID -> workload
+	workloads := map[string]*model.WorkloadInfo{}
+	addWorkload := func(w *model.WorkloadInfo) {
+		e, f := workloads[w.ResourceName()]
+		if !f {
+			workloads[w.ResourceName()] = w
+			return
+		}
+		// Already exists, make sure its identical
+		assert.Equal(t, e, w, "found inconsistency in workloads")
+	}
+	for _, w := range a.byUID {
+		addWorkload(w)
+	}
+	for _, w := range a.byPod {
+		addWorkload(w)
+	}
+	for _, w := range a.byWorkloadEntry {
+		addWorkload(w)
+	}
+	for _, m := range a.byService {
+		for _, w := range m {
+			addWorkload(w)
+		}
+	}
+
+	services := map[string]*model.ServiceInfo{}
+	addServices := func(w *model.ServiceInfo) {
+		e, f := services[w.ResourceName()]
+		if !f {
+			services[w.ResourceName()] = w
+			return
+		}
+		// Already exists, make sure its identical
+		assert.Equal(t, e, w, "found inconsistency in services")
+	}
+	for _, s := range a.serviceByAddr {
+		addServices(s)
+	}
+	for _, s := range a.serviceByNamespacedHostname {
+		addServices(s)
+	}
+}
+
 func (s *ambientTestServer) lookup(key string) []*model.AddressInfo {
 	if key == "" {
+		s.assertIndexConsistency(s.t)
 		return s.controller.ambientIndex.All()
 	}
+	s.assertIndexConsistency(s.t)
 	return s.controller.ambientIndex.Lookup(key)
 }
 


### PR DESCRIPTION
This addresses a specific issue, and attempts to future-proof the
implementation from similar bugs.

The specific issue is CalculateUpdatedWorkloads fails to update the
`byService` index. This can result in new pods failing to get authz
policies configured.

The general prevention is a new `assertIndexConsistency` that runs for
all tests, that detects this class of problems. A targetted test is
added for this specific case, but `assertIndexConsistency` found bugs in
a variety of existing tests as well.

Rather than a vary narrow fix, this pulls the index update logic into
some common code so its harder to mis-use.

Long term, https://github.com/istio/istio/pull/47891 would be a great
fit here. However, that is a much much larger change, so for now a
minimal fix is implemented.
