### PR TITLE
Adding MinIstioVersion for TestProxyHeaders

### DIFF
--- a/tests/integration/pilot/headers_test.go
+++ b/tests/integration/pilot/headers_test.go
@@ -39,6 +39,7 @@ import (
 func TestProxyHeaders(t *testing.T) {
 	framework.NewTest(t).
 		Features("traffic.routing").
+		RequireIstioVersion("1.19").
 		Run(func(t framework.TestContext) {
 			ns := namespace.NewOrFail(t, t, namespace.Config{Prefix: "proxy-headers", Inject: true})
 			cfg := echo.Config{


### PR DESCRIPTION
**Please provide a description of this PR:**
Tests are failing in Anthos when ran for multiversion clusters. Setting the MinVersion of Istio will run the ProxyHeaders test only for clusters with minimum Istio version 1.19


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure