### PR TITLE
Supports concurrent SidecarScope conversions

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -96,6 +96,13 @@ var (
 			" EDS pushes may be delayed, but there will be fewer pushes. By default this is enabled",
 	).Get()
 
+	ConvertSidecarScopeConcurrency = env.Register(
+		"PILOT_CONVERT_SIDECAR_SCOPE_CONCURRENCY",
+		1,
+		"Used to adjust the concurrency of SidecarScope conversions. "+
+			"When istiod is deployed on a multi-core CPU, increasing this value will help to use the CPU to accelerate configuration push, but it also means that istiod will consume more CPU resources.",
+	).Get()
+
 	SendUnhealthyEndpoints = atomic.NewBool(env.Register(
 		"PILOT_SEND_UNHEALTHY_ENDPOINTS",
 		false,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -100,7 +100,8 @@ var (
 		"PILOT_CONVERT_SIDECAR_SCOPE_CONCURRENCY",
 		1,
 		"Used to adjust the concurrency of SidecarScope conversions. "+
-			"When istiod is deployed on a multi-core CPU, increasing this value will help to use the CPU to accelerate configuration push, but it also means that istiod will consume more CPU resources.",
+			"When istiod is deployed on a multi-core CPU server, increasing this value will help to use the CPU to "+
+			"accelerate configuration push, but it also means that istiod will consume more CPU resources.",
 	).Get()
 
 	SendUnhealthyEndpoints = atomic.NewBool(env.Register(

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1851,7 +1851,7 @@ func (ps *PushContext) initSidecarScopes(env *Environment) {
 }
 
 func (ps *PushContext) doConvertToSidecarScope(sidecarConfigs []config.Config) {
-	if len(sidecarConfigs) <= 0 {
+	if len(sidecarConfigs) == 0 {
 		return
 	}
 	type taskItem struct {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1563,6 +1563,7 @@ func TestInitPushContext(t *testing.T) {
 }
 
 func TestSidecarScope(t *testing.T) {
+	test.SetForTest(t, &features.ConvertSidecarScopeConcurrency, 10)
 	ps := NewPushContext()
 	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
 	ps.Mesh = env.Mesh()


### PR DESCRIPTION
Currently, SidecarScope conversion is the main performance bottleneck of istiod. In the past year(see [here](https://github.com/istio/istio/issues/41453#issuecomment-1860290719)), we have optimized this many times, but we still have not reversed the situation. It is still the main performance bottleneck.

I think its performance problems mainly come from:

1. Large amount of calculation

In order to select CR resources related to egress host, use egress host to match VS, Service, DR, etc. Most of the ideas in the past were to improve speed by reducing calculations. Although some results have been achieved, configuration push is still very slow, taking about 1 minute in our production environment.


2. Inability to fully utilize the CPU

Currently, only one goroutine calculation is supported, and one goroutine can only use one core CPU at most. However, usually the server where istiod is deployed is a multi-core CPU server. For example, our istiod server has 32 cores. Using only one goroutine for calculation cannot make full use of the CPU to improve calculation speed, and cannot reflect the advantages of multi-core CPUs. This PR supports the use of multiple goroutines for concurrent calculations.

Using multiple goroutines does increase complexity and makes the code harder to maintain. I agree with this point of view, but I think it may be worth it. Also, using multiple goroutines for concurrent calculations is common in istio, like XDS translation, etc. I think it's more complicated than SidecarScope conversion, but it currently works well.


Some people may worry that concurrent calculations will consume too much CPU, so this PR sets the concurrency number to 1 by default. When we want to use more CPU for calculations, we can increase the concurrency number. In other words, this PR will NOT consume more CPU resources by default than currently, it just provides another option, giving us the opportunity to use the CPU in exchange for configuration push speed.

Related PR:  https://github.com/istio/istio/pull/41454
