### PR TITLE
agent: trim viper and yaml.v3 deps, dropping 2M off the binary size

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 
 	"istio.io/istio/cni/pkg/ambient"
@@ -140,7 +139,7 @@ func init() {
 	ctrlzOptions.AttachCobraFlags(rootCmd)
 
 	rootCmd.AddCommand(version.CobraCommand())
-	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
+	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{
 		Title:   "Istio CNI Plugin Installer",
 		Section: "install-cni CLI",
 		Manual:  "Istio CNI Plugin Installer",

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 
 	"istio.io/istio/istioctl/pkg/admin"
@@ -248,7 +247,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand(ctx))
 	rootCmd.AddCommand(proxyconfig.ClustersCommand(ctx))
 
-	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
+	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{
 		Title:   "Istio Control",
 		Section: "istioctl CLI",
 		Manual:  "Istio Control",

--- a/operator/cmd/operator/root.go
+++ b/operator/cmd/operator/root.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/version"
@@ -39,7 +38,7 @@ func getRootCmd(args []string) *cobra.Command {
 
 	rootCmd.AddCommand(serverCmd())
 	rootCmd.AddCommand(version.CobraCommand())
-	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
+	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{
 		Title:   "Istio Operator",
 		Section: "operator CLI",
 		Manual:  "Istio Operator",

--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -87,7 +86,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(iptables.GetCommand())
 	rootCmd.AddCommand(cleaniptables.GetCommand())
 
-	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
+	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{
 		Title:   "Istio Pilot Agent",
 		Section: "pilot-agent CLI",
 		Manual:  "Istio Pilot Agent",

--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/features"
@@ -59,7 +58,7 @@ func NewRootCommand() *cobra.Command {
 	addFlags(discoveryCmd)
 	rootCmd.AddCommand(discoveryCmd)
 	rootCmd.AddCommand(version.CobraCommand())
-	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
+	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{
 		Title:   "Istio Pilot Discovery",
 		Section: "pilot-discovery CLI",
 		Manual:  "Istio Pilot Discovery",

--- a/pkg/collateral/cobra.go
+++ b/pkg/collateral/cobra.go
@@ -14,57 +14,8 @@
 
 package collateral
 
-import (
-	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
-)
-
-// CobraCommand returns a Cobra command used to output a tool's collateral files (markdown docs, bash completion & man pages)
-// The root argument must be the root command for the tool.
-func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
-	return CobraCommandWithFilter(root, hdr, Predicates{})
-}
-
-// CobraCommandWithFilter returns a Cobra command used to output a tool's collateral files (markdown docs, bash
-// completion & man pages). It allows passing in a set of predicates to filter out and remove items selectively.
-// The root argument must be the root command for the tool.
-func CobraCommandWithFilter(root *cobra.Command, hdr *doc.GenManHeader, p Predicates) *cobra.Command {
-	c := Control{
-		OutputDir:  ".",
-		Predicates: p,
-	}
-
-	var all bool
-
-	cmd := &cobra.Command{
-		Use:    "collateral",
-		Short:  "Generate collateral support files for this program",
-		Hidden: true,
-
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if all {
-				c.EmitYAML = true
-				c.EmitBashCompletion = true
-				c.EmitZshCompletion = true
-				c.EmitManPages = true
-				c.EmitMarkdown = true
-				c.EmitHTMLFragmentWithFrontMatter = true
-				c.ManPageInfo = *hdr
-			}
-
-			return EmitCollateral(root, &c)
-		},
-	}
-
-	cmd.Flags().StringVarP(&c.OutputDir, "outputDir", "o", c.OutputDir, "Directory where to generate the collateral files")
-	cmd.Flags().BoolVarP(&all, "all", "", all, "Produce all supported collateral files")
-	cmd.Flags().BoolVarP(&c.EmitMarkdown, "markdown", "", c.EmitMarkdown, "Produce markdown documentation files")
-	cmd.Flags().BoolVarP(&c.EmitManPages, "man", "", c.EmitManPages, "Produce man pages")
-	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
-	cmd.Flags().BoolVarP(&c.EmitZshCompletion, "zsh", "", c.EmitZshCompletion, "Produce zsh completion files")
-	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
-	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
-		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
-
-	return cmd
+type Metadata struct {
+	Title   string
+	Section string
+	Manual  string
 }

--- a/pkg/collateral/cobra_agent.go
+++ b/pkg/collateral/cobra_agent.go
@@ -1,0 +1,39 @@
+//go:build agent
+// +build agent
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collateral
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// cobraCommandWithFilter returns a Cobra command used to output a tool's collateral files (markdown docs, bash
+// completion & man pages). It allows passing in a set of predicates to filter out and remove items selectively.
+// The root argument must be the root command for the tool.
+func CobraCommand(root *cobra.Command, meta Metadata) *cobra.Command {
+	return &cobra.Command{
+		Use:    "collateral",
+		Short:  "Generate collateral support files for this program",
+		Hidden: true,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("this build is not compiled with collateral support")
+		},
+	}
+}

--- a/pkg/collateral/cobra_noagent.go
+++ b/pkg/collateral/cobra_noagent.go
@@ -1,0 +1,70 @@
+//go:build !agent
+// +build !agent
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collateral
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+// CobraCommand returns a Cobra command used to output a tool's collateral files (markdown docs, bash completion & man pages)
+// The root argument must be the root command for the tool.
+func CobraCommand(root *cobra.Command, meta Metadata) *cobra.Command {
+	hdr := &doc.GenManHeader{
+		Title:   meta.Title,
+		Section: meta.Section,
+		Manual:  meta.Manual,
+	}
+	c := Control{
+		OutputDir: ".",
+	}
+
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:    "collateral",
+		Short:  "Generate collateral support files for this program",
+		Hidden: true,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				c.EmitYAML = true
+				c.EmitBashCompletion = true
+				c.EmitZshCompletion = true
+				c.EmitManPages = true
+				c.EmitMarkdown = true
+				c.EmitHTMLFragmentWithFrontMatter = true
+				c.ManPageInfo = *hdr
+			}
+
+			return EmitCollateral(root, &c)
+		},
+	}
+
+	cmd.Flags().StringVarP(&c.OutputDir, "outputDir", "o", c.OutputDir, "Directory where to generate the collateral files")
+	cmd.Flags().BoolVarP(&all, "all", "", all, "Produce all supported collateral files")
+	cmd.Flags().BoolVarP(&c.EmitMarkdown, "markdown", "", c.EmitMarkdown, "Produce markdown documentation files")
+	cmd.Flags().BoolVarP(&c.EmitManPages, "man", "", c.EmitManPages, "Produce man pages")
+	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
+	cmd.Flags().BoolVarP(&c.EmitZshCompletion, "zsh", "", c.EmitZshCompletion, "Produce zsh completion files")
+	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
+	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
+		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
+
+	return cmd
+}

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -1,3 +1,6 @@
+//go:build !agent
+// +build !agent
+
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -51,16 +51,6 @@ var exittypeToString = map[XTablesExittype]string{
 	XTablesResourceProblem:  "xtables resource problem",
 }
 
-// XTablesCmds is the set of all the xtables-related commands currently supported.
-var XTablesCmds = sets.New(
-	constants.IPTABLES,
-	constants.IP6TABLES,
-	constants.IPTABLESRESTORE,
-	constants.IP6TABLESRESTORE,
-	constants.IPTABLESSAVE,
-	constants.IP6TABLESSAVE,
-)
-
 // XTablesWriteCmds contains all xtables commands that do write actions (and thus need a lock)
 var XTablesWriteCmds = sets.New(
 	constants.IPTABLES,
@@ -137,20 +127,11 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 }
 
 // Run runs a command
-func (r *RealDependencies) Run(cmd string, stdin io.ReadSeeker, args ...string) (err error) {
-	if XTablesCmds.Contains(cmd) {
-		err = r.executeXTables(cmd, false, stdin, args...)
-	} else {
-		err = r.execute(cmd, false, stdin, args...)
-	}
-	return err
+func (r *RealDependencies) Run(cmd string, stdin io.ReadSeeker, args ...string) error {
+	return r.executeXTables(cmd, false, stdin, args...)
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
 func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, stdin io.ReadSeeker, args ...string) {
-	if XTablesCmds.Contains(cmd) {
-		_ = r.executeXTables(cmd, true, stdin, args...)
-	} else {
-		_ = r.execute(cmd, true, stdin, args...)
-	}
+	_ = r.executeXTables(cmd, true, stdin, args...)
 }


### PR DESCRIPTION
```
$ CGO_ENABLED=0 go build -ldflags '-s -w' -trimpath -tags=agent ./pilot/cmd/pilot-agent; du -sh pilot-agent; stat -c %s pilot-agent
41M     pilot-agent
42864640
$ g co master
$ CGO_ENABLED=0 go build -ldflags '-s -w' -trimpath -tags=agent ./pilot/cmd/pilot-agent; du -sh pilot-agent; stat -c %s pilot-agent
43M     pilot-agent
44249088
```

This removes the `execute` path in iptables code. This is legacy code no longer used. We can have a pretty high degree of confidence in this, too, because distroless _only_ has iptables binaries,