### PR TITLE
fix: revision value should be respected for remote cluster svc/endpoint

### DIFF
--- a/manifests/charts/istiod-remote/templates/endpoints.yaml
+++ b/manifests/charts/istiod-remote/templates/endpoints.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   {{- if .Values.pilot.enabled }}
-  name: istiod-remote
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
   {{- else }}
-  name: istiod
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/istiod-remote/templates/services.yaml
+++ b/manifests/charts/istiod-remote/templates/services.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   {{- if .Values.pilot.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
-  name: istiod-remote
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
   {{- else }}
   # when local istiod isn't enabled, we can use istiod service name to reach the remote control plane
-  name: istiod
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
**Please provide a description of this PR:**
remote cluster with revision specificied should repsect the value. 
fix #47552


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [X ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure