### PR TITLE
Add missing short (also the default) format type to istioctl

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -792,7 +792,7 @@ func StatsConfigCmd(ctx cli.Context) *cobra.Command {
 			return completion.ValidPodsNameArgs(cmd, ctx, args, toComplete)
 		},
 	}
-	statsConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|prom|prom-merged")
+	statsConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short|prom|prom-merged")
 	statsConfigCmd.PersistentFlags().StringVarP(&statsType, "type", "t", "server", "Where to grab the stats: one of server|clusters")
 
 	return statsConfigCmd


### PR DESCRIPTION
**Please provide a description of this PR:**

The (default) `short` output is missing from the `istioctl x envoy-stats --output` flag description.