### PR TITLE
Ambient CNI: Fix informer reconciliation logs

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -153,12 +153,17 @@ func processAddEvent(body []byte) (CNIPluginAddEvent, error) {
 func (s *CniPluginServer) ReconcileCNIAddEvent(ctx context.Context, addCmd CNIPluginAddEvent) error {
 	log := log.WithLabels("cni-event", addCmd)
 
+	log.Debugf("netns: %s", addCmd.Netns)
+
 	// The CNI node plugin should have already checked the pod against the k8s API before forwarding us the event,
 	// but we have to invoke the K8S client anyway, so to be safe we check it again here to make sure we get the same result.
-	maxStaleRetries := 5
+	maxStaleRetries := 10
+	msInterval := 10
 	retries := 0
 	var ambientPod *corev1.Pod
 	var err error
+
+	log.Debugf("Checking pod: %s in ns: %s is enabled for ambient", addCmd.PodName, addCmd.PodNamespace)
 	// The plugin already consulted the k8s API - but on this end handler caches may be stale, so retry a few times if we get no pod.
 	for ambientPod, err = s.handlers.GetPodIfAmbient(addCmd.PodName, addCmd.PodNamespace); (ambientPod == nil) && (retries < maxStaleRetries); retries++ {
 		if err != nil {
@@ -166,13 +171,13 @@ func (s *CniPluginServer) ReconcileCNIAddEvent(ctx context.Context, addCmd CNIPl
 		}
 		log.Warnf("got an event for pod %s in namespace %s not found in current pod cache, retry %d of %d",
 			addCmd.PodName, addCmd.PodNamespace, retries, maxStaleRetries)
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(time.Duration(msInterval) * time.Millisecond)
 	}
 
 	if ambientPod == nil {
 		return fmt.Errorf("got event for pod %s in namespace %s but could not find in pod cache after retries", addCmd.PodName, addCmd.PodNamespace)
 	}
-	log.Debugf("Pod: %s in ns: %s is enabled for ambient, adding to mesh. ", addCmd.PodName, addCmd.PodNamespace)
+	log.Debugf("Pod: %s in ns: %s is enabled for ambient, adding to mesh.", addCmd.PodName, addCmd.PodNamespace)
 
 	var podIps []netip.Addr
 	for _, configuredPodIPs := range addCmd.IPs {

--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -160,7 +160,7 @@ func (s *CniPluginServer) ReconcileCNIAddEvent(ctx context.Context, addCmd CNIPl
 	var ambientPod *corev1.Pod
 	var err error
 	// The plugin already consulted the k8s API - but on this end handler caches may be stale, so retry a few times if we get no pod.
-	for ambientPod, err = s.handlers.GetPodIfAmbient(addCmd.PodName, addCmd.PodNamespace); (ambientPod == nil) || (retries < maxStaleRetries); retries++ {
+	for ambientPod, err = s.handlers.GetPodIfAmbient(addCmd.PodName, addCmd.PodNamespace); (ambientPod == nil) && (retries < maxStaleRetries); retries++ {
 		if err != nil {
 			return err
 		}

--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -15,10 +15,20 @@
 package nodeagent
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/netip"
 	"testing"
 
+	"istio.io/istio/cni/pkg/util"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestProcessAddEventGoodPayload(t *testing.T) {
@@ -50,4 +60,158 @@ func TestProcessAddEventBadPayload(t *testing.T) {
 	_, err := processAddEvent([]byte(invalid))
 
 	assert.Error(t, err)
+}
+
+func TestCNIPluginServer(t *testing.T) {
+	fakePodIP := "11.1.1.12"
+	_, addr, _ := net.ParseCIDR(fakePodIP+"/32")
+	valid := CNIPluginAddEvent{
+		Netns:        "/var/netns/foo",
+		PodName:      "pod-bingo",
+		PodNamespace: "funkyns",
+		IPs: []IPConfig{{
+			Address: *addr,
+		}},
+	}
+
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-bingo",
+			Namespace: "funkyns",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: fakePodIP,
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "funkyns"}}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	// We are expecting at most 1 calls to the mock, wait for them
+	wg, waitForMockCalls := NewWaitForNCalls(t, 1)
+	fs := &fakeServer{testWG: wg}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		pod,
+		util.GetPodIPsIfPresent(pod),
+		valid.Netns,
+	).Return(nil)
+
+	dpServer := &meshDataplane{
+		kubeClient: client.Kube(),
+		netServer:  fs,
+	}
+
+	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
+
+	// We are not going to start the server, so the sockpath is irrelevant
+	pluginServer := startCniPluginServer(ctx, "/tmp/test.sock", handlers, dpServer)
+
+	// label the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		constants.DataplaneMode, constants.DataplaneModeAmbient))
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	client.RunAndWait(ctx.Done())
+
+	payload, _ := json.Marshal(valid)
+
+	// serialize our fake plugin event
+	addEvent, err := processAddEvent(payload)
+	assert.Equal(t, err, nil)
+
+	// Push it thru the handler
+	pluginServer.ReconcileCNIAddEvent(ctx, addEvent)
+
+	waitForMockCalls()
+
+	assertPodAnnotated(t, client, pod)
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
+func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
+	fakePodIP := "11.1.1.12"
+	_, addr, _ := net.ParseCIDR(fakePodIP+"/32")
+	valid := CNIPluginAddEvent{
+		Netns:        "/var/netns/foo",
+		PodName:      "pod-bingo",
+		PodNamespace: "funkyns",
+		IPs: []IPConfig{{
+			Address: *addr,
+		}},
+	}
+
+	setupLogging()
+	NodeName = "testnode"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-bingo",
+			Namespace: "funkyns",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "funkyns"}}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	// We are expecting at most 1 calls to the mock, wait for them
+	wg, waitForMockCalls := NewWaitForNCalls(t, 1)
+	fs := &fakeServer{testWG: wg}
+
+	// This pod should be enmeshed with the CNI ip, even tho the pod status had no ip
+	fs.On("AddPodToMesh",
+		ctx,
+		pod,
+		[]netip.Addr{netip.MustParseAddr(fakePodIP)},
+		valid.Netns,
+	).Return(nil)
+
+	dpServer := &meshDataplane{
+		kubeClient: client.Kube(),
+		netServer:  fs,
+	}
+
+	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
+
+	// We are not going to start the server, so the sockpath is irrelevant
+	pluginServer := startCniPluginServer(ctx, "/tmp/test.sock", handlers, dpServer)
+
+	// label the namespace
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		constants.DataplaneMode, constants.DataplaneModeAmbient))
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	client.RunAndWait(ctx.Done())
+
+	payload, _ := json.Marshal(valid)
+
+	// serialize our fake plugin event
+	addEvent, err := processAddEvent(payload)
+	assert.Equal(t, err, nil)
+
+	// Push it thru the handler
+	pluginServer.ReconcileCNIAddEvent(ctx, addEvent)
+
+	waitForMockCalls()
+
+	assertPodAnnotated(t, client, pod)
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
 }

--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -22,13 +22,14 @@ import (
 	"net/netip"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestProcessAddEventGoodPayload(t *testing.T) {
@@ -64,7 +65,7 @@ func TestProcessAddEventBadPayload(t *testing.T) {
 
 func TestCNIPluginServer(t *testing.T) {
 	fakePodIP := "11.1.1.12"
-	_, addr, _ := net.ParseCIDR(fakePodIP+"/32")
+	_, addr, _ := net.ParseCIDR(fakePodIP + "/32")
 	valid := CNIPluginAddEvent{
 		Netns:        "/var/netns/foo",
 		PodName:      "pod-bingo",
@@ -142,7 +143,7 @@ func TestCNIPluginServer(t *testing.T) {
 
 func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
 	fakePodIP := "11.1.1.12"
-	_, addr, _ := net.ParseCIDR(fakePodIP+"/32")
+	_, addr, _ := net.ParseCIDR(fakePodIP + "/32")
 	valid := CNIPluginAddEvent{
 		Netns:        "/var/netns/foo",
 		PodName:      "pod-bingo",

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -83,11 +83,6 @@ func setupHandlers(ctx context.Context, kubeClient kube.Client, dataplane MeshDa
 }
 
 func (s *InformerHandlers) GetPodIfAmbient(podName, podNamespace string) (*corev1.Pod, error) {
-	// Both the CNI plugin and the informer check the K8S API to validate that the pod in
-	// question should be part of ambient, on "both ends".
-	// In the informer, wait for cache sync here to make sure we are fresh, to avoid issues
-	// where this cache is out of date with what the plugin might have seen when contacting the k8s API directly.
-	kube.WaitForCacheSync("informer", s.ctx.Done(), s.pods.HasSynced, s.namespaces.HasSynced)
 	ns := s.namespaces.Get(podNamespace, "")
 	if ns == nil {
 		return nil, fmt.Errorf("failed to find namespace %v", ns)


### PR DESCRIPTION
Fixup for #48253

- Fix dorked conditional to avoid log spam
- WaitForCacheSync on the informer side, as it already has backoff logic for this