### PR TITLE
Disable Delta XDS in compatibility version

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:

--- a/manifests/helm-profiles/compatibility-version-1.20.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.20.yaml
@@ -10,7 +10,10 @@ pilot:
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
 meshConfig:
+  # 1.22 behavioral changes
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -3,6 +3,9 @@ pilot:
     # 1.22 behavioral changes
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 meshConfig:
+  # 1.22 behavioral changes
+  proxyMetadata:
+    ISTIO_DELTA_XDS: "false"
   defaultConfig:
     tracing:
       zipkin:


### PR DESCRIPTION
To avoid exposing users to risky changes.

There is no detection for this, as in theory its 100% compatible. This
is about safety for unknown incompatibilities.
