### PR TITLE
build: disable vtprotobuf by default

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -237,8 +237,8 @@ RELEASE_SIZE_TEST_BINARIES:=pilot-discovery pilot-agent istioctl envoy ztunnel c
 # not set vtprotobuf: this adds some performance improvement, but at a binary cost increase that is not worth it for the agent
 AGENT_TAGS=agent,disable_pgv
 # disable_pgv: disables protoc-gen-validation. This is not used buts adds many MB to Envoy protos
-# vtprotobuf: enables optimized protobuf marshalling
-STANDARD_TAGS=disable_pgv,vtprotobuf
+# vtprotobuf: enables optimized protobuf marshalling. Disabled until https://github.com/istio/istio/issues/49790 lands
+STANDARD_TAGS=disable_pgv
 
 .PHONY: build
 build: depend ## Builds all go binaries.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -224,7 +224,7 @@ var (
 		"If enabled, certificates received by the proxy will be verified against the OS CA certificate bundle.").Get()
 
 	EnableVtprotobuf = env.Register("ENABLE_VTPROTOBUF", false,
-		"If true, will use optimized vtprotobuf based marshaling").Get()
+		"If true, will use optimized vtprotobuf based marshaling. Requires a build with -tags=vtprotobuf.").Get()
 
 	GatewayAPIDefaultGatewayClass = env.Register("PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS_NAME", "istio",
 		"Name of the default GatewayClass").Get()


### PR DESCRIPTION
This is not ready to be enabled, so save the binary size by removing it.
