### PR TITLE
cni: use iptables distroless variant

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -9,7 +9,11 @@ ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} as distroless
+# This image is a custom built debian11 distroless image with multiarchitecture support.
+# It is built on the base distroless image, with iptables binary and libraries added
+# The source can be found at https://github.com/istio/distroless/tree/iptables
+# This version is from commit 86c4972a9f5f245cfb382c8e1e95f176d968c882.
+FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:87e7a5b30a2844e16363cdd3b6ff06565079627a592c95f5c0fc9aaa56366452 as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
Now the daemonset applies iptables.

See
https://storage.googleapis.com/istio-prow/logs/integ-distroless_istio_postsubmit/1755298748407222272/artifacts/helm-32e3a0798b3b4348b9b6df52a1/TestAmbientInstall/_test_context/istio-system-state2556513034/primary-0/istio-cni-node-dqbl4_install-cni.previous.log
for failure
