### PR TITLE
Make sure unknown vhosts fall through and get added eventually (if on port 80)

### DIFF
--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -39,6 +39,7 @@ import (
 	legacykube "istio.io/istio/pkg/config/analysis/legacy/source/kube"
 	"istio.io/istio/pkg/config/analysis/local"
 	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kubetypes"
@@ -142,6 +143,7 @@ func checkFromVersion(ctx cli.Context, revision, version string) (diag.Messages,
 	}
 
 	var messages diag.Messages = make([]diag.Message, 0)
+
 	if minor <= 20 {
 		// VERIFY_CERTIFICATE_AT_CLIENT and ENABLE_AUTO_SNI
 		if err := checkDestinationRuleTLS(cli, &messages); err != nil {
@@ -152,10 +154,9 @@ func checkFromVersion(ctx cli.Context, revision, version string) (diag.Messages,
 			return nil, err
 		}
 		// PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING
-		// TODO
-		messages.Add(msg.NewUnknownUpgradeCompatibility(nil,
-			"PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING", "1.20",
-			"consult upgrade notes for more information", "1.20"))
+		if err := checkVirtualServiceHostMatching(cli, &messages); err != nil {
+			return nil, err
+		}
 	}
 	return messages, nil
 }
@@ -218,6 +219,27 @@ func checkDestinationRuleTLS(cli kube.CLIClient, messages *diag.Messages) error 
 			messages.Add(msg.NewUpdateIncompatibility(res,
 				"ENABLE_AUTO_SNI", "1.20",
 				"previously, no SNI would be set; now it will be automatically set", "1.20"))
+		}
+	}
+	return nil
+}
+
+func checkVirtualServiceHostMatching(cli kube.CLIClient, messages *diag.Messages) error {
+	virtualServices, err := cli.Istio().NetworkingV1alpha3().VirtualServices(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, vs := range virtualServices.Items {
+		for _, hostname := range vs.Spec.Hosts {
+			if host.Name(hostname).IsWildCarded() {
+				res := ObjectToInstance(vs)
+				messages.Add(msg.NewUnknownUpgradeCompatibility(res,
+					"PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING", "1.20",
+					"previously, VirtualServices with overlapping wildcard hosts would have the oldest "+
+						"VirtualService take precedence. Now, the most specific VirtualService will win", "1.20"),
+				)
+				continue
+			}
 		}
 	}
 	return nil

--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -233,7 +233,7 @@ func checkVirtualServiceHostMatching(cli kube.CLIClient, messages *diag.Messages
 		for _, hostname := range vs.Spec.Hosts {
 			if host.Name(hostname).IsWildCarded() {
 				res := ObjectToInstance(vs)
-				messages.Add(msg.NewUnknownUpgradeCompatibility(res,
+				messages.Add(msg.NewUpdateIncompatibility(res,
 					"PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING", "1.20",
 					"previously, VirtualServices with overlapping wildcard hosts would have the oldest "+
 						"VirtualService take precedence. Now, the most specific VirtualService will win", "1.20"),

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -1218,7 +1218,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtualservices and services with overlapping wildcard hosts", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
-			Configs:  []config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost},
+			Configs: []config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			},
 			Services: []*model.Service{exampleWildcardService, exampleNestedWildcardService},
 		})
 
@@ -1234,13 +1238,60 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 
 		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
-			[]config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost}, 8080,
+			[]config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			}, 8080,
 			wildcardIndex,
 		)
 		log.Printf("%#v", vhosts)
+		// *.example.org, *.hello.example.org. The *.google.com VS is missing from virtualHosts because
+		// it is not attached to a service
 		g.Expect(vhosts).To(HaveLen(2))
 		for _, vhost := range vhosts {
 			g.Expect(vhost.Services).To(HaveLen(1))
+			g.Expect(vhost.Routes).To(HaveLen(1))
+		}
+	})
+
+	t.Run("for virtualservices with with wildcard hosts outside of the serviceregistry (on port 80)", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+			Configs: []config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			},
+			Services: []*model.Service{exampleWildcardService, exampleNestedWildcardService},
+		})
+
+		// Redefine the service registry for this test
+		serviceRegistry := map[host.Name]*model.Service{
+			"*.example.org":             exampleWildcardService,
+			"goodbye.hello.example.org": exampleNestedWildcardService,
+		}
+
+		// note that the VS containing *.google.com doesn't have an entry in the wildcard index
+		wildcardIndex := map[host.Name]types.NamespacedName{
+			"*.example.org":       virtualServiceWithWildcardHost.NamespacedName(),
+			"*.hello.example.org": virtualServiceWithNestedWildcardHost.NamespacedName(),
+		}
+
+		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
+			[]config.Config{virtualServiceWithGoogleWildcardHost}, 80, wildcardIndex,
+		)
+		// The service hosts (*.example.org and goodbye.hello.example.org) and the unattached VS host (*.google.com)
+		g.Expect(vhosts).To(HaveLen(3))
+		for _, vhost := range vhosts {
+			if len(vhost.VirtualServiceHosts) > 0 && vhost.VirtualServiceHosts[0] == "*.google.com" {
+				// The *.google.com VS shouldn't have any services
+				g.Expect(vhost.Services).To(HaveLen(0))
+			} else {
+				// The other two VSs should have one service each
+				g.Expect(vhost.Services).To(HaveLen(1))
+			}
+			// All VSs should have one route
 			g.Expect(vhost.Routes).To(HaveLen(1))
 		}
 	})
@@ -1549,6 +1600,36 @@ var virtualServiceWithNestedWildcardHost = config.Config{
 							Port: &networking.PortSelector{
 								Number: 8080,
 							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithGoogleWildcardHost = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "google-wildcard",
+	},
+	Spec: &networking.VirtualService{
+		Hosts: []string{"*.google.com"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+					},
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "internal-google.default.svc.cluster.local",
 						},
 					},
 				},

--- a/releasenotes/notes/49364.yaml
+++ b/releasenotes/notes/49364.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 49364
+releaseNotes:
+- |
+  **Fixed** an bug where VirtualServices containing wildcard hosts that aren't present in the service registry are ignored


### PR DESCRIPTION
**Please provide a description of this PR:**
VirtualServices have special behavior when configuring outbound routes on port 80. Therefore, we need to make sure that wildcard hosts _not_ matching any service in the service registry get added to the generated set of routes