### PR TITLE
kube: cleanup GetDeployMetaFromPod

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 
@@ -44,6 +45,7 @@ import (
 	proxyConfig "istio.io/api/networking/v1beta1"
 	opconfig "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	common_features "istio.io/istio/pkg/features"
 	"istio.io/istio/pkg/kube"
@@ -99,7 +101,7 @@ const (
 // version of `SidecarInjectionSpec` is applied.
 type SidecarTemplateData struct {
 	TypeMeta                 metav1.TypeMeta
-	DeploymentMeta           metav1.ObjectMeta
+	DeploymentMeta           types.NamespacedName
 	ObjectMeta               metav1.ObjectMeta
 	Spec                     corev1.PodSpec
 	ProxyConfig              *meshconfig.ProxyConfig
@@ -643,7 +645,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 ) (any, error) {
 	out := in.DeepCopyObject()
 
-	var deploymentMetadata metav1.ObjectMeta
+	var deploymentMetadata types.NamespacedName
 	var metadata *metav1.ObjectMeta
 	var podSpec *corev1.PodSpec
 	var typeMeta metav1.TypeMeta
@@ -680,7 +682,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 		job := v
 		typeMeta = job.TypeMeta
 		metadata = &job.Spec.JobTemplate.ObjectMeta
-		deploymentMetadata = job.ObjectMeta
+		deploymentMetadata = config.NamespacedName(job)
 		podSpec = &job.Spec.JobTemplate.Spec.Template.Spec
 	case *corev1.Pod:
 		pod := v
@@ -691,7 +693,7 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 	case *appsv1.Deployment: // Added to be explicit about the most expected case
 		deploy := v
 		typeMeta = deploy.TypeMeta
-		deploymentMetadata = deploy.ObjectMeta
+		deploymentMetadata = config.NamespacedName(deploy)
 		metadata = &deploy.Spec.Template.ObjectMeta
 		podSpec = &deploy.Spec.Template.Spec
 	default:
@@ -700,7 +702,8 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 
 		typeMeta = outValue.FieldByName("TypeMeta").Interface().(metav1.TypeMeta)
 
-		deploymentMetadata = outValue.FieldByName("ObjectMeta").Interface().(metav1.ObjectMeta)
+		om := outValue.FieldByName("ObjectMeta").Interface().(metav1.ObjectMeta)
+		deploymentMetadata = types.NamespacedName{Name: om.GetName(), Namespace: om.GetNamespace()}
 
 		templateValue := outValue.FieldByName("Spec").FieldByName("Template")
 		// `Template` is defined as a pointer in some older API

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/yaml"
@@ -377,7 +378,7 @@ func NewValuesConfig(v string) (ValuesConfig, error) {
 
 type InjectionParameters struct {
 	pod                 *corev1.Pod
-	deployMeta          metav1.ObjectMeta
+	deployMeta          types.NamespacedName
 	namespace           *corev1.Namespace
 	typeMeta            metav1.TypeMeta
 	templates           map[string]*template.Template

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -141,10 +142,10 @@ users:
 
 func TestCronJobMetadata(t *testing.T) {
 	tests := []struct {
-		name               string
-		jobName            string
-		wantTypeMetadata   metav1.TypeMeta
-		wantObjectMetadata metav1.ObjectMeta
+		name             string
+		jobName          string
+		wantTypeMetadata metav1.TypeMeta
+		wantName         types.NamespacedName
 	}{
 		{
 			name:    "cron-job-name-sec",
@@ -153,9 +154,8 @@ func TestCronJobMetadata(t *testing.T) {
 				Kind:       "CronJob",
 				APIVersion: "batch/v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "sec",
-				GenerateName: "sec-1234567890-pod",
+			wantName: types.NamespacedName{
+				Name: "sec",
 			},
 		},
 		{
@@ -165,9 +165,8 @@ func TestCronJobMetadata(t *testing.T) {
 				Kind:       "CronJob",
 				APIVersion: "batch/v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "min",
-				GenerateName: "min-12345678-pod",
+			wantName: types.NamespacedName{
+				Name: "min",
 			},
 		},
 		{
@@ -177,9 +176,8 @@ func TestCronJobMetadata(t *testing.T) {
 				Kind:       "Job",
 				APIVersion: "v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "job-123",
-				GenerateName: "job-123-pod",
+			wantName: types.NamespacedName{
+				Name: "job-123",
 			},
 		},
 	}
@@ -200,8 +198,8 @@ func TestCronJobMetadata(t *testing.T) {
 					},
 				},
 			)
-			if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-				t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
+			if !reflect.DeepEqual(gotObjectMeta, tt.wantName) {
+				t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantName)
 			}
 			if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
 				t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
@@ -212,10 +210,10 @@ func TestCronJobMetadata(t *testing.T) {
 
 func TestDeployMeta(t *testing.T) {
 	tests := []struct {
-		name               string
-		pod                *corev1.Pod
-		wantTypeMetadata   metav1.TypeMeta
-		wantObjectMetadata metav1.ObjectMeta
+		name             string
+		pod              *corev1.Pod
+		wantTypeMetadata metav1.TypeMeta
+		wantName         types.NamespacedName
 	}{
 		{
 			name: "deployconfig-name-deploy",
@@ -224,10 +222,8 @@ func TestDeployMeta(t *testing.T) {
 				Kind:       "DeploymentConfig",
 				APIVersion: "v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "deploy",
-				GenerateName: "deploy-rc-pod",
-				Labels:       map[string]string{},
+			wantName: types.NamespacedName{
+				Name: "deploy",
 			},
 		},
 		{
@@ -237,10 +233,8 @@ func TestDeployMeta(t *testing.T) {
 				Kind:       "DeploymentConfig",
 				APIVersion: "v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "deploy2",
-				GenerateName: "deploy2-rc-pod",
-				Labels:       map[string]string{},
+			wantName: types.NamespacedName{
+				Name: "deploy2",
 			},
 		},
 		{
@@ -250,10 +244,8 @@ func TestDeployMeta(t *testing.T) {
 				Kind:       "ReplicationController",
 				APIVersion: "v1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "dep-rc",
-				GenerateName: "dep-rc-pod",
-				Labels:       map[string]string{},
+			wantName: types.NamespacedName{
+				Name: "dep-rc",
 			},
 		},
 		{
@@ -276,18 +268,16 @@ func TestDeployMeta(t *testing.T) {
 				Kind:       "Rollout",
 				APIVersion: "v1alpha1",
 			},
-			wantObjectMetadata: metav1.ObjectMeta{
-				Name:         "name",
-				GenerateName: "name-6dc78b855c-",
-				Labels:       map[string]string{"rollouts-pod-template-hash": "6dc78b855c"},
+			wantName: types.NamespacedName{
+				Name: "name",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotObjectMeta, gotTypeMeta := GetDeployMetaFromPod(tt.pod)
-			assert.Equal(t, gotObjectMeta, tt.wantObjectMetadata)
+			gotName, gotTypeMeta := GetDeployMetaFromPod(tt.pod)
+			assert.Equal(t, gotName, tt.wantName)
 			assert.Equal(t, gotTypeMeta, tt.wantTypeMetadata)
 		})
 	}


### PR DESCRIPTION
We don't need the full meta, only the name/namespace
