### PR TITLE
Cleanup dead code about deleting deprecated validator

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -136,11 +136,6 @@ func Generate(ctx context.Context, client kube.Client, opts *GenerateOptions, is
 			if err != nil {
 				return "", fmt.Errorf("failed deactivating existing default revision: %w", err)
 			}
-			// delete deprecated validating webhook configuration if it exists.
-			err = DeleteDeprecatedValidator(ctx, client.Kube())
-			if err != nil {
-				return "", fmt.Errorf("failed removing deprecated validating webhook: %w", err)
-			}
 		}
 
 		// TODO(Monkeyanator) should extract the validationURL from revision's validating webhook here. However,


### PR DESCRIPTION
**Please provide a description of this PR:**
I think the revisioned validator has been used in many releases, and there will not be any old VWC to clean up.