### PR TITLE
proxy: remove unnecessary rbac and route imports

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -294,7 +294,7 @@ lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles li
 # Allow-list:
 # (k8s) Machinery, utils, klog
 # (proto) TLS for SDS
-# (proto) Wasm/RBAC for wasm xDS proxy, RBAC pulls envoy/config/route
+# (proto) Wasm for wasm xDS proxy
 .PHONY: check-agent-deps
 check-agent-deps:
 	@go list -f '{{ join .Deps "\n" }}' -tags=agent \
@@ -312,10 +312,10 @@ check-agent-deps:
 			./pkg/wasm/... \
 			./pkg/envoy/... | sort | uniq |\
 		grep -Pv '^k8s.io/(utils|klog|apimachinery)/' |\
-		grep -Pv 'envoy/type|envoy/annotations|envoy/config/(core|route|rbac)/' |\
+		grep -Pv 'envoy/type/|envoy/annotations|envoy/config/core/' |\
 		grep -Pv 'envoy/extensions/transport_sockets/tls/' |\
 		grep -Pv 'envoy/extensions/wasm/' |\
-		grep -Pv 'envoy/extensions/filters/(http|network)/(rbac|wasm)/' |\
+		grep -Pv 'envoy/extensions/filters/(http|network)/wasm/' |\
 		(! grep -P '^k8s.io|^sigs.k8s.io/gateway-api|cel|antlr|envoy/')
 
 go-gen:

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -22,9 +22,7 @@ import (
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	httprbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	httpwasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
-	networkrbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	networkwasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/wasm/v3"
 	wasmextensions "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
@@ -32,15 +30,18 @@ import (
 	anypb "google.golang.org/protobuf/types/known/anypb"
 
 	extensions "istio.io/api/extensions/v1alpha1"
-	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/util/istiomultierror"
 )
 
 var (
-	allowHTTPTypedConfig    = protoconv.MessageToAny(&httprbac.RBAC{})
-	allowNetworkTypedConfig = protoconv.MessageToAny(&networkrbac.RBAC{})
+	allowHTTPTypedConfig = &anypb.Any{
+		TypeUrl: "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+	}
+	allowNetworkTypedConfig = &anypb.Any{
+		TypeUrl: "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+	}
 )
 
 func createHTTPAllowAllFilter(name string) (*anypb.Any, error) {


### PR DESCRIPTION
Change-Id: I3342815b328de9af8bdbab3112de7e73d5fbba58

I realized we don't even need RBAC/route because the hard-coded proto is empty.

Issue: #50134 