### PR TITLE
Makefile: drop istioctl dependency: envoy, ztunnel

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -373,17 +373,17 @@ copy-templates:
 #-----------------------------------------------------------------------------
 
 # Non-static istioctl targets. These are typically a build artifact.
-${TARGET_OUT}/release/istioctl-linux-amd64: depend
+${TARGET_OUT}/release/istioctl-linux-amd64:
 	GOOS=linux GOARCH=amd64 LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
-${TARGET_OUT}/release/istioctl-linux-armv7: depend
+${TARGET_OUT}/release/istioctl-linux-armv7:
 	GOOS=linux GOARCH=arm GOARM=7 LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
-${TARGET_OUT}/release/istioctl-linux-arm64: depend
+${TARGET_OUT}/release/istioctl-linux-arm64:
 	GOOS=linux GOARCH=arm64 LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
-${TARGET_OUT}/release/istioctl-osx: depend
+${TARGET_OUT}/release/istioctl-osx:
 	GOOS=darwin GOARCH=amd64 LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
-${TARGET_OUT}/release/istioctl-osx-arm64: depend
+${TARGET_OUT}/release/istioctl-osx-arm64:
 	GOOS=darwin GOARCH=arm64 LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
-${TARGET_OUT}/release/istioctl-win.exe: depend
+${TARGET_OUT}/release/istioctl-win.exe:
 	GOOS=windows LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $@ ./istioctl/cmd/istioctl
 
 # generate the istioctl completion files


### PR DESCRIPTION
**Please provide a description of this PR:**
Continuing almost whole-workday storyline from #48990: updating Arch package for istioctl. (..and cutting usage from the part my previous PR fixed :upside_down_face:)

Just building ctl does seemingly not need the dependencies marked as dependants for pretty much all targets in Makefiles. Let's cut down on waste. AFAIK, the component is rather decoupled from the others, and I couldn't find anything breaking.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**
- [x] Test and Release

**Please check any characteristics that apply to this pull request.**
- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

***
tested:
- docker istioctl-all
- non-docker istioctl-all
- manual search in `istioctl/` for any embeds + glaze through mentions of the deps

tried to test:
- go test istioctl/cmd → fuzz fail
- make test → credential errors

Seems fine, CI tests might work™
/shrug