### PR TITLE
Assert generic 503 for mising/invalid cert

### DIFF
--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -103,19 +103,20 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					},
 				},
 				// Mutual TLS origination from an unauthorized sidecar to https endpoint
-				// This will result in `TLS ERROR Secret is not supplied by SDS`
+				// This will result in a 503 with the UH flag because the cluster will
+				// stay warming until a valid secret is sent.
 				{
 					name:            "unauthorized sidecar",
 					credentialToUse: credNameGeneric,
 					from:            apps.Ns1.B,
 					drSelector:      "b",
 					expectedResponse: ingressutil.ExpectedResponse{
-						StatusCode:   http.StatusServiceUnavailable,
-						ErrorMessage: "Secret is not supplied by SDS",
+						StatusCode: http.StatusServiceUnavailable,
 					},
 				},
 				// Mutual TLS origination using an invalid client certificate
-				// This will result in `TLS ERROR: Secret is not supplied by SDS`
+				// This will result in a 503 with the UH flag because the cluster will
+				// stay warming until a valid secret is sent.
 				{
 					name:             "invalid client cert",
 					credentialToUse:  fakeCredName,
@@ -123,8 +124,7 @@ func TestSidecarMutualTlsOrigination(t *testing.T) {
 					drSelector:       "c",
 					authorizeSidecar: true,
 					expectedResponse: ingressutil.ExpectedResponse{
-						StatusCode:   http.StatusServiceUnavailable,
-						ErrorMessage: "Secret is not supplied by SDS",
+						StatusCode: http.StatusServiceUnavailable,
 					},
 				},
 				// Mutual TLS origination from an authorized sidecar to https endpoint with a CRL specifying the server certificate as revoked.


### PR DESCRIPTION
**Please provide a description of this PR:**

After https://github.com/envoyproxy/envoy/commit/907e48ef5a48d2cfce2b4050c0e1d4498372c0e7, delta SDS no longer errors with "Secret is not supplied by SDS" for a nonexisting secret, so our tests shouldn't check for it


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
