### PR TITLE
merge service when resolution and svc attributes including namespace …

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -939,11 +939,11 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 }
 
 func canMergeServices(s1, s2 *Service) bool {
+	// Hostname has been compared in the caller `appendSidecarServices`, so we donot need to compare again.
+
 	if s1.Attributes.Namespace != s2.Attributes.Namespace {
 		return false
 	}
-
-	// Hostname has been compared
 
 	if s1.Resolution != s2.Resolution {
 		return false

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -938,16 +939,30 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 }
 
 func canMergeServices(s1, s2 *Service) bool {
-	if s1.Hostname != s2.Hostname {
+	if s1.Attributes.Namespace != s2.Attributes.Namespace {
 		return false
 	}
+
+	// Hostname has been compared
+
 	if s1.Resolution != s2.Resolution {
 		return false
 	}
-	if s1.Attributes.ServiceRegistry != provider.External || s2.Attributes.ServiceRegistry != provider.External {
+
+	// kuberneres service registry has been checked before
+	if s1.Attributes.ServiceRegistry != s2.Attributes.ServiceRegistry {
 		return false
 	}
-	if !s1.Attributes.Equals(&s2.Attributes) {
+
+	if !maps.Equal(s1.Attributes.Labels, s2.Attributes.Labels) {
+		return false
+	}
+
+	if !maps.Equal(s1.Attributes.LabelSelectors, s2.Attributes.LabelSelectors) {
+		return false
+	}
+
+	if !maps.Equal(s1.Attributes.ExportTo, s2.Attributes.ExportTo) {
 		return false
 	}
 

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -2344,6 +2344,117 @@ func TestCreateSidecarScope(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "serviceentry not merge when resolution is different",
+			sidecarConfig: configs22,
+			services: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+					},
+				},
+				{
+					Hostname:   "foobar.svc.cluster.local",
+					Ports:      port803x[3:],
+					Resolution: DNSLB,
+					Attributes: ServiceAttributes{
+						Name:      "bar",
+						Namespace: "ns1",
+					},
+				},
+			},
+			expectedServices: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+					},
+				},
+			},
+		},
+		{
+			name:          "serviceentry not merge when label selector is different",
+			sidecarConfig: configs22,
+			services: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+						LabelSelectors: map[string]string{
+							"app": "foo",
+						},
+					},
+				},
+				{
+					Hostname:   "foobar.svc.cluster.local",
+					Ports:      port803x[3:],
+					Resolution: DNSLB,
+					Attributes: ServiceAttributes{
+						Name:      "bar",
+						Namespace: "ns1",
+						LabelSelectors: map[string]string{
+							"app": "bar",
+						},
+					},
+				},
+			},
+			expectedServices: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+						LabelSelectors: map[string]string{
+							"app": "foo",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "serviceentry not merge when exportTo is different",
+			sidecarConfig: configs22,
+			services: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+						ExportTo:  sets.New(visibility.Public),
+					},
+				},
+				{
+					Hostname:   "foobar.svc.cluster.local",
+					Ports:      port803x[3:],
+					Resolution: DNSLB,
+					Attributes: ServiceAttributes{
+						Name:      "bar",
+						Namespace: "ns1",
+						ExportTo:  sets.New(visibility.Private),
+					},
+				},
+			},
+			expectedServices: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x[:3],
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+						ExportTo:  sets.New(visibility.Public),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3249,8 +3360,4 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TODO Add tests for AppendSidecarServices
-func TestAppendSidecarServices(t *testing.T) {
 }

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -3250,3 +3250,7 @@ func TestComputeWildcardHostVirtualServiceIndex(t *testing.T) {
 		})
 	}
 }
+
+// TODO Add tests for AppendSidecarServices
+func TestAppendSidecarServices(t *testing.T) {
+}

--- a/releasenotes/notes/merge-svc.yaml
+++ b/releasenotes/notes/merge-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a security fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+area: traffic-management
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** checking services' Resolution, LabelSelector in addition to ServiceRegistry and Namespace when merging services during SidecarScope construction.


### PR DESCRIPTION
…hostname label selector equal

**Please provide a description of this PR:**


Currently we can merge SEs with different resolution and label selectors, this is unexpected, it could change a SE's behavior. We should stop doing so.

Found when looking into https://github.com/istio/istio/issues/49550


Will supplement ut later.