### PR TITLE
fix istioctl describe ingress svc ignore http port

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -983,9 +983,11 @@ func printIngressService(writer io.Writer, ingressSvc *corev1.Service, ingressPo
 	// the most basic output.
 	portsToShow := map[string]bool{
 		"http2": true,
+		"http":  true,
 	}
 	protocolToScheme := map[string]string{
 		"HTTP2": "http",
+		"HTTP":  "http",
 	}
 	schemePortDefault := map[string]int{
 		"http": 80,


### PR DESCRIPTION
**Please provide a description of this PR:**
when ` istioctl x describe svc httpbin` is executed, and the httpbin service includes both an http and http2 port,
but the http port is ignored and not outputted.


```bash
$  istioctl x describe svc httpbin
Service: httpbin
   Port: http 8000/HTTP targets pod port 80
VirtualService: httpbin
   1 HTTP route(s)

Exposed on Ingress Gateway http://10.6.136.31
VirtualService: httpbin
   1 HTTP route(s)
```
Both HTTP and HTTP2 should be outputted, there shouldn't be any distinction.
```
$ kubectl get svc httpbin -oyaml
apiVersion: v1
kind: Service
metadata:
  name: istio-ingressgateway
  namespace: istio-system
  loadBalancer:
    ingress:
      - ip: 10.6.136.31
spec:
  ports:
    - name: http2
      protocol: TCP
      port: 80
      targetPort: 80
      nodePort: 30557
    - name: http
      protocol: TCP
      port: 8080
      targetPort: 8080
      nodePort: 30558
    - name: https
      protocol: TCP
      port: 443
      targetPort: 443
      nodePort: 32315
```