### PR TITLE
Update version portion of bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,8 +37,9 @@ body:
         client version: 1.0.0
         control plane version: 1.0.0
         data plane version: 1.0.0 (100 proxies)
-        $ kubectl version --short
+        $ kubectl version
         Client Version: v1.0.0
+        Kustomize Version: v1.0.0
         Server Version: v1.0.0
       render: Text
     validations:


### PR DESCRIPTION
**Please provide a description of this PR:**

> Flag `--short` has been deprecated, and will be removed in the future.

It was removed in 1.28 - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#deprecation