### PR TITLE
RFC: Smooth distooless experience with mini 'busybox' setup

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -245,6 +245,9 @@ STANDARD_TAGS=disable_pgv,vtprotobuf
 build: depend ## Builds all go binaries.
 	GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(TARGET_OUT)/ -tags=$(STANDARD_TAGS) $(STANDARD_BINARIES)
 	GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(TARGET_OUT)/ -tags=$(AGENT_TAGS) $(AGENT_BINARIES)
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sleep
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sh
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/bash
 
 # The build-linux target is responsible for building binaries used within containers.
 # This target should be expanded upon as we add more Linux architectures: i.e. build-arm64.
@@ -254,6 +257,9 @@ build: depend ## Builds all go binaries.
 build-linux: depend
 	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(TARGET_OUT_LINUX)/ -tags=$(STANDARD_TAGS) $(STANDARD_BINARIES)
 	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(TARGET_OUT_LINUX)/ -tags=$(AGENT_TAGS) $(LINUX_AGENT_BINARIES)
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sleep
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sh
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/bash
 
 # Create targets for TARGET_OUT_LINUX/binary
 # There are two use cases here:
@@ -268,6 +274,9 @@ $(TARGET_OUT_LINUX)/$(shell basename $(1)): build-linux
 else
 $(TARGET_OUT_LINUX)/$(shell basename $(1)): $(TARGET_OUT_LINUX)
 	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(TARGET_OUT_LINUX)/ -tags=$(2) $(1)
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sleep
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/sh
+	ln -sf $(TARGET_OUT)/pilot-agent $(TARGET_OUT)/bash
 endif
 endef
 

--- a/pilot/cmd/pilot-agent/app/busybox.go
+++ b/pilot/cmd/pilot-agent/app/busybox.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func RunBusybox() {
+	switch os.Args[0] {
+	case "/usr/bin/sleep", "sleep":
+		if len(os.Args) < 2 {
+			fmt.Fprintln(os.Stderr, "sleep: missing operand")
+			os.Exit(1)
+		}
+		dur, _ := time.ParseDuration(os.Args[1])
+		time.Sleep(dur)
+case "/usr/bin/sh", "sh":
+	fmt.Fprintln(os.Stderr, "Istio is running in distroless mode and does not have a shell. See https://istio.io/latest/docs/ops/configuration/security/harden-docker-images/ for more information.")
+	os.Exit(1)
+	}
+}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"istio.io/istio/pkg/util/sets"
 	"os"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/app"
@@ -23,9 +24,19 @@ import (
 
 // TODO: get the config and bootstrap from istiod, by passing the env
 
+var busybox = sets.New(
+	"/usr/bin/sleep", "sleep",
+	"/usr/bin/sh", "sh",
+	"/usr/bin/bash", "bash",
+	)
+
 // Use env variables - from injection, k8s and local namespace config map.
 // No CLI parameters.
 func main() {
+	if busybox.Contains(os.Args[0]) {
+		app.RunBusybox()
+		return
+	}
 	log.EnableKlogWithCobra()
 	rootCmd := app.NewRootCommand()
 	if err := rootCmd.Execute(); err != nil {

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -8,6 +8,9 @@ ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 # The following section is used as base image if BASE_DISTRIBUTION=debug
 FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
+#RUN ln -sf /usr/local/bin/pilot-agent /usr/bin/sleep
+#RUN ln -sf /usr/local/bin/pilot-agent /usr/bin/bash
+#RUN ln -sf /usr/local/bin/pilot-agent /usr/bin/sh
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 # This image is a custom built debian11 distroless image with multiarchitecture support.
 # It is built on the base distroless image, with iptables binary and libraries added
@@ -37,6 +40,12 @@ ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent
+
+#COPY --from=debug /usr/bin/bash /usr/bin/bash
+#COPY --from=debug /usr/bin/sh /usr/bin/sh
+COPY sleep /usr/bin/sleep
+COPY sh /usr/bin/sh
+COPY bash /usr/bin/bash
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/tools/docker-builder/builder/tar.go
+++ b/tools/docker-builder/builder/tar.go
@@ -27,6 +27,11 @@ func WriteArchiveFromFiles(base string, files map[string]string, out io.Writer) 
 	tw := tar.NewWriter(out)
 	defer tw.Close()
 
+	rev := map[string]string{}
+	for k, v := range files {
+		rev[v] = k
+	}
+
 	for dest, srcRel := range files {
 		src := srcRel
 		if !filepath.IsAbs(src) {
@@ -40,7 +45,7 @@ func WriteArchiveFromFiles(base string, files map[string]string, out io.Writer) 
 		ts := src
 		write := func(src string) error {
 			rel, _ := filepath.Rel(ts, src)
-			info, err := os.Stat(src)
+			info, err := os.Lstat(src)
 			if err != nil {
 				return err
 			}
@@ -50,6 +55,9 @@ func WriteArchiveFromFiles(base string, files map[string]string, out io.Writer) 
 				// fs.FS does not implement readlink, so we have this hack for now.
 				if link, err = os.Readlink(src); err != nil {
 					return err
+				}
+				if l2, f := rev[link]; f {
+					link = l2
 				}
 			}
 

--- a/tools/docker-copy.sh
+++ b/tools/docker-copy.sh
@@ -76,6 +76,7 @@ function may_copy_into_arch_named_sub_dir() {
     dst+="/${arch}/"
   fi
   mkdir -p "${dst}"
+  echo cp -rp "${FILE}" "${dst}"
   cp -rp "${FILE}" "${dst}"
 
   # Based on type, explicit set permissions. These may differ on host machine due to umask, so always override.

--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -32,6 +32,9 @@ images:
   - tools/packaging/common/envoy_bootstrap.json
   - tools/packaging/common/gcp_envoy_bootstrap.json
   - ${TARGET_OUT_LINUX}/${RELEASE_MODE}/${SIDECAR}
+  -  ${TARGET_OUT_LINUX}/sleep
+  -  ${TARGET_OUT_LINUX}/sh
+  -  ${TARGET_OUT_LINUX}/bash
   targets:
   - ${TARGET_OUT_LINUX}/pilot-agent
 - name: pilot


### PR DESCRIPTION
This PR attempts to provide the following experience for distroless users:

```
$ kubectl exec deploy/shell -c istio-proxy -- sleep 1s
# (sleeps for 1s)
$ kubectl exec deploy/shell -c istio-proxy -- sh
Istio is running in distroless mode and does not have a shell. See https://istio.io/latest/docs/ops/configuration/security/harden-docker-images/ for more information.
command terminated with exit code 1
```

Two motivations here:
* The number 1 usage of non-debugging utilities is `sleep` in lifecycle hooks, anecdotally. This is trivial to keep working
* Users who attempt to use a shell in distroless get obscure error messages; we can do better

This works by symlinking `/usr/bin/{sh,sleep}` to pilot-agent. In pilot-agent, it detects these are call (`os.Args[0]` shows the name of the file actually executed) and runs corresponding functionality. In this way, we keep only the existing binaries, but provide the UX above.

This is a hacky implementation, if we want to proceed I'll clean it up