### PR TITLE
Exclude leaderelection locks in in-cluster analysis

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/revisions"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // Various locks used throughout the code
@@ -55,6 +56,20 @@ const (
 	// * Other types use "prioritized leader election", which isn't implemented for Lease
 	GatewayDeploymentController = "istio-gateway-deployment"
 )
+
+var istioLocks = sets.New[string](
+	NamespaceController,
+	ServiceExportController,
+	IngressController,
+	GatewayStatusController,
+	StatusController,
+	AnalyzeController,
+	GatewayDeploymentController,
+)
+
+func IsIstioLocks(name string) bool {
+	return istioLocks.Contains(name)
+}
 
 // Leader election key prefix for remote istiod managed clusters
 const remoteIstiodPrefix = "^"

--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/file"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
 	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis"
@@ -310,7 +311,7 @@ func isIstioConfigMap(obj any) bool {
 	if !ok {
 		return false
 	}
-	return strings.HasPrefix(cObj.GetName(), "istio")
+	return strings.HasPrefix(cObj.GetName(), "istio") && !leaderelection.IsIstioLocks(cObj.GetName())
 }
 
 var secretFieldSelector = fields.AndSelectors(


### PR DESCRIPTION
**Please provide a description of this PR:**
Part of https://github.com/istio/istio/issues/48665

The locks are keeping changing, which results in excessive analysis loops even when no config is changed.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
