### PR TITLE
Cleanup legacy PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS flag

### DIFF
--- a/pilot/pkg/features/xds.go
+++ b/pilot/pkg/features/xds.go
@@ -51,14 +51,6 @@ var (
 		"UseRemoteAddress sets useRemoteAddress to true for sidecar outbound listeners.",
 	).Get()
 
-	EnableHeadlessService = env.Register(
-		"PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS",
-		true,
-		"If enabled, for a headless service/stateful set in Kubernetes, pilot will generate an "+
-			"outbound listener for each pod in a headless service. This feature should be disabled "+
-			"if headless services have a large number of pods.",
-	).Get()
-
 	EnableEDSForHeadless = env.Register(
 		"PILOT_ENABLE_EDS_FOR_HEADLESS_SERVICES",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -476,7 +476,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(node *model.Proxy,
 					// Instead of generating a single 0.0.0.0:Port listener, generate a listener
 					// for each instance. HTTP services can happily reside on 0.0.0.0:PORT and use the
 					// wildcard route match to get to the appropriate IP through original dst clusters.
-					if features.EnableHeadlessService && bind.Primary() == "" && service.Resolution == model.Passthrough &&
+					if bind.Primary() == "" && service.Resolution == model.Passthrough &&
 						saddress == constants.UnspecifiedIP && (servicePort.Protocol.IsTCP() || servicePort.Protocol.IsUnsupported()) {
 						instances := push.ServiceEndpointsByPort(service, servicePort.Port, nil)
 						if service.Attributes.ServiceRegistry != provider.Kubernetes && len(instances) == 0 && service.Attributes.LabelSelectors == nil {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -146,7 +146,7 @@ func (esc *endpointSliceController) onEventInternal(_, ep *v1.EndpointSlice, eve
 		esc.c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			// pure HTTP headless services should not need a full push since they do not
 			// require a Listener based on IP: https://github.com/istio/istio/issues/48207
-			Full: !pureHTTP && features.EnableHeadlessService,
+			Full: !pureHTTP,
 			// TODO: extend and set service instance type, so no need to re-init push context
 			ConfigsUpdated: configsUpdated,
 

--- a/releasenotes/notes/drop-headless.yaml
+++ b/releasenotes/notes/drop-headless.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Removed** the `PILOT_ENABLE_HEADLESS_SERVICE_POD_LISTENERS` feature flag.


### PR DESCRIPTION
This has been enabled by default for many years