### PR TITLE
Fix lint errors updating linter to 1.56

### DIFF
--- a/pilot/pkg/config/monitor/file_snapshot.go
+++ b/pilot/pkg/config/monitor/file_snapshot.go
@@ -126,5 +126,5 @@ func (rs byKey) Swap(i, j int) {
 }
 
 func (rs byKey) Less(i, j int) bool {
-	return compareIds(rs[i], rs[j]) < 0
+	return compareIDs(rs[i], rs[j]) < 0
 }

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -179,7 +179,7 @@ func (m *Monitor) checkAndUpdate() {
 	for oldIndex < oldLen && newIndex < newLen {
 		oldConfig := m.configs[oldIndex]
 		newConfig := newConfigs[newIndex]
-		if v := compareIds(oldConfig, newConfig); v < 0 {
+		if v := compareIDs(oldConfig, newConfig); v < 0 {
 			m.deleteConfig(oldConfig)
 			oldIndex++
 		} else if v > 0 {
@@ -234,8 +234,8 @@ func (m *Monitor) deleteConfig(c *config.Config) {
 	}
 }
 
-// compareIds compares the IDs (i.e. Namespace, GroupVersionKind, and Name) of the two configs and returns
+// compareIDs compares the IDs (i.e. Namespace, GroupVersionKind, and Name) of the two configs and returns
 // 0 if a == b, -1 if a < b, and 1 if a > b. Used for sorting config arrays.
-func compareIds(a, b *config.Config) int {
+func compareIDs(a, b *config.Config) int {
 	return strings.Compare(a.Key(), b.Key())
 }

--- a/security/pkg/pki/util/san_test.go
+++ b/security/pkg/pki/util/san_test.go
@@ -77,13 +77,13 @@ func TestBuildAndExtractIdentities(t *testing.T) {
 		t.Errorf("A unexpected error has been encountered (error: %v)", err)
 	}
 
-	actualIds, err := ExtractIDsFromSAN(san)
+	actualIDs, err := ExtractIDsFromSAN(san)
 	if err != nil {
 		t.Errorf("A unexpected error has been encountered (error: %v)", err)
 	}
 
-	if !reflect.DeepEqual(actualIds, ids) {
-		t.Errorf("Unmatched identities: before encoding: %v, after decoding %v", ids, actualIds)
+	if !reflect.DeepEqual(actualIDs, ids) {
+		t.Errorf("Unmatched identities: before encoding: %v, after decoding %v", ids, actualIDs)
 	}
 
 	if !san.Critical {


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix lint errors updating golangci-lint-version to 1.56 in https://github.com/istio/common-files/pull/987.