### PR TITLE
lint: adopt gofumpt 0.6.0 rules

### DIFF
--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -182,7 +182,6 @@ func TestCheckMismatchedExistingKubeConfig(t *testing.T) {
 	os.WriteFile(filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename), []byte(expectedKC.Full), 0o644)
 
 	err = checkExistingKubeConfigFile(cfg, expectedKC)
-
 	if err != nil {
 		t.Fatalf("expected no error, matching kubeconfig present, got %+v", err)
 	}

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -177,7 +177,6 @@ func (t *ReverseTranslator) TranslateFromValueToSpec(values []byte, force bool) 
 
 	cpSpec := &v1alpha1.IstioOperatorSpec{}
 	err = util.UnmarshalWithJSONPB(string(outputVal), cpSpec, force)
-
 	if err != nil {
 		return nil, fmt.Errorf("error when unmarshalling into control plane spec %v, \nyaml:\n %s", err, outputVal)
 	}

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -340,7 +340,6 @@ func handleEvent(s *Server) {
 		fileBundle.SigningKeyFile,
 		fileBundle.CertChainFiles,
 		fileBundle.RootCertFile)
-
 	if err != nil {
 		log.Errorf("Failed to update new Plug-in CA certs: %v", err)
 		return

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -952,7 +952,6 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 			KeyFile:    tlsKeyPath,
 			CertFile:   tlsCertPath,
 		})
-
 		if err != nil {
 			// Not crashing istiod - This typically happens if certs are missing and in tests.
 			log.Errorf("error initializing certificate watches: %v", err)

--- a/security/pkg/nodeagent/caclient/providers/google-cas/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google-cas/client.go
@@ -45,7 +45,6 @@ func NewGoogleCASClient(capool string, options ...option.ClientOption) (security
 	var err error
 
 	caClient.caClient, err = privateca.NewCertificateAuthorityClient(ctx, options...)
-
 	if err != nil {
 		googleCASClientLog.Errorf("unable to initialize google cas caclient: %v", err)
 		return nil, err

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -236,7 +236,6 @@ spec:
 
 			// update this new status
 			_, err = t.Clusters().Default().Istio().NetworkingV1alpha3().WorkloadEntries(ns.Name()).UpdateStatus(context.TODO(), we, metav1.UpdateOptions{})
-
 			if err != nil {
 				t.Error(err)
 			}

--- a/tools/istio-iptables/pkg/validation/vld_unix.go
+++ b/tools/istio-iptables/pkg/validation/vld_unix.go
@@ -77,7 +77,6 @@ func GetOriginalDestination(conn net.Conn) (daddr net.IP, dport uint16, err erro
 		addr, err = unix.GetsockoptIPv6MTUInfo(
 			int(fd), unix.IPPROTO_IPV6,
 			constants.SoOriginalDst)
-
 		if err != nil {
 			log.Errorf("Error to ipv6 getsockopt: %v", err)
 			return


### PR DESCRIPTION
See
https://github.com/mvdan/gofumpt/commit/025a91f64d518cb7e1c399428a61685d513c4214
