### PR TITLE
Use go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.21
+go 1.22
 
 // Client-go does not handle different versions of mergo due to some breaking changes - use the matching version
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5


### PR DESCRIPTION
**Please provide a description of this PR:**

Go 1.22 includes changes to the language (see https://tip.golang.org/doc/go1.22#language). It's possible that some unit tests may break or bugs appear. Let's start testing this early before 1.22.