### PR TITLE
tracing: always enable cluster id

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2584,6 +2584,14 @@ func customTracingTags() []*tracing.CustomTag {
 			},
 		},
 		&tracing.CustomTag{
+			Tag: "istio.cluster_id",
+			Type: &tracing.CustomTag_Literal_{
+				Literal: &tracing.CustomTag_Literal{
+					Value: "unknown",
+				},
+			},
+		},
+		&tracing.CustomTag{
 			Tag: "istio.mesh_id",
 			Type: &tracing.CustomTag_Literal_{
 				Literal: &tracing.CustomTag_Literal{

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -514,6 +514,10 @@ func buildServiceTags(metadata *model.NodeMetadata, labels map[string]string) []
 	if namespace == "" {
 		namespace = "default"
 	}
+	clusterID := string(metadata.ClusterID)
+	if clusterID == "" {
+		clusterID = "unknown"
+	}
 	return []*tracing.CustomTag{
 		{
 			Tag: "istio.canonical_revision",
@@ -549,9 +553,9 @@ func buildServiceTags(metadata *model.NodeMetadata, labels map[string]string) []
 		},
 		{
 			Tag: "istio.cluster_id",
-			Type: &tracing.CustomTag_Environment_{
-				Environment: &tracing.CustomTag_Environment{
-					Name: "ISTIO_META_CLUSTER_ID",
+			Type: &tracing.CustomTag_Literal_{
+				Literal: &tracing.CustomTag_Literal{
+					Value: clusterID,
 				},
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -547,6 +547,14 @@ func buildServiceTags(metadata *model.NodeMetadata, labels map[string]string) []
 				},
 			},
 		},
+		{
+			Tag: "istio.cluster_id",
+			Type: &tracing.CustomTag_Environment_{
+				Environment: &tracing.CustomTag_Environment{
+					Name: "ISTIO_META_CLUSTER_ID",
+				},
+			},
+		},
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -231,6 +231,14 @@ func defaultTracingTags() []*tracing.CustomTag {
 			},
 		},
 		&tracing.CustomTag{
+			Tag: "istio.cluster_id",
+			Type: &tracing.CustomTag_Literal_{
+				Literal: &tracing.CustomTag_Literal{
+					Value: "unknown",
+				},
+			},
+		},
+		&tracing.CustomTag{
 			Tag: "istio.mesh_id",
 			Type: &tracing.CustomTag_Literal_{
 				Literal: &tracing.CustomTag_Literal{

--- a/releasenotes/notes/48471.yaml
+++ b/releasenotes/notes/48471.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 48336
+releaseNotes:
+  - |
+    **Added** always `istio.cluster_id` tag to all tracing spans.

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -184,6 +184,7 @@ func testSetup(ctx resource.Context) error {
 		"ISTIO_META_INSECURE_STACKDRIVER_ENDPOINT":               sdInst.Address(),
 		"ISTIO_META_STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS": "10",
 		"ISTIO_META_MESH_ID":                                     "proj-test-mesh",
+		"ISTIO_META_CLUSTER_ID":                                  "Kubernetes",
 		"ISTIO_META_WORKLOAD_NAME":                               "vm-server-v1",
 		"ISTIO_METAJSON_LABELS":                                  vmLabelsJSON,
 		"CANONICAL_SERVICE":                                      "vm-server",

--- a/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
@@ -10,6 +10,7 @@ spans:{
     labels:{key:"http.url"  value:"http://server.{{ .EchoNamespace }}.svc.cluster.local/"}
     labels:{key:"istio.canonical_service"  value:"vm-server"}
     labels:{key:"istio.canonical_revision"  value:"v1"}
+    labels:{key:"istio.cluster_id"  value:"Kubernetes"}
     labels:{key:"istio.mesh_id"  value:"proj-test-mesh"}
     labels:{key:"istio.namespace"  value:"{{ .EchoNamespace }}"}
     labels:{key:"request_size"  value:"0"}
@@ -28,6 +29,7 @@ spans:{
     labels:{key:"http.url"  value:"http://server.{{ .EchoNamespace }}.svc.cluster.local/"}
     labels:{key:"istio.canonical_service"  value:"client"}
     labels:{key:"istio.canonical_revision"  value:"v1"}
+    labels:{key:"istio.cluster_id"  value:"Kubernetes"}
     labels:{key:"istio.mesh_id"  value:"proj-test-mesh"}
     labels:{key:"istio.namespace"  value:"{{ .EchoNamespace }}"}
     labels:{key:"request_size"  value:"0"}


### PR DESCRIPTION
**Please provide a description of this PR:**

inspired by [kiali's doc](https://kiali.io/docs/configuration/multi-cluster/), I think it's good to enable it by default.