### PR TITLE
fips: enforce security services transport algorithms

### DIFF
--- a/pilot/pkg/grpc/tls.go
+++ b/pilot/pkg/grpc/tls.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	sec_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -79,6 +80,8 @@ func getTLSDialOption(opts *TLSOptions) (grpc.DialOption, error) {
 	if opts.SAN != "" {
 		config.ServerName = opts.SAN
 	}
+	// Compliance for all gRPC clients (e.g. Citadel)..
+	sec_model.EnforceGoCompliance(&config)
 	transportCreds := credentials.NewTLS(&config)
 	return grpc.WithTransportCredentials(transportCreds), nil
 }

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -771,7 +771,7 @@ func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 		return cache.NewSecretManagerClient(caClient, a.secOpts)
 	} else if a.secOpts.CAProviderName == security.GoogleCASProvider {
 		// Use a plugin
-		tlsConfig := &tls.Config{}
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 		sec_model.EnforceGoCompliance(tlsConfig)
 		caClient, err := cas.NewGoogleCASClient(a.secOpts.CAEndpoint,
 			option.WithGRPCDialOption(grpc.WithPerRPCCredentials(caclient.NewCATokenProvider(a.secOpts))),

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -16,6 +16,7 @@ package istioagent
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -28,6 +29,7 @@ import (
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
@@ -35,6 +37,7 @@ import (
 	"istio.io/istio/pilot/cmd/pilot-agent/config"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/model"
+	sec_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/backoff"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/bootstrap/platform"
@@ -768,8 +771,11 @@ func (a *Agent) newSecretManager() (*cache.SecretManagerClient, error) {
 		return cache.NewSecretManagerClient(caClient, a.secOpts)
 	} else if a.secOpts.CAProviderName == security.GoogleCASProvider {
 		// Use a plugin
+		tlsConfig := &tls.Config{}
+		sec_model.EnforceGoCompliance(tlsConfig)
 		caClient, err := cas.NewGoogleCASClient(a.secOpts.CAEndpoint,
-			option.WithGRPCDialOption(grpc.WithPerRPCCredentials(caclient.NewCATokenProvider(a.secOpts))))
+			option.WithGRPCDialOption(grpc.WithPerRPCCredentials(caclient.NewCATokenProvider(a.secOpts))),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))))
 		if err != nil {
 			return nil, err
 		}

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -137,7 +137,7 @@ func (cl *googleCAClient) getTLSDialOption() (grpc.DialOption, error) {
 		googleCAClientLog.Errorf("could not get SystemCertPool: %v", err)
 		return nil, errors.New("could not get SystemCertPool")
 	}
-	tlsConfig := &tls.Config{RootCAs: pool}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool}
 	sec_model.EnforceGoCompliance(tlsConfig)
 	creds := credentials.NewTLS(tlsConfig)
 	return grpc.WithTransportCredentials(creds), nil

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -16,6 +16,7 @@ package caclient
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	sec_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
@@ -135,7 +137,9 @@ func (cl *googleCAClient) getTLSDialOption() (grpc.DialOption, error) {
 		googleCAClientLog.Errorf("could not get SystemCertPool: %v", err)
 		return nil, errors.New("could not get SystemCertPool")
 	}
-	creds := credentials.NewClientTLSFromCert(pool, "")
+	tlsConfig := &tls.Config{RootCAs: pool}
+	sec_model.EnforceGoCompliance(tlsConfig)
+	creds := credentials.NewTLS(tlsConfig)
 	return grpc.WithTransportCredentials(creds), nil
 }
 

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -17,12 +17,14 @@ package stsclient
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 
+	sec_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
@@ -66,9 +68,16 @@ func NewSecureTokenServiceExchanger(credFetcher security.CredFetcher, trustDomai
 	if err != nil {
 		return nil, err
 	}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	sec_model.EnforceGoCompliance(tlsConfig)
 	return &SecureTokenServiceExchanger{
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
 		},
 		backoff:     time.Millisecond * 50,
 		credFetcher: credFetcher,

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	sec_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
@@ -83,14 +84,16 @@ func CreateTokenManagerPlugin(credFetcher security.CredFetcher, trustDomain, gcp
 		pluginLog.Errorf("Failed to get SystemCertPool: %v", err)
 		return nil, err
 	}
+	tlsConfig := &tls.Config{
+		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	sec_model.EnforceGoCompliance(tlsConfig)
 	p := &Plugin{
 		httpClient: &http.Client{
 			Timeout: httpTimeOutInSec * time.Second,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs:    caCertPool,
-					MinVersion: tls.VersionTLS12,
-				},
+				TLSClientConfig: tlsConfig,
 			},
 		},
 		credFetcher:      credFetcher,


### PR DESCRIPTION
Change-Id: I585090775a978bc8774a7ec0925bb7e8f395b2ab

Extends https://github.com/istio/istio/issues/49081 to support:
* MeshCA
* STS (both implementations), which includes `iamcredentials`.
* GoogleCA
* Citadel