### PR TITLE
Add wait logic for istioctl waypoint apply cmd

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -148,7 +148,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				FieldManager: "istioctl",
 			})
 			if err != nil {
-				if kerrors.IsNotFound(err) {
+				if errors.IsNotFound(err) {
 					return fmt.Errorf("missing Kubernetes Gateway CRDs need to be installed before applying a waypoint: %s", err)
 				}
 				return err
@@ -390,7 +390,7 @@ func deleteWaypoints(cmd *cobra.Command, kubeClient kube.CLIClient, namespace st
 			defer wg.Done()
 			if err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(namespace).
 				Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
-				if kerrors.IsNotFound(err) {
+				if errors.IsNotFound(err) {
 					fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v not found\n", namespace, name)
 				} else {
 					mu.Lock()

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -54,7 +54,7 @@ var (
 )
 
 const (
-	waitTimeout = 5 * time.Second
+	waitTimeout = 90 * time.Second
 )
 
 func Cmd(ctx cli.Context) *cobra.Command {

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -127,8 +127,8 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		Example: `  # Apply a waypoint to the current namespace
   istioctl x waypoint apply
 
-  # Apply a waypoint to a specific namespace for a specific service account
-  istioctl x waypoint apply --service-account something --namespace default`,
+  # Apply a waypoint to a specific namespace for a specific service account and wait for it to be ready
+  istioctl x waypoint apply --service-account something --namespace default --wait-ready`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeClient, err := ctx.CLIClientWithRevision(revision)
 			if err != nil {
@@ -162,7 +162,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					programmed := false
 					gwc, err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(ctx.NamespaceOrDefault(ctx.Namespace())).Get(context.TODO(), gw.Name, metav1.GetOptions{})
 					if err == nil {
-						// Check if gateway has programmed condition set to true
+						// Check if gateway has Programmed condition set to true
 						for _, cond := range gwc.Status.Conditions {
 							if cond.Type == string(gatewayv1.GatewayConditionProgrammed) && string(cond.Status) == "True" {
 								programmed = true
@@ -348,7 +348,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 	}
 
 	waypointApplyCmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
-	waypointApplyCmd.PersistentFlags().BoolVarP(&waitReady, "wait-ready", "W", false, "Wait for the waypoint to be ready and synced")
+	waypointApplyCmd.PersistentFlags().BoolVarP(&waitReady, "wait-ready", "w", false, "Wait for the waypoint to be ready")
 	waypointCmd.AddCommand(waypointApplyCmd)
 	waypointGenerateCmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
 	waypointCmd.AddCommand(waypointGenerateCmd)

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -164,11 +164,9 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					if err == nil {
 						// Check if gateway has programmed condition set to true
 						for _, cond := range gwc.Status.Conditions {
-							if cond.Type == string(gatewayv1.GatewayConditionProgrammed) {
-								if string(cond.Status) == "True" {
-									programmed = true
-									break
-								}
+							if cond.Type == string(gatewayv1.GatewayConditionProgrammed) && string(cond.Status) == "True" {
+								programmed = true
+								break
 							}
 						}
 					}

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -243,7 +243,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				deploymentReady := false
 				for {
 					if !deploymentReady {
-						if deploymentReady, _ = isWaypointDeploymentReady(ctx, kubeClient, gw); deploymentReady {
+						if deploymentReady, _ = isWaypointDeploymentReady(ctx, kubeClient, gw); !deploymentReady {
 							time.Sleep(1 * time.Second)
 							continue
 						}

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -153,7 +153,9 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			}
 			if waitReady {
 				startTime := time.Now()
-				for {
+				ticker := time.NewTicker(1 * time.Second)
+				defer ticker.Stop()
+				for range ticker.C {
 					programmed := false
 					gwc, err := kubeClient.GatewayAPI().GatewayV1beta1().Gateways(ctx.NamespaceOrDefault(ctx.Namespace())).Get(context.TODO(), gw.Name, metav1.GetOptions{})
 					if err == nil {
@@ -175,7 +177,6 @@ func Cmd(ctx cli.Context) *cobra.Command {
 						}
 						return fmt.Errorf(errorMsg)
 					}
-					time.Sleep(1 * time.Second)
 				}
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v applied\n", gw.Namespace, gw.Name)

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -243,20 +243,19 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				deploymentReady := false
 				for {
 					if !deploymentReady {
-						if deploymentReady, _ = isWaypointDeploymentReady(ctx, kubeClient, gw); !deploymentReady {
-							time.Sleep(1 * time.Second)
-							continue
-						}
+						deploymentReady, _ = isWaypointDeploymentReady(ctx, kubeClient, gw)
 					}
-					if waypointSynced, _ := isWaypointSynced(ctx, kubeClient, gw); waypointSynced {
-						break
+					if deploymentReady {
+						if waypointSynced, _ := isWaypointSynced(ctx, kubeClient, gw); waypointSynced {
+							break
+						}
 					}
 					if time.Since(startTime) > waitTimeout {
 						var errorMsg string
 						if !deploymentReady {
 							errorMsg = "Ambient Waypoint deployment is not ready"
 						} else {
-							errorMsg = "Ambient Waypoint workload is not synced with controller"
+							errorMsg = "Ambient Waypoint workload is not synced"
 						}
 						manifestLog.ReportError(errorMsg)
 						return errors.New("timed out while waiting for Ambient Waypoint")

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -84,7 +84,6 @@ const (
 	// Operator components
 	IstioOperatorComponentName      ComponentName = "IstioOperator"
 	IstioOperatorCustomResourceName ComponentName = "IstioOperatorCustomResource"
-	WaypointComponentName           ComponentName = "AmbientWaypoint"
 )
 
 // ComponentNamesConfig is used for unmarshaling legacy and addon naming data.
@@ -124,7 +123,6 @@ var (
 		IstioOperatorComponentName:      "Istio operator",
 		IstioOperatorCustomResourceName: "Istio operator CRDs",
 		IstiodRemoteComponentName:       "Istiod remote",
-		WaypointComponentName:           "Waypoint",
 	}
 )
 

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -84,6 +84,7 @@ const (
 	// Operator components
 	IstioOperatorComponentName      ComponentName = "IstioOperator"
 	IstioOperatorCustomResourceName ComponentName = "IstioOperatorCustomResource"
+	WaypointComponentName           ComponentName = "AmbientWaypoint"
 )
 
 // ComponentNamesConfig is used for unmarshaling legacy and addon naming data.
@@ -123,6 +124,7 @@ var (
 		IstioOperatorComponentName:      "Istio operator",
 		IstioOperatorCustomResourceName: "Istio operator CRDs",
 		IstiodRemoteComponentName:       "Istiod remote",
+		WaypointComponentName:           "Waypoint",
 	}
 )
 

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -117,7 +117,7 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, sa string) (W
 	}
 
 	cls := ctx.Clusters().Kube().Default()
-	// Find the Prometheus pod and service, and start forwarding a local port.
+	// Find the Waypoint pod and service, and start forwarding a local port.
 	fetchFn := testKube.NewSinglePodFetch(cls, ns.Name(), fmt.Sprintf("%s=%s", constants.GatewayNameLabel, sa))
 	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -189,7 +189,7 @@ func (i *istioImpl) InternalDiscoveryAddressFor(c cluster.Cluster) (string, erro
 	if e, f := i.istiod[c.Name()]; f {
 		return e.Address(), nil
 	}
-	// Find the Prometheus pod and service, and start forwarding a local port.
+	// Find the istiod pod and service, and start forwarding a local port.
 	fetchFn := testKube.NewSinglePodFetch(c, i.cfg.SystemNamespace, "istio=pilot")
 	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {

--- a/releasenotes/notes/48769.yaml
+++ b/releasenotes/notes/48769.yaml
@@ -5,4 +5,4 @@ issue:
   - 33949
 releaseNotes:
   - |
-    **Added** --wait and --timeout option to 'istioctl waypoint apply' command
+    **Added** --wait option to 'istioctl waypoint apply' command

--- a/releasenotes/notes/48769.yaml
+++ b/releasenotes/notes/48769.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 33949
+releaseNotes:
+  - |
+    **Added** --wait-ready and --timeout option to 'istioctl waypoint apply' command

--- a/releasenotes/notes/48769.yaml
+++ b/releasenotes/notes/48769.yaml
@@ -2,7 +2,7 @@ apiVersion: release-notes/v2
 kind: feature
 area: istioctl
 issue:
-  - 33949
+  - 46297
 releaseNotes:
   - |
-    **Added** --wait option to 'istioctl waypoint apply' command
+    *Added** `--wait` option to `istioctl experimental waypoint apply` command.

--- a/releasenotes/notes/48769.yaml
+++ b/releasenotes/notes/48769.yaml
@@ -5,4 +5,4 @@ issue:
   - 46297
 releaseNotes:
   - |
-    *Added** `--wait` option to `istioctl experimental waypoint apply` command.
+    **Added** `--wait` option to `istioctl experimental waypoint apply` command.

--- a/releasenotes/notes/48769.yaml
+++ b/releasenotes/notes/48769.yaml
@@ -5,4 +5,4 @@ issue:
   - 33949
 releaseNotes:
   - |
-    **Added** --wait-ready and --timeout option to 'istioctl waypoint apply' command
+    **Added** --wait and --timeout option to 'istioctl waypoint apply' command

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -282,8 +282,17 @@ func TestOtherRevisionIgnored(t *testing.T) {
 				"sa",
 				"--revision",
 				"foo",
-				"--wait-ready",
 			})
+			waypointError := retry.UntilSuccess(func() error {
+				fetch := kubetest.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"="+"sa")
+				if _, err := kubetest.CheckPodsAreReady(fetch); err != nil {
+					return fmt.Errorf("gateway is not ready: %v", err)
+				}
+				return nil
+			}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
+			if waypointError == nil {
+				t.Fatal("Waypoint for non-existent tag foo created deployment!")
+			}
 		})
 }
 

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -311,7 +311,7 @@ func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, sa str
 		nsConfig.Name(),
 		"--service-account",
 		sa,
-		"--wait-ready",
+		"--wait",
 	})
 }
 

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -282,17 +282,8 @@ func TestOtherRevisionIgnored(t *testing.T) {
 				"sa",
 				"--revision",
 				"foo",
+				"--wait-ready",
 			})
-			waypointError := retry.UntilSuccess(func() error {
-				fetch := kubetest.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"="+"sa")
-				if _, err := kubetest.CheckPodsAreReady(fetch); err != nil {
-					return fmt.Errorf("gateway is not ready: %v", err)
-				}
-				return nil
-			}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
-			if waypointError == nil {
-				t.Fatal("Waypoint for non-existent tag foo created deployment!")
-			}
 		})
 }
 
@@ -311,17 +302,8 @@ func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, sa str
 		nsConfig.Name(),
 		"--service-account",
 		sa,
+		"--wait-ready",
 	})
-	waypointError := retry.UntilSuccess(func() error {
-		fetch := kubetest.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"="+sa)
-		if _, err := kubetest.CheckPodsAreReady(fetch); err != nil {
-			return fmt.Errorf("gateway is not ready: %v", err)
-		}
-		return nil
-	}, retry.Timeout(time.Minute), retry.BackoffDelay(time.Millisecond*100))
-	if waypointError != nil {
-		t.Fatal(waypointError)
-	}
 }
 
 func deleteWaypoints(t framework.TestContext, nsConfig namespace.Instance, sa string) {

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -87,7 +87,7 @@ func TestWaypoint(t *testing.T) {
 				"apply",
 				"--namespace",
 				nsConfig.Name(),
-				"--wait-ready",
+				"--wait",
 			})
 
 			saSet := []string{"sa1", "sa2", "sa3"}
@@ -100,7 +100,7 @@ func TestWaypoint(t *testing.T) {
 					nsConfig.Name(),
 					"--service-account",
 					sa,
-					"--wait-ready",
+					"--wait",
 				})
 			}
 

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -87,13 +87,8 @@ func TestWaypoint(t *testing.T) {
 				"apply",
 				"--namespace",
 				nsConfig.Name(),
+				"--wait-ready",
 			})
-			retry.UntilSuccessOrFail(t, func() error {
-				if err := checkWaypointIsReady(t, nsConfig.Name(), "namespace"); err != nil {
-					return fmt.Errorf("gateway is not ready: %v", err)
-				}
-				return nil
-			}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
 
 			saSet := []string{"sa1", "sa2", "sa3"}
 			for _, sa := range saSet {
@@ -105,15 +100,8 @@ func TestWaypoint(t *testing.T) {
 					nsConfig.Name(),
 					"--service-account",
 					sa,
+					"--wait-ready",
 				})
-			}
-			for _, sa := range saSet {
-				retry.UntilSuccessOrFail(t, func() error {
-					if err := checkWaypointIsReady(t, nsConfig.Name(), sa); err != nil {
-						return fmt.Errorf("gateway is not ready: %v", err)
-					}
-					return nil
-				}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
 			}
 
 			output, _ := istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{


### PR DESCRIPTION
Change-Id: Ifd65a062894710f197e6cc2ada7378511f8ae5f1

**Please provide a description of this PR:**
Fixes #46297
Add a --wait-ready (default: false) and --timeout logic (default: 90s) to "waypoint apply" cmd.
Adding wait will make istioctl wait for the waypoint deployment to be ready and it will wait for the waypoint to be synced with controller.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure