### PR TITLE
Make json processing more robust

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -430,14 +430,19 @@ func (l StringList) MarshalJSON() ([]byte, error) {
 	if l == nil {
 		return nil, nil
 	}
-	return []byte(`"` + strings.Join(l, ",") + `"`), nil
+	return json.Marshal(strings.Join(l, ","))
 }
 
 func (l *StringList) UnmarshalJSON(data []byte) error {
-	if len(data) < 2 || string(data) == `""` {
+	var inner string
+	err := json.Unmarshal(data, &inner)
+	if err != nil {
+		return err
+	}
+	if len(inner) == 0 {
 		*l = []string{}
 	} else {
-		*l = strings.Split(string(data[1:len(data)-1]), ",")
+		*l = strings.Split(inner, ",")
 	}
 	return nil
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -153,10 +153,10 @@ func TestStringList(t *testing.T) {
 		noRoundTrip bool
 	}{
 		{in: `"a,b,c"`, expect: []string{"a", "b", "c"}},
+		{in: `"\"a,b,c"`, expect: []string{`"a`, "b", "c"}},
 		{in: `"a"`, expect: []string{"a"}},
 		{in: `""`, expect: []string{}},
 		{in: `"123,@#$#,abcdef"`, expect: []string{"123", "@#$#", "abcdef"}},
-		{in: `1`, expect: []string{}, noRoundTrip: true},
 	}
 	for _, tt := range cases {
 		t.Run(tt.in, func(t *testing.T) {
@@ -179,6 +179,9 @@ func TestStringList(t *testing.T) {
 			}
 		})
 	}
+	// Invalid case
+	var out model.StringList
+	assert.Error(t, json.Unmarshal([]byte("1"), &out))
 }
 
 func TestPodPortList(t *testing.T) {


### PR DESCRIPTION
The old logic doesn't handle json escaping. As a result, we could send
out invalid strings like `"foo"bar"`. This confuses the json processor
*which can lead to panics in json marshal library*.
