### PR TITLE
handle errors from skel gracefully

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -50,8 +50,9 @@ func runPlugin() error {
 	err := skel.PluginMainWithError(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,
 		fmt.Sprintf("CNI plugin istio-cni %v", istioversion.Info.Version))
 	if err != nil {
+		log.Errorf("istio-cni failed with: %v", err)
 		if err := err.Print(); err != nil {
-			log.Infof("Error writing error JSON to stdout: ", err)
+			log.Errorf("istio-cni failed to write error JSON to stdout: %v", err)
 		}
 
 		return err

--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -29,8 +29,12 @@ import (
 )
 
 func main() {
+	os.Exit(runPlugin())
+}
+
+func runPlugin() int {
 	if err := log.Configure(plugin.GetLoggingOptions("")); err != nil {
-		os.Exit(1)
+		return 1
 	}
 	defer func() {
 		// Log sync will send logs to install-cni container via UDS.
@@ -41,6 +45,16 @@ func main() {
 	}()
 
 	// TODO: implement plugin version
-	skel.PluginMain(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,
+	err := skel.PluginMainWithError(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,
 		fmt.Sprintf("CNI plugin istio-cni %v", istioversion.Info.Version))
+
+	if err != nil {
+		if err := err.Print(); err != nil {
+			log.Infof("Error writing error JSON to stdout: ", err)
+		}
+
+		return 1
+	}
+
+	return 0
 }

--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -29,12 +29,14 @@ import (
 )
 
 func main() {
-	os.Exit(runPlugin())
+	if err := runPlugin(); err != nil {
+		os.Exit(1)
+	}
 }
 
-func runPlugin() int {
+func runPlugin() error {
 	if err := log.Configure(plugin.GetLoggingOptions("")); err != nil {
-		return 1
+		return err
 	}
 	defer func() {
 		// Log sync will send logs to install-cni container via UDS.
@@ -52,8 +54,8 @@ func runPlugin() int {
 			log.Infof("Error writing error JSON to stdout: ", err)
 		}
 
-		return 1
+		return err
 	}
 
-	return 0
+	return nil
 }

--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -47,7 +47,6 @@ func runPlugin() int {
 	// TODO: implement plugin version
 	err := skel.PluginMainWithError(plugin.CmdAdd, plugin.CmdCheck, plugin.CmdDelete, version.All,
 		fmt.Sprintf("CNI plugin istio-cni %v", istioversion.Info.Version))
-
 	if err != nil {
 		if err := err.Print(); err != nil {
 			log.Infof("Error writing error JSON to stdout: ", err)


### PR DESCRIPTION


**Please provide a description of this PR:**

Previously the `defer() { ... }` block which calls `_ = log.Sync()` would not exec if an error happened, because `skel.PluginMain` calls `os.Exit(1)` on error. This should ensure that `log.Sync` gets called regardless of the result of calling the CNI plugin skeleton.