### PR TITLE
Fix delta ADS client

### DIFF
--- a/pkg/adsc/delta.go
+++ b/pkg/adsc/delta.go
@@ -233,7 +233,8 @@ func (c *Client) trigger(ctx *handlerContext, typeURL string, r *discovery.Resou
 			Version: r.Version,
 			Entity:  entity,
 		}
-	} else { //EventDelete
+	} else {
+		// EventDelete
 		res = &Resource{
 			Name: r.Name,
 		}

--- a/pkg/adsc/delta.go
+++ b/pkg/adsc/delta.go
@@ -128,7 +128,13 @@ type DeltaADSConfig struct {
 	Config
 }
 
-type HandlerFunc func(ctx HandlerContext, res proto.Message, event Event, resourceName string)
+type Resource struct {
+	Name    string
+	Version string
+	Entity  proto.Message
+}
+
+type HandlerFunc func(ctx HandlerContext, res *Resource, event Event)
 
 // Client is a stateful ADS (Aggregated Discovery Service) client designed to handle delta updates from an xDS server.
 // Central to this client is a dynamic 'tree' of resources, representing the relationships and states of resources in the service mesh.
@@ -207,10 +213,29 @@ type Client struct {
 }
 
 func (c *Client) trigger(ctx *handlerContext, typeURL string, r *discovery.Resource, event Event) error {
-	res := newProto(typeURL)
-	if r != nil && r.Resource != nil && res != nil {
-		if err := r.Resource.UnmarshalTo(res); err != nil {
+	var res *Resource
+	if r == nil {
+		return fmt.Errorf("trigged by event %d,but resource is nil", event)
+	}
+	if event == EventAdd {
+		if r.Resource == nil {
+			return fmt.Errorf("trigged by EventAdd,but be added resource object is nil")
+		}
+		entity := newProto(typeURL)
+		if entity == nil {
+			return fmt.Errorf("new resource entity by typeURL: %s error", entity)
+		}
+		if err := r.Resource.UnmarshalTo(entity); err != nil {
 			return err
+		}
+		res = &Resource{
+			Name:    r.Name,
+			Version: r.Version,
+			Entity:  entity,
+		}
+	} else { //EventDelete
+		res = &Resource{
+			Name: r.Name,
 		}
 	}
 	handler, f := c.handlers[typeURL]
@@ -218,7 +243,7 @@ func (c *Client) trigger(ctx *handlerContext, typeURL string, r *discovery.Resou
 		deltaLog.Warnf("ignoring unknown type %v", typeURL)
 		return nil
 	}
-	handler(ctx, res, event, r.Name)
+	handler(ctx, res, event)
 	return nil
 }
 
@@ -316,10 +341,15 @@ func typeName[T proto.Message]() string {
 }
 
 // Register registers a handler for a type which is reflected by the proto message.
-func Register[T proto.Message](f func(ctx HandlerContext, res T, event Event, resourceName string)) Option {
+func Register[T proto.Message](f func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity T, event Event)) Option {
 	return func(c *Client) {
-		c.handlers[typeName[T]()] = func(ctx HandlerContext, res proto.Message, event Event, resourceName string) {
-			f(ctx, res.(T), event, resourceName)
+		c.handlers[typeName[T]()] = func(ctx HandlerContext, res *Resource, event Event) {
+			if res.Entity == nil {
+				var nilEntity T
+				f(ctx, res.Name, res.Version, nilEntity, event)
+			} else {
+				f(ctx, res.Name, res.Version, res.Entity.(T), event)
+			}
 		}
 	}
 }

--- a/pkg/adsc/delta_test.go
+++ b/pkg/adsc/delta_test.go
@@ -224,16 +224,16 @@ func TestDeltaClient(t *testing.T) {
 
 	var tests []testCase
 
-	clusterHandler := Register(func(ctx HandlerContext, res *cluster.Cluster, event Event) {
+	clusterHandler := Register(func(ctx HandlerContext, res *cluster.Cluster, event Event, resourceName string) {
 		if event == EventDelete {
 			return
 		}
 		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractClusterSecretResources(t, res)...)
 		ctx.RegisterDependency(v3.EndpointType, xdstest.ExtractEdsClusterNames([]*cluster.Cluster{res})...)
 	})
-	endpointsHandler := Register(func(ctx HandlerContext, res *endpoint.ClusterLoadAssignment, event Event) {
+	endpointsHandler := Register(func(ctx HandlerContext, res *endpoint.ClusterLoadAssignment, event Event, resourceName string) {
 	})
-	listenerHandler := Register(func(ctx HandlerContext, res *listener.Listener, event Event) {
+	listenerHandler := Register(func(ctx HandlerContext, res *listener.Listener, event Event, resourceName string) {
 		if event == EventDelete {
 			return
 		}
@@ -241,9 +241,9 @@ func TestDeltaClient(t *testing.T) {
 		ctx.RegisterDependency(v3.RouteType, xdstest.ExtractRoutesFromListeners([]*listener.Listener{res})...)
 		// TODO: ECDS
 	})
-	routesHandler := Register(func(ctx HandlerContext, res *route.RouteConfiguration, event Event) {
+	routesHandler := Register(func(ctx HandlerContext, res *route.RouteConfiguration, event Event, resourceName string) {
 	})
-	secretsHandler := Register(func(ctx HandlerContext, res *tls.Secret, event Event) {
+	secretsHandler := Register(func(ctx HandlerContext, res *tls.Secret, event Event, resourceName string) {
 	})
 
 	handlers := []Option{

--- a/pkg/adsc/delta_test.go
+++ b/pkg/adsc/delta_test.go
@@ -231,7 +231,8 @@ func TestDeltaClient(t *testing.T) {
 		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractClusterSecretResources(t, resourceEntity)...)
 		ctx.RegisterDependency(v3.EndpointType, xdstest.ExtractEdsClusterNames([]*cluster.Cluster{resourceEntity})...)
 	})
-	endpointsHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *endpoint.ClusterLoadAssignment, event Event) {
+	endpointsHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *endpoint.ClusterLoadAssignment,
+		event Event) {
 	})
 	listenerHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *listener.Listener, event Event) {
 		if event == EventDelete {

--- a/pkg/adsc/delta_test.go
+++ b/pkg/adsc/delta_test.go
@@ -224,26 +224,26 @@ func TestDeltaClient(t *testing.T) {
 
 	var tests []testCase
 
-	clusterHandler := Register(func(ctx HandlerContext, res *cluster.Cluster, event Event, resourceName string) {
+	clusterHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *cluster.Cluster, event Event) {
 		if event == EventDelete {
 			return
 		}
-		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractClusterSecretResources(t, res)...)
-		ctx.RegisterDependency(v3.EndpointType, xdstest.ExtractEdsClusterNames([]*cluster.Cluster{res})...)
+		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractClusterSecretResources(t, resourceEntity)...)
+		ctx.RegisterDependency(v3.EndpointType, xdstest.ExtractEdsClusterNames([]*cluster.Cluster{resourceEntity})...)
 	})
-	endpointsHandler := Register(func(ctx HandlerContext, res *endpoint.ClusterLoadAssignment, event Event, resourceName string) {
+	endpointsHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *endpoint.ClusterLoadAssignment, event Event) {
 	})
-	listenerHandler := Register(func(ctx HandlerContext, res *listener.Listener, event Event, resourceName string) {
+	listenerHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *listener.Listener, event Event) {
 		if event == EventDelete {
 			return
 		}
-		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractListenerSecretResources(t, res)...)
-		ctx.RegisterDependency(v3.RouteType, xdstest.ExtractRoutesFromListeners([]*listener.Listener{res})...)
+		ctx.RegisterDependency(v3.SecretType, xdstest.ExtractListenerSecretResources(t, resourceEntity)...)
+		ctx.RegisterDependency(v3.RouteType, xdstest.ExtractRoutesFromListeners([]*listener.Listener{resourceEntity})...)
 		// TODO: ECDS
 	})
-	routesHandler := Register(func(ctx HandlerContext, res *route.RouteConfiguration, event Event, resourceName string) {
+	routesHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *route.RouteConfiguration, event Event) {
 	})
-	secretsHandler := Register(func(ctx HandlerContext, res *tls.Secret, event Event, resourceName string) {
+	secretsHandler := Register(func(ctx HandlerContext, resourceName string, resourceVersion string, resourceEntity *tls.Secret, event Event) {
 	})
 
 	handlers := []Option{
@@ -380,6 +380,36 @@ LDS/:
     RDS/test-rds-config:
     SDS/kubernetes://test:
 RDS/test-route:
+`,
+		},
+
+		{
+			desc: "begin two clusters then remove one",
+			serverResponses: []*discovery.DeltaDiscoveryResponse{
+				{
+					TypeUrl: v3.ClusterType,
+					Resources: []*discovery.Resource{
+						{
+							Name:     "test-cluster1",
+							Resource: protoconv.MessageToAny(testCluster),
+						},
+						{
+							Name:     "test-cluster2",
+							Resource: protoconv.MessageToAny(testClusterNoSecret),
+						},
+					},
+				},
+				{
+					TypeUrl:          v3.ClusterType,
+					Resources:        []*discovery.Resource{},
+					RemovedResources: []string{"test-cluster2"},
+				},
+			},
+			expectedTree: `CDS/:
+  CDS/test-cluster1:
+    EDS/test-eds:
+    SDS/kubernetes://test:
+LDS/:
 `,
 		},
 	}

--- a/releasenotes/notes/49139.yaml
+++ b/releasenotes/notes/49139.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue where the delta ADS client received a response which contains RemoveResources


### PR DESCRIPTION
**Please provide a description of this PR:**


1） when received a response that contains RemoveResources, it would cause the client crash.  Because the remove resource only has a name.

```go
	for _, r := range d.RemovedResources {
		key := resourceKey{
			Name:    r,
			TypeURL: d.TypeUrl,
		}
		removed := &discovery.Resource{
			Name: r,
		}
		err := c.trigger(ctx, d.TypeUrl, removed, EventDelete)
		if err != nil {
			return err
		}

		if _, f := allRemoves[key.TypeURL]; !f {
			allRemoves[key.TypeURL] = set.New[string]()
		}
		allRemoves[key.TypeURL].Insert(key.Name)
		c.drop(key)
	}
```
2）Modified the HandlerFunc to add a resourceName parameter to identify the name of being deleted resource.