### PR TITLE
Fix GRPCRoute's kind passed to the parent reference solver

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -598,7 +598,7 @@ func buildGRPCVirtualServices(
 	meshRoutes map[string]map[string]*config.Config,
 ) {
 	route := obj.Spec.(*k8s.GRPCRouteSpec)
-	parentRefs := extractParentReferenceInfo(ctx.GatewayReferences, route.ParentRefs, route.Hostnames, gvk.HTTPRoute, obj.Namespace)
+	parentRefs := extractParentReferenceInfo(ctx.GatewayReferences, route.ParentRefs, route.Hostnames, gvk.GRPCRoute, obj.Namespace)
 	reportStatus := func(results []RouteParentResult) {
 		obj.Status.(*kstatus.WrappedStatus).Mutate(func(s config.Status) config.Status {
 			rs := s.(*k8s.GRPCRouteStatus)

--- a/pilot/pkg/config/kube/gateway/testdata/grpc.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/grpc.status.yaml.golden
@@ -61,8 +61,6 @@ status:
     name: default
     supportedKinds:
     - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-    - group: gateway.networking.k8s.io
       kind: GRPCRoute
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2

--- a/pilot/pkg/config/kube/gateway/testdata/grpc.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/grpc.yaml
@@ -23,6 +23,8 @@ spec:
     allowedRoutes:
       namespaces:
         from: All
+      kinds:
+      - kind: GRPCRoute
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GRPCRoute


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

**Please provide a description of this PR:**

Previous, the GRPCRoute can't attach to the Gateway when allowedRoutes.kinds.Kind is given.