### PR TITLE
agent: treat GOAWAY as expected

### DIFF
--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -146,6 +146,9 @@ func IsExpectedGRPCError(err error) bool {
 	if strings.Contains(err.Error(), "stream terminated by RST_STREAM with error code: NO_ERROR") {
 		return true
 	}
+	if strings.Contains(err.Error(), "received prior goaway: code: NO_ERROR") {
+		return true
+	}
 
 	return false
 }


### PR DESCRIPTION
We have code to treat RST_STREAM as expected, but not if there is a
prior GOAWAY. See
https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/49260/integ-security_istio/1755799139888664576/artifacts/security-sds-ingress-dae3bc96b8/TestSingleTlsGateway_SecretRotation/to_a/new_cert_should_succeed/_test_context/istio-state1328832520/primary-0/istio-ingressgateway-6d88cf45d6-zvf6l_istio-proxy.log
for when this happens in Istio
