### PR TITLE
Use session cookies instead of 2-min hardcoded persistent cookies

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -26,6 +26,7 @@ import (
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	headerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/header/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
+
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -26,8 +26,6 @@ import (
 	cookiev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
 	headerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/header/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
-	"google.golang.org/protobuf/types/known/durationpb"
-
 	meshapi "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
@@ -663,9 +661,6 @@ func TestSidecarStatefulsessionFilter(t *testing.T) {
 								Cookie: &httpv3.Cookie{
 									Name: "x-session-id",
 									Path: "/",
-									Ttl: &durationpb.Duration{
-										Seconds: 120,
-									},
 								},
 							}),
 						},

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -27,7 +27,6 @@ import (
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/type/http/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -1330,7 +1329,6 @@ func TestStatefulSessionFilterConfig(t *testing.T) {
 					TypedConfig: protoconv.MessageToAny(&cookiev3.CookieBasedSessionState{
 						Cookie: &httpv3.Cookie{
 							Path: "/",
-							Ttl:  &durationpb.Duration{Seconds: 120},
 							Name: "test-cookie",
 						},
 					}),
@@ -1350,7 +1348,6 @@ func TestStatefulSessionFilterConfig(t *testing.T) {
 					TypedConfig: protoconv.MessageToAny(&cookiev3.CookieBasedSessionState{
 						Cookie: &httpv3.Cookie{
 							Path: "/path",
-							Ttl:  &durationpb.Duration{Seconds: 120},
 							Name: "test-cookie",
 						},
 					}),


### PR DESCRIPTION
**Please provide a description of this PR:**

Current hardcoded 2-min value is not very useful - a client can ignore the MaxAge completely, there is no 
verification on the server side. Pods don't have persistence so large MaxAge are also not working properly.

Envoy is moving to add the expiration in the cookie value - which combined with signing or encrypting the 
cookie can provide the proper semantics. There are other factors - like  GDPR treatment of session vs persistent
cookies.

Depends on https://github.com/envoyproxy/envoy/pull/32093

Opening the PR early to get feedback on adding an option to still support 'persistent cookies' with custom 
age - I don't think it's going to be useful . The Gateway API implementation ( which is not yet started ) will
require some expiration - but it may use the new Envoy expiration encoded in the cookie value. 

Second part of the fix for https://github.com/istio/istio/issues/49000