### PR TITLE
proxy: eliminate most xDS

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -294,7 +294,7 @@ lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles li
 # Allow-list:
 # (k8s) Machinery, utils, klog
 # (proto) TLS for SDS
-# (proto) Wasm/RBAC for wasm xDS proxy
+# (proto) Wasm/RBAC for wasm xDS proxy, RBAC pulls envoy/config/route
 .PHONY: check-agent-deps
 check-agent-deps:
 	@go list -f '{{ join .Deps "\n" }}' -tags=agent \
@@ -311,11 +311,12 @@ check-agent-deps:
 			./pkg/bootstrap/... \
 			./pkg/wasm/... \
 			./pkg/envoy/... | sort | uniq |\
-		grep -Pv 'k8s.io/(utils|klog|apimachinery)/' |\
+		grep -Pv '^k8s.io/(utils|klog|apimachinery)/' |\
+		grep -Pv 'envoy/type|envoy/annotations|envoy/config/(core|route|rbac)/' |\
 		grep -Pv 'envoy/extensions/transport_sockets/tls/' |\
 		grep -Pv 'envoy/extensions/wasm/' |\
 		grep -Pv 'envoy/extensions/filters/(http|network)/(rbac|wasm)/' |\
-		(! grep -P '^k8s.io|^sigs.k8s.io/gateway-api|cel|antlr|envoy/extensions')
+		(! grep -P '^k8s.io|^sigs.k8s.io/gateway-api|cel|antlr|envoy/')
 
 go-gen:
 	@mkdir -p /tmp/bin

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	admin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/util"
 )
@@ -92,7 +90,7 @@ func (p *Probe) isEnvoyReady() error {
 	}
 	select {
 	case <-p.Context.Done():
-		return fmt.Errorf("server is not live, current state is: %s", admin.ServerInfo_DRAINING.String())
+		return fmt.Errorf("server is not live, current state is: %s", StateString(ServerInfo_DRAINING))
 	default:
 		return p.checkEnvoyReadiness()
 	}
@@ -117,6 +115,33 @@ func (p *Probe) checkEnvoyReadiness() error {
 	return err
 }
 
+type ServerInfo_State int32
+
+const (
+	// Server is live and serving traffic.
+	ServerInfo_LIVE ServerInfo_State = 0
+	// Server is draining listeners in response to external health checks failing.
+	ServerInfo_DRAINING ServerInfo_State = 1
+	// Server has not yet completed cluster manager initialization.
+	ServerInfo_PRE_INITIALIZING ServerInfo_State = 2
+	// Server is running the cluster manager initialization callbacks (e.g., RDS).
+	ServerInfo_INITIALIZING ServerInfo_State = 3
+)
+
+func StateString(state ServerInfo_State) string {
+	switch state {
+	case ServerInfo_LIVE:
+		return "LIVE"
+	case ServerInfo_DRAINING:
+		return "DRAINING"
+	case ServerInfo_PRE_INITIALIZING:
+		return "PRE_INITIALIZING"
+	case ServerInfo_INITIALIZING:
+		return "INITIALIZING"
+	}
+	return "UNKNOWN"
+}
+
 // checkEnvoyStats actually executes the Stats Query on Envoy admin endpoint.
 func checkEnvoyStats(host string, port uint16) error {
 	state, ws, err := util.GetReadinessStats(host, port)
@@ -124,8 +149,8 @@ func checkEnvoyStats(host string, port uint16) error {
 		return fmt.Errorf("failed to get readiness stats: %v", err)
 	}
 
-	if state != nil && admin.ServerInfo_State(*state) != admin.ServerInfo_LIVE {
-		return fmt.Errorf("server is not live, current state is: %v", admin.ServerInfo_State(*state).String())
+	if state != nil && ServerInfo_State(*state) != ServerInfo_LIVE {
+		return fmt.Errorf("server is not live, current state is: %v", StateString(ServerInfo_State(*state)))
 	}
 
 	if !ws {

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -90,7 +90,7 @@ func (p *Probe) isEnvoyReady() error {
 	}
 	select {
 	case <-p.Context.Done():
-		return fmt.Errorf("server is not live, current state is: %s", StateString(ServerInfo_DRAINING))
+		return fmt.Errorf("server is not live, current state is: %s", StateString(Draining))
 	default:
 		return p.checkEnvoyReadiness()
 	}
@@ -115,28 +115,28 @@ func (p *Probe) checkEnvoyReadiness() error {
 	return err
 }
 
-type ServerInfo_State int32
+type ServerInfoState int32
 
 const (
 	// Server is live and serving traffic.
-	ServerInfo_LIVE ServerInfo_State = 0
+	Live ServerInfoState = 0
 	// Server is draining listeners in response to external health checks failing.
-	ServerInfo_DRAINING ServerInfo_State = 1
+	Draining ServerInfoState = 1
 	// Server has not yet completed cluster manager initialization.
-	ServerInfo_PRE_INITIALIZING ServerInfo_State = 2
+	PreInitializing ServerInfoState = 2
 	// Server is running the cluster manager initialization callbacks (e.g., RDS).
-	ServerInfo_INITIALIZING ServerInfo_State = 3
+	Initializing ServerInfoState = 3
 )
 
-func StateString(state ServerInfo_State) string {
+func StateString(state ServerInfoState) string {
 	switch state {
-	case ServerInfo_LIVE:
+	case Live:
 		return "LIVE"
-	case ServerInfo_DRAINING:
+	case Draining:
 		return "DRAINING"
-	case ServerInfo_PRE_INITIALIZING:
+	case PreInitializing:
 		return "PRE_INITIALIZING"
-	case ServerInfo_INITIALIZING:
+	case Initializing:
 		return "INITIALIZING"
 	}
 	return "UNKNOWN"
@@ -149,8 +149,8 @@ func checkEnvoyStats(host string, port uint16) error {
 		return fmt.Errorf("failed to get readiness stats: %v", err)
 	}
 
-	if state != nil && ServerInfo_State(*state) != ServerInfo_LIVE {
-		return fmt.Errorf("server is not live, current state is: %v", StateString(ServerInfo_State(*state)))
+	if state != nil && ServerInfoState(*state) != Live {
+		return fmt.Errorf("server is not live, current state is: %v", StateString(ServerInfoState(*state)))
 	}
 
 	if !ws {

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"strings"
 
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"google.golang.org/protobuf/types/known/durationpb"
 	pstruct "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshAPI "istio.io/api/mesh/v1alpha1"
@@ -44,10 +43,22 @@ type TransportSocket struct {
 	TypedConfig *pstruct.Struct `json:"typed_config,omitempty"`
 }
 
+// TcpKeepalive wraps is a thin JSON for xDS proto
+type TcpKeepalive struct {
+	KeepaliveProbes   *wrapperspb.UInt32Value `json:"keepalive_probes,omitempty"`
+	KeepaliveTime     *wrapperspb.UInt32Value `json:"keepalive_time,omitempty"`
+	KeepaliveInterval *wrapperspb.UInt32Value `json:"keepalive_interval,omitempty"`
+}
+
+// UpstreamConnectionOptions wraps is a thin JSON for xDS proto
+type UpstreamConnectionOptions struct {
+	TcpKeepalive *TcpKeepalive `json:"tcp_keepalive,omitempty"`
+}
+
 func keepaliveConverter(value *networkingAPI.ConnectionPoolSettings_TCPSettings_TcpKeepalive) convertFunc {
 	return func(*instance) (any, error) {
-		upstreamConnectionOptions := &cluster.UpstreamConnectionOptions{
-			TcpKeepalive: &core.TcpKeepalive{},
+		upstreamConnectionOptions := &UpstreamConnectionOptions{
+			TcpKeepalive: &TcpKeepalive{},
 		}
 
 		if value.Probes > 0 {

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -25,7 +25,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"google.golang.org/protobuf/types/known/durationpb"
 	pstruct "google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	meshAPI "istio.io/api/mesh/v1alpha1"
@@ -43,34 +42,34 @@ type TransportSocket struct {
 	TypedConfig *pstruct.Struct `json:"typed_config,omitempty"`
 }
 
-// TcpKeepalive wraps is a thin JSON for xDS proto
-type TcpKeepalive struct {
-	KeepaliveProbes   *wrapperspb.UInt32Value `json:"keepalive_probes,omitempty"`
-	KeepaliveTime     *wrapperspb.UInt32Value `json:"keepalive_time,omitempty"`
-	KeepaliveInterval *wrapperspb.UInt32Value `json:"keepalive_interval,omitempty"`
+// TCPKeepalive wraps is a thin JSON for xDS proto
+type TCPKeepalive struct {
+	KeepaliveProbes   *wrappers.UInt32Value `json:"keepalive_probes,omitempty"`
+	KeepaliveTime     *wrappers.UInt32Value `json:"keepalive_time,omitempty"`
+	KeepaliveInterval *wrappers.UInt32Value `json:"keepalive_interval,omitempty"`
 }
 
 // UpstreamConnectionOptions wraps is a thin JSON for xDS proto
 type UpstreamConnectionOptions struct {
-	TcpKeepalive *TcpKeepalive `json:"tcp_keepalive,omitempty"`
+	TCPKeepalive *TCPKeepalive `json:"tcp_keepalive,omitempty"`
 }
 
 func keepaliveConverter(value *networkingAPI.ConnectionPoolSettings_TCPSettings_TcpKeepalive) convertFunc {
 	return func(*instance) (any, error) {
 		upstreamConnectionOptions := &UpstreamConnectionOptions{
-			TcpKeepalive: &TcpKeepalive{},
+			TCPKeepalive: &TCPKeepalive{},
 		}
 
 		if value.Probes > 0 {
-			upstreamConnectionOptions.TcpKeepalive.KeepaliveProbes = &wrappers.UInt32Value{Value: value.Probes}
+			upstreamConnectionOptions.TCPKeepalive.KeepaliveProbes = &wrappers.UInt32Value{Value: value.Probes}
 		}
 
 		if value.Time != nil && value.Time.Seconds > 0 {
-			upstreamConnectionOptions.TcpKeepalive.KeepaliveTime = &wrappers.UInt32Value{Value: uint32(value.Time.Seconds)}
+			upstreamConnectionOptions.TCPKeepalive.KeepaliveTime = &wrappers.UInt32Value{Value: uint32(value.Time.Seconds)}
 		}
 
 		if value.Interval != nil && value.Interval.Seconds > 0 {
-			upstreamConnectionOptions.TcpKeepalive.KeepaliveInterval = &wrappers.UInt32Value{Value: uint32(value.Interval.Seconds)}
+			upstreamConnectionOptions.TCPKeepalive.KeepaliveInterval = &wrappers.UInt32Value{Value: uint32(value.Interval.Seconds)}
 		}
 		return convertToJSON(upstreamConnectionOptions), nil
 	}


### PR DESCRIPTION
Change-Id: Ifdd99ff6f939273888de0e9aab4d4c26e573dcd5

Tighten proto imports further for the agent and remove cluster, listener, and admin xDS.

Protobuf are known to bloat the binary, especially when the validation code is linked.

Issue: #50134 