### PR TITLE
delta xds: fix deletion of clusters and listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -3048,8 +3049,6 @@ func TestVerifyCertAtClient(t *testing.T) {
 }
 
 func TestBuildDeltaClusters(t *testing.T) {
-	g := NewWithT(t)
-
 	testService1 := &model.Service{
 		Hostname: host.Name("test.com"),
 		Ports: []*model.Port{
@@ -3495,8 +3494,8 @@ func TestBuildDeltaClusters(t *testing.T) {
 			if delta != tc.usedDelta {
 				t.Errorf("un expected delta, want %v got %v", tc.usedDelta, delta)
 			}
-			g.Expect(removed).To(Equal(tc.removedClusters))
-			g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal(tc.expectedClusters))
+			assert.Equal(t, removed, tc.removedClusters)
+			assert.Equal(t, xdstest.MapKeys(xdstest.ExtractClusters(clusters)), tc.expectedClusters)
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -135,6 +135,13 @@ func (sd *ServiceDiscovery) RemoveService(name host.Name) {
 	svc := sd.services[name]
 	delete(sd.services, name)
 
+	// remove old entries
+	for k, v := range sd.ip2instance {
+		sd.ip2instance[k] = slices.FilterInPlace(v, func(instance *model.ServiceInstance) bool {
+			return instance.Service == nil || instance.Service.Hostname != name
+		})
+	}
+
 	if sd.XdsUpdater != nil {
 		sd.XdsUpdater.SvcUpdate(sd.shardKey(), string(svc.Hostname), svc.Attributes.Namespace, model.EventDelete)
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -468,7 +468,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 	switch g := gen.(type) {
 	case model.XdsDeltaResourceGenerator:
 		res, deletedRes, logdata, usedDelta, err = g.GenerateDeltas(con.proxy, req, w)
-		log.Errorf("howardjohn: %v %v", res, deletedRes)
 		if features.EnableUnsafeDeltaTest {
 			fullRes, l, _ := g.Generate(con.proxy, originalW, req)
 			s.compareDiff(con, originalW, fullRes, res, deletedRes, usedDelta, req.Delta, l.Incremental)
@@ -506,7 +505,6 @@ func (s *DiscoveryServer) pushDeltaXds(con *Connection,
 	if shouldSetWatchedResources(w) {
 		// this is probably a bad idea...
 		con.proxy.Lock()
-		log.Errorf("howardjohn:\n%v\n%v", w.ResourceNames, sets.SortedList(sets.New(w.ResourceNames...).DeleteAll(resp.RemovedResources...).InsertAll(currentResources...)))
 		// TODO is locking here right?? can't be
 		w.ResourceNames = sets.SortedList(sets.New(w.ResourceNames...).DeleteAll(resp.RemovedResources...).InsertAll(currentResources...))
 		con.proxy.Unlock()

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -39,8 +40,8 @@ var knownOptimizationGaps = sets.New(
 func (s *DiscoveryServer) compareDiff(
 	con *Connection,
 	w *model.WatchedResource,
-	full model.Resources,
-	resp model.Resources,
+	sotwRes model.Resources,
+	deltaRes model.Resources,
 	deleted model.DeletedResources,
 	usedDelta bool,
 	delta model.ResourceDelta,
@@ -51,23 +52,17 @@ func (s *DiscoveryServer) compareDiff(
 		log.Debugf("ADS:%s: resources initialized", v3.GetShortType(w.TypeUrl))
 		return
 	}
-	if resp == nil && deleted == nil && len(full) == 0 {
+	if deltaRes == nil && deleted == nil && len(sotwRes) == 0 {
 		// TODO: it suspicious full is never nil - are there case where we should be deleting everything?
 		// Both SotW and Delta did not respond, nothing to compare
 		return
 	}
-	newByName := map[string]*discovery.Resource{}
-	for _, v := range full {
-		newByName[v.Name] = v
-	}
-	curByName := map[string]*discovery.Resource{}
-	for _, v := range current {
-		curByName[v.Name] = v
-	}
+	newByName := slices.GroupUnique(sotwRes, (*discovery.Resource).GetName)
+	curByName := slices.GroupUnique(current, (*discovery.Resource).GetName)
 
 	watched := sets.New(w.ResourceNames...)
 
-	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(full), len(resp), len(deleted))
+	details := fmt.Sprintf("last:%v sotw:%v delta:%v-%v", len(current), len(sotwRes), len(deltaRes), len(deleted))
 	wantDeleted := sets.New[string]()
 	wantChanged := sets.New[string]()
 	wantUnchanged := sets.New[string]()
@@ -87,7 +82,7 @@ func (s *DiscoveryServer) compareDiff(
 			wantUnchanged.Insert(c.Name)
 		}
 	}
-	for _, v := range full {
+	for _, v := range sotwRes {
 		if _, f := curByName[v.Name]; !f {
 			// Resource is added. Delta doesn't distinguish add vs update, so just put it with changed
 			wantChanged.Insert(v.Name)
@@ -99,7 +94,7 @@ func (s *DiscoveryServer) compareDiff(
 		gotDeleted.InsertAll(deleted...)
 	}
 	gotChanged := sets.New[string]()
-	for _, v := range resp {
+	for _, v := range deltaRes {
 		gotChanged.Insert(v.Name)
 	}
 

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -310,7 +310,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Subsets: []echo.SubsetConfig{{
 				Labels: map[string]string{label.SidecarInject.Name: "true"},
 				Annotations: echo.NewAnnotations().Set(echo.SidecarProxyConfig, `proxyMetadata:
-ISTIO_DELTA_XDS: "false"`),
+  ISTIO_DELTA_XDS: "false"`),
 			}},
 		}
 		defaultConfigs = append(defaultConfigs, sotw)


### PR DESCRIPTION
Due to this bug, clusters and listeners are basically never deleted.

There are two distinct bugs here:
* Our `ResourceNames` computation was wrong, which is used to determine deletes, causing misses. I also removed the lock here, since its not needed (we are operating on a clone of the WatchedResources that we write back later
* We just did not account for inbound in delta CDS at all

Fixes https://github.com/istio/istio/issues/49814