### PR TITLE
fix: revision value should be respected for remote cluster svc/endpoint

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   {{- if .Values.pilot.enabled }}
-  name: istiod-remote
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
-  name: istiod
+  name: istiod{{- if eq .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.pilot.enabled }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
-  name: istiod{{- if eq .Values.revision }}-{{ .Values.revision}}{{- end }}
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   {{- if .Values.pilot.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
-  name: istiod-remote
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
   # when local istiod isn't enabled, we can use istiod service name to reach the remote control plane
-  name: istiod
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/manifests/charts/istiod-remote/templates/endpoints.yaml
+++ b/manifests/charts/istiod-remote/templates/endpoints.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   {{- if .Values.pilot.enabled }}
-  name: istiod-remote
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
   {{- else }}
-  name: istiod
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/istiod-remote/templates/endpoints.yaml
+++ b/manifests/charts/istiod-remote/templates/endpoints.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.pilot.enabled }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
-  name: istiod{{- if eq .Values.revision }}-{{ .Values.revision}}{{- end }}
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/istiod-remote/templates/endpoints.yaml
+++ b/manifests/charts/istiod-remote/templates/endpoints.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   {{- if .Values.pilot.enabled }}
-  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
-  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
+  name: istiod{{- if eq .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 subsets:

--- a/manifests/charts/istiod-remote/templates/services.yaml
+++ b/manifests/charts/istiod-remote/templates/services.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   {{- if .Values.pilot.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
-  name: istiod-remote
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
   {{- else }}
   # when local istiod isn't enabled, we can use istiod service name to reach the remote control plane
-  name: istiod
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/manifests/charts/istiod-remote/templates/services.yaml
+++ b/manifests/charts/istiod-remote/templates/services.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   {{- if .Values.pilot.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
-  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end -}}-remote
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
   # when local istiod isn't enabled, we can use istiod service name to reach the remote control plane
-  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision}}{{- end }}
+  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/releasenotes/notes/remote-cluster-respect-revision.yaml
+++ b/releasenotes/notes/remote-cluster-respect-revision.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - 47552
+
+releaseNotes:
+- |
+  **Fixed** an issue that Endpoint and Service in istiod-remote chart do not respect the revision value


### PR DESCRIPTION
remote cluster with revision specificied should repsect the value. fix #47552

**Please provide a description of this PR:**