### PR TITLE
Fix duplicate rev namespace in injector list

### DIFF
--- a/releasenotes/notes/48595.yaml
+++ b/releasenotes/notes/48595.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** injector list has duplicated namespace shown for the same injector hook.


### PR DESCRIPTION
**Please provide a description of this PR:**
The webhook can contains several webhooks that is matching the namespace, and currently the namespace may be duplicated: 
```
istioctl x injector list                    
...

NAMESPACES          INJECTOR-HOOK              ISTIO-REVISION SIDECAR-IMAGE
...
hello               istio-revision-tag-default default        hanxiaop/proxyv2:1.21.0-1226
...
hello               istio-revision-tag-default default        hanxiaop/proxyv2:1.21.0-1226
```

this is to remove the duplications per revisioned webhook.