### PR TITLE
Ambient PeerAuthentication should use AND semantics instead of OR

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/authorization.go
@@ -621,19 +621,15 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 	}
 
 	action := security.Action_DENY
-	var groups []*security.Group
+	var rules []*security.Rules
 
 	if mode == v1beta1.PeerAuthentication_MutualTLS_STRICT {
-		groups = append(groups, &security.Group{
-			Rules: []*security.Rules{
+		rules = append(rules, &security.Rules{
+			Matches: []*security.Match{
 				{
-					Matches: []*security.Match{
+					NotPrincipals: []*security.StringMatch{
 						{
-							NotPrincipals: []*security.StringMatch{
-								{
-									MatchType: &security.StringMatch_Presence{},
-								},
-							},
+							MatchType: &security.StringMatch_Presence{},
 						},
 					},
 				},
@@ -649,19 +645,15 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 	for port, mtls := range pa.PortLevelMtls {
 		switch portMtlsMode := mtls.GetMode(); {
 		case portMtlsMode == v1beta1.PeerAuthentication_MutualTLS_STRICT:
-			groups = append(groups, &security.Group{
-				Rules: []*security.Rules{
+			rules = append(rules, &security.Rules{
+				Matches: []*security.Match{
 					{
-						Matches: []*security.Match{
+						NotPrincipals: []*security.StringMatch{
 							{
-								NotPrincipals: []*security.StringMatch{
-									{
-										MatchType: &security.StringMatch_Presence{},
-									},
-								},
-								DestinationPorts: []uint32{port},
+								MatchType: &security.StringMatch_Presence{},
 							},
 						},
+						DestinationPorts: []uint32{port},
 					},
 				},
 			})
@@ -676,14 +668,10 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 			foundNonStrictPortmTLS = true
 
 			// If the top level policy is STRICT, we need to add a rule for the port that exempts it from the deny policy
-			groups = append(groups, &security.Group{
-				Rules: []*security.Rules{
+			rules = append(rules, &security.Rules{
+				Matches: []*security.Match{
 					{
-						Matches: []*security.Match{
-							{
-								NotDestinationPorts: []uint32{port}, // if the incoming connection does not match this port, deny (notice there's no principals requirement)
-							},
-						},
+						NotDestinationPorts: []uint32{port}, // if the incoming connection does not match this port, deny (notice there's no principals requirement)
 					},
 				},
 			})
@@ -698,14 +686,10 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 			foundNonStrictPortmTLS = true
 
 			// If the top level policy is STRICT, we need to add a rule for the port that exempts it from the deny policy
-			groups = append(groups, &security.Group{
-				Rules: []*security.Rules{
+			rules = append(rules, &security.Rules{
+				Matches: []*security.Match{
 					{
-						Matches: []*security.Match{
-							{
-								NotDestinationPorts: []uint32{port}, // if the incoming connection does not match this port, deny (notice there's no principals requirement)
-							},
-						},
+						NotDestinationPorts: []uint32{port}, // if the incoming connection does not match this port, deny (notice there's no principals requirement)
 					},
 				},
 			})
@@ -720,7 +704,7 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 		return nil
 	}
 
-	if len(groups) == 0 {
+	if len(rules) == 0 {
 		// we never added any rules; return
 		return nil
 	}
@@ -734,7 +718,7 @@ func convertPeerAuthentication(rootNamespace string, cfg config.Config) *securit
 		Namespace: cfg.Namespace,
 		Scope:     scope,
 		Action:    action,
-		Groups:    groups,
+		Groups:    []*security.Group{{Rules: rules}},
 	}
 
 	return opol

--- a/pilot/pkg/serviceregistry/kube/controller/testdata/peer-authn-strict-and-disable-port-mtls.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/testdata/peer-authn-strict-and-disable-port-mtls.yaml
@@ -4,7 +4,6 @@ groups:
   - matches:
     - notPrincipals:
       - presence: {}
-- rules:
   - matches:
     - notDestinationPorts:
       - 9090

--- a/pilot/pkg/serviceregistry/kube/controller/testdata/peer-authn-strict-and-permissive-port-mtls.yaml
+++ b/pilot/pkg/serviceregistry/kube/controller/testdata/peer-authn-strict-and-permissive-port-mtls.yaml
@@ -4,7 +4,6 @@ groups:
   - matches:
     - notPrincipals:
       - presence: {}
-- rules:
   - matches:
     - notDestinationPorts:
       - 9090

--- a/releasenotes/notes/49098.yaml
+++ b/releasenotes/notes/49098.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issues:
+- 49098
+releaseNotes:
+- |
+  **Fixed** a bug that made PeerAuthentication too restrictive in Ambient mode.


### PR DESCRIPTION
**Please provide a description of this PR:**
ztunnel Authorization resources are different than Istio's AuthorizationPolicy resources in the sense that there's an extra level of nesting. PeerAuthentication port-level exclusions should result in policy blocks that are AND'd with the top-level policy, not OR'd.

NOTE: This would've been caught with an integration tests, but we still don't have a way to do check the existence of a peer identity with Ambient tests. 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
