### PR TITLE
cleanup: remove deprecated hpa api v2beta2

### DIFF
--- a/manifests/addons/values-kiali.yaml
+++ b/manifests/addons/values-kiali.yaml
@@ -8,6 +8,6 @@ deployment:
   - '**'
   ingress_enabled: false
   hpa:
-    api_version: autoscaling/v2beta2
+    api_version: autoscaling/v2
 login_token:
   signing_key: CHANGEME00000000

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -59,7 +59,7 @@ data:
       custom_secrets: []
       host_aliases: []
       hpa:
-        api_version: autoscaling/v2beta2
+        api_version: autoscaling/v2
         spec: {}
       image_digest: ""
       image_name: quay.io/kiali/kiali
@@ -465,7 +465,7 @@ spec:
         app.kubernetes.io/part-of: "kiali"
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: ce97ed2896a797e7aace42e18922786c78956f2ee862cfae70cc24ff1a9a600f
+        checksum/config: 5df0dcfdbf1b7f4bf6cd593286ead627290d8afafd0953d5e252a39d6a698119
         prometheus.io/scrape: "false"
         prometheus.io/port: ""
         kiali.io/dashboards: go,kiali


### PR DESCRIPTION
**Please provide a description of this PR:**

`autoscaling/v2beta2` api version is also no longer served as of k8s v1.26: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126