### PR TITLE
Drop direct dependency on xds to networking/v1alpha3

### DIFF
--- a/pilot/pkg/bootstrap/discovery.go
+++ b/pilot/pkg/bootstrap/discovery.go
@@ -1,0 +1,69 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"net/http"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/apigen"
+	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/grpcgen"
+	"istio.io/istio/pilot/pkg/xds"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/cluster"
+)
+
+func InitGenerators(
+	s *xds.DiscoveryServer,
+	cg core.ConfigGenerator,
+	systemNameSpace string,
+	clusterID cluster.ID,
+	internalDebugMux *http.ServeMux,
+) {
+	env := s.Env
+	generators := map[string]model.XdsResourceGenerator{}
+	edsGen := &xds.EdsGenerator{Cache: s.Cache, EndpointIndex: env.EndpointIndex}
+	generators[v3.ClusterType] = &xds.CdsGenerator{ConfigGenerator: cg}
+	generators[v3.ListenerType] = &xds.LdsGenerator{ConfigGenerator: cg}
+	generators[v3.RouteType] = &xds.RdsGenerator{ConfigGenerator: cg}
+	generators[v3.EndpointType] = edsGen
+	ecdsGen := &xds.EcdsGenerator{ConfigGenerator: cg}
+	if env.CredentialsController != nil {
+		generators[v3.SecretType] = xds.NewSecretGen(env.CredentialsController, s.Cache, clusterID, env.Mesh())
+		ecdsGen.SetCredController(env.CredentialsController)
+	}
+	generators[v3.ExtensionConfigurationType] = ecdsGen
+	generators[v3.NameTableType] = &xds.NdsGenerator{ConfigGenerator: cg}
+	generators[v3.ProxyConfigType] = &xds.PcdsGenerator{TrustBundle: env.TrustBundle}
+
+	workloadGen := &xds.WorkloadGenerator{Server: s}
+	generators[v3.AddressType] = workloadGen
+	generators[v3.WorkloadType] = workloadGen
+	generators[v3.WorkloadAuthorizationType] = &xds.WorkloadRBACGenerator{Server: s}
+
+	generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
+	generators["grpc/"+v3.EndpointType] = edsGen
+	generators["grpc/"+v3.ListenerType] = generators["grpc"]
+	generators["grpc/"+v3.RouteType] = generators["grpc"]
+	generators["grpc/"+v3.ClusterType] = generators["grpc"]
+
+	generators["api"] = apigen.NewGenerator(env.ConfigStore)
+	generators["api/"+v3.EndpointType] = edsGen
+
+	generators["event"] = xds.NewStatusGen(s)
+	generators[v3.DebugType] = xds.NewDebugGen(s, systemNameSpace, internalDebugMux)
+	s.Generators = generators
+}

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -21,7 +21,6 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 )
 
@@ -52,9 +51,4 @@ type ConfigGenerator interface {
 
 	// MeshConfigChanged is invoked when mesh config is changed, giving a chance to rebuild any cached config.
 	MeshConfigChanged(mesh *meshconfig.MeshConfig)
-}
-
-// NewConfigGenerator creates a new instance of the dataplane configuration generator
-func NewConfigGenerator(cache model.XdsCache) ConfigGenerator {
-	return v1alpha3.NewConfigGenerator(cache)
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -353,7 +353,7 @@ func getWatchedResources(tpe string, tt ConfigInput, s *xds.FakeDiscoveryServer,
 		}
 		return &model.WatchedResource{ResourceNames: watchedResources}
 	case v3.RouteType:
-		l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext())
+		l := s.ConfigGen.BuildListeners(proxy, s.PushContext())
 		routeNames := xdstest.ExtractRoutesFromListeners(l)
 		return &model.WatchedResource{ResourceNames: routeNames}
 	}

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -17,13 +17,14 @@ package xds
 import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/util/sets"
 )
 
 type CdsGenerator struct {
-	Server *DiscoveryServer
+	ConfigGenerator core.ConfigGenerator
 }
 
 var _ model.XdsDeltaResourceGenerator = &CdsGenerator{}
@@ -83,7 +84,7 @@ func (c CdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req
 	if !cdsNeedsPush(req, proxy) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	clusters, logs := c.Server.ConfigGenerator.BuildClusters(proxy, req)
+	clusters, logs := c.ConfigGenerator.BuildClusters(proxy, req)
 	return clusters, logs, nil
 }
 
@@ -94,6 +95,6 @@ func (c CdsGenerator) GenerateDeltas(proxy *model.Proxy, req *model.PushRequest,
 	if !cdsNeedsPush(req, proxy) {
 		return nil, nil, model.DefaultXdsLogDetails, false, nil
 	}
-	updatedClusters, removedClusters, logs, usedDelta := c.Server.ConfigGenerator.BuildDeltaClusters(proxy, req, w)
+	updatedClusters, removedClusters, logs, usedDelta := c.ConfigGenerator.BuildDeltaClusters(proxy, req, w)
 	return updatedClusters, removedClusters, logs, usedDelta, nil
 }

--- a/pilot/pkg/xds/ecds.go
+++ b/pilot/pkg/xds/ecds.go
@@ -23,6 +23,7 @@ import (
 	credscontroller "istio.io/istio/pilot/pkg/credentials"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/credentials"
+	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -31,7 +32,7 @@ import (
 
 // EcdsGenerator generates ECDS configuration.
 type EcdsGenerator struct {
-	Server           *DiscoveryServer
+	ConfigGenerator  core.ConfigGenerator
 	secretController credscontroller.MulticlusterController
 }
 
@@ -118,7 +119,7 @@ func (e *EcdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, r
 		}
 	}
 
-	ec := e.Server.ConfigGenerator.BuildExtensionConfiguration(proxy, req.Push, w.ResourceNames, secrets)
+	ec := e.ConfigGenerator.BuildExtensionConfiguration(proxy, req.Push, w.ResourceNames, secrets)
 
 	if ec == nil {
 		return nil, model.DefaultXdsLogDetails, nil

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -18,13 +18,14 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
 )
 
 type LdsGenerator struct {
-	Server *DiscoveryServer
+	ConfigGenerator core.ConfigGenerator
 }
 
 var _ model.XdsResourceGenerator = &LdsGenerator{}
@@ -93,7 +94,7 @@ func (l LdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req
 	if !ldsNeedsPush(proxy, req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	listeners := l.Server.ConfigGenerator.BuildListeners(proxy, req.Push)
+	listeners := l.ConfigGenerator.BuildListeners(proxy, req.Push)
 	resources := model.Resources{}
 	for _, c := range listeners {
 		resources = append(resources, &discovery.Resource{

--- a/pilot/pkg/xds/nds.go
+++ b/pilot/pkg/xds/nds.go
@@ -18,6 +18,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
@@ -30,7 +31,7 @@ import (
 // in the pod the agent will capture all DNS requests and attempt to resolve locally before
 // forwarding to upstream dns servers.
 type NdsGenerator struct {
-	Server *DiscoveryServer
+	ConfigGenerator core.ConfigGenerator
 }
 
 var _ model.XdsResourceGenerator = &NdsGenerator{}
@@ -81,7 +82,7 @@ func (n NdsGenerator) Generate(proxy *model.Proxy, _ *model.WatchedResource, req
 	if !ndsNeedsPush(req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	nt := n.Server.ConfigGenerator.BuildNameTable(proxy, req.Push)
+	nt := n.ConfigGenerator.BuildNameTable(proxy, req.Push)
 	if nt == nil {
 		return nil, model.DefaultXdsLogDetails, nil
 	}

--- a/pilot/pkg/xds/pcds.go
+++ b/pilot/pkg/xds/pcds.go
@@ -26,7 +26,6 @@ import (
 
 // PcdsGenerator generates proxy configuration for proxies to consume
 type PcdsGenerator struct {
-	Server      *DiscoveryServer
 	TrustBundle *tb.TrustBundle
 }
 

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -16,12 +16,13 @@ package xds
 
 import (
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/sets"
 )
 
 type RdsGenerator struct {
-	Server *DiscoveryServer
+	ConfigGenerator core.ConfigGenerator
 }
 
 var _ model.XdsResourceGenerator = &RdsGenerator{}
@@ -63,6 +64,6 @@ func (c RdsGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource, req
 	if !rdsNeedsPush(req) {
 		return nil, model.DefaultXdsLogDetails, nil
 	}
-	resources, logDetails := c.Server.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames)
+	resources, logDetails := c.ConfigGenerator.BuildHTTPRoutes(proxy, req, w.ResourceNames)
 	return resources, logDetails, nil
 }

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -25,7 +25,7 @@ import (
 )
 
 type WorkloadGenerator struct {
-	s *DiscoveryServer
+	Server *DiscoveryServer
 }
 
 var (
@@ -65,7 +65,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 		// didn't explicitly request.
 		// For wildcard, they subscribe to everything already.
 		// TODO: optimize me
-		additional := e.s.Env.ServiceDiscovery.AdditionalPodSubscriptions(proxy, addresses, subs)
+		additional := e.Server.Env.ServiceDiscovery.AdditionalPodSubscriptions(proxy, addresses, subs)
 		addresses.Merge(additional)
 	}
 
@@ -84,7 +84,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 		return nil, nil, model.XdsLogDetails{}, false, nil
 	}
 	resources := make(model.Resources, 0)
-	addrs, removed := e.s.Env.ServiceDiscovery.AddressInformation(addresses)
+	addrs, removed := e.Server.Env.ServiceDiscovery.AddressInformation(addresses)
 	// Note: while "removed" is a weird name for a resource that never existed, this is how the spec works:
 	// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#id2
 	have := sets.New[string]()
@@ -136,7 +136,7 @@ func (e WorkloadGenerator) Generate(proxy *model.Proxy, w *model.WatchedResource
 }
 
 type WorkloadRBACGenerator struct {
-	s *DiscoveryServer
+	Server *DiscoveryServer
 }
 
 func (e WorkloadRBACGenerator) GenerateDeltas(
@@ -167,7 +167,7 @@ func (e WorkloadRBACGenerator) GenerateDeltas(
 		return nil, nil, model.DefaultXdsLogDetails, false, nil
 	}
 
-	policies := e.s.Env.ServiceDiscovery.Policies(updatedPolicies)
+	policies := e.Server.Env.ServiceDiscovery.Policies(updatedPolicies)
 
 	resources := make(model.Resources, 0)
 	expected := sets.New[string]()


### PR DESCRIPTION
This trims 2MB off istio-agent binary

Probably an ideal structure would have the generators entirely decoupled
from the DiscoveryServer/xds package, but its a high cost so I am not
going that far right now


Builds on https://github.com/istio/istio/pull/48710