### PR TITLE
helm: drop flag that does nothing, `oneNamespace`

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -99,10 +99,6 @@ spec:
 {{- end }}
           - --domain
           - {{ .Values.global.proxy.clusterDomain }}
-{{- if .Values.global.oneNamespace }}
-          - "-a"
-          - {{ .Release.Namespace }}
-{{- end }}
           - --keepaliveMaxServerConnectionAge
           - "{{ .Values.pilot.keepaliveMaxServerConnectionAge }}"
 {{- if .Values.pilot.extraContainerArgs }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -251,10 +251,6 @@ defaults:
 
     omitSidecarInjectorConfigMap: false
 
-    # Whether to restrict the applications namespace the controller manages;
-    # If not set, controller watches all namespaces
-    oneNamespace: false
-
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.
     # When this option is set as true, Istio Operator, instead of webhooks, manages the

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -211,9 +211,6 @@ defaults:
     logging:
       level: "default:info"
     omitSidecarInjectorConfigMap: true
-    # Whether to restrict the applications namespace the controller manages;
-    # If not set, controller watches all namespaces
-    oneNamespace: false
     # Configure whether Operator manages webhook configurations. The current behavior
     # of Istiod is to manage its own webhook configurations.
     # When this option is set as true, Istio Operator, instead of webhooks, manages the

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -1738,9 +1738,6 @@ type GlobalConfig struct {
 	// Controls whether the creation of the sidecar injector ConfigMap should be skipped.
 	// Defaults to false. When set to true, the sidecar injector ConfigMap will not be created.
 	OmitSidecarInjectorConfigMap *wrapperspb.BoolValue `protobuf:"bytes,38,opt,name=omitSidecarInjectorConfigMap,proto3" json:"omitSidecarInjectorConfigMap,omitempty"`
-	// Controls whether to restrict the applications namespace the controller manages;
-	// If set it to false, the controller watches all namespaces.
-	OneNamespace *wrapperspb.BoolValue `protobuf:"bytes,23,opt,name=oneNamespace,proto3" json:"oneNamespace,omitempty"`
 	// Controls whether the WebhookConfiguration resource(s) should be created. The current behavior
 	// of Istiod is to manage its own webhook configurations.
 	// When this option is set to true, Istio Operator, instead of webhooks, manages the
@@ -1994,13 +1991,6 @@ func (x *GlobalConfig) GetPodDNSSearchNamespaces() []string {
 func (x *GlobalConfig) GetOmitSidecarInjectorConfigMap() *wrapperspb.BoolValue {
 	if x != nil {
 		return x.OmitSidecarInjectorConfigMap
-	}
-	return nil
-}
-
-func (x *GlobalConfig) GetOneNamespace() *wrapperspb.BoolValue {
-	if x != nil {
-		return x.OneNamespace
 	}
 	return nil
 }
@@ -5671,7 +5661,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x0b, 0x32, 0x1e, 0x2e, 0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2e, 0x49, 0x6e, 0x67,
 	0x72, 0x65, 0x73, 0x73, 0x47, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x43, 0x6f, 0x6e, 0x66, 0x69,
 	0x67, 0x52, 0x14, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2d, 0x69, 0x6e, 0x67, 0x72, 0x65, 0x73, 0x73,
-	0x67, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x22, 0xe8, 0x12, 0x0a, 0x0c, 0x47, 0x6c, 0x6f, 0x62,
+	0x67, 0x61, 0x74, 0x65, 0x77, 0x61, 0x79, 0x22, 0xa8, 0x12, 0x0a, 0x0c, 0x47, 0x6c, 0x6f, 0x62,
 	0x61, 0x6c, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x2c, 0x0a, 0x04, 0x61, 0x72, 0x63, 0x68,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61,
 	0x31, 0x2e, 0x41, 0x72, 0x63, 0x68, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x42, 0x02, 0x18, 0x01,
@@ -5748,11 +5738,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42,
 	0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x1c, 0x6f, 0x6d, 0x69, 0x74, 0x53, 0x69,
 	0x64, 0x65, 0x63, 0x61, 0x72, 0x49, 0x6e, 0x6a, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x43, 0x6f, 0x6e,
-	0x66, 0x69, 0x67, 0x4d, 0x61, 0x70, 0x12, 0x3e, 0x0a, 0x0c, 0x6f, 0x6e, 0x65, 0x4e, 0x61, 0x6d,
-	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x18, 0x17, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67,
-	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42,
-	0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x0c, 0x6f, 0x6e, 0x65, 0x4e, 0x61, 0x6d,
-	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0x52, 0x0a, 0x16, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74,
+	0x66, 0x69, 0x67, 0x4d, 0x61, 0x70, 0x12, 0x52, 0x0a, 0x16, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74,
 	0x6f, 0x72, 0x4d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x57, 0x65, 0x62, 0x68, 0x6f, 0x6f, 0x6b, 0x73,
 	0x18, 0x29, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c,
@@ -6635,132 +6621,131 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
 	56,  // 58: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
 	22,  // 59: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
 	54,  // 60: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
-	54,  // 61: v1alpha1.GlobalConfig.oneNamespace:type_name -> google.protobuf.BoolValue
-	54,  // 62: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
-	33,  // 63: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
-	35,  // 64: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
-	37,  // 65: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
-	55,  // 66: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
-	40,  // 67: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
-	54,  // 68: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
-	18,  // 69: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
-	17,  // 70: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
-	54,  // 71: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
-	54,  // 72: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
-	54,  // 73: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
-	54,  // 74: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
-	54,  // 75: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	54,  // 76: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 77: v1alpha1.IngressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
-	9,   // 78: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	54,  // 79: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	54,  // 80: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 81: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	53,  // 82: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
-	56,  // 83: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	56,  // 84: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	56,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
-	56,  // 86: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
-	32,  // 87: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	56,  // 88: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
-	38,  // 89: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	56,  // 90: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	21,  // 91: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
-	49,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	49,  // 93: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	56,  // 94: v1alpha1.IngressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
-	56,  // 95: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	56,  // 96: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	56,  // 97: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	54,  // 98: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 99: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	54,  // 100: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 101: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 102: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
-	2,   // 103: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
-	54,  // 104: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 105: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	56,  // 106: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
-	10,  // 107: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
-	9,   // 108: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	56,  // 109: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	57,  // 110: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	56,  // 111: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	56,  // 112: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	54,  // 113: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	54,  // 114: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
-	56,  // 115: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	56,  // 116: v1alpha1.PilotConfig.affinity:type_name -> google.protobuf.Struct
-	49,  // 117: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	49,  // 118: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	56,  // 119: v1alpha1.PilotConfig.tolerations:type_name -> google.protobuf.Struct
-	54,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
-	54,  // 121: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
-	56,  // 122: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	56,  // 123: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	31,  // 124: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
-	55,  // 125: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	56,  // 126: v1alpha1.PilotConfig.seccompProfile:type_name -> google.protobuf.Struct
-	56,  // 127: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> google.protobuf.Struct
-	56,  // 128: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
-	56,  // 129: v1alpha1.PilotConfig.volumeMounts:type_name -> google.protobuf.Struct
-	56,  // 130: v1alpha1.PilotConfig.volumes:type_name -> google.protobuf.Struct
-	9,   // 131: v1alpha1.PilotConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
-	5,   // 132: v1alpha1.PilotConfig.cni:type_name -> v1alpha1.CNIUsageConfig
-	0,   // 133: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
-	54,  // 134: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 135: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
-	28,  // 136: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
-	54,  // 137: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
-	29,  // 138: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
-	30,  // 139: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
-	54,  // 140: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 141: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	54,  // 142: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	54,  // 143: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
-	34,  // 144: v1alpha1.ProxyConfig.startupProbe:type_name -> v1alpha1.StartupProbe
-	10,  // 145: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
-	1,   // 146: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
-	56,  // 147: v1alpha1.ProxyConfig.lifecycle:type_name -> google.protobuf.Struct
-	54,  // 148: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	54,  // 149: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
-	10,  // 150: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
-	56,  // 151: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	54,  // 152: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	56,  // 153: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
-	56,  // 154: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
-	54,  // 155: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	56,  // 156: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	56,  // 157: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
-	56,  // 158: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	54,  // 159: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
-	41,  // 160: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
-	42,  // 161: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
-	43,  // 162: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
-	44,  // 163: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	54,  // 164: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	54,  // 165: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	54,  // 166: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	54,  // 167: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	4,   // 168: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
-	15,  // 169: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
-	16,  // 170: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
-	24,  // 171: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	55,  // 172: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	27,  // 173: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
-	39,  // 174: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
-	5,   // 175: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
-	55,  // 176: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	45,  // 177: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
-	46,  // 178: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	54,  // 179: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 180: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	59,  // 181: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	182, // [182:182] is the sub-list for method output_type
-	182, // [182:182] is the sub-list for method input_type
-	182, // [182:182] is the sub-list for extension type_name
-	182, // [182:182] is the sub-list for extension extendee
-	0,   // [0:182] is the sub-list for field type_name
+	54,  // 61: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
+	33,  // 62: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
+	35,  // 63: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
+	37,  // 64: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
+	55,  // 65: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
+	40,  // 66: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
+	54,  // 67: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
+	18,  // 68: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
+	17,  // 69: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
+	54,  // 70: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
+	54,  // 71: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
+	54,  // 72: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
+	54,  // 73: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
+	54,  // 74: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	54,  // 75: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	9,   // 76: v1alpha1.IngressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
+	9,   // 77: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
+	54,  // 78: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	54,  // 79: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 80: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	53,  // 81: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
+	56,  // 82: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	56,  // 83: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	56,  // 84: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> google.protobuf.Struct
+	56,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> google.protobuf.Struct
+	32,  // 86: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
+	56,  // 87: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	38,  // 88: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
+	56,  // 89: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	21,  // 90: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
+	49,  // 91: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	49,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	56,  // 93: v1alpha1.IngressGatewayConfig.tolerations:type_name -> google.protobuf.Struct
+	56,  // 94: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	56,  // 95: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	56,  // 96: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	54,  // 97: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	11,  // 98: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
+	54,  // 99: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 100: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 101: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	2,   // 102: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
+	54,  // 103: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 104: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	56,  // 105: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
+	10,  // 106: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
+	9,   // 107: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
+	56,  // 108: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	57,  // 109: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	56,  // 110: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	56,  // 111: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	54,  // 112: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	54,  // 113: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
+	56,  // 114: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	56,  // 115: v1alpha1.PilotConfig.affinity:type_name -> google.protobuf.Struct
+	49,  // 116: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	49,  // 117: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	56,  // 118: v1alpha1.PilotConfig.tolerations:type_name -> google.protobuf.Struct
+	54,  // 119: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
+	54,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
+	56,  // 121: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	56,  // 122: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	31,  // 123: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
+	55,  // 124: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	56,  // 125: v1alpha1.PilotConfig.seccompProfile:type_name -> google.protobuf.Struct
+	56,  // 126: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> google.protobuf.Struct
+	56,  // 127: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
+	56,  // 128: v1alpha1.PilotConfig.volumeMounts:type_name -> google.protobuf.Struct
+	56,  // 129: v1alpha1.PilotConfig.volumes:type_name -> google.protobuf.Struct
+	9,   // 130: v1alpha1.PilotConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
+	5,   // 131: v1alpha1.PilotConfig.cni:type_name -> v1alpha1.CNIUsageConfig
+	0,   // 132: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
+	54,  // 133: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 134: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	28,  // 135: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
+	54,  // 136: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	29,  // 137: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
+	30,  // 138: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
+	54,  // 139: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 140: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	54,  // 141: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	54,  // 142: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	34,  // 143: v1alpha1.ProxyConfig.startupProbe:type_name -> v1alpha1.StartupProbe
+	10,  // 144: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
+	1,   // 145: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
+	56,  // 146: v1alpha1.ProxyConfig.lifecycle:type_name -> google.protobuf.Struct
+	54,  // 147: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	54,  // 148: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	10,  // 149: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
+	56,  // 150: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	54,  // 151: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	56,  // 152: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
+	56,  // 153: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
+	54,  // 154: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	56,  // 155: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	56,  // 156: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
+	56,  // 157: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	54,  // 158: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	41,  // 159: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
+	42,  // 160: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
+	43,  // 161: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
+	44,  // 162: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
+	54,  // 163: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	54,  // 164: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	54,  // 165: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	54,  // 166: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	4,   // 167: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
+	15,  // 168: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
+	16,  // 169: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
+	24,  // 170: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
+	55,  // 171: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	27,  // 172: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
+	39,  // 173: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
+	5,   // 174: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
+	55,  // 175: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	45,  // 176: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
+	46,  // 177: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
+	54,  // 178: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 179: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	59,  // 180: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	181, // [181:181] is the sub-list for method output_type
+	181, // [181:181] is the sub-list for method input_type
+	181, // [181:181] is the sub-list for extension type_name
+	181, // [181:181] is the sub-list for extension extendee
+	0,   // [0:181] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -527,10 +527,6 @@ message GlobalConfig {
   // Defaults to false. When set to true, the sidecar injector ConfigMap will not be created.
   google.protobuf.BoolValue omitSidecarInjectorConfigMap = 38;
 
-  // Controls whether to restrict the applications namespace the controller manages;
-  // If set it to false, the controller watches all namespaces.
-  google.protobuf.BoolValue oneNamespace = 23;
-
   // Controls whether the WebhookConfiguration resource(s) should be created. The current behavior
   // of Istiod is to manage its own webhook configurations.
   // When this option is set to true, Istio Operator, instead of webhooks, manages the

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -39,7 +39,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "network1",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -39,7 +39,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "podDNSSearchNamespaces": [

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -37,7 +37,6 @@
     "namespace": "istio-system",
     "network": "",
     "omitSidecarInjectorConfigMap": false,
-    "oneNamespace": false,
     "operatorManageWebhooks": false,
     "pilotCertProvider": "istiod",
     "priorityClassName": "",


### PR DESCRIPTION
This does nothing (we ignore unknown flags for compatibility)