### PR TITLE
pilot: do not skip creating istio-ca-root-cert in kube-system namespace

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -79,6 +79,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 		ObjectFilter:  c.GetFilter(),
 	})
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)
+	// kube-system is not skipped to enable deploying ztunnel in that namespace
 	c.ignoredNamespaces = inject.IgnoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
 
 	c.configmaps.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -23,11 +23,13 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/keycertbundle"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/namespace"
+	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/security/pkg/k8s"
 )
 
@@ -54,6 +56,8 @@ type NamespaceController struct {
 	namespaces kclient.Client[*v1.Namespace]
 	configmaps kclient.Client[*v1.ConfigMap]
 
+	ignoredNamespaces sets.Set[string]
+
 	// if meshConfig.DiscoverySelectors specified, DiscoveryNamespacesFilter tracks the namespaces to be watched by this controller.
 	DiscoveryNamespacesFilter namespace.DiscoveryNamespacesFilter
 }
@@ -75,10 +79,11 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 		ObjectFilter:  c.GetFilter(),
 	})
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)
+	c.ignoredNamespaces = inject.IgnoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
 
 	c.configmaps.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {
 		// skip special kubernetes system namespaces
-		return !inject.IgnoredNamespaces.Contains(o.GetNamespace())
+		return !c.ignoredNamespaces.Contains(o.GetNamespace())
 	}))
 
 	if c.DiscoveryNamespacesFilter != nil {
@@ -91,7 +96,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 				// We are only watching one namespace, and its not this one
 				return false
 			}
-			if inject.IgnoredNamespaces.Contains(o.GetName()) {
+			if c.ignoredNamespaces.Contains(o.GetName()) {
 				// skip special kubernetes system namespaces
 				return false
 			}
@@ -167,7 +172,7 @@ func (nc *NamespaceController) namespaceChange(ns *v1.Namespace) {
 
 func (nc *NamespaceController) syncNamespace(ns string) {
 	// skip special kubernetes system namespaces
-	if inject.IgnoredNamespaces.Contains(ns) {
+	if nc.ignoredNamespaces.Contains(ns) {
 		return
 	}
 	nc.queue.Add(types.NamespacedName{Name: ns})

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -76,7 +76,8 @@ func TestNamespaceController(t *testing.T) {
 	deleteConfigMap(t, client.Kube(), "foo")
 	expectConfigMap(t, nc.configmaps, CACertNamespaceConfigMap, "foo", newData)
 
-	for _, namespace := range inject.IgnoredNamespaces.UnsortedList() {
+	ignoredNamespaces := inject.IgnoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
+	for _, namespace := range ignoredNamespaces.UnsortedList() {
 		// Create namespace in ignored list, make sure its not created
 		createNamespace(t, client.Kube(), namespace, newData)
 		// Configmap in that namespace should not do anything either

--- a/releasenotes/notes/istio-ca-root-cert-kube-system.yaml
+++ b/releasenotes/notes/istio-ca-root-cert-kube-system.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue: []
+
+releaseNotes:
+  - |
+    **Updated** namespace controller to create `istio-ca-root-cert` in the `kube-system` namespace.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a simplified approach to #49129, which we discussed on WG ambient meeting. We agreed that istiod will try to create `istio-ca-root-cert` in the `kube-system` namespace. I did not add any special handling of an error that might be returned for kube-system, because I don't know how different distros restrict it. I guess it would be a permission error, but then it couldn't be distinguished from missing permissions on any other cluster.

I created another PR to not lose the context of the previous approach.