### PR TITLE
validation: check duplicate DR subset names

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -678,10 +678,14 @@ var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
 			ValidateWildcardDomain(rule.Host),
 			validateTrafficPolicy(rule.TrafficPolicy))
 
+		subsets := sets.String{}
 		for _, subset := range rule.Subsets {
 			if subset == nil {
 				v = appendValidation(v, errors.New("subset may not be null"))
 				continue
+			}
+			if subsets.InsertContains(subset.Name) {
+				v = appendValidation(v, fmt.Errorf("duplicate subset names: %s", subset.Name))
 			}
 			v = appendValidation(v, validateSubset(subset))
 		}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3584,6 +3584,14 @@ func TestValidateDestinationRule(t *testing.T) {
 			},
 		}, valid: false},
 
+		{name: "duplicate subset names", in: &networking.DestinationRule{
+			Host: "reviews",
+			Subsets: []*networking.Subset{
+				{Name: "foo", Labels: map[string]string{"version": "v1"}},
+				{Name: "foo", Labels: map[string]string{"version": "v2"}},
+			},
+		}, valid: false},
+
 		{name: "valid traffic policy, top level", in: &networking.DestinationRule{
 			Host: "reviews",
 			TrafficPolicy: &networking.TrafficPolicy{

--- a/releasenotes/notes/duplicate-subset-names.yaml
+++ b/releasenotes/notes/duplicate-subset-names.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+- |
+  **Added** rejecting duplicate DestinationRule subset names in the validating webhook.

--- a/releasenotes/notes/duplicate-subset-names.yaml
+++ b/releasenotes/notes/duplicate-subset-names.yaml
@@ -4,4 +4,4 @@ area: traffic-management
 
 releaseNotes:
 - |
-  **Added** rejecting duplicate DestinationRule subset names in the validating webhook.
+  **Added** rejecting DestinationRules with duplicate subset names.


### PR DESCRIPTION
**Please provide a description of this PR:**
Problem:
East-west gateways return NACKs due to [duplicate DR subset names](https://github.com/istio/istio/blob/ab194331988d8740237ee12e5036df7b6d017e88/pilot/pkg/networking/core/v1alpha3/gateway.go#L994):
```bash
warning    envoy config    gRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: 
Error adding/updating listener(s) 0.0.0.0_15443: error adding listener '0.0.0.0:15443': 
filter chain '' has the same matching rules defined as ''
```

We already [skip duplicate subsets](https://github.com/istio/istio/blob/ab194331988d8740237ee12e5036df7b6d017e88/pilot/pkg/model/destination_rule.go#L94) when merging DRs. I think a single DR with duplicate subsets should be rejected as well.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
