### PR TITLE
Extend fake client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -250,5 +250,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.16.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/gateway-api v1.0.1-0.20240112015229-444631bfe06f
 	sigs.k8s.io/mcs-api v0.1.0
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/pkg/config/schema/codegen/templates/clients.go.tmpl
+++ b/pkg/config/schema/codegen/templates/clients.go.tmpl
@@ -55,7 +55,7 @@ func GetClient[T, TL runtime.Object](c ClientGetter, namespace string) ktypes.Re
 	}
 }
 
-func gvrToObject(g schema.GroupVersionResource) runtime.Object {
+func GVRToObject(g schema.GroupVersionResource) runtime.Object {
 	switch g {
 {{- range .Entries }}
 	{{- if not .Resource.Synthetic }}
@@ -101,7 +101,7 @@ func getInformerFiltered(c ClientGetter, opts ktypes.InformerOptions, g schema.G
 					return w(options)
 				},
 			},
-			gvrToObject(g),
+			GVRToObject(g),
 			0,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		)

--- a/pkg/config/schema/kubeclient/resources.gen.go
+++ b/pkg/config/schema/kubeclient/resources.gen.go
@@ -211,7 +211,7 @@ func GetClient[T, TL runtime.Object](c ClientGetter, namespace string) ktypes.Re
 	}
 }
 
-func gvrToObject(g schema.GroupVersionResource) runtime.Object {
+func GVRToObject(g schema.GroupVersionResource) runtime.Object {
 	switch g {
 	case gvr.AuthorizationPolicy:
 		return &apiistioioapisecurityv1beta1.AuthorizationPolicy{}
@@ -609,7 +609,7 @@ func getInformerFiltered(c ClientGetter, opts ktypes.InformerOptions, g schema.G
 					return w(options)
 				},
 			},
-			gvrToObject(g),
+			GVRToObject(g),
 			0,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -34,7 +34,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,19 +46,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/discovery"
-	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/metadata"
-	metadatafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/rest"
-	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
@@ -67,7 +59,6 @@ import (
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapibeta "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
-	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
@@ -77,7 +68,6 @@ import (
 	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
 	clienttelemetry "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
-	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/informerfactory"
@@ -217,100 +207,6 @@ var (
 	_ Client    = &client{}
 	_ CLIClient = &client{}
 )
-
-// NewFakeClient creates a new, fake, client
-func NewFakeClient(objects ...runtime.Object) CLIClient {
-	c := &client{
-		informerWatchesPending: atomic.NewInt32(0),
-		clusterID:              "fake",
-	}
-	c.kube = fake.NewSimpleClientset(objects...)
-
-	c.config = &rest.Config{
-		Host: "server",
-	}
-
-	c.informerFactory = informerfactory.NewSharedInformerFactory()
-	s := FakeIstioScheme
-
-	c.metadata = metadatafake.NewSimpleMetadataClient(s)
-	c.dynamic = dynamicfake.NewSimpleDynamicClient(s)
-	c.istio = istiofake.NewSimpleClientset()
-	c.gatewayapi = gatewayapifake.NewSimpleClientset()
-	c.extSet = extfake.NewSimpleClientset()
-
-	// https://github.com/kubernetes/kubernetes/issues/95372
-	// There is a race condition in the client fakes, where events that happen between the List and Watch
-	// of an informer are dropped. To avoid this, we explicitly manage the list and watch, ensuring all lists
-	// have an associated watch before continuing.
-	// This would likely break any direct calls to List(), but for now our tests don't do that anyways. If we need
-	// to in the future we will need to identify the Lists that have a corresponding Watch, possibly by looking
-	// at created Informers
-	// an atomic.Int is used instead of sync.WaitGroup because wg.Add and wg.Wait cannot be called concurrently
-	listReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-		c.informerWatchesPending.Inc()
-		return false, nil, nil
-	}
-	watchReactor := func(tracker clienttesting.ObjectTracker) func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
-		return func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
-			gvr := action.GetResource()
-			ns := action.GetNamespace()
-			watch, err := tracker.Watch(gvr, ns)
-			if err != nil {
-				return false, nil, err
-			}
-			c.informerWatchesPending.Dec()
-			return true, watch, nil
-		}
-	}
-	// https://github.com/kubernetes/client-go/issues/439
-	createReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-		ret = action.(clienttesting.CreateAction).GetObject()
-		meta, ok := ret.(metav1.Object)
-		if !ok {
-			return
-		}
-
-		if meta.GetName() == "" && meta.GetGenerateName() != "" {
-			meta.SetName(names.SimpleNameGenerator.GenerateName(meta.GetGenerateName()))
-		}
-
-		return
-	}
-	for _, fc := range []fakeClient{
-		c.kube.(*fake.Clientset),
-		c.istio.(*istiofake.Clientset),
-		c.gatewayapi.(*gatewayapifake.Clientset),
-		c.dynamic.(*dynamicfake.FakeDynamicClient),
-		c.metadata.(*metadatafake.FakeMetadataClient),
-	} {
-		fc.PrependReactor("list", "*", listReactor)
-		fc.PrependWatchReactor("*", watchReactor(fc.Tracker()))
-		fc.PrependReactor("create", "*", createReactor)
-	}
-
-	c.fastSync = true
-
-	c.version = lazy.NewWithRetry(c.kube.Discovery().ServerVersion)
-
-	if NewCrdWatcher != nil {
-		c.crdWatcher = NewCrdWatcher(c)
-	}
-
-	return c
-}
-
-func NewFakeClientWithVersion(minor string, objects ...runtime.Object) CLIClient {
-	c := NewFakeClient(objects...).(*client)
-	c.Kube().Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kubeVersion.Info{Major: "1", Minor: minor, GitVersion: fmt.Sprintf("v1.%v.0", minor)}
-	return c
-}
-
-type fakeClient interface {
-	PrependReactor(verb, resource string, reaction clienttesting.ReactionFunc)
-	PrependWatchReactor(resource string, reaction clienttesting.WatchReactionFunc)
-	Tracker() clienttesting.ObjectTracker
-}
 
 // Client is a helper wrapper around the Kube RESTClient for istioctl -> Pilot/Envoy/Mesh related things
 type client struct {

--- a/pkg/kube/fakeclient.go
+++ b/pkg/kube/fakeclient.go
@@ -394,6 +394,4 @@ func generateNameOnCreate(ret runtime.Object) {
 	if meta.GetName() == "" && meta.GetGenerateName() != "" {
 		meta.SetName(names.SimpleNameGenerator.GenerateName(meta.GetGenerateName()))
 	}
-
-	return
 }

--- a/pkg/kube/fakeclient.go
+++ b/pkg/kube/fakeclient.go
@@ -1,0 +1,389 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"go.uber.org/atomic"
+	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	kubeVersion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage/names"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+	gatewayapifake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/kubeclient"
+	"istio.io/istio/pkg/kube/informerfactory"
+	"istio.io/istio/pkg/lazy"
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// NewFakeClient creates a new, fake, client
+func NewFakeClient(objects ...runtime.Object) CLIClient {
+	c := &client{
+		informerWatchesPending: atomic.NewInt32(0),
+		clusterID:              "fake",
+	}
+	c.config = &rest.Config{
+		Host: "server",
+	}
+
+	c.informerFactory = informerfactory.NewSharedInformerFactory()
+
+	s := FakeIstioScheme
+	fmf := newFieldManagerFacotry(s)
+	merger := fakeMerger{
+		scheme: s,
+	}
+
+	f := fake.NewSimpleClientset(objects...)
+	insertPatchReactor(f, fmf)
+	merger.Merge(f)
+	c.kube = f
+
+	c.metadata = metadatafake.NewSimpleMetadataClient(s)
+	df := dynamicfake.NewSimpleDynamicClient(s)
+	insertPatchReactor(df, fmf)
+	merger.MergeDynamic(df)
+	c.dynamic = df
+
+	ifc := istiofake.NewSimpleClientset()
+	insertPatchReactor(ifc, fmf)
+	merger.Merge(ifc)
+	c.istio = ifc
+
+	gf := gatewayapifake.NewSimpleClientset()
+	insertPatchReactor(gf, fmf)
+	merger.Merge(gf)
+	c.gatewayapi = gf
+	c.extSet = extfake.NewSimpleClientset()
+
+	// https://github.com/kubernetes/kubernetes/issues/95372
+	// There is a race condition in the client fakes, where events that happen between the List and Watch
+	// of an informer are dropped. To avoid this, we explicitly manage the list and watch, ensuring all lists
+	// have an associated watch before continuing.
+	// This would likely break any direct calls to List(), but for now our tests don't do that anyways. If we need
+	// to in the future we will need to identify the Lists that have a corresponding Watch, possibly by looking
+	// at created Informers
+	// an atomic.Int is used instead of sync.WaitGroup because wg.Add and wg.Wait cannot be called concurrently
+	listReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		c.informerWatchesPending.Inc()
+		return false, nil, nil
+	}
+	watchReactor := func(tracker clienttesting.ObjectTracker) func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		return func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+			gvr := action.GetResource()
+			ns := action.GetNamespace()
+			watch, err := tracker.Watch(gvr, ns)
+			if err != nil {
+				return false, nil, err
+			}
+			c.informerWatchesPending.Dec()
+			return true, watch, nil
+		}
+	}
+	// https://github.com/kubernetes/client-go/issues/439
+	createReactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		ret = action.(clienttesting.CreateAction).GetObject()
+		meta, ok := ret.(metav1.Object)
+		if !ok {
+			return
+		}
+
+		if meta.GetName() == "" && meta.GetGenerateName() != "" {
+			meta.SetName(names.SimpleNameGenerator.GenerateName(meta.GetGenerateName()))
+		}
+
+		return
+	}
+	for _, fc := range []fakeClient{
+		c.kube.(*fake.Clientset),
+		c.istio.(*istiofake.Clientset),
+		c.gatewayapi.(*gatewayapifake.Clientset),
+		c.dynamic.(*dynamicfake.FakeDynamicClient),
+		c.metadata.(*metadatafake.FakeMetadataClient),
+	} {
+		fc.PrependWatchReactor("*", watchReactor(fc.Tracker()))
+	}
+	df.PrependReactor("list", "*", listReactor)
+	df.PrependReactor("create", "*", createReactor)
+	c.metadata.(*metadatafake.FakeMetadataClient).PrependReactor("list", "*", listReactor)
+	c.metadata.(*metadatafake.FakeMetadataClient).PrependReactor("create", "*", createReactor)
+
+	c.fastSync = true
+
+	c.version = lazy.NewWithRetry(c.kube.Discovery().ServerVersion)
+
+	if NewCrdWatcher != nil {
+		c.crdWatcher = NewCrdWatcher(c)
+	}
+
+	return c
+}
+
+func NewFakeClientWithVersion(minor string, objects ...runtime.Object) CLIClient {
+	c := NewFakeClient(objects...).(*client)
+	c.Kube().Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kubeVersion.Info{Major: "1", Minor: minor, GitVersion: fmt.Sprintf("v1.%v.0", minor)}
+	return c
+}
+
+type fakeClient interface {
+	PrependReactor(verb, resource string, reaction clienttesting.ReactionFunc)
+	PrependWatchReactor(resource string, reaction clienttesting.WatchReactionFunc)
+	Tracker() clienttesting.ObjectTracker
+}
+
+func insertPatchReactor(f clienttesting.FakeClient, fmf *fieldManagerFactory) {
+	f.PrependReactor(
+		"patch",
+		"*",
+		func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+			pa := action.(clienttesting.PatchAction)
+			if pa.GetPatchType() == types.ApplyPatchType {
+				// Apply patches are supposed to upsert, but fake client fails if the object doesn't exist,
+				// if an apply patch occurs for a deployment that doesn't yet exist, create it.
+				// However, we already hold the fakeclient lock, so we can't use the front door.
+				// rfunc := clienttesting.ObjectReaction(f.Tracker())
+				original, err := f.Tracker().Get(pa.GetResource(), pa.GetNamespace(), pa.GetName())
+				var isNew bool
+				mygvk := gvk.MustFromGVR(pa.GetResource()).Kubernetes()
+				if kerrors.IsNotFound(err) || original == nil {
+					isNew = true
+					original = kubeclient.GVRToObject(pa.GetResource())
+					d := original.(metav1.Object)
+					d.SetName(pa.GetName())
+					d.SetNamespace(pa.GetNamespace())
+					e := original.(schema.ObjectKind)
+					e.SetGroupVersionKind(mygvk)
+				}
+
+				applyObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+				if err := json.Unmarshal(pa.GetPatch(), &applyObj.Object); err != nil {
+					log.Errorf("error decoding YAML: %v", err)
+					return false, nil, err
+				}
+				// TODO: I'm not 100% sure this should always force, but we lose the apply option...
+				res, err := fmf.FieldManager(mygvk).Apply(original, applyObj, "istio", true)
+				if err != nil {
+					log.Errorf("error applying patch: %v", err)
+					return false, res, err
+				}
+
+				// field manager outputs typed objects.  We might need unustructured here.
+				var typedResult runtime.Object
+				if _, ok := f.(*dynamicfake.FakeDynamicClient); ok {
+					typedResult = &unstructured.Unstructured{}
+					err = fmf.schema.Convert(res, typedResult, nil)
+					if err != nil {
+						log.Errorf("error converting object (%v), fakeclients may become inconsistent: %v", res, err)
+						return false, nil, err
+					}
+				} else {
+					typedResult = res
+				}
+
+				if isNew {
+					err = f.Tracker().Create(pa.GetResource(), typedResult, pa.GetNamespace())
+				} else if !reflect.DeepEqual(original, typedResult) {
+					err = f.Tracker().Update(pa.GetResource(), typedResult, pa.GetNamespace())
+				}
+
+				return true, typedResult, err
+			}
+			return false, nil, nil
+		},
+	)
+}
+
+func actionKey(action clienttesting.Action) string {
+	out := strings.Builder{}
+	out.WriteString(action.GetVerb())
+	out.WriteString("/")
+	out.WriteString(action.GetResource().String())
+	out.WriteString("/")
+	out.WriteString(action.GetNamespace())
+	if n, ok := action.(named); ok {
+		out.WriteString("/")
+		out.WriteString(n.GetName())
+	}
+	return out.String()
+}
+
+type named interface {
+	GetName() string
+}
+type fakeMerger struct {
+	inProgress sets.Set[string]
+	mergeLock  sync.RWMutex
+	initOnce   sync.Once
+	alertList  []clienttesting.FakeClient
+	scheme     *runtime.Scheme
+	dynamic    *dynamicfake.FakeDynamicClient
+}
+
+func (fm *fakeMerger) init() {
+	fm.initOnce.Do(func() {
+		fm.mergeLock.Lock()
+		defer fm.mergeLock.Unlock()
+		fm.inProgress = sets.Set[string]{}
+	})
+}
+
+func (fm *fakeMerger) propagateReactionSingle(destination clienttesting.FakeClient, action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+	// prevent recursion with inProgress
+	// TODO: this is probably excessive locking
+	key := actionKey(action)
+	fm.mergeLock.RLock()
+	if fm.inProgress.Contains(key) {
+		// this is an action 'echoing' back after we propagated it.  drop it.
+		fm.mergeLock.RUnlock()
+		return false, nil, nil
+	}
+	fm.mergeLock.RUnlock()
+	fm.mergeLock.Lock()
+	fm.inProgress.Insert(key)
+	fm.mergeLock.Unlock()
+	// if action is update or create, it includes a runtim.Object, which needs to be
+	// passed to Invokes (either as unstructured [in the case of dynamic], or typed),
+	// otherwise the obj var is ignored, and is traditionally defaulted to metav1.status
+	defaultObj := &metav1.Status{Status: "metadata get fail"}
+	var tObj, uObj runtime.Object
+	if o, ok := action.(objectiveAction); ok {
+		uObj = o.GetObject()
+		if _, ok := destination.(*dynamicfake.FakeDynamicClient); ok {
+			tObj = &unstructured.Unstructured{}
+		} else {
+			if _, ok := collections.All.FindByGroupVersionResource(action.GetResource()); ok {
+				tObj = kubeclient.GVRToObject(action.GetResource())
+			} else {
+				return false, nil, fmt.Errorf("cannot find gvk for %v", action.GetResource())
+			}
+		}
+		// convert the object to the required type
+		err = fm.scheme.Convert(uObj, tObj, nil)
+		if err != nil {
+			log.Errorf("Cannot convert %v to the desired type for %v: %v", defaultObj, destination, err)
+			return false, nil, nil
+		}
+		// Convert from unstructured to typed sometimes drops the gvk, re-add it here.
+		tObj.GetObjectKind().SetGroupVersionKind(uObj.GetObjectKind().GroupVersionKind())
+	}
+	switch newAction := action.DeepCopy().(type) {
+	case clienttesting.CreateActionImpl:
+		newAction.Object = tObj
+		_, err := destination.Invokes(newAction, defaultObj)
+		if err != nil {
+			log.Errorf("Propagating Invoke resulted in error for fake %v: %v", destination, err)
+		}
+	case clienttesting.UpdateActionImpl:
+		newAction.Object = tObj
+		_, err := destination.Invokes(newAction, defaultObj)
+		if err != nil {
+			log.Errorf("Propagating Invoke resulted in error for fake %v: %v", destination, err)
+		}
+	default:
+		_, err := destination.Invokes(newAction, defaultObj)
+		if err != nil {
+			log.Errorf("Propagating Invoke resulted in error for fake %v: %v", destination, err)
+		}
+	}
+	fm.mergeLock.Lock()
+	fm.inProgress.Delete(key)
+	fm.mergeLock.Unlock()
+	// even if others return handled=true, we still want this client to react.
+	return false, nil, nil
+}
+
+func (fm *fakeMerger) Merge(f clienttesting.FakeClient) {
+	fm.init()
+	fm.mergeLock.Lock()
+	defer fm.mergeLock.Unlock()
+	fm.alertList = append(fm.alertList, f)
+	myPropagator := func(action clienttesting.Action) (bool, runtime.Object, error) {
+		// propagate from typed client to dynamic
+		return fm.propagateReactionSingle(fm.dynamic, action)
+	}
+	f.PrependReactor("*", "*", myPropagator)
+}
+
+func (fm *fakeMerger) MergeDynamic(df *dynamicfake.FakeDynamicClient) {
+	fm.dynamic = df
+	myPropagator := func(action clienttesting.Action) (bool, runtime.Object, error) {
+		for _, f := range fm.alertList {
+			// propagate from dynamic to any typed client that cares.
+			_, _, _ = fm.propagateReactionSingle(f, action)
+		}
+		// even if others return handled=true, we still want this client to react.
+		return false, nil, nil
+	}
+	df.PrependReactor("*", "*", myPropagator)
+}
+
+type objectiveAction interface {
+	GetObject() runtime.Object
+}
+
+type fieldManagerFactory struct {
+	schema    *runtime.Scheme
+	existing  map[schema.GroupVersionKind]*managedfields.FieldManager
+	converter managedfields.TypeConverter
+	mu        sync.Mutex
+}
+
+func newFieldManagerFacotry(myschema *runtime.Scheme) *fieldManagerFactory {
+	return &fieldManagerFactory{
+		schema:    myschema,
+		converter: managedfields.NewDeducedTypeConverter(),
+		existing:  make(map[schema.GroupVersionKind]*managedfields.FieldManager),
+	}
+}
+
+func (fmf *fieldManagerFactory) FieldManager(gvk schema.GroupVersionKind) *managedfields.FieldManager {
+	fmf.mu.Lock()
+	defer fmf.mu.Unlock()
+	if result, ok := fmf.existing[gvk]; ok {
+		return result
+	}
+	result, err := managedfields.NewDefaultFieldManager(
+		fmf.converter, fmf.schema, fmf.schema, fmf.schema,
+		gvk, gvk.GroupVersion(), "", make(map[fieldpath.APIVersion]*fieldpath.Set))
+	if err != nil {
+		panic(err)
+	}
+	fmf.existing[gvk] = result
+	return result
+}

--- a/pkg/kube/fakeclient.go
+++ b/pkg/kube/fakeclient.go
@@ -343,7 +343,6 @@ func (fm *fakeMerger) propagateReactionSingle(destination clienttesting.FakeClie
 	fm.mergeLock.Lock()
 	fm.inProgress.Delete(key)
 	fm.mergeLock.Unlock()
-	return
 }
 
 func (fm *fakeMerger) Merge(f clienttesting.FakeClient) {

--- a/pkg/kube/fakeclient.go
+++ b/pkg/kube/fakeclient.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 
 	"go.uber.org/atomic"
@@ -233,23 +232,6 @@ func insertPatchReactor(f clienttesting.FakeClient, fmf *fieldManagerFactory) {
 	)
 }
 
-func actionKey(action clienttesting.Action) string {
-	out := strings.Builder{}
-	out.WriteString(action.GetVerb())
-	out.WriteString("/")
-	out.WriteString(action.GetResource().String())
-	out.WriteString("/")
-	out.WriteString(action.GetNamespace())
-	if n, ok := action.(named); ok {
-		out.WriteString("/")
-		out.WriteString(n.GetName())
-	}
-	return out.String()
-}
-
-type named interface {
-	GetName() string
-}
 type fakeMerger struct {
 	mergeLock sync.RWMutex
 	alertList []clienttesting.FakeClient

--- a/pkg/kube/fakeclient_test.go
+++ b/pkg/kube/fakeclient_test.go
@@ -1,0 +1,148 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/config/schema/gvr"
+)
+
+func TestFakeApply(t *testing.T) {
+	c := NewFakeClient()
+	g := gomega.NewWithT(t)
+	cma := corev1ac.ConfigMap("name", "default").
+		WithData(map[string]string{
+			"key": string("value"),
+		})
+	out, err := c.Kube().CoreV1().ConfigMaps("default").Apply(context.Background(), cma, metav1.ApplyOptions{
+		FieldManager: "istio",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	outac, err := corev1ac.ExtractConfigMap(out, "istio")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(outac).To(gomega.Equal(cma))
+}
+
+func helpTestMergeTypedToDynamic(g gomega.Gomega, f kubernetes.Interface, df dynamic.Interface) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key": "value",
+		},
+	}
+	z := atomic.Int32{}
+	di := dynamicinformer.NewFilteredDynamicSharedInformerFactory(df, 0, "default", nil).ForResource(gvr.ConfigMap).Informer()
+
+	di.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) { z.Add(1) },
+	})
+
+	stopper := make(chan struct{})
+	go di.Run(stopper)
+
+	_, err := f.CoreV1().ConfigMaps("default").Create(context.Background(), cm, metav1.CreateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ro, err := df.(*dynamicfake.FakeDynamicClient).Tracker().Get(gvr.ConfigMap, "default", "name")
+	ucm := ro.(*unstructured.Unstructured)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ucm.Object).To(gomega.HaveKey("data"))
+
+	g.Eventually(z.Load).Should(gomega.Equal(int32(1)))
+}
+
+func TestFakeClientMerge(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	c := NewFakeClient()
+	helpTestMergeTypedToDynamic(g, c.Kube(), c.Dynamic())
+}
+
+func TestMergeTypedToDynamic(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	f := fake.NewSimpleClientset()
+	s := FakeIstioScheme
+	df := dynamicfake.NewSimpleDynamicClient(s)
+	fm := fakeMerger{
+		scheme: s,
+	}
+
+	fm.Merge(f)
+	fm.MergeDynamic(df)
+	helpTestMergeTypedToDynamic(g, f, df)
+}
+
+func TestMergeDynamicToTyped(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	f := fake.NewSimpleClientset()
+	i := istiofake.NewSimpleClientset()
+	df := dynamicfake.NewSimpleDynamicClient(FakeIstioScheme)
+	fm := fakeMerger{
+		scheme: FakeIstioScheme,
+	}
+
+	fm.Merge(f)
+	fm.Merge(i)
+	fm.MergeDynamic(df)
+
+	cm := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"data": map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+
+	cm.SetGroupVersionKind(gvk.ConfigMap.Kubernetes())
+	cm.SetName("second")
+
+	z := atomic.Int32{}
+	inf := informers.NewSharedInformerFactory(f, 0).Core().V1().ConfigMaps().Informer()
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) { z.Add(1) },
+	})
+	stopper := make(chan struct{})
+	go inf.Run(stopper)
+
+	_, err := df.Resource(gvr.ConfigMap).Namespace("default").Create(context.Background(), cm, metav1.CreateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	ro, err := f.Tracker().Get(gvr.ConfigMap, "default", "second")
+	ucm := ro.(*corev1.ConfigMap)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(ucm.Data).To(gomega.HaveKey("foo"))
+
+	g.Eventually(z.Load).Should(gomega.Equal(int32(1)))
+}

--- a/pkg/kube/fakeclient_test.go
+++ b/pkg/kube/fakeclient_test.go
@@ -93,6 +93,7 @@ func TestMergeDynamicToTyped(t *testing.T) {
 	})
 	stopper := make(chan struct{})
 	go inf.Run(stopper)
+	g.Eventually(inf.HasSynced).Should(gomega.BeTrue())
 
 	_, err := df.Resource(gvr.ConfigMap).Namespace("default").Create(context.Background(), cm, metav1.CreateOptions{})
 	assert.NoError(t, err)

--- a/pkg/kube/fakeclient_test.go
+++ b/pkg/kube/fakeclient_test.go
@@ -157,6 +157,7 @@ func TestNameGeneration(t *testing.T) {
 		},
 	}
 	unsObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	ucm := &unstructured.Unstructured{Object: unsObj}
 	out, err := c.Kube().CoreV1().ConfigMaps("default").Create(context.Background(), cm, metav1.CreateOptions{})
 	g.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR fixes two major issues with client-go's fake clients.  

First, client-go does not support server-side-apply functionality in fakes.  There are two missing features here, first if you apply() an object that doesn't already exist, the fake will return a 404, while the API Server will return a 201.  Second, the server-side-apply pattern relies heavily on the population of managedFields, which are not set by the existing fake client.  Both of these issues are fixed in insertPatchReactor below.

Secon, client-go fakes are isolated from one-another, so that you cannot write to a typed client and read the result from a dynamic client, and vice versa.  This is particularly painful when testing controllers which use both clients for different purposes, and effectively causes tests to dictate the design of the controller.  This is fixed by replicating events in and out of the dynamic client to typed clients with fakeMerger.