### PR TITLE
1.21: Revert "logging: ordered json keys (#48882)"

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -278,7 +278,6 @@ func buildFileAccessJSONLogFormat(
 			Format: &core.SubstitutionFormatString_JsonFormat{
 				JsonFormat: jsonLogStruct,
 			},
-			JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 		},
 	}, formatters
 }
@@ -423,7 +422,6 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *acce
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: jsonLogStruct,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		}
 	default:

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -1277,7 +1277,6 @@ func TestTelemetryAccessLog(t *testing.T) {
 						},
 					},
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -102,7 +102,6 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: EnvoyJSONLogFormatIstio,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}
@@ -125,7 +124,6 @@ var (
 						},
 					},
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -349,7 +349,6 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: model.EnvoyJSONLogFormatIstio,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
 			},
 		},
 	}

--- a/releasenotes/notes/json-log-sort.yaml
+++ b/releasenotes/notes/json-log-sort.yaml
@@ -1,6 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: telemetry
-releaseNotes:
-  - |
-    **Improved** JSON access logs to emit keys in a stable ordering.


### PR DESCRIPTION
This reverts commit 232df85afd85ebcabe3208e3149047893177f14f.
