### PR TITLE
Add support for DestinationRule max concurrent streams setting

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -73,9 +73,29 @@ func TestApplyDestinationRule(t *testing.T) {
 			Protocol: protocol.Unsupported,
 		},
 	}
+	http2ServicePort := model.PortList{
+		&model.Port{
+			Name:     "default",
+			Port:     8080,
+			Protocol: protocol.HTTP2,
+		},
+		&model.Port{
+			Name:     "auto",
+			Port:     9090,
+			Protocol: protocol.Unsupported,
+		},
+	}
 	service := &model.Service{
 		Hostname:   host.Name("foo.default.svc.cluster.local"),
 		Ports:      servicePort,
+		Resolution: model.ClientSideLB,
+		Attributes: model.ServiceAttributes{
+			Namespace: TestServiceNamespace,
+		},
+	}
+	http2Service := &model.Service{
+		Hostname:   host.Name("foo.default.svc.cluster.local"),
+		Ports:      http2ServicePort,
 		Resolution: model.ClientSideLB,
 		Attributes: model.ServiceAttributes{
 			Namespace: TestServiceNamespace,
@@ -279,6 +299,26 @@ func TestApplyDestinationRule(t *testing.T) {
 						Http: &networking.ConnectionPoolSettings_HTTPSettings{
 							MaxRetries:               10,
 							MaxRequestsPerConnection: 10,
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "destination rule with maxConcurrentStreams",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     http2Service,
+			port:        http2ServicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							MaxRetries:           10,
+							MaxConcurrentStreams: 10,
 						},
 					},
 				},
@@ -702,6 +742,10 @@ func TestApplyDestinationRule(t *testing.T) {
 			tt.cluster.CommonLbConfig = &cluster.Cluster_CommonLbConfig{}
 
 			ec := newClusterWrapper(tt.cluster)
+			// Set cluster wrapping with HTTP2 options if port protocol is HTTP2
+			if tt.port.Protocol == protocol.HTTP2 {
+				setH2Options(ec)
+			}
 			destRule := proxy.SidecarScope.DestinationRule(model.TrafficDirectionOutbound, proxy, tt.service.Hostname)
 			eb := endpoints.NewCDSEndpointBuilder(proxy, cb.req.Push, tt.cluster.Name,
 				model.TrafficDirectionOutbound, "", tt.service.Hostname, tt.port.Port,
@@ -725,7 +769,7 @@ func TestApplyDestinationRule(t *testing.T) {
 				}
 			}
 
-			// Validate that use client protocol configures cluster correctly.
+			// Validate that max requests per connection configures cluster correctly.
 			if tt.destRule != nil && tt.destRule.TrafficPolicy != nil && tt.destRule.TrafficPolicy.GetConnectionPool().GetHttp().GetMaxRequestsPerConnection() > 0 {
 				if ec.httpProtocolOptions == nil {
 					t.Errorf("Expected cluster %s to have http protocol options but not found", tt.cluster.Name)
@@ -736,6 +780,22 @@ func TestApplyDestinationRule(t *testing.T) {
 				if ec.httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.GetValue() !=
 					uint32(tt.destRule.TrafficPolicy.GetConnectionPool().GetHttp().MaxRequestsPerConnection) {
 					t.Errorf("Unexpected max_requests_per_connection found")
+				}
+			}
+
+			if tt.destRule.GetTrafficPolicy().GetConnectionPool().GetHttp().GetMaxConcurrentStreams() > 0 {
+				if ec.httpProtocolOptions == nil {
+					t.Errorf("Expected cluster %s to have http protocol options but not found", tt.cluster.Name)
+				}
+				if ec.httpProtocolOptions.GetExplicitHttpConfig() == nil {
+					t.Errorf("Expected cluster %s to have explicit http config but not found", tt.cluster.Name)
+				}
+				if ec.httpProtocolOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions() == nil {
+					t.Errorf("Expected cluster %s to have HTTP2 protocol options but not found", tt.cluster.Name)
+				}
+				if ec.httpProtocolOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions().GetMaxConcurrentStreams().GetValue() !=
+					uint32(tt.destRule.TrafficPolicy.GetConnectionPool().GetHttp().MaxConcurrentStreams) {
+					t.Errorf("Unexpected max_concurrent_streams found")
 				}
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
@@ -164,8 +164,9 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		if maxConnectionDuration != nil {
 			options.CommonHttpProtocolOptions.MaxConnectionDuration = maxConnectionDuration
 		}
-		if cb.isHttp2Cluster(mc) && maxConcurrentStreams > 0 {
-			http2ProtocolOptions := options.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+		// Check if cluster is HTTP2
+		http2ProtocolOptions := options.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+		if http2ProtocolOptions != nil && maxConcurrentStreams > 0 {
 			http2ProtocolOptions.MaxConcurrentStreams = &wrapperspb.UInt32Value{Value: maxConcurrentStreams}
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
@@ -104,6 +104,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 	threshold := getDefaultCircuitBreakerThresholds()
 	var idleTimeout *durationpb.Duration
 	var maxRequestsPerConnection uint32
+	var maxConcurrentStreams uint32
 	var maxConnectionDuration *duration.Duration
 
 	if settings.Http != nil {
@@ -123,6 +124,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 
 		idleTimeout = settings.Http.IdleTimeout
 		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
+		maxConcurrentStreams = uint32(settings.Http.MaxConcurrentStreams)
 	}
 
 	cb.applyDefaultConnectionPool(mc.cluster)
@@ -144,23 +146,27 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		Thresholds: []*cluster.CircuitBreakers_Thresholds{threshold},
 	}
 
-	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 {
+	if maxConnectionDuration != nil || idleTimeout != nil || maxRequestsPerConnection > 0 || maxConcurrentStreams > 0 {
 		if mc.httpProtocolOptions == nil {
 			mc.httpProtocolOptions = &http.HttpProtocolOptions{}
 		}
-		commonOptions := mc.httpProtocolOptions
-		if commonOptions.CommonHttpProtocolOptions == nil {
-			commonOptions.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
+		options := mc.httpProtocolOptions
+		if options.CommonHttpProtocolOptions == nil {
+			options.CommonHttpProtocolOptions = &core.HttpProtocolOptions{}
 		}
 		if idleTimeout != nil {
 			idleTimeoutDuration := idleTimeout
-			commonOptions.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
+			options.CommonHttpProtocolOptions.IdleTimeout = idleTimeoutDuration
 		}
 		if maxRequestsPerConnection > 0 {
-			commonOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrapperspb.UInt32Value{Value: maxRequestsPerConnection}
+			options.CommonHttpProtocolOptions.MaxRequestsPerConnection = &wrapperspb.UInt32Value{Value: maxRequestsPerConnection}
 		}
 		if maxConnectionDuration != nil {
-			commonOptions.CommonHttpProtocolOptions.MaxConnectionDuration = maxConnectionDuration
+			options.CommonHttpProtocolOptions.MaxConnectionDuration = maxConnectionDuration
+		}
+		if cb.isHttp2Cluster(mc) && maxConcurrentStreams > 0 {
+			http2ProtocolOptions := options.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+			http2ProtocolOptions.MaxConcurrentStreams = &wrapperspb.UInt32Value{Value: maxConcurrentStreams}
 		}
 	}
 	if settings.Http != nil && settings.Http.UseClientProtocol {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1472,6 +1472,9 @@ func validateConnectionPool(settings *networking.ConnectionPoolSettings) (errs e
 		if httpSettings.H2UpgradePolicy == networking.ConnectionPoolSettings_HTTPSettings_UPGRADE && httpSettings.UseClientProtocol {
 			errs = appendErrors(errs, fmt.Errorf("use client protocol must not be true when H2UpgradePolicy is UPGRADE"))
 		}
+		if httpSettings.MaxConcurrentStreams < 0 {
+			errs = appendErrors(errs, fmt.Errorf("max concurrent streams must be non-negative"))
+		}
 	}
 
 	if tcp := settings.Tcp; tcp != nil {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4222,6 +4222,7 @@ func TestValidateConnectionPool(t *testing.T) {
 					MaxRequestsPerConnection: 5,
 					MaxRetries:               4,
 					IdleTimeout:              &durationpb.Duration{Seconds: 30},
+					MaxConcurrentStreams:     5,
 				},
 			},
 			valid: true,
@@ -4245,6 +4246,7 @@ func TestValidateConnectionPool(t *testing.T) {
 					MaxRequestsPerConnection: 5,
 					MaxRetries:               4,
 					IdleTimeout:              &durationpb.Duration{Seconds: 30},
+					MaxConcurrentStreams:     5,
 				},
 			},
 			valid: true,
@@ -4257,6 +4259,7 @@ func TestValidateConnectionPool(t *testing.T) {
 					Http2MaxRequests:         11,
 					MaxRequestsPerConnection: 5,
 					MaxRetries:               4,
+					MaxConcurrentStreams:     5,
 				},
 			},
 			valid: true,
@@ -4311,6 +4314,13 @@ func TestValidateConnectionPool(t *testing.T) {
 		{
 			name: "invalid connection pool, bad idle timeout", in: &networking.ConnectionPoolSettings{
 				Http: &networking.ConnectionPoolSettings_HTTPSettings{IdleTimeout: &durationpb.Duration{Seconds: 30, Nanos: 5}},
+			},
+			valid: false,
+		},
+
+		{
+			name: "invalid connection pool, bad max concurrent streams", in: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{MaxConcurrentStreams: -1},
 			},
 			valid: false,
 		},

--- a/releasenotes/notes/max-concurrent-streams.yaml
+++ b/releasenotes/notes/max-concurrent-streams.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** support for a max concurrent streams setting in the DestinationRule's HTTP traffic policy for HTTP2 conections.


### PR DESCRIPTION
**Please provide a description of this PR:**

istiod changes to support the [max concurrent streams](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-http2protocoloptions-max-concurrent-streams) setting added in https://github.com/istio/api/pull/2952 in a traffic policy definition in a DestinationRule.  

Resolves #47166 

Outstanding Questions:
- Should http2 specific settings apply to clusters upgraded to HTTP2? With the current change, the max concurrent streams field is ignored unless the upstream protocol is explicitly set to HTTP2.

Testing:
- Verified envoy config is updated in response to a DestinationRule being applied with maxConcurrentStreams set on a service with `appProtocol: http2`
- Verified maxConcurrentStream is not set in the envoy config when the corresponding service does not explicitly set `appProtocol` to http2