### PR TITLE
adds unit tests to pkg/slices

### DIFF
--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -158,9 +158,6 @@ func Map[E any, O any](s []E, f func(E) O) []O {
 // MapFilter runs f() over all elements in s and returns any non-nil results
 func MapFilter[E any, O any](s []E, f func(E) *O) []O {
 	n := make([]O, 0, len(s))
-	if f == nil {
-		return n
-	}
 	for _, e := range s {
 		if res := f(e); res != nil {
 			n = append(n, *res)

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -158,6 +158,9 @@ func Map[E any, O any](s []E, f func(E) O) []O {
 // MapFilter runs f() over all elements in s and returns any non-nil results
 func MapFilter[E any, O any](s []E, f func(E) *O) []O {
 	n := make([]O, 0, len(s))
+	if f == nil {
+		return n
+	}
 	for _, e := range s {
 		if res := f(e); res != nil {
 			n = append(n, *res)
@@ -189,6 +192,9 @@ func Dereference[E any](s []*E) []E {
 
 // Flatten merges a slice of slices into a single slice.
 func Flatten[E any](s [][]E) []E {
+	if s == nil {
+		return nil
+	}
 	res := make([]E, 0)
 	for _, v := range s {
 		res = append(res, v...)

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -32,7 +32,7 @@ type s struct {
 }
 
 func TestEqual(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name string
 		s1   []int
 		s2   []int

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -493,12 +493,6 @@ func TestMapFilter(t *testing.T) {
 			},
 			want: []int{2, 4},
 		},
-		{
-			name:     "NilFunction",
-			input:    []int{1, 2, 3, 4, 5},
-			function: nil,
-			want:     []int{},
-		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	cmp2 "github.com/google/go-cmp/cmp"
+
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/tests/util/leak"
 )
@@ -29,7 +31,244 @@ type s struct {
 	Junk string
 }
 
+func TestEqual(t *testing.T) {
+	var tests = []struct {
+		name string
+		s1   []int
+		s2   []int
+		want bool
+	}{
+		{"Empty Slices", []int{}, []int{}, true},
+		{"Equal Slices", []int{1, 2, 3}, []int{1, 2, 3}, true},
+		{"Unequal Slices", []int{1, 2, 3}, []int{3, 2, 1}, false},
+		{"One Empty Slice", []int{}, []int{1, 2, 3}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Equal(tt.s1, tt.s2)
+			if got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEqualFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   []int
+		s2   []int
+		eq   func(int, int) bool
+		want bool
+	}{
+		{
+			name: "Equal slices",
+			s1:   []int{1, 2, 3},
+			s2:   []int{1, 2, 3},
+			eq: func(a, b int) bool {
+				return a == b
+			},
+			want: true,
+		},
+		{
+			name: "Unequal slices",
+			s1:   []int{1, 2, 3},
+			s2:   []int{4, 5, 6},
+			eq: func(a, b int) bool {
+				return a == b
+			},
+			want: false,
+		},
+		{
+			name: "Empty slices",
+			s1:   []int{},
+			s2:   []int{},
+			eq: func(a, b int) bool {
+				return a == b
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EqualFunc(tt.s1, tt.s2, tt.eq)
+			if diff := cmp2.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSortBy(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []int
+		extract  func(a int) int
+		expected []int
+	}{
+		{
+			name:     "Normal Case",
+			input:    []int{4, 2, 3, 1},
+			extract:  func(a int) int { return a },
+			expected: []int{1, 2, 3, 4},
+		},
+		{
+			name:     "Reverse Case",
+			input:    []int{1, 2, 3, 4},
+			extract:  func(a int) int { return -a },
+			expected: []int{4, 3, 2, 1},
+		},
+		{
+			name:     "Same Elements Case",
+			input:    []int{2, 2, 2, 2},
+			extract:  func(a int) int { return a },
+			expected: []int{2, 2, 2, 2},
+		},
+		{
+			name:     "Empty Slice Case",
+			input:    []int{},
+			extract:  func(a int) int { return a },
+			expected: []int{},
+		},
+		{
+			name:     "One Element Case",
+			input:    []int{1},
+			extract:  func(a int) int { return a },
+			expected: []int{1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SortBy(tc.input, tc.extract)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Fatalf("Expected: %+v, but got: %+v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestSort(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{
+			name:     "Single_Element",
+			input:    []int{1},
+			expected: []int{1},
+		},
+		{
+			name:     "Already_Sorted",
+			input:    []int{1, 2, 3, 4},
+			expected: []int{1, 2, 3, 4},
+		},
+		{
+			name:     "Reverse_Order",
+			input:    []int{4, 3, 2, 1},
+			expected: []int{1, 2, 3, 4},
+		},
+		{
+			name:     "Unique_Elements",
+			input:    []int{12, 3, 5, 1, 27},
+			expected: []int{1, 3, 5, 12, 27},
+		},
+		{
+			name:     "Empty_Slice",
+			input:    []int{},
+			expected: []int{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Sort(tc.input)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Fatalf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestReverse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []int
+		expected []int
+	}{
+		{
+			name:     "empty slice",
+			input:    []int{},
+			expected: []int{},
+		},
+		{
+			name:     "single element",
+			input:    []int{1},
+			expected: []int{1},
+		},
+		{
+			name:     "two elements",
+			input:    []int{1, 2},
+			expected: []int{2, 1},
+		},
+		{
+			name:     "multiple elements",
+			input:    []int{1, 2, 3, 4, 5},
+			expected: []int{5, 4, 3, 2, 1},
+		},
+		{
+			name:     "odd number of elements",
+			input:    []int{1, 2, 3},
+			expected: []int{3, 2, 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Reverse(tc.input)
+			if diff := cmp2.Diff(tc.expected, result); diff != "" {
+				t.Errorf("Reverse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClone(t *testing.T) {
+	tests := []struct {
+		name  string
+		slice []interface{}
+	}{
+		{
+			name:  "Empty",
+			slice: []interface{}{},
+		},
+		{
+			name:  "Single Element",
+			slice: []interface{}{1},
+		},
+		{
+			name:  "Multiple Elements",
+			slice: []interface{}{1, "a", 3.14159},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone := Clone(tt.slice)
+			if !reflect.DeepEqual(clone, tt.slice) {
+				t.Errorf("Clone() got = %v, want = %v", clone, tt.slice)
+			}
+		})
+	}
+}
+
 func TestDelete(t *testing.T) {
+	type s struct {
+		Junk string
+	}
 	var input []*s
 	var output []*s
 	t.Run("inner", func(t *testing.T) {
@@ -42,6 +281,42 @@ func TestDelete(t *testing.T) {
 	})
 	assert.Equal(t, output, []*s{{"a"}})
 	assert.Equal(t, input, []*s{{"a"}, nil})
+}
+
+func TestContains(t *testing.T) {
+	testCases := []struct {
+		name  string
+		slice []int
+		v     int
+		want  bool
+	}{
+		{
+			name:  "ContainsElement",
+			slice: []int{1, 2, 3, 4, 5},
+			v:     3,
+			want:  true,
+		},
+		{
+			name:  "DoesNotContainElement",
+			slice: []int{1, 2, 3, 4, 5},
+			v:     6,
+			want:  false,
+		},
+		{
+			name:  "EmptySlice",
+			slice: []int{},
+			v:     1,
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Contains(tc.slice, tc.v); got != tc.want {
+				t.Errorf("Contains(%v, %v) = %v; want %v", tc.slice, tc.v, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestFindFunc(t *testing.T) {
@@ -200,6 +475,49 @@ var (
 	s1, s2, s3 = "a", "b", "c"
 )
 
+func TestMapFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []int
+		function func(int) *int
+		want     []int
+	}{
+		{
+			name:  "RegularMapping",
+			input: []int{1, 2, 3, 4, 5},
+			function: func(num int) *int {
+				if num%2 == 0 {
+					return &num
+				}
+				return nil
+			},
+			want: []int{2, 4},
+		},
+		{
+			name:     "NilFunction",
+			input:    []int{1, 2, 3, 4, 5},
+			function: nil,
+			want:     []int{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapFilter(tc.input, tc.function)
+
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %d, want %d", got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestReference(t *testing.T) {
 	type args[E any] struct {
 		s []E
@@ -337,6 +655,54 @@ func TestDereference(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Dereference(tt.args.s); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Dereference() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input [][]int
+		want  []int
+	}{
+		{
+			name:  "simple case",
+			input: [][]int{{1, 2}, {3, 4}, {5, 6}},
+			want:  []int{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:  "empty inner slices",
+			input: [][]int{{}, {}, {}},
+			want:  []int{},
+		},
+		{
+			name:  "nil slice",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty slice",
+			input: [][]int{},
+			want:  []int{},
+		},
+		{
+			name:  "single element slices",
+			input: [][]int{{1}, {2}, {3}},
+			want:  []int{1, 2, 3},
+		},
+		{
+			name:  "mixed empty and non-empty slices",
+			input: [][]int{{1, 2}, {}, {3, 4}},
+			want:  []int{1, 2, 3, 4},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Flatten(tc.input)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Flatten(%v) = %v; want %v", tc.input, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
- adds tests to `pkg/slices` as part of #37354 
- modifies `slices.Flatten` to explicitly handle a `nil` slice as an argument
- modifies `slices.MapFilter` to add quick return in the case of a `nil` filter function, preventing a panic