### PR TITLE
Misc xds cleanup

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -467,7 +467,7 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 	log.Debugf("ADS:%s: RESOURCE CHANGE added %v removed %v %s %s %s", stype,
 		added, removed, con.conID, request.VersionInfo, request.ResponseNonce)
 
-	// For non wildcard resource, if no new resources are subscribed, it means we donot need to push.
+	// For non wildcard resource, if no new resources are subscribed, it means we do not need to push.
 	if !isWildcardTypeURL(request.TypeUrl) && len(added) == 0 {
 		return false, emptyResourceDelta
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -474,7 +474,7 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 
 	return true, model.ResourceDelta{
 		Subscribed: added,
-		// we donot need to set unsubscribed for StoW
+		// we do not need to set unsubscribed for StoW
 	}
 }
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -453,23 +453,28 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 	removed := prev.Difference(cur)
 	added := cur.Difference(prev)
 
-	if len(removed) == 0 && len(added) == 0 {
-		// We should always respond "alwaysRespond" marked requests to let Envoy finish warming
-		// even though Nonce match and it looks like an ACK.
-		if alwaysRespond {
-			log.Infof("ADS:%s: FORCE RESPONSE %s for warming.", stype, con.conID)
-			return true, emptyResourceDelta
-		}
+	// We should always respond "alwaysRespond" marked requests to let Envoy finish warming
+	// even though Nonce match and it looks like an ACK.
+	if alwaysRespond {
+		log.Infof("ADS:%s: FORCE RESPONSE %s for warming.", stype, con.conID)
+		return true, emptyResourceDelta
+	}
 
+	if len(removed) == 0 && len(added) == 0 {
 		log.Debugf("ADS:%s: ACK %s %s %s", stype, con.conID, request.VersionInfo, request.ResponseNonce)
 		return false, emptyResourceDelta
 	}
 	log.Debugf("ADS:%s: RESOURCE CHANGE added %v removed %v %s %s %s", stype,
 		added, removed, con.conID, request.VersionInfo, request.ResponseNonce)
 
+	// For non wildcard resource, if no new resources are subscribed, it means we donot need to push.
+	if !isWildcardTypeURL(request.TypeUrl) && len(added) == 0 {
+		return false, emptyResourceDelta
+	}
+
 	return true, model.ResourceDelta{
-		Subscribed:   added,
-		Unsubscribed: removed,
+		Subscribed: added,
+		// we donot need to set unsubscribed for StoW
 	}
 }
 

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -473,8 +473,8 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 	} else if req.Full {
 		// similar to sotw
 		subscribed := sets.New(w.ResourceNames...)
-		subscribed.DeleteAll(currentResources...)
-		resp.RemovedResources = sets.SortedList(subscribed)
+		removed := subscribed.DeleteAll(currentResources...)
+		resp.RemovedResources = sets.SortedList(removed)
 	}
 	if len(resp.RemovedResources) > 0 {
 		deltaLog.Debugf("ADS:%v REMOVE for node:%s %v", v3.GetShortType(w.TypeUrl), con.conID, resp.RemovedResources)
@@ -510,7 +510,7 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 	}
 
 	switch {
-	case !req.Full && w.TypeUrl != v3.AddressType:
+	case !req.Full:
 		if deltaLog.DebugEnabled() {
 			deltaLog.Debugf("%s: %s%s for node:%s resources:%d size:%s%s",
 				v3.GetShortType(w.TypeUrl), ptype, req.PushReason(), con.proxy.ID, len(res), util.ByteCount(configSize), info)

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -16,7 +16,6 @@ package xds
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -372,16 +371,6 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		return true
 	}
 
-	// If there is mismatch in the nonce, that is a case of expired/stale nonce.
-	// A nonce becomes stale following a newer nonce being sent to Envoy.
-	// TODO: due to concurrent unsubscribe, this probably doesn't make sense. Do we need any logic here?
-	if request.ResponseNonce != "" && request.ResponseNonce != previousInfo.NonceSent {
-		deltaLog.Debugf("ADS:%s: REQ %s Expired nonce received %s, sent %s", stype,
-			con.conID, request.ResponseNonce, previousInfo.NonceSent)
-		xdsExpiredNonce.With(typeTag.Value(v3.GetMetricType(request.TypeUrl))).Increment()
-		return false
-	}
-
 	// If it comes here, that means nonce match. This an ACK. We should record
 	// the ack details and respond if there is a change in resource names.
 	con.proxy.Lock()
@@ -393,21 +382,13 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	previousInfo.AlwaysRespond = false
 	con.proxy.Unlock()
 
-	oldAck := slices.EqualUnordered(previousResources, currentResources)
 	// Spontaneous DeltaDiscoveryRequests from the client.
 	// This can be done to dynamically add or remove elements from the tracked resource_names set.
-	// In this case response_nonce is empty.
-	newAck := request.ResponseNonce != ""
-	if newAck != oldAck {
-		// Not sure which is better, lets just log if they don't match for now and compare.
-		deltaLog.Errorf("ADS:%s: New ACK and old ACK check mismatch: %v vs %v", stype, newAck, oldAck)
-		if features.EnableUnsafeAssertions {
-			panic(fmt.Sprintf("ADS:%s: New ACK and old ACK check mismatch: %v vs %v", stype, newAck, oldAck))
-		}
-	}
+	// In this case watches resources change.
+	unchanged := slices.EqualUnordered(previousResources, currentResources)
 	// Envoy can send two DiscoveryRequests with same version and nonce
 	// when it detects a new resource. We should respond if they change.
-	if oldAck {
+	if unchanged {
 		// We should always respond "alwaysRespond" marked requests to let Envoy finish warming
 		// even though Nonce match and it looks like an ACK.
 		if alwaysRespond {

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -410,7 +410,7 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 
 	// Envoy can send two DiscoveryRequests with same version and nonce
 	// when it detects a new resource. We should respond if they change.
-	if unchanged {
+	if !subChanged {
 		// We should always respond "alwaysRespond" marked requests to let Envoy finish warming
 		// even though Nonce match and it looks like an ACK.
 		if alwaysRespond {

--- a/pilot/pkg/xds/xdsgen.go
+++ b/pilot/pkg/xds/xdsgen.go
@@ -23,7 +23,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -134,12 +133,6 @@ func (s *DiscoveryServer) pushXds(con *Connection, w *model.WatchedResource, req
 			log.Debugf("%s: SKIP%s for node:%s%s", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, info)
 		}
 
-		// If we are sending a request, we must respond or we can get Envoy stuck. Assert we do.
-		// One exception is if Envoy is simply unsubscribing from some resources, in which case we can skip.
-		isUnsubscribe := !req.Delta.IsEmpty() && req.Delta.Subscribed.IsEmpty()
-		if features.EnableUnsafeAssertions && err == nil && res == nil && req.IsRequest() && !isUnsubscribe {
-			log.Fatalf("%s: SKIPPED%s for node:%s%s but expected a response for request", v3.GetShortType(w.TypeUrl), req.PushReason(), con.proxy.ID, info)
-		}
 		return err
 	}
 	defer func() { recordPushTime(w.TypeUrl, time.Since(t0)) }()


### PR DESCRIPTION
**Please provide a description of this PR:**

This pr does some mis cleanup on xds:

1. For Stow remove depend on `ResourceDelta.Unsubscribed`, maybe we can do similar for delta.
2. For delta,  it is very common that request.ResponseNonce != previousInfo.NonceSent because of spontaneous requests, so remove the logging
3. remove hard understanding code in delta `newAck != oldAck`