### PR TITLE
kclient: do not panic on handlers after stopped

### DIFF
--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -123,7 +123,11 @@ func (n *informerClient[T]) AddEventHandler(h cache.ResourceEventHandler) {
 		},
 		Handler: h,
 	}
-	reg, _ := n.informer.AddEventHandler(fh)
+	reg, err := n.informer.AddEventHandler(fh)
+	if err != nil {
+		// Should only happen if its already stopped. We should exit early.
+		return
+	}
 	n.handlerMu.Lock()
 	defer n.handlerMu.Unlock()
 	n.registeredHandlers = append(n.registeredHandlers, reg)


### PR DESCRIPTION
Currently, if we add a handler after the informer has stopped, it will
crash. This is not great, though it rarely happens.

Better handling of this is to just not add the handler.

Note this cannot be handled by clients, since there would be TOCTOU race
conditions (and we don't expose HasStopped anyways)
