### PR TITLE
Remove KubeClient from webhookParameters

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -80,7 +80,6 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		Env:          s.environment,
 		Mux:          s.httpsMux,
 		Revision:     args.Revision,
-		KubeClient:   s.kubeClient,
 		MultiCluster: s.multiclusterController,
 	}
 

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -188,8 +188,7 @@ type WebhookParameters struct {
 	// The istio.io/rev this injector is responsible for
 	Revision string
 
-	KubeClient kube.Client
-
+	// MultiCluster is used to access namespaces across clusters
 	MultiCluster multicluster.ComponentBuilder
 }
 


### PR DESCRIPTION
We're retrieving the client from the MultiCluster object now.

This is a leftover from https://github.com/istio/istio/pull/49336 and https://github.com/istio/istio/pull/49689

**Please provide a description of this PR:**