### PR TITLE
Add ability to set gateway container's lifecycle hooks

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
           - name: {{ $key }}
             value: {{ $val | quote }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle: {{ toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: 15090
             protocol: TCP

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -150,3 +150,11 @@ defaults:
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   # for more detail.
   priorityClassName: ""
+
+  # Lifecycle describes actions that the management system should take
+  # in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers,
+  # management of the container blocks until the action is complete,
+  # unless the container process fails, in which case the handler is aborted.
+  # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+  lifecycle: {}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fulfills https://github.com/istio/istio/issues/47265 https://github.com/istio/istio/issues/47779 https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2131
In my company, we do not have any `kustomize` workflows or the ability to add it to our CI/CD.
The addition of the ability to set container `lifecycle` hooks does not interfere with any existing setups.

**Tests**
Test values yaml
```yaml
lifecycle:
  preStop:
    exec:
      command: ["/bin/sh","-c","sleep 300"]
```

Render template
```sh
helm template \
./istio/manifests/charts/gateway \
--set name=istio-ingressgateway \
-f values-gw-test.yaml \
-s templates/deployment.yaml \
--dry-run --debug
```

Output with enabled preStop lifecycle hook:
```yaml
# Source: gateway/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: istio-ingressgateway
  namespace: kube-system
  labels:
    helm.sh/chart: gateway-1.0.0
    app: istio-ingressgateway
    istio: ingressgateway
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: istio-ingressgateway
  annotations:
    {}
spec:
  selector:
    matchLabels:
      app: istio-ingressgateway
      istio: ingressgateway
  template:
    metadata:
      annotations:
        inject.istio.io/templates: gateway
        prometheus.io/path: /stats/prometheus
        prometheus.io/port: "15020"
        prometheus.io/scrape: "true"
        sidecar.istio.io/inject: "true"
      labels:
        sidecar.istio.io/inject: "true"
        app: istio-ingressgateway
        istio: ingressgateway
    spec:
      serviceAccountName: istio-ingressgateway
      securityContext:
        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
        sysctls:
        - name: net.ipv4.ip_unprivileged_port_start
          value: "0"
      containers:
        - name: istio-proxy
          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
          image: auto
          securityContext:
            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
            capabilities:
              drop:
              - ALL
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsUser: 1337
            runAsGroup: 1337
            runAsNonRoot: true
          env:
          lifecycle: 
            preStop:
              exec:
                command:
                - /bin/sh
                - -c
                - sleep 300
          ports:
          - containerPort: 15090
            protocol: TCP
            name: http-envoy-prom
          resources:
            limits:
              cpu: 2000m
              memory: 1024Mi
            requests:
              cpu: 100m
              memory: 128Mi
      terminationGracePeriodSeconds: 30
```

Output with empty `lifecycle: {}` var:
```yaml
# Source: gateway/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: istio-ingressgateway
  namespace: kube-system
  labels:
    helm.sh/chart: gateway-1.0.0
    app: istio-ingressgateway
    istio: ingressgateway
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: istio-ingressgateway
  annotations:
    {}
spec:
  selector:
    matchLabels:
      app: istio-ingressgateway
      istio: ingressgateway
  template:
    metadata:
      annotations:
        inject.istio.io/templates: gateway
        prometheus.io/path: /stats/prometheus
        prometheus.io/port: "15020"
        prometheus.io/scrape: "true"
        sidecar.istio.io/inject: "true"
      labels:
        sidecar.istio.io/inject: "true"
        app: istio-ingressgateway
        istio: ingressgateway
    spec:
      serviceAccountName: istio-ingressgateway
      securityContext:
        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
        sysctls:
        - name: net.ipv4.ip_unprivileged_port_start
          value: "0"
      containers:
        - name: istio-proxy
          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
          image: auto
          securityContext:
            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
            capabilities:
              drop:
              - ALL
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsUser: 1337
            runAsGroup: 1337
            runAsNonRoot: true
          env:
          ports:
          - containerPort: 15090
            protocol: TCP
            name: http-envoy-prom
          resources:
            limits:
              cpu: 2000m
              memory: 1024Mi
            requests:
              cpu: 100m
              memory: 128Mi
      terminationGracePeriodSeconds: 30
```