### PR TITLE
wds: add required information for sandwich

### DIFF
--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -154,11 +154,12 @@ message Workload {
   // WorkloadName represents the name for the workload (of type WorkloadType). Used for telemetry.
   string workload_name = 13;
 
+  // Deprecated: superseded by native_tunnel.
+  // If set, it's equivilant to using native_tunnel with HBONE protocol.
+  bool is_native_tunnel = 14;
+
   // If set, this indicates a workload expects to directly receive tunnel traffic.
-  // In ztunnel, this means:
-  // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
-  // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
-  bool native_tunnel = 14;
+  NativeTunnel native_tunnel = 23;
 
   // The services for which this workload is an endpoint.
   // The key is the NamespacedHostname string of the format namespace/hostname.
@@ -213,6 +214,33 @@ enum TunnelProtocol {
   // This does not dictate HTTP/1.1 vs HTTP/2; ALPN should be used for that purpose.
   HBONE = 1;
   // Future options may include things like QUIC/HTTP3, etc.
+}
+
+// NativeTunnel describes how an application or gateway
+// can consume tunnel information directly.
+message NativeTunnel {
+  // A target natively handles this type of traffic.  
+  GatewayProtocol protocol;
+  // optional: if set, traffic should be sent to this port after the last zTunnel hop
+  uint32 port;
+}
+
+enum GatewayProtocol {
+  // Bytes are just copied directly.
+  NONE = 1;
+
+  // The workload nativley supports HBONE
+  // For the zTunnel, this means:
+  // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
+  // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
+  HBONE = 2;
+
+  // Prepend PROXY protocol headers before copying bytes
+  // Standard PROXY source and destination information
+  // is included, along with potential extra TLV headers:
+  // 0xD0 - The SPIFFE identity of the source workload
+  // 0xD1 - The FQDN or Hostname of the targeted Service
+  PROXY = 3;
 }
 
 // GatewayAddress represents the address of a gateway

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -216,11 +216,11 @@ enum TunnelProtocol {
   // Future options may include things like QUIC/HTTP3, etc.
 }
 
-// NativeTunnel describes how an application or gateway
-// can consume tunnel information directly.
+// NativeTunnel describes how a workload (application or gateway)
+// can consume tunnel connections directly.
 message NativeTunnel {
   // A target natively handles this type of traffic.  
-  GatewayProtocol protocol;
+  GatewayProtocol protocol = 1;
   // optional: if set, traffic should be sent to this port after the last zTunnel hop
   uint32 port;
 }
@@ -229,7 +229,7 @@ enum GatewayProtocol {
   // Bytes are just copied directly.
   NONE = 1;
 
-  // The workload nativley supports HBONE
+  // The workload natively supports HBONE
   // For the zTunnel, this means:
   // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -227,20 +227,20 @@ message NativeTunnel {
 
 enum GatewayProtocol {
   // Bytes are just copied directly.
-  NONE = 1;
+  NONE = 0;
 
   // The workload natively supports HBONE
   // For the zTunnel, this means:
   // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
   // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
-  HBONE = 2;
+  HBONE = 1;
 
   // Prepend PROXY protocol headers before copying bytes
   // Standard PROXY source and destination information
   // is included, along with potential extra TLV headers:
   // 0xD0 - The SPIFFE identity of the source workload
   // 0xD1 - The FQDN or Hostname of the targeted Service
-  PROXY = 3;
+  PROXY = 2;
 }
 
 // GatewayAddress represents the address of a gateway


### PR DESCRIPTION
Outbound for all cases is mostly well covered: _TunnelAddress_ specifies what to send and _GatewayAddress_ specifies where to send it. 

For a sandwiched Gateway a zTunnel **inbound** needs the ability do one or both of the following:

1. Prepend the bytestream with PROXY protocol information
2. Send traffic to a specific port that handles all routing

WDS doesn't have a way to express that. 

This proposal adds a `NativeTunnel` struct that specifies for a Workload:

* what to send -> a protocol for inbound to use
* where to send -> an (optional) port to override the HBONE destination. Useful if the Waypoint uses a single inbound port to handle all traffic.

---

```yaml
# backend workload
- name: foo-svc
  waypoint:
    destination: 10.0.0.1
    # This is _not_ the waypoint's port, but the zTunnel's. The control plane knows the Waypoint is sandwiched.
    hbone_mtls_port: 15008
# waypoint instance
- name: waypoint-wl
  native_tunnel:
    protocol: PROXY
    port: 15888
```

There is possibly one uncovered piece for outbound: picking the HBONE port. We can either:

* Defer to the control plane to detect sandwiched-ness and use the ztunnel port on the GatewayAddress
* Continue to use the old method of detecting native_tunnel to decide inside zTunnel to switch the port. 

Related to #48362

https://github.com/istio/ztunnel/commit/c1701e2cbabbe8aa9031561130a74b2927afe10f illustrates usage
