### PR TITLE
ambient: cleanup dup logs while del/opt-out Pods

### DIFF
--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -225,7 +225,7 @@ func realDependencies() *dep.RealDependencies {
 // Remove pod from mesh: pod is not deleted, we just want to remove it from the mesh.
 func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debugf("Pod is now stopped or opt out... cleaning up.")
+	log.Debugf("Pod is now opt out... cleaning up.")
 
 	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
 	if openNetns == nil {
@@ -254,7 +254,7 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) erro
 // Delete pod from mesh: pod is deleted. iptables rules will die with it, we just need to update ztunnel
 func (s *NetServer) DelPodFromMesh(ctx context.Context, pod *corev1.Pod) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debug("Pod is now stopped or opt out... cleaning up.")
+	log.Debug("Pod is now stopped... cleaning up.")
 
 	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
 		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -221,10 +221,9 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 
 func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debug("Pod is now stopped or opt out... cleaning up.")
 	err := s.netServer.RemovePodFromMesh(ctx, pod)
 	if err != nil {
-		log.Errorf("failed to remove pod to ztunnel: %v", err)
+		log.Errorf("failed to remove pod from mesh: %v", err)
 		return err
 	}
 	log.Debug("removing annotation from pod")
@@ -238,11 +237,9 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) 
 // Delete pod from mesh: pod is deleted. iptables rules will die with it, we just need to update ztunnel
 func (s *meshDataplane) DelPodFromMesh(ctx context.Context, pod *corev1.Pod) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debug("Pod is now stopped or opt out... cleaning up.")
-	log.Info("in pod mode - deleting pod from ztunnel")
 	err := s.netServer.DelPodFromMesh(ctx, pod)
 	if err != nil {
-		log.Errorf("failed to remove pod to ztunnel: %v", err)
+		log.Errorf("failed to delete pod from mesh: %v", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
**Please provide a description of this PR:**
duplicated logs output for one event while deleting Pods in ambient mode
```
2024-02-05T02:08:04.497005Z    debug    ambient    Pod is now stopped or opt out... cleaning up.    ns=default name=httpbin-worker1-7b47f9576c-vt8mh                                                                                                       ??
2024-02-05T02:08:04.497028Z    info    ambient    in pod mode - deleting pod from ztunnel    ns=default name=httpbin-worker1-7b47f9576c-vt8mh                                                                                                              ??
2024-02-05T02:08:04.497034Z    debug    ambient    Pod is now stopped or opt out... cleaning up.    ns=default name=httpbin-worker1-7b47f9576c-vt8mh                                                                                                       ??
2024-02-05T02:08:04.497236Z    debug    ambient    removed pod name httpbin-worker1-7b47f9576c-vt8mh with UID 78e0e965-fc00-46ba-b40b-abe0a2c94cce from host ipset istio-inpod-probes by ip 10.101.1.26                                                    ??
2024-02-05T02:08:04.497243Z    info    ambient    in pod mode - deleting pod from ztunnel    ns=default name=httpbin-worker1-7b47f9576c-vt8mh            
```