### PR TITLE
samples: extauthz: do not return request body as a header when it exceeds 60KB

### DIFF
--- a/samples/extauthz/cmd/extauthz/main.go
+++ b/samples/extauthz/cmd/extauthz/main.go
@@ -360,7 +360,7 @@ func main() {
 }
 
 func returnIfNotTooLong(body string) string {
-	// Maximum size of a header accepted by Envoy is 60MiB, so when the request body is bigger than 60MB,
+	// Maximum size of a header accepted by Envoy is 60KiB, so when the request body is bigger than 60KB,
 	// we don't return it in a response header to avoid rejecting it by Envoy and returning 431 to the client
 	if len(body) > 60000 {
 		return "<too-long>"


### PR DESCRIPTION
**Please provide a description of this PR:**

When I was testing external authorization for big inputs, e.g. a few MB files, I noticed that requests were failing with status 403 for HTTP (due to RST flag) and 431 for gRPC. This is because extauthz returns received request body in a header, which can't be bigger than 60KiB. Otherwise, Envoy will reject it and return 431 to the client.