### PR TITLE
Assert kind.Service is disallowed in ConfigKey

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
@@ -88,22 +87,6 @@ func ConfigNamesOfKind(configs sets.Set[ConfigKey], kind kind.Kind) sets.String 
 	for conf := range configs {
 		if conf.Kind == kind {
 			ret.Insert(conf.Name)
-		}
-	}
-
-	return ret
-}
-
-// ConfigNamespacedNameOfKind extracts config names of the specified kind.
-func ConfigNamespacedNameOfKind(configs map[ConfigKey]struct{}, kind kind.Kind) sets.Set[types.NamespacedName] {
-	ret := sets.New[types.NamespacedName]()
-
-	for conf := range configs {
-		if conf.Kind == kind {
-			ret.Insert(types.NamespacedName{
-				Namespace: conf.Namespace,
-				Name:      conf.Name,
-			})
 		}
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

To prevent the use of Service by mistake, we all use ServiceEntry now

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
