### PR TITLE
Remove duplicated and unused custom setup label

### DIFF
--- a/tests/integration/security/file_mounted_certs/main_test.go
+++ b/tests/integration/security/file_mounted_certs/main_test.go
@@ -73,7 +73,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		RequireSingleCluster().
 		RequireMultiPrimary().
-		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, CreateCustomIstiodSecret)).
 		Setup(namespace.Setup(&echo1NS, namespace.Config{Prefix: "echo1", Inject: true})).
 		Setup(func(ctx resource.Context) error {

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -54,7 +54,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
-		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCustomEgressSecret)).
 		Setup(namespace.Setup(&appNS, namespace.Config{Prefix: "appns", Inject: true})).
 		Setup(namespace.Setup(&serviceNS, namespace.Config{Prefix: "serverns", Inject: true})).

--- a/tests/integration/security/https_jwt/main_test.go
+++ b/tests/integration/security/https_jwt/main_test.go
@@ -45,7 +45,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
-		Label("CustomSetup").
 		Setup(istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			var err error


### PR DESCRIPTION
**Please provide a description of this PR:**

Both `"CustomSetup"` and `label.CustomSetup` labels are applied.
Although different camel cases, the string ones are not being used anymore in the tests.