### PR TITLE
Add support to export OpenTelemetry traces via HTTP

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -16,6 +16,7 @@ package v1alpha3
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strconv"
 
@@ -224,7 +225,7 @@ func configureFromProviderConfig(pushCtx *model.PushContext, proxy *model.Proxy,
 				model.IncLookupClusterFailures("opentelemetry")
 				return nil, fmt.Errorf("could not find cluster for tracing provider %q: %v", provider, err)
 			}
-			return otelConfig(serviceCluster, hostname, clusterName)
+			return otelConfig(serviceCluster, hostname, clusterName, provider.Opentelemetry)
 		}
 		// Providers without any tracing support
 		// Explicitly list to be clear what does and does not support tracing
@@ -265,19 +266,52 @@ func datadogConfig(serviceName, hostname, cluster string) (*anypb.Any, error) {
 	return protoconv.MessageToAnyWithError(dc)
 }
 
-func otelConfig(serviceName, hostname, cluster string) (*anypb.Any, error) {
-	dc := &tracingcfg.OpenTelemetryConfig{
-		GrpcService: &core.GrpcService{
-			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
-					ClusterName: cluster,
-					Authority:   hostname,
+func otelConfig(serviceName, hostname, cluster string, otelProvider *meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider) (*anypb.Any, error) {
+	var oc *tracingcfg.OpenTelemetryConfig
+
+	if otelProvider.GetHttp() == nil {
+		oc = &tracingcfg.OpenTelemetryConfig{
+			GrpcService: &core.GrpcService{
+				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+						ClusterName: cluster,
+						Authority:   hostname,
+					},
 				},
 			},
-		},
-		ServiceName: serviceName,
+		}
+	} else {
+		httpService := otelProvider.GetHttp()
+		te, err := url.JoinPath(hostname, httpService.GetPath())
+		if err != nil {
+			return nil, fmt.Errorf("could not parse otlp/http traces endpoint: %v", err)
+		}
+		oc = &tracingcfg.OpenTelemetryConfig{
+			HttpService: &core.HttpService{
+				HttpUri: &core.HttpUri{
+					Uri: te,
+					HttpUpstreamType: &core.HttpUri_Cluster{
+						Cluster: cluster,
+					},
+					Timeout: httpService.GetTimeout(),
+				},
+			},
+		}
+
+		for _, h := range httpService.GetHeaders() {
+			hvo := &core.HeaderValueOption{
+				AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+				Header: &core.HeaderValue{
+					Key:   h.GetName(),
+					Value: h.GetValue(),
+				},
+			}
+			oc.GetHttpService().RequestHeadersToAdd = append(oc.GetHttpService().GetRequestHeadersToAdd(), hvo)
+		}
 	}
-	return anypb.New(dc)
+
+	oc.ServiceName = serviceName
+	return anypb.New(oc)
 }
 
 func opencensusConfig(opencensusProvider *meshconfig.MeshConfig_ExtensionProvider_OpenCensusAgentTracingProvider) (*anypb.Any, error) {

--- a/pilot/pkg/networking/core/v1alpha3/tracing.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing.go
@@ -270,6 +270,7 @@ func otelConfig(serviceName, hostname, cluster string, otelProvider *meshconfig.
 	var oc *tracingcfg.OpenTelemetryConfig
 
 	if otelProvider.GetHttp() == nil {
+		// export via gRPC
 		oc = &tracingcfg.OpenTelemetryConfig{
 			GrpcService: &core.GrpcService{
 				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
@@ -281,6 +282,7 @@ func otelConfig(serviceName, hostname, cluster string, otelProvider *meshconfig.
 			},
 		}
 	} else {
+		// export via HTTP
 		httpService := otelProvider.GetHttp()
 		te, err := url.JoinPath(hostname, httpService.GetPath())
 		if err != nil {

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -841,7 +841,7 @@ func fakeOpenTelemetryGrpcProvider(expectClusterName, expectAuthority string) *t
 }
 
 func fakeOpenTelemetryHTTPProvider(expectClusterName, expectAuthority string) *tracingcfg.Tracing_Http {
-	fakeOTelHttpProviderConfig := &tracingcfg.OpenTelemetryConfig{
+	fakeOTelHTTPProviderConfig := &tracingcfg.OpenTelemetryConfig{
 		HttpService: &core.HttpService{
 			HttpUri: &core.HttpUri{
 				Uri: expectAuthority + "/v1/traces",
@@ -861,7 +861,7 @@ func fakeOpenTelemetryHTTPProvider(expectClusterName, expectAuthority string) *t
 			},
 		},
 	}
-	fakeOtelHttpAny := protoconv.MessageToAny(fakeOTelHttpProviderConfig)
+	fakeOtelHttpAny := protoconv.MessageToAny(fakeOTelHTTPProviderConfig)
 	return &tracingcfg.Tracing_Http{
 		Name:       envoyOpenTelemetry,
 		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeOtelHttpAny},

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -861,9 +861,9 @@ func fakeOpenTelemetryHTTPProvider(expectClusterName, expectAuthority string) *t
 			},
 		},
 	}
-	fakeOtelHttpAny := protoconv.MessageToAny(fakeOTelHTTPProviderConfig)
+	fakeOtelHTTPAny := protoconv.MessageToAny(fakeOTelHTTPProviderConfig)
 	return &tracingcfg.Tracing_Http{
 		Name:       envoyOpenTelemetry,
-		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeOtelHttpAny},
+		ConfigType: &tracingcfg.Tracing_Http_TypedConfig{TypedConfig: fakeOtelHTTPAny},
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/tracing_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tracing_test.go
@@ -183,9 +183,9 @@ func TestConfigureTracing(t *testing.T) {
 		},
 		{
 			name:               "basic config (with opentelemetry provider via http)",
-			inSpec:             fakeTracingSpec(fakeOpenTelemetryHttp(), 99.999, false, true),
-			opts:               fakeOptsOnlyOpenTelemetryHttpTelemetryAPI(),
-			want:               fakeTracingConfig(fakeOpenTelemetryHttpProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			inSpec:             fakeTracingSpec(fakeOpenTelemetryHTTP(), 99.999, false, true),
+			opts:               fakeOptsOnlyOpenTelemetryHTTPTelemetryAPI(),
+			want:               fakeTracingConfig(fakeOpenTelemetryHTTPProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 			wantStartChildSpan: false,
 			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
 		},
@@ -560,7 +560,7 @@ func fakeOpenTelemetryGrpc() *meshconfig.MeshConfig_ExtensionProvider {
 	}
 }
 
-func fakeOpenTelemetryHttp() *meshconfig.MeshConfig_ExtensionProvider {
+func fakeOpenTelemetryHTTP() *meshconfig.MeshConfig_ExtensionProvider {
 	return &meshconfig.MeshConfig_ExtensionProvider{
 		Name: "opentelemetry",
 		Provider: &meshconfig.MeshConfig_ExtensionProvider_Opentelemetry{
@@ -610,7 +610,7 @@ func fakeOptsOnlyOpenTelemetryGrpcTelemetryAPI() gatewayListenerOpts {
 	return opts
 }
 
-func fakeOptsOnlyOpenTelemetryHttpTelemetryAPI() gatewayListenerOpts {
+func fakeOptsOnlyOpenTelemetryHTTPTelemetryAPI() gatewayListenerOpts {
 	var opts gatewayListenerOpts
 	opts.push = &model.PushContext{
 		Mesh: &meshconfig.MeshConfig{
@@ -840,7 +840,7 @@ func fakeOpenTelemetryGrpcProvider(expectClusterName, expectAuthority string) *t
 	}
 }
 
-func fakeOpenTelemetryHttpProvider(expectClusterName, expectAuthority string) *tracingcfg.Tracing_Http {
+func fakeOpenTelemetryHTTPProvider(expectClusterName, expectAuthority string) *tracingcfg.Tracing_Http {
 	fakeOTelHttpProviderConfig := &tracingcfg.OpenTelemetryConfig{
 		HttpService: &core.HttpService{
 			HttpUri: &core.HttpUri{

--- a/releasenotes/notes/47835-otlp-http-exporter.yaml
+++ b/releasenotes/notes/47835-otlp-http-exporter.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/47835
+
+docs:
+ - '[reference] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-OpenTelemetryTracingProvider'
+
+releaseNotes:
+- |
+  **Added** option to export OpenTelemetry traces via HTTP

--- a/samples/open-telemetry/otel.yaml
+++ b/samples/open-telemetry/otel.yaml
@@ -65,6 +65,10 @@ spec:
       port: 4317
       protocol: TCP
       targetPort: 4317
+    - name: http-otlp # HTTP endpoint for OpenTelemetry receiver.
+      port: 4318
+      protocol: TCP
+      targetPort: 4318
   selector:
     app: opentelemetry-collector
 ---
@@ -107,6 +111,8 @@ spec:
           name: opentelemetry-collector
           ports:
             - containerPort: 4317
+              protocol: TCP
+            - containerPort: 4318
               protocol: TCP
             - name: grpc-opencensus
               containerPort: 55678

--- a/tests/integration/telemetry/tracing/otelcollector/testdata/otel-tracing-http.yaml
+++ b/tests/integration/telemetry/tracing/otelcollector/testdata/otel-tracing-http.yaml
@@ -10,4 +10,4 @@ spec:
     customTags:
       "provider":
         literal:
-          value: "otel"
+          value: "otel-http"

--- a/tests/integration/telemetry/tracing/otelcollector/testdata/otel-tracing-http.yaml
+++ b/tests/integration/telemetry/tracing/otelcollector/testdata/otel-tracing-http.yaml
@@ -1,0 +1,13 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: otel-tracing
+spec:
+  tracing:
+  - providers:
+    - name: test-otel-http
+    randomSamplingPercentage: 100.0
+    customTags:
+      "provider":
+        literal:
+          value: "otel"

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -135,7 +135,7 @@ func TestProxyTracingOpenTelemetryProviderHTTPExporter(t *testing.T) {
 						}
 
 						// the OTel collector exports to Zipkin
-						traces, err := tracing.GetZipkinInstance().QueryTraces(300, "", "provider=otel")
+						traces, err := tracing.GetZipkinInstance().QueryTraces(300, "", "provider=otel-http")
 						t.Logf("got traces %v from %s", traces, cluster)
 						if err != nil {
 							return fmt.Errorf("cannot get traces from zipkin: %v", err)

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -72,6 +72,9 @@ func TestProxyTracingOpenCensusMeshConfig(t *testing.T) {
 //go:embed testdata/otel-tracing.yaml
 var otelTracingCfg string
 
+//go:embed testdata/otel-tracing-http.yaml
+var otelTracingHTTPCfg string
+
 // TestProxyTracingOpenTelemetryProvider validates that Telemetry API configuration
 // referencing an OpenTelemetry provider will generate traces appropriately.
 // NOTE: This test relies on the priority of Telemetry API over MeshConfig tracing
@@ -85,6 +88,41 @@ func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
 
 			// apply Telemetry resource with OTel provider
 			t.ConfigIstio().YAML(appNsInst.Name(), otelTracingCfg).ApplyOrFail(t)
+
+			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
+			for _, cluster := range t.Clusters().ByNetwork()[t.Clusters().Default().NetworkName()] {
+				cluster := cluster
+				t.NewSubTest(cluster.StableName()).Run(func(ctx framework.TestContext) {
+					retry.UntilSuccessOrFail(ctx, func() error {
+						err := tracing.SendTraffic(ctx, nil, cluster)
+						if err != nil {
+							return fmt.Errorf("cannot send traffic from cluster %s: %v", cluster.Name(), err)
+						}
+
+						// the OTel collector exports to Zipkin
+						traces, err := tracing.GetZipkinInstance().QueryTraces(300, "", "provider=otel")
+						t.Logf("got traces %v from %s", traces, cluster)
+						if err != nil {
+							return fmt.Errorf("cannot get traces from zipkin: %v", err)
+						}
+						if !tracing.VerifyOtelEchoTraces(ctx, appNsInst.Name(), cluster.Name(), traces) {
+							return errors.New("cannot find expected traces")
+						}
+						return nil
+					}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
+				})
+			}
+		})
+}
+
+func TestProxyTracingOpenTelemetryProviderHTTPExporter(t *testing.T) {
+	framework.NewTest(t).
+		Features("observability.telemetry.tracing.server").
+		Run(func(t framework.TestContext) {
+			appNsInst := tracing.GetAppNamespace()
+
+			// apply Telemetry resource with OTel provider, exporting via HTTP
+			t.ConfigIstio().YAML(appNsInst.Name(), otelTracingHTTPCfg).ApplyOrFail(t)
 
 			// TODO fix tracing tests in multi-network https://github.com/istio/istio/issues/28890
 			for _, cluster := range t.Clusters().ByNetwork()[t.Clusters().Default().NetworkName()] {
@@ -139,6 +177,16 @@ meshConfig:
     opentelemetry:
       service: opentelemetry-collector.istio-system.svc.cluster.local
       port: 4317
+  - name: test-otel-http
+    opentelemetry:
+      service: opentelemetry-collector.istio-system.svc.cluster.local
+      port: 4318
+      http:
+        path: "v1/traces"
+        timeout: 10s
+        headers:
+          - name: "some-header"
+            value: "some-value"
 `
 	cfg.Values["pilot.traceSampling"] = "100.0"
 	cfg.Values["global.proxy.tracer"] = "openCensusAgent"


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes #47835

This PR uses the [newly added API configs](https://github.com/istio/api/pull/2998) to allow exporting OpenTelemetry traces via OTLP/HTTP. As of now, it is only possible to export traces via gRPC, but there is several use cases where only HTTP is available. (e.g. a back-end only offers HTTP ingest endpoints)

Reference: [OpenTelemetry Protocol Exporter](https://opentelemetry.io/docs/specs/otel/protocol/exporter/)


CC @zirain 