### PR TITLE
istioctl: support v1 Gateway API

### DIFF
--- a/istioctl/pkg/util/handlers/handlers.go
+++ b/istioctl/pkg/util/handlers/handlers.go
@@ -30,7 +30,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/util/podutils"
-	gatewayapi "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapibeta "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"istio.io/istio/pilot/pkg/config/kube/gateway"


### PR DESCRIPTION
We used to only have alpha, and no v1. Alpha is long removed, so now
just switch to v1 support. This makes `istioctl pc gtw/foo` work
