### PR TITLE
Prioritize DRs with selector in merging

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -369,9 +369,9 @@ func OldestMatchingHost(needle host.Name, specific map[host.Name]config.Config, 
 	return matchHost, matchValue, found
 }
 
-// sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
-func sortConfigByCreationTime(configs []config.Config) []config.Config {
-	sort.Slice(configs, func(i, j int) bool {
+// sortByCreationComparator is a comparator function for sorting config objects by creation time.
+func sortByCreationComparator(configs []config.Config) func(i, j int) bool {
+	return func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.
@@ -381,6 +381,11 @@ func sortConfigByCreationTime(configs []config.Config) []config.Config {
 			return in < jn
 		}
 		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
-	})
+	}
+}
+
+// sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time
+func sortConfigByCreationTime(configs []config.Config) []config.Config {
+	sort.Slice(configs, sortByCreationComparator(configs))
 	return configs
 }

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -29,7 +29,7 @@ import (
 
 // This function merges one or more destination rules for a given host string
 // into a single destination rule. Note that it does not perform inheritance style merging.
-// IOW, given three dest rules (*.foo.com, *.foo.com, *.com), calling this function for
+// IOW, given three dest rules (*.foo.com, *.foo.com, *.com) without selectors, calling this function for
 // each config will result in a final dest rule set (*.foo.com, and *.com).
 //
 // The following is the merge logic:

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1931,6 +1931,30 @@ func (ps *PushContext) SetDestinationRulesForTesting(configs []config.Config) {
 	ps.setDestinationRules(configs)
 }
 
+// sortConfigBySelectorAndCreationTime sorts the list of config objects based on priority and creation time.
+func sortConfigBySelectorAndCreationTime(configs []config.Config) []config.Config {
+	creationTimeComparator := sortByCreationComparator(configs)
+	// Define a comparator function for sorting configs by priority and creation time
+	comparator := func(i, j int) bool {
+		idr := configs[i].Spec.(*networking.DestinationRule)
+		jdr := configs[j].Spec.(*networking.DestinationRule)
+
+		// Check if one of the configs has priority set to true
+		if idr.GetWorkloadSelector() != nil && jdr.GetWorkloadSelector() == nil {
+			return true
+		} else if idr.GetWorkloadSelector() == nil && jdr.GetWorkloadSelector() != nil {
+			return false
+		}
+
+		// If priority is the same or neither has priority, fallback to creation time ordering
+		return creationTimeComparator(i, j)
+	}
+
+	// Sort the configs using the defined comparator function
+	sort.Slice(configs, comparator)
+	return configs
+}
+
 // setDestinationRules updates internal structures using a set of configs.
 // Split out of DestinationRule expensive conversions, computed once per push.
 // This will not work properly for Sidecars, which will precompute their
@@ -1938,7 +1962,7 @@ func (ps *PushContext) SetDestinationRulesForTesting(configs []config.Config) {
 func (ps *PushContext) setDestinationRules(configs []config.Config) {
 	// Sort by time first. So if two destination rule have top level traffic policies
 	// we take the first one.
-	sortConfigByCreationTime(configs)
+	sortConfigBySelectorAndCreationTime(configs)
 	namespaceLocalDestRules := make(map[string]*consolidatedDestRules)
 	exportedDestRulesByNamespace := make(map[string]*consolidatedDestRules)
 	rootNamespaceLocalDestRules := newConsolidatedDestRules()


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR is changing how the merging operation is performed when DR with workload selector are present.
Related to https://github.com/istio/istio/issues/48918

Assuming we have 3 DRs, one without selector "drWithout1" and two containing different selectors "drWith1, drWith2".
The creation time of the 3 DRs is drWithout1 < drWith1 < drWith2

**Current behavior on master:**
DRs list is sorted in ascending order based on creationTimestamp: [drWithout1, drWith1, drWith2]:
```
    push_context_test.go:2204: we consolidate to 3 DRs
    push_context_test.go:2206: consolidated destination rule test/drWithout1 info:
    push_context_test.go:2207:  from: [test/drWithout1 test/drWith1 test/drWith2]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":111,"connectTimeout":"1s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert.pem","privateKey":"/etc/certs/client_private_key.pem","caCertificates":"/etc/certs/rootcacerts.pem"}},"subsets":[{"name":"v1"},{"name":"v3"}]}
    push_context_test.go:2206: consolidated destination rule test/drWith1 info:
    push_context_test.go:2207:  from: [test/drWith1]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":111,"connectTimeout":"1s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert_fromwith1.pem","privateKey":"/etc/certs/client_private_key_fromwith1.pem","caCertificates":"/etc/certs/rootcacerts_fromwith1.pem"}},"workloadSelector":{"matchLabels":{"app":"app1"}}}
    push_context_test.go:2206: consolidated destination rule test/drWith2 info:
    push_context_test.go:2207:  from: [test/drWith2]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":222,"connectTimeout":"2s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert_fromwith2.pem","privateKey":"/etc/certs/client_private_key_fromwith2.pem","caCertificates":"/etc/certs/rootcacerts_fromwith2.pem"}},"subsets":[{"name":"v3"}],"workloadSelector":{"matchLabels":{"app":"app2"}}}
--- PASS: TestMyMergeDestinationRule (0.00s
```
- Content of the ones with selectors got merged into the one without selector (Traffic policy was not present in the original drWithout1 and it got added from drWith1).
- Content of drWith1 is prioritized when compared to drWith2 (in case of conflicting fields like traffic policies).
- Behavior will change wildly based on the creation timestamp, if the creation timestamp was akin to drWith1 < drWith2 < drWithout1 we would end up with the same behavior that is enforced with this PR (see below).

**After this PR:**
DRs is sorted to [drWith1, drWith2, drWithout1].
List is sorted both on the presence/absence of selectors and creation timestamp.
```
    push_context_test.go:2204: we consolidate to 3 DRs
    push_context_test.go:2206: destination rule test/drWith1 info:
    push_context_test.go:2207:  from: [test/drWith1 test/drWithout1]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":111,"connectTimeout":"1s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert_fromwith1.pem","privateKey":"/etc/certs/client_private_key_fromwith1.pem","caCertificates":"/etc/certs/rootcacerts_fromwith1.pem"}},"subsets":[{"name":"v1"}],"workloadSelector":{"matchLabels":{"app":"app1"}}}
    push_context_test.go:2206: destination rule test/drWith2 info:
    push_context_test.go:2207:  from: [test/drWith2 test/drWithout1]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":222,"connectTimeout":"2s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert_fromwith2.pem","privateKey":"/etc/certs/client_private_key_fromwith2.pem","caCertificates":"/etc/certs/rootcacerts_fromwith2.pem"}},"subsets":[{"name":"v3"},{"name":"v1"}],"workloadSelector":{"matchLabels":{"app":"app2"}}}
    push_context_test.go:2206: destination rule test/drWithout1 info:
    push_context_test.go:2207:  from: [test/drWithout1]
    push_context_test.go:2209:  spec: {"host":"httpbin.org","trafficPolicy":{"connectionPool":{"tcp":{"maxConnections":111,"connectTimeout":"1s"}},"tls":{"mode":"MUTUAL","clientCertificate":"/etc/certs/myclientcert.pem","privateKey":"/etc/certs/client_private_key.pem","caCertificates":"/etc/certs/rootcacerts.pem"}},"subsets":[{"name":"v1"}]}
--- PASS: TestMyMergeDestinationRule (0.00s)
```
- content of the drWithout1 got merged into drWith1 and drWith2
- Content of drWith1/2 is prioritized when compared to drWithout1 (at least for conflicting fields like traffic policies)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
