### PR TITLE
fix: label change in WLE should push EDS

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -311,8 +312,8 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 		}
 		for _, nie := range istioEndpoints {
 			if oie, exists := emap[nie.Address]; exists {
-				// If endpoint exists already, we should push if it's health status changes.
-				if oie.HealthStatus != nie.HealthStatus {
+				// If endpoint exists already, we should push if it's health status changes or labels change.
+				if oie.HealthStatus != nie.HealthStatus || !maps.Equal(oie.Labels, nie.Labels) {
 					needPush = true
 				}
 				newIstioEndpoints = append(newIstioEndpoints, nie)


### PR DESCRIPTION
**Please provide a description of this PR:**

Label change in WLE/SE does not trigger EDS push to the connected proxies. This is required to configure endpoints priority if FailoverPriority is defined on https://istio.io/latest/docs/reference/config/networking/destination-rule/#LocalityLoadBalancerSetting. Hence this change is required, so that if there is a change in WE label, the failoverPriority can be used otherwise we would need to delete a pod or something and trigger EDS update for priority re-calculation.