### PR TITLE
Fix the sidecar injection on OpenShift

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -449,7 +449,7 @@ defaults:
       enabled: false
       # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
       # to properly label proxies
-      clusterName: ""
+      clusterName: "Kubernetes"
 
     # Network defines the network this cluster belong to. This name
     # corresponds to the networks in the map of mesh networks.

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -381,7 +381,7 @@ defaults:
       enabled: false
       # Should be set to the name of the cluster this installation will run in. This is required for sidecar injection
       # to properly label proxies
-      clusterName: ""
+      clusterName: "Kubernetes"
     # Network defines the network this cluster belong to. This name
     # corresponds to the networks in the map of mesh networks.
     network: ""

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -89,8 +89,6 @@ spec:
                 resourceFieldRef:
                   divisor: "0"
                   resource: limits.cpu
-            - name: ISTIO_META_CLUSTER_ID
-              value: Kubernetes
             - name: ISTIO_META_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -105,6 +103,8 @@ spec:
               value: cluster.local
             - name: TRUST_DOMAIN
               value: cluster.local
+            - name: ISTIO_META_CLUSTER_ID
+              value: Kubernetes
             image: gcr.io/istio-testing/proxyv2:latest
             name: istio-proxy
             ports:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -93,8 +93,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -109,6 +107,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -108,8 +108,6 @@ items:
               resourceFieldRef:
                 divisor: "0"
                 resource: limits.cpu
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: ISTIO_META_NODE_NAME
             valueFrom:
               fieldRef:
@@ -124,6 +122,8 @@ items:
             value: cluster.local
           - name: TRUST_DOMAIN
             value: cluster.local
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-proxy
           ports:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -93,8 +93,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -109,6 +107,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -93,8 +93,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -109,6 +107,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/explicit-security-context.yaml.injected
@@ -86,8 +86,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -102,6 +100,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -112,8 +112,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -128,6 +126,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/gateway.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/gateway.yaml.injected
@@ -81,8 +81,6 @@ spec:
               divisor: "0"
               resource: limits.cpu
         - name: ISTIO_META_APP_CONTAINERS
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -97,6 +95,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: IfNotPresent
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -92,8 +92,6 @@ spec:
             ]
         - name: ISTIO_META_APP_CONTAINERS
           value: traffic
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -110,6 +108,8 @@ spec:
           value: "false"
         - name: DISABLE_ENVOY
           value: "true"
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           postStart:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -100,8 +100,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -116,6 +114,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -100,8 +100,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -116,6 +114,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -100,8 +100,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -116,6 +114,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -97,8 +97,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -113,6 +111,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:
@@ -338,8 +338,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -354,6 +352,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-proxy

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -91,8 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -107,6 +105,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -91,8 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -107,6 +105,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -120,8 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -136,6 +134,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -117,8 +117,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -133,6 +131,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -90,8 +90,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -106,6 +104,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -119,8 +119,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -135,6 +133,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: docker.io/istio/proxy2_debug:unittest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -99,8 +99,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -115,6 +113,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"path":"/ip","port":8000}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tracing-disabled.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -89,8 +89,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -105,6 +103,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           postStart:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -100,8 +100,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -116,6 +114,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_META_NETWORK
           value: network1
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.proxyImageName.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyTest:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -120,8 +120,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -136,6 +134,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333,"scheme":"HTTPS"}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -87,8 +87,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -103,6 +101,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -113,8 +113,6 @@ items:
               resourceFieldRef:
                 divisor: "0"
                 resource: limits.cpu
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: ISTIO_META_NODE_NAME
             valueFrom:
               fieldRef:
@@ -129,6 +127,8 @@ items:
             value: cluster.local
           - name: TRUST_DOMAIN
             value: cluster.local
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-proxy
           ports:

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -99,8 +99,6 @@ items:
               resourceFieldRef:
                 divisor: "0"
                 resource: limits.cpu
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: ISTIO_META_NODE_NAME
             valueFrom:
               fieldRef:
@@ -115,6 +113,8 @@ items:
             value: cluster.local
           - name: TRUST_DOMAIN
             value: cluster.local
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-proxy
           ports:
@@ -339,8 +339,6 @@ items:
               resourceFieldRef:
                 divisor: "0"
                 resource: limits.cpu
-          - name: ISTIO_META_CLUSTER_ID
-            value: Kubernetes
           - name: ISTIO_META_NODE_NAME
             valueFrom:
               fieldRef:
@@ -355,6 +353,8 @@ items:
             value: cluster.local
           - name: TRUST_DOMAIN
             value: cluster.local
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           image: gcr.io/istio-testing/proxyv2:latest
           name: istio-proxy
           ports:

--- a/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/merge-probers.yaml.injected
@@ -93,8 +93,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/new/livez":{"httpGet":{"path":"/testLive","port":8008}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           postStart:

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -97,8 +97,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -113,6 +111,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multiple-templates.yaml.injected
@@ -88,8 +88,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -104,6 +102,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: foo/bar
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -99,8 +99,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -115,6 +113,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"port":80}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/native-sidecar.yaml.injected
@@ -123,8 +123,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -139,6 +137,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     - name: ISTIO_KUBE_APP_PROBERS
       value: '{"/app-health/other-sidecar/readyz":{"httpGet":{"port":3333}}}'
     image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -103,8 +103,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -119,6 +117,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/only-proxy-container.yaml.injected
@@ -81,8 +81,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -97,6 +95,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -81,8 +81,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -97,6 +95,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-proxy
     ports:

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape.yaml.injected
@@ -79,8 +79,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -95,6 +93,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-proxy
     ports:

--- a/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/prometheus-scrape2.yaml.injected
@@ -79,8 +79,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -95,6 +93,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-proxy
     ports:

--- a/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args-native.yaml.injected
@@ -126,8 +126,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -142,6 +140,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           preStop:

--- a/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-args.yaml.injected
@@ -84,8 +84,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -100,6 +98,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -87,8 +87,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -103,6 +101,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           preStop:

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -119,8 +119,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -135,6 +133,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -99,8 +99,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -115,6 +113,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -90,8 +90,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -106,6 +104,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -89,8 +89,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -105,6 +103,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -119,8 +119,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -135,6 +133,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/startupz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -99,8 +99,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -115,6 +113,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/startupz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -127,8 +127,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -143,6 +141,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/hello/startupz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}},"/app-health/world/startupz":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -98,8 +98,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -114,6 +112,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -96,8 +96,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -112,6 +110,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -91,8 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -107,6 +105,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/tcp-probes.yaml.injected
@@ -103,8 +103,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -119,6 +117,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"tcpSocket":{"port":80}},"/app-health/hello/readyz":{"tcpSocket":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -95,8 +95,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -111,6 +109,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -103,8 +103,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -123,6 +121,8 @@ spec:
           value: bar
         - name: ISTIO_META_TLS_CLIENT_KEY
           value: /etc/identity2/client/keys/client-key.pem
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -91,8 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -107,6 +105,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -91,8 +91,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -107,6 +105,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inject/truncate-canonical-name-custom-controller-pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/truncate-canonical-name-custom-controller-pod.yaml.injected
@@ -88,8 +88,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -104,6 +102,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-proxy
     ports:

--- a/pkg/kube/inject/testdata/inject/truncate-canonical-name-pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/truncate-canonical-name-pod.yaml.injected
@@ -81,8 +81,6 @@ spec:
         resourceFieldRef:
           divisor: "0"
           resource: limits.cpu
-    - name: ISTIO_META_CLUSTER_ID
-      value: Kubernetes
     - name: ISTIO_META_NODE_NAME
       valueFrom:
         fieldRef:
@@ -97,6 +95,8 @@ spec:
       value: cluster.local
     - name: TRUST_DOMAIN
       value: cluster.local
+    - name: ISTIO_META_CLUSTER_ID
+      value: Kubernetes
     image: gcr.io/istio-testing/proxyv2:latest
     name: istio-proxy
     ports:

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -110,8 +110,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -126,6 +124,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"path":"/ip","port":8000}},"/app-health/world/readyz":{"httpGet":{"path":"/ipv6","port":9000}}}'
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -97,8 +97,6 @@ spec:
             resourceFieldRef:
               divisor: "0"
               resource: limits.cpu
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
         - name: ISTIO_META_NODE_NAME
           valueFrom:
             fieldRef:
@@ -113,6 +111,8 @@ spec:
           value: cluster.local
         - name: TRUST_DOMAIN
           value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -33,7 +33,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -33,7 +33,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": true,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -31,7 +31,7 @@
     "meshNetworks": {},
     "mountMtlsCerts": false,
     "multiCluster": {
-      "clusterName": "",
+      "clusterName": "Kubernetes",
       "enabled": false
     },
     "namespace": "istio-system",


### PR DESCRIPTION
By actually setting the default value for cluster name in the values file.

This values file becomes part of the `sidecar-injector` config map, and this config map will store the raw values, i.e., it currently contains the empty value for `global.multiCluster.clusterName`.

This value is then read at https://github.com/istio/istio/blob/ab194331988d8740237ee12e5036df7b6d017e88/pkg/kube/inject/inject.go#L379 and used to help sidecar injection on OpenShift.

Because it's the empty string, a client is not being found for it in https://github.com/istio/istio/blob/ab194331988d8740237ee12e5036df7b6d017e88/pkg/kube/inject/webhook.go#L1080
