### PR TITLE
log: increase timeout to reduce UDS test flakes

### DIFF
--- a/pkg/log/uds.go
+++ b/pkg/log/uds.go
@@ -46,7 +46,7 @@ func teeToUDSServer(baseCore zapcore.Core, address, path string) zapcore.Core {
 				return net.Dial("unix", address)
 			},
 		},
-		Timeout: 100 * time.Millisecond,
+		Timeout: time.Second,
 	}
 	uc := &udsCore{
 		client:  c,


### PR DESCRIPTION
Fixes flakes like
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/49644/unit-tests-arm64_istio/1768401500075200512

We only see these on ARM. I have no clue why.

Basically, at 100ms we see timeouts. 100ms is a pretty aggressive
timeout anyways, so bump to 1s

Without PR:
```
39 runs so far, 4 failures (90.70% pass rate). 496.701448ms avg, 651.035779ms max, 310.556531ms min
```
With PR:
```
63781 runs so far, 0 failures (100.00% pass rate). 92.626708ms avg, 376.347405ms max, 13.924519ms mi
```

fixes https://github.com/istio/istio/issues/43115 and https://github.com/istio/istio/issues/42451