### PR TITLE
Improve WASM integration tests

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -359,17 +359,18 @@ func (p *XdsProxy) buildUpstreamConn(ctx context.Context) (*grpc.ClientConn, err
 }
 
 func (p *XdsProxy) handleUpstream(ctx context.Context, con *ProxyConnection, xds discovery.AggregatedDiscoveryServiceClient) error {
+	log := proxyLog.WithLabels("id", con.conID)
 	upstream, err := xds.StreamAggregatedResources(ctx,
 		grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize))
 	if err != nil {
 		// Envoy logs errors again, so no need to log beyond debug level
-		proxyLog.Debugf("failed to create upstream grpc client: %v", err)
+		log.Debugf("failed to create upstream grpc client: %v", err)
 		// Increase metric when xds connection error, for example: forgot to restart ingressgateway or sidecar after changing root CA.
 		metrics.IstiodConnectionErrors.Increment()
 		return err
 	}
-	proxyLog.Infof("connected to upstream XDS server[%d]: %s", con.conID, p.istiodAddress)
-	defer proxyLog.Debugf("disconnected from XDS server[%d]: %s", con.conID, p.istiodAddress)
+	log.Infof("connected to upstream XDS server: %s", p.istiodAddress)
+	defer log.Debugf("disconnected from XDS server: %s", p.istiodAddress)
 
 	con.upstream = upstream
 
@@ -402,7 +403,7 @@ func (p *XdsProxy) handleUpstream(ctx context.Context, con *ProxyConnection, xds
 			// On downstream error, we will return. This propagates the error to downstream envoy which will trigger reconnect
 			return err
 		case <-con.stopChan:
-			proxyLog.Debugf("stream [%d] stopped", con.conID)
+			log.Debugf("upstream stopped")
 			return nil
 		}
 	}
@@ -481,7 +482,11 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 		select {
 		case resp := <-con.responsesChan:
 			// TODO: separate upstream response handling from requests sending, which are both time costly
-			proxyLog.Debugf("upstream [%d] response for type url %s", con.conID, resp.TypeUrl)
+			proxyLog.WithLabels(
+				"id", con.conID,
+				"type", resp.TypeUrl,
+				"resources", len(resp.Resources),
+			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()
 			if h, f := p.handlers[resp.TypeUrl]; f {
 				if len(resp.Resources) == 0 {
@@ -569,7 +574,7 @@ func forwardToEnvoy(con *ProxyConnection, resp *discovery.DiscoveryResponse) {
 		return
 	}
 	if con.isClosed() {
-		proxyLog.Errorf("downstream [%d] dropped xds push to Envoy, connection already closed", con.conID)
+		proxyLog.WithLabels("id", con.conID).Errorf("downstream dropped xds push to Envoy, connection already closed")
 		return
 	}
 	if err := sendDownstream(con.downstream, resp); err != nil {
@@ -817,10 +822,10 @@ func (p *XdsProxy) initDebugInterface(port int) error {
 // upstreamErr sends the error to upstreamError channel, and return immediately if the connection closed.
 func upstreamErr(con *ProxyConnection, err error) {
 	if istiogrpc.IsExpectedGRPCError(err) {
-		proxyLog.Debugf("upstream [%d] terminated with status %v", con.conID, err)
+		proxyLog.WithLabels("id", con.conID).Debugf("upstream terminated with status %v", err)
 		metrics.IstiodConnectionCancellations.Increment()
 	} else {
-		proxyLog.Warnf("upstream [%d] terminated with unexpected error %v", con.conID, err)
+		proxyLog.WithLabels("id", con.conID).Warnf("upstream terminated with unexpected error %v", err)
 		metrics.IstiodConnectionErrors.Increment()
 	}
 	select {
@@ -832,10 +837,10 @@ func upstreamErr(con *ProxyConnection, err error) {
 // downstreamErr sends the error to downstreamError channel, and return immediately if the connection closed.
 func downstreamErr(con *ProxyConnection, err error) {
 	if istiogrpc.IsExpectedGRPCError(err) {
-		proxyLog.Debugf("downstream [%d] terminated with status %v", con.conID, err)
+		proxyLog.WithLabels("id", con.conID).Debugf("downstream terminated with status %v", err)
 		metrics.EnvoyConnectionCancellations.Increment()
 	} else {
-		proxyLog.Warnf("downstream [%d] terminated with unexpected error %v", con.conID, err)
+		proxyLog.WithLabels("id", con.conID).Warnf("downstream terminated with unexpected error %v", err)
 		metrics.EnvoyConnectionErrors.Increment()
 	}
 	select {

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -484,7 +484,7 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 			// TODO: separate upstream response handling from requests sending, which are both time costly
 			proxyLog.WithLabels(
 				"id", con.conID,
-				"type", resp.TypeUrl,
+				"type", v3.GetShortType(resp.TypeUrl),
 				"resources", len(resp.Resources),
 			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -184,9 +184,10 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 				continue
 			}
 			log.WithLabels(
-				"type", req.TypeUrl,
+				"type", v3.GetShortType(req.TypeUrl),
 				"sub", len(req.ResourceNamesSubscribe),
 				"unsub", len(req.ResourceNamesUnsubscribe),
+				"nonce", req.ResponseNonce,
 				"initial", len(req.InitialResourceVersions),
 			).Debugf("delta request")
 			metrics.XdsProxyRequests.Increment()
@@ -213,7 +214,8 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 			// TODO: separate upstream response handling from requests sending, which are both time costly
 			proxyLog.WithLabels(
 				"id", con.conID,
-				"type", resp.TypeUrl,
+				"type", v3.GetShortType(resp.TypeUrl),
+				"nonce", resp.Nonce,
 				"resources", len(resp.Resources),
 				"removes", len(resp.RemovedResources),
 			).Debugf("upstream response")

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -296,7 +296,7 @@ func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.
 		resp.Resources[i].Resource = resources[i]
 	}
 
-	proxyLog.WithLabels("resources", slices.Map(resp.Resources, (*discovery.Resource).GetName), "removals", resp.RemovedResources).Debugf("forward ECDS")
+	proxyLog.WithLabels("resources", slices.Map(resp.Resources, (*discovery.Resource).GetName), "removes", resp.RemovedResources).Debugf("forward ECDS")
 	forward(resp)
 }
 

--- a/pkg/istio-agent/xds_proxy_delta.go
+++ b/pkg/istio-agent/xds_proxy_delta.go
@@ -85,17 +85,18 @@ func (p *XdsProxy) DeltaAggregatedResources(downstream xds.DeltaDiscoveryStream)
 }
 
 func (p *XdsProxy) handleDeltaUpstream(ctx context.Context, con *ProxyConnection, xds discovery.AggregatedDiscoveryServiceClient) error {
+	log := proxyLog.WithLabels("id", con.conID)
 	deltaUpstream, err := xds.DeltaAggregatedResources(ctx,
 		grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize))
 	if err != nil {
 		// Envoy logs errors again, so no need to log beyond debug level
-		proxyLog.Debugf("failed to create delta upstream grpc client: %v", err)
+		log.Debugf("failed to create delta upstream grpc client: %v", err)
 		// Increase metric when xds connection error, for example: forgot to restart ingressgateway or sidecar after changing root CA.
 		metrics.IstiodConnectionErrors.Increment()
 		return err
 	}
-	proxyLog.Infof("connected to delta upstream XDS server[%d]: %s", con.conID, p.istiodAddress)
-	defer proxyLog.Debugf("disconnected from delta XDS server[%d]: %s", con.conID, p.istiodAddress)
+	log.Infof("connected to delta upstream XDS server: %s", p.istiodAddress)
+	defer log.Debugf("disconnected from delta XDS server: %s", p.istiodAddress)
 
 	con.upstreamDeltas = deltaUpstream
 
@@ -125,13 +126,14 @@ func (p *XdsProxy) handleDeltaUpstream(ctx context.Context, con *ProxyConnection
 			// On downstream error, we will return. This propagates the error to downstream envoy which will trigger reconnect
 			return err
 		case <-con.stopChan:
-			proxyLog.Debugf("stream [%d] stopped", con.conID)
+			log.Debugf("upstream stopped")
 			return nil
 		}
 	}
 }
 
 func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
+	log := proxyLog.WithLabels("id", con.conID)
 	initialRequestsSent := atomic.NewBool(false)
 	go func() {
 		for {
@@ -181,7 +183,12 @@ func (p *XdsProxy) handleUpstreamDeltaRequest(con *ProxyConnection) {
 				// only send healthcheck probe after LDS request has been sent
 				continue
 			}
-			proxyLog.Debugf("delta request for type url %s", req.TypeUrl)
+			log.WithLabels(
+				"type", req.TypeUrl,
+				"sub", len(req.ResourceNamesSubscribe),
+				"unsub", len(req.ResourceNamesUnsubscribe),
+				"initial", len(req.InitialResourceVersions),
+			).Debugf("delta request")
 			metrics.XdsProxyRequests.Increment()
 			if req.TypeUrl == v3.ExtensionConfigurationType {
 				p.ecdsLastNonce.Store(req.ResponseNonce)
@@ -204,7 +211,12 @@ func (p *XdsProxy) handleUpstreamDeltaResponse(con *ProxyConnection) {
 		select {
 		case resp := <-con.deltaResponsesChan:
 			// TODO: separate upstream response handling from requests sending, which are both time costly
-			proxyLog.Debugf("upstream [%d] response for type url %s", con.conID, resp.TypeUrl)
+			proxyLog.WithLabels(
+				"id", con.conID,
+				"type", resp.TypeUrl,
+				"resources", len(resp.Resources),
+				"removes", len(resp.RemovedResources),
+			).Debugf("upstream response")
 			metrics.XdsProxyResponses.Increment()
 			if h, f := p.handlers[resp.TypeUrl]; f {
 				if len(resp.Resources) == 0 {
@@ -282,7 +294,7 @@ func (p *XdsProxy) deltaRewriteAndForward(con *ProxyConnection, resp *discovery.
 		resp.Resources[i].Resource = resources[i]
 	}
 
-	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
+	proxyLog.WithLabels("resources", slices.Map(resp.Resources, (*discovery.Resource).GetName), "removals", resp.RemovedResources).Debugf("forward ECDS")
 	forward(resp)
 }
 
@@ -292,7 +304,7 @@ func forwardDeltaToEnvoy(con *ProxyConnection, resp *discovery.DeltaDiscoveryRes
 		return
 	}
 	if con.isClosed() {
-		proxyLog.Errorf("downstream [%d] dropped delta xds push to Envoy, connection already closed", con.conID)
+		proxyLog.WithLabels("id", con.conID).Errorf("downstream dropped delta xds push to Envoy, connection already closed")
 		return
 	}
 	if err := sendDownstreamDelta(con.downstreamDeltas, resp); err != nil {

--- a/pkg/test/framework/components/registryredirector/kube.go
+++ b/pkg/test/framework/components/registryredirector/kube.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
@@ -87,7 +88,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 
 	// apply YAML
-	if err := ctx.ConfigKube(c.cluster).EvalFile(c.ns.Name(), args, env.RegistryRedirectorServerInstallFilePath).Apply(); err != nil {
+	if err := ctx.ConfigKube(c.cluster).EvalFile(c.ns.Name(), args, env.RegistryRedirectorServerInstallFilePath).Apply(apply.CleanupConditionally); err != nil {
 		return nil, fmt.Errorf("failed to apply rendered %s, err: %v", env.RegistryRedirectorServerInstallFilePath, err)
 	}
 

--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -19,7 +19,6 @@ package api
 
 import (
 	_ "embed"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
@@ -29,7 +28,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 )
@@ -47,6 +45,7 @@ func TestCustomizeMetrics(t *testing.T) {
 		Features("observability.telemetry.request-classification").
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
+			setupWasmExtension(t)
 			t.ConfigIstio().YAML(apps.Namespace.Name(), `
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
@@ -116,20 +115,15 @@ spec:
 		})
 }
 
-func setupWasmExtension(ctx resource.Context) error {
+func setupWasmExtension(t framework.TestContext) {
 	proxySHA := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
 	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:%v", registry.Address(), proxySHA)
 	args := map[string]any{
 		"AttributeGenURL": attrGenImageURL,
-		"DockerConfigJson": base64.StdEncoding.EncodeToString(
-			[]byte(createDockerCredential(registryUser, registryPasswd, registry.Address()))),
 	}
-	if err := ctx.ConfigIstio().EvalFile(apps.Namespace.Name(), args, "testdata/attributegen.yaml").
-		Apply(); err != nil {
-		return err
-	}
-
-	return nil
+	t.ConfigIstio().
+		EvalFile(apps.Namespace.Name(), args, "testdata/attributegen.yaml").
+		ApplyOrFail(t)
 }
 
 func sendCustomizeMetricsTraffic() error {

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/config/apply"
 )
 
 const (
@@ -71,7 +72,6 @@ spec:
 		}).
 		Setup(testRegistrySetup).
 		Setup(SetupSuite).
-		Setup(setupWasmExtension).
 		Run()
 }
 
@@ -84,6 +84,7 @@ meshConfig:
   accessLogFile: "" # disable from install, we will enable via Telemetry layer
 `
 	cfg.RemoteClusterValues = cfg.ControlPlaneValues
+	cfg.Values["global.logging.level"] = "xdsproxy:debug,wasm:debug"
 }
 
 // SetupSuite set up echo app for stats testing.
@@ -153,7 +154,7 @@ proxyMetadata:
 			[]byte(createDockerCredential(registryUser, registryPasswd, registry.Address()))),
 	}
 	if err := ctx.ConfigIstio().EvalFile(apps.Namespace.Name(), args, "testdata/registry-secret.yaml").
-		Apply(); err != nil {
+		Apply(apply.CleanupConditionally); err != nil {
 		return err
 	}
 	return nil

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -91,8 +91,10 @@ meshConfig:
 func SetupSuite(ctx resource.Context) (err error) {
 	echos := (&cdeployment.Config{}).DefaultEchoConfigs(ctx)
 	customBuckets := `{"istio":[1,5,10,50,100,500,1000,5000,10000]}`
+	// TODO(https://github.com/istio/istio/issues/49847): remove the Delta XDS skip
 	proxyMetadata := fmt.Sprintf(`
 proxyMetadata:
+  ISTIO_DELTA_XDS: "false"
   WASM_INSECURE_REGISTRIES: %q`, registry.Address())
 	for _, e := range echos {
 		if e.Subsets[0].Annotations == nil {

--- a/tests/integration/telemetry/api/testdata/attributegen.yaml
+++ b/tests/integration/telemetry/api/testdata/attributegen.yaml
@@ -1,12 +1,3 @@
----
-apiVersion: v1
-data:
-  .dockerconfigjson: {{ .DockerConfigJson }}
-kind: Secret
-metadata:
-  name: regcred
-type: kubernetes.io/dockerconfigjson
----
 apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -17,7 +8,7 @@ spec:
     matchLabels:
       app: b
   url: {{ .AttributeGenURL }}
-  imagePullSecret: regcred
+  imagePullSecret: reg-cred
   pluginConfig:
     attributes:
     - output_attribute: istio_responseClass

--- a/tests/integration/telemetry/api/testdata/bad-wasm-envoy-filter-fail-open.yaml
+++ b/tests/integration/telemetry/api/testdata/bad-wasm-envoy-filter-fail-open.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions.istio.io/v1alpha1
 kind: WasmPlugin
 metadata:
-  name: bad-filter-config
+  name: bad-filter-config-failopen
 spec:
   url: https://bad-url.wasm
   sha256: f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2

--- a/tests/integration/telemetry/api/wasmplugin_test.go
+++ b/tests/integration/telemetry/api/wasmplugin_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apiserver/pkg/storage/names"
+
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/test/framework"
@@ -106,60 +108,31 @@ func TestImagePullPolicy(t *testing.T) {
 		Features("extensibility.wasm.image-pull-policy").
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
-			applyAndTestWasmWithOCI(t, wasmTestConfigs{
-				desc:            "initial creation with latest",
-				name:            "wasm-test-module",
-				tag:             "latest",
-				policy:          "",
-				upstreamVersion: "0.0.1",
-				expectedVersion: "0.0.1",
-			})
-
-			resetWasm(t, "wasm-test-module")
-			applyAndTestWasmWithOCI(t, wasmTestConfigs{
-				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present and policy is IfNotPresent, so should not pull",
-				name:            "wasm-test-module",
-				tag:             "latest",
-				policy:          "IfNotPresent",
-				upstreamVersion: "0.0.2",
-				expectedVersion: "0.0.1",
-			})
-
-			// Intentionally, do not reset here to see the upgrade from 0.0.1.
-			applyAndTestWasmWithOCI(t, wasmTestConfigs{
-				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present. But policy is default and tag is latest, so pull the image",
-				name:            "wasm-test-module",
-				tag:             "latest",
-				policy:          "",
-				upstreamVersion: "0.0.2",
-				expectedVersion: "0.0.2",
-			})
-			resetWasm(t, "wasm-test-module")
-
+			tag := names.SimpleNameGenerator.GenerateName("test-tag-")
 			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "initial creation with 0.0.1",
-				name:            "wasm-test-module-test-tag-1",
-				tag:             "test-tag-1",
+				name:            "wasm-test-module",
+				tag:             tag,
 				policy:          "",
 				upstreamVersion: "0.0.1",
 				expectedVersion: "0.0.1",
 			})
 
-			resetWasm(t, "wasm-test-module-test-tag-1")
+			resetWasm(t, "wasm-test-module")
 			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is IfNotPresent",
-				name:            "wasm-test-module-test-tag-1",
-				tag:             "test-tag-1",
+				name:            "wasm-test-module",
+				tag:             tag,
 				policy:          "IfNotPresent",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.1",
 			})
 
-			resetWasm(t, "wasm-test-module-test-tag-1")
+			resetWasm(t, "wasm-test-module")
 			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is default",
-				name:            "wasm-test-module-test-tag-1",
-				tag:             "test-tag-1",
+				name:            "wasm-test-module",
+				tag:             tag,
 				policy:          "",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.1",
@@ -168,8 +141,8 @@ func TestImagePullPolicy(t *testing.T) {
 			// Intentionally, do not reset here to see the upgrade from 0.0.1.
 			applyAndTestWasmWithOCI(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present but policy is Always, so pull 0.0.2",
-				name:            "wasm-test-module-test-tag-1",
-				tag:             "test-tag-1",
+				name:            "wasm-test-module",
+				tag:             tag,
 				policy:          "Always",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.2",
@@ -319,10 +292,11 @@ func TestImagePullPolicyWithHTTP(t *testing.T) {
 		Features("extensibility.wasm.image-pull-policy").
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
+			tag := names.SimpleNameGenerator.GenerateName("test-tag-")
 			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
 				desc:            "initial creation with 0.0.1",
 				name:            "wasm-test-module-http",
-				tag:             "test-tag-http",
+				tag:             tag,
 				policy:          "",
 				upstreamVersion: "0.0.1",
 				expectedVersion: "0.0.1",
@@ -332,7 +306,7 @@ func TestImagePullPolicyWithHTTP(t *testing.T) {
 			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is IfNotPresent",
 				name:            "wasm-test-module-http",
-				tag:             "test-tag-http",
+				tag:             tag,
 				policy:          "IfNotPresent",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.1",
@@ -342,7 +316,7 @@ func TestImagePullPolicyWithHTTP(t *testing.T) {
 			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2, but 0.0.1 is already present and policy is default",
 				name:            "wasm-test-module-http",
-				tag:             "test-tag-http",
+				tag:             tag,
 				policy:          "",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.1",
@@ -352,7 +326,7 @@ func TestImagePullPolicyWithHTTP(t *testing.T) {
 			applyAndTestWasmWithHTTP(t, wasmTestConfigs{
 				desc:            "upstream is upgraded to 0.0.2. 0.0.1 is already present but policy is Always, so pull 0.0.2",
 				name:            "wasm-test-module-http",
-				tag:             "test-tag-http",
+				tag:             tag,
 				policy:          "Always",
 				upstreamVersion: "0.0.2",
 				expectedVersion: "0.0.2",

--- a/tests/integration/telemetry/api/wasmplugin_test.go
+++ b/tests/integration/telemetry/api/wasmplugin_test.go
@@ -343,6 +343,8 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 	framework.NewTest(t).
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
+			// Enable logging for debugging
+			applyTelemetryResource(t, true)
 			badWasmTestHelper(t, "testdata/bad-filter.yaml", false, true)
 		})
 }
@@ -357,6 +359,8 @@ func TestBadWasmWithFailOpen(t *testing.T) {
 	framework.NewTest(t).
 		Features("extensibility.wasm.remote-load").
 		Run(func(t framework.TestContext) {
+			// Enable logging for debugging
+			applyTelemetryResource(t, true)
 			// since this case is for "fail_open=true", ecds is not rejected.
 			badWasmTestHelper(t, "testdata/bad-wasm-envoy-filter-fail-open.yaml", true, false)
 		})


### PR DESCRIPTION
The actual primary change fixing test flakes: disable delta xds due to https://github.com/istio/istio/issues/49847

Other changes to help improve things:

* Enable debug logs to make investigation easier
* Make components not cleanup during local testing
* Avoid using the same tag between tests to test caching; this makes it
  impossible to run the test multiple times. Also remove the redundant
test for `latest` vs `explicit` tag, which is pretty redundant -- we
have plenty of unit test coverage for the trivial `latest` special
behavior
