### PR TITLE
Remove "Connect" type URL

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -568,10 +568,6 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 		s.closeConnection(con)
 		return err
 	}
-
-	if s.StatusGen != nil {
-		s.StatusGen.OnConnect(con)
-	}
 	return nil
 }
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -45,43 +45,6 @@ const (
 	routeB = "https.443.https.my-gateway.testns"
 )
 
-func TestStatusEvents(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-
-	ads := s.Connect(
-		&model.Proxy{
-			Metadata: &model.NodeMetadata{
-				Generator: "event",
-			},
-		},
-		[]string{xds.TypeURLConnect},
-		[]string{},
-	)
-	defer ads.Close()
-
-	dr, err := ads.WaitVersion(5*time.Second, xds.TypeURLConnect, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if dr.Resources == nil || len(dr.Resources) == 0 {
-		t.Error("Expected connections, but not found")
-	}
-
-	// Create a second connection - we should get an event.
-	ads2 := s.Connect(nil, nil, nil)
-	defer ads2.Close()
-
-	dr, err = ads.WaitVersion(5*time.Second, xds.TypeURLConnect,
-		dr.VersionInfo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dr.Resources == nil || len(dr.Resources) == 0 {
-		t.Error("Expected connections, but not found")
-	}
-}
-
 func TestAdsReconnectAfterRestart(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -116,8 +116,6 @@ type DiscoveryServer struct {
 	// Authenticators for XDS requests. Should be same/subset of the CA authenticators.
 	Authenticators []security.Authenticator
 
-	// StatusGen is notified of connect/disconnect/nack on all connections
-	StatusGen               *StatusGen
 	WorkloadEntryController *autoregistration.Controller
 
 	// serverReady indicates caches have been synced up and server is ready to process requests.
@@ -529,7 +527,6 @@ func (s *DiscoveryServer) sendPushes(stopCh <-chan struct{}) {
 // InitGenerators initializes generators to be used by XdsServer.
 func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace string, clusterID cluster.ID, internalDebugMux *http.ServeMux) {
 	edsGen := &EdsGenerator{Server: s}
-	s.StatusGen = NewStatusGen(s)
 	s.Generators[v3.ClusterType] = &CdsGenerator{Server: s}
 	s.Generators[v3.ListenerType] = &LdsGenerator{Server: s}
 	s.Generators[v3.RouteType] = &RdsGenerator{Server: s}
@@ -557,9 +554,7 @@ func (s *DiscoveryServer) InitGenerators(env *model.Environment, systemNameSpace
 	s.Generators["api"] = apigen.NewGenerator(env.ConfigStore)
 	s.Generators["api/"+v3.EndpointType] = edsGen
 
-	s.Generators["api/"+TypeURLConnect] = s.StatusGen
-
-	s.Generators["event"] = s.StatusGen
+	s.Generators["event"] = NewStatusGen(s)
 	s.Generators[v3.DebugType] = NewDebugGen(s, systemNameSpace, internalDebugMux)
 }
 


### PR DESCRIPTION
Builds on https://github.com/istio/istio/pull/48706

This has two usage:
1. Real usage in istioctl to serve `istioctl x version`.
2. Theoretical use case to subscribe to Connection events. I don't think
  there are any actual users of this

This PR moves (1) to use the Syncz mechanism. This already reports all
proxies, so the info is pretty much redundant. We can just use that.
Typically we would make istioctl change first then Istiod in future
release, but since this is experimental I think its fine to change
together.