### PR TITLE
Cleanup deadcode in StatusGen

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -379,9 +379,6 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 		errCode := codes.Code(request.ErrorDetail.Code)
 		log.Warnf("ADS:%s: ACK ERROR %s %s:%s", stype, con.conID, errCode.String(), request.ErrorDetail.GetMessage())
 		incrementXDSRejects(request.TypeUrl, con.proxy.ID, errCode.String())
-		if s.StatusGen != nil {
-			s.StatusGen.OnNack(con.proxy, request)
-		}
 		return false, emptyResourceDelta
 	}
 
@@ -583,9 +580,6 @@ func (s *DiscoveryServer) closeConnection(con *Connection) {
 		return
 	}
 	s.removeCon(con.conID)
-	if s.StatusGen != nil {
-		s.StatusGen.OnDisconnect(con)
-	}
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterDisconnect(con.conID, AllEventTypesList)
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -325,9 +325,6 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		errCode := codes.Code(request.ErrorDetail.Code)
 		deltaLog.Warnf("ADS:%s: ACK ERROR %s %s:%s", stype, con.conID, errCode.String(), request.ErrorDetail.GetMessage())
 		incrementXDSRejects(request.TypeUrl, con.proxy.ID, errCode.String())
-		if s.StatusGen != nil {
-			s.StatusGen.OnNack(con.proxy, deltaToSotwRequest(request))
-		}
 		return false
 	}
 

--- a/pilot/pkg/xds/statusgen.go
+++ b/pilot/pkg/xds/statusgen.go
@@ -32,14 +32,6 @@ const (
 	// TypeURLConnect generate connect event.
 	TypeURLConnect = "istio.io/connect"
 
-	// TypeURLDisconnect generate disconnect event.
-	TypeURLDisconnect = "istio.io/disconnect"
-
-	// TypeURLNACK will receive messages of type DiscoveryRequest, containing
-	// the 'NACK' from envoy on rejected configs. Only ID is set in metadata.
-	// This includes all the info that envoy (client) provides.
-	TypeURLNACK = "istio.io/nack"
-
 	TypeDebugPrefix = v3.DebugType + "/"
 
 	// TypeDebugSyncronization requests Envoy CSDS for proxy sync status
@@ -211,19 +203,6 @@ func (sg *StatusGen) debugConfigDump(proxyID string) (model.Resources, error) {
 
 func (sg *StatusGen) OnConnect(con *Connection) {
 	sg.pushStatusEvent(TypeURLConnect, []proto.Message{con.node})
-}
-
-func (sg *StatusGen) OnDisconnect(con *Connection) {
-	sg.pushStatusEvent(TypeURLDisconnect, []proto.Message{con.node})
-}
-
-func (sg *StatusGen) OnNack(node *model.Proxy, dr *discovery.DiscoveryRequest) {
-	// Make sure we include the ID - the DR may not include metadata
-	if dr.Node == nil {
-		dr.Node = &core.Node{}
-	}
-	dr.Node.Id = node.ID
-	sg.pushStatusEvent(TypeURLNACK, []proto.Message{dr})
 }
 
 // pushStatusEvent is similar with DiscoveryServer.pushStatusEvent() - but called directly,


### PR DESCRIPTION
These are unused; the types are not part of generators so its impossible to query.

Ill have another PR cleaning up more, but splitting out the non-controversial bits