### PR TITLE
istioctl: fix commands rely on config dump may not work due to the presence of ECDS config or unknown config

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/configdump.go
+++ b/istioctl/pkg/writer/envoy/configdump/configdump.go
@@ -43,14 +43,12 @@ func SetPrintConfigTypeInSummary(p bool) {
 
 // Prime loads the config dump into the writer ready for printing
 func (c *ConfigWriter) Prime(b []byte) error {
-	cd := &adminv3.ConfigDump{}
-	err := protomarshal.UnmarshalWithGlobalTypesResolver(b, cd)
+	w := &configdump.Wrapper{}
+	err := w.UnmarshalJSON(b)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config dump response from Envoy: %v", err)
 	}
-	c.configDump = &configdump.Wrapper{
-		ConfigDump: cd,
-	}
+	c.configDump = w
 	return nil
 }
 

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson" // nolint: depguard
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/log"
@@ -50,6 +51,18 @@ func UnmarshalString(s string, m proto.Message) error {
 
 func UnmarshalAllowUnknown(b []byte, m proto.Message) error {
 	return unmarshaler.Unmarshal(bytes.NewReader(b), legacyproto.MessageV1(m))
+}
+
+type resolver interface {
+	protoregistry.MessageTypeResolver
+	protoregistry.ExtensionTypeResolver
+}
+
+func UnmarshalAllowUnknownWithAnyResolver(anyResolver resolver, b []byte, m proto.Message) error {
+	return (&protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+		Resolver:       anyResolver,
+	}).Unmarshal(b, m)
 }
 
 func UnmarshalWithGlobalTypesResolver(b []byte, m proto.Message) error {

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -65,10 +65,6 @@ func UnmarshalAllowUnknownWithAnyResolver(anyResolver resolver, b []byte, m prot
 	}).Unmarshal(b, m)
 }
 
-func UnmarshalWithGlobalTypesResolver(b []byte, m proto.Message) error {
-	return protojson.Unmarshal(b, m)
-}
-
 // ToJSON marshals a proto to canonical JSON
 func ToJSON(msg proto.Message) (string, error) {
 	return ToJSONWithIndent(msg, "")

--- a/pkg/util/protomarshal/protomarshal.go
+++ b/pkg/util/protomarshal/protomarshal.go
@@ -52,13 +52,6 @@ func UnmarshalAllowUnknown(b []byte, m proto.Message) error {
 	return unmarshaler.Unmarshal(bytes.NewReader(b), legacyproto.MessageV1(m))
 }
 
-func UnmarshalAllowUnknownWithAnyResolver(anyResolver jsonpb.AnyResolver, b []byte, m proto.Message) error {
-	return (&jsonpb.Unmarshaler{
-		AllowUnknownFields: true,
-		AnyResolver:        anyResolver,
-	}).Unmarshal(bytes.NewReader(b), legacyproto.MessageV1(m))
-}
-
 func UnmarshalWithGlobalTypesResolver(b []byte, m proto.Message) error {
 	return protojson.Unmarshal(b, m)
 }

--- a/releasenotes/notes/49511.yaml
+++ b/releasenotes/notes/49511.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: istioctl
 releaseNotes:
 - |
-  **Fixed** an issue where `istioctl experimental proxy-status <proxy>` is not working when there's ECDS config exists in the config dump.
+  **Fixed** an issue where commands relying on Envoy config dump may not work due to the presence of ECDS config.

--- a/releasenotes/notes/49511.yaml
+++ b/releasenotes/notes/49511.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** an issue where `istioctl experimental proxy-status <proxy>` is not working when there's ECDS config exists in the config dump.


### PR DESCRIPTION
**Please provide a description of this PR:**
Currently If a proxy has the ECDS config synced, `x ps` will fail with something like:
```
istioctl x ps httpbin-5f646964cb-ftj22.bookinfo
Error: can't unmarshal Any nested proto type.googleapis.com/envoy.admin.v3.EcdsConfigDump: can't unmarshal Any nested proto type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig: can't unmarshal Any nested proto type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm: Any JSON doesn't have '@type'
```
Since ps will be replaced with `experimental ps` soon, I'd just fix the `experimental ps` command.

Also, this PR improves `pc` to handle unknown types that may caused by envoy mismatch.