### PR TITLE
networking: add support for setting TCP idle timeout for HTTP services

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -2416,6 +2416,9 @@ func TestApplyConnectionPool(t *testing.T) {
 						Seconds: 10,
 					},
 				},
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					IdleTimeout: nil,
+				},
 			},
 			expectedHTTPPOpt: &http.HttpProtocolOptions{
 				CommonHttpProtocolOptions: &core.HttpProtocolOptions{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -2403,6 +2403,59 @@ func TestApplyConnectionPool(t *testing.T) {
 			},
 		},
 		{
+			name:    "set TCP idle timeout",
+			cluster: &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			httpProtocolOptions: &http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+					MaxRequestsPerConnection: &wrappers.UInt32Value{Value: 10},
+				},
+			},
+			connectionPool: &networking.ConnectionPoolSettings{
+				Tcp: &networking.ConnectionPoolSettings_TCPSettings{
+					IdleTimeout: &durationpb.Duration{
+						Seconds: 10,
+					},
+				},
+			},
+			expectedHTTPPOpt: &http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+					IdleTimeout: &durationpb.Duration{
+						Seconds: 10,
+					},
+					MaxRequestsPerConnection: &wrappers.UInt32Value{Value: 10},
+				},
+			},
+		},
+		{
+			name:    "ignore TCP idle timeout when HTTP idle timeout is specified",
+			cluster: &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			httpProtocolOptions: &http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+					MaxRequestsPerConnection: &wrappers.UInt32Value{Value: 10},
+				},
+			},
+			connectionPool: &networking.ConnectionPoolSettings{
+				Tcp: &networking.ConnectionPoolSettings_TCPSettings{
+					IdleTimeout: &durationpb.Duration{
+						Seconds: 10,
+					},
+				},
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					IdleTimeout: &durationpb.Duration{
+						Seconds: 20,
+					},
+				},
+			},
+			expectedHTTPPOpt: &http.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &core.HttpProtocolOptions{
+					IdleTimeout: &durationpb.Duration{
+						Seconds: 20,
+					},
+					MaxRequestsPerConnection: &wrappers.UInt32Value{Value: 10},
+				},
+			},
+		},
+		{
 			name:    "only update MaxRequestsPerConnection ",
 			cluster: &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			httpProtocolOptions: &http.HttpProtocolOptions{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
@@ -102,7 +102,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 	}
 
 	threshold := getDefaultCircuitBreakerThresholds()
-	idleTimeout := settings.GetTcp().GetIdleTimeout()
+	var idleTimeout *durationpb.Duration
 	var maxRequestsPerConnection uint32
 	var maxConcurrentStreams uint32
 	var maxConnectionDuration *duration.Duration
@@ -138,6 +138,9 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 		}
 		if settings.Tcp.MaxConnectionDuration != nil {
 			maxConnectionDuration = settings.Tcp.MaxConnectionDuration
+		}
+		if idleTimeout == nil {
+			idleTimeout = settings.Tcp.IdleTimeout
 		}
 	}
 	applyTCPKeepalive(mesh, mc.cluster, settings.Tcp)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_traffic_policy.go
@@ -102,7 +102,7 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 	}
 
 	threshold := getDefaultCircuitBreakerThresholds()
-	var idleTimeout *durationpb.Duration
+	idleTimeout := settings.GetTcp().GetIdleTimeout()
 	var maxRequestsPerConnection uint32
 	var maxConcurrentStreams uint32
 	var maxConnectionDuration *duration.Duration

--- a/releasenotes/notes/set-tcp-idle-timeout-in-http-clusters.yaml
+++ b/releasenotes/notes/set-tcp-idle-timeout-in-http-clusters.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue: []
+releaseNotes:
+  - |
+    **Added** support for setting TCP idle timeout for HTTP services.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a follow-up to #48009 and this [comment](https://github.com/istio/api/pull/2999#discussion_r1427584062).

As the [documentation](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-TCPSettings) says, `connectionPool.tcp` settings are common to both HTTP and TCP upstream connections, so I added missing logic to the cluster builder.