### PR TITLE
skip consistent hash ttl test cases

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2621,12 +2621,20 @@ spec:
 				config: svc + tmpl.MustEvaluate(cookieWithTTLDest, ""),
 				call:   c.CallOrFail,
 				opts:   cookieCallOpts,
+				skip: skip{
+					skip:   true,
+					reason: "https://github.com/istio/istio/issues/48156: not currently working, as test framework is not passing the cookies back",
+				},
 			})
 			t.RunTraffic(TrafficTestCase{
 				name:   "http cookie without ttl" + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(cookieWithoutTTLDest, ""),
 				call:   c.CallOrFail,
 				opts:   cookieWithoutTTLCallOpts,
+				skip: skip{
+					skip:   true,
+					reason: "https://github.com/istio/istio/issues/48156: not currently working, as test framework is not passing the cookies back",
+				},
 			})
 		}
 	}


### PR DESCRIPTION
As found while debugging https://github.com/istio/istio/pull/48201, the test framework is not passing the cookies back for gRPC calls. For now I am skipping these tests. Will think about how to pass them in gRPC.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure