### PR TITLE
ImageAnalyzer  imageType  matched the  pod labels error

### DIFF
--- a/pkg/config/analysis/analyzers/util/proxyconfig.go
+++ b/pkg/config/analysis/analyzers/util/proxyconfig.go
@@ -54,7 +54,7 @@ func (e *EffectiveProxyConfigResolver) ImageType(pod *resource.Instance) string 
 		if !strings.HasPrefix(k, pod.Metadata.FullName.Namespace.String()) {
 			continue
 		}
-		if maps.Contains(v.GetSelector().GetMatchLabels(), pod.Metadata.Labels) {
+		if maps.Contains(pod.Metadata.Labels, v.GetSelector().GetMatchLabels()) {
 			if v.GetImage().GetImageType() != "" {
 				variant = v.GetImage().GetImageType()
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

ImageAnalyzer ImageType() misuse maps.Contains to matched pod labels



<img width="951" alt="image" src="https://github.com/istio/istio/assets/44200120/f38aacdf-947f-4c07-b2e8-d8823e410292">

https://github.com/istio/istio/blob/master/pkg/maps/maps.go#L64-L71