### PR TITLE
Fix get private ip in adsc

### DIFF
--- a/pilot/pkg/util/network/ip.go
+++ b/pilot/pkg/util/network/ip.go
@@ -59,9 +59,9 @@ func GetPrivateIPs(ctx context.Context) ([]string, bool) {
 	for {
 		select {
 		case <-ctx.Done():
-			return getPrivateIPsIfAvailable()
+			return GetPrivateIPsIfAvailable()
 		default:
-			addr, ok := getPrivateIPsIfAvailable()
+			addr, ok := GetPrivateIPsIfAvailable()
 			if ok {
 				return addr, true
 			}
@@ -70,8 +70,8 @@ func GetPrivateIPs(ctx context.Context) ([]string, bool) {
 	}
 }
 
-// Returns all the private IP addresses
-func getPrivateIPsIfAvailable() ([]string, bool) {
+// GetPrivateIPsIfAvailable returns all the private IP addresses
+func GetPrivateIPsIfAvailable() ([]string, bool) {
 	ok := true
 	ipAddresses := make([]string, 0)
 


### PR DESCRIPTION
**Please provide a description of this PR:**
After the changes in https://github.com/istio/istio/pull/41624, the function now returns an IPv6 link-local unicast address `fe80::1` for my client. I have no dual-stack feature enabled.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
