### PR TITLE
logging: ordered json keys

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -422,6 +422,7 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *acce
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: jsonLogStruct,
 				},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		}
 	default:

--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -278,6 +278,7 @@ func buildFileAccessJSONLogFormat(
 			Format: &core.SubstitutionFormatString_JsonFormat{
 				JsonFormat: jsonLogStruct,
 			},
+			JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 		},
 	}, formatters
 }

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -1277,6 +1277,7 @@ func TestTelemetryAccessLog(t *testing.T) {
 						},
 					},
 				},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -102,6 +102,7 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: EnvoyJSONLogFormatIstio,
 				},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}
@@ -124,6 +125,7 @@ var (
 						},
 					},
 				},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -349,6 +349,7 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: model.EnvoyJSONLogFormatIstio,
 				},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/releasenotes/notes/json-log-sort.yaml
+++ b/releasenotes/notes/json-log-sort.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Improved** JSON access logs to emit keys in a stable ordering.


### PR DESCRIPTION
This makes the log format quite a bit nicer, since the keys are not scrambled each time. 

Performance WITH sort:
```
DEST          CLIENT  QPS   CONS  DUR  SUCCESS  THROUGHPUT   P50     P90     P99
http://hyper  fortio  0     8     2    24583    12288.40qps  0.63ms  0.79ms  1.21ms
http://hyper  fortio  1000  8     2    2000     996.04qps    0.30ms  0.43ms  0.59ms
```

WITHOUT sort (master):
```
DEST          CLIENT  QPS   CONS  DUR  SUCCESS  THROUGHPUT   P50     P90     P99
http://hyper  fortio  0     8     180  1920049  10666.91qps  0.78ms  1.13ms  1.71ms
http://hyper  fortio  1000  8     180  180000   999.96qps    0.29ms  0.42ms  0.60ms
```

So overall we see equivalent performance here. It would probably be better to microbench this instead of macrobenchmark if we are worried about the performance though, to reduce noise