### PR TITLE
Split waypoint and ztunnel flags

### DIFF
--- a/manifests/charts/base/files/profile-ambient.yaml
+++ b/manifests/charts/base/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/default/files/profile-ambient.yaml
+++ b/manifests/charts/default/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateway/files/profile-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-cni/files/profile-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-operator/files/profile-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istiod-remote/files/profile-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/ztunnel/files/profile-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/helm-profiles/ambient.yaml
+++ b/manifests/helm-profiles/ambient.yaml
@@ -14,6 +14,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   ambient:

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -29,6 +29,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -359,7 +359,7 @@ D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
 
 func init() {
 	features.EnableAlphaGatewayAPI = true
-	features.EnableAmbientControllers = true
+	features.EnableAmbientWaypoints = true
 	// Recompute with ambient enabled
 	classInfos = getClassInfos()
 	builtinClasses = getBuiltinClasses()

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -129,7 +129,7 @@ func getBuiltinClasses() map[gateway.ObjectName]gateway.GatewayController {
 		res[constants.RemoteGatewayClassName] = constants.UnmanagedGatewayController
 	}
 
-	if features.EnableAmbientControllers {
+	if features.EnableAmbientWaypoints {
 		res[constants.WaypointGatewayClassName] = constants.ManagedGatewayMeshController
 	}
 	return res
@@ -156,7 +156,7 @@ func getClassInfos() map[gateway.GatewayController]classInfo {
 			addressType:            gateway.HostnameAddressType,
 		}
 	}
-	if features.EnableAmbientControllers {
+	if features.EnableAmbientWaypoints {
 		m[constants.ManagedGatewayMeshController] = classInfo{
 			controller:         constants.ManagedGatewayMeshController,
 			description:        "The default Istio waypoint GatewayClass",
@@ -364,7 +364,7 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 			hasAmbientAnnotation = true
 		}
 	}
-	if features.EnableAmbientControllers && !isWaypointGateway && !hasAmbientAnnotation {
+	if features.EnableAmbientWaypoints && !isWaypointGateway && !hasAmbientAnnotation {
 		if gw.Annotations == nil {
 			gw.Annotations = make(map[string]string)
 		}

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -180,6 +180,17 @@ var (
 		false,
 		"If enabled, controllers required for ambient will run. This is required to run ambient mesh.").Get()
 
+	EnableAmbientWaypoints = func() bool {
+		v := env.Register(
+			"PILOT_ENABLE_AMBIENT_WAYPOINTS",
+			false,
+			"If enabled, controllers required for ambient will run. This is required to run ambient mesh.").Get()
+		if v && !EnableAmbientControllers {
+			log.Fatalf("PILOT_ENABLE_AMBIENT_WAYPOINTS requires PILOT_ENABLE_AMBIENT_CONTROLLERS")
+		}
+		return v
+	}()
+
 	DeltaXds = env.Register("ISTIO_DELTA_XDS", true,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1757,7 +1757,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) {
 		}
 
 		// For mesh virtual services, build a map of host -> referenced destinations
-		if features.EnableAmbientControllers && (len(rule.Gateways) == 0 || slices.Contains(rule.Gateways, constants.IstioMeshGateway)) {
+		if features.EnableAmbientWaypoints && (len(rule.Gateways) == 0 || slices.Contains(rule.Gateways, constants.IstioMeshGateway)) {
 			for host := range virtualServiceDestinations(rule) {
 				for _, rhost := range rule.Hosts {
 					if _, f := ps.virtualServiceIndex.referencedDestinations[rhost]; !f {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -55,7 +55,7 @@ type Controller struct {
 }
 
 func (c *Controller) Waypoint(network, address string) []netip.Addr {
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbientWaypoints {
 		return nil
 	}
 	var res []netip.Addr
@@ -66,7 +66,7 @@ func (c *Controller) Waypoint(network, address string) []netip.Addr {
 }
 
 func (c *Controller) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo {
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbientWaypoints {
 		return nil
 	}
 	var res []model.WorkloadInfo

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_serviceentry_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestAmbientIndex_ServiceEntry(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	// test code path where service entry creates a workload entry via `ServiceEntry.endpoints`
@@ -323,7 +322,6 @@ func TestAmbientIndex_ServiceEntry(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceEntry_DisableK8SServiceSelectWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	test.SetForTest(t, &features.EnableK8SServiceSelectWorkloadEntries, false)
 	s := newAmbientTestServer(t, testC, testNW)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -69,9 +69,12 @@ const (
 	testC    = "cluster0"
 )
 
-func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+func init() {
+	features.EnableAmbientWaypoints = true
+	features.EnableAmbientControllers = true
+}
 
+func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
 	cases := []struct {
 		name    string
 		cluster cluster.ID
@@ -100,7 +103,6 @@ func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
 }
 
 func TestAmbientIndex_WorkloadNotFound(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	// Add a pod.
@@ -111,7 +113,6 @@ func TestAmbientIndex_WorkloadNotFound(t *testing.T) {
 }
 
 func TestAmbientIndex_LookupWorkloads(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -182,7 +183,6 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceSelectsCorrectWorkloads(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	// Add 2 pods with the "a" label, and one without.
@@ -258,7 +258,6 @@ func TestAmbientIndex_ServiceSelectsCorrectWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addPods(t,
@@ -291,7 +290,6 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 }
 
 func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.ns.Update(&corev1.Namespace{
@@ -497,7 +495,6 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 
 // TODO(nmittler): Consider splitting this into multiple, smaller tests.
 func TestAmbientIndex_Policy(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -935,7 +932,6 @@ func TestAmbientIndex_Policy(t *testing.T) {
 }
 
 func TestPodLifecycleWorkloadGates(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, "", "")
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
@@ -955,7 +951,6 @@ func TestPodLifecycleWorkloadGates(t *testing.T) {
 }
 
 func TestAddressInformation(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	// Add 2 pods with the "a" label, and one without.
@@ -1080,7 +1075,6 @@ func (s *ambientTestServer) assertWaypointAddressForPod(t *testing.T, key, expec
 }
 
 func TestUpdateWaypointForWorkload(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, "", "")
 
 	// add our waypoints but they won't be used until annotations are added
@@ -1162,7 +1156,6 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 }
 
 func TestWorkloadsForWaypoint(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, "", testNW)
 
 	assertWaypoint := func(t *testing.T, waypointNetwork string, waypointAddress string, expected ...string) {
@@ -1264,7 +1257,6 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 // This is a regression test for a case where policies added after pods were not applied when
 // querying by service
 func TestPolicyAfterPod(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addService(t, "svc1",

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestAmbientIndex_WorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addWorkloadEntries(t, "127.0.0.1", "name1", "sa1", map[string]string{"app": "a"})
@@ -284,7 +283,6 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 	s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
@@ -308,7 +306,6 @@ func TestAmbientIndex_EmptyAddrWorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 	s.addWorkloadEntries(t, "", "emptyaddr1", "sa1", map[string]string{"app": "a"})
 	s.assertEvent(t, s.wleXdsName("emptyaddr1"))
@@ -321,7 +318,6 @@ func TestAmbientIndex_UpdateExistingWorkloadEntry(t *testing.T) {
 }
 
 func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addServiceEntry(t, "se.istio.io", []string{"240.240.23.45"}, "se1", testNS, map[string]string{"app": "a"}, []string{"127.0.0.1", "127.0.0.2"})
@@ -351,7 +347,6 @@ func TestAmbientIndex_InlinedWorkloadEntries(t *testing.T) {
 }
 
 func TestAmbientIndex_WorkloadEntries_DisableK8SServiceSelectWorkloadEntries(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	test.SetForTest(t, &features.EnableK8SServiceSelectWorkloadEntries, false)
 	s := newAmbientTestServer(t, testC, testNW)
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -540,9 +540,6 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 	con.conID = connectionID(proxy.ID)
 	con.node = node
 	con.proxy = proxy
-	if proxy.IsWaypointProxy() && !features.EnableAmbientWaypoints {
-		return fmt.Errorf("waypoint proxies require PILOT_ENABLE_AMBIENT_WAYPOINTS=true")
-	}
 	if proxy.IsZTunnel() && !features.EnableAmbientControllers {
 		return fmt.Errorf("ztunnel requires PILOT_ENABLE_AMBIENT_CONTROLLERS=true")
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -539,6 +540,12 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 	con.conID = connectionID(proxy.ID)
 	con.node = node
 	con.proxy = proxy
+	if proxy.IsWaypointProxy() && !features.EnableAmbientWaypoints {
+		return fmt.Errorf("waypoint proxies require PILOT_ENABLE_AMBIENT_WAYPOINTS=true")
+	}
+	if proxy.IsZTunnel() && !features.EnableAmbientControllers {
+		return fmt.Errorf("ztunnel requires PILOT_ENABLE_AMBIENT_CONTROLLERS=true")
+	}
 
 	// Authorize xds clients
 	if err := s.authorize(con, identities); err != nil {

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -94,6 +94,7 @@ pilot:
     PILOT_ENABLE_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   logLevel: info
   privileged: true

--- a/tests/integration/iop-wds.yaml
+++ b/tests/integration/iop-wds.yaml
@@ -12,4 +12,5 @@ spec:
     pilot:
       env:
         PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+        PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
         PILOT_DISABLE_MX_ALPN: "true"


### PR DESCRIPTION
The goal here is to make it possible to split the alpha and beta aspects of ambient, and allow a user to explicitly turn on the core (ztunnels) vs the less stable (waypoint).

This introduces a new flag for waypoints specifically.

The intent is immediately after this, we will merge a PR to make ambient controllers on by default (pending https://github.com/istio/istio/pull/49642)