### PR TITLE
Fix no tag webhook is installed after revisioned installation failure

### DIFF
--- a/istioctl/pkg/tag/util.go
+++ b/istioctl/pkg/tag/util.go
@@ -106,7 +106,7 @@ func DeleteTagWebhooks(ctx context.Context, client kubernetes.Interface, tag str
 // whether to make an installation the default.
 func PreviousInstallExists(ctx context.Context, client kubernetes.Interface) bool {
 	mwhs, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-		LabelSelector: "app=sidecar-injector",
+		LabelSelector: "app=sidecar-injector,istio.io/tag=default",
 	})
 	if err != nil {
 		return false

--- a/releasenotes/notes/48919.yaml
+++ b/releasenotes/notes/48919.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** an inconsistency in the behavior of revisioned default installations following a prior installation failure.


### PR DESCRIPTION
**Please provide a description of this PR:**
There is an inconsistent behavior in revisioned installations in a clean environment (with no prior installations). Using `istioctl install --revision=test` in such an environment successfully installs a default webhook. However, if there are failures during the initial installation and you attempt to reinstall again using `istioctl install --revision=test`, a successful installation will not install a default webhook. 
I think that if there is no prior installation, or if no installation has been successfully completed, we should ensure the installation of the default webhook.