### PR TITLE
do not compute ordered watched resources on every push

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -369,6 +369,12 @@ type Proxy struct {
 	// WatchedResources contains the list of watched resources for the proxy, keyed by the DiscoveryRequest TypeUrl.
 	WatchedResources map[string]*WatchedResource
 
+	// OrderedWatchedResources contains the watched resources for the proxy, ordered in accordance with known push order.
+	OrderedWatchedResources []*WatchedResource
+
+	// KnownTypeUrls contains the set of known type URLs for the proxy.
+	KnownTypeUrls sets.String
+
 	// XdsNode is the xDS node identifier
 	XdsNode *core.Node
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -488,15 +488,14 @@ func addWatchedResource(proxy *model.Proxy, wr *model.WatchedResource) {
 }
 
 // deleteWatchedResource deletes a WatchedResource to the proxy and updates push order.
+// This should always be called in the context of a proxy lock.
 func deleteWatchedResource(proxy *model.Proxy, typeURL string) {
-	proxy.Lock()
 	delete(proxy.WatchedResources, typeURL)
 	proxy.OrderedWatchedResources = orderWatchedResources(proxy.WatchedResources)
 	proxy.KnownTypeUrls = sets.New[string]()
 	for k := range proxy.WatchedResources {
 		proxy.KnownTypeUrls.Insert(k)
 	}
-	proxy.Unlock()
 }
 
 // shouldUnsubscribe checks if we should unsubscribe. This is done when Envoy is

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -249,7 +249,7 @@ func (conn *Connection) sendDelta(res *discovery.DeltaDiscoveryResponse) error {
 		if res.Nonce != "" && !strings.HasPrefix(res.TypeUrl, v3.DebugType) {
 			conn.proxy.Lock()
 			if conn.proxy.WatchedResources[res.TypeUrl] == nil {
-				conn.proxy.WatchedResources[res.TypeUrl] = &model.WatchedResource{TypeUrl: res.TypeUrl}
+				addWatchedResource(conn.proxy, &model.WatchedResource{TypeUrl: res.TypeUrl})
 			}
 			conn.proxy.WatchedResources[res.TypeUrl].NonceSent = res.Nonce
 			if features.EnableUnsafeDeltaTest {
@@ -353,11 +353,11 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		defer con.proxy.Unlock()
 
 		res, wildcard := deltaWatchedResources(nil, request)
-		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{
+		addWatchedResource(con.proxy, &model.WatchedResource{
 			TypeUrl:       request.TypeUrl,
 			ResourceNames: res,
 			Wildcard:      wildcard,
-		}
+		})
 		// For all EDS requests that we have already responded with in the same stream let us
 		// force the response. It is important to respond to those requests for Envoy to finish
 		// warming of those resources(Clusters).


### PR DESCRIPTION
OrderedWatchedResources and KnownTypeUrls is computed on every push even though they change very rarely. This PR stores it in the proxy.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
