### PR TITLE
Support installing without IOP kind

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -362,6 +362,18 @@ func TestManifestGenerateDefaultWithRevisionedWebhook(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestManifestGenerateWithOnlyIOPSpec(t *testing.T) {
+	objss, err := runManifestCommands("only_spec", "", liveCharts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dobjss, err := runManifestCommands("default", "", liveCharts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(objss), len(dobjss))
+}
+
 func TestManifestGenerateIstiodRemote(t *testing.T) {
 	g := NewWithT(t)
 

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -42,7 +42,7 @@ const (
 	revisionFlagHelpStr         = `Target control plane revision for the command.`
 	skipConfirmationFlagHelpStr = `The skipConfirmation determines whether the user is prompted for confirmation.
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
-	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
+	filenameFlagHelpStr = `Path to file containing the custom configuration.
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
 	installationCompleteStr            = `Installation complete`
 	ForceFlagHelpStr                   = `Proceed even with validation errors.`

--- a/operator/cmd/mesh/testdata/manifest-generate/input/only_spec.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/only_spec.yaml
@@ -1,0 +1,2 @@
+profile: default
+namespace: istio-system

--- a/releasenotes/notes/49014.yaml
+++ b/releasenotes/notes/49014.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** support for installations using custom configurations without the `IstioOperator` kind. Providing configs within the [spec](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec) is acceptable.


### PR DESCRIPTION
**Please provide a description of this PR:**
As we are not installing the IOP, it makes sense to include only the custom config instead of the entire IOP resource. This is a simple way to eliminate the need to specify the IOP's gvk or metadata, allowing for the installation using only the custom configurations specified in the 'spec'. Then we can update the doc to not include the kind.

However, there are limitations: Helm format values are not supported. For example, values need to be provided in the format `values.pilot.env` rather than `pilot.env`. While it can be supported, it would require some hacky conversion logic, such as converting the ztunnel values. Converting from IOP to Helm values would be simpler after the issue at https://github.com/istio/istio/issues/47838 is resolved.