### PR TITLE
[release-1.20] Add option to only run gateway conformance tests with standard resources (#49085)

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -242,6 +242,7 @@ linters-settings:
       AllGoFiles:
         files:
           - $all
+          - "!**/tests/integration/**"
         deny:
           - pkg: golang.org/x/net/http2/h2c
             desc: "h2c.NewHandler is unsafe; use wrapper istio.io/istio/pkg/h2c"

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -209,4 +209,8 @@ func init() {
 		"Deploy Istio with Dual Stack enabled.")
 
 	flag.StringVar(&settingsFromCommandLine.HelmRepo, "istio.test.helmRepo", settingsFromCommandLine.HelmRepo, "Helm repo to use to pull the charts.")
+
+	flag.BoolVar(&settingsFromCommandLine.GatewayConformanceStandardOnly, "istio.test.gatewayConformanceStandardOnly",
+		settingsFromCommandLine.GatewayConformanceStandardOnly,
+		"If set, only the standard gateway conformance tests will be run; tests relying on experimental resources will be skipped.")
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -178,6 +178,9 @@ type Settings struct {
 	DisableDefaultExternalServiceConnectivity bool
 
 	PeerMetadataDiscovery bool
+
+	// GatewayConformanceStandardOnly indicates that only the standard gateway conformance tests should be run.
+	GatewayConformanceStandardOnly bool
 }
 
 // SkipVMs changes the skip settings at runtime
@@ -237,25 +240,26 @@ func DefaultSettings() *Settings {
 func (s *Settings) String() string {
 	result := ""
 
-	result += fmt.Sprintf("TestID:            %s\n", s.TestID)
-	result += fmt.Sprintf("RunID:             %s\n", s.RunID.String())
-	result += fmt.Sprintf("NoCleanup:         %v\n", s.NoCleanup)
-	result += fmt.Sprintf("BaseDir:           %s\n", s.BaseDir)
-	result += fmt.Sprintf("Selector:          %v\n", s.Selector)
-	result += fmt.Sprintf("FailOnDeprecation: %v\n", s.FailOnDeprecation)
-	result += fmt.Sprintf("CIMode:            %v\n", s.CIMode)
-	result += fmt.Sprintf("Retries:           %v\n", s.Retries)
-	result += fmt.Sprintf("StableNamespaces:  %v\n", s.StableNamespaces)
-	result += fmt.Sprintf("Revision:          %v\n", s.Revision)
-	result += fmt.Sprintf("SkipWorkloads      %v\n", s.SkipWorkloadClasses)
-	result += fmt.Sprintf("Compatibility:     %v\n", s.Compatibility)
-	result += fmt.Sprintf("Revisions:         %v\n", s.Revisions.String())
-	result += fmt.Sprintf("Hub:               %s\n", s.Image.Hub)
-	result += fmt.Sprintf("Tag:               %s\n", s.Image.Tag)
-	result += fmt.Sprintf("PullPolicy:        %s\n", s.Image.PullPolicy)
-	result += fmt.Sprintf("PullSecret:        %s\n", s.Image.PullSecret)
-	result += fmt.Sprintf("MaxDumps:          %d\n", s.MaxDumps)
-	result += fmt.Sprintf("HelmRepo:          %v\n", s.HelmRepo)
+	result += fmt.Sprintf("TestID:            						 %s\n", s.TestID)
+	result += fmt.Sprintf("RunID:             						 %s\n", s.RunID.String())
+	result += fmt.Sprintf("NoCleanup:         						 %v\n", s.NoCleanup)
+	result += fmt.Sprintf("BaseDir:           						 %s\n", s.BaseDir)
+	result += fmt.Sprintf("Selector:          						 %v\n", s.Selector)
+	result += fmt.Sprintf("FailOnDeprecation: 						 %v\n", s.FailOnDeprecation)
+	result += fmt.Sprintf("CIMode:            						 %v\n", s.CIMode)
+	result += fmt.Sprintf("Retries:           						 %v\n", s.Retries)
+	result += fmt.Sprintf("StableNamespaces:  						 %v\n", s.StableNamespaces)
+	result += fmt.Sprintf("Revision:          						 %v\n", s.Revision)
+	result += fmt.Sprintf("SkipWorkloads      						 %v\n", s.SkipWorkloadClasses)
+	result += fmt.Sprintf("Compatibility:     						 %v\n", s.Compatibility)
+	result += fmt.Sprintf("Revisions:         						 %v\n", s.Revisions.String())
+	result += fmt.Sprintf("Hub:               						 %s\n", s.Image.Hub)
+	result += fmt.Sprintf("Tag:               						 %s\n", s.Image.Tag)
+	result += fmt.Sprintf("PullPolicy:        						 %s\n", s.Image.PullPolicy)
+	result += fmt.Sprintf("PullSecret:        						 %s\n", s.Image.PullSecret)
+	result += fmt.Sprintf("MaxDumps:          						 %d\n", s.MaxDumps)
+	result += fmt.Sprintf("HelmRepo:          						 %v\n", s.HelmRepo)
+	result += fmt.Sprintf("GatewayConformanceStandardOnly: %v\n", s.GatewayConformanceStandardOnly)
 	return result
 }
 

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -20,6 +20,7 @@ package pilot
 import (
 	"testing"
 
+	k8ssets "k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api/conformance/tests"
@@ -90,6 +91,14 @@ func TestGatewayConformance(t *testing.T) {
 			}
 
 			features := suite.AllFeatures
+			if ctx.Settings().GatewayConformanceStandardOnly {
+				features = k8ssets.New[suite.SupportedFeature]().
+					Insert(suite.GatewayExtendedFeatures.UnsortedList()...).
+					Insert(suite.ReferenceGrantCoreFeatures.UnsortedList()...).
+					Insert(suite.HTTPRouteCoreFeatures.UnsortedList()...).
+					Insert(suite.HTTPRouteExtendedFeatures.UnsortedList()...).
+					Insert(suite.MeshCoreFeatures.UnsortedList()...)
+			}
 			opts := suite.Options{
 				Client:               c,
 				Clientset:            gatewayConformanceInputs.Client.Kube(),


### PR DESCRIPTION
Fixes #49089

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
