### PR TITLE
use hash.WriteString to optimize mem alloc

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -47,10 +47,10 @@ func (key ConfigKey) HashCode() ConfigHash {
 	h := hash.New()
 	h.Write([]byte{byte(key.Kind)})
 	// Add separator / to avoid collision.
-	h.Write([]byte("/"))
-	h.Write([]byte(key.Namespace))
-	h.Write([]byte("/"))
-	h.Write([]byte(key.Name))
+	h.WriteString("/")
+	h.WriteString(key.Namespace)
+	h.WriteString("/")
+	h.WriteString(key.Name)
 	return ConfigHash(h.Sum64())
 }
 

--- a/pilot/pkg/model/typed_xds_cache_test.go
+++ b/pilot/pkg/model/typed_xds_cache_test.go
@@ -36,7 +36,7 @@ type entry struct {
 
 func (e entry) Key() uint64 {
 	h := hash.New()
-	h.Write([]byte(e.key))
+	h.WriteString(e.key)
 	return h.Sum64()
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_cache.go
@@ -68,60 +68,60 @@ func (t *clusterCache) Key() any {
 	// nolint: gosec
 	// Not security sensitive code
 	h := hash.New()
-	h.Write([]byte(t.clusterName))
+	h.WriteString(t.clusterName)
 	h.Write(Separator)
-	h.Write([]byte(t.proxyVersion))
+	h.WriteString(t.proxyVersion)
 	h.Write(Separator)
-	h.Write([]byte(util.LocalityToString(t.locality)))
+	h.WriteString(util.LocalityToString(t.locality))
 	h.Write(Separator)
-	h.Write([]byte(t.proxyClusterID))
+	h.WriteString(t.proxyClusterID)
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(t.proxySidecar)))
+	h.WriteString(strconv.FormatBool(t.proxySidecar))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(t.http2)))
+	h.WriteString(strconv.FormatBool(t.http2))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(t.downstreamAuto)))
+	h.WriteString(strconv.FormatBool(t.downstreamAuto))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(t.supportsIPv4)))
+	h.WriteString(strconv.FormatBool(t.supportsIPv4))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(t.hbone)))
+	h.WriteString(strconv.FormatBool(t.hbone))
 	h.Write(Separator)
 
 	if t.proxyView != nil {
-		h.Write([]byte(t.proxyView.String()))
+		h.WriteString(t.proxyView.String())
 	}
 	h.Write(Separator)
 
 	if t.metadataCerts != nil {
-		h.Write([]byte(t.metadataCerts.String()))
+		h.WriteString(t.metadataCerts.String())
 	}
 	h.Write(Separator)
 
 	if t.service != nil {
-		h.Write([]byte(t.service.Hostname))
+		h.WriteString(string(t.service.Hostname))
 		h.Write(Slash)
-		h.Write([]byte(t.service.Attributes.Namespace))
+		h.WriteString(t.service.Attributes.Namespace)
 	}
 	h.Write(Separator)
 
 	for _, dr := range t.destinationRule.GetFrom() {
-		h.Write([]byte(dr.Name))
+		h.WriteString(dr.Name)
 		h.Write(Slash)
-		h.Write([]byte(dr.Namespace))
+		h.WriteString(dr.Namespace)
 	}
 	h.Write(Separator)
 
 	for _, efk := range t.envoyFilterKeys {
-		h.Write([]byte(efk))
+		h.WriteString(efk)
 		h.Write(Separator)
 	}
 	h.Write(Separator)
 
-	h.Write([]byte(t.peerAuthVersion))
+	h.WriteString(t.peerAuthVersion)
 	h.Write(Separator)
 
 	for _, sa := range t.serviceAccounts {
-		h.Write([]byte(sa))
+		h.WriteString(sa)
 		h.Write(Separator)
 	}
 	h.Write(Separator)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_cache.go
@@ -145,36 +145,36 @@ func (r *Cache) Key() any {
 	// Not security sensitive code
 	h := hash.New()
 
-	h.Write([]byte(r.RouteName))
+	h.WriteString(r.RouteName)
 	h.Write(Separator)
-	h.Write([]byte(r.ProxyVersion))
+	h.WriteString(r.ProxyVersion)
 	h.Write(Separator)
-	h.Write([]byte(r.ClusterID))
+	h.WriteString(r.ClusterID)
 	h.Write(Separator)
-	h.Write([]byte(r.DNSDomain))
+	h.WriteString(r.DNSDomain)
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(r.DNSCapture)))
+	h.WriteString(strconv.FormatBool(r.DNSCapture))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(r.DNSAutoAllocate)))
+	h.WriteString(strconv.FormatBool(r.DNSAutoAllocate))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(r.AllowAny)))
+	h.WriteString(strconv.FormatBool(r.AllowAny))
 	h.Write(Separator)
 
 	for _, svc := range r.Services {
-		h.Write([]byte(svc.Hostname))
+		h.WriteString(string(svc.Hostname))
 		h.Write(Slash)
-		h.Write([]byte(svc.Attributes.Namespace))
+		h.WriteString(svc.Attributes.Namespace)
 		h.Write(Separator)
 	}
 	h.Write(Separator)
 
 	for _, vs := range r.VirtualServices {
 		for _, cfg := range model.VirtualServiceDependencies(vs) {
-			h.Write([]byte(cfg.Kind.String()))
+			h.WriteString(cfg.Kind.String())
 			h.Write(Slash)
-			h.Write([]byte(cfg.Name))
+			h.WriteString(cfg.Name)
 			h.Write(Slash)
-			h.Write([]byte(cfg.Namespace))
+			h.WriteString(cfg.Namespace)
 			h.Write(Separator)
 		}
 	}
@@ -188,16 +188,16 @@ func (r *Cache) Key() any {
 
 	for _, mergedDR := range r.DestinationRules {
 		for _, dr := range mergedDR.GetFrom() {
-			h.Write([]byte(dr.Name))
+			h.WriteString(dr.Name)
 			h.Write(Slash)
-			h.Write([]byte(dr.Namespace))
+			h.WriteString(dr.Namespace)
 			h.Write(Separator)
 		}
 	}
 	h.Write(Separator)
 
 	for _, efk := range r.EnvoyFilterKeys {
-		h.Write([]byte(efk))
+		h.WriteString(efk)
 		h.Write(Separator)
 	}
 	h.Write(Separator)

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -203,52 +203,52 @@ func (b *EndpointBuilder) WriteHash(h hash.Hash) {
 	if b == nil {
 		return
 	}
-	h.Write([]byte(b.clusterName))
+	h.WriteString(b.clusterName)
 	h.Write(Separator)
-	h.Write([]byte(b.network))
+	h.WriteString(string(b.network))
 	h.Write(Separator)
-	h.Write([]byte(b.clusterID))
+	h.WriteString(string(b.clusterID))
 	h.Write(Separator)
-	h.Write([]byte(b.nodeType))
+	h.WriteString(string(b.nodeType))
 	h.Write(Separator)
-	h.Write([]byte(strconv.FormatBool(b.clusterLocal)))
+	h.WriteString(strconv.FormatBool(b.clusterLocal))
 	h.Write(Separator)
 	if features.EnableHBONE && b.proxy != nil {
-		h.Write([]byte(strconv.FormatBool(b.proxy.IsProxylessGrpc())))
+		h.WriteString(strconv.FormatBool(b.proxy.IsProxylessGrpc()))
 		h.Write(Separator)
 	}
-	h.Write([]byte(util.LocalityToString(b.locality)))
+	h.WriteString(util.LocalityToString(b.locality))
 	h.Write(Separator)
 	if len(b.failoverPriorityLabels) > 0 {
 		h.Write(b.failoverPriorityLabels)
 		h.Write(Separator)
 	}
 	if b.service.Attributes.NodeLocal {
-		h.Write([]byte(b.proxy.GetNodeName()))
+		h.WriteString(b.proxy.GetNodeName())
 		h.Write(Separator)
 	}
 
 	if b.push != nil && b.push.AuthnPolicies != nil {
-		h.Write([]byte(b.push.AuthnPolicies.GetVersion()))
+		h.WriteString(b.push.AuthnPolicies.GetVersion())
 	}
 	h.Write(Separator)
 
 	for _, dr := range b.destinationRule.GetFrom() {
-		h.Write([]byte(dr.Name))
+		h.WriteString(dr.Name)
 		h.Write(Slash)
-		h.Write([]byte(dr.Namespace))
+		h.WriteString(dr.Namespace)
 	}
 	h.Write(Separator)
 
 	if b.service != nil {
-		h.Write([]byte(b.service.Hostname))
+		h.WriteString(string(b.service.Hostname))
 		h.Write(Slash)
-		h.Write([]byte(b.service.Attributes.Namespace))
+		h.WriteString(b.service.Attributes.Namespace)
 	}
 	h.Write(Separator)
 
 	if b.proxyView != nil {
-		h.Write([]byte(b.proxyView.String()))
+		h.WriteString(b.proxyView.String())
 	}
 	h.Write(Separator)
 }

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -22,6 +22,7 @@ import (
 
 type Hash interface {
 	Write(p []byte) (n int)
+	WriteString(p string) (n int)
 	Sum() string
 	Sum64() uint64
 }
@@ -42,6 +43,13 @@ func New() Hash {
 // Hash.Write error always return nil, this func simplify caller handle error
 func (i *instance) Write(p []byte) (n int) {
 	n, _ = i.hash.Write(p)
+	return
+}
+
+// WriteString wraps the Hash.WriteString function call
+// Hash.Write error always return nil, this func simplify caller handle error
+func (i *instance) WriteString(p string) (n int) {
+	n, _ = i.hash.WriteString(p)
 	return
 }
 

--- a/pkg/util/hash/hash_test.go
+++ b/pkg/util/hash/hash_test.go
@@ -38,13 +38,24 @@ func TestFactory(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			h := New()
+			var (
+				hs []Hash
+				h  Hash
+			)
+			h = New()
 			h.Write([]byte(tt.str))
-			if gotStr := h.Sum(); tt.wantStr != gotStr {
-				t.Errorf("wantStr %v, but got %v", tt.wantStr, gotStr)
-			}
-			if gotUint64 := h.Sum64(); tt.wantUint64 != gotUint64 {
-				t.Errorf("wantUint64 %v, but got %v", tt.wantUint64, gotUint64)
+			hs = append(hs, h)
+			h = New()
+			h.WriteString(tt.str)
+			hs = append(hs, h)
+
+			for _, h := range hs {
+				if gotStr := h.Sum(); tt.wantStr != gotStr {
+					t.Errorf("wantStr %v, but got %v", tt.wantStr, gotStr)
+				}
+				if gotUint64 := h.Sum64(); tt.wantUint64 != gotUint64 {
+					t.Errorf("wantUint64 %v, but got %v", tt.wantUint64, gotUint64)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR aims to optimize the memory allocation when converting a string to []byte during hash calculation in Istio.

The changes are as follows:

1. Added the `WriteString` interface to `hash.Hash`, which internally wraps the `WriteString` call of `xxhash`.

2. Modified the parts involving string in the `hash.Hash.Write` call to use `WriteString`.

Considering that this calculation is used in many critical paths, this optimization has shown significant reduction in memory allocation in our internal practice/stress testing.