### PR TITLE
cni: revisioned install-cni & istio-cni binaries

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -162,7 +162,7 @@ func init() {
 	registerStringParameter(constants.KubeCAFile, "", "CA file for kubeconfig. Defaults to the same as install-cni pod")
 	registerBooleanParameter(constants.SkipTLSVerify, false, "Whether to use insecure TLS in kubeconfig file")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
-	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log output to")
+	registerStringParameter(constants.LogUDSAddress, "", "The UDS server address which CNI plugin will copy log output to")
 	registerBooleanParameter(constants.AmbientEnabled, false, "Whether ambient controller is enabled")
 	registerBooleanParameter(constants.EbpfEnabled, false, "Whether ebpf redirection is enabled")
 	// Repair

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -150,6 +150,7 @@ func init() {
 	registerStringParameter(constants.CNIConfName, "", "Name of the CNI configuration file")
 	registerBooleanParameter(constants.ChainedCNIPlugin, true, "Whether to install CNI plugin as a chained or standalone")
 	registerStringParameter(constants.CNINetworkConfig, "", "CNI configuration template as a string")
+	registerStringParameter(constants.Revision, "", "The Istio revision to associate CNI binaries with")
 	registerStringParameter(constants.LogLevel, "warn", "Fallback value for log level in CNI config file, if not specified in helm template")
 
 	// Not configurable in CNI helm charts
@@ -228,6 +229,7 @@ func constructConfig() (*config.Config, error) {
 		CNINetworkConfigFile: viper.GetString(constants.CNINetworkConfigFile),
 		CNINetworkConfig:     viper.GetString(constants.CNINetworkConfig),
 
+		Revision:           viper.GetString(constants.Revision),
 		LogLevel:           viper.GetString(constants.LogLevel),
 		KubeconfigFilename: viper.GetString(constants.KubeconfigFilename),
 		KubeconfigMode:     viper.GetInt(constants.KubeconfigMode),

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -40,6 +40,8 @@ type InstallConfig struct {
 	// CNI config template string
 	CNINetworkConfig string
 
+	// The Istio revision to associate CNI binaries with
+	Revision string
 	// Logging level
 	LogLevel string
 	// Name of the kubeconfig file used by the CNI plugin
@@ -117,6 +119,7 @@ func (c InstallConfig) String() string {
 	b.WriteString("CNINetworkConfigFile: " + c.CNINetworkConfigFile + "\n")
 	b.WriteString("CNINetworkConfig: " + c.CNINetworkConfig + "\n")
 
+	b.WriteString("Revision: " + c.Revision + "\n")
 	b.WriteString("LogLevel: " + c.LogLevel + "\n")
 	b.WriteString("KubeconfigFilename: " + c.KubeconfigFilename + "\n")
 	b.WriteString("KubeconfigMode: " + fmt.Sprintf("%#o", c.KubeconfigMode) + "\n")

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -23,6 +23,7 @@ const (
 	ChainedCNIPlugin     = "chained-cni-plugin"
 	CNINetworkConfigFile = "cni-network-config-file"
 	CNINetworkConfig     = "cni-network-config"
+	Revision             = "revision"
 	LogLevel             = "log-level"
 	KubeconfigFilename   = "kubecfg-file-name"
 	KubeconfigMode       = "kubeconfig-mode"

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -28,6 +28,7 @@ func TestCopyBinaries(t *testing.T) {
 		srcFiles      map[string]string
 		existingFiles map[string]string
 		expectedFiles map[string]string
+		revision      string
 	}{
 		{
 			name:          "basic",
@@ -39,6 +40,12 @@ func TestCopyBinaries(t *testing.T) {
 			srcFiles:      map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
 			existingFiles: map[string]string{"istio-cni": "cni000", "istio-iptables": "iptables111"},
 			expectedFiles: map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
+		},
+		{
+			name:          "append revision",
+			revision:      "canary",
+			srcFiles:      map[string]string{"istio-cni": "cni111", "istio-iptables": "iptables111"},
+			expectedFiles: map[string]string{"istio-cni-canary": "cni111", "istio-iptables-canary": "iptables111"},
 		},
 	}
 
@@ -54,7 +61,7 @@ func TestCopyBinaries(t *testing.T) {
 				file.WriteOrFail(t, filepath.Join(targetDir, filename), []byte(contents))
 			}
 
-			binariesCopied, err := copyBinaries(srcDir, []string{targetDir})
+			binariesCopied, err := copyBinaries(srcDir, []string{targetDir}, c.revision)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install/cniconfig_test.go
@@ -304,6 +304,7 @@ func TestInsertCNIConfig(t *testing.T) {
 		expectedFailure      bool
 		existingConfFilename string
 		newConfFilename      string
+		revision             string
 	}{
 		{
 			name:                 "invalid existing config format (map)",
@@ -338,6 +339,12 @@ func TestInsertCNIConfig(t *testing.T) {
 			existingConfFilename: "list-with-istio.conflist",
 			newConfFilename:      "istio-cni.conf",
 		},
+		{
+			name:                 "revision provided",
+			existingConfFilename: "list-with-revision.conflist",
+			newConfFilename:      "istio-cni-revisioned.conf",
+			revision:             "canary",
+		},
 	}
 
 	for _, c := range cases {
@@ -346,7 +353,7 @@ func TestInsertCNIConfig(t *testing.T) {
 			existingConfFilepath := filepath.Join("testdata", c.existingConfFilename)
 			existingConf := testutils.ReadFile(t, existingConfFilepath)
 
-			output, err := insertCNIConfig(istioConf, existingConf)
+			output, err := insertCNIConfig(istioConf, existingConf, c.revision)
 			if err != nil {
 				if !c.expectedFailure {
 					t.Fatal(err)

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -37,6 +37,7 @@ func TestCheckInstall(t *testing.T) {
 		cniConfName       string
 		chainedCNIPlugin  bool
 		existingConfFiles map[string]string // {srcFilename: targetFilename, ...}
+		revision          string
 	}{
 		{
 			name:              "preempted config",
@@ -89,6 +90,12 @@ func TestCheckInstall(t *testing.T) {
 			cniConfigFilename: "istio-cni.conf",
 			existingConfFiles: map[string]string{"istio-cni.conf": "istio-cni.conf"},
 		},
+		{
+			name:              "include revision",
+			cniConfigFilename: "istio-cni.conf",
+			revision:          "canary",
+			existingConfFiles: map[string]string{"istio-cni-revisioned.conf": "istio-cni.conf"},
+		},
 	}
 
 	for _, c := range cases {
@@ -107,6 +114,7 @@ func TestCheckInstall(t *testing.T) {
 				MountedCNINetDir: tempDir,
 				CNIConfName:      c.cniConfName,
 				ChainedCNIPlugin: c.chainedCNIPlugin,
+				Revision:         c.revision,
 			}
 			err := checkValidCNIConfig(cfg, filepath.Join(tempDir, c.cniConfigFilename))
 			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -154,7 +154,8 @@ func TestCheckNoExistingKubeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error: %+v", err)
 	}
-	err = checkExistingKubeConfigFile(cfg, expectedKC)
+	kubeconfigFilepath := filepath.Join(cfg.MountedCNINetDir, kubeconfigFilename)
+	err = checkExistingKubeConfigFile(kubeconfigFilepath, expectedKC)
 
 	if err == nil {
 		t.Fatalf("expected error, no kubeconfig present")
@@ -179,9 +180,10 @@ func TestCheckMismatchedExistingKubeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error: %+v", err)
 	}
-	os.WriteFile(filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename), []byte(expectedKC.Full), 0o644)
+	kubeconfigFilepath := filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename)
+	os.WriteFile(kubeconfigFilepath, []byte(expectedKC.Full), 0o644)
 
-	err = checkExistingKubeConfigFile(cfg, expectedKC)
+	err = checkExistingKubeConfigFile(kubeconfigFilepath, expectedKC)
 
 	if err != nil {
 		t.Fatalf("expected no error, matching kubeconfig present, got %+v", err)

--- a/cni/pkg/install/testdata/istio-cni-revisioned.conf
+++ b/cni/pkg/install/testdata/istio-cni-revisioned.conf
@@ -1,0 +1,10 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "istio-cni-canary",
+  "type": "istio-cni-canary",
+  "log_level": "debug",
+  "kubernetes": {
+      "kubeconfig": "/path/to/kubeconfig",
+      "cni_bin_dir": "/path/cni/bin"
+  }
+}

--- a/cni/pkg/install/testdata/list-with-revision.conflist
+++ b/cni/pkg/install/testdata/list-with-revision.conflist
@@ -1,0 +1,40 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "dbnet",
+  "plugins": [
+    {
+      "args": {
+        "labels": {
+          "appVersion": "1.0"
+        }
+      },
+      "bridge": "cni0",
+      "dns": {
+        "nameservers": [
+          "10.1.0.1"
+        ]
+      },
+      "ipam": {
+        "gateway": "10.1.0.1",
+        "subnet": "10.1.0.0/16",
+        "type": "host-local"
+      },
+      "type": "bridge"
+    },
+    {
+      "sysctl": {
+        "net.core.somaxconn": "500"
+      },
+      "type": "tuning"
+    },
+    {
+      "kubernetes": {
+        "cni_bin_dir": "/path/cni/bin",
+        "kubeconfig": "/path/to/kubeconfig"
+      },
+      "log_level": "debug",
+      "name": "istio-cni",
+      "type": "istio-cni"
+    }
+  ]
+}

--- a/cni/pkg/install/testdata/list-with-revision.conflist.golden
+++ b/cni/pkg/install/testdata/list-with-revision.conflist.golden
@@ -1,0 +1,49 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "dbnet",
+  "plugins": [
+    {
+      "args": {
+        "labels": {
+          "appVersion": "1.0"
+        }
+      },
+      "bridge": "cni0",
+      "dns": {
+        "nameservers": [
+          "10.1.0.1"
+        ]
+      },
+      "ipam": {
+        "gateway": "10.1.0.1",
+        "subnet": "10.1.0.0/16",
+        "type": "host-local"
+      },
+      "type": "bridge"
+    },
+    {
+      "sysctl": {
+        "net.core.somaxconn": "500"
+      },
+      "type": "tuning"
+    },
+    {
+      "kubernetes": {
+        "cni_bin_dir": "/path/cni/bin",
+        "kubeconfig": "/path/to/kubeconfig"
+      },
+      "log_level": "debug",
+      "name": "istio-cni",
+      "type": "istio-cni"
+    },
+    {
+      "kubernetes": {
+        "cni_bin_dir": "/path/cni/bin",
+        "kubeconfig": "/path/to/kubeconfig"
+      },
+      "log_level": "debug",
+      "name": "istio-cni-canary",
+      "type": "istio-cni-canary"
+    }
+  ]
+}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -6,7 +6,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: istio-cni-config
+  name: istio-cni-config{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: istio-cni
@@ -21,7 +21,7 @@ data:
         {
           "cniVersion": "0.3.1",
           "name": "istio-cni",
-          "type": "istio-cni",
+          "type": "istio-cni{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}",
           "log_level": {{ quote .Values.cni.logLevel }},
           "log_uds_address": "__LOG_UDS_ADDRESS__",
           {{if .Values.cni.ambient.enabled}}"ambient_enabled": true,{{end}}

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -20,10 +20,11 @@ data:
   cni_network_config: |-
         {
           "cniVersion": "0.3.1",
-          "name": "istio-cni",
+          "name": "istio-cni{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}",
           "type": "istio-cni{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}",
           "log_level": {{ quote .Values.cni.logLevel }},
           "log_uds_address": "__LOG_UDS_ADDRESS__",
+          "revision": {{ .Values.revision | default "default" | quote }},
           {{if .Values.cni.ambient.enabled}}"ambient_enabled": true,{{end}}
           "kubernetes": {
               "kubeconfig": "__KUBECONFIG_FILEPATH__",

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -101,19 +101,23 @@ spec:
 {{- if .Values.cni.cniConfFileName }}
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
-              value: "{{ .Values.cni.cniConfFileName }}"
+              value: "{{ .Values.cni.cniConfFileName }}{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}"
 {{- end }}
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: istio-cni-config
+                  name: istio-cni-config{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
                   key: cni_network_config
             - name: CNI_NET_DIR
               value: {{ default "/etc/cni/net.d" .Values.cni.cniConfDir }}
             # Deploy as a standalone CNI plugin or as chained?
             - name: CHAINED_CNI_PLUGIN
               value: "{{ .Values.cni.chained }}"
+{{- if .Values.revision }}
+            - name: REVISION
+              value: "{{ .Values.revision }}"
+{{- end }}
             - name: REPAIR_ENABLED
               value: "{{ .Values.cni.repair.enabled }}"
             - name: REPAIR_NODE_NAME

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: istio-cni-node
+      k8s-app: istio-cni-node{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: istio-cni-node
+        k8s-app: istio-cni-node{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -118,6 +118,8 @@ spec:
             - name: REVISION
               value: "{{ .Values.revision }}"
 {{- end }}
+            - name: LOG_UDS_ADDRESS
+              value: /var/run/istio-cni/{{ .Values.revision | default "default" }}/log.sock
             - name: REPAIR_ENABLED
               value: "{{ .Values.cni.repair.enabled }}"
             - name: REPAIR_NODE_NAME
@@ -167,7 +169,7 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-            - mountPath: /var/run/istio-cni
+            - mountPath: /var/run/istio-cni/{{ .Values.revision | default "default" }}
               name: cni-log-dir
             {{- if .Values.cni.ambient.enabled }}
             - mountPath: /etc/ambient-config
@@ -203,7 +205,7 @@ spec:
         # Used for UDS log
         - name: cni-log-dir
           hostPath:
-            path: /var/run/istio-cni
+            path: /var/run/istio-cni/{{ .Values.revision | default "default" }}
         - name: cni-netns-dir
           hostPath:
             path: {{ .Values.cni.cniNetnsDir | default "/var/run/netns" }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -9,7 +9,7 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: istio-cni-node
+  name: istio-cni-node{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: istio-cni-node


### PR DESCRIPTION
- Enables multiple install-cni daemonsets and istio-cni plugins to be installed & run on each node
- Appends the Istio revision to the install-cni daemonset, istio-cni binaries, and cni config
- Each plugin instance checks the revision of the pod it is being invoked against and skips setting up the redirect if the revision does not match its own

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure