### PR TITLE
Increase NOFILE limit for Envoy

### DIFF
--- a/pilot/cmd/pilot-agent/app/cmd.go
+++ b/pilot/cmd/pilot-agent/app/cmd.go
@@ -107,7 +107,7 @@ func newProxyCommand() *cobra.Command {
 			cmd.PrintFlags(c.Flags())
 			log.Infof("Version %s", version.Info.String())
 
-			logLimits()
+			raiseLimits()
 
 			proxy, err := initProxy(args)
 			if err != nil {
@@ -384,11 +384,11 @@ func getExcludeInterfaces() sets.String {
 	return excludeAddrs
 }
 
-func logLimits() {
-	limit, err := GetFDLimit()
+func raiseLimits() {
+	limit, err := RaiseFileLimits()
 	if err != nil {
-		log.Warnf("failed getting fd limit: %s", err)
+		log.Warnf("failed setting file limit: %v", err)
 	} else {
-		log.Infof("Maximum file descriptors (ulimit -n): %d", limit)
+		log.Infof("Set max file descriptors (ulimit -n) to: %d", limit)
 	}
 }

--- a/pilot/cmd/pilot-agent/app/fds.go
+++ b/pilot/cmd/pilot-agent/app/fds.go
@@ -14,6 +14,15 @@
 
 package app
 
-func GetFDLimit() (uint64, error) {
-	return getFDLimit()
+// RaiseFileLimits sets the file limit to the maximum allowed, to avoid exhaustion of file descriptors.
+// This is done by setting soft limit == hard limit.
+// Typical container runtimes already do this, but on VMs, etc this is generally not the case, and a limit of 1024 is common -- this is quite low!
+//
+// Go already sets this (https://github.com/golang/go/issues/46279).
+// However, it will restore the original limit for subprocesses (Envoy): https://github.com/golang/go/blob/f0d1195e13e06acdf8999188decc63306f9903f5/src/syscall/rlimit.go#L14.
+// By explicitly doing it ourselves, we get the limit passed through to Envoy.
+//
+// This function returns the new limit additionally, for convenience.
+func RaiseFileLimits() (uint64, error) {
+	return raiseFileLimits()
 }

--- a/pilot/cmd/pilot-agent/app/fds.go
+++ b/pilot/cmd/pilot-agent/app/fds.go
@@ -19,7 +19,8 @@ package app
 // Typical container runtimes already do this, but on VMs, etc this is generally not the case, and a limit of 1024 is common -- this is quite low!
 //
 // Go already sets this (https://github.com/golang/go/issues/46279).
-// However, it will restore the original limit for subprocesses (Envoy): https://github.com/golang/go/blob/f0d1195e13e06acdf8999188decc63306f9903f5/src/syscall/rlimit.go#L14.
+// However, it will restore the original limit for subprocesses (Envoy):
+// https://github.com/golang/go/blob/f0d1195e13e06acdf8999188decc63306f9903f5/src/syscall/rlimit.go#L14.
 // By explicitly doing it ourselves, we get the limit passed through to Envoy.
 //
 // This function returns the new limit additionally, for convenience.

--- a/pilot/cmd/pilot-agent/app/fds_unix.go
+++ b/pilot/cmd/pilot-agent/app/fds_unix.go
@@ -19,9 +19,13 @@ package app
 
 import "golang.org/x/sys/unix"
 
-func getFDLimit() (uint64, error) {
+func raiseFileLimits() (uint64, error) {
 	rlimit := unix.Rlimit{}
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
+		return 0, err
+	}
+	rlimit.Cur = rlimit.Max
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 		return 0, err
 	}
 

--- a/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
@@ -116,11 +116,6 @@ spec:
           sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
 
-          # su will mess with the limits set on the process we run. This may lead to quickly exhausting the file limits
-          # We will get the host limit and set it in the child as well.
-          # TODO(https://superuser.com/questions/1645513/why-does-executing-a-command-in-su-change-limits) can we do better?
-          currentLimit=$(ulimit -n)
-
           # This looks weird but Kubernetes escapes $$ to $; we want double dollar sign for current PID
           pid="$$$$"
 
@@ -136,7 +131,7 @@ spec:
           chmod +x /tmp/start.sh
           
           export ISTIO_AGENT_FLAGS="--concurrency 2 --proxyLogLevel warning,misc:error,rbac:debug,jwt:debug"
-          sudo -E -s /bin/bash -c "ulimit -n ${currentLimit}; exec /tmp/start.sh $pid &"
+          sudo -E /tmp/start.sh $pid &
           override_core_limits&
           /usr/local/bin/server --cluster "{{ $cluster }}" --version "{{ $subset.Version }}" \
 {{- range $i, $p := $.ContainerPorts }}

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -131,12 +131,6 @@ if [ "${EXEC_USER}" == "${USER:-}" ] ; then
   # redirecting stderr.
   INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} "${ISTIO_BIN_BASE}/pilot-agent" proxy "${ISTIO_AGENT_FLAGS_ARRAY[@]}"
 else
-
-  # su will mess with the limits set on the process we run. This may lead to quickly exhausting the file limits
-  # We will get the host limit and set it in the child as well.
-  # TODO(https://superuser.com/questions/1645513/why-does-executing-a-command-in-su-change-limits) can we do better?
-  currentLimit=$(ulimit -n)
-
   # Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-  exec sudo -E -u "${EXEC_USER}" -s /bin/bash -c "ulimit -n ${currentLimit}; INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2>> ${ISTIO_LOG_DIR}/istio.err.log >> ${ISTIO_LOG_DIR}/istio.log"
+  exec sudo -E -u "${EXEC_USER}" -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} 2>> ${ISTIO_LOG_DIR}/istio.err.log >> ${ISTIO_LOG_DIR}/istio.log"
 fi


### PR DESCRIPTION
Follow up to
https://github.com/istio/istio/pull/49761#issuecomment-1981362376.

Before, we hack around limits in bash to make VMs work fine. Majority of
k8s platforms do not need this, since they always have
softlimit==hardlimit and a reasonable value, but VMs usually have 1024.

With this fix, we ensure from the agent that Envoy always has the
highest limit, so we can remove all our bash hacks.

If we do not do this, we need to revert
https://github.com/istio/istio/pull/49761
