### PR TITLE
Remove unused analysis message

### DIFF
--- a/pkg/config/analysis/msg/messages.gen.go
+++ b/pkg/config/analysis/msg/messages.gen.go
@@ -56,10 +56,6 @@ var (
 	// Description: A VirtualService routes to a service with more than one port exposed, but does not specify which to use.
 	VirtualServiceDestinationPortSelectorRequired = diag.NewMessageType(diag.Error, "IST0112", "This VirtualService routes to a service %q that exposes multiple ports %v. Specifying a port in the destination is required to disambiguate.")
 
-	// MTLSPolicyConflict defines a diag.MessageType for message "MTLSPolicyConflict".
-	// Description: A DestinationRule and Policy are in conflict with regards to mTLS.
-	MTLSPolicyConflict = diag.NewMessageType(diag.Error, "IST0113", "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s.")
-
 	// DeploymentAssociatedToMultipleServices defines a diag.MessageType for message "DeploymentAssociatedToMultipleServices".
 	// Description: The resulting pods of a service mesh deployment can't be associated with multiple services using the same port but different protocols.
 	DeploymentAssociatedToMultipleServices = diag.NewMessageType(diag.Warning, "IST0116", "This deployment %s is associated with multiple services using port %d but different protocols: %v")
@@ -264,7 +260,6 @@ func All() []*diag.MessageType {
 		ConflictingSidecarWorkloadSelectors,
 		MultipleSidecarsWithoutWorkloadSelectors,
 		VirtualServiceDestinationPortSelectorRequired,
-		MTLSPolicyConflict,
 		DeploymentAssociatedToMultipleServices,
 		PortNameIsNotUnderNamingConvention,
 		InvalidRegexp,
@@ -428,19 +423,6 @@ func NewVirtualServiceDestinationPortSelectorRequired(r *resource.Instance, dest
 		r,
 		destHost,
 		destPorts,
-	)
-}
-
-// NewMTLSPolicyConflict returns a new diag.Message based on MTLSPolicyConflict.
-func NewMTLSPolicyConflict(r *resource.Instance, host string, destinationRuleName string, destinationRuleMTLSMode bool, policyName string, policyMTLSMode string) diag.Message {
-	return diag.NewMessage(
-		MTLSPolicyConflict,
-		r,
-		host,
-		destinationRuleName,
-		destinationRuleMTLSMode,
-		policyName,
-		policyMTLSMode,
 	)
 }
 

--- a/pkg/config/analysis/msg/messages.yaml
+++ b/pkg/config/analysis/msg/messages.yaml
@@ -128,23 +128,7 @@ messages:
       - name: destPorts
         type: "[]int"
 
-  - name: "MTLSPolicyConflict"
-    code: IST0113
-    level: Error
-    description: "A DestinationRule and Policy are in conflict with regards to mTLS."
-    template: "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s."
-    args:
-      - name: host
-        type: string
-      - name: destinationRuleName
-        type: string
-      - name: destinationRuleMTLSMode
-        type: bool
-      - name: policyName
-        type: string
-      - name: policyMTLSMode
-        type: string
-
+  # IST0113 RETIRED
   # IST0114 RETIRED
   # IST0115 RETIRED
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Removing the unused `IST0113` analysis message.
[Documentation](https://istio.io/latest/docs/reference/config/analysis/) update to remove it: https://github.com/istio/istio.io/pull/14403.