### PR TITLE
optimize schema analysis performance

### DIFF
--- a/pkg/config/analysis/analyzer.go
+++ b/pkg/config/analysis/analyzer.go
@@ -83,8 +83,9 @@ func (c *CombinedAnalyzer) Analyze(ctx Context) {
 // should be disabled. Any analyzers that require those output collections will be removed.
 // 2. The analyzer requires a collection not available in the current snapshot(s)
 func (c *CombinedAnalyzer) RemoveSkipped(schemas collection.Schemas) []string {
-	s := sets.New[config.GroupVersionKind]()
-	for _, sc := range schemas.All() {
+	allSchemas := schemas.All()
+	s := sets.NewWithLength[config.GroupVersionKind](len(allSchemas))
+	for _, sc := range allSchemas {
 		s.Insert(sc.GroupVersionKind())
 	}
 
@@ -109,7 +110,7 @@ mainloop:
 
 // AnalyzerNames returns the names of analyzers in this combined analyzer
 func (c *CombinedAnalyzer) AnalyzerNames() []string {
-	var result []string
+	result := make([]string, 0, len(c.analyzers))
 	for _, a := range c.analyzers {
 		result = append(result, a.Metadata().Name)
 	}
@@ -117,7 +118,7 @@ func (c *CombinedAnalyzer) AnalyzerNames() []string {
 }
 
 func combineInputs(analyzers []Analyzer) []config.GroupVersionKind {
-	result := sets.New[config.GroupVersionKind]()
+	result := sets.NewWithLength[config.GroupVersionKind](len(analyzers))
 	for _, a := range analyzers {
 		result.InsertAll(a.Metadata().Inputs...)
 	}

--- a/pkg/config/analysis/analyzers/schema/validation.go
+++ b/pkg/config/analysis/analyzers/schema/validation.go
@@ -14,8 +14,6 @@
 package schema
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/config"
@@ -53,8 +51,8 @@ func AllValidationAnalyzers() []analysis.Analyzer {
 // Metadata implements Analyzer
 func (a *ValidationAnalyzer) Metadata() analysis.Metadata {
 	return analysis.Metadata{
-		Name:        fmt.Sprintf("schema.ValidationAnalyzer.%s", a.s.Kind()),
-		Description: fmt.Sprintf("Runs schema validation as an analyzer on '%s' resources", a.s.Kind()),
+		Name:        "schema.ValidationAnalyzer." + a.s.Kind(),
+		Description: "Runs schema validation as an analyzer on '" + a.s.Kind() + "' resources",
 		Inputs:      []config.GroupVersionKind{a.s.GroupVersionKind()},
 	}
 }

--- a/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -130,6 +130,17 @@ func TestSchemaValidationWrapper(t *testing.T) {
 	})
 }
 
+func BenchmarkMetadata(b *testing.B) {
+	a := ValidationAnalyzer{
+		s: schemaWithValidateFn(validation.EmptyValidate),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		a.Metadata()
+	}
+}
+
 func schemaWithValidateFn(validateFn func(cfg config.Config) (validation.Warning, error)) resource2.Schema {
 	original := collections.VirtualService
 	return resource2.Builder{

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -132,11 +132,12 @@ func (sa *IstiodAnalyzer) ReAnalyze(cancel <-chan struct{}) (AnalysisResult, err
 }
 
 func (sa *IstiodAnalyzer) internalAnalyze(a *analysis.CombinedAnalyzer, cancel <-chan struct{}) (AnalysisResult, error) {
-	var result AnalysisResult
-	result.MappedMessages = map[string]diag.Messages{}
 	store := sa.initializedStore
+
+	var result AnalysisResult
 	result.ExecutedAnalyzers = a.AnalyzerNames()
 	result.SkippedAnalyzers = a.RemoveSkipped(store.Schemas())
+	result.MappedMessages = make(map[string]diag.Messages, len(result.ExecutedAnalyzers))
 
 	kubelib.WaitForCacheSync("istiod analyzer", cancel, store.HasSynced)
 


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/48665#issuecomment-1880316526, optimize `mapassign` and `fmt.Sprintf` performance issues.

Benchmark Metadata result: 
```code
$ benchstat old.txt new.txt
goos: darwin
goarch: amd64
pkg: istio.io/istio/pkg/config/analysis/analyzers/schema
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
            │   old.txt   │              new.txt               │
            │   sec/op    │   sec/op     vs base               │
Metadata-12   348.0n ± 6%   146.3n ± 7%  -57.96% (p=0.002 n=6)

            │  old.txt   │              new.txt              │
            │    B/op    │    B/op     vs base               │
Metadata-12   208.0 ± 0%   176.0 ± 0%  -15.38% (p=0.002 n=6)

            │  old.txt   │              new.txt              │
            │ allocs/op  │ allocs/op   vs base               │
Metadata-12   5.000 ± 0%   3.000 ± 0%  -40.00% (p=0.002 n=6)
```