### PR TITLE
Fix high CPU consumption on pilot when in-cluster analysis is enabled

### DIFF
--- a/pkg/util/concurrent/debouncer.go
+++ b/pkg/util/concurrent/debouncer.go
@@ -46,12 +46,16 @@ func (d *Debouncer[T]) Run(ch chan T, stopCh <-chan struct{}, debounceMinInterva
 		quietTime := time.Since(lastConfigUpdateTime)
 		// it has been too long or quiet enough
 		if eventDelay >= debounceMaxInterval || quietTime >= debounceMinInterval {
-			if combinedEvents != nil {
+			if combinedEvents.Len() > 0 {
 				pushCounter++
 				free = false
 				go push(combinedEvents, debouncedEvents, startDebounce)
 				combinedEvents = sets.New[T]()
 				debouncedEvents = 0
+			} else {
+				// For no combined events to process, we can also do nothing here and wait for the config change to trigger
+				// the next debounce, but I think it's better to set it's to the defined analysis interval.
+				timeChan = time.After(debounceMaxInterval)
 			}
 		} else {
 			timeChan = time.After(debounceMinInterval - quietTime)

--- a/pkg/util/concurrent/debouncer.go
+++ b/pkg/util/concurrent/debouncer.go
@@ -54,7 +54,7 @@ func (d *Debouncer[T]) Run(ch chan T, stopCh <-chan struct{}, debounceMinInterva
 				debouncedEvents = 0
 			} else {
 				// For no combined events to process, we can also do nothing here and wait for the config change to trigger
-				// the next debounce, but I think it's better to set it's to the defined analysis interval.
+				// the next debounce, but I think it's better to set it's to the debounce max interval.
 				timeChan = time.After(debounceMaxInterval)
 			}
 		} else {

--- a/releasenotes/notes/50157.yaml
+++ b/releasenotes/notes/50157.yaml
@@ -5,4 +5,4 @@ issue:
 - 49340
 releaseNotes:
 - |
-  **Fixed** an issue that pilot CPU consumption is abnormally high when the in-cluster analysis is enabled.
+  **Fixed** an issue where pilot CPU consumption was abnormally high when the in-cluster analysis was enabled.

--- a/releasenotes/notes/50157.yaml
+++ b/releasenotes/notes/50157.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 49340
+releaseNotes:
+- |
+  **Fixed** an issue that pilot CPU consumption is abnormally high when the in-cluster analysis is enabled.


### PR DESCRIPTION
**Please provide a description of this PR:**
Resolves https://github.com/istio/istio/issues/49340.

I think the root cause is that the set will never be nil, but rather an empty initialized set, which results in the analysis being stuck in a push loop forever.