### PR TITLE
gateway api: scope service VIPs to cluster

### DIFF
--- a/pilot/pkg/config/kube/gateway/context.go
+++ b/pilot/pkg/config/kube/gateway/context.go
@@ -32,11 +32,12 @@ import (
 
 // GatewayContext contains a minimal subset of push context functionality to be exposed to GatewayAPIControllers
 type GatewayContext struct {
-	ps *model.PushContext
+	ps      *model.PushContext
+	cluster cluster.ID
 }
 
-func NewGatewayContext(ps *model.PushContext) GatewayContext {
-	return GatewayContext{ps}
+func NewGatewayContext(ps *model.PushContext, cluster cluster.ID) GatewayContext {
+	return GatewayContext{ps, cluster}
 }
 
 // ResolveGatewayInstances attempts to resolve all instances that a gateway will be exposed on.
@@ -87,7 +88,7 @@ func (gc GatewayContext) ResolveGatewayInstances(
 			instances := gc.ps.ServiceEndpointsByPort(svc, port, nil)
 			if len(instances) > 0 {
 				foundInternal.Insert(fmt.Sprintf("%s:%d", g, port))
-				foundInternalIP.InsertAll(svc.GetAddresses(&model.Proxy{})...)
+				foundInternalIP.InsertAll(svc.GetAddresses(&model.Proxy{Metadata: &model.NodeMetadata{ClusterID: gc.cluster}})...)
 				if svc.Attributes.ClusterExternalAddresses.Len() > 0 {
 					// Fetch external IPs from all clusters
 					svc.Attributes.ClusterExternalAddresses.ForEach(func(c cluster.ID, externalIPs []string) {

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -195,7 +195,7 @@ func (c *Controller) Reconcile(ps *model.PushContext) error {
 		ReferenceGrant: referenceGrant,
 		ServiceEntry:   serviceEntry,
 		Domain:         c.domain,
-		Context:        NewGatewayContext(ps),
+		Context:        NewGatewayContext(ps, c.cluster),
 	}
 
 	if !input.hasResources() {

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -439,7 +439,7 @@ func TestConvertResources(t *testing.T) {
 				Instances: instances,
 			})
 			kr := splitInput(t, input)
-			kr.Context = NewGatewayContext(cg.PushContext())
+			kr.Context = NewGatewayContext(cg.PushContext(), "Kubernetes")
 			output := convertResources(kr)
 			output.AllowedReferences = AllowedReferences{} // Not tested here
 			output.ReferencedNamespaceKeys = nil           // Not tested here
@@ -1114,7 +1114,7 @@ spec:
 			input := readConfigString(t, tt.config, validator, nil)
 			cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{})
 			kr := splitInput(t, input)
-			kr.Context = NewGatewayContext(cg.PushContext())
+			kr.Context = NewGatewayContext(cg.PushContext(), "Kubernetes")
 			output := convertResources(kr)
 			c := &Controller{
 				state: output,
@@ -1350,7 +1350,7 @@ func BenchmarkBuildHTTPVirtualServices(b *testing.B) {
 	validator := crdvalidation.NewIstioValidator(b)
 	input := readConfig(b, "testdata/benchmark-httproute.yaml", validator, nil)
 	kr := splitInput(b, input)
-	kr.Context = NewGatewayContext(cg.PushContext())
+	kr.Context = NewGatewayContext(cg.PushContext(), "Kubernetes")
 	ctx := configContext{
 		GatewayResources:  kr,
 		AllowedReferences: convertReferencePolicies(kr),

--- a/releasenotes/notes/50138.yaml
+++ b/releasenotes/notes/50138.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+releaseNotes:
+- |
+  **Fixed** Gateway status addresses receiving Service VIPs from outside the cluster.


### PR DESCRIPTION
The current behavior could have a Gateway defined in cluster-1 that writes VIPs from all clusters. Perhaps this is valid for some kind of cross-cluster routing. 

My thought is: If we were to have a waypoint in cluster-1 AND cluster-2, we likely only want the cluster-local VIPs being sent to zTunnels. 