### PR TITLE
Add set functions with better performance

### DIFF
--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -340,12 +340,8 @@ func pruneHostIPset(expected sets.Set[netip.Addr], hostsideProbeSet *ipset.IPSet
 		log.Warnf("unable to list IPSet: %v", err)
 		return err
 	}
-	actual := sets.New[netip.Addr]()
-	for _, ip := range actualIPSetContents {
-		actual.Insert(ip)
-	}
-
-	stales := actual.Difference(expected)
+	actual := sets.New[netip.Addr](actualIPSetContents...)
+	stales := actual.DifferenceInPlace(expected)
 
 	for staleIP := range stales {
 		if err := hostsideProbeSet.ClearEntriesWithIP(staleIP); err != nil {

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -321,7 +321,7 @@ func (c *Controller) namespaceEvent(oldNs, newNs *corev1.Namespace) {
 
 	// Next, we find all keys our Gateways actually reference.
 	c.stateMu.RLock()
-	intersection := touchedNamespaceLabels.Intersection(c.state.ReferencedNamespaceKeys)
+	intersection := touchedNamespaceLabels.IntersectInPlace(c.state.ReferencedNamespaceKeys)
 	c.stateMu.RUnlock()
 
 	// If there was any overlap, then a relevant namespace label may have changed, and we trigger a

--- a/pilot/pkg/model/typed_xds_cache.go
+++ b/pilot/pkg/model/typed_xds_cache.go
@@ -197,7 +197,7 @@ func (l *lruCache[K]) clearConfigIndex(k K, dependentConfigs []ConfigHash) {
 	if exists {
 		newDependents := c.dependentConfigs
 		// we only need to clear configs {old difference new}
-		dependents := sets.New(dependentConfigs...).Difference(sets.New(newDependents...))
+		dependents := sets.New(dependentConfigs...).DifferenceInPlace(sets.New(newDependents...))
 		for cfg := range dependents {
 			sets.DeleteCleanupLast(l.configIndex, cfg, k)
 		}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -131,7 +131,7 @@ func (configgen *ConfigGeneratorImpl) BuildDeltaClusters(proxy *model.Proxy, upd
 		builtClusters.Insert(c.Name)
 	}
 	// Remove anything we built from the deleted list
-	deletedClusters = deletedClusters.Difference(builtClusters)
+	deletedClusters = deletedClusters.DifferenceInPlace(builtClusters)
 	return clusters, sets.SortedList(deletedClusters), log, true
 }
 

--- a/pilot/pkg/xds/workload.go
+++ b/pilot/pkg/xds/workload.go
@@ -65,7 +65,7 @@ func (e WorkloadGenerator) GenerateDeltas(
 		} else {
 			// this is from the external triggers instead of request
 			// send response for all the subscribed intersect with the updated
-			addresses = updatedAddresses.Intersection(subs)
+			addresses = updatedAddresses.IntersectInPlace(subs)
 		}
 	}
 

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -81,7 +81,7 @@ func (s Set[T]) Merge(s2 Set[T]) Set[T] {
 
 // Copy this set.
 func (s Set[T]) Copy() Set[T] {
-	result := New[T]()
+	result := NewWithLength[T](s.Len())
 	for key := range s {
 		result.Insert(key)
 	}
@@ -117,6 +117,17 @@ func (s Set[T]) Difference(s2 Set[T]) Set[T] {
 	return result
 }
 
+// DifferenceInPlace similar to Difference, but has better performance.
+// Note: This function modifies s in place.
+func (s Set[T]) DifferenceInPlace(s2 Set[T]) Set[T] {
+	for key := range s {
+		if s2.Contains(key) {
+			delete(s, key)
+		}
+	}
+	return s
+}
+
 // Diff takes a pair of Sets, and returns the elements that occur only on the left and right set.
 func (s Set[T]) Diff(other Set[T]) (left []T, right []T) {
 	for k := range s {
@@ -145,6 +156,17 @@ func (s Set[T]) Intersection(s2 Set[T]) Set[T] {
 		}
 	}
 	return result
+}
+
+// IntersectInPlace similar to Intersection, but has better performance.
+// Note: This function modifies s in place.
+func (s Set[T]) IntersectInPlace(s2 Set[T]) Set[T] {
+	for key := range s {
+		if !s2.Contains(key) {
+			delete(s, key)
+		}
+	}
+	return s
 }
 
 // SupersetOf returns true if s contains all elements of s2


### PR DESCRIPTION
Operate in place to save copies and temporary space.

```
# Benchmark test comparing "in place" and "not in place"
$ go test -run=^$ -bench=BenchmarkOperateInPlace -test.benchmem -count=1
os: darwin
goarch: amd64
pkg: istio.io/istio/pkg/util/sets
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkOperateInPlace/Difference-12         	  215138	      5794 ns/op	    1522 B/op	      12 allocs/op
BenchmarkOperateInPlace/DifferenceInPlace-12  	  909678	      1351 ns/op	       0 B/op	       0 allocs/op
BenchmarkOperateInPlace/Intersection-12       	  860622	      1391 ns/op	      48 B/op	       1 allocs/op
BenchmarkOperateInPlace/IntersectInPlace-12   	361817298	         3.302 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	istio.io/istio/pkg/util/sets	6.857s
```