### PR TITLE
Envoy: improve logging format configuration

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	*model.Node
 	// CompliancePolicy to decouple the environment variable dependency.
 	CompliancePolicy string
+	LogAsJson        bool
 }
 
 // toTemplateParams creates a new template configuration for the given configuration.
@@ -109,6 +110,7 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 		option.NodeType(cfg.ID),
 		option.PilotSubjectAltName(cfg.Metadata.PilotSubjectAltName),
 		option.OutlierLogPath(cfg.Metadata.OutlierLogPath),
+		option.ApplicationLogJSON(cfg.LogAsJson),
 		option.DiscoveryHost(discHost),
 		option.Metadata(cfg.Metadata),
 		option.XdsType(xdsType),

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	*model.Node
 	// CompliancePolicy to decouple the environment variable dependency.
 	CompliancePolicy string
-	LogAsJson        bool
+	LogAsJSON        bool
 }
 
 // toTemplateParams creates a new template configuration for the given configuration.
@@ -110,7 +110,7 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 		option.NodeType(cfg.ID),
 		option.PilotSubjectAltName(cfg.Metadata.PilotSubjectAltName),
 		option.OutlierLogPath(cfg.Metadata.OutlierLogPath),
-		option.ApplicationLogJSON(cfg.LogAsJson),
+		option.ApplicationLogJSON(cfg.LogAsJSON),
 		option.DiscoveryHost(discHost),
 		option.Metadata(cfg.Metadata),
 		option.XdsType(xdsType),

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -121,6 +121,10 @@ func OutlierLogPath(value string) Instance {
 	return newOptionOrSkipIfZero("outlier_log_path", value)
 }
 
+func ApplicationLogJSON(value bool) Instance {
+	return newOption("log_json", value)
+}
+
 func LightstepAddress(value string) Instance {
 	return newOptionOrSkipIfZero("lightstep", value).withConvert(addressConverter(value))
 }

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "test.test",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "test.test",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -1,4 +1,9 @@
 {
+  "application_log_config": {
+    "log_format": {
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+    }
+  },
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -1,7 +1,7 @@
 {
   "application_log_config": {
     "log_format": {
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
     }
   },
   "node": {

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -139,16 +139,6 @@ func (e *envoy) args(fname string, overrideFname string) []string {
 		"--disable-hot-restart", // We don't use it, so disable it to simplify Envoy's logic
 		"--allow-unknown-static-fields",
 	}
-	if e.ProxyConfig.LogAsJSON {
-		startupArgs = append(startupArgs,
-			"--log-format",
-			`{"level":"%l","time":"%Y-%m-%dT%T.%fZ","scope":"envoy %n","msg":"%j","caller":"%g:%#","thread":%t}`,
-		)
-	} else {
-		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
-		// this matches Istio log format
-		startupArgs = append(startupArgs, "--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t")
-	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)
 

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -61,7 +61,6 @@ func TestEnvoyArgs(t *testing.T) {
 		"--file-flush-interval-msec", "1000",
 		"--disable-hot-restart",
 		"--allow-unknown-static-fields",
-		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key":"value"}`,

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -275,7 +275,7 @@ func (a *Agent) initializeEnvoyAgent(_ context.Context) error {
 		out, err := bootstrap.New(bootstrap.Config{
 			Node:             node,
 			CompliancePolicy: common_features.CompliancePolicy,
-			LogAsJson:        a.envoyOpts.LogAsJSON,
+			LogAsJSON:        a.envoyOpts.LogAsJSON,
 		}).CreateFile()
 		if err != nil {
 			return fmt.Errorf("failed to generate bootstrap config: %v", err)

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -275,6 +275,7 @@ func (a *Agent) initializeEnvoyAgent(_ context.Context) error {
 		out, err := bootstrap.New(bootstrap.Config{
 			Node:             node,
 			CompliancePolicy: common_features.CompliancePolicy,
+			LogAsJson:        a.envoyOpts.LogAsJSON,
 		}).CreateFile()
 		if err != nil {
 			return fmt.Errorf("failed to generate bootstrap config: %v", err)

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -7,11 +7,11 @@
         "level": "%l",
         "scope": "envoy %n",
         "msg": "%j",
-        "caller": "%s:%# %!",
+        "caller": "%g:%#",
         "thread": "%t"
       }
 {{- else }}
-        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %g:%#\t%v\tthread=%t"
 {{- end }}
     }
   },

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -1,4 +1,20 @@
 {
+  "application_log_config": {
+    "log_format": {
+{{- if .log_json }}
+      "json_format": {
+        "time": "%Y-%m-%dT%T.%fZ",
+        "level": "%l",
+        "scope": "envoy %n",
+        "msg": "%j",
+        "caller": "%s:%# %!",
+        "thread": "%t"
+      }
+{{- else }}
+        "text_format": "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n %s:%# %!\t%v\tthread=%t"
+{{- end }}
+    }
+  },
   "node": {
     "id": "{{ .nodeID }}",
     "cluster": "{{ .cluster }}",


### PR DESCRIPTION
Before/After JSON:
```
{"level":"debug","time":"2024-03-04T12:11:46.931655Z","scope":"envoy connection","msg":"[Tags: \"ConnectionId\":\"2\"] closing socket: 1","caller":"external/envoy/source/common/network/connection_impl.cc:281","thread":947194}
{"time":"2024-03-04T12:15:57.204132Z","level":"debug","scope":"envoy connection","msg":"closing socket: 0","caller":"connection_impl.cc:281 closeSocket","thread":"956652","ConnectionId":"2"}
```

Before/After plain:
```
2024-03-04T12:21:24.654824Z     debug   envoy connection external/envoy/source/common/network/connection_impl.cc:281    [Tags: "ConnectionId":"2"] closing socket: 0    thread=963777
2024-03-04T12:21:00.256847Z     debug   envoy connection connection_impl.cc:281 closeSocket     [Tags: "ConnectionId":"2"] closing socket: 0    thread=962566
```

Primary benefit is to put envoys structured logs (`[Tags: "ConnectionId":"2"])` into proper top level json keys. We also improve the source file format 