### PR TITLE
ambient: close netns before err return to avoid potential leak

### DIFF
--- a/cni/pkg/nodeagent/netns_linux.go
+++ b/cni/pkg/nodeagent/netns_linux.go
@@ -53,6 +53,7 @@ func OpenNetns(nspath string) (NetnsCloser, error) {
 	}
 	i, err := inodeForFd(n)
 	if err != nil {
+		n.Close()
 		return nil, err
 	}
 	return &NetnsWrapper{innerNetns: n, inode: i}, nil


### PR DESCRIPTION
**Please provide a description of this PR:**
close netns before err return to avoid potential leak in OpenNetns implementation