### PR TITLE
refactor: extract VSMatches function

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -85,6 +85,27 @@ func (hc hostClassification) Matches(h host.Name) bool {
 	return false
 }
 
+func (hc hostClassification) VSMatches(vsHost host.Name, useGatewaySemantics bool) bool {
+	// first, check exactHosts
+	if hc.exactHosts.Contains(vsHost) {
+		return true
+	}
+
+	// exactHosts not found, fallback to loop allHosts
+	hIsWildCard := vsHost.IsWildCarded()
+	for _, importedHost := range hc.allHosts {
+		// If both are exact hosts, then fallback is not needed.
+		// In this scenario it should be determined by exact lookup.
+		if !hIsWildCard && !importedHost.IsWildCarded() {
+			continue
+		}
+		if vsHostMatches(vsHost, importedHost, useGatewaySemantics) {
+			return true
+		}
+	}
+	return false
+}
+
 // SidecarScope is a wrapper over the Sidecar resource with some
 // preprocessed data to determine the list of services, virtualServices,
 // and destinationRules that are accessible to a given

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -36,35 +36,19 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 	importedVirtualServices := make([]config.Config, 0)
 	vsset := sets.New[types.NamespacedName]()
 
-	addVirtualService := func(vs config.Config, hosts hostClassification) {
+	addVirtualService := func(vs config.Config, hc hostClassification) {
 		key := vs.NamespacedName()
 		if vsset.Contains(key) {
 			return
 		}
 
 		rule := vs.Spec.(*networking.VirtualService)
+		useGatewaySemantics := UseGatewaySemantics(vs)
 		for _, vh := range rule.Hosts {
-			// first, check exactHosts
-			if hosts.exactHosts.Contains(host.Name(vh)) {
+			if hc.VSMatches(host.Name(vh), useGatewaySemantics) {
 				importedVirtualServices = append(importedVirtualServices, vs)
 				vsset.Insert(key)
 				return
-			}
-
-			// exactHosts not found, fallback to loop allHosts
-			vhIsWildCard := host.Name(vh).IsWildCarded()
-			for _, ah := range hosts.allHosts {
-				// If both are exact hosts, then fallback is not needed.
-				// In this scenario it should be determined by exact lookup.
-				if !vhIsWildCard && !ah.IsWildCarded() {
-					continue
-				}
-				if vsHostMatches(vh, ah, vs) {
-					importedVirtualServices = append(importedVirtualServices, vs)
-					vsset.Insert(key)
-					// break both loops
-					return
-				}
 			}
 		}
 	}
@@ -99,15 +83,15 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 }
 
 // vsHostMatches checks if the given VirtualService host matches the importedHost (from Sidecar)
-func vsHostMatches(vsHost string, importedHost host.Name, vs config.Config) bool {
-	if UseGatewaySemantics(vs) {
+func vsHostMatches(vsHost host.Name, importedHost host.Name, useGatewaySemantics bool) bool {
+	if useGatewaySemantics {
 		// The new way. Matching logic exactly mirrors Service matching
 		// If a route defines `*.com` and we import `a.com`, it will not match
-		return host.Name(vsHost).SubsetOf(importedHost)
+		return vsHost.SubsetOf(importedHost)
 	}
 
 	// The old way. We check Matches which is bi-directional. This is for backwards compatibility
-	return host.Name(vsHost).Matches(importedHost)
+	return vsHost.Matches(importedHost)
 }
 
 func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.Meta) {

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -82,18 +82,6 @@ func SelectVirtualServices(vsidx virtualServiceIndex, configNamespace string, ho
 	return importedVirtualServices
 }
 
-// vsHostMatches checks if the given VirtualService host matches the importedHost (from Sidecar)
-func vsHostMatches(vsHost host.Name, importedHost host.Name, useGatewaySemantics bool) bool {
-	if useGatewaySemantics {
-		// The new way. Matching logic exactly mirrors Service matching
-		// If a route defines `*.com` and we import `a.com`, it will not match
-		return vsHost.SubsetOf(importedHost)
-	}
-
-	// The old way. We check Matches which is bi-directional. This is for backwards compatibility
-	return vsHost.Matches(importedHost)
-}
-
 func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.Meta) {
 	// Kubernetes Gateway API semantics support shortnames
 	if UseGatewaySemantics(config.Config{Meta: meta}) {


### PR DESCRIPTION
Minor refactoring:
1. Extract the VS matching logic into `VSMatches` function to be consistent with `Service` matching.

https://github.com/istio/istio/blob/e011f1aec5cdcc0780768aaa31328cad1412f6e8/pilot/pkg/model/sidecar.go#L66

2. Determine whether to use gateway semantics before the for loop (see L46). No need to determine in every loop.