### PR TITLE
Remove an analysis code that is no longer used: ist0119

### DIFF
--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -68,10 +68,6 @@ var (
 	// Description: Port name is not under naming convention. Protocol detection is applied to the port.
 	PortNameIsNotUnderNamingConvention = diag.NewMessageType(diag.Info, "IST0118", "Port name %s (port: %d, targetPort: %s) doesn't follow the naming convention of Istio port.")
 
-	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
-	// Description: Authentication policy with JWT targets Service with invalid port specification.
-	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Warning, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
-
 	// InvalidRegexp defines a diag.MessageType for message "InvalidRegexp".
 	// Description: Invalid Regex
 	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Field %q regular expression invalid: %q (%s)")
@@ -271,7 +267,6 @@ func All() []*diag.MessageType {
 		MTLSPolicyConflict,
 		DeploymentAssociatedToMultipleServices,
 		PortNameIsNotUnderNamingConvention,
-		JwtFailureDueToInvalidServicePortPrefix,
 		InvalidRegexp,
 		NamespaceMultipleInjectionLabels,
 		InvalidAnnotation,
@@ -467,18 +462,6 @@ func NewPortNameIsNotUnderNamingConvention(r *resource.Instance, portName string
 		r,
 		portName,
 		port,
-		targetPort,
-	)
-}
-
-// NewJwtFailureDueToInvalidServicePortPrefix returns a new diag.Message based on JwtFailureDueToInvalidServicePortPrefix.
-func NewJwtFailureDueToInvalidServicePortPrefix(r *resource.Instance, port int, portName string, protocol string, targetPort string) diag.Message {
-	return diag.NewMessage(
-		JwtFailureDueToInvalidServicePortPrefix,
-		r,
-		port,
-		portName,
-		protocol,
 		targetPort,
 	)
 }

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -176,21 +176,7 @@ messages:
       - name: targetPort
         type: string
 
-  - name: "JwtFailureDueToInvalidServicePortPrefix"
-    code: IST0119
-    level: Warning
-    description: "Authentication policy with JWT targets Service with invalid port specification."
-    template: "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s)."
-    args:
-      - name: port
-        type: int
-      - name: portName
-        type: string
-      - name: protocol
-        type: string
-      - name: targetPort
-        type: string
-
+  # IST0119 RETIRED
   # IST0120 RETIRED
   # IST0121 RETIRED
 


### PR DESCRIPTION
An analysis code is no longer generated by Istio. See #22706 and [ist0119 comments](https://github.com/istio/istio.io/pull/14382/files#r1437327758).

Removing these dead codes will remove them from http://istio.io/latest/docs/reference/config/analysis/

cc @hanxiaop 

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure