### PR TITLE
feat: allow reader role aggregation to k8s view role

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
       - "config.istio.io"
@@ -16,7 +17,7 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list" ]

--- a/manifests/charts/istiod-remote/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/reader-clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
       - "config.istio.io"
@@ -16,7 +17,7 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list" ]

--- a/releasenotes/notes/49977.yaml
+++ b/releasenotes/notes/49977.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 49977
+releaseNotes:
+- |
+  **Added** Ability to aggregate the istio reader role with the kubernetes viewer role and remove secrets view from reader role because it give too much elevated permissions.


### PR DESCRIPTION
**Please provide a description of this PR:**
The istio reader role is not aggregated with the kubernetes view role which is required if we want to give view access to non-admins on istio resources. The current want to allow this is either to configure manually or create a separate cluster role just for that purpose. 

Also took the opportunity to remove some elevated permissions from the reader role. The istio reader role give to many permissions as if you aggregate it to the k8s view cluster role, it will give access to secrets which is [explicitly not allowed](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) from the view role perspective because of the sensitivity of the secret content.