### PR TITLE
Fix empty ECDS with Delta XDS

### DIFF
--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -288,13 +288,9 @@ func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.
 		return
 	}
 
-	respResources := make([]*discovery.Resource, 0, len(resources))
 	for i := range resources {
-		respResources = append(respResources, &discovery.Resource{
-			Resource: resources[i],
-		})
+		resp.Resources[i].Resource = resources[i]
 	}
-	resp.Resources = respResources
 
 	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
 	forward(resp)

--- a/pkg/istio-agent/xds_proxy_delta_test.go
+++ b/pkg/istio-agent/xds_proxy_delta_test.go
@@ -15,6 +15,16 @@
 package istioagent
 
 import (
+	"errors"
+	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	wasmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+	"google.golang.org/protobuf/proto"
+	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -109,4 +119,110 @@ func sendDeltaDownstreamWithNode(t *testing.T, downstream discovery.AggregatedDi
 	if res == nil || res.TypeUrl != v3.ListenerType {
 		t.Fatalf("Expected to get listener response but got %v", res)
 	}
+}
+
+func TestDeltaECDSWasmConversion(t *testing.T) {
+	node := model.NodeMetadata{
+		Namespace:   "default",
+		InstanceIPs: []string{"1.1.1.1"},
+		ClusterID:   "Kubernetes",
+	}
+	proxy := setupXdsProxy(t)
+	// Reset wasm cache to a fake ACK cache.
+	proxy.wasmCache.Cleanup()
+	proxy.wasmCache = &fakeAckCache{}
+
+	// Initialize discovery server with an ECDS resource.
+	ef, err := os.ReadFile(path.Join(env.IstioSrc, "pilot/pkg/xds/testdata/ecds.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: string(ef),
+	})
+	setDialOptions(proxy, f.BufListener)
+	conn := setupDownstreamConnection(t, proxy)
+	downstream := deltaStream(t, conn)
+
+	// Send first request, wasm module async fetch should work fine and
+	// downstream should receive a local file based wasm extension config.
+	err = downstream.Send(&discovery.DeltaDiscoveryRequest{
+		TypeUrl:                v3.ExtensionConfigurationType,
+		ResourceNamesSubscribe: []string{"extension-config"},
+		Node: &core.Node{
+			Id:       "sidecar~1.1.1.1~debug~cluster.local",
+			Metadata: node.ToStruct(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the request received has been rewritten to local file.
+	gotResp, err := downstream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotResp.Resources) != 1 {
+		t.Errorf("xds proxy ecds wasm conversion number of received resource got %v want 1", len(gotResp.Resources))
+	}
+	gotEcdsConfig := &core.TypedExtensionConfig{}
+	if err := gotResp.Resources[0].Resource.UnmarshalTo(gotEcdsConfig); err != nil {
+		t.Fatalf("wasm config conversion output %v failed to unmarshal", gotResp.Resources[0])
+	}
+	assert.Equal(t, gotResp.Resources[0].Name, "extension-config")
+	wasm := &wasm.Wasm{
+		Config: &wasmv3.PluginConfig{
+			Vm: &wasmv3.PluginConfig_VmConfig{
+				VmConfig: &wasmv3.VmConfig{
+					Code: &core.AsyncDataSource{Specifier: &core.AsyncDataSource_Local{
+						Local: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "test",
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	wantEcdsConfig := &core.TypedExtensionConfig{
+		Name:        "extension-config",
+		TypedConfig: protoconv.MessageToAny(wasm),
+	}
+
+	if !proto.Equal(gotEcdsConfig, wantEcdsConfig) {
+		t.Errorf("xds proxy wasm config conversion got %v want %v", gotEcdsConfig, wantEcdsConfig)
+	}
+	n1 := proxy.ecdsLastNonce
+
+	// reset wasm cache to a NACK cache, and recreate xds server as well to simulate a version bump
+	proxy.wasmCache = &fakeNackCache{}
+	f = xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: string(ef),
+	})
+	setDialOptions(proxy, f.BufListener)
+	conn = setupDownstreamConnection(t, proxy)
+	downstream = deltaStream(t, conn)
+
+	// send request again, this time a nack should be returned from the xds proxy due to NACK wasm cache.
+	err = downstream.Send(&discovery.DeltaDiscoveryRequest{
+		TypeUrl:                v3.ExtensionConfigurationType,
+		ResourceNamesSubscribe: []string{"extension-config"},
+		Node: &core.Node{
+			Id:       "sidecar~1.1.1.1~debug~cluster.local",
+			Metadata: node.ToStruct(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until nonce was updated, which represents an ACK/NACK has been received.
+	retry.UntilSuccessOrFail(t, func() error {
+		if proxy.ecdsLastNonce.Load() == n1.Load() {
+			return errors.New("last process nonce has not been updated. no ecds ack/nack is received yet")
+		}
+		return nil
+	}, retry.Timeout(time.Second), retry.Delay(time.Millisecond))
 }

--- a/pkg/istio-agent/xds_proxy_delta_test.go
+++ b/pkg/istio-agent/xds_proxy_delta_test.go
@@ -16,26 +16,26 @@ package istioagent
 
 import (
 	"errors"
-	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
-	wasmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
-	"google.golang.org/protobuf/proto"
-	"istio.io/istio/pilot/pkg/util/protoconv"
-	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/test/util/assert"
-	"istio.io/istio/pkg/test/util/retry"
 	"os"
 	"path"
 	"testing"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	wasmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/protoconv"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 // TestXdsLeak is a regression test for https://github.com/istio/istio/issues/34097


### PR DESCRIPTION
This was caused by only sending the `Resource`, and ignoring the other
fields (Name, version, etc).

Fixes https://github.com/istio/istio/issues/47227
