### PR TITLE
fix Makefile.k8s.mk fetch-root-ca if-condition not work

### DIFF
--- a/releasenotes/notes/48545.yaml
+++ b/releasenotes/notes/48545.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** an issue `Makefile.k8s.mk` `fetch-root-ca` if-condition not work and can not handle `cacerts` case.

--- a/tools/certs/Makefile.k8s.mk
+++ b/tools/certs/Makefile.k8s.mk
@@ -27,14 +27,14 @@ export KUBECONFIG
 fetch-root-ca:
 	@echo "fetching root ca from k8s cluster: "$(cluster)""
 	@mkdir -p $(pwd)/$(cluster)
-	@res=$(shell kubectl get secret istio-ca-secret  -n  $(ISTIO-NAMESPACE) >/dev/null 2>&1;  echo $$?)
-ifeq ($(res), 1)
-	@kubectl get secret cacerts   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
-	@kubectl get secret cacerts  -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
-else
-	@kubectl get secret istio-ca-secret   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
-	@kubectl get secret istio-ca-secret   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
-endif
+	@res=$$(kubectl get secret istio-ca-secret -n $(ISTIO_NAMESPACE) >/dev/null 2>&1; echo $$?); \
+	if [ $$res -eq 1 ]; then \
+		kubectl get secret cacerts -n $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem; \
+		kubectl get secret cacerts -n $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem; \
+	else \
+		kubectl get secret istio-ca-secret -n $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem; \
+		kubectl get secret istio-ca-secret -n $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem; \
+	fi
 
 k8s-root-cert.pem:
 	@cat $(cluster)/k8s-root-cert.pem > $@


### PR DESCRIPTION
**Please provide a description of this PR:**

In the makefile, the top-level `if` actually operates in a manner similar to macros, so the source code `ifeq ($(res), 1)` cannot access the expected result from the previous line, but rather results in a constant **empty value**. 

In terms of business impact, when `istio-ca-cert` does not exist, it incorrectly assumes a successful result, leading to the execution of the `else` block and obtaining incorrect content.