### PR TITLE
Remove default security context from gateway injection

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -12,10 +12,6 @@ metadata:
     {{ end }}
   }
 spec:
-  securityContext:
-    sysctls:
-    - name: net.ipv4.ip_unprivileged_port_start
-      value: "0"
   containers:
   - name: istio-proxy
   {{- if contains "/" .Values.global.proxy.image }}

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -12,10 +12,6 @@ metadata:
     {{ end }}
   }
 spec:
-  securityContext:
-    sysctls:
-    - name: net.ipv4.ip_unprivileged_port_start
-      value: "0"
   containers:
   - name: istio-proxy
   {{- if contains "/" .Values.global.proxy.image }}

--- a/pkg/kube/inject/testdata/inject/gateway.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway.yaml.injected
@@ -132,10 +132,6 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
-      securityContext:
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
       volumes:
       - emptyDir: {}
         name: workload-socket


### PR DESCRIPTION
**Please provide a description of this PR:**

I recently tried upgrading from Istio 1.19.4 to 1.20.3 and was unable to because of the reasons outlined in #49549. This PR removes the default incompatible kernel settings so users still on 3.x based kernels can deploy gateways.