### PR TITLE
convertToEnvoyFilterWrapper skip invalid patch

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -100,6 +100,7 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 		// Should only happen in tests or without validation
 		if err != nil {
 			log.Errorf("failed to build envoy filter value: %v", err)
+			continue
 		}
 		if cp.Match == nil {
 			// create a match all object

--- a/releasenotes/notes/48544.yaml
+++ b/releasenotes/notes/48544.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue that `convertToEnvoyFilterWrapper` still returns the invalid patch and may cause NPE when apply it.


### PR DESCRIPTION
**Please provide a description of this PR:**

While the content of EnvoyFilter can be validated to ensure its validity, from an engineering perspective, it is also necessary to mitigate the risk of this code not spreading or exacerbating. Assuming a scenario where there is no validation or a validation miss, [performing an actual patch](https://github.com/istio/istio/blob/master/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go#L256) could lead to a null pointer exception (NPE).

So it is considered better practice to employ defensive programming here.