### PR TITLE
istioctl describe supports displaying portlevelsettings

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -267,7 +267,7 @@ func printDestinationRule(writer io.Writer, dr *clientnetworking.DestinationRule
 		}
 	}
 
-	// Ignore LoadBalancer, ConnectionPool, OutlierDetection, and PortLevelSettings
+	// Ignore LoadBalancer, ConnectionPool, OutlierDetection
 	trafficPolicy := dr.Spec.TrafficPolicy
 	if trafficPolicy == nil {
 		fmt.Fprintf(writer, "   No Traffic Policy\n")
@@ -275,23 +275,53 @@ func printDestinationRule(writer io.Writer, dr *clientnetworking.DestinationRule
 		if trafficPolicy.Tls != nil {
 			fmt.Fprintf(writer, "   Traffic Policy TLS Mode: %s\n", dr.Spec.TrafficPolicy.Tls.Mode.String())
 		}
-		extra := []string{}
-		if trafficPolicy.LoadBalancer != nil {
-			extra = append(extra, "load balancer")
+		shortPolicies := recordShortPolicies(
+			trafficPolicy.LoadBalancer,
+			trafficPolicy.ConnectionPool,
+			trafficPolicy.OutlierDetection)
+		if shortPolicies != "" {
+			fmt.Fprintf(writer, "%s%s", printSpaces(3), shortPolicies)
 		}
-		if trafficPolicy.ConnectionPool != nil {
-			extra = append(extra, "connection pool")
-		}
-		if trafficPolicy.OutlierDetection != nil {
-			extra = append(extra, "outlier detection")
-		}
+
 		if trafficPolicy.PortLevelSettings != nil {
-			extra = append(extra, "port level settings")
-		}
-		if len(extra) > 0 {
-			fmt.Fprintf(writer, "   %s\n", strings.Join(extra, "/"))
+			fmt.Fprintf(writer, "%sPort Level Settings:\n", printSpaces(3))
+			for _, ps := range trafficPolicy.PortLevelSettings {
+				fmt.Fprintf(writer, "%s%d:\n", printSpaces(4), ps.GetPort().GetNumber())
+				if ps.Tls != nil {
+					fmt.Fprintf(writer, "%sTLS Mode: %s\n", printSpaces(6), ps.Tls.Mode.String())
+				}
+				if sp := recordShortPolicies(
+					ps.LoadBalancer,
+					ps.ConnectionPool,
+					ps.OutlierDetection); sp != "" {
+					fmt.Fprintf(writer, "%s%s", printSpaces(6), sp)
+				}
+			}
 		}
 	}
+}
+
+func printSpaces(numSpaces int) string {
+	return strings.Repeat(" ", numSpaces)
+}
+
+func recordShortPolicies(lb *v1alpha3.LoadBalancerSettings,
+	connectionPool *v1alpha3.ConnectionPoolSettings,
+	outlierDetection *v1alpha3.OutlierDetection) string {
+	extra := make([]string, 0)
+	if lb != nil {
+		extra = append(extra, "load balancer")
+	}
+	if connectionPool != nil {
+		extra = append(extra, "connection pool")
+	}
+	if outlierDetection != nil {
+		extra = append(extra, "outlier detection")
+	}
+	if len(extra) > 0 {
+		return fmt.Sprintf("Policies: %s\n", strings.Join(extra, "/"))
+	}
+	return ""
 }
 
 // httpRouteMatchSvc returns true if it matches and a slice of facts about the match

--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -307,7 +307,8 @@ func printSpaces(numSpaces int) string {
 
 func recordShortPolicies(lb *v1alpha3.LoadBalancerSettings,
 	connectionPool *v1alpha3.ConnectionPoolSettings,
-	outlierDetection *v1alpha3.OutlierDetection) string {
+	outlierDetection *v1alpha3.OutlierDetection,
+) string {
 	extra := make([]string, 0)
 	if lb != nil {
 		extra = append(extra, "load balancer")

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -444,6 +444,211 @@ VirtualService: bookinfo
    Match: /prefix*
 `,
 		},
+		// have traffic policy
+		{
+			k8sConfigs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "productpage",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       9080,
+								TargetPort: intstr.FromInt32(9080),
+							},
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+						Labels: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"istio": "ingressgateway",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt32(80),
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage-v1-1234567890",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "productpage",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "productpage",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 9080,
+									},
+								},
+							},
+							{
+								Name: "istio-proxy",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "istio-proxy",
+								Ready: true,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+						Labels: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "istio-proxy",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "istio-proxy",
+								Ready: true,
+							},
+						},
+					},
+				},
+			},
+			istioConfigs: []runtime.Object{
+				&v1alpha3.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bookinfo",
+						Namespace: "default",
+					},
+					Spec: v1alpha32.VirtualService{
+						Hosts:    []string{"productpage"},
+						Gateways: []string{"fake-gw"},
+						Http: []*v1alpha32.HTTPRoute{
+							{
+								Match: []*v1alpha32.HTTPMatchRequest{
+									{
+										Uri: &v1alpha32.StringMatch{
+											MatchType: &v1alpha32.StringMatch_Prefix{
+												Prefix: "/prefix",
+											},
+										},
+									},
+								},
+								Route: []*v1alpha32.HTTPRouteDestination{
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage",
+										},
+										Weight: 30,
+									},
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage2",
+										},
+										Weight: 20,
+									},
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage3",
+										},
+										Weight: 50,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1alpha3.DestinationRule{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage",
+						Namespace: "default",
+					},
+					Spec: v1alpha32.DestinationRule{
+						Host: "productpage",
+						Subsets: []*v1alpha32.Subset{
+							{
+								Name:   "v1",
+								Labels: map[string]string{"version": "v1"},
+							},
+						},
+						TrafficPolicy: &v1alpha32.TrafficPolicy{
+							LoadBalancer:     &v1alpha32.LoadBalancerSettings{LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST}},
+							ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},
+							OutlierDetection: &v1alpha32.OutlierDetection{MinHealthPercent: 10},
+							Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_ISTIO_MUTUAL},
+							PortLevelSettings: []*v1alpha32.TrafficPolicy_PortTrafficPolicy{
+								{
+									LoadBalancer:     &v1alpha32.LoadBalancerSettings{LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST}},
+									Port:             &v1alpha32.PortSelector{Number: 8080},
+									Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_DISABLE},
+									ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},
+									OutlierDetection: &v1alpha32.OutlierDetection{MinHealthPercent: 10},
+								},
+							},
+							Tunnel:        nil,
+							ProxyProtocol: nil,
+						},
+					},
+				},
+			},
+			configDumps: map[string][]byte{
+				"productpage-v1-1234567890": config,
+				"ingress":                   []byte("{}"),
+			},
+			namespace:      "default",
+			istioNamespace: "default",
+			// case 9, vs route to multiple hosts
+			args: strings.Split("service productpage", " "),
+			expectedOutput: `Service: productpage
+DestinationRule: productpage for "productpage"
+  WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
+   Matching subsets: 
+      (Non-matching subsets v1)
+   Traffic Policy TLS Mode: ISTIO_MUTUAL
+   Policies: load balancer/connection pool/outlier detection
+   Port Level Settings:
+    8080:
+      TLS Mode: DISABLE
+      Policies: load balancer/connection pool/outlier detection
+VirtualService: bookinfo
+   Route to host "productpage" with weight 30%
+   Route to host "productpage2" with weight 20%
+   Route to host "productpage3" with weight 50%
+   Match: /prefix*
+`,
+		},
 	}
 
 	for i, c := range cases {

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -604,13 +604,17 @@ VirtualService: bookinfo
 							},
 						},
 						TrafficPolicy: &v1alpha32.TrafficPolicy{
-							LoadBalancer:     &v1alpha32.LoadBalancerSettings{LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST}},
+							LoadBalancer: &v1alpha32.LoadBalancerSettings{
+								LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST},
+							},
 							ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},
 							OutlierDetection: &v1alpha32.OutlierDetection{MinHealthPercent: 10},
 							Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_ISTIO_MUTUAL},
 							PortLevelSettings: []*v1alpha32.TrafficPolicy_PortTrafficPolicy{
 								{
-									LoadBalancer:     &v1alpha32.LoadBalancerSettings{LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST}},
+									LoadBalancer: &v1alpha32.LoadBalancerSettings{
+										LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST},
+									},
 									Port:             &v1alpha32.PortSelector{Number: 8080},
 									Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_DISABLE},
 									ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},

--- a/releasenotes/notes/49802.yaml
+++ b/releasenotes/notes/49802.yaml
@@ -1,0 +1,34 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: feature
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: istioctl
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 49802
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Added** `istioctl x describe` supports displaying the details of policies for `PortLevelSettings`.


### PR DESCRIPTION
**Please provide a description of this PR:**
`istioctl x describe` supports displaying the details of policies for `PortLevelSettings`

the feature from #49802

output demo:
```yaml
$ istioctl x describe pod httpbin-658bfff985-v75g7 
Pod: httpbin-658bfff985-v75g7
   Pod Revision: default
   Pod Ports: 80 (httpbin), 15090 (istio-proxy)
--------------------
Service: httpbin
   Port: http 8000/HTTP targets pod port 80
DestinationRule: httpbin for "httpbin"
   Matching subsets: v1
   Traffic Policy TLS Mode: ISTIO_MUTUAL
   Policies: load balancer/connection pool/outlier detection
   Port Level Settings:
    8080:
      TLS Mode: DISABLE
      Policies: connection pool/outlier detection
VirtualService: httpbin
   1 HTTP route(s)
```