### PR TITLE
skip consistent hash ttl test cases (#48501)

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2550,12 +2550,20 @@ spec:
 				config: svc + tmpl.MustEvaluate(cookieWithTTLDest, ""),
 				call:   c.CallOrFail,
 				opts:   cookieCallOpts,
+				skip: skip{
+					skip:   true,
+					reason: "https://github.com/istio/istio/issues/48156: not currently working, as test framework is not passing the cookies back",
+				},
 			})
 			t.RunTraffic(TrafficTestCase{
 				name:   "http cookie without ttl" + c.Config().Service,
 				config: svc + tmpl.MustEvaluate(cookieWithoutTTLDest, ""),
 				call:   c.CallOrFail,
 				opts:   cookieCallOpts,
+				skip: skip{
+					skip:   true,
+					reason: "https://github.com/istio/istio/issues/48156: not currently working, as test framework is not passing the cookies back",
+				},
 			})
 		}
 	}


### PR DESCRIPTION
Cherrypicking the following commit : https://github.com/istio/istio/commit/db18352c179eafec8feb4f1943123df9b1f21062