### PR TITLE
envoy filter: warn about instability on usage

### DIFF
--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4693,13 +4693,13 @@ func TestValidateEnvoyFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			warn, err := ValidateEnvoyFilter(config.Config{
+			warn, err := validateEnvoyFilter(config.Config{
 				Meta: config.Meta{
 					Name:      someName,
 					Namespace: someNamespace,
 				},
 				Spec: tt.in,
-			})
+			}, Validation{})
 			checkValidationMessage(t, warn, err, tt.warning, tt.error)
 		})
 	}


### PR DESCRIPTION
This is just a small QOL adjustment to ensure user are appropriately
aware of the risks involved with EnvoyFilter usage. This is *just a
warning* and does not block any usage.
