### PR TITLE
fix gen duplicate clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -250,7 +250,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 	}
 
 	// OutboundTunnel cluster is needed for sidecar and gateway.
-	if proxy.EnableHBONE() {
+	if proxy.EnableHBONE() && proxy.Type != model.Waypoint {
 		clusters = append(clusters, cb.buildConnectOriginate(proxy, req.Push, nil))
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

```
2024-03-01T00:48:03.248589Z	info	ads	Push Status: {
    "pilot_duplicate_envoy_clusters": {
        "connect_originate": {
            "proxy": "waypoint-istio-waypoint-675bfdb76c-xtbmg.echo-1-909",
            "message": "Duplicate cluster connect_originate found while pushing CDS"
        }
    },
```



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
