### PR TITLE
correct CODEOWNER for /pkg/adsc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,8 +21,8 @@ Makefile*                                                        @istio/wg-test-
 /pilot/pkg/model/                                                @istio/wg-networking-maintainers-pilot
 /pilot/pkg/networking/core                                       @istio/wg-networking-maintainers-pilot
 /pilot/pkg/proxy                                                 @istio/wg-networking-maintainers-pilot
-/pkg/adsc/                                                       @istio/wg-networking-maintainers
 /pkg/                                                            @istio/wg-test-and-release-maintainers
+/pkg/adsc/                                                       @istio/wg-networking-maintainers
 /pkg/bootstrap/                                                  @istio/wg-networking-maintainers
 /pkg/config/                                                     @istio/wg-networking-maintainers
 /pkg/config/analysis/                                            @istio/wg-networking-maintainers @istio/wg-user-experience-maintainers


### PR DESCRIPTION
**Please provide a description of this PR:**

Reviewers for https://github.com/istio/istio/pull/49139 seems not right.