### PR TITLE
Temporarily skip broken test

### DIFF
--- a/tests/integration/ambient/cacert_rotation_test.go
+++ b/tests/integration/ambient/cacert_rotation_test.go
@@ -46,6 +46,7 @@ func TestIntermediateCertificateRefresh(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.cacert-rotation").
 		Run(func(t framework.TestContext) {
+			t.Skip("https://github.com/istio/istio/issues/49648")
 			istioCfg := istio.DefaultConfigOrFail(t, t)
 			istioCtl := istioctl.NewOrFail(t, t, istioctl.Config{})
 			namespace.ClaimOrFail(t, t, istioCfg.SystemNamespace)


### PR DESCRIPTION
See https://github.com/istio/istio/issues/49648. This test is 100% broken, but we have no assertions. Worse, though, its masking other real (crashing) issues. Skip for now; I have another PR but it is not ready