### PR TITLE
Add default webhook shift message before install

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -183,7 +183,7 @@ func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, 
 	exists := revtag.PreviousInstallExists(context.Background(), kubeClient.Kube())
 	err = detectDefaultWebhookChange(p, kubeClient, iop, exists)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to detect the default webhook change: %v", err)
 	}
 
 	// Warn users if they use `istioctl install` without any config args.

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
@@ -179,6 +180,11 @@ func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, 
 	// Ignore the err because we don't want to show
 	// "no running Istio pods in istio-system" for the first time
 	_ = detectIstioVersionDiff(p, tag, ns, kubeClient, iop)
+	exists := revtag.PreviousInstallExists(context.Background(), kubeClient.Kube())
+	err = detectDefaultWebhookChange(p, kubeClient, iop, exists)
+	if err != nil {
+		return err
+	}
 
 	// Warn users if they use `istioctl install` without any config args.
 	if !rootArgs.DryRun && !iArgs.SkipConfirmation {
@@ -196,7 +202,6 @@ func Install(kubeClient kube.CLIClient, rootArgs *RootArgs, iArgs *InstallArgs, 
 	iop.Name = savedIOPName(iop)
 
 	// Detect whether previous installation exists prior to performing the installation.
-	exists := revtag.PreviousInstallExists(context.Background(), kubeClient.Kube())
 	if err := InstallManifests(iop, iArgs.Force, rootArgs.DryRun, kubeClient, client, iArgs.ReadinessTimeout, l); err != nil {
 		return fmt.Errorf("failed to install manifests: %v", err)
 	}
@@ -390,4 +395,23 @@ func humanReadableJoin(ss []string) string {
 	default:
 		return strings.Join(ss[:len(ss)-1], ", ") + ", and " + ss[len(ss)-1]
 	}
+}
+
+func detectDefaultWebhookChange(p Printer, client kube.CLIClient, iop *v1alpha12.IstioOperator, exists bool) error {
+	if !helmreconciler.DetectIfTagWebhookIsNeeded(iop, exists) {
+		return nil
+	}
+	mwhs, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app=sidecar-injector,istio.io/rev=default,istio.io/tag=default",
+	})
+	if err != nil {
+		return err
+	}
+	// If there is no default webhook but a revisioned default webhook exists,
+	// and we are installing a new IOP with default semantics, the default webhook shifts.
+	if exists && len(mwhs.Items) == 0 && iop.Spec.GetRevision() == "" {
+		p.Println("This installation will make default injection and validation pointing to the default revision, and " +
+			"originally it was pointing to the revisioned one.")
+	}
+	return nil
 }

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -508,7 +508,7 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 			return err
 		}
 		// Here if we need to create a default tag, we need to skip the webhooks that are going to be deactivated.
-		if !detectIfTagWebhookIsNeeded(h.iop, exists) {
+		if !DetectIfTagWebhookIsNeeded(h.iop, exists) {
 			whReaderSource := local.ReaderSource{
 				Name:   fmt.Sprintf("installed-webhook-%d", i),
 				Reader: strings.NewReader(objYaml),
@@ -599,7 +599,7 @@ type ProcessDefaultWebhookOptions struct {
 	DryRun    bool
 }
 
-func detectIfTagWebhookIsNeeded(iop *istioV1Alpha1.IstioOperator, exists bool) bool {
+func DetectIfTagWebhookIsNeeded(iop *istioV1Alpha1.IstioOperator, exists bool) bool {
 	rev := iop.Spec.Revision
 	isDefaultInstallation := rev == "" && iop.Spec.Components.Pilot != nil && iop.Spec.Components.Pilot.Enabled.Value
 	operatorManageWebhooks := operatorManageWebhooks(iop)
@@ -608,7 +608,7 @@ func detectIfTagWebhookIsNeeded(iop *istioV1Alpha1.IstioOperator, exists bool) b
 
 func ProcessDefaultWebhook(client kube.Client, iop *istioV1Alpha1.IstioOperator, exists bool, opt *ProcessDefaultWebhookOptions) (processed bool, err error) {
 	// Detect whether previous installation exists prior to performing the installation.
-	if !detectIfTagWebhookIsNeeded(iop, exists) {
+	if !DetectIfTagWebhookIsNeeded(iop, exists) {
 		return false, nil
 	}
 	rev := iop.Spec.Revision

--- a/releasenotes/notes/48982.yaml
+++ b/releasenotes/notes/48982.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- https://github.com/istio/istio/issues/48643
+releaseNotes:
+- |
+  **Added** a message to indicate the default webhook shifting from a revisioned installation to a default installation.


### PR DESCRIPTION
**Please provide a description of this PR:**
This is related to https://github.com/istio/istio/issues/48643.

There's an inconsistent behavior between:
```
default installation -> then do a revisioned installation # this will use default's default webhook

revisioned installation -> default installation # this will change the default webhook from revisioned to default
```

Instead of changing the default behaviors described in https://istio.io/latest/docs/setup/upgrade/canary/#default-tag, which may affect existing users, I think adding a warning about the default webhook shifting would be good.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
