### PR TITLE
log: override values instead of adding when multiple k/v pairs

### DIFF
--- a/pkg/log/scope.go
+++ b/pkg/log/scope.go
@@ -302,7 +302,12 @@ func (s *Scope) WithLabels(kvlist ...any) *Scope {
 			out.labels["WithLabels error"] = fmt.Sprintf("label name %v must be a string, got %T ", keyi, keyi)
 			return out
 		}
+		_, override := out.labels[key]
 		out.labels[key] = kvlist[i+1]
+		if override {
+			// Key already set, just modify the value
+			continue
+		}
 		out.labelKeys = append(out.labelKeys, key)
 	}
 	return out

--- a/pkg/log/scope_test.go
+++ b/pkg/log/scope_test.go
@@ -269,7 +269,7 @@ func TestScopeWithLabel(t *testing.T) {
 	lines, err := captureStdout(func() {
 		Configure(DefaultOptions())
 		funcs.Store(funcs.Load().(patchTable))
-		s2 := s.WithLabels("foo", "bar").WithLabels("baz", 123, "qux", 0.123)
+		s2 := s.WithLabels("foo", "bar").WithLabels("baz", 123, "qux", 0.123).WithLabels("foo", "override")
 		s2.Debug("Hello")
 		// s should be unmodified.
 		s.Debug("Hello")
@@ -280,7 +280,7 @@ func TestScopeWithLabel(t *testing.T) {
 		t.Errorf("Got error '%v', expected success", err)
 	}
 
-	mustRegexMatchString(t, lines[0], `Hello	foo=bar baz=123 qux=0.123`)
+	mustRegexMatchString(t, lines[0], `Hello	foo=override baz=123 qux=0.123`)
 	mustRegexMatchString(t, lines[1], "Hello$")
 }
 


### PR DESCRIPTION
Otherwise we end up printing the same value twice
