### PR TITLE
Add support for targetPort in `NONE` resolution mode

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/helm-profiles/compatibility-version-1.20.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.20.yaml
@@ -1,9 +1,14 @@
 pilot:
   env:
+    # 1.21 behavioral changes
     ENABLE_EXTERNAL_NAME_ALIAS: "false"
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+
+    # 1.22 behavioral changes
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
+
 meshConfig:
   defaultConfig:
     tracing:

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -1,5 +1,6 @@
 pilot:
   env:
+    # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -1,3 +1,6 @@
+pilot:
+  env:
+    ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
   defaultConfig:
     tracing:

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -224,6 +224,9 @@ var (
 	OptimizedConfigRebuild = env.Register("ENABLE_OPTIMIZED_CONFIG_REBUILD", true,
 		"If enabled, pilot will only rebuild config for resources that have changed").Get()
 
+	PassthroughTargetPort = env.Register("ENABLE_RESOLUTION_NONE_TARGET_PORT", true,
+		"If enabled, targetPort will be supported for resolution=NONE ServiceEntry").Get()
+
 	PersistOldestWinsHeuristicForVirtualServiceHostMatching = env.Register("PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING", false,
 		"If enabled, istiod will persist the oldest first heuristic for subtly conflicting traffic policy selection"+
 			"(such as with overlapping wildcard hosts)").Get()

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -703,6 +703,8 @@ type ServiceAttributes struct {
 	// We translate that to the appropriate node port here.
 	ClusterExternalPorts map[cluster.ID]map[uint32]uint32
 
+	PassthroughTargetPorts map[uint32]uint32
+
 	K8sAttributes
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -325,14 +325,12 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		}
 	case cluster.Cluster_ORIGINAL_DST:
 		if features.PassthroughTargetPort {
-			dport := uint32(port.Port)
 			if override, f := service.Attributes.PassthroughTargetPorts[uint32(port.Port)]; f {
-				dport = override
-			}
-			c.LbConfig = &cluster.Cluster_OriginalDstLbConfig_{
-				OriginalDstLbConfig: &cluster.Cluster_OriginalDstLbConfig{
-					UpstreamPortOverride: wrappers.UInt32(dport),
-				},
+				c.LbConfig = &cluster.Cluster_OriginalDstLbConfig_{
+					OriginalDstLbConfig: &cluster.Cluster_OriginalDstLbConfig{
+						UpstreamPortOverride: wrappers.UInt32(override),
+					},
+				}
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -168,7 +168,7 @@ func convertServices(cfg config.Config) []*model.Service {
 	var portOverrides map[uint32]uint32
 	for _, port := range serviceEntry.Ports {
 		svcPorts = append(svcPorts, convertPort(port))
-		if resolution == model.Passthrough && port.TargetPort != port.Number && port.TargetPort != 0 {
+		if resolution == model.Passthrough  && port.TargetPort != 0 {
 			if portOverrides == nil {
 				portOverrides = map[uint32]uint32{}
 			}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -168,7 +168,7 @@ func convertServices(cfg config.Config) []*model.Service {
 	var portOverrides map[uint32]uint32
 	for _, port := range serviceEntry.Ports {
 		svcPorts = append(svcPorts, convertPort(port))
-		if resolution == model.Passthrough  && port.TargetPort != 0 {
+		if resolution == model.Passthrough && port.TargetPort != 0 {
 			if portOverrides == nil {
 				portOverrides = map[uint32]uint32{}
 			}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -165,8 +165,15 @@ func convertServices(cfg config.Config) []*model.Service {
 	}
 
 	svcPorts := make(model.PortList, 0, len(serviceEntry.Ports))
+	var portOverrides map[uint32]uint32
 	for _, port := range serviceEntry.Ports {
 		svcPorts = append(svcPorts, convertPort(port))
+		if resolution == model.Passthrough && port.TargetPort != port.Number {
+			if portOverrides == nil {
+				portOverrides = map[uint32]uint32{}
+			}
+			portOverrides[port.Number] = port.TargetPort
+		}
 	}
 
 	var exportTo sets.Set[visibility.Instance]
@@ -203,12 +210,12 @@ func convertServices(cfg config.Config) []*model.Service {
 	}
 
 	return buildServices(hostAddresses, cfg.Name, cfg.Namespace, svcPorts, serviceEntry.Location, resolution,
-		exportTo, labelSelectors, serviceEntry.SubjectAltNames, creationTime, cfg.Labels)
+		exportTo, labelSelectors, serviceEntry.SubjectAltNames, creationTime, cfg.Labels, portOverrides)
 }
 
 func buildServices(hostAddresses []*HostAddress, name, namespace string, ports model.PortList, location networking.ServiceEntry_Location,
 	resolution model.Resolution, exportTo sets.Set[visibility.Instance], selectors map[string]string, saccounts []string,
-	ctime time.Time, labels map[string]string,
+	ctime time.Time, labels map[string]string, overrides map[uint32]uint32,
 ) []*model.Service {
 	out := make([]*model.Service, 0, len(hostAddresses))
 	lbls := labels
@@ -224,12 +231,13 @@ func buildServices(hostAddresses []*HostAddress, name, namespace string, ports m
 			Ports:          ports,
 			Resolution:     resolution,
 			Attributes: model.ServiceAttributes{
-				ServiceRegistry: provider.External,
-				Name:            ha.host,
-				Namespace:       namespace,
-				Labels:          lbls,
-				ExportTo:        exportTo,
-				LabelSelectors:  selectors,
+				ServiceRegistry:        provider.External,
+				PassthroughTargetPorts: overrides,
+				Name:                   ha.host,
+				Namespace:              namespace,
+				Labels:                 lbls,
+				ExportTo:               exportTo,
+				LabelSelectors:         selectors,
 			},
 			ServiceAccounts: saccounts,
 		})

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -168,7 +168,7 @@ func convertServices(cfg config.Config) []*model.Service {
 	var portOverrides map[uint32]uint32
 	for _, port := range serviceEntry.Ports {
 		svcPorts = append(svcPorts, convertPort(port))
-		if resolution == model.Passthrough && port.TargetPort != port.Number {
+		if resolution == model.Passthrough && port.TargetPort != port.Number && port.TargetPort != 0 {
 			if portOverrides == nil {
 				portOverrides = map[uint32]uint32{}
 			}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -3515,7 +3515,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 			servicePortNumbers[port.Number] = true
 			if port.TargetPort != 0 {
 				errs = appendValidation(errs, ValidatePort(int(port.TargetPort)))
-				if serviceEntry.Resolution == networking.ServiceEntry_NONE {
+				if serviceEntry.Resolution == networking.ServiceEntry_NONE && !features.PassthroughTargetPort {
 					errs = appendWarningf(errs, "targetPort has no effect when resolution mode is NONE")
 				}
 			}

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -94,6 +94,17 @@ func (i Instances) Clusters() cluster.Clusters {
 	return out
 }
 
+// ForCluster returns a list of instances that match the cluster name
+func (i Instances) ForCluster(name string) Instances {
+	out := make(Instances, 0, len(i))
+	for _, c := range i {
+		if c.Config().Cluster.Name() == name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 func (i Instances) Workloads() (Workloads, error) {
 	var out Workloads
 	for _, inst := range i {

--- a/releasenotes/notes/targetPort-service-entry.yaml
+++ b/releasenotes/notes/targetPort-service-entry.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 releaseNotes:
   - |
     **Improved** `ServiceEntry` with `resolution: NONE` to respect `targetPort`, if specified.

--- a/releasenotes/notes/targetPort-service-entry.yaml
+++ b/releasenotes/notes/targetPort-service-entry.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+  - |
+    **Improved** `ServiceEntry` with `resolution: NONE` to respect `targetPort`, if specified.
+    This is particularly useful when doing TLS origination, allowing to set `port:80, targetPort: 443`.
+    If undesired set `--compatibilityVersion=1.21` to revert to the old behavior, or remove the `targetPort` specification.
+upgradeNotes:
+  - title: "`ServiceEntry` with `resolution: NONE` now respects `targetPort`"
+    content: |
+      `ServiceEntry` with `resolution: NONE` previously ignored any `targetPort` specifier.
+      In this release, the `targetPort` is now respected.
+      If undesired set `--compatibilityVersion=1.21` to revert to the old behavior, or remove the `targetPort` specification.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1279,8 +1279,8 @@ spec:
 			tc.children = append(tc.children, TrafficCall{
 				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
 				opts: echo.CallOptions{
-					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
-					Count:   1,
+					Port:  echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Count: 1,
 					// Failed requests will go to non-existent port which hangs forever
 					// Set a low timeout to fail faster
 					Timeout: time.Millisecond * 500,
@@ -1316,7 +1316,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: external-service
+  name: alt-external-service
 spec:
   exportTo: [.]
   hosts:
@@ -1344,8 +1344,8 @@ spec:
 			tc.children = append(tc.children, TrafficCall{
 				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
 				opts: echo.CallOptions{
-					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
-					Count:   1,
+					Port:  echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Count: 1,
 					// Failed requests will go to non-existent port which hangs forever
 					// Set a low timeout to fail faster
 					Timeout: time.Millisecond * 500,
@@ -1396,7 +1396,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: external-service
+  name: alt-external-service
 spec:
   exportTo: [.]
   hosts:
@@ -1434,8 +1434,8 @@ spec:
 			tc.children = append(tc.children, TrafficCall{
 				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
 				opts: echo.CallOptions{
-					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
-					Count:   1,
+					Port:  echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Count: 1,
 					// Failed requests will go to non-existent port which hangs forever
 					// Set a low timeout to fail faster
 					Timeout: time.Millisecond * 500,

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1349,7 +1349,7 @@ spec:
 					// Failed requests will go to non-existent port which hangs forever
 					// Set a low timeout to fail faster
 					Timeout: time.Millisecond * 500,
-					Address: t.Apps.External.All[0].Address(),
+					Address: t.Apps.External.All.ForCluster(c.Config().Cluster.Name())[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),
 					},
@@ -1438,7 +1438,7 @@ spec:
 					// Failed requests will go to non-existent port which hangs forever
 					// Set a low timeout to fail faster
 					Timeout: time.Millisecond * 500,
-					Address: t.Apps.External.All[0].Address(),
+					Address: t.Apps.External.All.ForCluster(c.Config().Cluster.Name())[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),
 					},

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1281,6 +1281,9 @@ spec:
 				opts: echo.CallOptions{
 					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
 					Count:   1,
+					// Failed requests will go to non-existent port which hangs forever
+					// Set a low timeout to fail faster
+					Timeout: time.Millisecond * 500,
 					Address: t.Apps.External.All[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().DefaultHostHeader),
@@ -1343,6 +1346,9 @@ spec:
 				opts: echo.CallOptions{
 					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
 					Count:   1,
+					// Failed requests will go to non-existent port which hangs forever
+					// Set a low timeout to fail faster
+					Timeout: time.Millisecond * 500,
 					Address: t.Apps.External.All[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),
@@ -1430,6 +1436,9 @@ spec:
 				opts: echo.CallOptions{
 					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
 					Count:   1,
+					// Failed requests will go to non-existent port which hangs forever
+					// Set a low timeout to fail faster
+					Timeout: time.Millisecond * 500,
 					Address: t.Apps.External.All[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1249,7 +1249,7 @@ func HostHeader(header string) http.Header {
 // tlsOriginationCases contains tests TLS origination from DestinationRule
 func tlsOriginationCases(t TrafficContext) {
 	tc := TrafficTestCase{
-		name: "",
+		name: "DNS",
 		config: fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -1284,6 +1284,155 @@ spec:
 					Address: t.Apps.External.All[0].Address(),
 					HTTP: echo.HTTP{
 						Headers: HostHeader(t.Apps.External.All[0].Config().DefaultHostHeader),
+					},
+					Scheme: scheme.HTTP,
+					Check: check.And(
+						check.OK(),
+						check.Alpn(e.alpn)),
+				},
+				call: c.CallOrFail,
+			})
+		}
+	}
+	t.RunTraffic(tc)
+
+	tc = TrafficTestCase{
+		name: "NONE",
+		config: fmt.Sprintf(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: external
+spec:
+  host: %s
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-service
+spec:
+  exportTo: [.]
+  hosts:
+  - %s
+  resolution: NONE
+  ports:
+  - name: http-tls-origination
+    number: 8888
+    protocol: http
+    targetPort: 443
+  - name: http2-tls-origination
+    number: 8882
+    protocol: http2
+    targetPort: 443`,
+			"external."+t.Apps.External.Namespace.Name()+".svc.cluster.local",
+			"external."+t.Apps.External.Namespace.Name()+".svc.cluster.local",
+		),
+		children: []TrafficCall{},
+	}
+	for _, c := range t.Apps.A {
+		for _, e := range expects {
+			c := c
+			e := e
+
+			tc.children = append(tc.children, TrafficCall{
+				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
+				opts: echo.CallOptions{
+					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Count:   1,
+					Address: t.Apps.External.All[0].Address(),
+					HTTP: echo.HTTP{
+						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),
+					},
+					Scheme: scheme.HTTP,
+					Check: check.And(
+						check.OK(),
+						check.Alpn(e.alpn)),
+				},
+				call: c.CallOrFail,
+			})
+		}
+	}
+	t.RunTraffic(tc)
+
+	time.Sleep(time.Second)
+	tc = TrafficTestCase{
+		name: "Redirect NONE",
+		config: tmpl.MustEvaluate(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: external
+spec:
+  host: {{.}}
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: httpbin.org
+spec:
+  hosts:
+  - {{.}}
+  http:
+  - route:
+    - destination:
+        host: {{.}}
+        port:
+          number: 443
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-service
+spec:
+  exportTo: [.]
+  hosts:
+  - {{.}}
+  resolution: NONE
+  ports:
+  - name: http
+    number: 8888
+    protocol: http
+  - name: http2
+    number: 8882
+    protocol: http2
+  - name: https
+    number: 443
+    targetPort: 443
+    protocol: https
+    `,
+			"external."+t.Apps.External.Namespace.Name()+".svc.cluster.local",
+		),
+		children: []TrafficCall{},
+	}
+	expects = []struct {
+		port int
+		alpn string
+	}{
+		{8888, "http/1.1"},
+		// Note: here we expect HTTP/1.1, because the 443 port is not configured to be HTTP2!
+		{8882, "http/1.1"},
+	}
+	for _, c := range t.Apps.A {
+		for _, e := range expects {
+			c := c
+			e := e
+
+			tc.children = append(tc.children, TrafficCall{
+				name: fmt.Sprintf("%s: %s", c.Config().Cluster.StableName(), e.alpn),
+				opts: echo.CallOptions{
+					Port:    echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Count:   1,
+					Address: t.Apps.External.All[0].Address(),
+					HTTP: echo.HTTP{
+						Headers: HostHeader(t.Apps.External.All[0].Config().ClusterLocalFQDN()),
 					},
 					Scheme: scheme.HTTP,
 					Check: check.And(

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -1364,7 +1364,6 @@ spec:
 	}
 	t.RunTraffic(tc)
 
-	time.Sleep(time.Second)
 	tc = TrafficTestCase{
 		name: "Redirect NONE",
 		config: tmpl.MustEvaluate(`


### PR DESCRIPTION
There are two use cases we can support here:

1. TargetPort
```yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: httpbin.org
spec:
  exportTo:
  - .
  hosts:
  - httpbin.org
  location: MESH_EXTERNAL
  ports:
  - name: http
    number: 80
    protocol: HTTP
    targetPort: 443
  resolution: NONE
```

Great for TLS origination. Before targetPort is ignored (with a warning), now its respected.

2. VirtualService direct to another port:
```yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: httpbin.org
spec:
  hosts:
  - httpbin.org
  location: MESH_EXTERNAL
  ports:
  - name: http
    number: 80
    protocol: HTTP
  - name: https-port
    number: 443
    protocol: HTTPS
  resolution: NONE
---
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: httpbin.org
spec:
  hosts:
  - httpbin.org
  http:
  - route:
    - destination:
        host: httpbin.org
        port:
          number: 443
```
Before, this would send to httpbin.org on port 80 but through the 443 cluster. Now it will send to port 443. Again, great for TLS origination.

**IMO we should not support this**  its too niche and seems not really required.

----

We can do (1) or (2) or neither, they are not coupled. This only applies to ServiceEntry of NONE mode, and not Headless k8s services -- in Kubernetes, they already defined targetPort to have no meaning, so it seems wrong to give it a meaning. Additionally, the use case to do this is almost always to hit external sites.

If we do this, there is compatibility risk. This will be behind a feature flag with `compatibilityVersion` set to revert it. `istioctl x precheck` can easily check for SE type NONE with targetPort set and warn these users; it is expected to have very little usage because it does nothing.
