### PR TITLE
pilot: autoscale concurrency and rate limit on xds

### DIFF
--- a/releasenotes/notes/pilot-autoscale.yaml
+++ b/releasenotes/notes/pilot-autoscale.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+  - |
+    **Improved** the variables `PILOT_MAX_REQUESTS_PER_SECOND` (which rate limits the incoming requests, previously defaulted to 25.0)
+    and `PILOT_PUSH_THROTTLE` (which limits the number of concurrent responses, previously defaulted to 100) to automatically scale with the
+    CPU size Istiod is running on if not explicitly configured.


### PR DESCRIPTION
This is an attempt to improve the defaults here.

25 for RL is decent, but for giant clusters we have seen folks report
   its too small.

The bigger issue is 100 throttle. This is way to high for most
environments, 100 concurrent CPU-intensive operations on 1-2 cores is
terrible. We see much better results with lower values. Internally we
have run with 25 here for years.

I definitely want to lower the throttle. In the process, I thought it
might be nice to have more dynamicism here instead of just statically
changing.

Relevant prior discussion:
* https://github.com/istio/istio/issues/35263
* https://github.com/istio/istio/issues/44985
