### PR TITLE
Fixing the priority of the test data in the `push_context`

### DIFF
--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -335,6 +335,7 @@ func TestEnvoyFilterOrder(t *testing.T) {
 		{
 			Meta: config.Meta{Name: "a-medium-priority", Namespace: "testns-1", GroupVersionKind: gvk.EnvoyFilter, CreationTimestamp: ctime},
 			Spec: &networking.EnvoyFilter{
+				Priority: 10,
 				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
 					{
 						Patch: &networking.EnvoyFilter_Patch{},


### PR DESCRIPTION
**Adding missing priority field in the push_context test data**
Test data `a-medium-priority` should have priority 10. It is currently relying on the default priority.