### PR TITLE
Update istio integration tests to account for removal of cacert field from config dump

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "2c1296aba1e73d20fdc49a79927c5de94711b2d6"
+    "lastStableSHA": "6143a1bd44a6e470e42613dc40731790cccb3438"
   }
 ]

--- a/istioctl/pkg/util/configdump/workload.go
+++ b/istioctl/pkg/util/configdump/workload.go
@@ -52,7 +52,6 @@ type ZtunnelDump struct {
 type CertsDump struct {
 	Identity  string  `json:"identity"`
 	State     string  `json:"state"`
-	CaCert    []*Cert `json:"ca_cert"`
 	CertChain []*Cert `json:"cert_chain"`
 }
 

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -86,15 +86,9 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 		if strings.Contains(secret.State, "Unavailable") {
 			secret.State = "Unavailable"
 		}
-		if len(secret.CaCert) == 0 && len(secret.CertChain) == 0 {
+		if len(secret.CertChain) == 0 {
 			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 				secret.Identity, valueOrNA(""), secret.State, false, valueOrNA(""), valueOrNA(""), valueOrNA(""))
-		}
-		for _, ca := range secret.CaCert {
-			n := new(big.Int)
-			n, _ = n.SetString(ca.SerialNumber, 10)
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%x\t%v\t%v\n",
-				secret.Identity, "CA", secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
 		}
 		for _, ca := range secret.CertChain {
 			n := new(big.Int)

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/dump.json
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/dump.json
@@ -1597,15 +1597,13 @@
     {
       "identity": "spiffe://cluster.local/ns/istio-system/sa/istiod",
       "state": "Available",
-      "ca_cert": [
+      "cert_chain": [
         {
           "pem": "-----BEGIN CERTIFICATE-----\nMIICejCCAWKgAwIBAgIRAOXftZFQsrp/EI2T3OxaphMwDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEChMNY2x1c3Rlci5sb2NhbDAeFw0yMzAzMjExMzAyNTdaFw0yMzAz\nMjIxMzA0NTdaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATYcNh2oplaXXcU\n775emfKiA5Ki9wyLTn/6ksy+PXvLvIcDwnf0XX/3bJ4CBxmFO8vBpFEhnklQUNzQ\nhrU5sj+8o4GhMIGeMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcD\nAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBTHJv/TQ6E5U30B\nesYpAA6B2CXKcTA+BgNVHREBAf8ENDAyhjBzcGlmZmU6Ly9jbHVzdGVyLmxvY2Fs\nL25zL2lzdGlvLXN5c3RlbS9zYS9pc3Rpb2QwDQYJKoZIhvcNAQELBQADggEBAFmw\nUn8mk9cNs+qxMHZN6qdljeGAcm4kp0vdY7rFGeAvtSc5lOSwFtNZC9K8bDayJAVo\n9DFy1iVH41052lcJ6VOZHQkbpVHHD38Kxi6wb1Fn7JpOhf/AR31qURIGzPHl6YFS\nwpd29DlZ8pyaHNR+zj5LcKmsFiKV5bRBbYn+sRoqtput+0tFaK+0EMkRsQk8GkEP\nVI5xMlIS5HRJwZGxqqYOh/aDm1ldKUazL0ipGg+3YTzP2fYDgp0bCgtFxiUdQJca\nRvTRMp33vNQygdouKAzlmT1p8yAV9/LSL12dF1Ac/rot6kh/Ieo+5Wlg4ydijCTF\nYWFM1Eyc7UwLHP2Gkfk=\n-----END CERTIFICATE-----\n",
           "serial_number": "305554775863395697262503895661564044819",
           "valid_from": "2023-03-21T13:02:57Z",
           "expiration_time": "2033-03-22T13:04:57Z"
-        }
-      ],
-      "cert_chain": [
+        },
         {
           "pem": "-----BEGIN CERTIFICATE-----\nMIIC/TCCAeWgAwIBAgIRAIpRZkXEDOdsLA0nq04kYcEwDQYJKoZIhvcNAQELBQAw\nGDEWMBQGA1UEChMNY2x1c3Rlci5sb2NhbDAeFw0yMzAzMjExMzA0NDlaFw0zMzAz\nMTgxMzA0NDlaMBgxFjAUBgNVBAoTDWNsdXN0ZXIubG9jYWwwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQC+DjsoK3KwPpPalDMYf5RlIwMoeX2nhWdqYLWW\nrRfXO9pyEySputmqoD8lqnqssJYvi3nerqJdXRjtZnJ6zYZ6Fc+QxldSpaHm4t56\nYxz0K22USMkSfEgu6PP/a5RZpPH9/LpJaSRPICXOP2GkAfF4djSUAFmRkC9XYgjX\nmk8ls01qKencIruEfSy3cTof8Uds2kyCiMOTqOvhyNKjAU3xeYJU8ztMA8k2AS0Z\nDSaf+qei6iVPTQkhqX8msBMaS1Y9kC8mYL5RchiYoknjL1xx3IxrmaIsD8qU1+In\n3GTvCD5w7+MgDKl58dHInPcFyGQSEo0nTokcWZ0p6KFvej3zAgMBAAGjQjBAMA4G\nA1UdDwEB/wQEAwICBDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTHJv/TQ6E5\nU30BesYpAA6B2CXKcTANBgkqhkiG9w0BAQsFAAOCAQEAh0tDT/aF0Z0GrGzshJUQ\nxtplY24pKnjcaZVyn9xfQP3S/907eNov+l4QiCV7J9ruH2ns9MJhxr88ilVfNKcl\nvPiAHBx+OnxnMYOupQQbEZ+F7uepfoRFKkQCOuh9YKoUNqd59RMl2N9mwIy1T18f\nh/7Ys6vTemPywiUYQ+USNKUfGS7Vuyi0br1XN0LzTmzk9aMaKQkpNnt5GYKwIDoC\nkxS1z5RNf9yOQVZuC1l3CajWvJS9XEm6N85tkFnSSkx+vJGljbR1NcIkhZfP9tA6\nqVGI7QfvPgIjeNsQWhlBqGRozHujMo1ekJVNN+cdbF7fUG2mIsrCx/707ZVKXSMj\nqg==\n-----END CERTIFICATE-----\n",
           "serial_number": "183856113797057159350158029893417591233",
@@ -1617,19 +1615,16 @@
     {
       "identity": "spiffe://cluster.local/ns/istio-system/sa/ztunnel",
       "state": "Initializing",
-      "ca_cert": [],
       "cert_chain": []
     },
     {
       "identity": "spiffe://cluster.local/ns/istio-system/sa/another-sa",
       "state": "Unavailable: the identity is no longer needed",
-      "ca_cert": [],
       "cert_chain": []
     },
     {
       "identity": "spiffe://cluster.local/ns/istio-system/sa/istiod",
       "state": "Unavailable: signing gRPC error (The service is currently unavailable): error trying to connect: TLS handshake failed: cert verification failed - unable to get local issuer certificate [CERTIFICATE_VERIFY_FAILED]",
-      "ca_cert": [],
       "cert_chain": []
     }
   ]

--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -92,11 +92,8 @@ func getWorkloadSecret(t framework.TestContext, zPods []v1.Pod, serviceAccount s
 
 		for _, s := range dump {
 			if strings.Contains(s.Identity, serviceAccount) {
-				if len(s.CaCert) == 0 {
-					t.Errorf("ca cert missing in %v for identity: %v", ztunnel.Name, s.Identity)
-				}
 				if len(s.CertChain) == 0 {
-					t.Errorf("cert chain missing in %v for identity: %v", ztunnel.Name, s.Identity)
+					t.Fatalf("cert chain missing in %v for identity: %v", ztunnel.Name, s.Identity)
 				}
 				return &s, ztunnel, nil
 			}
@@ -118,7 +115,7 @@ func waitForWorkloadCertUpdate(t framework.TestContext, ztunnelPod v1.Pod, servi
 		}
 
 		// retry when workload cert is not updated
-		if originalCert.CaCert[0].ValidFrom != updatedCert.CaCert[0].ValidFrom {
+		if originalCert.CertChain[0].ValidFrom != updatedCert.CertChain[0].ValidFrom {
 			newSecret = updatedCert
 			t.Logf("workload cert is updated")
 			return true
@@ -130,7 +127,7 @@ func waitForWorkloadCertUpdate(t framework.TestContext, ztunnelPod v1.Pod, servi
 }
 
 func verifyWorkloadCert(t framework.TestContext, workloadSecret *configdump.CertsDump, caX590 *x509.Certificate) error {
-	intermediateCert, err := base64.StdEncoding.DecodeString(workloadSecret.CertChain[0].Pem)
+	intermediateCert, err := base64.StdEncoding.DecodeString(workloadSecret.CertChain[1].Pem)
 	if err != nil {
 		t.Errorf("failed to decode intermediate certificate: %v", err)
 	}
@@ -141,7 +138,7 @@ func verifyWorkloadCert(t framework.TestContext, workloadSecret *configdump.Cert
 			intermediateX509.SerialNumber.String(), caX590.SerialNumber.String())
 	}
 
-	workloadCert, err := base64.StdEncoding.DecodeString(workloadSecret.CaCert[0].Pem)
+	workloadCert, err := base64.StdEncoding.DecodeString(workloadSecret.CertChain[0].Pem)
 	if err != nil {
 		return fmt.Errorf("failed to decode workload certificate: %v", err)
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR addresses the istio integration failures noticed here: https://github.com/istio/istio/pull/49964#issuecomment-2010577377

This was a result of the recent changes to[ migrate to rustls](https://github.com/istio/ztunnel/pull/820) where a struct was modified in ztunnel and removed a field (ca_cert) that gets checked for an istio integration test called TestIntermediateCertRefresh. 

Here is the struct in it's current state:
```
pub struct CertsDump {
    identity: String,
    state: String,
    cert_chain: Vec<CertDump>,
}
```

instead of:
```
pub struct CertsDump {
    identity: String,
    state: String,
    ca_cert: Vec<CertDump>,
    cert_chain: Vec<CertDump>,
}
```

This failure is preventing ztunnel from getting updated in istio.deps because the integration tests are failing. This should address the issue by pointing to the ca cert that resides in the cert chain as opposed to pointing to a field that no longer exists in this updated CertsDump struct.