### PR TITLE
handling use-waypoint

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1315,20 +1315,6 @@ func (node *Proxy) EnableHBONE() bool {
 	return node.IsAmbient() || (features.EnableHBONE && bool(node.Metadata.EnableHBONE))
 }
 
-// WaypointScope is either an entire namespace or an individual service account
-// in the namespace. This setting dictates the upstream TLS verification
-// strategy, depending on the binding of the waypoints to its backend
-// workloads.
-type WaypointScope struct {
-	Namespace string
-}
-
-func (node *Proxy) WaypointScope() WaypointScope {
-	return WaypointScope{
-		Namespace: node.ConfigNamespace,
-	}
-}
-
 func (node *Proxy) SetWorkloadEntry(name string, create bool) {
 	node.Lock()
 	defer node.Unlock()

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -1320,14 +1320,12 @@ func (node *Proxy) EnableHBONE() bool {
 // strategy, depending on the binding of the waypoints to its backend
 // workloads.
 type WaypointScope struct {
-	Namespace      string
-	ServiceAccount string // optional
+	Namespace string
 }
 
 func (node *Proxy) WaypointScope() WaypointScope {
 	return WaypointScope{
-		Namespace:      node.ConfigNamespace,
-		ServiceAccount: node.Metadata.Annotations[constants.WaypointServiceAccount],
+		Namespace: node.ConfigNamespace,
 	}
 }
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2457,6 +2457,6 @@ func (ps *PushContext) WaypointsFor(network, address string) []netip.Addr {
 }
 
 // WorkloadsForWaypoint returns all workloads associated with a given waypoint identified by it's network address
-func (ps *PushContext) WorkloadsForWaypoint(network, address string) []WorkloadInfo {
-	return ps.ambientIndex.WorkloadsForWaypoint(network, address)
+func (ps *PushContext) WorkloadsForWaypoint(key WaypointKey) []WorkloadInfo {
+	return ps.ambientIndex.WorkloadsForWaypoint(key)
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2456,7 +2456,7 @@ func (ps *PushContext) WaypointsFor(network, address string) []netip.Addr {
 	return ps.ambientIndex.Waypoint(network, address)
 }
 
-// WorkloadsForWaypoint returns all workloads associated with a given WaypointScope
-func (ps *PushContext) WorkloadsForWaypoint(scope WaypointScope) []WorkloadInfo {
-	return ps.ambientIndex.WorkloadsForWaypoint(scope)
+// WorkloadsForWaypoint returns all workloads associated with a given waypoint identified by it's network address
+func (ps *PushContext) WorkloadsForWaypoint(network, address string) []WorkloadInfo {
+	return ps.ambientIndex.WorkloadsForWaypoint(network, address)
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2452,8 +2452,8 @@ func (ps *PushContext) SupportsTunnel(n network.ID, ip string) bool {
 	return false
 }
 
-func (ps *PushContext) WaypointsFor(scope WaypointScope) []netip.Addr {
-	return ps.ambientIndex.Waypoint(scope)
+func (ps *PushContext) WaypointsFor(network, address string) []netip.Addr {
+	return ps.ambientIndex.Waypoint(network, address)
 }
 
 // WorkloadsForWaypoint returns all workloads associated with a given WaypointScope

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -867,7 +867,12 @@ type AmbientIndexes interface {
 	) sets.String
 	Policies(requested sets.Set[ConfigKey]) []WorkloadAuthorization
 	Waypoint(network, address string) []netip.Addr
-	WorkloadsForWaypoint(network, address string) []WorkloadInfo
+	WorkloadsForWaypoint(WaypointKey) []WorkloadInfo
+}
+
+type WaypointKey struct {
+	Network   string
+	Addresses []string
 }
 
 // NoopAmbientIndexes provides an implementation of AmbientIndexes that always returns nil, to easily "skip" it.
@@ -893,7 +898,7 @@ func (u NoopAmbientIndexes) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 
-func (u NoopAmbientIndexes) WorkloadsForWaypoint(string, string) []WorkloadInfo {
+func (u NoopAmbientIndexes) WorkloadsForWaypoint(WaypointKey) []WorkloadInfo {
 	return nil
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -866,7 +866,7 @@ type AmbientIndexes interface {
 		currentSubs sets.String,
 	) sets.String
 	Policies(requested sets.Set[ConfigKey]) []WorkloadAuthorization
-	Waypoint(scope WaypointScope) []netip.Addr
+	Waypoint(network, address string) []netip.Addr
 	WorkloadsForWaypoint(scope WaypointScope) []WorkloadInfo
 }
 
@@ -889,7 +889,7 @@ func (u NoopAmbientIndexes) Policies(sets.Set[ConfigKey]) []WorkloadAuthorizatio
 	return nil
 }
 
-func (u NoopAmbientIndexes) Waypoint(WaypointScope) []netip.Addr {
+func (u NoopAmbientIndexes) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -867,7 +867,7 @@ type AmbientIndexes interface {
 	) sets.String
 	Policies(requested sets.Set[ConfigKey]) []WorkloadAuthorization
 	Waypoint(network, address string) []netip.Addr
-	WorkloadsForWaypoint(scope WaypointScope) []WorkloadInfo
+	WorkloadsForWaypoint(network, address string) []WorkloadInfo
 }
 
 // NoopAmbientIndexes provides an implementation of AmbientIndexes that always returns nil, to easily "skip" it.
@@ -893,7 +893,7 @@ func (u NoopAmbientIndexes) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 
-func (u NoopAmbientIndexes) WorkloadsForWaypoint(scope WaypointScope) []WorkloadInfo {
+func (u NoopAmbientIndexes) WorkloadsForWaypoint(string, string) []WorkloadInfo {
 	return nil
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -153,14 +153,8 @@ func (cb *ClusterBuilder) buildWaypointConnectOriginate(proxy *model.Proxy, push
 	// Restrict upstream SAN to waypoint scope.
 	scope := proxy.WaypointScope()
 	m := &matcher.StringMatcher{}
-	if scope.ServiceAccount != "" {
-		m.MatchPattern = &matcher.StringMatcher_Exact{
-			Exact: spiffe.MustGenSpiffeURI(scope.Namespace, scope.ServiceAccount),
-		}
-	} else {
-		m.MatchPattern = &matcher.StringMatcher_Prefix{
-			Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + scope.Namespace + "/sa/",
-		}
+	m.MatchPattern = &matcher.StringMatcher_Prefix{
+		Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + scope.Namespace + "/sa/",
 	}
 	return cb.buildConnectOriginate(proxy, push, m)
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -148,9 +148,6 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 	return clusters
 }
 
-// TODO(ilrudie) this is a bit broken by removing sa scoping as a concept. need to rework it
-// we now calculate a list of all sa's that are served by a waypoint based on waypoint network address, consider using that
-// CONNECT origination cluster
 func (cb *ClusterBuilder) buildWaypointConnectOriginate(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
 	m := &matcher.StringMatcher{}
 	m.MatchPattern = &matcher.StringMatcher_Prefix{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_waypoint.go
@@ -152,11 +152,9 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 // we now calculate a list of all sa's that are served by a waypoint based on waypoint network address, consider using that
 // CONNECT origination cluster
 func (cb *ClusterBuilder) buildWaypointConnectOriginate(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
-	// Restrict upstream SAN to waypoint scope.
-	scope := proxy.WaypointScope()
 	m := &matcher.StringMatcher{}
 	m.MatchPattern = &matcher.StringMatcher_Prefix{
-		Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + scope.Namespace + "/sa/",
+		Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + proxy.Metadata.Namespace + "/sa/",
 	}
 	return cb.buildConnectOriginate(proxy, push, m)
 }

--- a/pilot/pkg/networking/core/v1alpha3/waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/waypoint.go
@@ -49,8 +49,11 @@ func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.
 	network := node.Metadata.Network.String()
 	workloads := make([]model.WorkloadInfo, 0)
 	for _, svct := range node.ServiceTargets {
-		ip := svct.Service.ClusterVIPs.GetAddressesFor(node.GetClusterID())[0]
-		wl := push.WorkloadsForWaypoint(network, ip)
+		ips := svct.Service.ClusterVIPs.GetAddressesFor(node.GetClusterID())
+		wl := push.WorkloadsForWaypoint(model.WaypointKey{
+			Network:   network,
+			Addresses: ips,
+		})
 		workloads = append(workloads, wl...)
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/waypoint.go
+++ b/pilot/pkg/networking/core/v1alpha3/waypoint.go
@@ -46,8 +46,14 @@ type waypointServices struct {
 
 // findWaypointResources returns workloads and services associated with the waypoint proxy
 func findWaypointResources(node *model.Proxy, push *model.PushContext) ([]model.WorkloadInfo, *waypointServices) {
-	scope := node.WaypointScope()
-	workloads := push.WorkloadsForWaypoint(scope)
+	network := node.Metadata.Network.String()
+	workloads := make([]model.WorkloadInfo, 0)
+	for _, svct := range node.ServiceTargets {
+		ip := svct.Service.ClusterVIPs.GetAddressesFor(node.GetClusterID())[0]
+		wl := push.WorkloadsForWaypoint(network, ip)
+		workloads = append(workloads, wl...)
+	}
+
 	return workloads, findWorkloadServices(workloads, push)
 }
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -65,13 +65,13 @@ func (c *Controller) Waypoint(network, address string) []netip.Addr {
 	return res
 }
 
-func (c *Controller) WorkloadsForWaypoint(network, address string) []model.WorkloadInfo {
+func (c *Controller) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo {
 	if !features.EnableAmbientControllers {
 		return nil
 	}
 	var res []model.WorkloadInfo
 	for _, p := range c.GetRegistries() {
-		res = append(res, p.WorkloadsForWaypoint(network, address)...)
+		res = append(res, p.WorkloadsForWaypoint(key)...)
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -54,13 +54,13 @@ type Controller struct {
 	model.NetworkGatewaysHandler
 }
 
-func (c *Controller) Waypoint(scope model.WaypointScope) []netip.Addr {
+func (c *Controller) Waypoint(network, address string) []netip.Addr {
 	if !features.EnableAmbientControllers {
 		return nil
 	}
 	var res []netip.Addr
 	for _, p := range c.GetRegistries() {
-		res = append(res, p.Waypoint(scope)...)
+		res = append(res, p.Waypoint(network, address)...)
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -65,13 +65,13 @@ func (c *Controller) Waypoint(network, address string) []netip.Addr {
 	return res
 }
 
-func (c *Controller) WorkloadsForWaypoint(scope model.WaypointScope) []model.WorkloadInfo {
+func (c *Controller) WorkloadsForWaypoint(network, address string) []model.WorkloadInfo {
 	if !features.EnableAmbientControllers {
 		return nil
 	}
 	var res []model.WorkloadInfo
 	for _, p := range c.GetRegistries() {
-		res = append(res, p.WorkloadsForWaypoint(scope)...)
+		res = append(res, p.WorkloadsForWaypoint(network, address)...)
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -209,20 +209,17 @@ func New(options Options) Index {
 		if waypoint == nil {
 			return nil
 		}
-		log.Errorf("waypoint found for %v in %v\n", w.Name, w.Namespace)
 		waypointAddress := waypoint.GetAddress()
 		if waypointAddress == nil {
 			return nil
 		}
 
-		log.Errorf("waypoint had address %v, for %v in %v\n", waypointAddress, w.Name, w.Namespace)
 		ip := waypointAddress.GetAddress()
 		netip, _ := netip.AddrFromSlice(ip)
 		netaddr := networkAddress{
 			network: waypointAddress.GetNetwork(),
 			ip:      netip.String(),
 		}
-		log.Errorf("indexed waypoint{%v, %v} for %v\n", netaddr, waypointAddress, w.Name)
 		return append(make([]networkAddress, 1), netaddr)
 	})
 	// Subtle: make sure we register the event after the Index are created. This ensures when we get the event, the index is populated.

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -175,6 +175,7 @@ func New(options Options) Index {
 		WorkloadEntries,
 		ServiceEntries,
 		AllPolicies,
+		Namespaces,
 	)
 	WorkloadAddressIndex := krt.CreateIndex[model.WorkloadInfo, networkAddress](Workloads, networkAddressFromWorkload)
 	WorkloadServiceIndex := krt.CreateIndex[model.WorkloadInfo, string](Workloads, func(o model.WorkloadInfo) []string {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -44,7 +44,7 @@ import (
 type Index interface {
 	Lookup(key string) []model.AddressInfo
 	All() []model.AddressInfo
-	WorkloadsForWaypoint(network, address string) []model.WorkloadInfo
+	WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 	Waypoint(network, address string) []netip.Addr
 	SyncAll()
 	model.AmbientIndexes
@@ -380,14 +380,18 @@ func (a *index) AddressInformation(addresses sets.String) ([]model.AddressInfo, 
 	return res, sets.New(removed...)
 }
 
-func (a *index) WorkloadsForWaypoint(network, address string) []model.WorkloadInfo {
+func (a *index) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo {
+	// TODO: we should be able to handle multiple IPs or a hostname
+	if len(key.Addresses) == 0 {
+		return nil
+	}
 	workloads := a.workloads.ByOwningWaypoint.Lookup(networkAddress{
-		network: network,
-		ip:      address,
+		network: key.Network,
+		ip:      key.Addresses[0],
 	})
 	services := a.services.ByOwningWaypoint.Lookup(networkAddress{
-		network: network,
-		ip:      address,
+		network: key.Network,
+		ip:      key.Addresses[0],
 	})
 	workloadsFromServices := make([]model.WorkloadInfo, 0)
 	for _, s := range services {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -151,7 +151,7 @@ func New(options Options) Index {
 		return model.ConfigKey{Kind: kind.AuthorizationPolicy, Name: i.Authorization.Name, Namespace: i.Authorization.Namespace}
 	}), false)
 
-	WorkloadServices := a.ServicesCollection(Services, ServiceEntries)
+	WorkloadServices := a.ServicesCollection(Services, ServiceEntries, Waypoints)
 	ServiceAddressIndex := krt.CreateIndex[model.ServiceInfo, networkAddress](WorkloadServices, networkAddressFromService)
 	WorkloadServices.RegisterBatch(krt.BatchedEventFilter(
 		func(a model.ServiceInfo) *workloadapi.Service {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -400,8 +400,6 @@ func (a *index) WorkloadsForWaypoint(network, address string) []model.WorkloadIn
 	return workloads
 }
 
-// Waypoint finds all waypoint IP addresses for a given scope.  Performs first a Namespace+ServiceAccount
-// then falls back to any Namespace wide waypoints
 func (a *index) Waypoint(network, address string) []netip.Addr {
 	res := sets.Set[netip.Addr]{}
 	networkAddr := networkAddress{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -388,7 +388,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		s.lookup(s.addrXdsName("127.0.0.200"))[0].Address.GetWorkload().Waypoint,
 		nil)
 
-	// make sure looking up the waypoint for a wl by network and adcdress functions correctly
+	// make sure looking up the waypoint for a wl by network and address functions correctly
 	assert.Equal(t, len(s.Waypoint(testNW, "127.0.0.1")), 1)
 	for _, k := range s.Waypoint(testNW, "127.0.0.1") {
 		assert.Equal(t, k.AsSlice(), netip.MustParseAddr("10.0.0.2").AsSlice())
@@ -1423,12 +1423,6 @@ func (s *ambientTestServer) annotatePod(t *testing.T, name, ns string, annotatio
 
 func (s *ambientTestServer) addWorkloadEntries(t *testing.T, ip string, name, sa string, labels map[string]string) {
 	t.Helper()
-
-	// hmmmm.... this causes some issues
-	// s.ns.CreateOrUpdate(&corev1.Namespace{
-	// 	ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{"istio.io/dataplane-mode": "ambient"}},
-	// })
-
 	s.we.CreateOrUpdate(generateWorkloadEntry(ip, name, "ns1", sa, labels, nil))
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1156,26 +1156,27 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 
 func TestWorkloadsForWaypointOrder(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
-	s := newAmbientTestServer(t, "", "")
+	s := newAmbientTestServer(t, "", testNW)
 
-	assertOrderedWaypoint := func(t *testing.T, waypoint model.WaypointScope, expected ...string) {
+	assertOrderedWaypoint := func(t *testing.T, network, address string, expected ...string) {
 		t.Helper()
-		wls := s.WorkloadsForWaypoint(waypoint)
+		wls := s.WorkloadsForWaypoint(network, address)
 		wl := make([]string, len(wls))
 		for i, e := range wls {
 			wl[i] = e.ResourceName()
 		}
 		assert.Equal(t, wl, expected)
 	}
+	s.addWaypoint(t, "10.0.0.1", "waypoint", "", true)
 
 	// expected order is pod3, pod1, pod2, which is the order of creation
-	s.addPods(t, "127.0.0.3", "pod3", "sa3", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
+	s.addPods(t, "127.0.0.3", "pod3", "sa3", map[string]string{"app": "a"}, map[string]string{constants.AmbientUseWaypoint: "waypoint"}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod3"))
-	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
+	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, map[string]string{constants.AmbientUseWaypoint: "waypoint"}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
-	s.addPods(t, "127.0.0.2", "pod2", "sa2", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
+	s.addPods(t, "127.0.0.2", "pod2", "sa2", map[string]string{"app": "a"}, map[string]string{constants.AmbientUseWaypoint: "waypoint"}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod2"))
-	assertOrderedWaypoint(t, model.WaypointScope{Namespace: testNS},
+	assertOrderedWaypoint(t, testNW, "10.0.0.1",
 		s.podXdsName("pod3"), s.podXdsName("pod1"), s.podXdsName("pod2"))
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1138,7 +1138,10 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 
 	assertWaypoint := func(t *testing.T, waypointNetwork string, waypointAddress string, expected ...string) {
 		t.Helper()
-		wl := sets.New(slices.Map(s.WorkloadsForWaypoint(waypointNetwork, waypointAddress), func(e model.WorkloadInfo) string {
+		wl := sets.New(slices.Map(s.WorkloadsForWaypoint(model.WaypointKey{
+			Network:   waypointNetwork,
+			Addresses: []string{waypointAddress},
+		}), func(e model.WorkloadInfo) string {
 			return e.ResourceName()
 		})...)
 		assert.Equal(t, wl, sets.New(expected...))
@@ -1185,7 +1188,10 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 
 	assertOrderedWaypoint := func(t *testing.T, network, address string, expected ...string) {
 		t.Helper()
-		wls := s.WorkloadsForWaypoint(network, address)
+		wls := s.WorkloadsForWaypoint(model.WaypointKey{
+			Network:   network,
+			Addresses: []string{address},
+		})
 		wl := make([]string, len(wls))
 		for i, e := range wls {
 			wl[i] = e.ResourceName()

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1002,14 +1002,14 @@ func TestEmptyVIPsExcluded(t *testing.T) {
 // assertWaypointAddressForPod takes a pod name for key and the expected waypoint IP Address
 // if the IP is empty we assume you're asserting that the pod's waypoint address is nil
 // will assert that the GW address for the pod's waypoint is the expected address
-func (s *ambientTestServer) assertWaypointAddressForPod(t *testing.T, key, expectedIp string) {
+func (s *ambientTestServer) assertWaypointAddressForPod(t *testing.T, key, expectedIP string) {
 	t.Helper()
 	var expectedAddress *workloadapi.GatewayAddress
-	if expectedIp != "" { // "" is assumed to mean a nil address
+	if expectedIP != "" { // "" is assumed to mean a nil address
 		expectedAddress = &workloadapi.GatewayAddress{
 			Destination: &workloadapi.GatewayAddress_Address{
 				Address: &workloadapi.NetworkAddress{
-					Address: netip.MustParseAddr(expectedIp).AsSlice(),
+					Address: netip.MustParseAddr(expectedIP).AsSlice(),
 				},
 			},
 			HboneMtlsPort: 15008,
@@ -1363,16 +1363,16 @@ func (s *ambientTestServer) addPods(t *testing.T, ip string, name, sa string, la
 }
 
 // just overwrites the annotations
+// nolint: unparam
 func (s *ambientTestServer) annotatePod(t *testing.T, name, ns string, annotations map[string]string) {
 	t.Helper()
 
 	p := s.pc.Get(name, ns)
 	if p == nil {
 		return
-	} else {
-		p.ObjectMeta.Annotations = annotations
-		s.pc.Update(p)
 	}
+	p.ObjectMeta.Annotations = annotations
+	s.pc.Update(p)
 }
 
 func (s *ambientTestServer) addWorkloadEntries(t *testing.T, ip string, name, sa string, labels map[string]string) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -232,9 +232,23 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
-	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa1"}, true, corev1.PodRunning)
+	s.addPods(t,
+		"127.0.0.1",
+		"pod1",
+		"sa1",
+		map[string]string{"app": "a"},
+		map[string]string{constants.AmbientUseWaypoint: "waypoint-sa1"},
+		true,
+		corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
-	s.addPods(t, "127.0.0.2", "pod2", "sa2", map[string]string{"app": "b"}, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa2"}, true, corev1.PodRunning)
+	s.addPods(t,
+		"127.0.0.2",
+		"pod2",
+		"sa2",
+		map[string]string{"app": "b"},
+		map[string]string{constants.AmbientUseWaypoint: "waypoint-sa2"},
+		true,
+		corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod2"))
 
 	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", "sa1", false)
@@ -268,7 +282,14 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	s.addPods(t, "127.0.0.3", "pod3", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod3"))
 	// Add pods for app "b".
-	s.addPods(t, "127.0.0.4", "pod4", "sa2", map[string]string{"app": "b"}, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa2"}, true, corev1.PodRunning)
+	s.addPods(t,
+		"127.0.0.4",
+		"pod4",
+		"sa2",
+		map[string]string{"app": "b"},
+		map[string]string{constants.AmbientUseWaypoint: "waypoint-sa2"},
+		true,
+		corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod4"))
 
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "", true)
@@ -360,7 +381,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-ns-pod"))
 	assert.Equal(t,
-		s.lookup(s.addrXdsName("127.0.0.3"))[0].Address.GetWorkload().Waypoint.GetAddress().Address, netip.MustParseAddr("10.0.0.2").AsSlice())
+		s.lookup(s.addrXdsName("127.0.0.3"))[0].Address.GetWorkload().Waypoint.GetAddress().Address,
+		netip.MustParseAddr("10.0.0.2").AsSlice())
 	// Waypoints do not have waypoints
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.200"))[0].Address.GetWorkload().Waypoint,
@@ -385,7 +407,8 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	)
 	// Make sure Service sees waypoints as well
 	assert.Equal(t,
-		s.lookup(s.addrXdsName("10.0.0.1"))[1].Address.GetWorkload().Waypoint.GetAddress().Address, netip.MustParseAddr("10.0.0.2").AsSlice())
+		s.lookup(s.addrXdsName("10.0.0.1"))[1].Address.GetWorkload().Waypoint.GetAddress().Address,
+		netip.MustParseAddr("10.0.0.2").AsSlice())
 
 	// Delete a waypoint
 	s.deletePod(t, "waypoint2-ns-pod")
@@ -1430,12 +1453,15 @@ func (s *ambientTestServer) deleteWorkloadEntry(t *testing.T, name string) {
 	s.we.Delete(name, "ns1")
 }
 
-func (s *ambientTestServer) addServiceEntry(t *testing.T, hostStr string, addresses []string, name, ns string, labels map[string]string, epAddresses []string) {
+func (s *ambientTestServer) addServiceEntry(t *testing.T,
+	hostStr string,
+	addresses []string,
+	name,
+	ns string,
+	labels map[string]string,
+	epAddresses []string,
+) {
 	t.Helper()
-
-	// s.ns.CreateOrUpdate(&corev1.Namespace{
-	// 	ObjectMeta: metav1.ObjectMeta{Name: ns, Labels: map[string]string{"istio.io/dataplane-mode": "ambient"}},
-	// })
 
 	se := &apiv1alpha3.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -366,10 +366,10 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.200"))[0].Address.GetWorkload().Waypoint,
 		nil)
-	assert.Equal(t, len(s.Waypoint(model.WaypointScope{Namespace: testNS, ServiceAccount: "namespace-wide"})), 1)
-	for _, k := range s.Waypoint(model.WaypointScope{Namespace: testNS, ServiceAccount: "namespace-wide"}) {
-		assert.Equal(t, k.AsSlice(), netip.MustParseAddr("10.0.0.2").AsSlice())
-	}
+	// assert.Equal(t, len(s.Waypoint(model.WaypointScope{Namespace: testNS, ServiceAccount: "namespace-wide"})), 1)
+	// for _, k := range s.Waypoint(model.WaypointScope{Namespace: testNS, ServiceAccount: "namespace-wide"}) {
+	// 	assert.Equal(t, k.AsSlice(), netip.MustParseAddr("10.0.0.2").AsSlice())
+	// }
 
 	s.addService(t, "svc1",
 		map[string]string{},
@@ -1139,21 +1139,18 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"))
 	assertWaypoint(t, model.WaypointScope{Namespace: testNS}, s.podXdsName("pod1"), s.podXdsName("pod2"))
 	// TODO: should this be returned? Or should it be filtered because such a waypoint does not exist
-	assertWaypoint(t, model.WaypointScope{Namespace: testNS, ServiceAccount: "sa1"}, s.podXdsName("pod1"))
 
 	// Add a service account waypoint to the pod
 	s.annotatePod(t, "pod1", testNS, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa1"})
 	s.assertEvent(t, s.podXdsName("pod1"))
 
-	assertWaypoint(t, model.WaypointScope{Namespace: testNS}, s.podXdsName("pod2"))
-	assertWaypoint(t, model.WaypointScope{Namespace: testNS, ServiceAccount: "sa1"}, s.podXdsName("pod1"))
+	assertWaypoint(t, model.WaypointScope{Namespace: testNS}, s.podXdsName("pod1"), s.podXdsName("pod2"))
 
 	// Revert back
 	s.annotatePod(t, "pod1", testNS, map[string]string{})
 	s.assertEvent(t, s.podXdsName("pod1"))
 
 	assertWaypoint(t, model.WaypointScope{Namespace: testNS}, s.podXdsName("pod1"), s.podXdsName("pod2"))
-	assertWaypoint(t, model.WaypointScope{Namespace: testNS, ServiceAccount: "sa1"}, s.podXdsName("pod1"))
 }
 
 func TestWorkloadsForWaypointOrder(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -78,7 +78,6 @@ func byteIPToAddr(b []byte) netip.Addr {
 }
 
 func (a index) getWaypointAddress(w *Waypoint) *workloadapi.GatewayAddress {
-
 	// probably overly cautious... I don't think the ambient index impl counts something with zero addresses as waypoint
 	if w != nil && len(w.Addresses) >= 1 {
 		return &workloadapi.GatewayAddress{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/helpers.go
@@ -77,6 +77,22 @@ func byteIPToAddr(b []byte) netip.Addr {
 	return ip
 }
 
+func (a index) getWaypointAddress(w *Waypoint) *workloadapi.GatewayAddress {
+
+	// probably overly cautious... I don't think the ambient index impl counts something with zero addresses as waypoint
+	if w != nil && len(w.Addresses) >= 1 {
+		return &workloadapi.GatewayAddress{
+			Destination: &workloadapi.GatewayAddress_Address{
+				// probably use from Cidr instead?
+				Address: a.toNetworkAddressFromIP(w.Addresses[0]),
+			},
+			// TODO: look up the HBONE port instead of hardcoding it
+			HboneMtlsPort: 15008,
+		}
+	}
+	return nil
+}
+
 func (a *index) toNetworkAddress(vip string) (*workloadapi.NetworkAddress, error) {
 	ip, err := netip.ParseAddr(vip)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -33,6 +33,7 @@ func (a *index) ServicesCollection(
 	Services krt.Collection[*v1.Service],
 	ServiceEntries krt.Collection[*networkingclient.ServiceEntry],
 	Waypoints krt.Collection[Waypoint],
+	Namespaces krt.Collection[*v1.Namespace],
 ) krt.Collection[model.ServiceInfo] {
 	ServicesInfo := krt.NewCollection(Services, func(ctx krt.HandlerContext, s *v1.Service) *model.ServiceInfo {
 		portNames := map[int32]model.ServicePortName{}
@@ -42,7 +43,7 @@ func (a *index) ServicesCollection(
 				TargetPortName: p.TargetPort.StrVal,
 			}
 		}
-		waypoint := fetchWaypoint(ctx, Waypoints, s.ObjectMeta)
+		waypoint := fetchWaypoint(ctx, Waypoints, Namespaces, s.ObjectMeta)
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
 		return &model.ServiceInfo{
 			Service:       a.constructService(s, waypoint),
@@ -52,7 +53,7 @@ func (a *index) ServicesCollection(
 		}
 	}, krt.WithName("ServicesInfo"))
 	ServiceEntriesInfo := krt.NewManyCollection(ServiceEntries, func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []model.ServiceInfo {
-		waypoint := fetchWaypoint(ctx, Waypoints, s.ObjectMeta)
+		waypoint := fetchWaypoint(ctx, Waypoints, Namespaces, s.ObjectMeta)
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
 		return a.serviceEntriesInfo(s, waypoint)
 	}, krt.WithName("ServiceEntriesInfo"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -58,6 +58,7 @@ func (a *index) ServicesCollection(
 		return a.serviceEntriesInfo(s, waypoint)
 	}, krt.WithName("ServiceEntriesInfo"))
 	WorkloadServices := krt.JoinCollection([]krt.Collection[model.ServiceInfo]{ServicesInfo, ServiceEntriesInfo}, krt.WithName("WorkloadServices"))
+	// workloadapi services NOT workloads x services somehow
 	return WorkloadServices
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/ptr"
 )
 
 type Waypoint struct {
@@ -48,10 +49,10 @@ func fetchWaypoint(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], N
 	}
 
 	// try fetching the namespace-defined waypoint
-	namespace := krt.FetchOne[*v1.Namespace](ctx, Namespaces, krt.FilterKey(o.Namespace))
+	namespace := ptr.OrEmpty[*v1.Namespace](krt.FetchOne[*v1.Namespace](ctx, Namespaces, krt.FilterKey(o.Namespace)))
 	// this probably should never be nil. How would o exist in a namespace we know nothing about? maybe edge case of starting the controller or ns delete?
-	if namespace != nil && *namespace != nil {
-		wpNamespace := getUseWaypoint((*namespace).ObjectMeta)
+	if namespace != nil {
+		wpNamespace := getUseWaypoint(namespace.ObjectMeta)
 		if wpNamespace != nil {
 			return krt.FetchOne[Waypoint](ctx, Waypoints, krt.FilterName(wpNamespace.Name, wpNamespace.Namespace))
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -47,7 +47,7 @@ func fetchWaypoint(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], N
 		// plausible the object has a waypoint defined but that waypoint's underlying gateway is not ready, in this case we'd return nil here even if
 		// the namespace-defined waypoint is ready and would not be nil... is this OK or should we handle that? Could lead to odd behavior when
 		// o was reliant on the namespace waypoint and then get's a use-waypoint annotation added before that gateway is ready.
-		// goes from having a waypoint to having no waypoint and then eventualy gets a waypoint back
+		// goes from having a waypoint to having no waypoint and then eventually gets a waypoint back
 		// return krt.FetchOne[Waypoint](ctx, Waypoints, krt.FilterName(wp.Name, wp.Namespace))
 		return krt.FetchOne[Waypoint](ctx, Waypoints, krt.FilterKey(wp.ResourceName()))
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -50,7 +50,6 @@ func fetchWaypoint(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], N
 		// the namespace-defined waypoint is ready and would not be nil... is this OK or should we handle that? Could lead to odd behavior when
 		// o was reliant on the namespace waypoint and then get's a use-waypoint annotation added before that gateway is ready.
 		// goes from having a waypoint to having no waypoint and then eventually gets a waypoint back
-		// return krt.FetchOne[Waypoint](ctx, Waypoints, krt.FilterName(wp.Name, wp.Namespace))
 		return krt.FetchOne[Waypoint](ctx, Waypoints, krt.FilterKey(wp.ResourceName()))
 	}
 
@@ -65,7 +64,7 @@ func fetchWaypoint(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], N
 		}
 	}
 
-	// neither o nore it's namespace has a use-waypoint annotation
+	// neither o nor it's namespace has a use-waypoint annotation
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -33,8 +33,7 @@ import (
 type Waypoint struct {
 	krt.Named
 
-	ForServiceAccount string
-	Addresses         []netip.Addr
+	Addresses []netip.Addr
 }
 
 func fetchWaypoint(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], Namespaces krt.Collection[*v1.Namespace], o metav1.ObjectMeta) *Waypoint {
@@ -116,11 +115,9 @@ func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway]) krt.Collecti
 			// ignore Kubernetes Gateways which aren't waypoints
 			return nil
 		}
-		sa := gateway.Annotations[constants.WaypointServiceAccount]
 		return &Waypoint{
-			Named:             krt.NewNamed(gateway),
-			ForServiceAccount: sa,
-			Addresses:         getGatewayAddrs(gateway),
+			Named:     krt.NewNamed(gateway),
+			Addresses: getGatewayAddrs(gateway),
 		}
 	}, krt.WithName("Waypoints"))
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -69,7 +69,7 @@ func (a *index) WorkloadsCollection(
 		wp := fetchWaypoint(ctx, Waypoints, Namespaces, se.ObjectMeta)
 
 		// this is some partial object meta we can pass through so that WL found in the Endpoints
-		// may inherrit the namespace scope waypoint from the SE... the Endpoints do not have real object meta
+		// may inherit the namespace scope waypoint from the SE... the Endpoints do not have real object meta
 		// and therefore they can't be annotated with wl scope waypoints right now
 		someObjectMeta := metav1.ObjectMeta{
 			Namespace: se.Namespace,
@@ -166,7 +166,6 @@ func (a *index) workloadEntryWorkloadBuilder(
 		policies = append(policies, convertedSelectorPeerAuthentications(meshCfg.GetRootNamespace(), auths)...)
 		var waypoint *Waypoint
 		if p.Labels[constants.ManagedGatewayLabel] != constants.ManagedGatewayMeshControllerLabel {
-			// waypoints = fetchWaypoints(ctx, Waypoints, p.Namespace, p.Spec.ServiceAccount)
 			waypoint = fetchWaypoint(ctx, Waypoints, Namespaces, p.ObjectMeta)
 		}
 		var waypointAddress *workloadapi.GatewayAddress
@@ -249,7 +248,6 @@ func (a *index) podWorkloadBuilder(
 		var waypoint *Waypoint
 		if p.Labels[constants.ManagedGatewayLabel] != constants.ManagedGatewayMeshControllerLabel {
 			// Waypoints do not have waypoints, but anything else does
-			// waypoints = fetchWaypoints(ctx, Waypoints, p.Namespace, p.Spec.ServiceAccountName)
 			waypoint = fetchWaypoint(ctx, Waypoints, Namespaces, p.ObjectMeta)
 		}
 		var waypointAddress *workloadapi.GatewayAddress
@@ -312,27 +310,6 @@ func pickTrustDomain() string {
 	return ""
 }
 
-// func (a *index) pickWaypoint(waypoints []Waypoint) *workloadapi.GatewayAddress {
-// 	if len(waypoints) > 0 {
-// 		// Pick the best waypoint. One scoped to a SA is higher precedence
-// 		wp := ptr.OrDefault(
-// 			slices.FindFunc(waypoints, func(waypoint Waypoint) bool {
-// 				return waypoint.ForServiceAccount != ""
-// 			}),
-// 			waypoints[0],
-// 		)
-// 		// TODO: should we support multiple addresses?
-// 		return &workloadapi.GatewayAddress{
-// 			Destination: &workloadapi.GatewayAddress_Address{
-// 				Address: a.toNetworkAddressFromIP(wp.Addresses[0]),
-// 			},
-// 			// TODO: look up the HBONE port instead of hardcoding it
-// 			HboneMtlsPort: 15008,
-// 		}
-// 	}
-// 	return nil
-// }
-
 func fetchPeerAuthentications(
 	ctx krt.HandlerContext,
 	PeerAuths krt.Collection[*securityclient.PeerAuthentication],
@@ -355,14 +332,6 @@ func fetchPeerAuthentications(
 		return labels.Instance(sel.MatchLabels).SubsetOf(matchLabels)
 	}))
 }
-
-// func fetchWaypoints(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], ns, sa string) []Waypoint {
-// 	return krt.Fetch(ctx, Waypoints,
-// 		krt.FilterNamespace(ns), krt.FilterGeneric(func(a any) bool {
-// 			w := a.(Waypoint)
-// 			return w.ForServiceAccount == "" || w.ForServiceAccount == sa
-// 		}))
-// }
 
 func constructServicesFromWorkloadEntry(p *networkingv1alpha3.WorkloadEntry, services []model.ServiceInfo) map[string]*workloadapi.PortList {
 	res := map[string]*workloadapi.PortList{}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -48,6 +48,7 @@ func (a *index) WorkloadsCollection(
 	WorkloadEntries krt.Collection[*networkingclient.WorkloadEntry],
 	ServiceEntries krt.Collection[*networkingclient.ServiceEntry],
 	AllPolicies krt.Collection[model.WorkloadAuthorization],
+	Namespaces krt.Collection[*v1.Namespace],
 ) krt.Collection[model.WorkloadInfo] {
 	PodWorkloads := krt.NewCollection(
 		Pods,
@@ -65,7 +66,9 @@ func (a *index) WorkloadsCollection(
 		}
 		res := make([]model.WorkloadInfo, 0, len(se.Spec.Endpoints))
 
-		svc := slices.First(a.serviceEntriesInfo(se))
+		wp := fetchWaypoint(ctx, Waypoints, Namespaces, se.ObjectMeta)
+
+		svc := slices.First(a.serviceEntriesInfo(se, wp))
 		if svc == nil {
 			// Not ready yet
 			return nil

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -264,8 +264,9 @@ func TestPodWorkloads(t *testing.T) {
 			Waypoints := krt.NewStaticCollection(extractType[Waypoint](&inputs))
 			WorkloadServices := krt.NewStaticCollection(extractType[model.ServiceInfo](&inputs))
 			MeshConfig := krt.NewStatic(&MeshConfig{slices.First(extractType[meshapi.MeshConfig](&inputs))})
+			Namespaces := krt.NewStaticCollection(extractType[*v1.Namespace](&inputs))
 			assert.Equal(t, len(inputs), 0, fmt.Sprintf("some inputs were not consumed: %v", inputs))
-			builder := a.podWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices)
+			builder := a.podWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices, Namespaces)
 			wrapper := builder(krt.TestingDummyContext{}, tt.pod)
 			var res *workloadapi.Workload
 			if wrapper != nil {
@@ -512,9 +513,10 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			PeerAuths := krt.NewStaticCollection(extractType[*securityclient.PeerAuthentication](&inputs))
 			Waypoints := krt.NewStaticCollection(extractType[Waypoint](&inputs))
 			WorkloadServices := krt.NewStaticCollection(extractType[model.ServiceInfo](&inputs))
+			Namespaces := krt.NewStaticCollection(extractType[*v1.Namespace](&inputs))
 			MeshConfig := krt.NewStatic(&MeshConfig{slices.First(extractType[meshapi.MeshConfig](&inputs))})
 			assert.Equal(t, len(inputs), 0, fmt.Sprintf("some inputs were not consumed: %v", inputs))
-			builder := a.workloadEntryWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices)
+			builder := a.workloadEntryWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices, Namespaces)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
 			var res *workloadapi.Workload
 			if wrapper != nil {

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -376,7 +376,7 @@ func (sd *ServiceDiscovery) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 
-func (sd *ServiceDiscovery) WorkloadsForWaypoint(string, string) []model.WorkloadInfo {
+func (sd *ServiceDiscovery) WorkloadsForWaypoint(model.WaypointKey) []model.WorkloadInfo {
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -372,7 +372,7 @@ func (sd *ServiceDiscovery) Policies(sets.Set[model.ConfigKey]) []model.Workload
 	return nil
 }
 
-func (sd *ServiceDiscovery) Waypoint(model.WaypointScope) []netip.Addr {
+func (sd *ServiceDiscovery) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -376,7 +376,7 @@ func (sd *ServiceDiscovery) Waypoint(string, string) []netip.Addr {
 	return nil
 }
 
-func (sd *ServiceDiscovery) WorkloadsForWaypoint(scope model.WaypointScope) []model.WorkloadInfo {
+func (sd *ServiceDiscovery) WorkloadsForWaypoint(string, string) []model.WorkloadInfo {
 	return nil
 }
 

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -59,9 +59,25 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	if req == nil {
 		return true
 	}
-	if !req.Full {
-		// CDS only handles full push
-		return false
+	switch proxy.Type {
+	case model.Waypoint:
+		if model.HasConfigsOfKind(req.ConfigsUpdated, kind.Address) {
+			// TODO: this logic is identical to that used in LDS, consider refactor into a common function
+			// taken directly from LDS... waypoints need CDS updates on kind.Address changes
+			// after implementing use-waypoint which decouples waypoint creation, wl pod creation
+			// user specifying waypoint use. Without this we're not getting correct waypoint config
+			// in a timely manner
+			return true
+		}
+		// Otherwise, only handle full pushes (skip endpoint-only updates)
+		if !req.Full {
+			return false
+		}
+	default:
+		if !req.Full {
+			// CDS only handles full push
+			return false
+		}
 	}
 	// If none set, we will always push
 	if len(req.ConfigsUpdated) == 0 {

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -739,9 +739,7 @@ func waypointInScope(waypoint *model.Proxy, e *model.IstioEndpoint) bool {
 }
 
 func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr {
-	ips := push.WaypointsFor(model.WaypointScope{
-		Namespace: e.Namespace,
-	})
+	ips := push.WaypointsFor(e.Network.String(), e.Address)
 	return ips
 }
 

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -731,8 +731,7 @@ func supportTunnel(b *EndpointBuilder, e *model.IstioEndpoint) bool {
 
 // waypointInScope computes whether the endpoint is owned by the waypoint
 func waypointInScope(waypoint *model.Proxy, e *model.IstioEndpoint) bool {
-	scope := waypoint.WaypointScope()
-	return scope.Namespace == e.Namespace
+	return waypoint.GetNamespace() == e.Namespace
 }
 
 func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr {

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -732,10 +732,7 @@ func supportTunnel(b *EndpointBuilder, e *model.IstioEndpoint) bool {
 // waypointInScope computes whether the endpoint is owned by the waypoint
 func waypointInScope(waypoint *model.Proxy, e *model.IstioEndpoint) bool {
 	scope := waypoint.WaypointScope()
-	if scope.Namespace != e.Namespace {
-		return false
-	}
-	return true
+	return scope.Namespace == e.Namespace
 }
 
 func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr {

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -40,7 +40,6 @@ import (
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/slices"
-	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/hash"
 )
 
@@ -736,18 +735,12 @@ func waypointInScope(waypoint *model.Proxy, e *model.IstioEndpoint) bool {
 	if scope.Namespace != e.Namespace {
 		return false
 	}
-	ident, _ := spiffe.ParseIdentity(e.ServiceAccount)
-	if scope.ServiceAccount != "" && (scope.ServiceAccount != ident.ServiceAccount) {
-		return false
-	}
 	return true
 }
 
 func findWaypoints(push *model.PushContext, e *model.IstioEndpoint) []netip.Addr {
-	ident, _ := spiffe.ParseIdentity(e.ServiceAccount)
 	ips := push.WaypointsFor(model.WaypointScope{
-		Namespace:      e.Namespace,
-		ServiceAccount: ident.ServiceAccount,
+		Namespace: e.Namespace,
 	})
 	return ips
 }

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -193,4 +193,7 @@ const (
 	AmbientRedirectionEnabled = "enabled"
 	// AmbientRedirectionDisabled is an opt-out, configured by user.
 	AmbientRedirectionDisabled = "disabled"
+
+	// AmbientUseWaypoint is the annotation used to specify which waypoint should be used for a given pod, service, etc...
+	AmbientUseWaypoint = "istio.io/use-waypoint"
 )

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -227,7 +227,6 @@ func DeleteWaypoint(t framework.TestContext, ns namespace.Instance) {
 }
 
 func TeardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, service string) {
-	DeleteWaypoint(t, nsConfig)
 	if service != "" {
 		cs := t.AllClusters().Configs()
 		for _, c := range cs {
@@ -246,6 +245,7 @@ func TeardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, ser
 			}
 		}
 	}
+	DeleteWaypoint(t, nsConfig)
 	waypointError := retry.UntilSuccess(func() error {
 		fetch := testKube.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"="+service)
 		pods, err := testKube.CheckPodsAreReady(fetch)

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -223,6 +223,8 @@ func DeleteWaypoint(t framework.TestContext, ns namespace.Instance) {
 		"delete",
 		"--namespace",
 		ns.Name(),
+		"--service-account",
+		"namespace",
 	})
 }
 
@@ -247,7 +249,7 @@ func TeardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, ser
 	}
 	DeleteWaypoint(t, nsConfig)
 	waypointError := retry.UntilSuccess(func() error {
-		fetch := testKube.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"="+service)
+		fetch := testKube.NewPodFetch(t.AllClusters()[0], nsConfig.Name(), constants.GatewayNameLabel+"=namespace")
 		pods, err := testKube.CheckPodsAreReady(fetch)
 		if err != nil && !errors.Is(err, testKube.ErrNoPodsFetched) {
 			return fmt.Errorf("cannot fetch pod: %v", err)

--- a/pkg/test/framework/components/echo/annotations.go
+++ b/pkg/test/framework/components/echo/annotations.go
@@ -49,6 +49,7 @@ var (
 	SidecarInjectTemplates         = workloadAnnotation(annotation.InjectTemplates.Name, "")
 	SidecarStatsHistogramBuckets   = workloadAnnotation(annotation.SidecarStatsHistogramBuckets.Name, "")
 	AmbientType                    = workloadAnnotation(constants.AmbientRedirection, "")
+	AmbientUseWaypoint             = workloadAnnotation(constants.AmbientUseWaypoint, "")
 )
 
 type AnnotationValue struct {

--- a/releasenotes/notes/49700.yaml
+++ b/releasenotes/notes/49700.yaml
@@ -1,0 +1,45 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+- 49436
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** capability to annotate pods, services, namespaces and other similar kinds with an annotation, `istio.io/use-waypoint`, to specify a waypoint in the form `[<namespace name>]/<waypoint name>`. This replaces the old requirement for waypoints either being scoped to the entire namespace or to a single service account. Opting out of a waypoint can also be done with a value of `#none` to allow a namespace-wide waypoint where specific pods or services are not guarded by a waypoint allowing greater flexibility in waypoint specification and use.
+     
+
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes.
+upgradeNotes:
+  - title: New ambient mode waypoint attachment method
+    content: |
+      Waypoints in Istio's ambient mode no longer use the original service account or namespace attachment semantics. If you were using a namespace-scope waypoint previously migration should be fairly straight forward. Annotate your namespace with the appropriate waypoint and it should function in a similar way.
+
+      If you were using service account attachment there will be more to understand. Under the old waypoint logic all types of traffic, both addressed to a service as well as addressed to a workload, were treated similarly because there wasn't a good way to properly associate a waypoint to a service. With the new attachment this limitation has been resolved. This includes adding a distinction between service addressed and workload addressed traffic. Annotating a service, or service-like kind, will redirect traffic which is service addressed to your waypoint. Likewise annotating a workload will redirect workload addressed traffic. It is therefore important to understand how consumers address your providers and select a waypoint attachment method which corresponds to this method of access. 
+

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -335,6 +335,9 @@ func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, servic
 		cs := t.AllClusters().Configs()
 		for _, c := range cs {
 			oldSvc, err := c.Kube().CoreV1().Services(nsConfig.Name()).Get(t.Context(), service, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting svc %s, err %v", service, err)
+			}
 			annotations := oldSvc.ObjectMeta.GetAnnotations()
 			if annotations == nil {
 				annotations = make(map[string]string, 1)
@@ -365,6 +368,9 @@ func teardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, ser
 		cs := t.AllClusters().Configs()
 		for _, c := range cs {
 			oldSvc, err := c.Kube().CoreV1().Services(nsConfig.Name()).Get(t.Context(), service, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting svc %s, err %v", service, err)
+			}
 			annotations := oldSvc.ObjectMeta.GetAnnotations()
 			if annotations != nil {
 				delete(annotations, constants.AmbientUseWaypoint)

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/test/env"
@@ -43,7 +45,6 @@ import (
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -265,7 +265,6 @@ func TestBookinfo(t *testing.T) {
 					return getGracePeriod(3)
 				})
 			})
-			time.Sleep(time.Minute)
 			ambientComponent.TeardownWaypoints(t, nsConfig, "reviews")
 		})
 }

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -341,11 +341,10 @@ func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, servic
 			}
 			annotations[constants.AmbientUseWaypoint] = "namespace"
 			oldSvc.ObjectMeta.SetAnnotations(annotations)
-			svc, err := c.Kube().CoreV1().Services(nsConfig.Name()).Update(t.Context(), oldSvc, metav1.UpdateOptions{})
+			_, err = c.Kube().CoreV1().Services(nsConfig.Name()).Update(t.Context(), oldSvc, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("error updating svc %s, err %v", service, err)
 			}
-			t.Logf("service updated: %v", svc)
 		}
 	}
 }
@@ -371,11 +370,10 @@ func teardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, ser
 				delete(annotations, constants.AmbientUseWaypoint)
 				oldSvc.ObjectMeta.SetAnnotations(annotations)
 			}
-			svc, err := c.Kube().CoreV1().Services(nsConfig.Name()).Update(t.Context(), oldSvc, metav1.UpdateOptions{})
+			_, err = c.Kube().CoreV1().Services(nsConfig.Name()).Update(t.Context(), oldSvc, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("error updating svc %s, err %v", service, err)
 			}
-			t.Logf("service updated: %v", svc)
 		}
 	}
 	waypointError := retry.UntilSuccess(func() error {

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -128,7 +128,7 @@ func TestBookinfo(t *testing.T) {
 						return nil
 					}, retry.Converge(5))
 				}
-				deleteWaypoints(t, nsConfig, "productpage")
+				teardownWaypoints(t, nsConfig, "productpage")
 				for _, ingressURL := range ingressURLs {
 					retry.UntilSuccessOrFail(t, func() error {
 						resp, err := ingressClient.Get(ingressURL + "/productpage")
@@ -267,7 +267,7 @@ func TestBookinfo(t *testing.T) {
 				})
 			})
 			time.Sleep(time.Minute)
-			deleteWaypoints(t, nsConfig, "reviews")
+			teardownWaypoints(t, nsConfig, "reviews")
 		})
 }
 
@@ -318,15 +318,19 @@ func applyDefaultRouting(t framework.TestContext, nsConfig namespace.Instance) {
 	applyFileOrFail(t, nsConfig.Name(), routingV1)
 }
 
-func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, service string) {
+func applyWaypoint(t framework.TestContext, ns namespace.Instance) {
 	istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 		"x",
 		"waypoint",
 		"apply",
 		"--namespace",
-		nsConfig.Name(),
+		ns.Name(),
 		"--wait",
 	})
+}
+
+func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, service string) {
+	applyWaypoint(t, nsConfig)
 	if service != "" {
 		cs := t.AllClusters().Configs()
 		for _, c := range cs {
@@ -346,14 +350,18 @@ func setupWaypoints(t framework.TestContext, nsConfig namespace.Instance, servic
 	}
 }
 
-func deleteWaypoints(t framework.TestContext, nsConfig namespace.Instance, service string) {
+func deleteWaypoint(t framework.TestContext, ns namespace.Instance) {
 	istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 		"x",
 		"waypoint",
 		"delete",
 		"--namespace",
-		nsConfig.Name(),
+		ns.Name(),
 	})
+}
+
+func teardownWaypoints(t framework.TestContext, nsConfig namespace.Instance, service string) {
+	deleteWaypoint(t, nsConfig)
 	if service != "" {
 		cs := t.AllClusters().Configs()
 		for _, c := range cs {

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -172,11 +172,9 @@ func TestBookinfo(t *testing.T) {
 				})
 
 				ambientComponent.AddWaypointToService(t, nsConfig, "reviews", "namespace")
-				// time.Sleep(time.Second * 45)
 
 				t.NewSubTest("reviews v1").Run(func(t framework.TestContext) {
 					applyFileOrFail(t, nsConfig.Name(), routingV1)
-					// time.Sleep(time.Minute * 30)
 					for _, ingressURL := range ingressURLs {
 						retry.UntilSuccessOrFail(t, func() error {
 							resp, err := ingressClient.Get(ingressURL + "/productpage")
@@ -270,7 +268,10 @@ func TestBookinfo(t *testing.T) {
 					return getGracePeriod(3)
 				})
 			})
-			// ambientComponent.RemoveWaypointFromService(t, nsConfig, "reviews", "namespace")
+			t.CleanupConditionally(func() {
+				ambientComponent.RemoveWaypointFromService(t, nsConfig, "reviews", "namespace")
+				ambientComponent.DeleteWaypoint(t, nsConfig, "namespace")
+			})
 		})
 }
 

--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -46,7 +46,6 @@ func TestIntermediateCertificateRefresh(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.cacert-rotation").
 		Run(func(t framework.TestContext) {
-			// t.Skip("arg...")
 			istioCfg := istio.DefaultConfigOrFail(t, t)
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)

--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -46,7 +46,7 @@ func TestIntermediateCertificateRefresh(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.cacert-rotation").
 		Run(func(t framework.TestContext) {
-			t.Skip("arg...")
+			// t.Skip("arg...")
 			istioCfg := istio.DefaultConfigOrFail(t, t)
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)

--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -46,6 +46,7 @@ func TestIntermediateCertificateRefresh(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.cacert-rotation").
 		Run(func(t framework.TestContext) {
+			t.Skip("arg...")
 			istioCfg := istio.DefaultConfigOrFail(t, t)
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework"
+	ambientComponent "istio.io/istio/pkg/test/framework/components/ambient"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/scopes"
 )
@@ -119,7 +120,7 @@ func TestGatewayConformance(t *testing.T) {
 
 			// create a waypoint for mesh conformance
 			meshNS := namespace.Static("gateway-conformance-mesh")
-			applyWaypoint(ctx, meshNS)
+			ambientComponent.NewWaypointProxyOrFail(ctx, meshNS, "namespace")
 			for _, k := range ctx.AllClusters() {
 				ns, err := k.Kube().CoreV1().Namespaces().Get(ctx.Context(), meshNS.Name(), v1.GetOptions{})
 				if err != nil {

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -20,6 +20,7 @@ package ambient
 import (
 	"testing"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -117,7 +118,21 @@ func TestGatewayConformance(t *testing.T) {
 			ns.RemoveLabel(constants.DataplaneMode)
 
 			// create a waypoint for mesh conformance
-			setupWaypoints(ctx, namespace.Static("gateway-conformance-mesh"), "default")
+			meshNS := namespace.Static("gateway-conformance-mesh")
+			applyWaypoint(ctx, meshNS)
+			for _, k := range ctx.AllClusters() {
+				ns, err := k.Kube().CoreV1().Namespaces().Get(ctx.Context(), meshNS.Name(), v1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				annotations := ns.Annotations
+				if annotations == nil {
+					annotations = make(map[string]string)
+				}
+				annotations[constants.AmbientUseWaypoint] = "namespace"
+				ns.Annotations = annotations
+				k.Kube().CoreV1().Namespaces().Update(ctx.Context(), ns, v1.UpdateOptions{})
+			}
 
 			for _, ct := range tests.ConformanceTests {
 				t.Run(ct.ShortName, func(t *testing.T) {

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -169,6 +169,11 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 						"app":     "waypoint",
 						"version": "v1",
 					},
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.AmbientUseWaypoint: {
+							Value: "waypoint",
+						},
+					},
 				},
 				{
 					Replicas: 1,
@@ -176,6 +181,11 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Labels: map[string]string{
 						"app":     "waypoint",
 						"version": "v2",
+					},
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.AmbientUseWaypoint: {
+							Value: "waypoint",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
implements basic use-waypoint logic:

- removes waypoint scope from _most_ places but not entirely (yet) although I'm not opposed to just getting that fully removed if we want
- adds parsing of use-waypoint on svc and wl types as well a namespace
- adjusts unit and integ tests to reflect the new waypoint attachment method
- adjusts how SA are selected for waypoints since scope became largely vestigial and fully namespace scoping a waypoint that isn't actually namespace in scope was problematic for several test scenarios
- allows for wds configuration of service attached waypoints