### PR TITLE
fix warnings getting fd limit in distroless

### DIFF
--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -386,11 +385,10 @@ func getExcludeInterfaces() sets.String {
 }
 
 func logLimits() {
-	out, err := exec.Command("bash", "-c", "ulimit -n").Output()
-	outStr := strings.TrimSpace(string(out))
+	limit, err := GetFDLimit()
 	if err != nil {
-		log.Warnf("failed running ulimit command: %v", outStr)
+		log.Warnf("failed getting fd limit: %s", err)
 	} else {
-		log.Infof("Maximum file descriptors (ulimit -n): %v", outStr)
+		log.Infof("Maximum file descriptors (ulimit -n): %d", limit)
 	}
 }

--- a/pilot/cmd/pilot-agent/app/fds.go
+++ b/pilot/cmd/pilot-agent/app/fds.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 func GetFDLimit() (uint64, error) {

--- a/pilot/cmd/pilot-agent/app/fds.go
+++ b/pilot/cmd/pilot-agent/app/fds.go
@@ -1,0 +1,5 @@
+package app
+
+func GetFDLimit() (uint64, error) {
+	return getFDLimit()
+}

--- a/pilot/cmd/pilot-agent/app/fds_unix.go
+++ b/pilot/cmd/pilot-agent/app/fds_unix.go
@@ -1,0 +1,15 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package app
+
+import "golang.org/x/sys/unix"
+
+func getFDLimit() (uint64, error) {
+	rlimit := unix.Rlimit{}
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
+		return 0, err
+	}
+
+	return rlimit.Cur, nil
+}

--- a/pilot/cmd/pilot-agent/app/fds_unix.go
+++ b/pilot/cmd/pilot-agent/app/fds_unix.go
@@ -1,6 +1,20 @@
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 import "golang.org/x/sys/unix"


### PR DESCRIPTION
**Please provide a description of this PR:**

When using distroless istio images, since there is not bash it always log a warning about "failed running ulimit command: ".
This PR avoid using bash, instead using golang to get the fd limit directly in unix systems. 