### PR TITLE
Support injecting init container to pods backed by ztunnel

### DIFF
--- a/istioctl/pkg/kubeinject/kubeinject.go
+++ b/istioctl/pkg/kubeinject/kubeinject.go
@@ -484,6 +484,7 @@ var (
 	injectConfigMapName string
 	whcName             string
 	iopFilename         string
+	ambientMode         bool
 )
 
 const (
@@ -607,7 +608,7 @@ It's best to do kube-inject when the resource is initially created.
 			if err != nil {
 				return err
 			}
-			retval := inject.IntoResourceFile(injector, templs, vc, rev, meshConfig,
+			retval := inject.IntoResourceFile(injector, templs, vc, rev, meshConfig, ambientMode,
 				reader, writer, func(warning string) {
 					warnings = append(warnings, warning)
 				})
@@ -648,6 +649,7 @@ It's best to do kube-inject when the resource is initially created.
 	injectCmd.PersistentFlags().StringVar(&iopFilename, "operatorFileName", "",
 		"Path to file containing IstioOperator custom resources. If configs from files like "+
 			"meshConfigFile, valuesFile are provided, they will be overridden by iop config values.")
+	injectCmd.PersistentFlags().BoolVar(&ambientMode, "ambient", false, "Inject for ambient mode.")
 
 	injectCmd.PersistentFlags().StringVar(&meshConfigMapName, "meshConfigMapName", defaultMeshConfigMapName,
 		fmt.Sprintf("ConfigMap name for Istio mesh configuration, key should be %q", configMapKey))

--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -5,6 +5,7 @@
 {{- $whv := dict
  "revision" .Values.revision
   "injectionURL" .Values.istiodRemote.injectionURL
+  "injectionSuffix" ""
   "namespace" .Release.Namespace }}
 {{- define "core" }}
 - name: {{.Prefix}}sidecar-injector.istio.io
@@ -15,7 +16,7 @@
     service:
       name: istiod{{- if not (eq .revision "") }}-{{ .revision }}{{- end }}
       namespace: {{ .namespace }}
-      path: "/inject"
+      path: "/inject{{ .injectionSuffix }}"
     {{- end }}
   sideEffects: None
   rules:
@@ -123,3 +124,18 @@ webhooks:
     - key: istio.io/rev
       operator: DoesNotExist
 {{- end }}
+
+{{- /* Case 4: Ambient */}}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient." "injectionSuffix" "/redirection/ambient") ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/dataplane-mode
+      operator: In
+      values:
+      - ambient
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/redirection
+      operator: NotIn
+      values:
+      - "disabled"

--- a/manifests/charts/istio-control/istio-discovery/files/ztunnel-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/ztunnel-injection-template.yaml
@@ -1,0 +1,22 @@
+spec:
+  initContainers:
+  - name: istio-validation
+  {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+    image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+  {{- else }}
+    image: "{{ .ProxyImage }}"
+  {{- end }}
+    args:
+    - istio-ambient
+    - "--validate-ambient"
+    {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: {{ .ProxyGID | default "1337" }}
+      runAsUser: {{ .ProxyUID | default "1337" }}
+      runAsNonRoot: true

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -52,6 +52,10 @@ data:
       gateway: |
 {{ .Files.Get "files/gateway-injection-template.yaml" | trim | indent 8 }}
 {{- end }}
+{{- if not (hasKey .Values.sidecarInjectorWebhook.templates "ztunnel") }}
+      ztunnel: |
+{{ .Files.Get "files/ztunnel-injection-template.yaml" | trim | indent 8 }}
+{{- end }}
 {{- if not (hasKey .Values.sidecarInjectorWebhook.templates "grpc-simple") }}
       grpc-simple: |
 {{ .Files.Get "files/grpc-simple.yaml" | trim | indent 8 }}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -1,7 +1,7 @@
 {{- /* Core defines the common configuration used by all webhook segments */}}
 {{/* Copy just what we need to avoid expensive deepCopy */}}
 {{- $whv := dict
- "revision" .Values.revision
+  "revision" .Values.revision
   "injectionPath" .Values.istiodRemote.injectionPath
   "injectionURL" .Values.istiodRemote.injectionURL
   "reinvocationPolicy" .Values.sidecarInjectorWebhook.reinvocationPolicy
@@ -149,6 +149,21 @@ webhooks:
     - key: istio.io/rev
       operator: DoesNotExist
 {{- end }}
+
+{{- /* Case 4: Ambient */}}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient." "injectionPath" (printf "%s%s" .Values.istiodRemote.injectionPath "/redirection/ambient")) ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/dataplane-mode
+      operator: In
+      values:
+      - ambient
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/redirection
+      operator: NotIn
+      values:
+      - "disabled"
 
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -136,6 +136,21 @@ webhooks:
       operator: DoesNotExist
 {{- end }}
 
+{{- /* Case 4: Ambient */}}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient." "injectionPath" (printf "%s%s" .Values.istiodRemote.injectionPath "/redirection/ambient")) ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/dataplane-mode
+      operator: In
+      values:
+      - ambient
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/redirection
+      operator: NotIn
+      values:
+      - "disabled"
+
 {{- end }}
 ---
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -150,5 +150,20 @@ webhooks:
       operator: DoesNotExist
 {{- end }}
 
+{{- /* Case 4: Ambient */}}
+{{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "ambient." "injectionPath" (printf "%s%s" .Values.istiodRemote.injectionPath "/redirection/ambient")) ) }}
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/dataplane-mode
+      operator: In
+      values:
+      - ambient
+  objectSelector:
+    matchExpressions:
+    - key: ambient.istio.io/redirection
+      operator: NotIn
+      values:
+      - "disabled"
+
 {{- end }}
 {{- end }}

--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -45,6 +45,7 @@ import (
 	"istio.io/istio/pkg/version"
 	stsserver "istio.io/istio/security/pkg/stsservice/server"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager"
+	ambient "istio.io/istio/tools/ambient/pkg/cmd"
 	cleaniptables "istio.io/istio/tools/istio-clean-iptables/pkg/cmd"
 	iptables "istio.io/istio/tools/istio-iptables/pkg/cmd"
 	iptableslog "istio.io/istio/tools/istio-iptables/pkg/log"
@@ -84,6 +85,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(waitCmd)
 	rootCmd.AddCommand(version.CobraCommand())
 	rootCmd.AddCommand(iptables.GetCommand())
+	rootCmd.AddCommand(ambient.GetCommand())
 	rootCmd.AddCommand(cleaniptables.GetCommand())
 
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, collateral.Metadata{

--- a/pkg/kube/inject/testdata/inject/hello.yaml.ambient.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.ambient.injected
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  selector:
+    matchLabels:
+      app: hello
+      tier: backend
+      track: stable
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/status: '{"initContainers":["istio-validation"],"containers":null,"volumes":null,"imagePullSecrets":null,"revision":"default"}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      initContainers:
+      - args:
+        - istio-ambient
+        - --validate-ambient
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-validation
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+status: {}
+---

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -802,6 +802,29 @@ templates:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+  ztunnel: |
+    spec:
+      initContainers:
+      - name: istio-validation
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy_init.image }}"
+      {{- else }}
+        image: "{{ .ProxyImage }}"
+      {{- end }}
+        args:
+        - istio-ambient
+        - "--validate-ambient"
+        {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsNonRoot: true
   grpc-simple: |
     metadata:
       annotations:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1069,21 +1069,26 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	if wh.namespaces != nil {
 		podNamespace = wh.namespaces.Get(pod.Namespace, "")
 	}
-
+	defaultTemplate := wh.Config.DefaultTemplates
+	proxyEnvs := parseInjectEnvs(path)
+	if proxyEnvs["REDIRECTION"] == "ambient" {
+		defaultTemplate = wh.Config.DefaultAmbientTemplates
+		delete(proxyEnvs, "REDIRECTION")
+	}
 	params := InjectionParameters{
 		pod:                 &pod,
 		deployMeta:          deploy,
 		namespace:           podNamespace,
 		typeMeta:            typeMeta,
 		templates:           wh.Config.Templates,
-		defaultTemplate:     wh.Config.DefaultTemplates,
+		defaultTemplate:     defaultTemplate,
 		aliases:             wh.Config.Aliases,
 		meshConfig:          wh.meshConfig,
 		proxyConfig:         proxyConfig,
 		valuesConfig:        wh.valuesConfig,
 		revision:            wh.revision,
 		injectedAnnotations: wh.Config.InjectedAnnotations,
-		proxyEnvs:           parseInjectEnvs(path),
+		proxyEnvs:           proxyEnvs,
 	}
 	wh.mu.RUnlock()
 

--- a/tools/ambient/pkg/cmd/root.go
+++ b/tools/ambient/pkg/cmd/root.go
@@ -1,0 +1,58 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/pkg/flag"
+	"istio.io/istio/tools/ambient/pkg/validation"
+)
+
+const (
+	ValidateAmbient = "validate-ambient"
+)
+
+// Command line options
+type Config struct {
+	ValidateAmbient bool `json:"VALIDATE_AMBIENT"`
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		ValidateAmbient: true,
+	}
+}
+
+func bindCmdlineFlags(cfg *Config, cmd *cobra.Command) {
+	fs := cmd.Flags()
+	flag.BindEnv(fs, ValidateAmbient, "", "Validate ambient proxy is attached.", &cfg.ValidateAmbient)
+}
+
+func GetCommand() *cobra.Command {
+	cfg := DefaultConfig()
+	cmd := &cobra.Command{
+		Use:   "istio-ambient",
+		Short: "Validate ambient for pods",
+		Long:  "istio-ambient is responsible for validating that the ztunnel is attached to the pod.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if cfg.ValidateAmbient {
+				validation.RunAmbientCheck()
+			}
+		},
+	}
+	bindCmdlineFlags(cfg, cmd)
+	return cmd
+}

--- a/tools/ambient/pkg/validation/validation.go
+++ b/tools/ambient/pkg/validation/validation.go
@@ -1,0 +1,56 @@
+package validation
+
+import (
+	"errors"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"istio.io/istio/cni/pkg/ambient/constants"
+)
+
+var (
+	ErrorPortNotOpen = errors.New("listening port was not found")
+)
+
+func NewOpenPortValidator(port uint16) *OpenPortValidator {
+	return &OpenPortValidator{
+		port: port,
+	}
+}
+
+type OpenPortValidator struct {
+	port uint16
+}
+
+func (o *OpenPortValidator) Validate() error {
+	socks4, err1 := netlink.SocketDiagTCP(unix.AF_INET)
+	socks6, err2 := netlink.SocketDiagTCP(unix.AF_INET6)
+	if err1 != nil && err2 != nil {
+		return errors.Join(err1, err2)
+	}
+	const TCP_LISTEN = 10
+	for _, sock := range append(socks4, socks6...) {
+		if sock.State != TCP_LISTEN {
+			continue
+		}
+		if sock.ID.SourcePort == o.port {
+			return nil
+		}
+	}
+
+	return ErrorPortNotOpen
+}
+
+func isZtunnelPresent() error {
+	return NewOpenPortValidator(constants.ZtunnelInboundPort).Validate()
+}
+
+func RunAmbientCheck() {
+	for {
+		if err := isZtunnelPresent(); err == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+}

--- a/tools/ambient/pkg/validation/validation_test.go
+++ b/tools/ambient/pkg/validation/validation_test.go
@@ -1,0 +1,41 @@
+package validation_test
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+
+	"istio.io/istio/tools/ambient/pkg/validation"
+)
+
+func TestOpenPortValidator(t *testing.T) {
+
+	// start ipv4 listening port
+	for _, addr := range []string{"127.0.0.1:0", "[::1]:0"} {
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, portString, err := net.SplitHostPort(l.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		port, err := strconv.Atoi(portString)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		opv := validation.NewOpenPortValidator(uint16(port))
+		if err := opv.Validate(); err != nil {
+			t.Fatal(err)
+		}
+
+		l.Close()
+		if err := opv.Validate(); !errors.Is(err, validation.ErrorPortNotOpen) {
+			t.Fatal("expected error")
+		}
+	}
+
+}


### PR DESCRIPTION
The init container appraoch to solve the CNI race problem. This requires a mutating web hook to inject an init container. The init container will block the application pod from starting, until the ztunnel sockets are present.

Notes:
- To make the distinction between sidecar and ambient pod we pass in "/redirection/ambient" as part of the webhook http path.
- This does mean that the ambient pod selection logic is "duplicated" in the webhook config.
- I'll wait on https://github.com/istio/istio/pull/48818 to merge first, as i'll want to re-use some the code from there for integration testing.