### PR TITLE
ambient: shutdown client in test to prevent races

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1304,6 +1304,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	up := xdsfake.NewFakeXDS()
 	up.SplitEvents = true
 	cl := kubeclient.NewFakeClient()
+	t.Cleanup(cl.Shutdown)
 	for _, crd := range []schema.GroupVersionResource{
 		gvr.AuthorizationPolicy,
 		gvr.PeerAuthentication,


### PR DESCRIPTION
https://storage.googleapis.com/istio-prow/logs/unit-tests-arm64_istio_postsubmit/1773396921478549504/build-log.txt
```
2267 runs so far, 14 failures (99.39% pass rate). 418.905338ms avg, 766.491613ms max, 320.787806ms min
```

vs with this PR
```
3007 runs so far, 0 failures (100.00% pass rate). 435.21344ms avg, 675.333504ms max, 328.187762ms min\
```

Its from `features` being accessed concurrently. Cannot happen in prod as they do not change at runtime in real code