### PR TITLE
fix following 49463

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -145,7 +145,7 @@ func (esc *endpointSliceController) onEventInternal(_, ep *v1.EndpointSlice, eve
 	configsUpdated := sets.New[model.ConfigKey]()
 	for _, config := range configs {
 		if !pureHTTP {
-			configsUpdated.Insert(model.ConfigKey{Kind: kind.Service, Name: config.Name, Namespace: config.Namespace})
+			configsUpdated.Insert(model.ConfigKey{Kind: kind.ServiceEntry, Name: config.Name, Namespace: config.Namespace})
 		} else {
 			// pure HTTP headless services should not need a full push since they do not
 			// require a Listener based on IP: https://github.com/istio/istio/issues/48207


### PR DESCRIPTION
**Please provide a description of this PR:**

This is accidently introduced in #49463

We always use ServiceEntry for ConfigUpdate, and never use kind.Service.

We may introduce assert  to protect it


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
