### PR TITLE
helm: fix validation webhook not installed by default

### DIFF
--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -12,7 +12,6 @@ defaults:
     istiod:
       enableAnalysis: false
 
-    configValidation: true
     externalIstiod: false
     remotePilotAddress: ""
 

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -383,6 +383,9 @@ defaults:
     # Configure a remote cluster as the config cluster for an external istiod.
     configCluster: false
 
+    # configValidation enables the validation webhook for Istio configuration.
+    configValidation: true
+
     # Mesh ID means Mesh Identifier. It should be unique within the scope where
     # meshes will interact with each other, but it is not required to be
     # globally/universally unique. For example, if any of the following are true,

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -319,6 +319,8 @@ defaults:
     externalIstiod: true
     # Configure a remote cluster as the config cluster for an external istiod.
     configCluster: false
+    # configValidation enables the validation webhook for Istio configuration.
+    configValidation: true
     # Mesh ID means Mesh Identifier. It should be unique within the scope where
     # meshes will interact with each other, but it is not required to be
     # globally/universally unique. For example, if any of the following are true,


### PR DESCRIPTION
**Please provide a description of this PR:**
This is inconsistent to istioctl, where has a default webhook installed, and a webhook per revision.