### PR TITLE
helm: Add default `divisor` for `GOMEMLIMIT` and `GOMAXPROCS`

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -173,10 +173,12 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+                  divisor: '1'
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
+                  divisor: '1'
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir


### PR DESCRIPTION
**Please provide a description of this PR:**
When deploying istio via ArgoCD with auto-sync, this field is flagged as being removed since Kubernetes appears to add the default after-the-fact.