### PR TITLE
piggyback: close immediately if the connection closes

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -676,6 +676,7 @@ func (p *XdsProxy) tapRequest(req *discovery.DiscoveryRequest, timeout time.Dura
 	if connection == nil {
 		return nil, fmt.Errorf("proxy not connected to Istiod")
 	}
+	stop := connection.stopChan
 
 	// Only allow one tap request at a time
 	p.tapMutex.Lock()
@@ -704,6 +705,8 @@ func (p *XdsProxy) tapRequest(req *discovery.DiscoveryRequest, timeout time.Dura
 			if res.TypeUrl == req.TypeUrl {
 				return res, nil
 			}
+		case <-stop:
+			return nil, nil
 		case <-delay.C:
 			return nil, nil
 		}


### PR DESCRIPTION
This avoids hanging for 15s if you get unlucky and connect during a
reconnect
