### PR TITLE
istioctl: fix pc ecds

### DIFF
--- a/istioctl/pkg/util/configdump/ecds.go
+++ b/istioctl/pkg/util/configdump/ecds.go
@@ -20,12 +20,22 @@ import (
 
 // GetEcdsConfigDump retrieves the extension config dump from the ConfigDump
 func (w *Wrapper) GetEcdsConfigDump() (*admin.EcdsConfigDump, error) {
-	ecdsDumpAny, err := w.getSection(ecds)
+	ecdsDumpAny, err := w.getSections(ecds)
 	if err != nil {
 		return nil, err
 	}
+
 	ecdsDump := &admin.EcdsConfigDump{}
-	err = ecdsDumpAny.UnmarshalTo(ecdsDump)
+	for _, dump := range ecdsDumpAny {
+		ecds := &admin.EcdsConfigDump{}
+		err = dump.UnmarshalTo(ecds)
+		if err != nil {
+			return nil, err
+		}
+
+		ecdsDump.EcdsFilters = append(ecdsDump.EcdsFilters, ecds.EcdsFilters...)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/util/configdump/util.go
+++ b/istioctl/pkg/util/configdump/util.go
@@ -47,3 +47,17 @@ func (w *Wrapper) getSection(sectionTypeURL configTypeURL) (*anypb.Any, error) {
 
 	return dumpAny, nil
 }
+
+func (w *Wrapper) getSections(sectionTypeURL configTypeURL) ([]*anypb.Any, error) {
+	var dumpAny []*anypb.Any
+	for _, conf := range w.Configs {
+		if conf.TypeUrl == string(sectionTypeURL) {
+			dumpAny = append(dumpAny, conf)
+		}
+	}
+	if dumpAny == nil {
+		return nil, fmt.Errorf("config dump has no configuration type %s", sectionTypeURL)
+	}
+
+	return dumpAny, nil
+}

--- a/istioctl/pkg/writer/envoy/configdump/testdata/ecds/configdump.json
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/ecds/configdump.json
@@ -66,6 +66,44 @@
                     "last_updated": "2022-12-08T11:03:53.225Z"
                 }
             ]
+        },
+        {
+            "@type": "type.googleapis.com/envoy.admin.v3.EcdsConfigDump",
+            "ecds_filters": [
+                {
+                    "ecds_filter": {
+                        "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                        "name": "istio.io/telemetry/stats/prometheus/sidecar/Outbound/HTTP"
+                    },
+                    "last_updated": "2023-12-23T13:46:00.701Z"
+                },
+                {
+                    "ecds_filter": {
+                        "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                        "name": "istio.io/telemetry/stats/prometheus/sidecar/Inbound/HTTP"
+                    },
+                    "last_updated": "2023-12-23T13:46:00.708Z"
+                }
+            ]
+        },
+        {
+            "@type": "type.googleapis.com/envoy.admin.v3.EcdsConfigDump",
+            "ecds_filters": [
+                {
+                    "ecds_filter": {
+                        "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                        "name": "istio.io/telemetry/stats/prometheus/sidecar/Inbound/TCP"
+                    },
+                    "last_updated": "2023-12-23T13:46:00.707Z"
+                },
+                {
+                    "ecds_filter": {
+                        "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                        "name": "istio.io/telemetry/stats/prometheus/sidecar/Outbound/TCP"
+                    },
+                    "last_updated": "2023-12-23T13:46:00.699Z"
+                }
+            ]
         }
     ]
 }

--- a/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.json
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.json
@@ -61,6 +61,34 @@
                 }
             },
             "lastUpdated": "2022-12-08T11:03:53.225Z"
+        },
+        {
+            "ecdsFilter": {
+                "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                "name": "istio.io/telemetry/stats/prometheus/sidecar/Outbound/HTTP"
+            },
+            "lastUpdated": "2023-12-23T13:46:00.701Z"
+        },
+        {
+            "ecdsFilter": {
+                "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                "name": "istio.io/telemetry/stats/prometheus/sidecar/Inbound/HTTP"
+            },
+            "lastUpdated": "2023-12-23T13:46:00.708Z"
+        },
+        {
+            "ecdsFilter": {
+                "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                "name": "istio.io/telemetry/stats/prometheus/sidecar/Inbound/TCP"
+            },
+            "lastUpdated": "2023-12-23T13:46:00.707Z"
+        },
+        {
+            "ecdsFilter": {
+                "@type": "type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig",
+                "name": "istio.io/telemetry/stats/prometheus/sidecar/Outbound/TCP"
+            },
+            "lastUpdated": "2023-12-23T13:46:00.699Z"
         }
     ]
 }

--- a/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.txt
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.txt
@@ -1,3 +1,7 @@
-ECDS NAME                         TYPE
-default.display-metadata          envoy.extensions.filters.http.wasm.v3.Wasm
-default.httpbin-rate-limiting     envoy.extensions.filters.http.wasm.v3.Wasm
+ECDS NAME                                                     TYPE
+istio.io/telemetry/stats/prometheus/sidecar/Inbound/HTTP      
+istio.io/telemetry/stats/prometheus/sidecar/Inbound/TCP       
+istio.io/telemetry/stats/prometheus/sidecar/Outbound/HTTP     
+istio.io/telemetry/stats/prometheus/sidecar/Outbound/TCP      
+default.display-metadata                                      envoy.extensions.filters.http.wasm.v3.Wasm
+default.httpbin-rate-limiting                                 envoy.extensions.filters.http.wasm.v3.Wasm

--- a/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.yaml
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/ecds/output.yaml
@@ -39,3 +39,19 @@ ecdsFilters:
           runtime: envoy.wasm.runtime.v8
   lastUpdated: "2022-12-08T11:03:53.225Z"
   versionInfo: 2022-12-08T09:07:09Z/10
+- ecdsFilter:
+    '@type': type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig
+    name: istio.io/telemetry/stats/prometheus/sidecar/Outbound/HTTP
+  lastUpdated: "2023-12-23T13:46:00.701Z"
+- ecdsFilter:
+    '@type': type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig
+    name: istio.io/telemetry/stats/prometheus/sidecar/Inbound/HTTP
+  lastUpdated: "2023-12-23T13:46:00.708Z"
+- ecdsFilter:
+    '@type': type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig
+    name: istio.io/telemetry/stats/prometheus/sidecar/Inbound/TCP
+  lastUpdated: "2023-12-23T13:46:00.707Z"
+- ecdsFilter:
+    '@type': type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig
+    name: istio.io/telemetry/stats/prometheus/sidecar/Outbound/TCP
+  lastUpdated: "2023-12-23T13:46:00.699Z"

--- a/releasenotes/notes/48526.yaml
+++ b/releasenotes/notes/48526.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+  - |
+    **Fixed** an issue `proxyconfig ecds` didn't show all `EcdsConfigDump`.


### PR DESCRIPTION
**Please provide a description of this PR:**

mismatched before following output:
```console
istioctl pc ecds sleep-7656cf8794-kqc52.default
ECDS NAME                                                    TYPE
istio.io/telemetry/stats/prometheus/sidecar/Inbound/TCP
istio.io/telemetry/stats/prometheus/sidecar/Outbound/TCP
```

```console
istioctl x internal-debug "config_dump?types=ecds&proxyID=sleep-7656cf8794-kqc52.default" | jq '.configs | length'
4
```

```console
istioctl pc all sleep-7656cf8794-kqc52 -ojson | grep -c "type.googleapis.com/envoy.admin.v3.EcdsConfigDump"
```