### PR TITLE
Feature/istio proxy add additional volumes

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -239,6 +239,9 @@ spec:
             mountPath: /etc/istio/proxy
           - name: config-volume
             mountPath: /etc/istio/config
+{{- with .Values.global.proxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+{{- end }}
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - mountPath: /var/run/secrets/istio
             name: istiod-ca-cert
@@ -278,6 +281,9 @@ spec:
         name: credential-socket
       - emptyDir: {}
         name: workload-certs
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
         configMap:

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -239,9 +239,9 @@ spec:
             mountPath: /etc/istio/proxy
           - name: config-volume
             mountPath: /etc/istio/config
-{{- with .Values.global.proxy.volumeMounts }}
+          {{- with .Values.global.proxy.volumeMounts }}
           {{- toYaml . | nindent 10 }}
-{{- end }}
+          {{- end }}
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - mountPath: /var/run/secrets/istio
             name: istiod-ca-cert

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -106,6 +106,9 @@ spec:
             value: {{ $val | quote }}
           {{- end }}
           volumeMounts:
+          {{- with .Values.global.proxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- range $gateway.secretVolumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath | quote }}
@@ -122,6 +125,9 @@ spec:
 {{ toYaml $gateway.additionalContainers | indent 8 }}
 {{- end }}
       volumes:
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- range $gateway.secretVolumes }}
       - name: {{ .name }}
         secret:

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -208,6 +208,15 @@ defaults:
       # Expected values are: trace|debug|info|warning|error|critical|off
       logLevel: warning
 
+      # Additional volumes add to the gateway
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumes: []
+
+      # Additional volumes add to the gateawy
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumesMounts: []
+
+
     ##############################################################################################
     # The following values are found in other charts. To effectively modify these values, make   #
     # make sure they are consistent across your Istio helm charts                                #

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -239,6 +239,9 @@ spec:
             mountPath: /etc/istio/proxy
           - name: config-volume
             mountPath: /etc/istio/config
+          {{- with .Values.global.proxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - mountPath: /var/run/secrets/istio
             name: istiod-ca-cert
@@ -278,6 +281,9 @@ spec:
         name: credential-socket
       - emptyDir: {}
         name: workload-certs
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- if eq .Values.global.pilotCertProvider "istiod" }}
       - name: istiod-ca-cert
         configMap:

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -106,6 +106,9 @@ spec:
             value: {{ $val | quote }}
           {{- end }}
           volumeMounts:
+          {{- with .Values.global.proxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- range $gateway.secretVolumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath | quote }}
@@ -122,6 +125,9 @@ spec:
 {{ toYaml $gateway.additionalContainers | indent 8 }}
 {{- end }}
       volumes:
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- range $gateway.secretVolumes }}
       - name: {{ .name }}
         secret:

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -224,6 +224,14 @@ defaults:
       # Expected values are: trace|debug|info|warning|error|critical|off
       logLevel: warning
 
+      # Additional volumes add to the gateway
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumes: []
+
+      # Additional volumes add to the gateawy
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumesMounts: []
+
     ##############################################################################################
     # The following values are found in other charts. To effectively modify these values, make   #
     # make sure they are consistent across your Istio helm charts                                #

--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -160,6 +160,9 @@ spec:
       mountPath: /var/run/secrets/workload-spiffe-uds
     - name: credential-socket
       mountPath: /var/run/secrets/credential-uds
+    {{- with .Values.global.proxy.volumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -192,6 +195,9 @@ spec:
     name: workload-socket
   - emptyDir: {}
     name: credential-socket
+  {{- with .Values.global.proxy.volumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -415,6 +415,9 @@ spec:
       mountPath: /var/run/secrets/workload-spiffe-uds
     - name: credential-socket
       mountPath: /var/run/secrets/credential-uds
+    {{- with .Values.global.proxy.volumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -466,6 +469,9 @@ spec:
     name: workload-socket
   - emptyDir:
     name: credential-socket
+  {{- with .Values.global.proxy.volumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -248,6 +248,9 @@ spec:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts  }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -274,6 +277,9 @@ spec:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes  }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -355,6 +355,14 @@ defaults:
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
       tracer: "zipkin"
 
+      # Additional volumes add to the gateway
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumes: []
+
+      # Additional volumes add to the gateawy
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumesMounts: []
+
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -160,6 +160,9 @@ spec:
       mountPath: /var/run/secrets/workload-spiffe-uds
     - name: credential-socket
       mountPath: /var/run/secrets/credential-uds
+    {{- with .Values.global.proxy.volumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -192,6 +195,9 @@ spec:
     name: workload-socket
   - emptyDir: {}
     name: credential-socket
+  {{- with .Values.global.proxy.volumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -415,6 +415,9 @@ spec:
       mountPath: /var/run/secrets/workload-spiffe-uds
     - name: credential-socket
       mountPath: /var/run/secrets/credential-uds
+    {{- with .Values.global.proxy.volumeMounts  }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
     - name: gke-workload-certificate
       mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -466,6 +469,9 @@ spec:
     name: workload-socket
   - emptyDir:
     name: credential-socket
+  {{- with .Values.global.proxy.volumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -415,7 +415,7 @@ spec:
       mountPath: /var/run/secrets/workload-spiffe-uds
     - name: credential-socket
       mountPath: /var/run/secrets/credential-uds
-    {{- with .Values.global.proxy.volumeMounts  }}
+    {{- with .Values.global.proxy.volumeMounts }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -297,6 +297,15 @@ defaults:
       # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
       # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
       tracer: "zipkin"
+
+      # Additional volumes add to the gateway
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumes: []
+
+      # Additional volumes add to the gateawy
+      # Can be use to mount the host timezone file or some other volumes to the gateway pod
+      volumesMounts: []
+
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -3932,6 +3932,10 @@ type ProxyConfig struct {
 	IncludeInboundPorts string `protobuf:"bytes,38,opt,name=includeInboundPorts,proto3" json:"includeInboundPorts,omitempty"`
 	// A comma separated list of outbound ports for which traffic is to be redirected to Envoy, regardless of the destination IP.
 	IncludeOutboundPorts string `protobuf:"bytes,39,opt,name=includeOutboundPorts,proto3" json:"includeOutboundPorts,omitempty"`
+	// Additional volumes to add to the istio-proxy container, including side and gateway.
+	Volumes []*structpb.Struct `protobuf:"bytes,40,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	// Additional volumeMounts to add to the istio-proxy container, including side and gateway.
+	VolumeMounts []*structpb.Struct `protobuf:"bytes,42,rep,name=volumeMounts,proto3" json:"volumeMounts,omitempty"`
 }
 
 func (x *ProxyConfig) Reset() {
@@ -4120,6 +4124,20 @@ func (x *ProxyConfig) GetIncludeOutboundPorts() string {
 		return x.IncludeOutboundPorts
 	}
 	return ""
+}
+
+func (x *ProxyConfig) GetVolumes() []*structpb.Struct {
+	if x != nil {
+		return x.Volumes
+	}
+	return nil
+}
+
+func (x *ProxyConfig) GetVolumeMounts() []*structpb.Struct {
+	if x != nil {
+		return x.VolumeMounts
+	}
+	return nil
 }
 
 type StartupProbe struct {
@@ -6187,7 +6205,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x12, 0x1e, 0x0a, 0x0a, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x50, 0x6f, 0x72, 0x74, 0x18, 0x04,
 	0x20, 0x01, 0x28, 0x05, 0x52, 0x0a, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x50, 0x6f, 0x72, 0x74,
 	0x12, 0x1a, 0x0a, 0x08, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x18, 0x05, 0x20, 0x01,
-	0x28, 0x09, 0x52, 0x08, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x22, 0xeb, 0x08, 0x0a,
+	0x28, 0x09, 0x52, 0x08, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x22, 0xdb, 0x09, 0x0a,
 	0x0b, 0x50, 0x72, 0x6f, 0x78, 0x79, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x1e, 0x0a, 0x0a,
 	0x61, 0x75, 0x74, 0x6f, 0x49, 0x6e, 0x6a, 0x65, 0x63, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09,
 	0x52, 0x0a, 0x61, 0x75, 0x74, 0x6f, 0x49, 0x6e, 0x6a, 0x65, 0x63, 0x74, 0x12, 0x24, 0x0a, 0x0d,
@@ -6258,7 +6276,14 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x64, 0x50, 0x6f, 0x72, 0x74, 0x73, 0x12, 0x32, 0x0a, 0x14, 0x69, 0x6e, 0x63, 0x6c, 0x75, 0x64,
 	0x65, 0x4f, 0x75, 0x74, 0x62, 0x6f, 0x75, 0x6e, 0x64, 0x50, 0x6f, 0x72, 0x74, 0x73, 0x18, 0x27,
 	0x20, 0x01, 0x28, 0x09, 0x52, 0x14, 0x69, 0x6e, 0x63, 0x6c, 0x75, 0x64, 0x65, 0x4f, 0x75, 0x74,
-	0x62, 0x6f, 0x75, 0x6e, 0x64, 0x50, 0x6f, 0x72, 0x74, 0x73, 0x22, 0x70, 0x0a, 0x0c, 0x53, 0x74,
+	0x62, 0x6f, 0x75, 0x6e, 0x64, 0x50, 0x6f, 0x72, 0x74, 0x73, 0x12, 0x31, 0x0a, 0x07, 0x76, 0x6f,
+	0x6c, 0x75, 0x6d, 0x65, 0x73, 0x18, 0x28, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f,
+	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74,
+	0x72, 0x75, 0x63, 0x74, 0x52, 0x07, 0x76, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x73, 0x12, 0x3b, 0x0a,
+	0x0c, 0x76, 0x6f, 0x6c, 0x75, 0x6d, 0x65, 0x4d, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x18, 0x2a, 0x20,
+	0x03, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74, 0x52, 0x0c, 0x76, 0x6f,
+	0x6c, 0x75, 0x6d, 0x65, 0x4d, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x22, 0x70, 0x0a, 0x0c, 0x53, 0x74,
 	0x61, 0x72, 0x74, 0x75, 0x70, 0x50, 0x72, 0x6f, 0x62, 0x65, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e,
 	0x61, 0x62, 0x6c, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f,
 	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f,
@@ -6708,44 +6733,46 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
 	1,   // 145: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
 	56,  // 146: v1alpha1.ProxyConfig.lifecycle:type_name -> google.protobuf.Struct
 	54,  // 147: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	54,  // 148: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
-	10,  // 149: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
-	56,  // 150: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	54,  // 151: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	56,  // 152: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
-	56,  // 153: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
-	54,  // 154: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	56,  // 155: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	56,  // 156: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
-	56,  // 157: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	54,  // 158: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
-	41,  // 159: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
-	42,  // 160: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
-	43,  // 161: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
-	44,  // 162: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	54,  // 163: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	54,  // 164: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	54,  // 165: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	54,  // 166: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	4,   // 167: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
-	15,  // 168: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
-	16,  // 169: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
-	24,  // 170: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	55,  // 171: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	27,  // 172: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
-	39,  // 173: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
-	5,   // 174: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
-	55,  // 175: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	45,  // 176: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
-	46,  // 177: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	54,  // 178: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 179: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	59,  // 180: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	181, // [181:181] is the sub-list for method output_type
-	181, // [181:181] is the sub-list for method input_type
-	181, // [181:181] is the sub-list for extension type_name
-	181, // [181:181] is the sub-list for extension extendee
-	0,   // [0:181] is the sub-list for field type_name
+	56,  // 148: v1alpha1.ProxyConfig.volumes:type_name -> google.protobuf.Struct
+	56,  // 149: v1alpha1.ProxyConfig.volumeMounts:type_name -> google.protobuf.Struct
+	54,  // 150: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	10,  // 151: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
+	56,  // 152: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	54,  // 153: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	56,  // 154: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> google.protobuf.Struct
+	56,  // 155: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> google.protobuf.Struct
+	54,  // 156: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	56,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	56,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
+	56,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	54,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	41,  // 161: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
+	42,  // 162: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
+	43,  // 163: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
+	44,  // 164: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
+	54,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	54,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	54,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	54,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	4,   // 169: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
+	15,  // 170: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
+	16,  // 171: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
+	24,  // 172: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
+	55,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	27,  // 174: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
+	39,  // 175: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
+	5,   // 176: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
+	55,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	45,  // 178: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
+	46,  // 179: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
+	54,  // 180: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	58,  // 181: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	59,  // 182: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	183, // [183:183] is the sub-list for method output_type
+	183, // [183:183] is the sub-list for method input_type
+	183, // [183:183] is the sub-list for extension type_name
+	183, // [183:183] is the sub-list for extension extendee
+	0,   // [0:183] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -1148,6 +1148,12 @@ message ProxyConfig {
 
   // A comma separated list of outbound ports for which traffic is to be redirected to Envoy, regardless of the destination IP.
   string includeOutboundPorts = 39;
+
+  // Additional volumes to add to the istio-proxy container, including side and gateway.
+  repeated google.protobuf.Struct volumes = 40;
+
+  // Additional volumeMounts to add to the istio-proxy container, including side and gateway.
+  repeated google.protobuf.Struct volumeMounts = 42;
 }
 
 message StartupProbe {

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -426,6 +426,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -477,6 +480,9 @@ templates:
         name: workload-socket
       - emptyDir:
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -714,6 +720,9 @@ templates:
           mountPath: /var/run/secrets/workload-spiffe-uds
         - name: credential-socket
           mountPath: /var/run/secrets/credential-uds
+        {{- with .Values.global.proxy.volumeMounts }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
         {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
         - name: gke-workload-certificate
           mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -746,6 +755,9 @@ templates:
         name: workload-socket
       - emptyDir: {}
         name: credential-socket
+      {{- with .Values.global.proxy.volumes }}
+      {{- toYaml . | nindent 2 }}
+      {{- end }}
       {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
       - name: gke-workload-certificate
         csi:
@@ -1731,6 +1743,9 @@ templates:
               mountPath: /var/run/secrets/workload-spiffe-uds
             - name: credential-socket
               mountPath: /var/run/secrets/credential-uds
+            {{- with .Values.global.proxy.volumeMounts  }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
             {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
             - name: gke-workload-certificate
               mountPath: /var/run/secrets/workload-spiffe-credentials
@@ -1757,6 +1772,9 @@ templates:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
+          {{- with .Values.global.proxy.volumes  }}
+          {{- toYaml . | nindent 6 }}
+          {{- end }}
           {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
           - name: gke-workload-certificate
             csi:

--- a/releasenotes/notes/49782.yaml
+++ b/releasenotes/notes/49782.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** Provide The ability to spificy the additional volumes to mount to the istio-proxy,including sidecar and gateway. PR: #48047


### PR DESCRIPTION
**Please provide a description of this PR:**
We can use ```accessLogFile``` to specify the ```file address for the proxy access log```, including ```istio-proxy``` sidecar or other gateways.
But the problem is the istio-proxy container is setting ```readOnlyRootFilesystem: true```.
And sometimes, the user want to set the time to ```CST``` format, the have to mount the timezone file in the running host.

So this PR modify the ```values_types.proto``` and the charts, provide the ability to mount the volumes to the istio-proxy sidecar and gateway.

For Example:
```
  accessLogFile: /accesslog/access.log
  values:
    global:
      proxy:
        volumes:
        - name: istio-accesslog
          emptyDir: {}
        - name: timezone
          hostPath:
            path: "/usr/share/zoneinfo/Asia/Shanghai"
        volumeMounts:
        - name: istio-accesslog
          mountPath: /accesslog
        - name: timezone
          mountPath: "/etc/localtime"
          
```



**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.