### PR TITLE
framework: improve logging

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -98,6 +98,13 @@ func init() {
 	viper.SetDefault("xds-port", 15012)
 }
 
+func ConfigureLogging(cmd *cobra.Command, args []string) error {
+	if err := configureLogging(cmd, args); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -105,6 +112,7 @@ func GetRootCmd(args []string) *cobra.Command {
 		Short:             "Istio control interface.",
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
+		PersistentPreRunE: ConfigureLogging,
 		Long: `Istio configuration command line utility for service operators to
 debug and diagnose their Istio mesh.
 `,
@@ -116,13 +124,6 @@ debug and diagnose their Istio mesh.
 	rootOptions := cli.AddRootFlags(flags)
 
 	ctx := cli.NewCLIContext(rootOptions)
-
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if err := configureLogging(cmd, args); err != nil {
-			return err
-		}
-		return nil
-	}
 
 	_ = rootCmd.RegisterFlagCompletionFunc(cli.FlagIstioNamespace, func(
 		cmd *cobra.Command, args []string, toComplete string,

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -98,13 +98,6 @@ func init() {
 	viper.SetDefault("xds-port", 15012)
 }
 
-func ConfigureLogging(cmd *cobra.Command, args []string) error {
-	if err := configureLogging(cmd, args); err != nil {
-		return err
-	}
-	return nil
-}
-
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -297,11 +290,8 @@ func hideInheritedFlags(orig *cobra.Command, hidden ...string) {
 	})
 }
 
-func configureLogging(_ *cobra.Command, _ []string) error {
-	if err := log.Configure(root.LoggingOptions); err != nil {
-		return err
-	}
-	return nil
+func ConfigureLogging(_ *cobra.Command, _ []string) error {
+	return log.Configure(root.LoggingOptions)
 }
 
 // seeExperimentalCmd is used for commands that have been around for a release but not graduated from

--- a/istioctl/pkg/kubeinject/kubeinject.go
+++ b/istioctl/pkg/kubeinject/kubeinject.go
@@ -626,7 +626,7 @@ It's best to do kube-inject when the resource is initially created.
 			if root != nil {
 				_ = c.Root().PersistentFlags().Set("log_target", "stderr")
 			}
-			if c.Parent() != nil {
+			if c.Parent() != nil && c.Parent().PersistentPreRunE != nil {
 				return c.Parent().PersistentPreRunE(c, args)
 			}
 

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,19 +65,6 @@ func (w *writerPrinter) Printf(format string, a ...any) {
 
 func (w *writerPrinter) Println(str string) {
 	_, _ = fmt.Fprintln(w.writer, str)
-}
-
-var logMutex = sync.Mutex{}
-
-func ConfigLogs(opt *log.Options) error {
-	logMutex.Lock()
-	defer logMutex.Unlock()
-	op := []string{"stderr"}
-	opt2 := *opt
-	opt2.OutputPaths = op
-	opt2.ErrorOutputPaths = op
-
-	return log.Configure(&opt2)
 }
 
 func refreshGoldenFiles() bool {

--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/log"
 	testenv "istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -93,10 +92,6 @@ func (i *installer) Install(c cluster.Cluster, args installArgs) error {
 	kubeClient, err := kube.NewCLIClient(kube.NewClientConfigForRestConfig(rc), "")
 	if err != nil {
 		return fmt.Errorf("create Kubernetes client: %v", err)
-	}
-
-	if mesh.ConfigLogs(cmdLogOptions()) != nil {
-		return fmt.Errorf("failed to configure logs")
 	}
 
 	// Generate the manifest YAML, so that we can uninstall it in Close.
@@ -165,18 +160,6 @@ func (i *installer) Dump(resource.Context) {
 			}
 		}
 	}
-}
-
-func cmdLogOptions() *log.Options {
-	o := log.DefaultOptions()
-
-	// These scopes are, at the default "INFO" level, too chatty for command line use
-	o.SetDefaultOutputLevel("validation", log.ErrorLevel)
-	o.SetDefaultOutputLevel("processing", log.ErrorLevel)
-	o.SetDefaultOutputLevel("default", log.WarnLevel)
-	o.SetDefaultOutputLevel("kube", log.ErrorLevel)
-
-	return o
 }
 
 func cmdLogger(stdOut, stdErr io.Writer) clog.Logger {

--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -34,7 +34,7 @@ func init() {
 
 func configureLogging() error {
 	o := *logOptionsFromCommandline
-	// This is spammy, even for tests
+	// This is spammy at info level, even for tests, so set to warn level
 	o.SetDefaultOutputLevel("installer", log.WarnLevel)
 	return log.Configure(&o)
 }

--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -34,6 +34,7 @@ func init() {
 
 func configureLogging() error {
 	o := *logOptionsFromCommandline
-
+	// This is spammy, even for tests
+	o.SetDefaultOutputLevel("installer", log.WarnLevel)
 	return log.Configure(&o)
 }


### PR DESCRIPTION
Ultimate goal here is to avoid the istioctl command from setting logs to
warn/error, which means we cannot see them in tests.
