### PR TITLE
cni-plugin: fix plugin execution broken by ambient

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -229,9 +229,9 @@ func doAddRun(args *skel.CmdArgs, conf *Config) error {
 				log.Errorf("istio-cni cmdAdd failed to signal node Istio CNI agent: %s", err)
 				return err
 			}
-		} else {
-			log.Debugf("istio-cni ambient cmdAdd podName: %s - not ambient enabled, ignoring", podName)
+			return nil
 		}
+		log.Debugf("istio-cni ambient cmdAdd podName: %s - not ambient enabled, ignoring", podName)
 	}
 	// End ambient plugin logic
 

--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -232,8 +232,6 @@ func doAddRun(args *skel.CmdArgs, conf *Config) error {
 		} else {
 			log.Debugf("istio-cni ambient cmdAdd podName: %s - not ambient enabled, ignoring", podName)
 		}
-
-		return nil
 	}
 	// End ambient plugin logic
 


### PR DESCRIPTION
**Please provide a description of this PR:**
cni-plugin: fix plugin execution broken by ambient

cni cmdADD will not take any effect for legacy sidecar mode while cni configuration enabling ambient.
Fortunately/unfortunately, redirection still works in sidecar because we have the repair/reconcile mechanism for sidecar mode.