### PR TITLE
add fallback support for privateKeyProvider

### DIFF
--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -343,6 +343,10 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 				},
 			},
 		})
+		fallback := false
+		if crypto.GetFallback() != nil {
+			fallback = crypto.GetFallback().Value
+		}
 		res = protoconv.MessageToAny(&envoytls.Secret{
 			Name: name,
 			Type: &envoytls.Secret_TlsCertificate{
@@ -357,6 +361,7 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
+						Fallback: fallback,
 					},
 				},
 			},
@@ -371,6 +376,10 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 				},
 			},
 		})
+		fallback := false
+		if qatConf.GetFallback() != nil {
+			fallback = qatConf.GetFallback().Value
+		}
 		res = protoconv.MessageToAny(&envoytls.Secret{
 			Name: name,
 			Type: &envoytls.Secret_TlsCertificate{
@@ -385,6 +394,7 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
+						Fallback: fallback,
 					},
 				},
 			},

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -343,10 +343,6 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 				},
 			},
 		})
-		fallback := false
-		if crypto.GetFallback() != nil {
-			fallback = crypto.GetFallback().Value
-		}
 		res = protoconv.MessageToAny(&envoytls.Secret{
 			Name: name,
 			Type: &envoytls.Secret_TlsCertificate{
@@ -361,7 +357,7 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
-						Fallback: fallback,
+						Fallback: crypto.GetFallback().GetValue(),
 					},
 				},
 			},
@@ -376,10 +372,6 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 				},
 			},
 		})
-		fallback := false
-		if qatConf.GetFallback() != nil {
-			fallback = qatConf.GetFallback().Value
-		}
 		res = protoconv.MessageToAny(&envoytls.Secret{
 			Name: name,
 			Type: &envoytls.Secret_TlsCertificate{
@@ -394,7 +386,7 @@ func toEnvoyTLSSecret(name string, certInfo *credscontroller.CertInfo, proxy *mo
 						ConfigType: &envoytls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
-						Fallback: fallback,
+						Fallback: qatConf.GetFallback().GetValue(),
 					},
 				},
 			},

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -436,6 +436,7 @@ func TestPrivateKeyProviderProxyConfig(t *testing.T) {
 		privateKeyProvider := scrt.GetTlsCertificate().GetPrivateKeyProvider()
 		if privateKeyProvider == nil {
 			t.Fatalf("expect private key provider in secret")
+		} else {
 			if privateKeyProvider.GetFallback() == true {
 				t.Fatalf("expect fallback for private key provider in secret as false")
 			}

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -436,10 +436,9 @@ func TestPrivateKeyProviderProxyConfig(t *testing.T) {
 		privateKeyProvider := scrt.GetTlsCertificate().GetPrivateKeyProvider()
 		if privateKeyProvider == nil {
 			t.Fatalf("expect private key provider in secret")
-		} else {
-			if privateKeyProvider.GetFallback() == true {
-				t.Fatalf("expect fallback for private key provider in secret as false")
-			}
+		}
+		if privateKeyProvider.GetFallback() {
+			t.Fatalf("expect fallback for private key provider in secret as false")
 		}
 	}
 

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -433,8 +433,12 @@ func TestPrivateKeyProviderProxyConfig(t *testing.T) {
 	secrets, _, _ = gen.Generate(s.SetupProxy(pkpProxy), &model.WatchedResource{ResourceNames: []string{"kubernetes://generic"}}, fullPush)
 	raw = xdstest.ExtractTLSSecrets(t, model.ResourcesToAny(secrets))
 	for _, scrt := range raw {
-		if scrt.GetTlsCertificate().GetPrivateKeyProvider() == nil {
+		privateKeyProvider := scrt.GetTlsCertificate().GetPrivateKeyProvider()
+		if privateKeyProvider == nil {
 			t.Fatalf("expect private key provider in secret")
+			if privateKeyProvider.GetFallback() == true {
+				t.Fatalf("expect fallback for private key provider in secret as false")
+			}
 		}
 	}
 

--- a/releasenotes/notes/48843.yaml
+++ b/releasenotes/notes/48843.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+releaseNotes:
+  - |
+    **Added** an `fallback` field for PrivateKeyProvider to support fallback to the BoringSSL default implementation if the private key provider isn’t available.

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -269,10 +269,6 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 					},
 				},
 			})
-			fallback := false
-			if crypto.GetFallback() != nil {
-				fallback = crypto.GetFallback().Value
-			}
 			secret.Type = &tls.Secret_TlsCertificate{
 				TlsCertificate: &tls.TlsCertificate{
 					CertificateChain: &core.DataSource{
@@ -285,7 +281,7 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 						ConfigType: &tls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
-						Fallback: fallback,
+						Fallback: crypto.GetFallback().GetValue(),
 					},
 				},
 			}
@@ -299,10 +295,6 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 					},
 				},
 			})
-			fallback := false
-			if qatConf.GetFallback() != nil {
-				fallback = qatConf.GetFallback().Value
-			}
 			secret.Type = &tls.Secret_TlsCertificate{
 				TlsCertificate: &tls.TlsCertificate{
 					CertificateChain: &core.DataSource{
@@ -315,7 +307,7 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 						ConfigType: &tls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
-						Fallback: fallback,
+						Fallback: qatConf.GetFallback().GetValue(),
 					},
 				},
 			}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -269,6 +269,10 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 					},
 				},
 			})
+			fallback := false
+			if crypto.GetFallback() != nil {
+				fallback = crypto.GetFallback().Value
+			}
 			secret.Type = &tls.Secret_TlsCertificate{
 				TlsCertificate: &tls.TlsCertificate{
 					CertificateChain: &core.DataSource{
@@ -281,6 +285,7 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 						ConfigType: &tls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
+						Fallback: fallback,
 					},
 				},
 			}
@@ -294,6 +299,10 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 					},
 				},
 			})
+			fallback := false
+			if qatConf.GetFallback() != nil {
+				fallback = qatConf.GetFallback().Value
+			}
 			secret.Type = &tls.Secret_TlsCertificate{
 				TlsCertificate: &tls.TlsCertificate{
 					CertificateChain: &core.DataSource{
@@ -306,6 +315,7 @@ func toEnvoySecret(s *security.SecretItem, caRootPath string, pkpConf *mesh.Priv
 						ConfigType: &tls.PrivateKeyProvider_TypedConfig{
 							TypedConfig: msg,
 						},
+						Fallback: fallback,
 					},
 				},
 			}

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/durationpb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/xds"
@@ -56,6 +57,9 @@ var (
 				PollDelay: &durationpb.Duration{
 					Seconds: 0,
 					Nanos:   10000,
+				},
+				Fallback: &wrappers.BoolValue{
+					Value: true,
 				},
 			},
 		},


### PR DESCRIPTION
Envoy recently add support for fallback in PrivateKeyProvider as in https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-privatekeyprovider

Add the related support into Istio.

corresponding API change is in https://github.com/istio/api/pull/3045