### PR TITLE
[release-1.19] Make sure unknown vhosts fall through and get added eventually (if on port 80)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -144,62 +144,81 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 // plain non-registry hostnames
 func separateVSHostsAndServices(virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service,
-	mostSpecificWildcardIndex map[host.Name]types.NamespacedName,
+	mostSpecificWildcardVsIndex map[host.Name]types.NamespacedName,
 ) ([]string, []*model.Service) {
 	// TODO: A further optimization would be to completely rely on the index and not do the loop below
 	// However, that requires assuming that serviceRegistry never got filtered after the
 	// egressListener was created.
 	rule := virtualService.Spec.(*networking.VirtualService)
-	hosts := make([]string, 0)
-	servicesInVirtualService := make([]*model.Service, 0)
+	// Stores VS hosts that don't correspond to services in the registry
+	// Currently, the only use for this list is to enable VirtualService configuration to affect
+	// traffic to hosts outside of the service registry (e.g. google.com) on port 80
+	nonServiceRegistryHosts := make([]string, 0)
+	// Stores services for this VirtualService that are in the registry (based on hostname)
+	matchingRegistryServices := make([]*model.Service, 0)
 	wchosts := make([]host.Name, 0)
 
 	// As a performance optimization, process non wildcard hosts first, so that they can be
 	// looked up directly in the service registry map.
 	for _, hostname := range rule.Hosts {
 		vshost := host.Name(hostname)
-		if !vshost.IsWildCarded() {
-			if svc, exists := serviceRegistry[vshost]; exists {
-				servicesInVirtualService = append(servicesInVirtualService, svc)
-			} else {
-				hosts = append(hosts, hostname)
-			}
-		} else {
-			// Add it to the wildcard hosts so that they can be processed later.
+		if vshost.IsWildCarded() {
+			// We'll process wild card hosts later
 			wchosts = append(wchosts, vshost)
+			continue
+		}
+		if svc, exists := serviceRegistry[vshost]; exists {
+			matchingRegistryServices = append(matchingRegistryServices, svc)
+		} else {
+			nonServiceRegistryHosts = append(nonServiceRegistryHosts, hostname)
 		}
 	}
 
 	// Now process wild card hosts as they need to follow the slow path of looping through all Services in the registry.
 	for _, hostname := range wchosts {
 		if model.UseGatewaySemantics(virtualService) {
-			hosts = append(hosts, string(hostname))
+			nonServiceRegistryHosts = append(nonServiceRegistryHosts, string(hostname))
 			continue
 		}
-		// Say this VS's host is *.global and there's another VS with host *.foo.global
+		// foundSvcMatch's only purpose is to make sure we don't add hosts that correspond to services
+		// to the list of non-serviceregistry hosts
 		foundSvcMatch := false
-		// Say we have Services *.foo.global, *.bar.global
 		for svcHost, svc := range serviceRegistry {
-			vs, ok := mostSpecificWildcardIndex[svcHost]
+			// First, check if this service matches the VS host.
+			// If it does, then we never want to add it to the nonServiceRegistryHosts list.
+			// The result is OR'd so we don't overwrite a previously true value
+			// localMatch is tracking the match found within this iteration of the loop
+			localMatch := svcHost.Matches(hostname)
+			// foundSvcMatch is tracking in the wider context whether or not ANY match was found during an iteration
+			foundSvcMatch = foundSvcMatch || localMatch
+			if !localMatch {
+				// If the wildcard doesn't even match this service, it won't be in the index
+				continue
+			}
+			// The mostSpecificWildcardIndex ensures that each VirtualService host is only associated with
+			// a single service in the registry. This is generally results in the most specific wildcard match for
+			// a given wildcard host (unless PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING is true).
+			vs, ok := mostSpecificWildcardVsIndex[svcHost]
 			if !ok {
 				// This service doesn't have a virtualService that matches it.
 				continue
 			}
-			foundSvcMatch = true // we did find a match
 			if vs != virtualService.NamespacedName() {
 				// This virtual service is not the most specific wildcard match for this service.
 				// So we don't add it to the list of services in this virtual service so as
 				// to avoid duplicates
 				continue
 			}
-			servicesInVirtualService = append(servicesInVirtualService, svc)
+			matchingRegistryServices = append(matchingRegistryServices, svc)
 		}
+
+		// If we never found a match for this hostname in the service registry, add it to the list of non-service hosts
 		if !foundSvcMatch {
-			hosts = append(hosts, string(hostname))
+			nonServiceRegistryHosts = append(nonServiceRegistryHosts, string(hostname))
 		}
 	}
 
-	return hosts, servicesInVirtualService
+	return nonServiceRegistryHosts, matchingRegistryServices
 }
 
 // buildSidecarVirtualHostsForVirtualService creates virtual hosts corresponding to a virtual service.
@@ -212,7 +231,7 @@ func buildSidecarVirtualHostsForVirtualService(
 	hashByDestination DestinationHashMap,
 	listenPort int,
 	mesh *meshconfig.MeshConfig,
-	mostSpecificWildcardIndex map[host.Name]types.NamespacedName,
+	mostSpecificWildcardVsIndex map[host.Name]types.NamespacedName,
 ) []VirtualHostWrapper {
 	meshGateway := sets.New(constants.IstioMeshGateway)
 	opts := RouteOptions{
@@ -228,12 +247,12 @@ func buildSidecarVirtualHostsForVirtualService(
 		return nil
 	}
 
-	hosts, servicesInVirtualService := separateVSHostsAndServices(virtualService, serviceRegistry, mostSpecificWildcardIndex)
+	hosts, matchingRegistryServices := separateVSHostsAndServices(virtualService, serviceRegistry, mostSpecificWildcardVsIndex)
 
 	// Gateway allows only routes from the namespace of the proxy, or namespace of the destination.
 	if model.UseGatewaySemantics(virtualService) {
-		res := make([]*model.Service, 0, len(servicesInVirtualService))
-		for _, s := range servicesInVirtualService {
+		res := make([]*model.Service, 0, len(matchingRegistryServices))
+		for _, s := range matchingRegistryServices {
 			if s.Attributes.Namespace != virtualService.Namespace && node.ConfigNamespace != virtualService.Namespace {
 				continue
 			}
@@ -250,7 +269,7 @@ func buildSidecarVirtualHostsForVirtualService(
 	// If the destination service is being accessed on port X, we set that as the default
 	// destination port
 	serviceByPort := make(map[int][]*model.Service)
-	for _, svc := range servicesInVirtualService {
+	for _, svc := range matchingRegistryServices {
 		for _, port := range svc.Ports {
 			if port.Protocol.IsHTTPOrSniffed() {
 				serviceByPort[port.Port] = append(serviceByPort[port.Port], svc)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -1171,7 +1171,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtualservices and services with overlapping wildcard hosts", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
-			Configs:  []config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost},
+			Configs: []config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			},
 			Services: []*model.Service{exampleWildcardService, exampleNestedWildcardService},
 		})
 
@@ -1187,13 +1191,60 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 
 		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
-			[]config.Config{virtualServiceWithWildcardHost, virtualServiceWithNestedWildcardHost}, 8080,
+			[]config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			}, 8080,
 			wildcardIndex,
 		)
 		log.Printf("%#v", vhosts)
+		// *.example.org, *.hello.example.org. The *.google.com VS is missing from virtualHosts because
+		// it is not attached to a service
 		g.Expect(vhosts).To(gomega.HaveLen(2))
 		for _, vhost := range vhosts {
 			g.Expect(vhost.Services).To(gomega.HaveLen(1))
+			g.Expect(vhost.Routes).To(gomega.HaveLen(1))
+		}
+	})
+
+	t.Run("for virtualservices with with wildcard hosts outside of the serviceregistry (on port 80)", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+			Configs: []config.Config{
+				virtualServiceWithWildcardHost,
+				virtualServiceWithNestedWildcardHost,
+				virtualServiceWithGoogleWildcardHost,
+			},
+			Services: []*model.Service{exampleWildcardService, exampleNestedWildcardService},
+		})
+
+		// Redefine the service registry for this test
+		serviceRegistry := map[host.Name]*model.Service{
+			"*.example.org":             exampleWildcardService,
+			"goodbye.hello.example.org": exampleNestedWildcardService,
+		}
+
+		// note that the VS containing *.google.com doesn't have an entry in the wildcard index
+		wildcardIndex := map[host.Name]types.NamespacedName{
+			"*.example.org":       virtualServiceWithWildcardHost.NamespacedName(),
+			"*.hello.example.org": virtualServiceWithNestedWildcardHost.NamespacedName(),
+		}
+
+		vhosts := route.BuildSidecarVirtualHostWrapper(nil, node(cg), cg.PushContext(), serviceRegistry,
+			[]config.Config{virtualServiceWithGoogleWildcardHost}, 80, wildcardIndex,
+		)
+		// The service hosts (*.example.org and goodbye.hello.example.org) and the unattached VS host (*.google.com)
+		g.Expect(vhosts).To(gomega.HaveLen(3))
+		for _, vhost := range vhosts {
+			if len(vhost.VirtualServiceHosts) > 0 && vhost.VirtualServiceHosts[0] == "*.google.com" {
+				// The *.google.com VS shouldn't have any services
+				g.Expect(vhost.Services).To(gomega.HaveLen(0))
+			} else {
+				// The other two VSs should have one service each
+				g.Expect(vhost.Services).To(gomega.HaveLen(1))
+			}
+			// All VSs should have one route
 			g.Expect(vhost.Routes).To(gomega.HaveLen(1))
 		}
 	})
@@ -1502,6 +1553,36 @@ var virtualServiceWithNestedWildcardHost = config.Config{
 							Port: &networking.PortSelector{
 								Number: 8080,
 							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithGoogleWildcardHost = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "google-wildcard",
+	},
+	Spec: &networking.VirtualService{
+		Hosts: []string{"*.google.com"},
+		Http: []*networking.HTTPRoute{
+			{
+				Match: []*networking.HTTPMatchRequest{
+					{
+						Uri: &networking.StringMatch{
+							MatchType: &networking.StringMatch_Prefix{
+								Prefix: "/",
+							},
+						},
+					},
+				},
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "internal-google.default.svc.cluster.local",
 						},
 					},
 				},

--- a/releasenotes/notes/49364.yaml
+++ b/releasenotes/notes/49364.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 49364
+releaseNotes:
+- |
+  **Fixed** an bug where VirtualServices containing wildcard hosts that aren't present in the service registry are ignored


### PR DESCRIPTION


* Make sure unknown vhosts fall through and get added eventually (if on port 80)



* Add istioctl precheck for PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING



* Change upgrade messaging



---------

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
