### PR TITLE
Fix waypoint listener order

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -967,12 +967,6 @@ func serviceResourceName(s *workloadapi.Service) string {
 
 type WorkloadSource string
 
-const (
-	WorkloadSourcePod           WorkloadSource = "pod"
-	WorkloadSourceServiceEntry  WorkloadSource = "serviceentry"
-	WorkloadSourceWorkloadEntry WorkloadSource = "workloadentry"
-)
-
 type WorkloadInfo struct {
 	*workloadapi.Workload
 	// Labels for the workload. Note these are only used internally, not sent over XDS
@@ -1045,7 +1039,7 @@ func ExtractWorkloadsFromAddresses(addrs []AddressInfo) []WorkloadInfo {
 	})
 }
 
-func SortWorkloadsByCreationTime(workloads []*WorkloadInfo) []*WorkloadInfo {
+func SortWorkloadsByCreationTime(workloads []WorkloadInfo) []WorkloadInfo {
 	sort.SliceStable(workloads, func(i, j int) bool {
 		if workloads[i].CreationTime.Equal(workloads[j].CreationTime) {
 			return workloads[i].Uid < workloads[j].Uid

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -354,7 +354,7 @@ func (a *index) AddressInformation(addresses sets.String) ([]model.AddressInfo, 
 func (a *index) WorkloadsForWaypoint(scope model.WaypointScope) []model.WorkloadInfo {
 	// Lookup scope. If its namespace wide, remove entries that are in SA scope
 	workloads := a.workloads.ByOwningWaypoint.Lookup(scope)
-
+	workloads = model.SortWorkloadsByCreationTime(workloads)
 	if scope.ServiceAccount == "" {
 		// This is a namespace wide waypoint. Per-SA waypoints have precedence, so we need to filter them out
 		workloads = slices.FilterInPlace(workloads, func(info model.WorkloadInfo) bool {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -118,7 +118,7 @@ func (a *index) WorkloadsCollection(
 			w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(se.Labels, w.WorkloadName)
 
 			setTunnelProtocol(se.Labels, se.Annotations, w)
-			res = append(res, model.WorkloadInfo{Workload: w, Labels: se.Labels, Source: kind.WorkloadEntry})
+			res = append(res, model.WorkloadInfo{Workload: w, Labels: se.Labels, Source: kind.WorkloadEntry, CreationTime: se.CreationTimestamp.Time})
 		}
 		return res
 	}, krt.WithName("ServiceEntryWorkloads"))
@@ -187,7 +187,7 @@ func (a *index) workloadEntryWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(p.Labels, w.WorkloadName)
 
 		setTunnelProtocol(p.Labels, p.Annotations, w)
-		return &model.WorkloadInfo{Workload: w, Labels: p.Labels, Source: kind.WorkloadEntry}
+		return &model.WorkloadInfo{Workload: w, Labels: p.Labels, Source: kind.WorkloadEntry, CreationTime: p.CreationTimestamp.Time}
 	}
 }
 
@@ -261,7 +261,7 @@ func (a *index) podWorkloadBuilder(
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(p.Labels, w.WorkloadName)
 
 		setTunnelProtocol(p.Labels, p.Annotations, w)
-		return &model.WorkloadInfo{Workload: w, Labels: p.Labels, Source: kind.Pod}
+		return &model.WorkloadInfo{Workload: w, Labels: p.Labels, Source: kind.Pod, CreationTime: p.CreationTimestamp.Time}
 	}
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
This seems to be a regression introduced by the ambient krt PR. Originally, the workloads were sorted by creation time, but after the rewrite, `SortWorkloadsByCreationTime` has become an unused function.