### PR TITLE
context: utilize new AfterFunc to avoid unneeded goroutines

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -99,15 +99,13 @@ func (s *CniPluginServer) Start() error {
 		}
 	}()
 
-	go func() {
-		<-s.ctx.Done()
+	context.AfterFunc(s.ctx, func() {
 		if err := s.cniListenServer.Close(); err != nil {
 			log.Errorf("CNI listen server terminated with error: %v", err)
 		} else {
 			log.Debug("CNI listen server terminated")
 		}
-	}()
-
+	})
 	return nil
 }
 

--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -145,10 +145,7 @@ func (z *ztunnelServer) Close() error {
 }
 
 func (z *ztunnelServer) Run(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		z.Close()
-	}()
+	context.AfterFunc(ctx, func() { _ = z.Close() })
 
 	for {
 		log.Debug("accepting conn")
@@ -179,11 +176,11 @@ func (z *ztunnelServer) Run(ctx context.Context) {
 // nolint: unparam
 func (z *ztunnelServer) handleConn(ctx context.Context, conn *ZtunnelConnection) error {
 	defer conn.Close()
-	go func() {
-		<-ctx.Done()
+
+	context.AfterFunc(ctx, func() {
 		log.Debug("context cancelled - closing conn")
 		conn.Close()
-	}()
+	})
 
 	// before doing anything, add the connection to the list of active connections
 	z.conns.addConn(conn)

--- a/pilot/pkg/status/resourcelock.go
+++ b/pilot/pkg/status/resourcelock.go
@@ -162,12 +162,11 @@ func (wp *WorkerPool) Push(target Resource, controller *Controller, context any)
 }
 
 func (wp *WorkerPool) Run(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
+	context.AfterFunc(ctx, func() {
 		wp.lock.Lock()
 		wp.closing = true
 		wp.lock.Unlock()
-	}()
+	})
 }
 
 // maybeAddWorker adds a worker unless we are at maxWorkers.  Workers exit when there are no more tasks, except for the

--- a/pilot/pkg/xds/adstest.go
+++ b/pilot/pkg/xds/adstest.go
@@ -97,10 +97,7 @@ func (a *AdsTest) Cleanup() {
 }
 
 func (a *AdsTest) adsReceiveChannel() {
-	go func() {
-		<-a.context.Done()
-		a.Cleanup()
-	}()
+	context.AfterFunc(a.context, a.Cleanup)
 	for {
 		resp, err := a.client.Recv()
 		if err != nil {

--- a/pilot/pkg/xds/deltaadstest.go
+++ b/pilot/pkg/xds/deltaadstest.go
@@ -95,10 +95,7 @@ func (a *DeltaAdsTest) Cleanup() {
 }
 
 func (a *DeltaAdsTest) adsReceiveChannel() {
-	go func() {
-		<-a.context.Done()
-		a.Cleanup()
-	}()
+	context.AfterFunc(a.context, a.Cleanup)
 	for {
 		resp, err := a.client.Recv()
 		if err != nil {


### PR DESCRIPTION
This should be functionally identical but doesn't waste a goroutine and
is simpler
