### PR TITLE
`iptables-save` does not always return 0 if it fails

### DIFF
--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -76,15 +76,15 @@ func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, erro
 	verCmd.Stderr = &verStdErr
 
 	verExec := verCmd.Run()
-	if verExec == nil && !strings.Contains(string(verStdErr.Bytes()), "unrecognized option") {
+	if verExec == nil && !strings.Contains(verStdErr.String(), "unrecognized option") {
 		var parseErr error
 		// we found the binary - extract the version, then try to detect if rules already exist for that variant
-		parsedVer, parseErr = parseIptablesVer(string(verStdOut.Bytes()))
+		parsedVer, parseErr = parseIptablesVer(verStdOut.String())
 		if parseErr != nil {
 			return IptablesVersion{}, fmt.Errorf("iptables version %q is not a valid version string: %v", verStdOut.Bytes(), parseErr)
 		}
 		// Legacy will have no marking or 'legacy', so just look for nf_tables
-		isNft = strings.Contains(string(verStdOut.Bytes()), "nf_tables")
+		isNft = strings.Contains(verStdOut.String(), "nf_tables")
 	} else {
 		log.Warnf("found iptables binary %s, but it does not appear to support the '--version' flag, assuming very old legacy version", iptablesSaveBin)
 		// Some really old iptables-legacy-save versions (1.6.1, ubuntu bionic) don't support any arguments at all, including `--version`

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -66,16 +66,25 @@ func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, erro
 	}
 
 	// Binary is there, so try to parse version
-	rawIptablesVer, execErr := exec.Command(iptablesSaveBin, "--version").CombinedOutput()
-	if execErr == nil {
+	verCmd := exec.Command(iptablesSaveBin, "--version")
+	// shockingly, `iptables-save` returns 0 if you pass it an unrecognized/bad option, so
+	// `os/exec` will return a *nil* error, even if the command fails. So, we must slurp stderr, and check it to
+	// see if the command *actually* failed due to not recognizing the version flag.
+	var verStdOut bytes.Buffer
+	var verStdErr bytes.Buffer
+	verCmd.Stdout = &verStdOut
+	verCmd.Stderr = &verStdErr
+
+	verExec := verCmd.Run()
+	if verExec == nil && !strings.Contains(string(verStdErr.Bytes()), "unrecognized option") {
 		var parseErr error
 		// we found the binary - extract the version, then try to detect if rules already exist for that variant
-		parsedVer, parseErr = parseIptablesVer(string(rawIptablesVer))
+		parsedVer, parseErr = parseIptablesVer(string(verStdOut.Bytes()))
 		if parseErr != nil {
-			return IptablesVersion{}, fmt.Errorf("iptables version %q is not a valid version string: %v", rawIptablesVer, parseErr)
+			return IptablesVersion{}, fmt.Errorf("iptables version %q is not a valid version string: %v", verStdOut.Bytes(), parseErr)
 		}
 		// Legacy will have no marking or 'legacy', so just look for nf_tables
-		isNft = strings.Contains(string(rawIptablesVer), "nf_tables")
+		isNft = strings.Contains(string(verStdOut.Bytes()), "nf_tables")
 	} else {
 		log.Warnf("found iptables binary %s, but it does not appear to support the '--version' flag, assuming very old legacy version", iptablesSaveBin)
 		// Some really old iptables-legacy-save versions (1.6.1, ubuntu bionic) don't support any arguments at all, including `--version`


### PR DESCRIPTION
**Please provide a description of this PR:**

https://github.com/istio/istio/pull/49850 attempted to fix issues where older, Debian-wrapped versions of `iptables-save` do not support the `--version` flag.

Unfortunately, in addition to not supporting the `--version` flag, these particular versions of `iptables-save` still return 0 (success) even if it fails to execute due to bad arguments.

So, we cannot rely on `os/exec` returning an error if the command fails, and must check process stderr ourselves to see if it did, for these cases.

(I have confirmed that e.g. 1.8.7/nftables DOES return a nonzero code with a bad argument - this appears to be unique to old versions + old Debian wrapper)