### PR TITLE
EDS metadata: fix ClusterID of network gateways

### DIFF
--- a/pilot/pkg/xds/endpoints/ep_filters.go
+++ b/pilot/pkg/xds/endpoints/ep_filters.go
@@ -151,7 +151,7 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*LocalityEndpoint
 			util.AppendLbEndpointMetadata(&model.EndpointMetadata{
 				Network:   gw.Network,
 				TLSMode:   model.IstioMutualTLSModeLabel,
-				ClusterID: b.clusterID,
+				ClusterID: gw.Cluster,
 				Labels:    labels.Instance{},
 			}, gwEp.Metadata)
 			// Currently gateway endpoint does not support tunnel.

--- a/releasenotes/notes/network-gw-metadata.yaml
+++ b/releasenotes/notes/network-gw-metadata.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+  - |
+    **Fixed** a bug where `destination_cluster` reported by client proxies may be wrong
+    when accessing workloads in a different network.


### PR DESCRIPTION
**Please provide a description of this PR:**
It's incorrect to set the ClusterID of network gateways to the proxy's ClusterID, which can generate wrong stas


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
