### PR TITLE
Forward Authorization headers to service when 'merged-metrics: true'

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -660,6 +660,7 @@ func (s *Server) scrape(url string, header http.Header) (io.ReadCloser, context.
 	applyHeaders(req.Header, header, "Accept",
 		"User-Agent",
 		"X-Prometheus-Scrape-Timeout-Seconds",
+		"Authorization",
 	)
 
 	resp, err := s.http.Do(req)


### PR DESCRIPTION
**Please provide a description of this PR:**

Prometheus [allows the use](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) of the `Authorization` header  during metrics scraping requests. This is useful when the service protects their metrics endpoint with a JWT token.

Currently, when Istio is configured with `meshConfig.enablePrometheusMerge=true`, the `Authorization` header is not forwarded to the service, causing an `401 Unauthorized` error on scrapping.

This commit introduces changes to forward the `Authorization` through the proxy during metrics collection, in order to avoid disabling metrics merging and requiring 2 scraping requests.