### PR TITLE
Fix gateway deployment on OpenShift

### DIFF
--- a/manifests/charts/base/files/profile-openshift.yaml
+++ b/manifests/charts/base/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/default/files/profile-openshift.yaml
+++ b/manifests/charts/default/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/gateway/README.md
+++ b/manifests/charts/gateway/README.md
@@ -54,7 +54,7 @@ That is, `--set some.field=true` should be passed, not `--set defaults.some.fiel
 When deploying the gateway in an OpenShift cluster, use the `openshift` profile to override the default values, for example:
 
 ```console
-helm install istio-ingressgateway istio/gateway -- set profile=openshift
+helm install istio-ingressgateway istio/gateway --set profile=openshift
 ```
 
 ### `image: auto` Information

--- a/manifests/charts/gateway/files/profile-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -64,8 +64,10 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
+            {{- if not (eq .Values.platform "openshift") }}
             runAsUser: 1337
             runAsGroup: 1337
+            {{- end }}
             runAsNonRoot: true
           {{- end }}
           env:

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/istio-cni/files/profile-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/istio-operator/files/profile-openshift.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/istiod-remote/files/profile-openshift.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/charts/ztunnel/files/profile-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift

--- a/manifests/helm-profiles/openshift.yaml
+++ b/manifests/helm-profiles/openshift.yaml
@@ -16,3 +16,4 @@ pilot:
   cni:
     enabled: true
     provider: "multus"
+platform: openshift


### PR DESCRIPTION
By only applying `runAs` in the deployment if *not* on OpenShift.
