### PR TITLE
Optimize config store `List`

### DIFF
--- a/pilot/pkg/config/memory/store.go
+++ b/pilot/pkg/config/memory/store.go
@@ -99,7 +99,17 @@ func (cr *store) List(kind config.GroupVersionKind, namespace string) []config.C
 	if !exists {
 		return nil
 	}
-	out := make([]config.Config, 0, len(cr.data[kind]))
+
+	var size int
+	if namespace == "" {
+		for _, ns := range data {
+			size += len(ns)
+		}
+	} else {
+		size = len(data[namespace])
+	}
+
+	out := make([]config.Config, 0, size)
 	if namespace == "" {
 		for _, ns := range data {
 			for _, value := range ns {

--- a/pilot/pkg/config/memory/store_test.go
+++ b/pilot/pkg/config/memory/store_test.go
@@ -53,6 +53,19 @@ func BenchmarkStoreGet(b *testing.B) {
 	}
 }
 
+func BenchmarkStoreList(b *testing.B) {
+	s := initStore(b)
+	gvk := config.GroupVersionKind{
+		Group:   "networking.istio.io",
+		Version: "v1alpha3",
+		Kind:    "ServiceEntry",
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		s.List(gvk, "")
+	}
+}
+
 func BenchmarkStoreCreate(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		initStore(b)


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR aims to optimize the memory allocation overhead in the List method of configstore. Considering the extensive use of this method in the Istio codebase, which constitutes a critical code path, optimizing it holds significant value.

Specific changes include:

1. Optimizing memory config store `List` method to pre-allocate a slice of appropriate size based on the actual returned data, avoiding multiple slice expansions caused by repeated `append`s.

2. Implementing similar optimizations for the aggregate config store.

3. Adding a `BenchmarkStoreList` test case to observe the actual impact of the optimization.

Optimization results:

```sh
# before
BenchmarkStoreList-8           7071        147289 ns/op      786132 B/op         12 allocs/op

# after
BenchmarkStoreList-8          22273         52986 ns/op      237568 B/op          1 allocs/op
```