### PR TITLE
telemetry: remove default tracing configuration

### DIFF
--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -183,7 +183,8 @@ func checkTracing(cli kube.CLIClient, messages *diag.Messages) error {
 	res := ObjectToInstance(svc)
 	messages.Add(msg.NewUpdateIncompatibility(res,
 		"meshConfig.defaultConfig.tracer", "1.21",
-		"tracing is no longer by default enabled to send to 'zipkin.istio-system.svc'; follow https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/",
+		"tracing is no longer by default enabled to send to 'zipkin.istio-system.svc'; "+
+			"follow https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/",
 		"1.21"))
 	return nil
 }

--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -26,6 +26,7 @@ import (
 	authorizationapi "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	crd "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -93,7 +94,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					outputMsgs = append(outputMsgs, m)
 				}
 			}
-			output, err := formatting.Print(msgs, msgOutputFormat, true)
+			output, err := formatting.Print(outputMsgs, msgOutputFormat, true)
 			if err != nil {
 				return err
 			}
@@ -158,7 +159,33 @@ func checkFromVersion(ctx cli.Context, revision, version string) (diag.Messages,
 			return nil, err
 		}
 	}
+
+	if minor <= 21 {
+		if err := checkTracing(cli, &messages); err != nil {
+			return nil, err
+		}
+	}
 	return messages, nil
+}
+
+func checkTracing(cli kube.CLIClient, messages *diag.Messages) error {
+	// In 1.22, we remove the default tracing config which points to zipkin.istio-system
+	// This has no effect for users, unless they have this service.
+	svc, err := cli.Kube().CoreV1().Services("istio-system").Get(context.Background(), "zipkin", metav1.GetOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return err
+	}
+	if err != nil {
+		// not found
+		return nil
+	}
+	// found
+	res := ObjectToInstance(svc)
+	messages.Add(msg.NewUpdateIncompatibility(res,
+		"meshConfig.defaultConfig.tracer", "1.21",
+		"tracing is no longer by default enabled to send to 'zipkin.istio-system.svc'; follow https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/",
+		"1.21"))
+	return nil
 }
 
 func checkExternalNameAlias(cli kube.CLIClient, messages *diag.Messages) error {

--- a/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -33,6 +33,7 @@
       image:
         imageType: {{. | quote}}
       {{- end }}
+      {{- if not (eq .Values.global.proxy.tracer "none") }}
       tracing:
       {{- if eq .Values.global.proxy.tracer "lightstep" }}
         lightstep:
@@ -61,8 +62,7 @@
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
       {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
 {{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}
-      {{- else }}
-        {}
+      {{- end }}
       {{- end }}
       {{- if .Values.global.remotePilotAddress }}
       {{- if .Values.pilot.enabled }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -351,9 +351,9 @@ defaults:
       # Default port for Pilot agent health checks. A value of 0 will disable health checking.
       statusPort: 15020
 
-      # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+      # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver, none.
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
-      tracer: "zipkin"
+      tracer: "none"
 
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -33,6 +33,7 @@
       image:
         imageType: {{. | quote}}
       {{- end }}
+      {{- if not (eq .Values.global.proxy.tracer "none") }}
       tracing:
       {{- if eq .Values.global.proxy.tracer "lightstep" }}
         lightstep:
@@ -61,8 +62,7 @@
       {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
       {{/* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */}}
 {{ toYaml $.Values.meshConfig.defaultConfig.tracing | indent 8 }}
-      {{- else }}
-        {}
+      {{- end }}
       {{- end }}
       {{- if .Values.global.remotePilotAddress }}
       {{- if .Values.pilot.enabled }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -294,9 +294,9 @@ defaults:
           memory: 1024Mi
       # Default port for Pilot agent health checks. A value of 0 will disable health checking.
       statusPort: 15020
-      # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+      # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver, none.
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
-      tracer: "zipkin"
+      tracer: "none"
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/helm-profiles/compatibility-version-1.20.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.20.yaml
@@ -4,3 +4,8 @@ pilot:
     PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING: "true"
     VERIFY_CERTIFICATE_AT_CLIENT: "false"
     ENABLE_AUTO_SNI: "false"
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -1,0 +1,5 @@
+meshConfig:
+  defaultConfig:
+    tracing:
+      zipkin:
+        address: zipkin.istio-system:9411

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -47,13 +47,6 @@ func DefaultProxyConfig() *meshconfig.ProxyConfig {
 		ProxyAdminPort:           15000,
 		ControlPlaneAuthPolicy:   meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 		DiscoveryAddress:         "istiod.istio-system.svc:15012",
-		Tracing: &meshconfig.Tracing{
-			Tracer: &meshconfig.Tracing_Zipkin_{
-				Zipkin: &meshconfig.Tracing_Zipkin{
-					Address: "zipkin.istio-system:9411",
-				},
-			},
-		},
 
 		// Code defaults
 		BinaryPath:     constants.BinaryPathFilename,

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/default.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -74,7 +74,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -73,7 +73,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -73,7 +73,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -74,7 +74,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -76,7 +76,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -73,7 +73,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 123,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
@@ -73,7 +73,7 @@
         "failureThreshold": 600
       },
       "statusPort": 15020,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 123,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.mesh.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.mesh.gen.yaml
@@ -1,8 +1,5 @@
 defaultConfig:
   discoveryAddress: istiod.istio-system.svc:15012
-  tracing:
-    zipkin:
-      address: zipkin.istio-system:9411
 defaultProviders:
   metrics:
   - prometheus

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -72,7 +72,7 @@
         "failureThreshold": 600
       },
       "statusPort": 0,
-      "tracer": "zipkin"
+      "tracer": "none"
     },
     "proxy_init": {
       "image": "proxyv2"

--- a/releasenotes/notes/drop-default-tracing.yaml
+++ b/releasenotes/notes/drop-default-tracing.yaml
@@ -1,0 +1,17 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Removed** default tracing configuration that enables tracing to `zipkin.istio-system.svc`. See upgrade notes for more information.
+upgradeNotes:
+  - title: Default tracing to `zipkin.istio-system.svc` removed
+    content: |
+      In previous versions of Istio, tracing was automatically configured to send traces to `zipkin.istio-system.svc`.
+      This default setting has been removed; users will need to explicitly configure where to send traces moving forward.
+
+      `istioctl x precheck --from-version=1.21` can automatically detect if you may be impacted by this change.
+
+      If you previously had tracing enabled implicitly, you can enable it by doing one of:
+      * Installing with `--set compatibilityVersion=1.21`.
+      * Following [Configure tracing with Telemetry API](/docs/tasks/observability/distributed-tracing/telemetry-api/).

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -54,9 +54,9 @@ import (
 func IsL7() echo.Checker {
 	return check.Each(func(r echot.Response) error {
 		// TODO: response headers?
-		_, f := r.RequestHeaders[http.CanonicalHeaderKey("x-b3-traceid")]
+		_, f := r.RequestHeaders[http.CanonicalHeaderKey("X-Request-Id")]
 		if !f {
-			return fmt.Errorf("x-b3-traceid not set, is L7 processing enabled?")
+			return fmt.Errorf("X-Request-Id not set, is L7 processing enabled?")
 		}
 		return nil
 	})
@@ -65,9 +65,9 @@ func IsL7() echo.Checker {
 func IsL4() echo.Checker {
 	return check.Each(func(r echot.Response) error {
 		// TODO: response headers?
-		_, f := r.RequestHeaders[http.CanonicalHeaderKey("x-b3-traceid")]
+		_, f := r.RequestHeaders[http.CanonicalHeaderKey("X-Request-Id")]
 		if f {
-			return fmt.Errorf("x-b3-traceid set, is L7 processing enabled unexpectedly?")
+			return fmt.Errorf("X-Request-Id set, is L7 processing enabled unexpectedly?")
 		}
 		return nil
 	})

--- a/tests/integration/telemetry/tracing/zipkin/main_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/main_test.go
@@ -41,4 +41,5 @@ func setupConfig(ctx resource.Context, cfg *istio.Config) {
 	}
 	cfg.Values["meshConfig.enableTracing"] = "true"
 	cfg.Values["pilot.traceSampling"] = "100.0"
+	cfg.Values["global.proxy.tracer"] = "zipkin"
 }


### PR DESCRIPTION
This default configuration doesn't really make sense; 99% of users do not have this service, but we waste configuration on it which has a real impact: each envoy sends ~16 DNS requests per minute from this configuration; for 10k pod cluser this is a whopping 2.6k QPS to the DNS server for a useless configuration.

Users can opt out of this with --compatibilityVersion=1.21, or ideally move to the more modern Telemetry API. `istioctl x precheck` can automatically detect if the zipkin service exists, and warn users.

**Please provide a description of this PR:**