### PR TITLE
Added endpoint to the debug config distribution report

### DIFF
--- a/istioctl/pkg/wait/wait.go
+++ b/istioctl/pkg/wait/wait.go
@@ -213,6 +213,7 @@ func poll(ctx cli.Context,
 			countVersions(versionCount, configVersion.ClusterVersion)
 			countVersions(versionCount, configVersion.RouteVersion)
 			countVersions(versionCount, configVersion.ListenerVersion)
+			countVersions(versionCount, configVersion.EndpointVersion)
 		}
 	}
 

--- a/istioctl/pkg/wait/wait_test.go
+++ b/istioctl/pkg/wait/wait_test.go
@@ -45,6 +45,7 @@ func TestWaitCmd(t *testing.T) {
 			ClusterVersion:  "1",
 			ListenerVersion: "1",
 			RouteVersion:    "1",
+			EndpointVersion: "1",
 		},
 	}
 	cannedResponse, _ := json.Marshal(cannedResponseObj)

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -139,6 +139,7 @@ type SyncedVersions struct {
 	ClusterVersion  string `json:"cluster_acked,omitempty"`
 	ListenerVersion string `json:"listener_acked,omitempty"`
 	RouteVersion    string `json:"route_acked,omitempty"`
+	EndpointVersion string `json:"endpoint_acked,omitempty"`
 }
 
 // InitDebug initializes the debug handlers and adds a debug in-memory registry.
@@ -378,6 +379,8 @@ func (s *DiscoveryServer) distributedVersions(w http.ResponseWriter, req *http.R
 					ListenerVersion: s.getResourceVersion(s.StatusReporter.QueryLastNonce(con.conID, v3.ListenerType),
 						resourceID, knownVersions),
 					RouteVersion: s.getResourceVersion(s.StatusReporter.QueryLastNonce(con.conID, v3.RouteType),
+						resourceID, knownVersions),
+					EndpointVersion: s.getResourceVersion(s.StatusReporter.QueryLastNonce(con.conID, v3.EndpointType),
 						resourceID, knownVersions),
 				})
 			}

--- a/releasenotes/notes/48985.yaml
+++ b/releasenotes/notes/48985.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - 48985
+
+releaseNotes:
+- |
+  **Added** endpoints acked generation to the proxy distribution report available through the pilot debug api (/debug/config_distribution).


### PR DESCRIPTION
**Please provide a description of this PR:**

As mentioned in #48985 the endpoint is currently not part of the debug config distribution report.

Fixes #48985