### PR TITLE
log: revamp logging options

### DIFF
--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -38,7 +38,7 @@ import (
 
 func setupLogging() {
 	opts := istiolog.DefaultOptions()
-	opts.SetOutputLevel(istiolog.OverrideScopeName, istiolog.DebugLevel)
+	opts.SetDefaultOutputLevel(istiolog.OverrideScopeName, istiolog.DebugLevel)
 	istiolog.Configure(opts)
 	for _, scope := range istiolog.Scopes() {
 		scope.SetOutputLevel(istiolog.DebugLevel)

--- a/istioctl/pkg/root/root.go
+++ b/istioctl/pkg/root/root.go
@@ -37,10 +37,11 @@ var (
 
 func defaultLogOptions() *log.Options {
 	o := log.DefaultOptions()
-	o.SetOutputLevel(log.DefaultScopeName, log.WarnLevel)
-	// These scopes are, at the default "WARN" level, too chatty for command line use
-	o.SetOutputLevel("validation", log.ErrorLevel)
-	o.SetOutputLevel("processing", log.ErrorLevel)
-	o.SetOutputLevel("kube", log.ErrorLevel)
+	// Default to warning for everything; we usually don't want logs in istioctl
+	o.SetDefaultOutputLevel("all", log.WarnLevel)
+	// These scopes are too noisy even at warning level
+	o.SetDefaultOutputLevel("validation", log.ErrorLevel)
+	o.SetDefaultOutputLevel("processing", log.ErrorLevel)
+	o.SetDefaultOutputLevel("kube", log.ErrorLevel)
 	return o
 }

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -128,7 +128,7 @@ func resolverForTest(t test.Failer, xdsPort int, ns string) resolver.Builder {
 func init() {
 	// Setup gRPC logging. Do it once in init to avoid races
 	o := log.DefaultOptions()
-	o.LogGrpc = true
+	o.SetDefaultOutputLevel(log.GrpcScopeName, log.DebugLevel)
 	log.Configure(o)
 }
 

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -109,7 +109,6 @@ var (
 	// controls whether all output is JSON or CLI style. This makes it easier to query how the zap encoder is configured
 	// vs. reading it's internal state.
 	useJSON atomic.Value
-	logGrpc bool
 )
 
 func init() {
@@ -132,8 +131,8 @@ func encodeStackdriverLevel(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) 
 	enc.AppendString(stackdriverSeverityMapping[l])
 }
 
-// prepZap is a utility function used by the Configure function.
-func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer, error) {
+// prepZap sets up the core Zap loggers
+func prepZap(options *Options) (zapcore.Core, func(string) zapcore.Core, zapcore.WriteSyncer, error) {
 	var enc zapcore.Encoder
 	if options.useStackdriverFormat {
 		// See also: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
@@ -197,20 +196,24 @@ func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer,
 		sink = outputSink
 	}
 
-	var enabler zap.LevelEnablerFunc = func(lvl zapcore.Level) bool {
-		switch lvl {
-		case zapcore.ErrorLevel:
-			return defaultScope.ErrorEnabled()
-		case zapcore.WarnLevel:
-			return defaultScope.WarnEnabled()
-		case zapcore.InfoLevel:
-			return defaultScope.InfoEnabled()
+	alwaysOn := zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(zapcore.DebugLevel))
+	conditionallyOn := func(scopeName string) zapcore.Core {
+		scope := FindScope(scopeName)
+		enabler := func(lvl zapcore.Level) bool {
+			switch lvl {
+			case zapcore.ErrorLevel:
+				return scope.ErrorEnabled()
+			case zapcore.WarnLevel:
+				return scope.WarnEnabled()
+			case zapcore.InfoLevel:
+				return scope.InfoEnabled()
+			}
+			return scope.DebugEnabled()
 		}
-		return defaultScope.DebugEnabled()
+		return zapcore.NewCore(enc, sink, zap.LevelEnablerFunc(enabler))
 	}
-
-	return zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(zapcore.DebugLevel)),
-		zapcore.NewCore(enc, sink, enabler),
+	return alwaysOn,
+		conditionallyOn,
 		errSink, nil
 }
 
@@ -257,25 +260,16 @@ func updateScopes(options *Options) error {
 	// snapshot what's there
 	allScopes := Scopes()
 
-	// set default if exists
-	levels := strings.Split(options.outputLevels, ",")
-	for _, sl := range levels {
-		s, l, err := convertScopedLevel(sl)
-		if err != nil {
-			return err
-		}
-		if s == DefaultScopeName {
-			for _, scope := range allScopes {
-				if scope.GetOutputLevel() == defaultOutputLevel {
-					scope.SetOutputLevel(l)
-				}
-			}
-			break
-		}
+	// Join defaultOutputLevels and outputLevels
+	levels := options.defaultOutputLevels
+	if levels == "" {
+		levels = options.outputLevels
+	} else if options.outputLevels != "" {
+		levels = levels + "," + options.outputLevels
 	}
 
 	// update the output levels of all listed scopes
-	if err := processLevels(allScopes, options.outputLevels, func(s *Scope, l Level) { s.SetOutputLevel(l) }); err != nil {
+	if err := processLevels(allScopes, levels, func(s *Scope, l Level) { s.SetOutputLevel(l) }); err != nil {
 		return err
 	}
 
@@ -296,8 +290,6 @@ func updateScopes(options *Options) error {
 			for _, scope := range allScopes {
 				scope.SetLogCallers(true)
 			}
-
-			return nil
 		}
 
 		if scope, ok := allScopes[s]; ok {
@@ -305,9 +297,9 @@ func updateScopes(options *Options) error {
 		}
 	}
 
-	// update LogGrpc if necessary
-	if logGrpc {
-		options.LogGrpc = true
+	// If gRPC logging is enabled, turn on gRPC logging automatically
+	if grpcScope.GetOutputLevel() != NoneLevel {
+		options.logGRPC = true
 	}
 
 	return nil
@@ -330,12 +322,6 @@ func processLevels(allScopes map[string]*Scope, arg string, setter func(*Scope, 
 			for _, scope := range allScopes {
 				setter(scope, l)
 			}
-			return nil
-		} else if s == GrpcScopeName {
-			grpcScope := registerScope(GrpcScopeName, "", 3)
-			logGrpc = true
-			setter(grpcScope, l)
-			return nil
 		}
 	}
 
@@ -348,46 +334,50 @@ func processLevels(allScopes map[string]*Scope, arg string, setter func(*Scope, 
 // Once this call returns, the logging system is ready to accept data.
 // nolint: staticcheck
 func Configure(options *Options) error {
-	core, captureCore, errSink, err := prepZap(options)
+	if err := updateScopes(options); err != nil {
+		return err
+	}
+	baseLogger, logBuilder, errSink, err := prepZap(options)
 	if err != nil {
 		return err
 	}
+	defaultLogger := logBuilder(DefaultScopeName)
+	allLoggers := []*zapcore.Core{&baseLogger, &defaultLogger}
 
-	if err := updateScopes(options); err != nil {
-		return err
+	var grpcLogger zapcore.Core
+	if options.logGRPC {
+		grpcLogger = logBuilder(GrpcScopeName)
+		allLoggers = append(allLoggers, &grpcLogger)
 	}
 
 	closeFns := make([]func() error, 0)
 
 	for _, ext := range options.extensions {
-		var closeFn, captureCloseFn func() error
-		var err error
-		core, closeFn, err = ext(core)
-		if err != nil {
-			return err
+		for _, logger := range allLoggers {
+			newLogger, closeFn, err := ext(*logger)
+			if err != nil {
+				return err
+			}
+			*logger = newLogger
+			closeFns = append(closeFns, closeFn)
 		}
-		captureCore, captureCloseFn, err = ext(captureCore)
-		if err != nil {
-			return err
-		}
-		closeFns = append(closeFns, closeFn, captureCloseFn)
 	}
 
 	pt := patchTable{
 		write: func(ent zapcore.Entry, fields []zapcore.Field) error {
-			err := core.Write(ent, fields)
+			err := baseLogger.Write(ent, fields)
 			if ent.Level == zapcore.FatalLevel {
 				funcs.Load().(patchTable).exitProcess(1)
 			}
 
 			return err
 		},
-		sync:        core.Sync,
+		sync:        baseLogger.Sync,
 		exitProcess: os.Exit,
 		errorSink:   errSink,
 		close: func() error {
 			// best-effort to sync
-			core.Sync() // nolint: errcheck
+			baseLogger.Sync() // nolint: errcheck
 			for _, f := range closeFns {
 				if err := f(); err != nil {
 					return err
@@ -412,17 +402,17 @@ func Configure(options *Options) error {
 		opts = append(opts, zap.AddStacktrace(levelToZap[l]))
 	}
 
-	captureLogger := zap.New(captureCore, opts...)
+	defaultZapLogger := zap.New(defaultLogger, opts...)
 
 	// capture global zap logging and force it through our logger
-	_ = zap.ReplaceGlobals(captureLogger)
+	_ = zap.ReplaceGlobals(defaultZapLogger)
 
 	// capture standard golang "log" package output and force it through our logger
-	_ = zap.RedirectStdLog(captureLogger)
+	_ = zap.RedirectStdLog(defaultZapLogger)
 
 	// capture gRPC logging
-	if options.LogGrpc {
-		grpclog.SetLogger(zapgrpc.NewLogger(captureLogger.WithOptions(zap.AddCallerSkip(3))))
+	if options.logGRPC {
+		grpclog.SetLoggerV2(zapgrpc.NewLogger(zap.New(grpcLogger, opts...).WithOptions(zap.AddCallerSkip(3))))
 	}
 
 	// capture klog (Kubernetes logging) through our logging

--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -16,11 +16,12 @@ package log
 
 // These functions enable logging using a global Scope. See scope.go for usage information.
 
-func registerDefaultScope() *Scope {
-	return registerScope(DefaultScopeName, "Unscoped logging messages.", 1)
+func registerDefaultScopes() (defaults *Scope, grpc *Scope) {
+	return registerScope(DefaultScopeName, "Unscoped logging messages.", 1),
+		registerScope(GrpcScopeName, "logs from gRPC", 3)
 }
 
-var defaultScope = registerDefaultScope()
+var defaultScope, grpcScope = registerDefaultScopes()
 
 // Fatal outputs a message at fatal level.
 func Fatal(fields any) {

--- a/pkg/log/default_test.go
+++ b/pkg/log/default_test.go
@@ -215,7 +215,7 @@ func TestEnabled(t *testing.T) {
 	for i, c := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			o := testOptions()
-			o.SetOutputLevel(DefaultScopeName, c.level)
+			o.SetDefaultOutputLevel(DefaultScopeName, c.level)
 
 			_ = Configure(o)
 

--- a/pkg/log/options_test.go
+++ b/pkg/log/options_test.go
@@ -31,226 +31,231 @@ func TestOpts(t *testing.T) {
 		result  Options
 	}{
 		{"--log_as_json", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			JSONEncoding:       true,
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			JSONEncoding:        true,
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_target stdout --log_target stderr", Options{
-			OutputPaths:        []string{"stdout", "stderr"},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{"stdout", "stderr"},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_caller default", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			logCallers:         DefaultScopeName,
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			logCallers:          DefaultScopeName,
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level debug", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   levelToString[DebugLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    levelToString[DebugLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level default:debug", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[DebugLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[DebugLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level info", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   levelToString[InfoLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    levelToString[InfoLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level default:info", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[InfoLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[InfoLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level warn", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   levelToString[WarnLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    levelToString[WarnLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level default:warn", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[WarnLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[WarnLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level error", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   levelToString[ErrorLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    levelToString[ErrorLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level default:error", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[ErrorLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[ErrorLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level none", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   levelToString[NoneLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    levelToString[NoneLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_stacktrace_level default:none", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[NoneLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    "default:none",
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_output_level debug", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       levelToString[DebugLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			outputLevels:        levelToString[DebugLevel],
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_output_level info", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       levelToString[InfoLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			outputLevels:        levelToString[InfoLevel],
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_output_level warn", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       levelToString[WarnLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			outputLevels:        levelToString[WarnLevel],
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_output_level error", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       levelToString[ErrorLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			outputLevels:        levelToString[ErrorLevel],
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_output_level none", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       levelToString[NoneLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			outputLevels:        levelToString[NoneLevel],
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_rotate foobar", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotateOutputPath:   "foobar",
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotateOutputPath:    "foobar",
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_rotate_max_age 1234", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     1234,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      1234,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_rotate_max_size 1234", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    1234,
-			RotationMaxBackups: defaultRotationMaxBackups,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     1234,
+			RotationMaxBackups:  defaultRotationMaxBackups,
 		}},
 
 		{"--log_rotate_max_backups 1234", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: 1234,
+			OutputPaths:         []string{defaultOutputPath},
+			ErrorOutputPaths:    []string{defaultErrorOutputPath},
+			defaultOutputLevels: "default:info,grpc:none",
+			stackTraceLevels:    DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
+			RotationMaxAge:      defaultRotationMaxAge,
+			RotationMaxSize:     defaultRotationMaxSize,
+			RotationMaxBackups:  1234,
 		}},
 	}
 
@@ -276,159 +281,53 @@ func TestOpts(t *testing.T) {
 	}
 }
 
-func TestSetLevel(t *testing.T) {
+func TestSetDefaultLevel(t *testing.T) {
 	resetGlobals()
 
 	_ = RegisterScope("TestSetLevel", "")
 
 	cases := []struct {
-		levels      string
-		scope       string
-		targetLevel Level
-	}{
-		{"debug", "default", DebugLevel},
-		{"default:debug", "default", DebugLevel},
-		{"info", "default", DebugLevel},
-		{"default:info", "default", DebugLevel},
-		{"warn", "default", DebugLevel},
-		{"default:warn", "default", DebugLevel},
-		{"error", "default", DebugLevel},
-		{"default:error", "default", DebugLevel},
-		{"none", "default", DebugLevel},
-		{"default:none", "default", DebugLevel},
-
-		{"debug", "default", ErrorLevel},
-		{"default:debug", "default", ErrorLevel},
-		{"info", "default", ErrorLevel},
-		{"default:info", "default", ErrorLevel},
-		{"warn", "default", ErrorLevel},
-		{"default:warn", "default", ErrorLevel},
-		{"error", "default", ErrorLevel},
-		{"default:error", "default", ErrorLevel},
-		{"none", "default", ErrorLevel},
-		{"default:none", "default", ErrorLevel},
-
-		{"default:none", "pizza", ErrorLevel},
-		{"default:none,TestSetLevel:debug", "pizza", ErrorLevel},
-
-		{"default:none,TestSetLevel:debug,all:debug", "all", DebugLevel},
-	}
-
-	for i, c := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			o := DefaultOptions()
-			o.outputLevels = c.levels
-			o.stackTraceLevels = c.levels
-
-			o.SetOutputLevel(c.scope, c.targetLevel)
-			o.SetStackTraceLevel(c.scope, c.targetLevel)
-
-			if newLevel, err := o.GetOutputLevel(c.scope); err != nil {
-				t.Errorf("Got error %v, expecting success", err)
-			} else if newLevel != c.targetLevel {
-				t.Errorf("Got level %v, expecting %v", newLevel, c.targetLevel)
-			}
-
-			if newLevel, err := o.GetStackTraceLevel(c.scope); err != nil {
-				t.Errorf("Got error %v, expecting success", err)
-			} else if newLevel != c.targetLevel {
-				t.Errorf("Got level %v, expecting %v", newLevel, c.targetLevel)
-			}
-		})
-	}
-}
-
-func TestGetLevel(t *testing.T) {
-	resetGlobals()
-
-	cases := []struct {
-		levels        string
+		flagLevels    string
 		scope         string
+		defaultLevel  Level
 		expectedLevel Level
-		expectedFail  bool
 	}{
-		{"debug", "default", DebugLevel, false},
-		{"default:debug", "default", DebugLevel, false},
-		{"info", "default", InfoLevel, false},
-		{"default:info", "default", InfoLevel, false},
-		{"warn", "default", WarnLevel, false},
-		{"default:warn", "default", WarnLevel, false},
-		{"error", "default", ErrorLevel, false},
-		{"default:error", "default", ErrorLevel, false},
+		{"debug", "default", DebugLevel, DebugLevel},
+		{"default:debug", "default", DebugLevel, DebugLevel},
+		{"info", "default", DebugLevel, InfoLevel},
+		{"default:info", "default", DebugLevel, InfoLevel},
+		{"warn", "default", DebugLevel, WarnLevel},
+		{"default:warn", "default", DebugLevel, WarnLevel},
+		{"error", "default", DebugLevel, ErrorLevel},
+		{"default:error", "default", DebugLevel, ErrorLevel},
+		{"none", "default", DebugLevel, NoneLevel},
+		{"default:none", "default", DebugLevel, NoneLevel},
 
-		{"badLevel", "default", NoneLevel, true},
-		{"default:badLevel", "default", NoneLevel, true},
-
-		{"error", "badScope", NoneLevel, true},
-		{"default:error", "badScope", NoneLevel, true},
-
-		{"default:err:or", "default", NoneLevel, true},
+		{"debug", "default", ErrorLevel, DebugLevel},
+		{"default:debug", "default", ErrorLevel, DebugLevel},
+		{"info", "default", ErrorLevel, InfoLevel},
+		{"default:info", "default", ErrorLevel, InfoLevel},
+		{"warn", "default", ErrorLevel, WarnLevel},
+		{"default:warn", "default", ErrorLevel, WarnLevel},
+		{"error", "default", ErrorLevel, ErrorLevel},
+		{"default:error", "default", ErrorLevel, ErrorLevel},
+		{"none", "default", ErrorLevel, NoneLevel},
+		{"default:none", "default", ErrorLevel, NoneLevel},
 	}
 
 	for i, c := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			o := DefaultOptions()
-			o.outputLevels = c.levels
-			o.stackTraceLevels = c.levels
+			o.outputLevels = c.flagLevels
+			o.stackTraceLevels = c.flagLevels
 
-			l, err := o.GetOutputLevel(c.scope)
-			if c.expectedFail {
-				if err == nil {
-					t.Errorf("Got success, expecting error")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Got error %s, expecting success", err)
-				}
-
-				if l != c.expectedLevel {
-					t.Errorf("Got level %v, expecting %v", l, c.expectedLevel)
-				}
+			o.SetDefaultOutputLevel(c.scope, c.defaultLevel)
+			if err := Configure(o); err != nil {
+				t.Fatal(err)
 			}
-
-			l, err = o.GetStackTraceLevel(c.scope)
-			if c.expectedFail {
-				if err == nil {
-					t.Errorf("Got success, expecting error")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Got error %s, expecting success", err)
-				}
-
-				if l != c.expectedLevel {
-					t.Errorf("Got level %v, expecting %v", l, c.expectedLevel)
-				}
+			if got := FindScope(c.scope).GetOutputLevel(); got != c.expectedLevel {
+				t.Fatalf("got %v want %v", got, c.expectedLevel)
 			}
 		})
-	}
-}
-
-func TestLogCallers(t *testing.T) {
-	resetGlobals()
-	o := DefaultOptions()
-
-	o.SetLogCallers("s1", true)
-	if !o.GetLogCallers("s1") {
-		t.Error("Expecting true")
-	}
-
-	o.SetLogCallers("s1", false)
-	if o.GetLogCallers("s1") {
-		t.Error("Expecting false")
-	}
-
-	o.SetLogCallers("s1", true)
-	o.SetLogCallers("s2", true)
-	if !o.GetLogCallers("s1") {
-		t.Error("Expecting true")
-	}
-
-	if !o.GetLogCallers("s2") {
-		t.Error("Expecting true")
-	}
-
-	if o.GetLogCallers("s3") {
-		t.Error("Expecting false")
 	}
 }

--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -171,10 +171,10 @@ func cmdLogOptions() *log.Options {
 	o := log.DefaultOptions()
 
 	// These scopes are, at the default "INFO" level, too chatty for command line use
-	o.SetOutputLevel("validation", log.ErrorLevel)
-	o.SetOutputLevel("processing", log.ErrorLevel)
-	o.SetOutputLevel("default", log.WarnLevel)
-	o.SetOutputLevel("kube", log.ErrorLevel)
+	o.SetDefaultOutputLevel("validation", log.ErrorLevel)
+	o.SetDefaultOutputLevel("processing", log.ErrorLevel)
+	o.SetDefaultOutputLevel("default", log.WarnLevel)
+	o.SetDefaultOutputLevel("kube", log.ErrorLevel)
 
 	return o
 }

--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -16,9 +16,6 @@ package framework
 
 import (
 	"flag"
-	"io"
-
-	"google.golang.org/grpc/grpclog"
 
 	"istio.io/istio/pkg/log"
 )
@@ -37,9 +34,6 @@ func init() {
 
 func configureLogging() error {
 	o := *logOptionsFromCommandline
-
-	o.LogGrpc = false
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
 	return log.Configure(&o)
 }

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -576,7 +576,7 @@ func configLogs(opt *log.Options) error {
 	opt2 := *opt
 	opt2.OutputPaths = op
 	opt2.ErrorOutputPaths = op
-	opt2.SetOutputLevel("default", log.InfoLevel)
+	opt2.SetDefaultOutputLevel("default", log.InfoLevel)
 
 	return log.Configure(&opt2)
 }


### PR DESCRIPTION
Various fixes here

* Make the SetDefaultOutputLevel set defaults, and --log_output_level
  overrides those. Before, ANY --log_output_level flag completely
override SetDefaultOutputLevel. So if I set `foo:warn`, I may
accidentally change every scope to `info`.
* Fix gRPC log to respect levels
* Fix a bunch of inconsistencies around gRPC logs
* Remove a bunch of functions only used in tests
