### PR TITLE
authz: fix external authorization when `maxRequestBytes` is greater than 1MiB

### DIFF
--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -314,9 +314,7 @@ func (b Builder) buildHTTP(rules *rbacpb.RBAC, shadowRules *rbacpb.RBAC, provide
 				MaxRequestBytes: &wrappers.UInt32Value{Value: extauthz.http.GetWithRequestBody().MaxRequestBytes},
 			})},
 		}
-		// insert buffer between rbac and ext_authz
-		httpFilters = append(httpFilters[:1], httpFilters[0:]...)
-		httpFilters[1] = httpBuffer
+		httpFilters = append([]*hcm.HttpFilter{httpBuffer}, httpFilters...)
 	}
 	return httpFilters
 }

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -108,6 +108,23 @@ var (
 			},
 		},
 	}
+	meshConfigHTTPMaxRequestBody1MiB = &meshconfig.MeshConfig{
+		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
+			{
+				Name: "default",
+				Provider: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExtAuthzHttp{
+					EnvoyExtAuthzHttp: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationHttpProvider{
+						Service: "foo/my-custom-ext-authz.foo.svc.cluster.local",
+						Port:    9000,
+						IncludeRequestBodyInCheck: &meshconfig.MeshConfig_ExtensionProvider_EnvoyExternalAuthorizationRequestBody{
+							// 1MiB + 1B
+							MaxRequestBytes: 1048577,
+						},
+					},
+				},
+			},
+		},
+	}
 	meshConfigInvalid = &meshconfig.MeshConfig{
 		ExtensionProviders: []*meshconfig.MeshConfig_ExtensionProvider{
 			{
@@ -188,6 +205,16 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			meshConfig: meshConfigInvalid,
 			input:      "custom-simple-http-in.yaml",
 			want:       []string{"custom-bad-out.yaml"},
+		},
+		{
+			name:       "custom-http-provider-with-max-request-body-bigger-than-1MiB",
+			meshConfig: meshConfigHTTPMaxRequestBody1MiB,
+			input:      "custom-simple-http-in.yaml",
+			want: []string{
+				"custom-http-provider-with-max-request-body-bigger-than-1MiB-out1.yaml",
+				"custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml",
+				"custom-http-provider-with-max-request-body-bigger-than-1MiB-out3.yaml",
+			},
 		},
 		{
 			name:  "deny-and-allow",

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out1.yaml
@@ -1,0 +1,33 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out1.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out1.yaml
@@ -1,33 +1,4 @@
-name: envoy.filters.http.rbac
+name: envoy.filters.http.buffer
 typedConfig:
-  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
-  shadowRules:
-    action: DENY
-    policies:
-      istio-ext-authz-ns[foo]-policy[httpbin-1]-rule[0]:
-        permissions:
-        - andRules:
-            rules:
-            - orRules:
-                rules:
-                - urlPath:
-                    path:
-                      exact: /httpbin1
-        principals:
-        - andIds:
-            ids:
-            - any: true
-      istio-ext-authz-ns[foo]-policy[httpbin-2]-rule[0]:
-        permissions:
-        - andRules:
-            rules:
-            - orRules:
-                rules:
-                - urlPath:
-                    path:
-                      exact: /httpbin2
-        principals:
-        - andIds:
-            ids:
-            - any: true
-  shadowRulesStatPrefix: istio_ext_authz_
+  '@type': type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
+  maxRequestBytes: 1048577

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
@@ -1,4 +1,4 @@
 name: envoy.filters.http.buffer
-typed_config:
+typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-  max_request_bytes: 1048577
+  maxRequestBytes: 1048577

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
@@ -1,4 +1,33 @@
-name: envoy.filters.http.buffer
+name: envoy.filters.http.rbac
 typedConfig:
-  '@type': type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-  maxRequestBytes: 1048577
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    action: DENY
+    policies:
+      istio-ext-authz-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin1
+        principals:
+        - andIds:
+            ids:
+            - any: true
+      istio-ext-authz-ns[foo]-policy[httpbin-2]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /httpbin2
+        principals:
+        - andIds:
+            ids:
+            - any: true
+  shadowRulesStatPrefix: istio_ext_authz_

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out2.yaml
@@ -1,0 +1,4 @@
+name: envoy.filters.http.buffer
+typed_config:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
+  max_request_bytes: 1048577

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out3.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out3.yaml
@@ -1,0 +1,18 @@
+name: envoy.filters.http.ext_authz
+typed_config:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+  filter_enabled_metadata:
+    filter: envoy.filters.http.rbac
+    path:
+      - key: istio_ext_authz_shadow_effective_policy_id
+    value:
+      string_match:
+        prefix: istio-ext-authz
+  http_service:
+    server_uri:
+      cluster: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
+      timeout: 600s
+      uri: http://my-custom-ext-authz.foo.svc.cluster.local
+  transport_api_version: V3
+  with_request_body:
+    max_request_bytes: 1048577

--- a/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out3.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/custom-http-provider-with-max-request-body-bigger-than-1MiB-out3.yaml
@@ -1,18 +1,18 @@
 name: envoy.filters.http.ext_authz
-typed_config:
+typedConfig:
   '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-  filter_enabled_metadata:
+  filterEnabledMetadata:
     filter: envoy.filters.http.rbac
     path:
-      - key: istio_ext_authz_shadow_effective_policy_id
+    - key: istio_ext_authz_shadow_effective_policy_id
     value:
-      string_match:
+      stringMatch:
         prefix: istio-ext-authz
-  http_service:
-    server_uri:
+  httpService:
+    serverUri:
       cluster: outbound|9000||my-custom-ext-authz.foo.svc.cluster.local
       timeout: 600s
       uri: http://my-custom-ext-authz.foo.svc.cluster.local
-  transport_api_version: V3
-  with_request_body:
-    max_request_bytes: 1048577
+  transportApiVersion: V3
+  withRequestBody:
+    maxRequestBytes: 1048577

--- a/releasenotes/notes/fix-ext-authz-with-max-request-body-gt-1mib.yaml
+++ b/releasenotes/notes/fix-ext-authz-with-max-request-body-gt-1mib.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+  - |
+    **Fixed** a bug in external authorization when `envoyExtAuthz{Http,Grpc}.includeRequestBodyInCheck.maxRequestBytes`
+    was greater than 1MiB, which caused returning `413 Payload Too Large`.


### PR DESCRIPTION
**Please provide a description of this PR:**

External authorization does not work when `envoyExtAuthz{Http,Grpc}.includeRequestBodyInCheck.maxRequestBytes` is greater than 1MiB, because HttpConnectionManager does not buffer more than 1MiB and returns `413 Payload Too Large` if it can't stream the request.

The solution is to add `envoy.filters.http.buffer` before `envoy.filters.http.ext_authz`.

You can quickly reproduce this issue and verify the solution by following steps from this [README](https://github.com/jewertow/istio-playground/tree/master/issues/ext-authz-max-requests-bytes-413-payload-too-large).