### PR TITLE
move port name and labels check outside of filterIstioEndpoint

### DIFF
--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -332,7 +332,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 		return nil
 	}
 	svcEps := b.snapshotShards(endpointIndex)
-	slices.Filter(svcEps, func(ep *model.IstioEndpoint) bool {
+	svcEps = slices.FilterInPlace(svcEps, func(ep *model.IstioEndpoint) bool {
 		// filter out endpoints that don't match the service port
 		if svcPort.Name != ep.ServicePortName {
 			return false

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -329,7 +329,7 @@ func (b *EndpointBuilder) FromServiceEndpoints() []*endpoint.LocalityLbEndpoints
 func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.EndpointIndex) *endpoint.ClusterLoadAssignment {
 	svcPort := b.servicePort(b.port)
 	if svcPort == nil {
-		return nil
+		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
 	svcEps := b.snapshotShards(endpointIndex)
 	svcEps = slices.FilterInPlace(svcEps, func(ep *model.IstioEndpoint) bool {
@@ -378,13 +378,9 @@ func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint, allowPrecomputed 
 	if !b.ServiceFound() {
 		return nil
 	}
-	svcPort := b.servicePort(b.port)
-	if svcPort == nil {
-		return nil
-	}
 
 	eps = slices.Filter(eps, func(ep *model.IstioEndpoint) bool {
-		return b.filterIstioEndpoint(ep, svcPort)
+		return b.filterIstioEndpoint(ep)
 	})
 
 	localityEpMap := make(map[string]*LocalityEndpoints)
@@ -477,7 +473,7 @@ func addUint32(left, right uint32) (uint32, bool) {
 	return left + right, false
 }
 
-func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint, svcPort *model.Port) bool {
+func (b *EndpointBuilder) filterIstioEndpoint(ep *model.IstioEndpoint) bool {
 	// for ServiceInternalTrafficPolicy
 	if b.service.Attributes.NodeLocal && ep.NodeName != b.proxy.GetNodeName() {
 		return false


### PR DESCRIPTION
**Please provide a description of this PR:**

filterIstioEndpoint is called within generate(), which is shared by both CDS and EDS builder.

CDS uses, and it has already checked portname and labels. So here it moved these two checks to be only used by EDS. 
```
func (b *EndpointBuilder) FromServiceEndpoints() []*endpoint.LocalityLbEndpoints {
	if b == nil {
		return nil
	}
	svcEps := b.push.ServiceEndpointsByPort(b.service, b.port, b.subsetLabels)
	// don't use the pre-computed endpoints for CDS to preserve previous behavior
	return ExtractEnvoyEndpoints(b.generate(svcEps, true))
}
```