### PR TITLE
withoutHeaders supports verification

### DIFF
--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -142,15 +142,26 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute, routeType HTTPRou
 					if header == nil {
 						errs = appendErrors(errs, fmt.Errorf("header match %v cannot be null", name))
 					}
-
 					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
 						if header.GetPrefix() == "" {
 							errs = appendErrors(errs, fmt.Errorf("header prefix match %v may not be empty", name))
 						}
 					}
-
 					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
 					errs = appendErrors(errs, validateStringMatchRegexp(header, "headers"))
+				}
+
+				for name, header := range match.WithoutHeaders {
+					if _, ok := header.GetMatchType().(*networking.StringMatch_Prefix); ok {
+						if header.GetPrefix() == "" {
+							errs = appendErrors(errs, fmt.Errorf("withoutHeaders prefix match %v may not be empty", name))
+						}
+					}
+					errs = appendErrors(errs, ValidateHTTPHeaderName(name))
+					// `*` is NOT a RE2 style regex, it will be translated as present_match.
+					if header != nil && header.GetRegex() != "*" {
+						errs = appendErrors(errs, validateStringMatchRegexp(header, "withoutHeaders"))
+					}
 				}
 
 				errs = appendErrors(errs, validateStringMatchRegexp(match.GetUri(), "uri"))

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -263,6 +263,58 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: true},
+		{name: "exact without headers match", route: &networking.HTTPRoute{
+			Redirect: &networking.HTTPRedirect{
+				Uri:       "/",
+				Authority: "foo.biz",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				WithoutHeaders: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Exact{Exact: "test"},
+					},
+				},
+			}},
+		}, valid: true},
+		{name: "regex without headers match", route: &networking.HTTPRoute{
+			Redirect: &networking.HTTPRedirect{
+				Uri:       "/",
+				Authority: "foo.biz",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				WithoutHeaders: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Regex{Regex: "test"},
+					},
+				},
+			}},
+		}, valid: true},
+		{name: "regex without headers match ?", route: &networking.HTTPRoute{
+			Redirect: &networking.HTTPRedirect{
+				Uri:       "/",
+				Authority: "foo.biz",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				WithoutHeaders: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Regex{Regex: "?"},
+					},
+				},
+			}},
+		}, valid: false},
+		{name: "regex without headers match *", route: &networking.HTTPRoute{
+			Redirect: &networking.HTTPRedirect{
+				Uri:       "/",
+				Authority: "foo.biz",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				WithoutHeaders: map[string]*networking.StringMatch{
+					"header": {
+						MatchType: &networking.StringMatch_Regex{Regex: "*"},
+					},
+				},
+			}},
+		}, valid: true},
 		{name: "regex uri match", route: &networking.HTTPRoute{
 			Delegate: &networking.Delegate{
 				Name:      "test",


### PR DESCRIPTION
fix #49607

Validation logic is copied from the validation headers (except with minor adjustments), see:

https://github.com/istio/istio/blob/e09586dc04198cda05224b7d26b6be237a37e7a3/pkg/config/validation/virtualservice.go#L141