### PR TITLE
Make default sidecar scope services merge consistent with sidecar

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -221,7 +221,6 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		Name:                    defaultSidecar,
 		Namespace:               configNamespace,
 		EgressListeners:         []*IstioEgressListenerWrapper{defaultEgressListener},
-		services:                defaultEgressListener.services,
 		destinationRules:        make(map[host.Name][]*ConsolidatedDestRule),
 		destinationRulesByNames: make(map[types.NamespacedName]*config.Config),
 		servicesByHostname:      make(map[host.Name]*Service, len(defaultEgressListener.services)),

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -290,6 +290,7 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 		Name:               sidecarConfig.Name,
 		Namespace:          configNamespace,
 		Sidecar:            sidecar,
+		servicesByHostname: make(map[host.Name]*Service),
 		configDependencies: make(sets.Set[ConfigHash]),
 		Version:            ps.PushVersion,
 	}
@@ -388,7 +389,6 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 	// Now that we have all the services that sidecars using this scope (in
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
-	out.servicesByHostname = make(map[host.Name]*Service, len(out.services))
 	out.destinationRules = make(map[host.Name][]*ConsolidatedDestRule)
 	out.destinationRulesByNames = make(map[types.NamespacedName]*config.Config)
 	for _, s := range out.services {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -229,22 +229,27 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		Version:                 ps.PushVersion,
 	}
 
+	servicesAdded := make(map[host.Name]sidecarServiceIndex)
+	for _, listener := range out.EgressListeners {
+		for _, s := range listener.services {
+			out.appendSidecarServices(servicesAdded, s)
+		}
+		// add dependencies on delegate virtual services
+		delegates := ps.DelegateVirtualServices(listener.virtualServices)
+		for _, delegate := range delegates {
+			out.AddConfigDependencies(delegate)
+		}
+		for _, vs := range listener.virtualServices {
+			for _, cfg := range VirtualServiceDependencies(vs) {
+				out.AddConfigDependencies(cfg.HashCode())
+			}
+		}
+	}
+
 	// Now that we have all the services that sidecars using this scope (in
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
 	for _, s := range out.services {
-		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
-		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
-		// newly created Services cannot take ownership unexpectedly.
-		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
-		// "domain squatting" on the hostname before a Kubernetes Service is created.
-		if existing, f := out.servicesByHostname[s.Hostname]; f &&
-			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
-			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
-				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
-			continue
-		}
-		out.servicesByHostname[s.Hostname] = s
 		if dr := ps.destinationRule(configNamespace, s); dr != nil {
 			out.destinationRules[s.Hostname] = dr
 			for _, cdr := range dr {
@@ -263,19 +268,6 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 			Name:      string(s.Hostname),
 			Namespace: s.Attributes.Namespace,
 		}.HashCode())
-	}
-
-	for _, el := range out.EgressListeners {
-		// add dependencies on delegate virtual services
-		delegates := ps.DelegateVirtualServices(el.virtualServices)
-		for _, delegate := range delegates {
-			out.AddConfigDependencies(delegate)
-		}
-		for _, vs := range el.virtualServices {
-			for _, cfg := range VirtualServiceDependencies(vs) {
-				out.AddConfigDependencies(cfg.HashCode())
-			}
-		}
 	}
 
 	if ps.Mesh.OutboundTrafficPolicy != nil {
@@ -321,53 +313,11 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 
 	// Now collect all the imported services across all egress listeners in
 	// this sidecar crd. This is needed to generate CDS output
-	out.services = make([]*Service, 0)
-	type serviceIndex struct {
-		svc   *Service
-		index int // index record the position of the svc in slice
-	}
-	servicesAdded := make(map[host.Name]serviceIndex)
-	addService := func(s *Service) {
-		if s == nil {
-			return
-		}
-		if foundSvc, found := servicesAdded[s.Hostname]; !found {
-			out.AddConfigDependencies(ConfigKey{
-				Kind:      kind.ServiceEntry,
-				Name:      string(s.Hostname),
-				Namespace: s.Attributes.Namespace,
-			}.HashCode())
-			out.services = append(out.services, s)
-			servicesAdded[s.Hostname] = serviceIndex{s, len(out.services) - 1}
-		} else if foundSvc.svc.Attributes.Namespace == s.Attributes.Namespace && len(s.Ports) > 0 {
-			// TODO: we should not merge k8s service with non k8s service.
-			// merge the ports to service when each listener generates partial service
-			// we only merge if the found service is in the same namespace as the one we're trying to add
-			copied := foundSvc.svc.DeepCopy()
-			for _, p := range s.Ports {
-				found := false
-				for _, osp := range copied.Ports {
-					if p.Port == osp.Port {
-						found = true
-						break
-					}
-				}
-				if !found {
-					copied.Ports = append(copied.Ports, p)
-				}
-			}
-			// replace service in slice
-			out.services[foundSvc.index] = copied
-			// Update index as well, so that future reads will merge into the new service
-			foundSvc.svc = copied
-			servicesAdded[foundSvc.svc.Hostname] = foundSvc
-		}
-	}
-
+	servicesAdded := make(map[host.Name]sidecarServiceIndex)
 	for _, listener := range out.EgressListeners {
 		// First add the explicitly requested services, which take priority
 		for _, s := range listener.services {
-			addService(s)
+			out.appendSidecarServices(servicesAdded, s)
 		}
 		// add dependencies on delegate virtual services
 		delegates := ps.DelegateVirtualServices(listener.virtualServices)
@@ -396,7 +346,7 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 						vss = serviceMatchingVirtualServicePorts(s, ports)
 					}
 					if vss != nil {
-						addService(vss)
+						out.appendSidecarServices(servicesAdded, vss)
 					}
 				} else {
 
@@ -427,7 +377,7 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 							vss = serviceMatchingVirtualServicePorts(byNamespace[ns[0]], ports)
 						}
 						if vss != nil {
-							addService(vss)
+							out.appendSidecarServices(servicesAdded, vss)
 						}
 					}
 				}
@@ -442,18 +392,6 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 	out.destinationRules = make(map[host.Name][]*ConsolidatedDestRule)
 	out.destinationRulesByNames = make(map[types.NamespacedName]*config.Config)
 	for _, s := range out.services {
-		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
-		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
-		// newly created Services cannot take ownership unexpectedly.
-		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
-		// "domain squatting" on the hostname before a Kubernetes Service is created.
-		if existing, f := out.servicesByHostname[s.Hostname]; f &&
-			!(existing.Attributes.ServiceRegistry != provider.Kubernetes && s.Attributes.ServiceRegistry == provider.Kubernetes) {
-			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
-				existing.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname)
-			continue
-		}
-		out.servicesByHostname[s.Hostname] = s
 		drList := ps.destinationRule(configNamespace, s)
 		if drList != nil {
 			out.destinationRules[s.Hostname] = drList
@@ -469,6 +407,11 @@ func convertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 				}
 			}
 		}
+		out.AddConfigDependencies(ConfigKey{
+			Kind:      kind.ServiceEntry,
+			Name:      string(s.Hostname),
+			Namespace: s.Attributes.Namespace,
+		}.HashCode())
 	}
 
 	if sidecar.OutboundTrafficPolicy == nil {
@@ -899,4 +842,67 @@ func needsPortMatch(l *networking.IstioEgressListener) bool {
 	//  - If Port's protocol is proxy protocol(HTTP_PROXY) in which case the egress listener is used as generic egress http proxy.
 	return l != nil && l.Port.GetNumber() != 0 &&
 		protocol.Parse(l.Port.Protocol) != protocol.HTTP_PROXY
+}
+
+type sidecarServiceIndex struct {
+	svc   *Service
+	index int // index record the position of the svc in slice
+}
+
+func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sidecarServiceIndex, s *Service) {
+	if s == nil {
+		return
+	}
+	if foundSvc, found := servicesAdded[s.Hostname]; !found {
+		sc.services = append(sc.services, s)
+		servicesAdded[s.Hostname] = sidecarServiceIndex{s, len(sc.services) - 1}
+		sc.servicesByHostname[s.Hostname] = s
+	} else {
+		existing := foundSvc.svc
+		// We donot merge k8s service with any other services from other registries
+		if existing.Attributes.ServiceRegistry == provider.Kubernetes {
+			return
+		}
+		// In some scenarios, there may be multiple Services defined for the same hostname due to ServiceEntry allowing
+		// arbitrary hostnames. In these cases, we want to pick the first Service, which is the oldest. This ensures
+		// newly created Services cannot take ownership unexpectedly.
+		// However, the Service is from Kubernetes it should take precedence over ones not. This prevents someone from
+		// "domain squatting" on the hostname before a Kubernetes Service is created.
+		if s.Attributes.ServiceRegistry == provider.Kubernetes {
+			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry,
+				s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry)
+			// replace service in slice
+			sc.services[foundSvc.index] = s
+			// Update index as well, so that future reads will merge into the new service
+			foundSvc.svc = s
+			servicesAdded[foundSvc.svc.Hostname] = foundSvc
+			sc.servicesByHostname[s.Hostname] = s
+			return
+		}
+
+		// we merge ports for services both defined by ServiceEntry in same namespace
+		if existing.Attributes.Namespace == s.Attributes.Namespace {
+			// merge the ports to service when each listener generates partial service
+			// we only merge if the found service is in the same namespace as the one we're trying to add
+			copied := foundSvc.svc.DeepCopy()
+			for _, p := range s.Ports {
+				found := false
+				for _, osp := range copied.Ports {
+					if p.Port == osp.Port {
+						found = true
+						break
+					}
+				}
+				if !found {
+					copied.Ports = append(copied.Ports, p)
+				}
+			}
+			// replace service in slice
+			sc.services[foundSvc.index] = copied
+			// Update index as well, so that future reads will merge into the new service
+			foundSvc.svc = copied
+			servicesAdded[foundSvc.svc.Hostname] = foundSvc
+			sc.servicesByHostname[s.Hostname] = s
+		}
+	}
 }

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2322,7 +2322,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 
 			for k, v := range tt.contains {
-				if ok := sidecarScope.DependsOnConfig(k); ok != v {
+				if ok := sidecarScope.DependsOnConfig(k, ps.Mesh.RootNamespace); ok != v {
 					t.Fatalf("Expected contains %v-%v, but no match", k, v)
 				}
 			}
@@ -2381,7 +2381,7 @@ func TestRootNsSidecarDependencies(t *testing.T) {
 			}
 
 			for k, v := range tt.contains {
-				if ok := sidecarScope.DependsOnConfig(k); ok != v {
+				if ok := sidecarScope.DependsOnConfig(k, ps.Mesh.RootNamespace); ok != v {
 					t.Fatalf("Expected contains %v-%v, but no match", k, v)
 				}
 			}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1035,6 +1035,59 @@ var (
 			},
 		},
 	}
+	services24 = []*Service{
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port803x,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns1",
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns2",
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:      "baz",
+				Namespace: "ns1", // same ns as foo
+			},
+		},
+	}
+	services25 = []*Service{
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port803x,
+			Attributes: ServiceAttributes{
+				Name:      "foo",
+				Namespace: "ns1",
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:      "bar",
+				Namespace: "ns2",
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:            "baz",
+				Namespace:       "ns3",
+				ServiceRegistry: provider.Kubernetes,
+			},
+		},
+	}
 
 	virtualServices1 = []config.Config{
 		{
@@ -1291,6 +1344,57 @@ func TestCreateSidecarScope(t *testing.T) {
 			[]*Service{
 				{
 					Hostname: "bar",
+				},
+			},
+			nil,
+		},
+		{
+			"no-sidecar-config-not-merge-service-in-diff-namespaces",
+			nil,
+			services23,
+			nil,
+			[]*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    append(port803x),
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"no-sidecar-config-merge-service-ports",
+			nil,
+			services24,
+			nil,
+			[]*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    append(port803x, port7443...),
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns",
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"no-sidecar-config-k8s-service-take-precedence",
+			nil,
+			services25,
+			nil,
+			[]*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port7443,
+					Attributes: ServiceAttributes{
+						Name:      "bar",
+						Namespace: "ns2",
+					},
 				},
 			},
 			nil,

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1356,7 +1356,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			[]*Service{
 				{
 					Hostname: "foobar.svc.cluster.local",
-					Ports:    append(port803x),
+					Ports:    port803x,
 					Attributes: ServiceAttributes{
 						Name:      "foo",
 						Namespace: "ns1",

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -2348,7 +2347,7 @@ func TestCreateSidecarScope(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s", tt.name), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			var serviceFound bool
 			var portsMatched bool
 			ps := NewPushContext()

--- a/pilot/pkg/xds/proxy_dependencies.go
+++ b/pilot/pkg/xds/proxy_dependencies.go
@@ -60,9 +60,9 @@ func proxyDependentOnConfig(proxy *model.Proxy, config model.ConfigKey, push *mo
 	// Detailed config dependencies check.
 	switch proxy.Type {
 	case model.SidecarProxy:
-		if proxy.SidecarScope.DependsOnConfig(config) {
+		if proxy.SidecarScope.DependsOnConfig(config, push.Mesh.RootNamespace) {
 			return true
-		} else if proxy.PrevSidecarScope != nil && proxy.PrevSidecarScope.DependsOnConfig(config) {
+		} else if proxy.PrevSidecarScope != nil && proxy.PrevSidecarScope.DependsOnConfig(config, push.Mesh.RootNamespace) {
 			return true
 		}
 	case model.Router:

--- a/pilot/pkg/xds/proxy_dependencies_test.go
+++ b/pilot/pkg/xds/proxy_dependencies_test.go
@@ -37,7 +37,6 @@ import (
 
 func TestProxyNeedsPush(t *testing.T) {
 	const (
-		invalidKind    = "INVALID_KIND"
 		svcName        = "svc1.com"
 		privateSvcName = "private.com"
 		drName         = "dr1"
@@ -59,7 +58,7 @@ func TestProxyNeedsPush(t *testing.T) {
 
 	sidecar := &model.Proxy{
 		Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}, Metadata: &model.NodeMetadata{},
-		SidecarScope: &model.SidecarScope{Name: generalName, Namespace: nsName, RootNamespace: nsRoot},
+		SidecarScope: &model.SidecarScope{Name: generalName, Namespace: nsName},
 	}
 	gateway := &model.Proxy{
 		Type:     model.Router,

--- a/pilot/pkg/xds/proxy_dependencies_test.go
+++ b/pilot/pkg/xds/proxy_dependencies_test.go
@@ -251,6 +251,7 @@ func TestProxyNeedsPush(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			cg.PushContext().Mesh.RootNamespace = nsRoot
 			got := DefaultProxyNeedsPush(tt.proxy, &model.PushRequest{ConfigsUpdated: tt.configs, Push: cg.PushContext()})
 			if got != tt.want {
 				t.Fatalf("Got needs push = %v, expected %v", got, tt.want)

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -456,7 +456,7 @@ func TestNameTable(t *testing.T) {
 			expectedNameTable: &dnsProto.NameTable{
 				Table: map[string]*dnsProto.NameTable_NameInfo{
 					serviceWithVIP1.Hostname.String(): {
-						Ips:      []string{serviceWithVIP1.DefaultAddress, serviceWithVIP2.DefaultAddress},
+						Ips:      []string{serviceWithVIP1.DefaultAddress},
 						Registry: provider.External.String(),
 					},
 				},


### PR DESCRIPTION
**Please provide a description of this PR:**

Now we merge services that are from SE and in same namespace.
And k8s service takes priority, we donot merge k8s services' ports before and after. 

I am not sure of any regression by this, open for feedback first