### PR TITLE
Clean up old plugin tests

### DIFF
--- a/cni/pkg/plugin/kubernetes.go
+++ b/cni/pkg/plugin/kubernetes.go
@@ -28,12 +28,6 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
-// newKubeClient is a unit test override variable for interface create.
-var newKubeClient = newK8sClient
-
-// getKubePodInfo is a unit test override variable for interface create.
-var getKubePodInfo = getK8sPodInfo
-
 type PodInfo struct {
 	Containers        sets.String
 	Labels            map[string]string

--- a/cni/pkg/plugin/plugin_cni_conformance.go
+++ b/cni/pkg/plugin/plugin_cni_conformance.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// Validate k8sArgs struct works for unmarshalling kubelet args
+// This is important for CNI plugin conformance
+func TestLoadArgs(t *testing.T) {
+	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
+		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +
+		"K8S_POD_INFRA_CONTAINER_ID=3c41e946cf17a32760ff86940a73b06982f1815e9083cf2f4bfccb9b7605f326"
+
+	k8sArgs := K8sArgs{}
+	if err := types.LoadArgs(kubeletArgs, &k8sArgs); err != nil {
+		t.Fatalf("LoadArgs failed with error: %v", err)
+	}
+
+	if string(k8sArgs.K8S_POD_NAMESPACE) == "" || string(k8sArgs.K8S_POD_NAME) == "" {
+		t.Fatalf("LoadArgs didn't convert args properly, K8S_POD_NAME=\"%s\";K8S_POD_NAMESPACE=\"%s\"",
+			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE))
+	}
+}

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -26,29 +26,21 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/containernetworking/plugins/pkg/testutils"
-	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/cmd/pilot-agent/options"
 	diff "istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/tools/istio-iptables/pkg/cmd"
 	"istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
-
-type k8sPodInfoFunc func(kubernetes.Interface, string, string) (*PodInfo, error)
-
-func generateMockK8sPodInfoFunc(pi *PodInfo) k8sPodInfoFunc {
-	return func(_ kubernetes.Interface, _, _ string) (*PodInfo, error) {
-		return pi, nil
-	}
-}
 
 type mockNetNs struct {
 	path string
@@ -82,140 +74,135 @@ func generateMockGetNsFunc(netNs string) netNsFunc {
 	}
 }
 
+func buildDryrunConf() string {
+	return fmt.Sprintf(
+		mockConfTmpl,
+		"1.0.0",
+		"1.0.0",
+		"eth0",
+		testSandboxDirectory,
+		"",
+		false,
+		"iptables",
+	)
+}
+
 func TestIPTablesRuleGeneration(t *testing.T) {
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, "", false, "iptables")
-	args := testSetArgs(cniConf)
-	newKubeClient = mocknewK8sClient
+	cniConf := buildDryrunConf()
 
 	customUID := int64(1000670000)
 	customGID := int64(1000670001)
 	zero := int64(0)
 
 	tests := []struct {
-		name   string
-		input  *PodInfo
-		golden string
+		name        string
+		annotations map[string]string
+		proxyEnv    []corev1.EnvVar
+		customUID   *int64
+		customGID   *int64
+		golden      string
 	}{
 		{
-			name: "basic",
-			input: &PodInfo{
-				Containers:        sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations:       map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyEnvironments: map[string]string{},
-			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/basic.txt.golden"),
+			name:        "basic",
+			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
+			proxyEnv:    []corev1.EnvVar{},
+			golden:      filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/basic.txt.golden"),
 		},
 		{
 			name: "include-exclude-ip",
-			input: &PodInfo{
-				Containers: sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{
-					annotation.SidecarStatus.Name:                         "true",
-					annotation.SidecarTrafficIncludeOutboundIPRanges.Name: "127.0.0.0/8",
-					annotation.SidecarTrafficExcludeOutboundIPRanges.Name: "10.0.0.0/8",
-				},
-				ProxyEnvironments: map[string]string{},
+			annotations: map[string]string{
+				annotation.SidecarStatus.Name:                         "true",
+				annotation.SidecarTrafficIncludeOutboundIPRanges.Name: "127.0.0.0/8",
+				annotation.SidecarTrafficExcludeOutboundIPRanges.Name: "10.0.0.0/8",
 			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/include-exclude-ip.txt.golden"),
+			proxyEnv: []corev1.EnvVar{},
+			golden:   filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/include-exclude-ip.txt.golden"),
 		},
 		{
 			name: "include-exclude-ports",
-			input: &PodInfo{
-				Containers: sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{
-					annotation.SidecarStatus.Name:                      "true",
-					annotation.SidecarTrafficIncludeInboundPorts.Name:  "1111,2222",
-					annotation.SidecarTrafficExcludeInboundPorts.Name:  "3333,4444",
-					annotation.SidecarTrafficExcludeOutboundPorts.Name: "5555,6666",
-				},
-				ProxyEnvironments: map[string]string{},
+			annotations: map[string]string{
+				annotation.SidecarStatus.Name:                      "true",
+				annotation.SidecarTrafficIncludeInboundPorts.Name:  "1111,2222",
+				annotation.SidecarTrafficExcludeInboundPorts.Name:  "3333,4444",
+				annotation.SidecarTrafficExcludeOutboundPorts.Name: "5555,6666",
 			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/include-exclude-ports.txt.golden"),
+			proxyEnv: []corev1.EnvVar{},
+			golden:   filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/include-exclude-ports.txt.golden"),
 		},
 		{
 			name: "tproxy",
-			input: &PodInfo{
-				Containers: sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{
-					annotation.SidecarStatus.Name:           "true",
-					annotation.SidecarInterceptionMode.Name: redirectModeTPROXY,
-				},
-				ProxyEnvironments: map[string]string{},
+			annotations: map[string]string{
+				annotation.SidecarStatus.Name:           "true",
+				annotation.SidecarInterceptionMode.Name: redirectModeTPROXY,
 			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/tproxy.txt.golden"),
+			proxyEnv: []corev1.EnvVar{},
+			golden:   filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/tproxy.txt.golden"),
 		},
 		{
-			name: "DNS",
-			input: &PodInfo{
-				Containers:        sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations:       map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyEnvironments: map[string]string{options.DNSCaptureByAgent.Name: "true"},
-			},
+			name:        "DNS",
+			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
+			proxyEnv:    []corev1.EnvVar{{Name: options.DNSCaptureByAgent.Name, Value: "true"}},
+			// ProxyEnvironments: map[string]string{options.DNSCaptureByAgent.Name: "true"},
 			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/dns.txt.golden"),
 		},
 		{
-			name: "invalid-drop",
-			input: &PodInfo{
-				Containers:        sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations:       map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables: "true"},
-			},
+			name:        "invalid-drop",
+			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
+			proxyEnv:    []corev1.EnvVar{{Name: cmd.InvalidDropByIptables, Value: "true"}},
+			// ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables: "true"},
 			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/invalid-drop.txt.golden"),
 		},
 		{
-			name: "custom-uid",
-			input: &PodInfo{
-				Containers:  sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyUID:    &customUID,
-				ProxyGID:    &customGID,
-			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/custom-uid.txt.golden"),
+			name:        "custom-uid",
+			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
+			customUID:   &customUID,
+			customGID:   &customGID,
+			golden:      filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/custom-uid.txt.golden"),
 		},
 		{
-			name: "custom-uid-zero",
-			input: &PodInfo{
-				Containers:  sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
-				ProxyUID:    &zero,
-			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/basic.txt.golden"),
+			name:        "custom-uid-zero",
+			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
+			customUID:   &zero,
+			golden:      filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/basic.txt.golden"),
 		},
 		{
 			name: "custom-uid-tproxy",
-			input: &PodInfo{
-				Containers: sets.New("test", "istio-proxy", "istio-validate"),
-				Annotations: map[string]string{
-					annotation.SidecarStatus.Name:           "true",
-					annotation.SidecarInterceptionMode.Name: redirectModeTPROXY,
-				},
-				ProxyUID: &customUID,
-				ProxyGID: &customGID,
+			annotations: map[string]string{
+				annotation.SidecarStatus.Name:           "true",
+				annotation.SidecarInterceptionMode.Name: redirectModeTPROXY,
 			},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/custom-uid-tproxy.txt.golden"),
+			customUID: &customUID,
+			customGID: &customGID,
+			golden:    filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/custom-uid-tproxy.txt.golden"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// TODO(bianpengyuan): How do we test ipv6 rules?
-			getKubePodInfo = generateMockK8sPodInfoFunc(tt.input)
-			getNs = generateMockGetNsFunc(sandboxDirectory)
+			getNs = generateMockGetNsFunc(testSandboxDirectory)
 			tmpDir := t.TempDir()
 			outputFilePath := filepath.Join(tmpDir, "output.txt")
 			if _, err := os.Create(outputFilePath); err != nil {
 				t.Fatalf("Failed to create temp file for IPTables rule output: %v", err)
 			}
 			t.Setenv(dependencies.DryRunFilePath.Name, outputFilePath)
-			_, _, err := testutils.CmdAddWithArgs(
-				&skel.CmdArgs{
-					Netns:     sandboxDirectory,
-					IfName:    ifname,
-					StdinData: []byte(cniConf),
-				}, func() error { return CmdAdd(args) })
-			if err != nil {
-				t.Fatalf("CNI cmdAdd failed with error: %v", err)
+
+			pod := buildFakeDryRunPod()
+			pod.ObjectMeta.Annotations = tt.annotations
+			pod.Spec.Containers[1].Env = tt.proxyEnv
+
+			pod.Spec.Containers[1].SecurityContext = &corev1.SecurityContext{}
+
+			if tt.customGID != nil {
+				pod.Spec.Containers[1].SecurityContext.RunAsGroup = tt.customGID
 			}
+
+			if tt.customUID != nil {
+				pod.Spec.Containers[1].SecurityContext.RunAsUser = tt.customUID
+			}
+
+			testdoAddRunWithIptablesIntercept(t, cniConf, testPodName, testNSName, pod)
 
 			generated, err := os.ReadFile(outputFilePath)
 			if err != nil {
@@ -265,4 +252,43 @@ func refreshGoldens(t *testing.T, goldenFileName string, generatedRules map[stri
 		goldenFileContent += generatedRules[t] + "\n"
 	}
 	diff.RefreshGoldenFile(t, []byte(goldenFileContent), goldenFileName)
+}
+
+func testdoAddRunWithIptablesIntercept(t *testing.T, stdinData, testPodName, testNSName string, objects ...runtime.Object) {
+	args := buildCmdArgs(stdinData, testPodName, testNSName)
+
+	conf, err := parseConfig(args.StdinData)
+	if err != nil {
+		t.Fatalf("config parse failed with error: %v", err)
+	}
+
+	// Create a kube client
+	client := kube.NewFakeClient(objects...)
+
+	err = doAddRun(args, conf, client.Kube(), IptablesInterceptRuleMgr())
+	if err != nil {
+		t.Fatalf("failed with error: %v", err)
+	}
+}
+
+func buildFakeDryRunPod() *corev1.Pod {
+	app := corev1.Container{Name: "test"}
+	proxy := corev1.Container{Name: "istio-proxy"}
+	validate := corev1.Container{Name: "istio-validate"}
+	fakePod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core/v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testPodName,
+			Namespace:   testNSName,
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{app, proxy, validate},
+		},
+	}
+
+	return fakePod
 }

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -142,15 +142,13 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 			name:        "DNS",
 			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
 			proxyEnv:    []corev1.EnvVar{{Name: options.DNSCaptureByAgent.Name, Value: "true"}},
-			// ProxyEnvironments: map[string]string{options.DNSCaptureByAgent.Name: "true"},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/dns.txt.golden"),
+			golden:      filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/dns.txt.golden"),
 		},
 		{
 			name:        "invalid-drop",
 			annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
 			proxyEnv:    []corev1.EnvVar{{Name: cmd.InvalidDropByIptables, Value: "true"}},
-			// ProxyEnvironments: map[string]string{cmd.InvalidDropByIptables: "true"},
-			golden: filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/invalid-drop.txt.golden"),
+			golden:      filepath.Join(env.IstioSrc, "cni/pkg/plugin/testdata/invalid-drop.txt.golden"),
 		},
 		{
 			name:        "custom-uid",

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -18,51 +18,30 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	"github.com/containernetworking/cni/pkg/types"
-	cniv1 "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/containernetworking/plugins/pkg/testutils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/assert"
-	"istio.io/istio/pkg/util/sets"
 )
 
-var (
-	ifname           = "eth0"
-	sandboxDirectory = "/tmp"
-	currentVersion   = "1.0.0"
-	testPodName      = "testPodName"
-	testNSName       = "testNS"
-	k8Args           = fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", testNSName, testPodName)
-	invalidVersion   = "0.1.0"
-	preVersion       = "0.2.0"
-	ambientEnabled   = true
-
-	getKubePodInfoCalled = false
-	nsenterFuncCalled    = false
-	cniAddServerCalled   = false
-
-	testContainers                = sets.New("mockContainer", "foo-init")
-	testLabels                    = map[string]string{}
-	testAnnotations               = map[string]string{}
-	testProxyEnv                  = map[string]string{}
-	singletonMockInterceptRuleMgr = &mockInterceptRuleMgr{}
+const (
+	testPodName          = "testPod"
+	testNSName           = "testNS"
+	testSandboxDirectory = "/tmp"
+	invalidVersion       = "0.1.0"
+	preVersion           = "0.2.0"
 )
 
-var mockConf = `{
+var mockConfTmpl = `{
     "cniVersion": "%s",
 	"name": "istio-plugin-sample-test",
 	"type": "sample",
@@ -114,56 +93,60 @@ type mockInterceptRuleMgr struct {
 	lastRedirect []*Redirect
 }
 
-func init() {
-	testAnnotations[sidecarStatusKey] = "true"
+func buildMockConf(ambientEnabled bool, eventURL string) string {
+	return fmt.Sprintf(
+		mockConfTmpl,
+		"1.0.0",
+		"1.0.0",
+		"eth0",
+		testSandboxDirectory,
+		eventURL,
+		ambientEnabled,
+		"mock",
+	)
+}
+
+func buildFakePodAndNSForClient() (*corev1.Pod, *corev1.Namespace) {
+	proxy := corev1.Container{Name: "mockContainer"}
+	app := corev1.Container{Name: "foo-init"}
+	fakePod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core/v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testPodName,
+			Namespace:   testNSName,
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{app, proxy},
+		},
+	}
+
+	fakeNS := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core/v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNSName,
+			Namespace: "",
+			Labels:    map[string]string{},
+		},
+	}
+
+	return fakePod, fakeNS
 }
 
 func (mrdir *mockInterceptRuleMgr) Program(podName, netns string, redirect *Redirect) error {
-	nsenterFuncCalled = true
 	mrdir.lastRedirect = append(mrdir.lastRedirect, redirect)
 	return nil
 }
 
-func NewMockInterceptRuleMgr() InterceptRuleMgr {
-	return singletonMockInterceptRuleMgr
-}
-
-func mocknewK8sClient(conf Config) (kubernetes.Interface, error) {
-	var cs kubernetes.Clientset
-
-	getKubePodInfoCalled = true
-
-	return &cs, nil
-}
-
-func mockgetK8sPodInfo(client kubernetes.Interface, podName, podNamespace string) (*PodInfo, error) {
-	pi := PodInfo{}
-	pi.Containers = testContainers
-	pi.Labels = testLabels
-	pi.Annotations = testAnnotations
-	pi.ProxyEnvironments = testProxyEnv
-
-	return &pi, nil
-}
-
-// FIXME most of this is really unnecessarily stateful and prone to create weird test bugs
-func resetGlobalTestVariables() {
-	ambientEnabled = false
-	getKubePodInfoCalled = false
-	nsenterFuncCalled = false
-	cniAddServerCalled = false
-	testContainers = sets.New("mockContainer", "foo-init")
-	testLabels = map[string]string{}
-	testAnnotations = map[string]string{}
-	testProxyEnv = map[string]string{}
-
-	testAnnotations[sidecarStatusKey] = "true"
-	k8Args = fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", testNSName, testPodName)
-	newKubeClient = nil
-}
-
 // returns the test server URL and a dispose func for the test server
-func setupCNIEventClientWithMockServer(serverErr bool) (string, func()) {
+func setupCNIEventClientWithMockServer(serverErr bool) (string, func() bool) {
+	cniAddServerCalled := false
 	// replace the global CNI client with mock
 	newCNIClient = func(address, path string) CNIEventClient {
 		c := http.DefaultClient
@@ -186,427 +169,244 @@ func setupCNIEventClientWithMockServer(serverErr bool) (string, func()) {
 		res.Write([]byte("server happy"))
 	}))
 
-	return testServer.URL, func() { testServer.Close() }
+	return testServer.URL, func() bool {
+		testServer.Close()
+		return cniAddServerCalled
+	}
 }
 
-func testSetArgs(stdinData string) *skel.CmdArgs {
+func buildCmdArgs(stdinData, podName, podNamespace string) *skel.CmdArgs {
 	return &skel.CmdArgs{
 		ContainerID: "testContainerID",
-		Netns:       sandboxDirectory,
-		IfName:      ifname,
-		Args:        k8Args,
+		Netns:       testSandboxDirectory,
+		IfName:      "eth0",
+		Args:        fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", podNamespace, podName),
 		Path:        "/tmp",
 		StdinData:   []byte(stdinData),
 	}
 }
 
-func testCmdInvalidVersion(t *testing.T, f func(args *skel.CmdArgs) error) {
-	cniConf := fmt.Sprintf(mockConf, invalidVersion, preVersion, ifname, sandboxDirectory, "", ambientEnabled, "mock")
-	args := testSetArgs(cniConf)
+func testCmdAddExpectFail(t *testing.T, stdinData string, objects ...runtime.Object) *mockInterceptRuleMgr {
+	args := buildCmdArgs(stdinData, testPodName, testNSName)
 
-	err := f(args)
+	conf, err := parseConfig(args.StdinData)
 	if err != nil {
-		if !strings.Contains(err.Error(), "cannot convert: no valid IP addresses") {
-			t.Fatalf("expected substring error 'cannot convert: no valid IP addresses', got: %v", err)
-		}
-	} else {
-		t.Fatalf("expected failed CNI version, got: no error")
-	}
-}
-
-func testCmdAddExpectFail(t *testing.T, stdinData string, objects ...runtime.Object) {
-	newKubeClient = func(_ Config) (kubernetes.Interface, error) {
-		return fake.NewSimpleClientset(objects...), nil
+		t.Fatalf("config parse failed with error: %v", err)
 	}
 
-	args := testSetArgs(stdinData)
+	// Create a kube client
+	client := kube.NewFakeClient(objects...)
 
-	_, _, err := testutils.CmdAddWithArgs(
-		&skel.CmdArgs{
-			Netns:     sandboxDirectory,
-			IfName:    ifname,
-			StdinData: []byte(stdinData),
-		}, func() error { return CmdAdd(args) })
+	mockRedir := &mockInterceptRuleMgr{}
+	err = doAddRun(args, conf, client.Kube(), mockRedir)
 	if err == nil {
-		t.Fatalf("expected to fail, but did not!")
-	}
-}
-
-func testCmdAdd(t *testing.T) {
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, "", ambientEnabled, "mock")
-	testCmdAddWithStdinData(t, cniConf)
-}
-
-func testCmdAddWithStdinData(t *testing.T, stdinData string, objects ...runtime.Object) {
-	// FIXME some older sidecar tests don't use the regular mockable kube client and won't pass an array of
-	// the expected objects.
-	if len(objects) == 0 {
-		newKubeClient = mocknewK8sClient
-		getKubePodInfo = mockgetK8sPodInfo
-	} else {
-		newKubeClient = func(_ Config) (kubernetes.Interface, error) {
-			return fake.NewSimpleClientset(objects...), nil
-		}
+		t.Fatal("expected to fail, but did not!")
 	}
 
-	args := testSetArgs(stdinData)
+	return mockRedir
+}
 
-	result, _, err := testutils.CmdAddWithArgs(
-		&skel.CmdArgs{
-			Netns:     sandboxDirectory,
-			IfName:    ifname,
-			StdinData: []byte(stdinData),
-		}, func() error { return CmdAdd(args) })
+func testDoAddRun(t *testing.T, stdinData, nsName string, objects ...runtime.Object) *mockInterceptRuleMgr {
+	args := buildCmdArgs(stdinData, testPodName, nsName)
+
+	conf, err := parseConfig(args.StdinData)
+	if err != nil {
+		t.Fatalf("config parse failed with error: %v", err)
+	}
+
+	// Create a kube client
+	client := kube.NewFakeClient(objects...)
+
+	mockRedir := &mockInterceptRuleMgr{}
+	err = doAddRun(args, conf, client.Kube(), mockRedir)
 	if err != nil {
 		t.Fatalf("failed with error: %v", err)
 	}
 
-	if result.Version() != cniv1.ImplementedSpecVersion {
-		t.Fatalf("failed with invalid version, expected: %v got:%v",
-			cniv1.ImplementedSpecVersion, result.Version())
-	}
+	return mockRedir
 }
 
-// Validate k8sArgs struct works for unmarshalling kubelet args
-func TestLoadArgs(t *testing.T) {
-	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
-		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +
-		"K8S_POD_INFRA_CONTAINER_ID=3c41e946cf17a32760ff86940a73b06982f1815e9083cf2f4bfccb9b7605f326"
+// func TestEmitsCorrectVersionInResult() {
+// 	// Plugin must return result in same version as specified in netconf
+// 	versionDecoder := &version.ConfigDecoder{}
+// 	confVersion, err := versionDecoder.Decode(conf)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
 
-	k8sArgs := K8sArgs{}
-	if err := types.LoadArgs(kubeletArgs, &k8sArgs); err != nil {
-		t.Fatalf("LoadArgs failed with error: %v", err)
-	}
-
-	if string(k8sArgs.K8S_POD_NAMESPACE) == "" || string(k8sArgs.K8S_POD_NAME) == "" {
-		t.Fatalf("LoadArgs didn't convert args properly, K8S_POD_NAME=\"%s\";K8S_POD_NAMESPACE=\"%s\"",
-			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE))
-	}
-}
+// 	result, err := version.NewResult(confVersion, out)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+// }
 
 func TestCmdAddAmbientEnabledOnNS(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
 
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+	cniConf := buildMockConf(true, url)
 
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testPodName,
-			Namespace: testNSName,
-		},
-	}
+	pod, ns := buildFakePodAndNSForClient()
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient},
-		},
-	}
+	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
-
+	wasCalled := serverClose()
 	// Pod in namespace with enabled ambient label, should be added to mesh
-	assert.Equal(t, cniAddServerCalled, true)
+	assert.Equal(t, wasCalled, true)
 }
 
 func TestCmdAddAmbientEnabledOnNSServerFails(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(true)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
 
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testPodName,
-			Namespace: testNSName,
-		},
-	}
+	cniConf := buildMockConf(true, url)
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient},
-		},
-	}
+	pod, ns := buildFakePodAndNSForClient()
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient}
 
-	testCmdAddExpectFail(t, cniConf, fakePod, fakeNS)
+	testCmdAddExpectFail(t, cniConf, pod, ns)
 
+	wasCalled := serverClose()
 	// server called, but errored
-	assert.Equal(t, cniAddServerCalled, true)
+	assert.Equal(t, wasCalled, true)
 }
 
 func TestCmdAddPodWithProxySidecarAmbientEnabledNS(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+
+	cniConf := buildMockConf(true, url)
+
+	pod, ns := buildFakePodAndNSForClient()
 
 	proxy := corev1.Container{Name: "istio-proxy"}
 	app := corev1.Container{Name: "app"}
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testPodName,
-			Namespace:   testNSName,
-			Annotations: map[string]string{annotation.SidecarStatus.Name: "true"},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{app, proxy},
-		},
-	}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient},
-		},
-	}
+	pod.Spec.Containers = []corev1.Container{app, proxy}
+	pod.ObjectMeta.Annotations = map[string]string{annotation.SidecarStatus.Name: "true"}
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient}
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
+	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
+	wasCalled := serverClose()
 	// Pod has sidecar annotation from injector, should not be added to mesh
-	assert.Equal(t, cniAddServerCalled, false)
+	assert.Equal(t, wasCalled, false)
 }
 
 func TestCmdAddPodWithGenericSidecar(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+
+	cniConf := buildMockConf(true, url)
+
+	pod, ns := buildFakePodAndNSForClient()
 
 	proxy := corev1.Container{Name: "istio-proxy"}
 	app := corev1.Container{Name: "app"}
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testPodName,
-			Namespace: testNSName,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{app, proxy},
-		},
-	}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient},
-		},
-	}
+	pod.Spec.Containers = []corev1.Container{app, proxy}
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.DataplaneModeAmbient}
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
+	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
+	wasCalled := serverClose()
 	// Pod should be added to ambient mesh
-	assert.Equal(t, cniAddServerCalled, true)
+	assert.Equal(t, wasCalled, true)
 }
 
 func TestCmdAddPodDisabledAnnotation(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+
+	cniConf := buildMockConf(true, url)
+
+	pod, ns := buildFakePodAndNSForClient()
 
 	app := corev1.Container{Name: "app"}
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testPodName,
-			Namespace:   testNSName,
-			Annotations: map[string]string{constants.DataplaneMode: constants.AmbientRedirectionDisabled},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{app},
-		},
-	}
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled}
+	pod.ObjectMeta.Annotations = map[string]string{constants.DataplaneMode: constants.AmbientRedirectionDisabled}
+	pod.Spec.Containers = []corev1.Container{app}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled},
-		},
-	}
+	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
-
+	wasCalled := serverClose()
 	// Pod has an explicit opt-out annotation, should not be added to ambient mesh
-	assert.Equal(t, cniAddServerCalled, false)
+	assert.Equal(t, wasCalled, false)
 }
 
 func TestCmdAddPodEnabledNamespaceDisabled(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+
+	cniConf := buildMockConf(true, url)
+
+	pod, ns := buildFakePodAndNSForClient()
 
 	app := corev1.Container{Name: "app"}
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testPodName,
-			Namespace:   testNSName,
-			Annotations: map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{app},
-		},
-	}
+	pod.ObjectMeta.Annotations = map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled}
+	pod.Spec.Containers = []corev1.Container{app}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNSName,
-			Namespace: "",
-		},
-	}
+	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
-
+	wasCalled := serverClose()
 	// Currently, we do not allow individual pod opt-in to ambient if namespace is not labeled, so pod
 	// shouls not be added to ambient
-	assert.Equal(t, cniAddServerCalled, false)
+	assert.Equal(t, wasCalled, false)
 }
 
 func TestCmdAddPodInExcludedNamespace(t *testing.T) {
-	defer resetGlobalTestVariables()
-
 	url, serverClose := setupCNIEventClientWithMockServer(false)
-	defer serverClose()
-	ambientEnabled = true
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, url, ambientEnabled, "mock")
+
+	cniConf := buildMockConf(true, url)
+
+	excludedNS := "testExcludeNS"
+	pod, ns := buildFakePodAndNSForClient()
 
 	app := corev1.Container{Name: "app"}
-	fakePod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testPodName,
-			Namespace: "testExcludeNS",
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{app},
-		},
-	}
+	ns.ObjectMeta.Name = excludedNS
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled}
 
-	fakeNS := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "core/v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testExcludeNS",
-			Namespace: "",
-			Labels:    map[string]string{constants.DataplaneMode: constants.AmbientRedirectionEnabled},
-		},
-	}
+	pod.ObjectMeta.Namespace = excludedNS
+	pod.Spec.Containers = []corev1.Container{app}
 
-	testCmdAddWithStdinData(t, cniConf, fakePod, fakeNS)
+	testDoAddRun(t, cniConf, excludedNS, pod, ns)
 
+	wasCalled := serverClose()
 	// If the pod is being added to a namespace that is explicitly excluded by plugin config denylist
 	// it should never be added, even if the namespace has the annotation
-	assert.Equal(t, cniAddServerCalled, false)
+	assert.Equal(t, wasCalled, false)
 }
 
 func TestCmdAdd(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	testCmdAdd(t)
+	pod, ns := buildFakePodAndNSForClient()
+	testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 }
 
 func TestCmdAddTwoContainersWithAnnotation(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
 
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testAnnotations[injectAnnotationKey] = "false"
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[injectAnnotationKey] = "false"
 
-	testCmdAdd(t)
+	testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 }
 
 func TestCmdAddTwoContainersWithLabel(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[label.SidecarInject.Name] = "false"
 
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testAnnotations[label.SidecarInject.Name] = "false"
-
-	testCmdAdd(t)
+	testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 }
 
 func TestCmdAddTwoContainers(t *testing.T) {
-	defer resetGlobalTestVariables()
-	testAnnotations[injectAnnotationKey] = "true"
-	testContainers = sets.New("mockContainer", "istio-proxy")
+	pod, ns := buildFakePodAndNSForClient()
 
-	testCmdAdd(t)
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
 
-	if !nsenterFuncCalled {
+	mockIntercept := testDoAddRun(t, buildMockConf(false, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) == 0 {
 		t.Fatalf("expected nsenterFunc to be called")
-	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"]())
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.includeInboundPorts != "*" {
@@ -615,17 +415,17 @@ func TestCmdAddTwoContainers(t *testing.T) {
 }
 
 func TestCmdAddTwoContainersWithStarInboundPort(t *testing.T) {
-	defer resetGlobalTestVariables()
-	testAnnotations[includeInboundPortsKey] = "*"
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testCmdAdd(t)
+	pod, ns := buildFakePodAndNSForClient()
 
-	if !nsenterFuncCalled {
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.ObjectMeta.Annotations[includeInboundPortsKey] = "*"
+
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) != 1 {
 		t.Fatalf("expected nsenterFunc to be called")
-	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"]())
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.includeInboundPorts != "*" {
@@ -634,18 +434,17 @@ func TestCmdAddTwoContainersWithStarInboundPort(t *testing.T) {
 }
 
 func TestCmdAddTwoContainersWithEmptyInboundPort(t *testing.T) {
-	defer resetGlobalTestVariables()
-	delete(testAnnotations, includeInboundPortsKey)
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testAnnotations[includeInboundPortsKey] = ""
-	testCmdAdd(t)
+	pod, ns := buildFakePodAndNSForClient()
 
-	if !nsenterFuncCalled {
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.ObjectMeta.Annotations[includeInboundPortsKey] = ""
+
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) != 1 {
 		t.Fatalf("expected nsenterFunc to be called")
-	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.includeInboundPorts != "" {
@@ -654,18 +453,16 @@ func TestCmdAddTwoContainersWithEmptyInboundPort(t *testing.T) {
 }
 
 func TestCmdAddTwoContainersWithEmptyExcludeInboundPort(t *testing.T) {
-	defer resetGlobalTestVariables()
-	delete(testAnnotations, includeInboundPortsKey)
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testAnnotations[excludeInboundPortsKey] = ""
-	testCmdAdd(t)
+	pod, ns := buildFakePodAndNSForClient()
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.ObjectMeta.Annotations[excludeInboundPortsKey] = ""
 
-	if !nsenterFuncCalled {
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) != 1 {
 		t.Fatalf("expected nsenterFunc to be called")
-	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.excludeInboundPorts != "15020,15021,15090" {
@@ -674,18 +471,16 @@ func TestCmdAddTwoContainersWithEmptyExcludeInboundPort(t *testing.T) {
 }
 
 func TestCmdAddTwoContainersWithExplictExcludeInboundPort(t *testing.T) {
-	defer resetGlobalTestVariables()
-	delete(testAnnotations, includeInboundPortsKey)
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testAnnotations[excludeInboundPortsKey] = "3306"
-	testCmdAdd(t)
+	pod, ns := buildFakePodAndNSForClient()
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.ObjectMeta.Annotations[excludeInboundPortsKey] = "3306"
 
-	if !nsenterFuncCalled {
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) == 0 {
 		t.Fatalf("expected nsenterFunc to be called")
-	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"])
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if r.excludeInboundPorts != "3306,15020,15021,15090" {
@@ -694,122 +489,51 @@ func TestCmdAddTwoContainersWithExplictExcludeInboundPort(t *testing.T) {
 }
 
 func TestCmdAddTwoContainersWithoutSideCar(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
+	pod.Spec.Containers[0].Name = "mockContainer"
+	pod.Spec.Containers[1].Name = "istio-proxy"
 
-	delete(testAnnotations, sidecarStatusKey)
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testCmdAdd(t)
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 
-	if nsenterFuncCalled {
+	if len(mockIntercept.lastRedirect) != 0 {
 		t.Fatalf("Didnt Expect nsenterFunc to be called because this pod does not contain a sidecar")
 	}
 }
 
 func TestCmdAddExcludePod(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
 
-	k8Args = "K8S_POD_NAMESPACE=testExcludeNS;K8S_POD_NAME=testPodName"
-	getKubePodInfoCalled = false
-
-	testCmdAdd(t)
-
-	if getKubePodInfoCalled {
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), "testExcludeNS", pod, ns)
+	if len(mockIntercept.lastRedirect) != 0 {
 		t.Fatalf("failed to exclude pod")
 	}
 }
 
 func TestCmdAddExcludePodWithIstioInitContainer(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "istio-init"})
 
-	k8Args = "K8S_POD_NAMESPACE=testNS;K8S_POD_NAME=testPodName"
-	testContainers = sets.New("mockContainer", "foo-init", "istio-init")
-	testAnnotations[sidecarStatusKey] = "true"
-	getKubePodInfoCalled = true
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 
-	testCmdAdd(t)
-
-	if nsenterFuncCalled {
-		t.Fatalf("expected nsenterFunc to not get called")
+	if len(mockIntercept.lastRedirect) != 0 {
+		t.Fatalf("failed to exclude pod")
 	}
 }
 
 func TestCmdAddExcludePodWithEnvoyDisableEnv(t *testing.T) {
-	defer resetGlobalTestVariables()
+	pod, ns := buildFakePodAndNSForClient()
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name: "istio-init",
+		Env:  []corev1.EnvVar{{Name: "DISABLE_ENVOY", Value: "true"}},
+	})
 
-	k8Args = "K8S_POD_NAMESPACE=testNS;K8S_POD_NAME=testPodName"
-	testContainers = sets.New("mockContainer", "istio-proxy", "foo-init")
-	testAnnotations[sidecarStatusKey] = "true"
-	testProxyEnv["DISABLE_ENVOY"] = "true"
-	getKubePodInfoCalled = true
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
 
-	testCmdAdd(t)
-
-	if nsenterFuncCalled {
-		t.Fatalf("expected nsenterFunc to not get called")
+	if len(mockIntercept.lastRedirect) != 0 {
+		t.Fatalf("failed to exclude pod")
 	}
-}
-
-func TestCmdAddWithKubevirtInterfaces(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	testAnnotations[kubevirtInterfacesKey] = "net1,net2"
-	testContainers = sets.New("mockContainer")
-
-	testCmdAdd(t)
-
-	value, ok := testAnnotations[kubevirtInterfacesKey]
-	if !ok {
-		t.Fatalf("expected kubevirtInterfaces annotation to exist")
-	}
-
-	if value != testAnnotations[kubevirtInterfacesKey] {
-		t.Fatalf("expected kubevirtInterfaces annotation to equals %s", testAnnotations[kubevirtInterfacesKey])
-	}
-}
-
-func TestCmdAddWithExcludeInterfaces(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	testAnnotations[excludeInterfacesKey] = "net2"
-	testContainers = sets.New("mockContainer")
-
-	testCmdAdd(t)
-
-	value, ok := testAnnotations[excludeInterfacesKey]
-	if !ok {
-		t.Fatalf("expected excludeInterfaces annotation to exist")
-	}
-
-	if value != testAnnotations[excludeInterfacesKey] {
-		t.Fatalf("expected excludeInterfaces annotation to equals %s", testAnnotations[excludeInterfacesKey])
-	}
-}
-
-func TestCmdAddInvalidK8sArgsKeyword(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	k8Args = "K8S_POD_NAMESPACE_InvalidKeyword=istio-system"
-
-	cniConf := fmt.Sprintf(mockConf, currentVersion, currentVersion, ifname, sandboxDirectory, "", ambientEnabled, "mock")
-	args := testSetArgs(cniConf)
-
-	err := CmdAdd(args)
-	if err != nil {
-		if !strings.Contains(err.Error(), "unknown args [\"K8S_POD_NAMESPACE_InvalidKeyword") {
-			t.Fatalf(`expected substring "unknown args ["K8S_POD_NAMESPACE_InvalidKeyword, got: %v`, err)
-		}
-	} else {
-		t.Fatalf("expected a failed response for an invalid K8sArgs setting, got: no error")
-	}
-}
-
-func TestCmdAddInvalidVersion(t *testing.T) {
-	defer resetGlobalTestVariables()
-
-	newKubeClient = func(_ Config) (kubernetes.Interface, error) {
-		return fake.NewSimpleClientset(), nil
-	}
-	testCmdInvalidVersion(t, CmdAdd)
 }
 
 func TestCmdAddNoPrevResult(t *testing.T) {
@@ -830,38 +554,29 @@ func TestCmdAddNoPrevResult(t *testing.T) {
     }
     }`
 
-	defer resetGlobalTestVariables()
-	testCmdAddWithStdinData(t, confNoPrevResult)
+	pod, ns := buildFakePodAndNSForClient()
+	testDoAddRun(t, confNoPrevResult, testNSName, pod, ns)
 }
 
 func TestCmdAddEnableDualStack(t *testing.T) {
-	defer resetGlobalTestVariables()
-	testProxyEnv["ISTIO_DUAL_STACK"] = "true"
-	testContainers = sets.New("mockContainer", "istio-proxy")
-	testCmdAdd(t)
-
-	if !nsenterFuncCalled {
-		t.Fatalf("expected nsenterFunc to be called")
+	pod, ns := buildFakePodAndNSForClient()
+	pod.ObjectMeta.Annotations[sidecarStatusKey] = "true"
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name: "istio-proxy",
+			Env:  []corev1.EnvVar{{Name: "ISTIO_DUAL_STACK", Value: "true"}},
+		}, {Name: "mockContainer"},
 	}
-	mockIntercept, ok := GetInterceptRuleMgrCtor("mock")().(*mockInterceptRuleMgr)
-	if !ok {
-		t.Fatalf("expect using mockInterceptRuleMgr, actual %v", InterceptRuleMgrTypes["mock"]())
+
+	mockIntercept := testDoAddRun(t, buildMockConf(true, ""), testNSName, pod, ns)
+
+	if len(mockIntercept.lastRedirect) == 0 {
+		t.Fatalf("expected nsenterFunc to be called")
 	}
 	r := mockIntercept.lastRedirect[len(mockIntercept.lastRedirect)-1]
 	if !r.dualStack {
 		t.Fatalf("expect dualStack is true, actual %v", r.dualStack)
 	}
-}
-
-func MockInterceptRuleMgrCtor() InterceptRuleMgr {
-	return NewMockInterceptRuleMgr()
-}
-
-func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-	InterceptRuleMgrTypes["mock"] = MockInterceptRuleMgrCtor
-
-	os.Exit(m.Run())
 }
 
 func Test_dedupPorts(t *testing.T) {

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -226,20 +226,6 @@ func testDoAddRun(t *testing.T, stdinData, nsName string, objects ...runtime.Obj
 	return mockRedir
 }
 
-// func TestEmitsCorrectVersionInResult() {
-// 	// Plugin must return result in same version as specified in netconf
-// 	versionDecoder := &version.ConfigDecoder{}
-// 	confVersion, err := versionDecoder.Decode(conf)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-
-// 	result, err := version.NewResult(confVersion, out)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-// }
-
 func TestCmdAddAmbientEnabledOnNS(t *testing.T) {
 	url, serverClose := setupCNIEventClientWithMockServer(false)
 

--- a/cni/pkg/plugin/sidecar_intercept_rule_mgr.go
+++ b/cni/pkg/plugin/sidecar_intercept_rule_mgr.go
@@ -14,28 +14,13 @@
 
 package plugin
 
-const (
-	defInterceptRuleMgrType = "iptables"
-)
-
 // InterceptRuleMgr configures networking tables (e.g. iptables or nftables) for
 // redirecting traffic to an Istio proxy.
 type InterceptRuleMgr interface {
 	Program(podName, netns string, redirect *Redirect) error
 }
 
-type InterceptRuleMgrCtor func() InterceptRuleMgr
-
-var InterceptRuleMgrTypes = map[string]InterceptRuleMgrCtor{
-	"iptables": IptablesInterceptRuleMgrCtor,
-}
-
-// Constructor factory for known types of InterceptRuleMgr's
-func GetInterceptRuleMgrCtor(interceptType string) InterceptRuleMgrCtor {
-	return InterceptRuleMgrTypes[interceptType]
-}
-
 // Constructor for iptables InterceptRuleMgr
-func IptablesInterceptRuleMgrCtor() InterceptRuleMgr {
+func IptablesInterceptRuleMgr() InterceptRuleMgr {
 	return newIPTables()
 }

--- a/cni/pkg/repair/repaircontroller.go
+++ b/cni/pkg/repair/repaircontroller.go
@@ -150,7 +150,7 @@ func redirectRunningPod(pod *corev1.Pod, netns string) error {
 	if err != nil {
 		return fmt.Errorf("setup redirect: %v", err)
 	}
-	rulesMgr := plugin.IptablesInterceptRuleMgrCtor()
+	rulesMgr := plugin.IptablesInterceptRuleMgr()
 	if err := rulesMgr.Program(pod.Name, netns, redirect); err != nil {
 		return fmt.Errorf("program redirection: %v", err)
 	}


### PR DESCRIPTION
Some of the CNI plugin tests that predate ambient make heavy use of global state (which naturally creates ordering and concurrency bugs) and generally do confusing/intrusive DIY mocking.

As part of inpod ambient I had added more tests to this suite, and added some FIXME nags to the existing machinery that clearly needed some TLC, but https://github.com/istio/istio/issues/49278 reminded me that I had punted on actually fully reworking this suite and the existing plugin code so it's less problematic/tests don't have loads of global state/don't do confusing mocking/don't have mysterious ordering or concurrency bugs.