### PR TITLE
eds: to-service waypoint capture from sidecars

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2452,6 +2452,11 @@ func (ps *PushContext) SupportsTunnel(n network.ID, ip string) bool {
 	return false
 }
 
+func (ps *PushContext) AddressInformation(n network.ID, ip string) []AddressInfo {
+	out, _ := ps.ambientIndex.AddressInformation(sets.New(n.String() + "/" + ip))
+	return out
+}
+
 func (ps *PushContext) WaypointsFor(network, address string) []netip.Addr {
 	return ps.ambientIndex.Waypoint(network, address)
 }

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -157,15 +157,9 @@ func TestServices(t *testing.T) {
 			opt.Check = check.And(opt.Check, OriginalSourceCheck(t, src))
 		}
 
-		if src.Config().ZTunnelCaptured() && dst.Config().HasWorkloadAddressedWaypointProxy() {
-			// ztunnel is going to send to a waypoint which won't accept this traffic
-			t.Skip("https://github.com/istio/ztunnel/pull/855")
-		}
-
-		if src.Config().HasSidecar() && dst.Config().HasWorkloadAddressedWaypointProxy() {
-			// We are testing to svc traffic but presently sidecar has not been updated to know that to svc traffic should not
-			// go to a workload-attached waypoint
-			t.Skip("TODO: open issue")
+		// The actuall traffic is to Service; don't go through the waypoint.
+		if dst.Config().HasWorkloadAddressedWaypointProxy() {
+			opt.Check = tcpValidator
 		}
 
 		// TODO test from all source workloads as well

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -305,9 +305,6 @@ spec:
 					continue
 				}
 				t.NewSubTestf("from %s", src.ServiceName()).Run(func(t framework.TestContext) {
-					if src.Config().HasSidecar() {
-						t.Skip("TODO: sidecars don't properly handle use-waypoint")
-					}
 					for _, host := range apps.Captured.Config().HostnameVariants() {
 						host := host
 						t.NewSubTestf("to %s", host).Run(func(t framework.TestContext) {

--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -103,20 +103,19 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					},
 				},
 				// Mutual TLS origination from an unauthorized sidecar to https endpoint
-				// This will result in a 503 with the UH flag because the cluster will
-				// stay warming until a valid secret is sent.
+				// This will result in `TLS ERROR Secret is not supplied by SDS`
 				{
 					name:            "unauthorized sidecar",
 					credentialToUse: credNameGeneric,
 					from:            apps.Ns1.B,
 					drSelector:      "b",
 					expectedResponse: ingressutil.ExpectedResponse{
-						StatusCode: http.StatusServiceUnavailable,
+						StatusCode:   http.StatusServiceUnavailable,
+						ErrorMessage: "Secret is not supplied by SDS",
 					},
 				},
 				// Mutual TLS origination using an invalid client certificate
-				// This will result in a 503 with the UH flag because the cluster will
-				// stay warming until a valid secret is sent.
+				// This will result in `TLS ERROR: Secret is not supplied by SDS`
 				{
 					name:             "invalid client cert",
 					credentialToUse:  fakeCredName,
@@ -124,7 +123,8 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					drSelector:       "c",
 					authorizeSidecar: true,
 					expectedResponse: ingressutil.ExpectedResponse{
-						StatusCode: http.StatusServiceUnavailable,
+						StatusCode:   http.StatusServiceUnavailable,
+						ErrorMessage: "Secret is not supplied by SDS",
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL specifying the server certificate as revoked.


### PR DESCRIPTION
Current behavior: "Service addressed traffic goes to waypoint if it picks and endpoint that has a workload-attached waypoint (or namespace attached). "

New behavior: "Service addressed traffic goes to waypoint if the service or namespace has a waypoint."

In both cases Workload addressed traffic never goes to the waypoint. This could potentially be added to virtualOutbound? 