### PR TITLE
remove unused parameter PILOT_XDS_SEND_TIMEOUT

### DIFF
--- a/pilot/pkg/features/tuning.go
+++ b/pilot/pkg/features/tuning.go
@@ -138,10 +138,4 @@ var (
 
 	XDSCacheIndexClearInterval = env.Register("PILOT_XDS_CACHE_INDEX_CLEAR_INTERVAL", 5*time.Second,
 		"The interval for xds cache index clearing.").Get()
-
-	XdsPushSendTimeout = env.Register(
-		"PILOT_XDS_SEND_TIMEOUT",
-		0*time.Second,
-		"The timeout to send the XDS configuration to proxies. After this timeout is reached, Pilot will discard that push.",
-	).Get()
 )


### PR DESCRIPTION
**Please provide a description of this PR:**
The pilot xds send timeout is removed in https://github.com/istio/istio/pull/48543, we think we can remove the env parameter PILOT_XDS_SEND_TIMEOUT safely. 