### PR TITLE
Revert "pilot: autoscale concurrency and rate limit on xds"

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -15,7 +15,6 @@
 package features
 
 import (
-	"runtime"
 	"strings"
 	"time"
 
@@ -59,43 +58,17 @@ var (
 		return f
 	}()
 
-	PushThrottle = func() int {
-		v := env.Register(
-			"PILOT_PUSH_THROTTLE",
-			0,
-			"Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes. "+
-				"If set to 0 or unset, the max will be automatically determined based on the machine size",
-		).Get()
-		if v > 0 {
-			return v
-		}
-		procs := runtime.GOMAXPROCS(0)
-		// Heuristic to scale with cores. We end up with...
-		// 1: 20
-		// 2: 25
-		// 4: 35
-		// 32: 100
-		return min(15+5*procs, 100)
-	}()
+	PushThrottle = env.Register(
+		"PILOT_PUSH_THROTTLE",
+		100,
+		"Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes",
+	).Get()
 
-	RequestLimit = func() float64 {
-		v := env.Register(
-			"PILOT_MAX_REQUESTS_PER_SECOND",
-			0.0,
-			"Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently. "+
-				"If set to 0 or unset, the max will be automatically determined based on the machine size",
-		).Get()
-		if v > 0 {
-			return v
-		}
-		procs := runtime.GOMAXPROCS(0)
-		// Heuristic to scale with cores. We end up with...
-		// 1: 20
-		// 2: 25
-		// 4: 35
-		// 32: 100
-		return min(float64(15+5*procs), 100.0)
-	}()
+	RequestLimit = env.Register(
+		"PILOT_MAX_REQUESTS_PER_SECOND",
+		25.0,
+		"Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.",
+	).Get()
 
 	// FilterGatewayClusterConfig controls if a subset of clusters(only those required) should be pushed to gateways
 	FilterGatewayClusterConfig = env.Register("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false,

--- a/releasenotes/notes/pilot-autoscale.yaml
+++ b/releasenotes/notes/pilot-autoscale.yaml
@@ -1,8 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: traffic-management
-releaseNotes:
-  - |
-    **Improved** the variables `PILOT_MAX_REQUESTS_PER_SECOND` (which rate limits the incoming requests, previously defaulted to 25.0)
-    and `PILOT_PUSH_THROTTLE` (which limits the number of concurrent responses, previously defaulted to 100) to automatically scale with the
-    CPU size Istiod is running on if not explicitly configured.


### PR DESCRIPTION
From https://testgrid.k8s.io/istio_istio_postsubmit#integ-ambient_istio_postsubmit, seems failure  start from the pr