### PR TITLE
Add delay parameter to jwt server sample

### DIFF
--- a/samples/jwt-server/src/Makefile
+++ b/samples/jwt-server/src/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 HUB ?= gcr.io/istio-testing/jwt-server
-TAG ?= 0.7
+TAG ?= 0.8
 
 push: main.go Dockerfile
 	docker buildx build --push --platform=linux/amd64,linux/arm64 . -t $(HUB):$(TAG)

--- a/samples/jwt-server/src/main.go
+++ b/samples/jwt-server/src/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 )
 
 const (
@@ -53,6 +54,23 @@ type JWTServer struct {
 
 // ServeHTTP serves the JWT Keys.
 func (s *JWTServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	// Add artificious delay based on delay query
+	delayParam := request.URL.Query().Get("delay")
+	if delayParam != "" {
+		delayDuration, err := time.ParseDuration(delayParam)
+		if err != nil {
+			// Handle invalid delay parameter
+			response.WriteHeader(http.StatusBadRequest)
+			response.Write([]byte("Invalid delay parameter"))
+			return
+		}
+
+		// If delay parameter is provided and valid, add delay
+		if delayDuration > 0 {
+			time.Sleep(delayDuration)
+		}
+	}
+
 	response.WriteHeader(http.StatusOK)
 	response.Write([]byte(string(jwtKey)))
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This will add an option to delay responses of the jwt server.
Needed for integration tests for per-jwtrule timeout in #48203