### PR TITLE
Fix nil-pointer dereference on OpenShift introduced in #49336

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -76,11 +76,12 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	log.Info("initializing sidecar injector")
 
 	parameters := inject.WebhookParameters{
-		Watcher:    watcher,
-		Env:        s.environment,
-		Mux:        s.httpsMux,
-		Revision:   args.Revision,
-		KubeClient: s.kubeClient,
+		Watcher:      watcher,
+		Env:          s.environment,
+		Mux:          s.httpsMux,
+		Revision:     args.Revision,
+		KubeClient:   s.kubeClient,
+		MultiCluster: s.multiclusterController,
 	}
 
 	wh, err := inject.NewWebhook(parameters)

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -206,7 +206,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		revision:   p.Revision,
 	}
 
-	if p.KubeClient != nil {
+	if p.MultiCluster != nil {
 		if platform.IsOpenShift() {
 			wh.namespaces = multicluster.BuildMultiClusterKclientComponent[*corev1.Namespace](p.MultiCluster, kubetypes.Filter{})
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fix nil-pointer dereference on OpenShift introduced in #49336. A `MultiCluster` field was introduced that is only accessed on the OpenShift platform, but it was never initialized.

cc @howardjohn 