### PR TITLE
Fix webhook conflict that occurs when reinstalling after the default installation has failed

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -291,7 +291,7 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 			force: true,
 			assertFunc: func(g *WithT, objs *ObjectSet, err error) {
 				g.Expect(err).Should(BeNil())
-				g.Expect(objs.kind(name.MutatingWebhookConfigurationStr).size()).Should(Equal(2))
+				g.Expect(objs.kind(name.MutatingWebhookConfigurationStr).size()).Should(Equal(3))
 			},
 		},
 		{
@@ -333,8 +333,16 @@ func TestManifestGenerateWithDuplicateMutatingWebhookConfig(t *testing.T) {
 }
 
 func TestManifestGenerateDefaultWithRevisionedWebhook(t *testing.T) {
+	runRevisionedWebhookTest(t, "minimal-revisioned", "default_tag")
+}
+
+func TestManifestGenerateFailedDefaultInstallation(t *testing.T) {
+	runRevisionedWebhookTest(t, "minimal", "default_installation_failed")
+}
+
+func runRevisionedWebhookTest(t *testing.T, testResourceFile, whSource string) {
+	t.Helper()
 	recreateSimpleTestEnv()
-	testResourceFile := "minimal-revisioned"
 	tmpDir := t.TempDir()
 	tmpCharts := chartSourceType(filepath.Join(tmpDir, operatorSubdirFilePath))
 	err := copyDir(string(liveCharts), string(tmpCharts))
@@ -343,7 +351,6 @@ func TestManifestGenerateDefaultWithRevisionedWebhook(t *testing.T) {
 	}
 
 	// Add a default tag which is the webhook that will be processed post-install
-	whSource := "default_tag"
 	rs, err := readFile(filepath.Join(testDataDir, "input-extra-resources", whSource+".yaml"))
 	if err != nil {
 		t.Fatal(err)

--- a/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/default_installation_failed.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input-extra-resources/default_installation_failed.yaml
@@ -1,11 +1,11 @@
+# Simulate the case where the default installation failed, and the user has to reinstall the components.
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: sidecar-injector
-    istio.io/tag: default
   name: w-istio-sidecar-injector-istio-system
-  
+
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -47,7 +47,6 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 10
 ---
-# same webhook but with different name, will result in a duplicate
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -519,7 +519,8 @@ func (h *HelmReconciler) analyzeWebhooks(whs []string) error {
 	}
 
 	sa := local.NewSourceAnalyzer(analysis.Combine("webhook", &webhook.Analyzer{
-		SkipServiceCheck: true,
+		SkipServiceCheck:             true,
+		SkipDefaultRevisionedWebhook: DetectIfTagWebhookIsNeeded(h.iop, exists),
 	}), resource.Namespace(h.iop.Spec.GetNamespace()), resource.Namespace(istioV1Alpha1.Namespace(h.iop.Spec)), nil)
 
 	// Add in-cluster webhooks

--- a/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -32,7 +32,8 @@ import (
 )
 
 type Analyzer struct {
-	SkipServiceCheck bool
+	SkipServiceCheck             bool
+	SkipDefaultRevisionedWebhook bool
 }
 
 var _ analysis.Analyzer = &Analyzer{}
@@ -73,6 +74,11 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 	resources := map[string]*resource.Instance{}
 	revisions := sets.New[string]()
 	context.ForEach(gvk.MutatingWebhookConfiguration, func(resource *resource.Instance) bool {
+		if a.SkipDefaultRevisionedWebhook {
+			if isDefaultRevisionedWebhook(resource.Message.(*v1.MutatingWebhookConfiguration)) {
+				return true
+			}
+		}
 		wh := resource.Message.(*v1.MutatingWebhookConfiguration)
 		revs := extractRevisions(wh)
 		if len(revs) == 0 && !isIstioWebhook(wh) {
@@ -183,6 +189,14 @@ func extractRevisions(wh *v1.MutatingWebhookConfiguration) []string {
 		}
 	}
 	return revs.UnsortedList()
+}
+
+func isDefaultRevisionedWebhook(wh *v1.MutatingWebhookConfiguration) bool {
+	_, ok := wh.GetLabels()["istio.io/tag"]
+	if !ok && wh.GetLabels()[label.IoIstioRev.Name] == "default" {
+		return true
+	}
+	return false
 }
 
 func selectorMatches(selector *metav1.LabelSelector, labels klabels.Set) bool {

--- a/pkg/config/analysis/analyzers/webhook/webhook.go
+++ b/pkg/config/analysis/analyzers/webhook/webhook.go
@@ -74,10 +74,8 @@ func (a *Analyzer) Analyze(context analysis.Context) {
 	resources := map[string]*resource.Instance{}
 	revisions := sets.New[string]()
 	context.ForEach(gvk.MutatingWebhookConfiguration, func(resource *resource.Instance) bool {
-		if a.SkipDefaultRevisionedWebhook {
-			if isDefaultRevisionedWebhook(resource.Message.(*v1.MutatingWebhookConfiguration)) {
-				return true
-			}
+		if a.SkipDefaultRevisionedWebhook && isDefaultRevisionedWebhook(resource.Message.(*v1.MutatingWebhookConfiguration)) {
+			return true
 		}
 		wh := resource.Message.(*v1.MutatingWebhookConfiguration)
 		revs := extractRevisions(wh)


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a supplement to https://github.com/istio/istio/pull/48700, covering the last missing case regarding webhook conflict. This fix is to ignore the in-cluster `istio-sidecar-injector` webhook in webhook analysis if the installation is a default one, as it will be deactivated upon successful installation. Otherwise if that webhook is activated due to failed installation before, which applied the webhook manifest and didn't do `ProcessDefaultWebhook`, the installation can still be conflict.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
