### PR TITLE
use istio gateways as basic HTTP waypoints

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2180,20 +2180,13 @@ func reportGatewayStatus(
 		gs := s.(*k8s.GatewayStatus)
 		addressesToReport := external
 		if len(addressesToReport) == 0 {
-			wantAddressType := classInfo.addressType
-			if override, ok := obj.Annotations[addressTypeOverride]; ok {
-				wantAddressType = k8s.AddressType(override)
-			}
 			// There are no external addresses, so report the internal ones
 			// TODO: should we always report both?
-			if wantAddressType == k8s.IPAddressType {
-				addressesToReport = internalIP
-			} else {
-				for _, hostport := range internal {
-					svchost, _, _ := net.SplitHostPort(hostport)
-					if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
-						addressesToReport = append(addressesToReport, svchost)
-					}
+			addressesToReport = internalIP
+			for _, hostport := range internal {
+				svchost, _, _ := net.SplitHostPort(hostport)
+				if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
+					addressesToReport = append(addressesToReport, svchost)
 				}
 			}
 		}

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -2180,13 +2180,20 @@ func reportGatewayStatus(
 		gs := s.(*k8s.GatewayStatus)
 		addressesToReport := external
 		if len(addressesToReport) == 0 {
+			wantAddressType := classInfo.addressType
+			if override, ok := obj.Annotations[addressTypeOverride]; ok {
+				wantAddressType = k8s.AddressType(override)
+			}
 			// There are no external addresses, so report the internal ones
 			// TODO: should we always report both?
-			addressesToReport = internalIP
-			for _, hostport := range internal {
-				svchost, _, _ := net.SplitHostPort(hostport)
-				if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
-					addressesToReport = append(addressesToReport, svchost)
+			if wantAddressType == k8s.IPAddressType {
+				addressesToReport = internalIP
+			} else {
+				for _, hostport := range internal {
+					svchost, _, _ := net.SplitHostPort(hostport)
+					if !slices.Contains(pending, svchost) && !slices.Contains(addressesToReport, svchost) {
+						addressesToReport = append(addressesToReport, svchost)
+					}
 				}
 			}
 		}

--- a/pilot/pkg/config/kube/gateway/model.go
+++ b/pilot/pkg/config/kube/gateway/model.go
@@ -32,6 +32,7 @@ const (
 	gatewayNameOverride          = "gateway.istio.io/name-override"
 	gatewaySAOverride            = "gateway.istio.io/service-account"
 	serviceTypeOverride          = "networking.istio.io/service-type"
+	addressTypeOverride          = "networking.istio.io/address-type"
 )
 
 // GatewayResources stores all gateway resources used for our conversion.

--- a/pilot/pkg/config/kube/gateway/model.go
+++ b/pilot/pkg/config/kube/gateway/model.go
@@ -32,7 +32,6 @@ const (
 	gatewayNameOverride          = "gateway.istio.io/name-override"
 	gatewaySAOverride            = "gateway.istio.io/service-account"
 	serviceTypeOverride          = "networking.istio.io/service-type"
-	addressTypeOverride          = "networking.istio.io/address-type"
 )
 
 // GatewayResources stores all gateway resources used for our conversion.

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -105,10 +105,6 @@ func (w Waypoint) ResourceName() string {
 
 func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway]) krt.Collection[Waypoint] {
 	return krt.NewCollection(Gateways, func(ctx krt.HandlerContext, gateway *v1beta1.Gateway) *Waypoint {
-		if gateway.Spec.GatewayClassName != constants.WaypointGatewayClassName {
-			// Not a gateway
-			return nil
-		}
 		if len(gateway.Status.Addresses) == 0 {
 			// gateway.Status.Addresses should only be populated once the Waypoint's deployment has at least 1 ready pod, it should never be removed after going ready
 			// ignore Kubernetes Gateways which aren't waypoints

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -175,6 +175,11 @@ const (
 	RemoteGatewayClassName   = "istio-remote"
 	WaypointGatewayClassName = "istio-waypoint"
 
+	// GatewayAddressTypeOverride allows overriding the address type for a Gateway
+	// to be IPAddress rather than Hostname. One usecase would be `istio` class Gateways
+	// being used internally to the cluster.
+	GatewayAddressTypeOverride = "gateway.istio.io/address-type"
+
 	// DeprecatedGatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
 	DeprecatedGatewayNameLabel = "istio.io/gateway-name"
 	// GatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -175,11 +175,6 @@ const (
 	RemoteGatewayClassName   = "istio-remote"
 	WaypointGatewayClassName = "istio-waypoint"
 
-	// GatewayAddressTypeOverride allows overriding the address type for a Gateway
-	// to be IPAddress rather than Hostname. One usecase would be `istio` class Gateways
-	// being used internally to the cluster.
-	GatewayAddressTypeOverride = "gateway.istio.io/address-type"
-
 	// DeprecatedGatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
 	DeprecatedGatewayNameLabel = "istio.io/gateway-name"
 	// GatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -264,6 +264,21 @@ func (c Config) ClusterSetLocalFQDN() string {
 	return out
 }
 
+// HostnameVariants for a Kubernetes service.
+// Results may be invalid for non k8s.
+func (c Config) HostnameVariants() []string {
+	ns := c.NamespaceName()
+	if ns == "" {
+		ns = "default"
+	}
+	return []string{
+		c.Service,
+		c.Service + "." + ns,
+		c.Service + "." + ns + ".svc",
+		c.ClusterLocalFQDN(),
+	}
+}
+
 // HostHeader returns the Host header that will be used for calls to this service.
 func (c Config) HostHeader() string {
 	if c.DefaultHostHeader != "" {

--- a/releasenotes/notes/50132.yaml
+++ b/releasenotes/notes/50132.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 48362
+releaseNotes:
+  - |
+    **Added** the annotation `gateway.istio.io/address-type` to allow `istio` class Gateways to use `ClusterIP` for status addresses.
+    **Added** the ability to annotate workloads or services with `istio.io/use-waypoint` pointing to Gateways of arbitrary gateway classes.
+
+    These changes allow configuring a standard `istio` gateway as a Waypoint.
+    For this to work, it must be configured as a `ClusterIP` Service with
+    redirection enabled. This is colloquially referred to as a "gateway
+    sandwich" where the zTunnel layer handles mTLS.

--- a/releasenotes/notes/50132.yaml
+++ b/releasenotes/notes/50132.yaml
@@ -5,10 +5,8 @@ issue:
   - 48362
 releaseNotes:
   - |
-    **Added** the annotation `gateway.istio.io/address-type` to allow `istio` class Gateways to use `ClusterIP` for status addresses.
     **Added** the ability to annotate workloads or services with `istio.io/use-waypoint` pointing to Gateways of arbitrary gateway classes.
 
-    These changes allow configuring a standard `istio` gateway as a Waypoint.
-    For this to work, it must be configured as a `ClusterIP` Service with
-    redirection enabled. This is colloquially referred to as a "gateway
-    sandwich" where the zTunnel layer handles mTLS.
+    These changes allow configuring a standard `istio` class gateway via Gateway API as a Waypoint.  For this to work, it must be 
+    configured as a `ClusterIP` Service (using the `networking.istio.io/service-type` annotation) redirection enabled. This is 
+    colloquially referred to as a "gateway sandwich" where the zTunnel layer handles mTLS.

--- a/releasenotes/notes/50132.yaml
+++ b/releasenotes/notes/50132.yaml
@@ -5,7 +5,7 @@ issue:
   - 48362
 releaseNotes:
   - |
-    **Added** the annotation `gateway.istio.io/address-type` to allow `istio` class Gateways to use `ClusterIP` for status addresses.
+    **Added** the annotation `networking.istio.io/address-type` to allow `istio` class Gateways to use `ClusterIP` for status addresses.
     **Added** the ability to annotate workloads or services with `istio.io/use-waypoint` pointing to Gateways of arbitrary gateway classes.
 
     These changes allow configuring a standard `istio` gateway as a Waypoint.

--- a/releasenotes/notes/50132.yaml
+++ b/releasenotes/notes/50132.yaml
@@ -5,8 +5,10 @@ issue:
   - 48362
 releaseNotes:
   - |
+    **Added** the annotation `gateway.istio.io/address-type` to allow `istio` class Gateways to use `ClusterIP` for status addresses.
     **Added** the ability to annotate workloads or services with `istio.io/use-waypoint` pointing to Gateways of arbitrary gateway classes.
 
-    These changes allow configuring a standard `istio` class gateway via Gateway API as a Waypoint.  For this to work, it must be 
-    configured as a `ClusterIP` Service (using the `networking.istio.io/service-type` annotation) redirection enabled. This is 
-    colloquially referred to as a "gateway sandwich" where the zTunnel layer handles mTLS.
+    These changes allow configuring a standard `istio` gateway as a Waypoint.
+    For this to work, it must be configured as a `ClusterIP` Service with
+    redirection enabled. This is colloquially referred to as a "gateway
+    sandwich" where the zTunnel layer handles mTLS.

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -214,7 +214,6 @@ metadata:
   namespace: {{.Namespace}}
   annotations:
     networking.istio.io/address-type: IPAddress
-    networking.istio.io/service-type: ClusterIP
     ambient.istio.io/redirection: enabled
 spec:
   gatewayClassName: istio

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -214,6 +214,7 @@ metadata:
   namespace: {{.Namespace}}
   annotations:
     networking.istio.io/address-type: IPAddress
+    networking.istio.io/service-type: ClusterIP
     ambient.istio.io/redirection: enabled
 spec:
   gatewayClassName: istio


### PR DESCRIPTION
* Remove the GatewayClass == istio-waypoint requirement for Waypoints. We don't really need it now that we have use-waypoint, although it will fill the krt.Collection with some unneeded items. Later could be reduced based on registered classes/GatewayCapabilities. 
* Add `networking.istio.io/address-type` to allow forcing `ClusterIP` for `istio` class Gateways
* Test use-waypoint sends traffic through this gateway

related to (but doesn't resolve) #48362 