### PR TITLE
metrics: make prometheus optional

### DIFF
--- a/cni/pkg/monitoring/monitoring.go
+++ b/cni/pkg/monitoring/monitoring.go
@@ -40,7 +40,9 @@ func SetupMonitoring(port int, path string, stop <-chan struct{}) {
 		log.Errorf("could not set up prometheus exporter: %v", err)
 		return
 	}
-	mux.Handle(path, exporter)
+	if exporter != nil {
+		mux.Handle(path, exporter)
+	}
 	monitoringServer := &http.Server{
 		Handler: mux,
 	}

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -60,7 +60,9 @@ func addMonitor(mux *http.ServeMux) error {
 	if err != nil {
 		return fmt.Errorf("could not set up prometheus exporter: %v", err)
 	}
-	mux.Handle(metricsPath, exporter)
+	if exporter != nil {
+		mux.Handle(metricsPath, exporter)
+	}
 
 	mux.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {
 		if _, err := out.Write([]byte(version.Info.String())); err != nil {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -15,14 +15,10 @@
 package monitoring
 
 import (
-	"net/http"
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
 	api "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 
@@ -41,36 +37,6 @@ var (
 
 func init() {
 	otel.SetLogger(log.NewLogrAdapter(monitoringLogger))
-}
-
-// RegisterPrometheusExporter sets the global metrics handler to the provided Prometheus registerer and gatherer.
-// Returned is an HTTP handler that can be used to read metrics from.
-func RegisterPrometheusExporter(reg prometheus.Registerer, gatherer prometheus.Gatherer) (http.Handler, error) {
-	if reg == nil {
-		reg = prometheus.DefaultRegisterer
-	}
-	if gatherer == nil {
-		gatherer = prometheus.DefaultGatherer
-	}
-	promOpts := []otelprom.Option{
-		otelprom.WithoutScopeInfo(),
-		otelprom.WithoutTargetInfo(),
-		otelprom.WithoutUnits(),
-		otelprom.WithRegisterer(reg),
-		otelprom.WithoutCounterSuffixes(),
-	}
-
-	prom, err := otelprom.New(promOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	opts := []metric.Option{metric.WithReader(prom)}
-	opts = append(opts, knownMetrics.toHistogramViews()...)
-	mp := metric.NewMeterProvider(opts...)
-	otel.SetMeterProvider(mp)
-	handler := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
-	return handler, nil
 }
 
 // A Metric collects numerical observations.

--- a/pkg/monitoring/prometheus.go
+++ b/pkg/monitoring/prometheus.go
@@ -1,0 +1,55 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/sdk/metric"
+)
+
+// RegisterPrometheusExporter sets the global metrics handler to the provided Prometheus registerer and gatherer.
+// Returned is an HTTP handler that can be used to read metrics from.
+func RegisterPrometheusExporter(reg prometheus.Registerer, gatherer prometheus.Gatherer) (http.Handler, error) {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	if gatherer == nil {
+		gatherer = prometheus.DefaultGatherer
+	}
+	promOpts := []otelprom.Option{
+		otelprom.WithoutScopeInfo(),
+		otelprom.WithoutTargetInfo(),
+		otelprom.WithoutUnits(),
+		otelprom.WithRegisterer(reg),
+		otelprom.WithoutCounterSuffixes(),
+	}
+
+	prom, err := otelprom.New(promOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []metric.Option{metric.WithReader(prom)}
+	opts = append(opts, knownMetrics.toHistogramViews()...)
+	mp := metric.NewMeterProvider(opts...)
+	otel.SetMeterProvider(mp)
+	handler := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+	return handler, nil
+}

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -275,7 +275,9 @@ func (s *Instance) startMetricsServer() {
 		log.Errorf("could not set up prometheus exporter: %v", err)
 		return
 	}
-	mux.Handle("/metrics", LogRequests(exporter))
+	if exporter != nil {
+		mux.Handle("/metrics", LogRequests(exporter))
+	}
 	s.metricsServer = &http.Server{
 		Handler: mux,
 	}


### PR DESCRIPTION
Change-Id: I632a7734a4aadf9075f0fd68c94bd27247fe0707

Some vendor platforms do not allow using Prometheus Otel exporter.
This change makes it optional, since Prometheus is not required for Otel SDK.