### PR TITLE
a multi-cluster node authorizer for ambient mesh

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -165,7 +165,7 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 	// The CA API uses cert with the max workload cert TTL.
 	// 'hostlist' must be non-empty - but is not used since a grpc server is passed.
 	// Adds client cert auth and kube (sds enabled)
-	caServer, startErr := caserver.New(ca, maxWorkloadCertTTL.Get(), opts.Authenticators, s.kubeClient, opts.DiscoveryFilter)
+	caServer, startErr := caserver.New(ca, maxWorkloadCertTTL.Get(), opts.Authenticators, s.kubeClient, opts.DiscoveryFilter, s.multiclusterController.AddHandler)
 	if startErr != nil {
 		log.Fatalf("failed to create istio ca server: %v", startErr)
 	}

--- a/pilot/pkg/features/security.go
+++ b/pilot/pkg/features/security.go
@@ -88,6 +88,11 @@ var (
 		return res
 	}()
 
+	EnableMultiClusterNodeAuthorizer = env.Register(
+		"ENABLE_MULTICLUSTER_NODE_AUTHORIZER",
+		false,
+		"If enabled, node authorization will be performed for CSRs originating from remote clusters.").Get()
+
 	CertSignerDomain = env.Register("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
 
 	UseCacertsForSelfSignedCA = env.Register("USE_CACERTS_FOR_SELF_SIGNED_CA", false,

--- a/security/pkg/server/ca/node_auth_test.go
+++ b/security/pkg/server/ca/node_auth_test.go
@@ -23,7 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
@@ -41,7 +43,7 @@ func (p pod) Identity() string {
 	}.String()
 }
 
-func TestNodeAuthorizer(t *testing.T) {
+func TestSingleClusterNodeAuthorization(t *testing.T) {
 	allowZtunnel := map[types.NamespacedName]struct{}{
 		{Name: "ztunnel", Namespace: "istio-system"}: {},
 	}
@@ -172,7 +174,7 @@ func TestNodeAuthorizer(t *testing.T) {
 				})
 			}
 			c := kube.NewFakeClient(pods...)
-			na, err := NewNodeAuthorizer(c, nil, tt.trustedAccounts)
+			na, err := NewClusterNodeAuthorizer(c, nil, tt.trustedAccounts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -180,6 +182,158 @@ func TestNodeAuthorizer(t *testing.T) {
 			kube.WaitForCacheSync("test", test.NewStop(t), na.pods.HasSynced)
 
 			err = na.authenticateImpersonation(tt.caller, tt.requestedIdentityString)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("wanted no error, got %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func toPod(p pod, isZtunnel bool) *v1.Pod {
+	po := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name,
+			Namespace: p.namespace,
+			UID:       types.UID(p.uid),
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: p.account,
+			NodeName:           p.node,
+		},
+	}
+	if isZtunnel {
+		po.Labels = map[string]string{
+			"app": "ztunnel",
+		}
+	}
+	return po
+}
+
+func TestMultiClusterNodeAuthorization(t *testing.T) {
+	allowZtunnel := map[types.NamespacedName]struct{}{
+		{Name: "ztunnel", Namespace: "istio-system"}: {},
+	}
+	ztunnelCallerPrimary := security.KubernetesInfo{
+		PodName:           "ztunnel-a",
+		PodNamespace:      "istio-system",
+		PodUID:            "12345",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPodPrimary := pod{
+		name:      ztunnelCallerPrimary.PodName,
+		namespace: ztunnelCallerPrimary.PodNamespace,
+		account:   ztunnelCallerPrimary.PodServiceAccount,
+		uid:       ztunnelCallerPrimary.PodUID,
+		node:      "zt-node-primary",
+	}
+	ztunnelCallerRemote := security.KubernetesInfo{
+		PodName:           "ztunnel-b",
+		PodNamespace:      "istio-system",
+		PodUID:            "12346",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPodRemote := pod{
+		name:      ztunnelCallerRemote.PodName,
+		namespace: ztunnelCallerRemote.PodNamespace,
+		account:   ztunnelCallerRemote.PodServiceAccount,
+		uid:       ztunnelCallerRemote.PodUID,
+		node:      "zt-node-remote",
+	}
+	ztunnelCallerRemote2 := security.KubernetesInfo{
+		PodName:           "ztunnel-c",
+		PodNamespace:      "istio-system",
+		PodUID:            "12347",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPodRemote2 := pod{
+		name:      ztunnelCallerRemote2.PodName,
+		namespace: ztunnelCallerRemote2.PodNamespace,
+		account:   ztunnelCallerRemote2.PodServiceAccount,
+		uid:       ztunnelCallerRemote2.PodUID,
+		node:      "zt-node-remote",
+	}
+	podSameNodePrimary := pod{
+		name:      "pod-a",
+		namespace: "ns-a",
+		account:   "sa-a",
+		uid:       "1",
+		node:      "zt-node-primary",
+	}
+	podSameNodeRemote := pod{
+		name:      "pod-b",
+		namespace: "ns-b",
+		account:   "sa-b",
+		uid:       "2",
+		node:      "zt-node-remote",
+	}
+	primaryClusterPods := []runtime.Object{
+		toPod(ztunnelPodPrimary, true),
+		toPod(podSameNodePrimary, false),
+	}
+	remoteClusterPods := []runtime.Object{
+		toPod(ztunnelPodRemote, true),
+		toPod(podSameNodeRemote, false),
+	}
+	remoteCluster2Pods := []runtime.Object{
+		toPod(ztunnelPodRemote2, true),
+	}
+
+	primaryClient := kube.NewFakeClient(primaryClusterPods...)
+
+	remoteClient := kube.NewFakeClient(remoteClusterPods...)
+
+	remote2Client := kube.NewFakeClient(remoteCluster2Pods...)
+
+	mNa := NewMulticlusterNodeAuthenticator(nil, allowZtunnel, nil)
+	mNa.ClusterAdded(&multicluster.Cluster{ID: "primary", Client: primaryClient}, nil)
+	mNa.ClusterAdded(&multicluster.Cluster{ID: "remote", Client: remoteClient}, nil)
+	mNa.ClusterAdded(&multicluster.Cluster{ID: "remote2", Client: remote2Client}, nil)
+	primaryClient.RunAndWait(test.NewStop(t))
+	remoteClient.RunAndWait(test.NewStop(t))
+	remote2Client.RunAndWait(test.NewStop(t))
+	mNa.ClusterDeleted(cluster.ID("remote2"))
+
+	kube.WaitForCacheSync("test", test.NewStop(t), mNa.ztunnelPodsClient[cluster.ID("primary")].HasSynced)
+	kube.WaitForCacheSync("test", test.NewStop(t), mNa.ztunnelPodsClient[cluster.ID("remote")].HasSynced)
+	kube.WaitForCacheSync("test", test.NewStop(t), mNa.remoteNodeAuthenticators[cluster.ID("primary")].pods.HasSynced)
+	kube.WaitForCacheSync("test", test.NewStop(t), mNa.remoteNodeAuthenticators[cluster.ID("remote")].pods.HasSynced)
+	cases := []struct {
+		name                    string
+		caller                  security.KubernetesInfo
+		requestedIdentityString string
+		wantErr                 string
+	}{
+		{
+			name:                    "allowed identities, on node of primary cluster",
+			caller:                  ztunnelCallerPrimary,
+			requestedIdentityString: podSameNodePrimary.Identity(),
+			wantErr:                 "",
+		},
+		{
+			name:                    "allowed identities, on node of remote cluster",
+			caller:                  ztunnelCallerRemote,
+			requestedIdentityString: podSameNodeRemote.Identity(),
+			wantErr:                 "",
+		},
+		{
+			name:    "ztunnel caller from removed remote cluster",
+			caller:  ztunnelCallerRemote2,
+			wantErr: "not found",
+		},
+		{
+			name:                    "allowed identities in remote cluster, but ztunnel caller from primary cluster",
+			caller:                  ztunnelCallerPrimary,
+			requestedIdentityString: podSameNodeRemote.Identity(),
+			wantErr:                 "no instance",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mNa.authenticateImpersonation(tt.caller, tt.requestedIdentityString)
 			if tt.wantErr == "" && err != nil {
 				t.Fatalf("wanted no error, got %v", err)
 			}

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -21,15 +21,25 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	pb "istio.io/api/security/v1alpha1"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/test"
 	mockca "istio.io/istio/security/pkg/pki/ca/mock"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
@@ -37,9 +47,10 @@ import (
 )
 
 type mockAuthenticator struct {
-	authSource security.AuthSource
-	identities []string
-	errMsg     string
+	authSource     security.AuthSource
+	identities     []string
+	kubernetesInfo security.KubernetesInfo
+	errMsg         string
 }
 
 func (authn *mockAuthenticator) AuthenticatorType() string {
@@ -52,8 +63,9 @@ func (authn *mockAuthenticator) Authenticate(_ security.AuthContext) (*security.
 	}
 
 	return &security.Caller{
-		AuthSource: authn.authSource,
-		Identities: authn.identities,
+		AuthSource:     authn.authSource,
+		Identities:     authn.identities,
+		KubernetesInfo: authn.kubernetesInfo,
 	}, nil
 }
 
@@ -258,5 +270,243 @@ func TestCreateCertificate(t *testing.T) {
 			}
 
 		}
+	}
+}
+
+type mockMultiClusterController struct {
+	handlers []multicluster.ClusterHandler
+}
+
+func (m *mockMultiClusterController) addHandler(h multicluster.ClusterHandler) {
+	m.handlers = append(m.handlers, h)
+}
+
+func (m *mockMultiClusterController) addCluster(c *multicluster.Cluster) {
+	for _, h := range m.handlers {
+		h.ClusterAdded(c, nil)
+	}
+}
+
+func TestCreateCertificateE2EWithImpersonateIdentity(t *testing.T) {
+	allowZtunnel := map[types.NamespacedName]struct{}{
+		{Name: "ztunnel", Namespace: "istio-system"}: {},
+	}
+	ztunnelCaller := security.KubernetesInfo{
+		PodName:           "ztunnel-a",
+		PodNamespace:      "istio-system",
+		PodUID:            "12345",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPod := pod{
+		name:      ztunnelCaller.PodName,
+		namespace: ztunnelCaller.PodNamespace,
+		account:   ztunnelCaller.PodServiceAccount,
+		uid:       ztunnelCaller.PodUID,
+		node:      "zt-node",
+	}
+	podSameNode := pod{
+		name:      "pod-a",
+		namespace: "ns-a",
+		account:   "sa-a",
+		uid:       "1",
+		node:      "zt-node",
+	}
+	podOtherNode := pod{
+		name:      "pod-b",
+		namespace: podSameNode.namespace,
+		account:   podSameNode.account,
+		uid:       "2",
+		node:      "other-node",
+	}
+
+	ztunnelCallerRemote := security.KubernetesInfo{
+		PodName:           "ztunnel-b",
+		PodNamespace:      "istio-system",
+		PodUID:            "12346",
+		PodServiceAccount: "ztunnel",
+	}
+	ztunnelPodRemote := pod{
+		name:      ztunnelCallerRemote.PodName,
+		namespace: ztunnelCallerRemote.PodNamespace,
+		account:   ztunnelCallerRemote.PodServiceAccount,
+		uid:       ztunnelCallerRemote.PodUID,
+		node:      "zt-node-remote",
+	}
+	podSameNodeRemote := pod{
+		name:      "pod-c",
+		namespace: podSameNode.namespace,
+		account:   podSameNode.account,
+		uid:       "3",
+		node:      "zt-node-remote",
+	}
+
+	testCases := []struct {
+		name                string
+		authenticators      []security.Authenticator
+		ca                  CertificateAuthority
+		certChain           []string
+		pods                []pod
+		impersonatePod      pod
+		trustedNodeAccounts map[types.NamespacedName]struct{}
+		isMultiCluster      bool
+		remoteClusterPods   []pod
+		code                codes.Code
+	}{
+		{
+			name: "No node authorizer",
+			authenticators: []security.Authenticator{&mockAuthenticator{
+				identities:     []string{"test-identity"},
+				kubernetesInfo: ztunnelCaller,
+			}},
+			ca: &mockca.FakeCA{
+				SignedCert:    []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte("cert_chain"), []byte("root_cert")),
+			},
+			certChain:           []string{"cert", "cert_chain", "root_cert"},
+			trustedNodeAccounts: map[types.NamespacedName]struct{}{},
+			code:                codes.Unauthenticated,
+		},
+		{
+			name: "Pod not passing node authorization",
+			authenticators: []security.Authenticator{&mockAuthenticator{
+				identities:     []string{"test-identity"},
+				kubernetesInfo: ztunnelCaller,
+			}},
+			ca: &mockca.FakeCA{
+				SignedCert:    []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte("cert_chain"), []byte("root_cert")),
+			},
+			certChain:           []string{"cert", "cert_chain", "root_cert"},
+			pods:                []pod{ztunnelPod, podOtherNode},
+			impersonatePod:      podOtherNode,
+			trustedNodeAccounts: allowZtunnel,
+			code:                codes.Unauthenticated,
+		},
+		{
+			name: "Successful signing with impersonate identity",
+			authenticators: []security.Authenticator{&mockAuthenticator{
+				identities:     []string{"test-identity"},
+				kubernetesInfo: ztunnelCaller,
+			}},
+			ca: &mockca.FakeCA{
+				SignedCert:    []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte("cert_chain"), []byte("root_cert")),
+			},
+			certChain:           []string{"cert", "cert_chain", "root_cert"},
+			pods:                []pod{ztunnelPod, podSameNode},
+			impersonatePod:      podSameNode,
+			trustedNodeAccounts: allowZtunnel,
+			code:                codes.OK,
+		},
+		{
+			name: "Pod not passing node authorization because of ztunnel from other clusters",
+			authenticators: []security.Authenticator{&mockAuthenticator{
+				identities:     []string{"test-identity"},
+				kubernetesInfo: ztunnelCaller,
+			}},
+			ca: &mockca.FakeCA{
+				SignedCert:    []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte("cert_chain"), []byte("root_cert")),
+			},
+			certChain:           []string{"cert", "cert_chain", "root_cert"},
+			pods:                []pod{ztunnelPod},
+			impersonatePod:      podSameNodeRemote,
+			trustedNodeAccounts: allowZtunnel,
+			isMultiCluster:      true,
+			remoteClusterPods:   []pod{ztunnelPodRemote, podSameNodeRemote},
+			code:                codes.Unauthenticated,
+		},
+		{
+			name: "Successful signing with impersonate identity from remote cluster",
+			authenticators: []security.Authenticator{&mockAuthenticator{
+				identities:     []string{"test-identity"},
+				kubernetesInfo: ztunnelCallerRemote,
+			}},
+			ca: &mockca.FakeCA{
+				SignedCert:    []byte("cert"),
+				KeyCertBundle: util.NewKeyCertBundleFromPem(nil, nil, []byte("cert_chain"), []byte("root_cert")),
+			},
+			certChain:           []string{"cert", "cert_chain", "root_cert"},
+			pods:                []pod{ztunnelPod, podSameNode},
+			impersonatePod:      podSameNodeRemote,
+			trustedNodeAccounts: allowZtunnel,
+			isMultiCluster:      true,
+			remoteClusterPods:   []pod{ztunnelPodRemote, podSameNodeRemote},
+			code:                codes.OK,
+		},
+	}
+
+	p := &peer.Peer{Addr: &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}, AuthInfo: credentials.TLSInfo{}}
+	ctx := peer.NewContext(context.Background(), p)
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			test.SetForTest(t, &features.CATrustedNodeAccounts, c.trustedNodeAccounts)
+			if c.isMultiCluster {
+				test.SetForTest(t, &features.EnableMultiClusterNodeAuthorizer, true)
+			}
+
+			var pods []runtime.Object
+			for _, p := range c.pods {
+				pods = append(pods, toPod(p, strings.HasPrefix(p.name, "ztunnel")))
+			}
+			client := kube.NewFakeClient(pods...)
+			multiClusterController := &mockMultiClusterController{}
+
+			server, _ := New(c.ca, time.Duration(1), c.authenticators, client, nil, multiClusterController.addHandler)
+			client.RunAndWait(test.NewStop(t))
+
+			if c.isMultiCluster {
+				var remoteClusterPods []runtime.Object
+				for _, p := range c.remoteClusterPods {
+					remoteClusterPods = append(remoteClusterPods, toPod(p, strings.HasPrefix(p.name, "ztunnel")))
+				}
+				remoteClient := kube.NewFakeClient(remoteClusterPods...)
+				remoteCluster := &multicluster.Cluster{
+					ID:     "fake-remote",
+					Client: remoteClient,
+				}
+				multiClusterController.addCluster(remoteCluster)
+				remoteClient.RunAndWait(test.NewStop(t))
+			}
+
+			if server.nodeAuthorizer != nil {
+				switch na := server.nodeAuthorizer.(type) {
+				case *ClusterNodeAuthorizer:
+					kube.WaitForCacheSync("test", test.NewStop(t), na.pods.HasSynced)
+				case *MulticlusterNodeAuthorizor:
+					kube.WaitForCacheSync("test", test.NewStop(t), na.ztunnelPodsClient[cluster.ID("fake")].HasSynced)
+					kube.WaitForCacheSync("test", test.NewStop(t), na.ztunnelPodsClient[cluster.ID("fake-remote")].HasSynced)
+					kube.WaitForCacheSync("test", test.NewStop(t), na.remoteNodeAuthenticators[cluster.ID("fake")].pods.HasSynced)
+					kube.WaitForCacheSync("test", test.NewStop(t), na.remoteNodeAuthenticators[cluster.ID("fake-remote")].pods.HasSynced)
+				}
+			}
+
+			reqMeta, _ := structpb.NewStruct(map[string]any{
+				security.ImpersonatedIdentity: c.impersonatePod.Identity(),
+			})
+			request := &pb.IstioCertificateRequest{
+				Csr:      "dumb CSR",
+				Metadata: reqMeta,
+			}
+
+			response, err := server.CreateCertificate(ctx, request)
+			s, _ := status.FromError(err)
+			code := s.Code()
+			if c.code != code {
+				t.Errorf("Case %s: expecting code to be (%d) but got (%d): %s", c.name, c.code, code, s.Message())
+			} else if c.code == codes.OK {
+				if len(response.CertChain) != len(c.certChain) {
+					t.Errorf("Case %s: expecting cert chain length to be (%d) but got (%d)",
+						c.name, len(c.certChain), len(response.CertChain))
+				}
+				for i, v := range response.CertChain {
+					if v != c.certChain[i] {
+						t.Errorf("Case %s: expecting cert to be (%s) but got (%s) at position [%d] of cert chain.",
+							c.name, c.certChain, v, i)
+					}
+				}
+
+			}
+		})
 	}
 }

--- a/tests/fuzz/security_fuzzer.go
+++ b/tests/fuzz/security_fuzzer.go
@@ -103,7 +103,7 @@ func FuzzCreateCertE2EUsingClientCertAuthenticator(data []byte) int {
 		SignedCert:    signedCert,
 		KeyCertBundle: kcb,
 	}
-	server, err := ca.New(mockCa, 1, []security.Authenticator{auth}, nil, nil)
+	server, err := ca.New(mockCa, 1, []security.Authenticator{auth}, nil, nil, nil)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Co-authored-by: zhlsunshine huailong.zhang@intel.com
Co-authored-by: osswangxining osswangxining@163.com

**Please provide a description of this PR:**

This PR fixes https://github.com/istio/istio/issues/47489. It adds an implementation of a multi-cluster form of node authorizer, which allows node authorizations for CSRs with impersonate identity from remote cluster. This could help istio CA to authenticate ztunnel in remote clusters in an external control plane scenario.

This PR also supplies some e2e test cases for node authorization scenario.

Please refer to https://docs.google.com/document/d/10uf4EvUVif4xGeCYQydaKh9Yaz9wpysao7gyLewJY2Q/edit?resourcekey=0-6i9VYHbp91h6Avy6syu_oA#heading=h.xw1gqgyqs5b for more details.