### PR TITLE
Clean constants

### DIFF
--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -27,11 +27,8 @@ import (
 // to be triggered. This is to avoid unnecessary pushes only when labels have changed
 // for example.
 func needsPush(prev config.Config, curr config.Config) bool {
-	if prev.GroupVersionKind != curr.GroupVersionKind {
-		// This should never happen.
-		return true
-	}
 	// If the config is not Istio, let us just push.
+	// Used for gateway api reconcile.
 	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
 		return true
 	}

--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -27,8 +27,11 @@ import (
 // to be triggered. This is to avoid unnecessary pushes only when labels have changed
 // for example.
 func needsPush(prev config.Config, curr config.Config) bool {
+	if prev.GroupVersionKind != curr.GroupVersionKind {
+		// This should never happen.
+		return true
+	}
 	// If the config is not Istio, let us just push.
-	// Used for gateway api reconcile.
 	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
 		return true
 	}

--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 )
 
 // needsPush checks whether the passed in config has same spec and hence push needs
@@ -35,27 +36,11 @@ func needsPush(prev config.Config, curr config.Config) bool {
 	if !strings.HasSuffix(prev.GroupVersionKind.Group, "istio.io") {
 		return true
 	}
-	// If current/previous metadata has "*istio.io" label/annotation, just push
-	for label := range curr.Meta.Labels {
-		if strings.Contains(label, "istio.io") {
-			return true
-		}
+
+	if _, ok := curr.Labels[constants.AlwaysPushLabel]; ok {
+		return true
 	}
-	for annotation := range curr.Meta.Annotations {
-		if strings.Contains(annotation, "istio.io") {
-			return true
-		}
-	}
-	for label := range prev.Meta.Labels {
-		if strings.Contains(label, "istio.io") {
-			return true
-		}
-	}
-	for annotation := range prev.Meta.Annotations {
-		if strings.Contains(annotation, "istio.io") {
-			return true
-		}
-	}
+
 	prevspecProto, okProtoP := prev.Spec.(proto.Message)
 	currspecProto, okProtoC := curr.Spec.(proto.Message)
 	if okProtoP && okProtoC {

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -31,26 +31,6 @@ func TestNeedsPush(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "different gvk",
-			prev: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.VirtualService,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-				Spec: &networking.VirtualService{},
-			},
-			curr: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.DestinationRule,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-				Spec: &networking.VirtualService{},
-			},
-			expected: true,
-		},
-		{
 			name: "same gvk label change",
 			prev: config.Config{
 				Meta: config.Meta{
@@ -95,29 +75,10 @@ func TestNeedsPush(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "current config with istio.io label",
+			name: "with AlwaysPushLabel label",
 			prev: config.Config{
 				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-			},
-			curr: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "previous config with istio.io label",
-			prev: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
+					GroupVersionKind: gvk.VirtualService,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
 					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
@@ -125,47 +86,10 @@ func TestNeedsPush(t *testing.T) {
 			},
 			curr: config.Config{
 				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
+					GroupVersionKind: gvk.VirtualService,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "current config with istio.io annotation",
-			prev: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-			},
-			curr: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "previous config with istio.io annotation",
-			prev: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
-				},
-			},
-			curr: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.Ingress,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -19,6 +19,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -29,6 +30,26 @@ func TestNeedsPush(t *testing.T) {
 		curr     config.Config
 		expected bool
 	}{
+		{
+			name: "different gvk",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+				Spec: &networking.VirtualService{},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.DestinationRule,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+				Spec: &networking.VirtualService{},
+			},
+			expected: true,
+		},
 		{
 			name: "same gvk label change",
 			prev: config.Config{
@@ -87,6 +108,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -98,6 +120,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -123,6 +146,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -134,6 +158,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -75,10 +75,29 @@ func TestNeedsPush(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "with AlwaysPushLabel label",
+			name: "current config with istio.io label",
 			prev: config.Config{
 				Meta: config.Meta{
-					GroupVersionKind: gvk.VirtualService,
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "previous config with istio.io label",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
 					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
@@ -86,10 +105,47 @@ func TestNeedsPush(t *testing.T) {
 			},
 			curr: config.Config{
 				Meta: config.Meta{
-					GroupVersionKind: gvk.VirtualService,
+					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "current config with istio.io annotation",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "previous config with istio.io annotation",
+			prev: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
+					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+				},
+			},
+			curr: config.Config{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.Ingress,
+					Name:             "acme2-v1",
+					Namespace:        "not-default",
 				},
 			},
 			expected: true,

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -87,7 +87,6 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					// Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -99,7 +98,6 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					// Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -125,7 +123,6 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					// Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -137,7 +134,6 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					// Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -169,7 +165,7 @@ func TestNeedsPush(t *testing.T) {
 				},
 				Spec: &networking.VirtualService{},
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/pilot/pkg/bootstrap/config_compare_test.go
+++ b/pilot/pkg/bootstrap/config_compare_test.go
@@ -19,7 +19,6 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -30,26 +29,6 @@ func TestNeedsPush(t *testing.T) {
 		curr     config.Config
 		expected bool
 	}{
-		{
-			name: "different gvk",
-			prev: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.VirtualService,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-				Spec: &networking.VirtualService{},
-			},
-			curr: config.Config{
-				Meta: config.Meta{
-					GroupVersionKind: gvk.DestinationRule,
-					Name:             "acme2-v1",
-					Namespace:        "not-default",
-				},
-				Spec: &networking.VirtualService{},
-			},
-			expected: true,
-		},
 		{
 			name: "same gvk label change",
 			prev: config.Config{
@@ -108,7 +87,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+					// Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -120,7 +99,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
+					// Labels:           map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -146,7 +125,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+					// Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			expected: true,
@@ -158,7 +137,7 @@ func TestNeedsPush(t *testing.T) {
 					GroupVersionKind: gvk.Ingress,
 					Name:             "acme2-v1",
 					Namespace:        "not-default",
-					Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
+					// Annotations:      map[string]string{constants.AlwaysPushLabel: "true"},
 				},
 			},
 			curr: config.Config{
@@ -190,7 +169,7 @@ func TestNeedsPush(t *testing.T) {
 				},
 				Spec: &networking.VirtualService{},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -510,7 +510,7 @@ func (d *DeploymentController) render(templateName string, mi TemplateInput) ([]
 		return nil, fmt.Errorf("no %q template defined", templateName)
 	}
 
-	labelToMatch := map[string]string{constants.GatewayNameLabel: mi.Name, constants.DeprecatedGatewayNameLabel: mi.Name}
+	labelToMatch := map[string]string{constants.GatewayNameLabel: mi.Name}
 	proxyConfig := d.env.GetProxyConfigOrDefault(mi.Namespace, labelToMatch, nil, cfg.MeshConfig)
 	input := derivedInput{
 		TemplateInput: mi,
@@ -618,16 +618,6 @@ func (d *DeploymentController) setGatewayNameLabel(ti *TemplateInput) {
 		log.Debugf("deployment %s/%s not found in store; using to the new gateway name label", ti.DeploymentName, ti.Namespace)
 		return
 	}
-
-	// Base label choice on the deployment's selector
-	_, exists := dep.(*appsv1.Deployment).Spec.Selector.MatchLabels[constants.DeprecatedGatewayNameLabel]
-	if !exists {
-		// The old label doesn't already exist on the deployment; use the new label
-		return
-	}
-
-	// The old label exists on the deployment; use the old label
-	ti.GatewayNameLabel = constants.DeprecatedGatewayNameLabel
 }
 
 type TemplateInput struct {

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -196,13 +196,15 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 		Name:             item.Name + "-" + "virtualservice",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.VirtualService,
-		Annotations:      map[string]string{constants.InternalRouteSemantics: constants.RouteSemanticsIngress},
+		// Set this label so that we do not compare configs and just push.
+		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
 	}
 	gatewaymetadata := config.Meta{
 		Name:             item.Name + "-" + "gateway",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.Gateway,
-		Annotations:      map[string]string{constants.InternalRouteSemantics: constants.RouteSemanticsIngress},
+		// Set this label so that we do not compare configs and just push.
+		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
 	}
 
 	// Trigger updates for Gateway and VirtualService

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -19,7 +19,6 @@ package ingress
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"sync"
 
@@ -187,13 +186,8 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 	// we should check need process only when event is not delete,
 	// if it is delete event, and previously processed, we need to process too.
 	if event != model.EventDelete {
-		oldIngress := c.ingresses[config.NamespacedName(ing)]
 		shouldProcess := c.shouldProcessIngressUpdate(ing)
 		if !shouldProcess {
-			return nil
-		}
-		// only trigger when real changes were found
-		if oldIngress != nil && reflect.DeepEqual(oldIngress.Spec, ing.Spec) {
 			return nil
 		}
 	}
@@ -212,6 +206,7 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 	}
 
 	// Trigger updates for Gateway and VirtualService
+	// TODO: we could be smarter here and only trigger when real changes were found
 	for _, f := range c.virtualServiceHandlers {
 		f(config.Config{Meta: vsmetadata}, config.Config{Meta: vsmetadata}, event)
 	}

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"sync"
 
@@ -186,8 +187,13 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 	// we should check need process only when event is not delete,
 	// if it is delete event, and previously processed, we need to process too.
 	if event != model.EventDelete {
+		oldIngress := c.ingresses[config.NamespacedName(ing)]
 		shouldProcess := c.shouldProcessIngressUpdate(ing)
 		if !shouldProcess {
+			return nil
+		}
+		// only trigger when real changes were found
+		if oldIngress != nil && reflect.DeepEqual(oldIngress.Spec, ing.Spec) {
 			return nil
 		}
 	}
@@ -196,15 +202,16 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 		Name:             item.Name + "-" + "virtualservice",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.VirtualService,
+		Annotations:      map[string]string{constants.InternalRouteSemantics: constants.RouteSemanticsIngress},
 	}
 	gatewaymetadata := config.Meta{
 		Name:             item.Name + "-" + "gateway",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.Gateway,
+		Annotations:      map[string]string{constants.InternalRouteSemantics: constants.RouteSemanticsIngress},
 	}
 
 	// Trigger updates for Gateway and VirtualService
-	// TODO: we could be smarter here and only trigger when real changes were found
 	for _, f := range c.virtualServiceHandlers {
 		f(config.Config{Meta: vsmetadata}, config.Config{Meta: vsmetadata}, event)
 	}

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -196,15 +196,11 @@ func (c *controller) onEvent(item types.NamespacedName) error {
 		Name:             item.Name + "-" + "virtualservice",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.VirtualService,
-		// Set this label so that we do not compare configs and just push.
-		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
 	}
 	gatewaymetadata := config.Meta{
 		Name:             item.Name + "-" + "gateway",
 		Namespace:        item.Namespace,
 		GroupVersionKind: gvk.Gateway,
-		// Set this label so that we do not compare configs and just push.
-		Labels: map[string]string{constants.AlwaysPushLabel: "true"},
 	}
 
 	// Trigger updates for Gateway and VirtualService

--- a/pilot/pkg/model/policyattachment.go
+++ b/pilot/pkg/model/policyattachment.go
@@ -49,11 +49,6 @@ const (
 
 func KubernetesGatewayNameAndExists(l labels.Instance) (string, bool) {
 	gwName, exists := l[constants.GatewayNameLabel]
-	if !exists {
-		// TODO: Remove deprecated gateway name label (1.22 or 1.23)
-		gwName, exists = l[constants.DeprecatedGatewayNameLabel]
-	}
-
 	return gwName, exists
 }
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -134,9 +134,6 @@ const (
 
 	TestVMVersionLabel = "istio.io/test-vm-version"
 
-	// Label to skip config comparison.
-	AlwaysPushLabel = "internal.istio.io/always-push"
-
 	// InternalParentNames declares the original resources of an internally-generated config.
 	// This is used by k8s gateway-api.
 	// It is a comma separated list. For example, "HTTPRoute/foo.default,HTTPRoute/bar.default"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -134,6 +134,9 @@ const (
 
 	TestVMVersionLabel = "istio.io/test-vm-version"
 
+	// Label to skip config comparison.
+	AlwaysPushLabel = "internal.istio.io/always-push"
+
 	// InternalParentNames declares the original resources of an internally-generated config.
 	// This is used by k8s gateway-api.
 	// It is a comma separated list. For example, "HTTPRoute/foo.default,HTTPRoute/bar.default"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -172,8 +172,6 @@ const (
 	RemoteGatewayClassName   = "istio-remote"
 	WaypointGatewayClassName = "istio-waypoint"
 
-	// DeprecatedGatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
-	DeprecatedGatewayNameLabel = "istio.io/gateway-name"
 	// GatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
 	GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
 


### PR DESCRIPTION
**Please provide a description of this PR:**

remove
```
// DeprecatedGatewayNameLabel indicates the gateway managing a particular proxy instances. Only populated for Gateway API gateways
DeprecatedGatewayNameLabel = "istio.io/gateway-name"
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
