### PR TITLE
Fix bookinfo samples

### DIFF
--- a/samples/bookinfo/gateway-api/route-all-v1.yaml
+++ b/samples/bookinfo/gateway-api/route-all-v1.yaml
@@ -7,7 +7,6 @@ spec:
   - group: ""
     kind: Service
     name: reviews
-    port: 9080
   rules:
   - backendRefs:
     - name: reviews-v1
@@ -22,7 +21,6 @@ spec:
   - group: ""
     kind: Service
     name: productpage
-    port: 9080
   rules:
   - backendRefs:
     - name: productpage-v1
@@ -37,7 +35,6 @@ spec:
   - group: ""
     kind: Service
     name: ratings
-    port: 9080
   rules:
   - backendRefs:
     - name: ratings-v1
@@ -52,7 +49,6 @@ spec:
   - group: ""
     kind: Service
     name: details
-    port: 9080
   rules:
   - backendRefs:
     - name: details-v1

--- a/samples/bookinfo/gateway-api/route-reviews-50-v3.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-50-v3.yaml
@@ -7,7 +7,6 @@ spec:
   - group: ""
     kind: Service
     name: reviews
-    port: 9080
   rules:
   - backendRefs:
     - name: reviews-v1

--- a/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
@@ -7,7 +7,6 @@ spec:
   - group: ""
     kind: Service
     name: reviews
-    port: 9080
   rules:
   - backendRefs:
     - name: reviews-v1

--- a/samples/bookinfo/gateway-api/route-reviews-v1.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-v1.yaml
@@ -7,7 +7,6 @@ spec:
   - group: ""
     kind: Service
     name: reviews
-    port: 9080
   rules:
   - backendRefs:
     - name: reviews-v1

--- a/samples/bookinfo/gateway-api/route-reviews-v3.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-v3.yaml
@@ -7,7 +7,6 @@ spec:
   - group: ""
     kind: Service
     name: reviews
-    port: 9080
   rules:
   - backendRefs:
     - name: reviews-v3


### PR DESCRIPTION
**Please provide a description of this PR:**
Follow https://istio.io/latest/docs/ops/ambient/getting-started/#control gives me:
```
 kubectl apply -f samples/bookinfo/gateway-api/route-reviews-90-10.yaml
Error from server (BadRequest): error when creating "samples/bookinfo/gateway-api/route-reviews-90-10.yaml": HTTPRoute in version "v1beta1" cannot be handled as a HTTPRoute: strict decoding error: unknown field "spec.parentRefs[0].port"
```
Applying without the port works well for the traffic shifts.