### PR TITLE
print warning log when virtual service config error

### DIFF
--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -224,7 +224,7 @@ func mergeVirtualServicesIfNeeded(
 				delegatesByRoot[rootConfigKey] = append(delegatesByRoot[rootConfigKey], delegateConfigKey)
 				delegateVS, ok := delegatesMap[types.NamespacedName{Namespace: delegateNamespace, Name: delegate.Name}]
 				if !ok {
-					log.Debugf("delegate virtual service %s/%s of %s/%s not found",
+					log.Warnf("delegate virtual service %s/%s of %s/%s not found",
 						delegateNamespace, delegate.Name, root.Namespace, root.Name)
 					// delegate not found, ignore only the current HTTP route
 					continue
@@ -232,7 +232,7 @@ func mergeVirtualServicesIfNeeded(
 				// make sure that the delegate is visible to root virtual service's namespace
 				exportTo := delegatesExportToMap[types.NamespacedName{Namespace: delegateNamespace, Name: delegate.Name}]
 				if !exportTo.Contains(visibility.Public) && !exportTo.Contains(visibility.Instance(root.Namespace)) {
-					log.Debugf("delegate virtual service %s/%s of %s/%s is not exported to %s",
+					log.Warnf("delegate virtual service %s/%s of %s/%s is not exported to %s",
 						delegateNamespace, delegate.Name, root.Namespace, root.Name, root.Namespace)
 					continue
 				}
@@ -280,7 +280,7 @@ func mergeHTTPRoute(root *networking.HTTPRoute, delegate *networking.HTTPRoute) 
 	// if match condition of N2 is a subset of anyone in N1, this is a valid matching conditions
 	merged, conflict := mergeHTTPMatchRequests(root.Match, delegate.Match)
 	if conflict {
-		log.Debugf("HTTPMatchRequests conflict: root route %s, delegate route %s", root.Name, delegate.Name)
+		log.Warnf("HTTPMatchRequests conflict: root route %s, delegate route %s", root.Name, delegate.Name)
 		return nil
 	}
 	delegate.Match = merged
@@ -343,7 +343,7 @@ func mergeHTTPMatchRequests(root, delegate []*networking.HTTPMatchRequest) (out 
 		foundMatch := false
 		for _, rootMatch := range root {
 			if hasConflict(rootMatch, subMatch) {
-				log.Debugf("HTTPMatchRequests conflict: root %v, delegate %v", rootMatch, subMatch)
+				log.Warnf("HTTPMatchRequests conflict: root %v, delegate %v", rootMatch, subMatch)
 				continue
 			}
 			// merge HTTPMatchRequest


### PR DESCRIPTION
These scenarios are matching conflicts or configuration errors and cannot be detected by webhooks. It makes sense to change to printing warning logs so that we can detect problems through logs in time when applying configuration, because we do not enable debug logs by default.