### PR TITLE
fixed istioctl describe output ingress info ignore non istio-system

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -1119,6 +1120,9 @@ func printIngressInfo(
 										}
 									}
 									if len(matchIngressInfos) > 0 {
+										sort.Slice(matchIngressInfos, func(i, j int) bool {
+											return matchIngressInfos[i].getIngressIP() < matchIngressInfos[j].getIngressIP()
+										})
 										fmt.Fprintf(writer, "--------------------\n")
 										for _, ingress := range matchIngressInfos {
 											printIngressService(writer, printLevel0, ingress)

--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -58,6 +58,7 @@ import (
 	pilotcontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
+	util2 "istio.io/istio/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	configKube "istio.io/istio/pkg/config/kube"
@@ -77,7 +78,15 @@ type myProtoValue struct {
 
 const (
 	k8sSuffix = ".svc." + constants.DefaultClusterLocalDomain
+
+	printLevel0 = 0
+	printLevel1 = 3
+	printLevel2 = 6
 )
+
+func printSpaces(numSpaces int) string {
+	return strings.Repeat(" ", numSpaces)
+}
 
 var (
 	// Ignore unmeshed pods.  This makes it easy to suppress warnings about kube-system etc
@@ -166,7 +175,7 @@ the configuration objects that affect that pod.`,
 			// TODO find sidecar configs that select this workload and render them
 
 			// Now look for ingress gateways
-			return printIngressInfo(writer, matchingServices, podsLabels, client.Kube(), configClient, kubeClient, ctx.IstioNamespace())
+			return printIngressInfo(writer, matchingServices, podsLabels, client.Kube(), configClient, kubeClient)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completion.ValidPodsNameArgs(cmd, ctx, args, toComplete)
@@ -251,58 +260,59 @@ func matchesAnyPod(subsetSelector klabels.Selector, podsLabels []klabels.Set) bo
 	return false
 }
 
-func printDestinationRule(writer io.Writer, dr *clientnetworking.DestinationRule, podsLabels []klabels.Set) {
-	fmt.Fprintf(writer, "DestinationRule: %s for %q\n", kname(dr.ObjectMeta), dr.Spec.Host)
+func printDestinationRule(writer io.Writer, initPrintNum int,
+	dr *clientnetworking.DestinationRule, podsLabels []klabels.Set,
+) {
+	fmt.Fprintf(writer, "%sDestinationRule: %s for %q\n",
+		printSpaces(initPrintNum+printLevel0), kname(dr.ObjectMeta), dr.Spec.Host)
 
 	matchingSubsets, nonmatchingSubsets := getDestRuleSubsets(dr.Spec.Subsets, podsLabels)
-
 	if len(matchingSubsets) != 0 || len(nonmatchingSubsets) != 0 {
 		if len(matchingSubsets) == 0 {
-			fmt.Fprintf(writer, "  WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets %s)\n",
-				strings.Join(nonmatchingSubsets, ","))
+			fmt.Fprintf(writer, "%sWARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets %s)\n",
+				printSpaces(initPrintNum+printLevel1), strings.Join(nonmatchingSubsets, ","))
 		}
-		fmt.Fprintf(writer, "   Matching subsets: %s\n", strings.Join(matchingSubsets, ","))
+		fmt.Fprintf(writer, "%sMatching subsets: %s\n",
+			printSpaces(initPrintNum+printLevel1), strings.Join(matchingSubsets, ","))
 		if len(nonmatchingSubsets) > 0 {
-			fmt.Fprintf(writer, "      (Non-matching subsets %s)\n", strings.Join(nonmatchingSubsets, ","))
+			fmt.Fprintf(writer, "%s(Non-matching subsets %s)\n",
+				printSpaces(initPrintNum+printLevel2), strings.Join(nonmatchingSubsets, ","))
 		}
 	}
 
 	// Ignore LoadBalancer, ConnectionPool, OutlierDetection
 	trafficPolicy := dr.Spec.TrafficPolicy
 	if trafficPolicy == nil {
-		fmt.Fprintf(writer, "   No Traffic Policy\n")
+		fmt.Fprintf(writer, "%sNo Traffic Policy\n", printSpaces(initPrintNum+printLevel1))
 	} else {
 		if trafficPolicy.Tls != nil {
-			fmt.Fprintf(writer, "   Traffic Policy TLS Mode: %s\n", dr.Spec.TrafficPolicy.Tls.Mode.String())
+			fmt.Fprintf(writer, "%sTraffic Policy TLS Mode: %s\n",
+				printSpaces(initPrintNum+printLevel1), dr.Spec.TrafficPolicy.Tls.Mode.String())
 		}
 		shortPolicies := recordShortPolicies(
 			trafficPolicy.LoadBalancer,
 			trafficPolicy.ConnectionPool,
 			trafficPolicy.OutlierDetection)
 		if shortPolicies != "" {
-			fmt.Fprintf(writer, "%s%s", printSpaces(3), shortPolicies)
+			fmt.Fprintf(writer, "%s%s", printSpaces(initPrintNum+printLevel1), shortPolicies)
 		}
 
 		if trafficPolicy.PortLevelSettings != nil {
-			fmt.Fprintf(writer, "%sPort Level Settings:\n", printSpaces(3))
+			fmt.Fprintf(writer, "%sPort Level Settings:\n", printSpaces(initPrintNum+printLevel1))
 			for _, ps := range trafficPolicy.PortLevelSettings {
 				fmt.Fprintf(writer, "%s%d:\n", printSpaces(4), ps.GetPort().GetNumber())
 				if ps.Tls != nil {
-					fmt.Fprintf(writer, "%sTLS Mode: %s\n", printSpaces(6), ps.Tls.Mode.String())
+					fmt.Fprintf(writer, "%sTLS Mode: %s\n", printSpaces(initPrintNum+printLevel2), ps.Tls.Mode.String())
 				}
 				if sp := recordShortPolicies(
 					ps.LoadBalancer,
 					ps.ConnectionPool,
 					ps.OutlierDetection); sp != "" {
-					fmt.Fprintf(writer, "%s%s", printSpaces(6), sp)
+					fmt.Fprintf(writer, "%s%s", printSpaces(initPrintNum+printLevel2), sp)
 				}
 			}
 		}
 	}
-}
-
-func printSpaces(numSpaces int) string {
-	return strings.Repeat(" ", numSpaces)
 }
 
 func recordShortPolicies(lb *v1alpha3.LoadBalancerSettings,
@@ -841,8 +851,10 @@ func getIstioDestinationRulePathForSvc(cd *configdump.Wrapper, svc corev1.Servic
 
 // TODO simplify this by showing for each matching Destination the negation of the previous HttpMatchRequest
 // and showing the non-matching Destinations.  (The current code is ad-hoc, and usually shows most of that information.)
-func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, svc corev1.Service, matchingSubsets []string, nonmatchingSubsets []string, dr *clientnetworking.DestinationRule) { // nolint: lll
-	fmt.Fprintf(writer, "VirtualService: %s\n", kname(vs.ObjectMeta))
+func printVirtualService(writer io.Writer, initPrintNum int,
+	vs *clientnetworking.VirtualService, svc corev1.Service, matchingSubsets []string, nonmatchingSubsets []string, dr *clientnetworking.DestinationRule,
+) { // nolint: lll
+	fmt.Fprintf(writer, "%sVirtualService: %s\n", printSpaces(initPrintNum+printLevel0), kname(vs.ObjectMeta))
 
 	// There is no point in checking that 'port' uses HTTP (for HTTP route matches)
 	// or uses TCP (for TCP route matches) because if the port has the wrong name
@@ -856,7 +868,7 @@ func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, 
 		if routeMatch {
 			matches++
 			for _, newfact := range newfacts {
-				fmt.Fprintf(writer, "   %s\n", newfact)
+				fmt.Fprintf(writer, "%s%s\n", printSpaces(initPrintNum+printLevel1), newfact)
 				facts++
 			}
 		} else {
@@ -871,7 +883,7 @@ func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, 
 		if routeMatch {
 			matches++
 			for _, newfact := range newfacts {
-				fmt.Fprintf(writer, "   %s\n", newfact)
+				fmt.Fprintf(writer, "%s%s\n", printSpaces(initPrintNum+printLevel1), newfact)
 				facts++
 			}
 		} else {
@@ -881,13 +893,16 @@ func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, 
 
 	if matches == 0 {
 		if len(vs.Spec.Http) > 0 {
-			fmt.Fprintf(writer, "   WARNING: No destinations match pod subsets (checked %d HTTP routes)\n", len(vs.Spec.Http))
+			fmt.Fprintf(writer, "%sWARNING: No destinations match pod subsets (checked %d HTTP routes)\n",
+				printSpaces(initPrintNum+printLevel1), len(vs.Spec.Http))
 		}
 		if len(vs.Spec.Tcp) > 0 {
-			fmt.Fprintf(writer, "   WARNING: No destinations match pod subsets (checked %d TCP routes)\n", len(vs.Spec.Tcp))
+			fmt.Fprintf(writer, "%sWARNING: No destinations match pod subsets (checked %d TCP routes)\n",
+				printSpaces(initPrintNum+printLevel1), len(vs.Spec.Tcp))
 		}
 		for _, mismatch := range mismatchNotes {
-			fmt.Fprintf(writer, "      %s\n", mismatch)
+			fmt.Fprintf(writer, "%s%s\n",
+				printSpaces(initPrintNum+printLevel2), mismatch)
 		}
 		return
 	}
@@ -896,11 +911,13 @@ func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, 
 	if matches < possibleDests {
 		// We've printed the match conditions.  We can't say for sure that matching
 		// traffic will reach this pod, because an earlier match condition could have captured it.
-		fmt.Fprintf(writer, "   %d additional destination(s) that will not reach this pod\n", possibleDests-matches)
+		fmt.Fprintf(writer, "%s%d additional destination(s) that will not reach this pod\n",
+			printSpaces(initPrintNum+printLevel1), possibleDests-matches)
 		// If we matched, but printed nothing, treat this as the catch-all
 		if facts == 0 {
 			for _, mismatch := range mismatchNotes {
-				fmt.Fprintf(writer, "      %s\n", mismatch)
+				fmt.Fprintf(writer, "%s%s\n",
+					printSpaces(initPrintNum+printLevel2), mismatch)
 			}
 		}
 
@@ -910,12 +927,21 @@ func printVirtualService(writer io.Writer, vs *clientnetworking.VirtualService, 
 	if facts == 0 {
 		// We printed nothing other than the name.  Print something.
 		if len(vs.Spec.Http) > 0 {
-			fmt.Fprintf(writer, "   %d HTTP route(s)\n", len(vs.Spec.Http))
+			fmt.Fprintf(writer, "%s%d HTTP route(s)\n", printSpaces(initPrintNum+printLevel1), len(vs.Spec.Http))
 		}
 		if len(vs.Spec.Tcp) > 0 {
-			fmt.Fprintf(writer, "   %d TCP route(s)\n", len(vs.Spec.Tcp))
+			fmt.Fprintf(writer, "%s%d TCP route(s)\n", printSpaces(initPrintNum+printLevel1), len(vs.Spec.Tcp))
 		}
 	}
+}
+
+func isSubsetOf(sub map[string]string, parent map[string]string) bool {
+	for k, v := range sub {
+		if vv, ok := parent[k]; !ok || vv != v {
+			return false
+		}
+	}
+	return true
 }
 
 func printIngressInfo(
@@ -925,9 +951,8 @@ func printIngressInfo(
 	kubeClient kubernetes.Interface,
 	configClient istioclient.Interface,
 	client kube.CLIClient,
-	istioNamespace string,
 ) error {
-	pods, err := kubeClient.CoreV1().Pods(istioNamespace).List(context.TODO(), metav1.ListOptions{
+	pods, err := kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "istio=ingressgateway",
 		FieldSelector: "status.phase=Running",
 	})
@@ -938,68 +963,105 @@ func printIngressInfo(
 		fmt.Fprintf(writer, "Skipping Gateway information (no ingress gateway pods)\n")
 		return nil
 	}
-	pod := pods.Items[0]
 
-	// Currently no support for non-standard gateways selecting non ingressgateway pods
-	ingressSvcs, err := kubeClient.CoreV1().Services(istioNamespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return multierror.Prefix(err, "Could not find ingress gateway service")
-	}
-	filteredIngressSvcs := []corev1.Service{}
-	for _, svc := range ingressSvcs.Items {
-		if v, ok := svc.Spec.Selector["istio"]; ok && v == "ingressgateway" {
-			filteredIngressSvcs = append(filteredIngressSvcs, svc)
+	haveGateways := false
+	findVss := map[string]bool{}
+	for _, pod := range pods.Items {
+		byConfigDump, err := client.EnvoyDo(context.TODO(), pod.Name, pod.Namespace, "GET", "config_dump")
+		if err != nil {
+			return fmt.Errorf("failed to execute command on ingress gateway sidecar: %v", err)
 		}
-	}
-	if len(filteredIngressSvcs) == 0 {
-		return fmt.Errorf("no ingress gateway service")
-	}
-	byConfigDump, err := client.EnvoyDo(context.TODO(), pod.Name, pod.Namespace, "GET", "config_dump")
-	if err != nil {
-		return fmt.Errorf("failed to execute command on ingress gateway sidecar: %v", err)
-	}
+		cd := configdump.Wrapper{}
+		err = cd.UnmarshalJSON(byConfigDump)
+		if err != nil {
+			return fmt.Errorf("can't parse ingress gateway sidecar config_dump: %v", err)
+		}
 
-	cd := configdump.Wrapper{}
-	err = cd.UnmarshalJSON(byConfigDump)
-	if err != nil {
-		return fmt.Errorf("can't parse ingress gateway sidecar config_dump: %v", err)
-	}
-
-	ipIngress := getIngressIP(filteredIngressSvcs[0], pod)
-
-	for row, svc := range matchingServices {
-		for _, port := range svc.Spec.Ports {
-			matchingSubsets := []string{}
-			nonmatchingSubsets := []string{}
-			drName, drNamespace, err := getIstioDestinationRuleNameForSvc(&cd, svc, port.Port)
-			var dr *clientnetworking.DestinationRule
-			if err == nil && drName != "" && drNamespace != "" {
-				dr, _ = configClient.NetworkingV1alpha3().DestinationRules(drNamespace).Get(context.Background(), drName, metav1.GetOptions{})
-				if dr != nil {
-					matchingSubsets, nonmatchingSubsets = getDestRuleSubsets(dr.Spec.Subsets, podsLabels)
-				} else {
-					fmt.Fprintf(writer,
-						"WARNING: Proxy is stale; it references to non-existent destination rule %s.%s\n",
-						drName, drNamespace)
-				}
-			}
-
-			vsName, vsNamespace, err := getIstioVirtualServiceNameForSvc(&cd, svc, port.Port)
-			if err == nil && vsName != "" && vsNamespace != "" {
-				vs, _ := configClient.NetworkingV1alpha3().VirtualServices(vsNamespace).Get(context.Background(), vsName, metav1.GetOptions{})
-				if vs != nil {
-					if row == 0 {
-						fmt.Fprintf(writer, "\n")
+		for _, svc := range matchingServices {
+			for _, port := range svc.Spec.Ports {
+				matchingSubsets := []string{}
+				nonmatchingSubsets := []string{}
+				drName, drNamespace, err := getIstioDestinationRuleNameForSvc(&cd, svc, port.Port)
+				var dr *clientnetworking.DestinationRule
+				if err == nil && drName != "" && drNamespace != "" {
+					dr, _ = configClient.NetworkingV1alpha3().DestinationRules(drNamespace).Get(context.Background(), drName, metav1.GetOptions{})
+					if dr != nil {
+						matchingSubsets, nonmatchingSubsets = getDestRuleSubsets(dr.Spec.Subsets, podsLabels)
 					} else {
-						fmt.Fprintf(writer, "--------------------\n")
+						fmt.Fprintf(writer,
+							"WARNING: Proxy is stale; it references to non-existent destination rule %s.%s\n",
+							drName, drNamespace)
 					}
+				}
 
-					printIngressService(writer, &filteredIngressSvcs[0], &pod, ipIngress)
-					printVirtualService(writer, vs, svc, matchingSubsets, nonmatchingSubsets, dr)
-				} else {
-					fmt.Fprintf(writer,
-						"WARNING: Proxy is stale; it references to non-existent virtual service %s.%s\n",
-						vsName, vsNamespace)
+				vsName, vsNamespace, err := getIstioVirtualServiceNameForSvc(&cd, svc, port.Port)
+				if err == nil && vsName != "" && vsNamespace != "" {
+					key := fmt.Sprintf("%s/%s", vsName, vsNamespace)
+					if findVss[key] {
+						continue
+					}
+					findVss[key] = true
+					vs, _ := configClient.NetworkingV1alpha3().VirtualServices(vsNamespace).Get(context.Background(), vsName, metav1.GetOptions{})
+					if vs != nil {
+						// get gateways service
+						for _, gatewayName := range vs.Spec.Gateways {
+							if gatewayName == "" || gatewayName == util2.MeshGateway {
+								continue
+							}
+							gns := vsNamespace
+							parts := strings.SplitN(gatewayName, "/", 2)
+							if len(parts) == 2 {
+								gatewayName = parts[1]
+								gns = parts[0]
+							}
+							gw, _ := configClient.NetworkingV1alpha3().Gateways(gns).Get(context.Background(), gatewayName, metav1.GetOptions{})
+							if gw != nil {
+								if gw.Spec.Selector == nil {
+									fmt.Fprintf(writer,
+										"Ingress Gateway %s/%s be applyed all workloads",
+										gns, gatewayName)
+								} else {
+									// match pods
+									gwPods, err := kubeClient.CoreV1().Pods(gns).List(context.TODO(), metav1.ListOptions{
+										LabelSelector: klabels.Set(gw.Spec.GetSelector()).String(),
+										FieldSelector: "status.phase=Running",
+									})
+									if err != nil {
+										continue
+									}
+									// match services
+									gwSvcs, err := kubeClient.CoreV1().Services(gns).List(context.TODO(), metav1.ListOptions{})
+									if err != nil {
+										continue
+									}
+									for i, s := range gwSvcs.Items {
+										for j, p := range gwPods.Items {
+											if p.GetLabels() == nil {
+												continue
+											}
+											if isSubsetOf(s.Spec.Selector, p.GetLabels()) {
+												if !haveGateways {
+													fmt.Fprintf(writer, "--------------------\n")
+												}
+												haveGateways = true
+												printIngressService(writer, printLevel0, &gwSvcs.Items[i], &gwPods.Items[j])
+												printVirtualService(writer, printLevel1, vs, svc, matchingSubsets, nonmatchingSubsets, dr)
+												break
+											}
+										}
+									}
+								}
+							} else {
+								fmt.Fprintf(writer,
+									"WARNING: Proxy is stale; it references to non-existent gateway %s/%s\n",
+									gns, gatewayName)
+							}
+						}
+					} else {
+						fmt.Fprintf(writer,
+							"WARNING: Proxy is stale; it references to non-existent virtual service %s.%s\n",
+							vsName, vsNamespace)
+					}
 				}
 			}
 		}
@@ -1008,7 +1070,9 @@ func printIngressInfo(
 	return nil
 }
 
-func printIngressService(writer io.Writer, ingressSvc *corev1.Service, ingressPod *corev1.Pod, ip string) {
+func printIngressService(writer io.Writer, initPrintNum int,
+	ingressSvc *corev1.Service, ingressPod *corev1.Pod,
+) {
 	// The ingressgateway service offers a lot of ports but the pod doesn't listen to all
 	// of them.  For example, it doesn't listen on 443 without additional setup.  This prints
 	// the most basic output.
@@ -1040,12 +1104,13 @@ func printIngressService(writer io.Writer, ingressSvc *corev1.Service, ingressPo
 			if schemePortDefault[scheme] != nport {
 				portSuffix = fmt.Sprintf(":%d", nport)
 			}
-			fmt.Fprintf(writer, "\nExposed on Ingress Gateway %s://%s%s\n", scheme, ip, portSuffix)
+			ip := getIngressIP(ingressSvc, ingressPod)
+			fmt.Fprintf(writer, "%sExposed on Ingress Gateway %s://%s%s\n", printSpaces(initPrintNum), scheme, ip, portSuffix)
 		}
 	}
 }
 
-func getIngressIP(service corev1.Service, pod corev1.Pod) string {
+func getIngressIP(service *corev1.Service, pod *corev1.Pod) string {
 	if len(service.Status.LoadBalancer.Ingress) > 0 {
 		return service.Status.LoadBalancer.Ingress[0].IP
 	}
@@ -1162,7 +1227,7 @@ the configuration objects that affect that service.`,
 			}
 
 			// Now look for ingress gateways
-			return printIngressInfo(writer, svcs, podsLabels, client.Kube(), configClient, kubeClient, ctx.IstioNamespace())
+			return printIngressInfo(writer, svcs, podsLabels, client.Kube(), configClient, kubeClient)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completion.ValidServiceArgs(cmd, ctx, args, toComplete)
@@ -1197,7 +1262,17 @@ func describePodServices(writer io.Writer, kubeClient kube.CLIClient, configClie
 		}
 		printService(writer, svc, pod)
 
+		needPrintPort := false
+		initPolicyLevel := printLevel0
+		if len(svc.Spec.Ports) > 1 {
+			needPrintPort = true
+			initPolicyLevel = printLevel1
+		}
 		for _, port := range svc.Spec.Ports {
+			if needPrintPort {
+				// If there is more than one port, prefix each DR by the port it applies to
+				fmt.Fprintf(writer, "%d:\n", port.Port)
+			}
 			matchingSubsets := []string{}
 			nonmatchingSubsets := []string{}
 			drName, drNamespace, err := getIstioDestinationRuleNameForSvc(&cd, svc, port.Port)
@@ -1208,11 +1283,7 @@ func describePodServices(writer io.Writer, kubeClient kube.CLIClient, configClie
 			if err == nil && drName != "" && drNamespace != "" {
 				dr, _ = configClient.NetworkingV1alpha3().DestinationRules(drNamespace).Get(context.Background(), drName, metav1.GetOptions{})
 				if dr != nil {
-					if len(svc.Spec.Ports) > 1 {
-						// If there is more than one port, prefix each DR by the port it applies to
-						fmt.Fprintf(writer, "%d ", port.Port)
-					}
-					printDestinationRule(writer, dr, podsLabels)
+					printDestinationRule(writer, initPolicyLevel, dr, podsLabels)
 					matchingSubsets, nonmatchingSubsets = getDestRuleSubsets(dr.Spec.Subsets, podsLabels)
 				} else {
 					fmt.Fprintf(writer,
@@ -1225,11 +1296,7 @@ func describePodServices(writer io.Writer, kubeClient kube.CLIClient, configClie
 			if err == nil && vsName != "" && vsNamespace != "" {
 				vs, _ := configClient.NetworkingV1alpha3().VirtualServices(vsNamespace).Get(context.Background(), vsName, metav1.GetOptions{})
 				if vs != nil {
-					if len(svc.Spec.Ports) > 1 {
-						// If there is more than one port, prefix each DR by the port it applies to
-						fmt.Fprintf(writer, "%d ", port.Port)
-					}
-					printVirtualService(writer, vs, svc, matchingSubsets, nonmatchingSubsets, dr)
+					printVirtualService(writer, initPolicyLevel, vs, svc, matchingSubsets, nonmatchingSubsets, dr)
 				} else {
 					fmt.Fprintf(writer,
 						"WARNING: Proxy is stale; it references to non-existent virtual service %s.%s\n",

--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -982,13 +982,6 @@ func (ingress *ingressInfo) getIngressIP() string {
 	return "unknown"
 }
 
-type gatewayIngressInfo struct {
-	name     string
-	ingress  *ingressInfo
-	gw       *clientnetworking.Gateway
-	allMatch bool
-}
-
 func printIngressInfo(
 	writer io.Writer,
 	matchingServices []corev1.Service,

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -949,8 +949,8 @@ VirtualService: bookinfo
    Route to host "productpage3" with weight 50%
    Match: /prefix*
 --------------------
-Exposed on Ingress Gateway http://2.2.2.2
 Exposed on Ingress Gateway http://1.1.1.1
+Exposed on Ingress Gateway http://2.2.2.2
 VirtualService: bookinfo
    Route to host "productpage" with weight 30%
    Route to host "productpage2" with weight 20%

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -253,7 +253,7 @@ func TestDescribe(t *testing.T) {
 			args: strings.Split("service productpage", " "),
 			expectedOutput: `Service: productpage
 DestinationRule: productpage for "productpage"
-  WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
+   WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
    Matching subsets: 
       (Non-matching subsets v1)
    No Traffic Policy
@@ -432,7 +432,7 @@ VirtualService: bookinfo
 			args: strings.Split("service productpage", " "),
 			expectedOutput: `Service: productpage
 DestinationRule: productpage for "productpage"
-  WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
+   WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
    Matching subsets: 
       (Non-matching subsets v1)
    No Traffic Policy
@@ -636,7 +636,7 @@ VirtualService: bookinfo
 			args: strings.Split("service productpage", " "),
 			expectedOutput: `Service: productpage
 DestinationRule: productpage for "productpage"
-  WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
+   WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
    Matching subsets: 
       (Non-matching subsets v1)
    Traffic Policy TLS Mode: ISTIO_MUTUAL
@@ -650,6 +650,256 @@ VirtualService: bookinfo
    Route to host "productpage2" with weight 20%
    Route to host "productpage3" with weight 50%
    Match: /prefix*
+`,
+		},
+		// have ingress gateway
+		{
+			k8sConfigs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "productpage",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       9080,
+								TargetPort: intstr.FromInt32(9080),
+							},
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+						Labels: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"istio": "ingressgateway",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt32(80),
+								Protocol:   corev1.ProtocolTCP,
+							},
+						},
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "2.2.2.2",
+							},
+						}},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage-v1-1234567890",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "productpage",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "productpage",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 9080,
+									},
+								},
+							},
+							{
+								Name: "istio-proxy",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "istio-proxy",
+								Ready: true,
+							},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+						Labels: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "istio-proxy",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  "istio-proxy",
+								Ready: true,
+							},
+						},
+					},
+				},
+			},
+			istioConfigs: []runtime.Object{
+				&v1alpha3.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bookinfo",
+						Namespace: "default",
+					},
+					Spec: v1alpha32.VirtualService{
+						Hosts: []string{
+							"productpage",
+							"productpage.exapple.com",
+						},
+						Gateways: []string{"fake-gw"},
+						Http: []*v1alpha32.HTTPRoute{
+							{
+								Match: []*v1alpha32.HTTPMatchRequest{
+									{
+										Uri: &v1alpha32.StringMatch{
+											MatchType: &v1alpha32.StringMatch_Prefix{
+												Prefix: "/prefix",
+											},
+										},
+									},
+								},
+								Route: []*v1alpha32.HTTPRouteDestination{
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage",
+										},
+										Weight: 30,
+									},
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage2",
+										},
+										Weight: 20,
+									},
+									{
+										Destination: &v1alpha32.Destination{
+											Host: "productpage3",
+										},
+										Weight: 50,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1alpha3.DestinationRule{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "productpage",
+						Namespace: "default",
+					},
+					Spec: v1alpha32.DestinationRule{
+						Host: "productpage",
+						Subsets: []*v1alpha32.Subset{
+							{
+								Name:   "v1",
+								Labels: map[string]string{"version": "v1"},
+							},
+						},
+						TrafficPolicy: &v1alpha32.TrafficPolicy{
+							LoadBalancer: &v1alpha32.LoadBalancerSettings{
+								LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST},
+							},
+							ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},
+							OutlierDetection: &v1alpha32.OutlierDetection{MinHealthPercent: 10},
+							Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_ISTIO_MUTUAL},
+							PortLevelSettings: []*v1alpha32.TrafficPolicy_PortTrafficPolicy{
+								{
+									LoadBalancer: &v1alpha32.LoadBalancerSettings{
+										LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST},
+									},
+									Port:             &v1alpha32.PortSelector{Number: 8080},
+									Tls:              &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_DISABLE},
+									ConnectionPool:   &v1alpha32.ConnectionPoolSettings{Tcp: &v1alpha32.ConnectionPoolSettings_TCPSettings{MaxConnections: 10}},
+									OutlierDetection: &v1alpha32.OutlierDetection{MinHealthPercent: 10},
+								},
+							},
+							Tunnel:        nil,
+							ProxyProtocol: nil,
+						},
+					},
+				},
+				&v1alpha3.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-gw",
+						Namespace: "default",
+					},
+					Spec: v1alpha32.Gateway{
+						Servers: []*v1alpha32.Server{
+							{
+								Port: &v1alpha32.Port{
+									Number:   80,
+									Name:     "default",
+									Protocol: "HTTP",
+								},
+								Hosts: []string{
+									"productpage.exapple.com",
+								},
+							},
+						},
+						Selector: map[string]string{
+							"istio": "ingressgateway",
+						},
+					},
+				},
+			},
+			configDumps: map[string][]byte{
+				"productpage-v1-1234567890": config,
+				"ingress":                   config,
+			},
+			namespace:      "default",
+			istioNamespace: "default",
+			// case 9, vs route to multiple hosts
+			args: strings.Split("service productpage", " "),
+			expectedOutput: `Service: productpage
+DestinationRule: productpage for "productpage"
+   WARNING POD DOES NOT MATCH ANY SUBSETS.  (Non matching subsets v1)
+   Matching subsets: 
+      (Non-matching subsets v1)
+   Traffic Policy TLS Mode: ISTIO_MUTUAL
+   Policies: load balancer/connection pool/outlier detection
+   Port Level Settings:
+    8080:
+      TLS Mode: DISABLE
+      Policies: load balancer/connection pool/outlier detection
+VirtualService: bookinfo
+   Route to host "productpage" with weight 30%
+   Route to host "productpage2" with weight 20%
+   Route to host "productpage3" with weight 50%
+   Match: /prefix*
+--------------------
+Exposed on Ingress Gateway http://2.2.2.2
+   VirtualService: bookinfo
+      Route to host "productpage" with weight 30%
+      Route to host "productpage2" with weight 20%
+      Route to host "productpage3" with weight 50%
+      Match: /prefix*
 `,
 		},
 	}

--- a/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
+++ b/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
@@ -26,4 +26,4 @@ area: istioctl
 # release notes.
 releaseNotes:
   - |
-    Fixed `istioctl describe` command not displaying Ingress information under non `istio-system` namespaces.
+    **Fixed** `istioctl describe` command not displaying Ingress information under non `istio-system` namespaces.

--- a/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
+++ b/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
@@ -1,29 +1,8 @@
 apiVersion: release-notes/v2
-
-# This YAML file describes the format for specifying a release notes entry for Istio.
-# This should be filled in for all user facing changes.
-
-# kind describes the type of change that this represents.
-# Valid Values are:
-# - bug-fix -- Used to specify that this change represents a bug fix.
-# - security-fix -- Used to specify that this change represents a vulnerability fix.
-# - feature -- Used to specify a new feature that has been added.
-# - test -- Used to describe additional testing added. This file is optional for
-#   tests, but included for completeness.
 kind: bug-fix
-
-# area describes the area that this change affects.
-# Valid values are:
-# - traffic-management
-# - security
-# - telemetry
-# - installation
-# - istioctl
-# - documentation
 area: istioctl
-
-# releaseNotes is a markdown listing of any user facing changes. This will appear in the
-# release notes.
+issue:
+  - 50074
 releaseNotes:
   - |
     **Fixed** `istioctl describe` command not displaying Ingress information under non `istio-system` namespaces.

--- a/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
+++ b/releasenotes/notes/fix-istioctl-describe-ingressinfo.yaml
@@ -1,0 +1,29 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: bug-fix
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: istioctl
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    Fixed `istioctl describe` command not displaying Ingress information under non `istio-system` namespaces.

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -47,9 +47,10 @@ var (
 	describeSvcAOutput = regexp.MustCompile(`(?s)Service: a\..*
    Port: http 80/HTTP targets pod port 18080
 .*
-80 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
+80:
+   DestinationRule: a\..* for "a"
+      Matching subsets: v1
+      No Traffic Policy
 `)
 
 	describePodAOutput = describeSvcAOutput


### PR DESCRIPTION
**Please provide a description of this PR:**
If service be exposed by non `istio-system`(default system namespace) gateway, we not found any informations form `istioctl x describe`.
so  we need to exposed those ingress informations by `istioctl x describe`.

- some ref issue: https://github.com/istio/istio/issues/46160#issuecomment-1979973885