### PR TITLE
Fix the webhook conflict issue that occurs when installing a default-revisioned Istio in an environment where revisioned Istio is already present

### DIFF
--- a/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/default_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/default_tag.yaml
@@ -1,0 +1,167 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  generation: 1
+  labels:
+    app: sidecar-injector
+    istio.io/rev: test-dev2
+    istio.io/tag: default
+    release: istio
+  name: istio-revision-tag-default
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod-test-dev2
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: rev.namespace.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - default
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod-test-dev2
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: rev.object.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - default
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod-test-dev2
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: namespace.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: In
+      values:
+      - enabled
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod-test-dev2
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: object.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: DoesNotExist
+    - key: istio.io/rev
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: In
+      values:
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10

--- a/operator/cmd/mesh/testdata/manifest-generate/input/minimal-revisioned.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/minimal-revisioned.yaml
@@ -1,0 +1,5 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: minimal
+  revision: test-rev

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -501,24 +501,24 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 	var localWebhookYAMLReaders []local.ReaderSource
 	var parsedK8sObjects object.K8sObjects
 	exists := revtag.PreviousInstallExists(context.Background(), h.kubeClient.Kube())
-	// Here if we need to create a default tag, we need to skip the webhooks that are going to be deactivated.
-	if !detectIfTagWebhookIsNeeded(h.iop, exists) {
-		for i, wh := range whs {
-			k8sObjects, err := object.ParseK8sObjectsFromYAMLManifest(wh)
-			if err != nil {
-				return err
-			}
-			objYaml, err := k8sObjects.YAMLManifest()
-			if err != nil {
-				return err
-			}
+	for i, wh := range whs {
+		k8sObjects, err := object.ParseK8sObjectsFromYAMLManifest(wh)
+		if err != nil {
+			return err
+		}
+		objYaml, err := k8sObjects.YAMLManifest()
+		if err != nil {
+			return err
+		}
+		// Here if we need to create a default tag, we need to skip the webhooks that are going to be deactivated.
+		if !detectIfTagWebhookIsNeeded(h.iop, exists) {
 			whReaderSource := local.ReaderSource{
 				Name:   fmt.Sprintf("installed-webhook-%d", i),
 				Reader: strings.NewReader(objYaml),
 			}
 			localWebhookYAMLReaders = append(localWebhookYAMLReaders, whReaderSource)
-			parsedK8sObjects = append(parsedK8sObjects, k8sObjects...)
 		}
+		parsedK8sObjects = append(parsedK8sObjects, k8sObjects...)
 	}
 
 	sa := local.NewSourceAnalyzer(analysis.Combine("webhook", &webhook.Analyzer{

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -52,7 +52,6 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/version"
 )
 
@@ -498,22 +497,32 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 		return nil
 	}
 
-	skippedWebhooks := sets.New[string]()
+	// Add webhook manifests to be applied
+	var localWebhookYAMLReaders []local.ReaderSource
+	var parsedK8sObjects object.K8sObjects
 	exists := revtag.PreviousInstallExists(context.Background(), h.kubeClient.Kube())
 	// Here if we need to create a default tag, we need to skip the webhooks that are going to be deactivated.
-	if detectIfTagWebhookIsNeeded(h.iop, exists) {
-		whs, err := revtag.GetWebhooksWithRevision(context.Background(), h.kubeClient.Kube(), revtag.DefaultRevisionName)
-		if err != nil {
-			return err
-		}
-		for _, wh := range whs {
-			skippedWebhooks.Insert(wh.GetName())
+	if !detectIfTagWebhookIsNeeded(h.iop, exists) {
+		for i, wh := range whs {
+			k8sObjects, err := object.ParseK8sObjectsFromYAMLManifest(wh)
+			if err != nil {
+				return err
+			}
+			objYaml, err := k8sObjects.YAMLManifest()
+			if err != nil {
+				return err
+			}
+			whReaderSource := local.ReaderSource{
+				Name:   fmt.Sprintf("installed-webhook-%d", i),
+				Reader: strings.NewReader(objYaml),
+			}
+			localWebhookYAMLReaders = append(localWebhookYAMLReaders, whReaderSource)
+			parsedK8sObjects = append(parsedK8sObjects, k8sObjects...)
 		}
 	}
 
 	sa := local.NewSourceAnalyzer(analysis.Combine("webhook", &webhook.Analyzer{
 		SkipServiceCheck: true,
-		SkippedWebhooks:  skippedWebhooks,
 	}), resource.Namespace(h.iop.Spec.GetNamespace()), resource.Namespace(istioV1Alpha1.Namespace(h.iop.Spec)), nil)
 
 	// Add in-cluster webhooks
@@ -538,25 +547,6 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 		}
 	}
 
-	// Add webhook manifests to be applied
-	var localWebhookYAMLReaders []local.ReaderSource
-	var parsedK8sObjects object.K8sObjects
-	for i, wh := range whs {
-		k8sObjects, err := object.ParseK8sObjectsFromYAMLManifest(wh)
-		if err != nil {
-			return err
-		}
-		objYaml, err := k8sObjects.YAMLManifest()
-		if err != nil {
-			return err
-		}
-		whReaderSource := local.ReaderSource{
-			Name:   fmt.Sprintf("installed-webhook-%d", i),
-			Reader: strings.NewReader(objYaml),
-		}
-		localWebhookYAMLReaders = append(localWebhookYAMLReaders, whReaderSource)
-		parsedK8sObjects = append(parsedK8sObjects, k8sObjects...)
-	}
 	err = sa.AddReaderKubeSource(localWebhookYAMLReaders)
 	if err != nil {
 		return err

--- a/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -33,9 +33,6 @@ import (
 
 type Analyzer struct {
 	SkipServiceCheck bool
-	// SkippedWebhooks is a list of webhooks to skip, this happens when the webhook is not actually
-	// going to be used in the current revision.
-	SkippedWebhooks sets.Set[string]
 }
 
 var _ analysis.Analyzer = &Analyzer{}
@@ -76,9 +73,6 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 	resources := map[string]*resource.Instance{}
 	revisions := sets.New[string]()
 	context.ForEach(gvk.MutatingWebhookConfiguration, func(resource *resource.Instance) bool {
-		if a.SkippedWebhooks.Contains(resource.Metadata.FullName.Name.String()) {
-			return true
-		}
 		wh := resource.Message.(*v1.MutatingWebhookConfiguration)
 		revs := extractRevisions(wh)
 		if len(revs) == 0 && !isIstioWebhook(wh) {


### PR DESCRIPTION
**Please provide a description of this PR:**
This issue is a regression from https://github.com/istio/istio/pull/48147. The conflict webhook occurs again when the revisioned control plane is installed first, such as with `istioctl install --revision=canary`. This command installs a default tag webhook because no Istio installation exists yet. 
Then, installing a normal "default" version using `istioctl install` results in a conflict, as the `istio-sidecar-injector` webhook to be installed conflicts with the existing default tag webhook. In this scenario, we cannot find the existing webhook in the cluster to skip it, as it hasn't been installed. Therefore, we can ignore this webhook instead of adding it to skippedWebhooks, as it will be deactivated after the installation.