### PR TITLE
Fix gateway helm deployment with openshift profile

### DIFF
--- a/manifests/charts/base/files/profile-openshift.yaml
+++ b/manifests/charts/base/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/default/files/profile-openshift.yaml
+++ b/manifests/charts/default/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/gateway/files/profile-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/istio-cni/files/profile-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/istio-operator/files/profile-openshift.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/istiod-remote/files/profile-openshift.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/charts/ztunnel/files/profile-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/manifests/helm-profiles/openshift.yaml
+++ b/manifests/helm-profiles/openshift.yaml
@@ -16,3 +16,11 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true


### PR DESCRIPTION

Re-adding `securityContext` override for gateway to the openshift profile. This was previously done by specifying the [openshift-values.yaml](https://raw.githubusercontent.com/istio/istio/release-1.20/manifests/charts/gateway/openshift-values.yaml) file, but that was removed when introducing helm profiles in #48249


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Installation