### PR TITLE
replace discuss.istio.io references with github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
         This is used to report product bugs:
         To report a security vulnerability, please visit <https://istio.io/about/security-vulnerabilities>.
         Any crashes are potentially security vulnerabilities and should be treated as such.
-        To ask questions about how to use Istio, please visit <https://discuss.istio.io>.
+        To ask questions about how to use Istio, please visit <https://github.com/istio/istio/discussions>.
       options:
         - label: "This is not a security vulnerability or a crashing bug"
           required: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Istio is an open source service mesh that layers transparently onto existing distributed applications. Istio’s powerful features provide a uniform and more efficient way to secure, connect, and monitor services. Istio is the path to load balancing, service-to-service authentication, and monitoring – with few or no service code changes.
 
 - For in-depth information about how to use Istio, visit [istio.io](https://istio.io)
-- To ask questions and get assistance from our community, visit [discuss.istio.io](https://discuss.istio.io)
+- To ask questions and get assistance from our community, visit [Github Discussions](https://github.com/istio/istio/discussions)
 - To learn how to participate in our overall community, visit [our community page](https://istio.io/about/community)
 
 In this README:


### PR DESCRIPTION
**Please provide a description of this PR:**

From my understanding [discuss.istio.io](https://discuss.istio.io) is removed. This updates the two references I found to point to Github discussions.