### PR TITLE
Improve formatting of multierror

### DIFF
--- a/pkg/util/istiomultierror/util.go
+++ b/pkg/util/istiomultierror/util.go
@@ -35,7 +35,7 @@ func MultiErrorFormat() multierror.ErrorFormatFunc {
 		}
 
 		return fmt.Sprintf(
-			"%d errors occurred:\n\t%s\n\n",
+			"%d errors occurred:\n\t%s\n",
 			len(es), strings.Join(points, "\n\t"))
 	}
 }

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/config/xds"
+	"istio.io/istio/pkg/util/istiomultierror"
 )
 
 var (
@@ -132,7 +133,7 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 	}
 
 	wg.Wait()
-	err := multierror.Append(nil, convertErrs...).ErrorOrNil()
+	err := multierror.Append(istiomultierror.New(), convertErrs...).ErrorOrNil()
 	if err != nil {
 		wasmLog.Errorf("convert the wasm config: %v", err)
 	}


### PR DESCRIPTION
* Avoid double newline, which is excessive for logs
* Use istiomultierror somewhere we forgot it
