### PR TITLE
Makefile: Fix race in init target

### DIFF
--- a/bin/build_ztunnel.sh
+++ b/bin/build_ztunnel.sh
@@ -63,15 +63,8 @@ function download_ztunnel_if_necessary () {
 
   # Download and make the binary executable
   echo "Downloading ztunnel: $1 to $2"
-  BASE_NAME="$(basename "${ISTIO_ZTUNNEL_RELEASE_URL}")"
-  time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > "${BASE_NAME}"
-  chmod +x "${BASE_NAME}"
-
-  # Copy the extracted binary to the output location
-  cp "${BASE_NAME}" "$2"
-
-  # Remove the extracted binary.
-  rm -rf usr
+  time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" > "$2"
+  chmod +x "$2"
 
   # Make a copy named just "ztunnel" in the same directory (overwrite if necessary).
   echo "Copying $2 to $(dirname "$2")/${3}"

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -110,13 +110,9 @@ function download_envoy_if_necessary () {
 
     # Download and extract the binary to the output directory.
     echo "Downloading ${SIDECAR}: $1 to $2"
-    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" | tar xz
-
-    # Copy the extracted binary to the output location
-    cp usr/local/bin/"${SIDECAR}" "$2"
-
-    # Remove the extracted binary.
-    rm -rf usr
+    time ${DOWNLOAD_COMMAND} --header "${AUTH_HEADER:-}" "$1" |\
+      tar --extract --gzip --strip-components=3 --to-stdout > "$2"
+    chmod +x "$2"
 
     # Make a copy named just "envoy" in the same directory (overwrite if necessary).
     echo "Copying $2 to $(dirname "$2")/${3}"


### PR DESCRIPTION
Closes #48990

**Please provide a description of this PR:**
Makefile init target runs its dependencies in parallel, where one dep removed the other's files.

Tested, now works with `BUILD_WITH_CONTAINER=0 make build`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Installation
- [x] Test and Release
- [x] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.