### PR TITLE
manifests: drop legacy Kubernetes version check

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       securityContext:
       {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 8 }}
-      {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+      {{- else }}
         # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
@@ -57,8 +57,7 @@ spec:
           securityContext:
           {{- if .Values.containerSecurityContext }}
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
-            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+          {{- else }}
             capabilities:
               drop:
               - ALL
@@ -68,17 +67,6 @@ spec:
             runAsUser: 1337
             runAsGroup: 1337
             runAsNonRoot: true
-          {{- else }}
-            capabilities:
-              drop:
-              - ALL
-              add:
-              - NET_BIND_SERVICE
-            runAsUser: 0
-            runAsGroup: 1337
-            runAsNonRoot: false
-            allowPrivilegeEscalation: true
-            readOnlyRootFilesystem: true
           {{- end }}
           env:
           {{- with .Values.networkGateway }}


### PR DESCRIPTION
See https://github.com/istio/istio/issues/39534, this check is
problematic. Fortunately, 1.22 is out of even our super-extended support
(https://preliminary.istio.io/latest/docs/releases/supported-releases/),
so no need to bother checking it at all
