### PR TITLE
Revert "use correct proxy sha (#49568)"

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "c6043aa697a170c3aa21afc2671958f1ca85de22"
+    "lastStableSHA": "30e213147c5e54158b6176417c39c46eca60c580"
   },
   {
     "_comment": "",


### PR DESCRIPTION
This reverts commit c204ecaff7af64f905cd51c6fc75844993b2dc1b.

See https://github.com/istio/istio/issues/49561 for more info.