### PR TITLE
dns: don't generate alt-hosts for FQDN

### DIFF
--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -479,6 +479,9 @@ func generateAltHosts(hostname string, nameinfo *dnsProto.NameTable_NameInfo, pr
 	proxyDomainParts []string,
 ) sets.String {
 	out := sets.New[string]()
+	if strings.HasSuffix(hostname, ".") {
+		return out
+	}
 	out.Insert(hostname + ".")
 	// do not generate alt hostnames if the service is in a different domain (i.e. cluster) than the proxy
 	// as we have no way to resolve conflicts on name.namespace entries across clusters of different domains

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -52,14 +52,34 @@ func testBuildAltHosts(t *testing.T, d *LocalDNSServer) {
 		expected   sets.Set[string]
 	}{
 		{
+			startsWith: "www.google.com",
+			expected:   sets.New("www.google.com", "www.google.com."),
+		},
+		{
+			startsWith: "example",
+			expected:   sets.New("example.ns2.", "example.ns2.svc.", "example.localhost.", "example.ns2.svc.cluster.local.", "example.ns2.svc.cluster.local"),
+		},
+		{
+			startsWith: "details",
+			expected:   sets.New("details.ns2.svc.cluster.remote", "details.ns2.svc.cluster.remote."),
+		},
+		{
 			startsWith: "productpage",
 			expected: sets.New(
 				"productpage.ns1.svc.cluster.local.", "productpage.", "productpage.ns1.svc.cluster.local", "productpage.ns1.", "productpage.ns1.svc.",
 			),
 		},
 		{
-			startsWith: "www.google.com",
-			expected:   sets.New("www.google.com."),
+			startsWith: "svc-with-alt",
+			expected:   sets.New("svc-with-alt.", "svc-with-alt.ns1.svc.", "svc-with-alt.ns1.", "svc-with-alt.ns1.svc.clusterset.local.", "svc-with-alt.ns1.svc.cluster.local.", "svc-with-alt.ns1.svc.cluster.local"),
+		},
+		{
+			startsWith: "*.wildcard",
+			expected:   sets.New("*.wildcard", "*.wildcard."),
+		},
+		{
+			startsWith: "example.localhost.",
+			expected:   sets.New("example.localhost."),
 		},
 	}
 

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -71,7 +71,14 @@ func testBuildAltHosts(t *testing.T, d *LocalDNSServer) {
 		},
 		{
 			startsWith: "svc-with-alt",
-			expected:   sets.New("svc-with-alt.", "svc-with-alt.ns1.svc.", "svc-with-alt.ns1.", "svc-with-alt.ns1.svc.clusterset.local.", "svc-with-alt.ns1.svc.cluster.local.", "svc-with-alt.ns1.svc.cluster.local"),
+			expected: sets.New(
+				"svc-with-alt.",
+				"svc-with-alt.ns1.",
+				"svc-with-alt.ns1.svc.",
+				"svc-with-alt.ns1.svc.clusterset.local.",
+				"svc-with-alt.ns1.svc.cluster.local.",
+				"svc-with-alt.ns1.svc.cluster.local",
+			),
 		},
 		{
 			startsWith: "*.wildcard",

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -41,12 +41,12 @@ func TestDNS(t *testing.T) {
 	testDNS(t, d)
 }
 
-func TestBuildAltHosts(t *testing.T) {
+func TestBuildAlternateHosts(t *testing.T) {
 	d := initDNS(t, false)
-	testBuildAltHosts(t, d)
+	testBuildAlternateHosts(t, d)
 }
 
-func testBuildAltHosts(t *testing.T, d *LocalDNSServer) {
+func testBuildAlternateHosts(t *testing.T, d *LocalDNSServer) {
 	testCases := []struct {
 		startsWith string
 		expected   sets.Set[string]

--- a/releasenotes/notes/47340.yaml
+++ b/releasenotes/notes/47340.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 47340
+releaseNotes:
+- |
+  **Fixed** an issue where the local DNS client contained incorrect entries in the name table

--- a/releasenotes/notes/47340.yaml
+++ b/releasenotes/notes/47340.yaml
@@ -5,4 +5,4 @@ issue:
   - 47340
 releaseNotes:
 - |
-  **Fixed** an issue where the local DNS client contained incorrect entries in the name table
+  **Fixed** an issue where the local client contained incorrect entries in the local DNS name table


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #47340

If we already have an unambigous name, don't generate additional alternatives hosts.
Otherwise we will end up with something like istio-egressgateway.istio-system.svc..