### PR TITLE
ambient: make IP handling safe

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -255,10 +255,6 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 	// 3. Service
 	if svc := a.lookupService(key); svc != nil {
-		vips := sets.New[string]()
-		for _, addr := range svc.Service.Addresses {
-			vips.Insert(byteIPToString(addr.Address))
-		}
 		res := []model.AddressInfo{serviceToAddressInfo(svc.Service)}
 		for _, w := range a.workloads.ByServiceKey.Lookup(svc.ResourceName()) {
 			res = append(res, workloadToAddressInfo(w.Workload))

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -180,6 +180,19 @@ func Map[E any, O any](s []E, f func(E) O) []O {
 	return n
 }
 
+// MapErr runs f() over all elements in s and returns the result, short circuiting if there is an error.
+func MapErr[E any, O any](s []E, f func(E) (O, error)) ([]O, error) {
+	n := make([]O, 0, len(s))
+	for _, e := range s {
+		res, err := f(e)
+		if err != nil {
+			return nil, err
+		}
+		n = append(n, res)
+	}
+	return n, nil
+}
+
 // MapFilter runs f() over all elements in s and returns any non-nil results
 func MapFilter[E any, O any](s []E, f func(E) *O) []O {
 	n := make([]O, 0, len(s))


### PR DESCRIPTION
This protects against theoretical errors, and 2 real ones that can cause a panic: SE with CIDR, and weird Pods