### PR TITLE
assert all events in TestAmbientIndex_Policy to reduce flakiness

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -493,6 +493,17 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		nil)
 }
 
+// define constants for the different types of XDS events which occur during policy unit tests
+const (
+	XDS_CONVERTED_STATIC_STRICT             = "istio_converted_static_strict"
+	XDS_CONVERTED_PEER_AUTH_SELECTOR        = "converted_peer_authentication_selector"
+	XDS_CONVERTED_PEER_AUTH_SELECTOR_STRICT = "converted_peer_authentication_selector-strict"
+	XDS_GLOBAL                              = "global"
+	XDS_NAMESPACE                           = "namespace"
+	XDS_SELECTOR                            = "selector"
+	XDS_GLOBAL_SELECTOR                     = "global-selector"
+)
+
 // TODO(nmittler): Consider splitting this into multiple, smaller tests.
 func TestAmbientIndex_Policy(t *testing.T) {
 	s := newAmbientTestServer(t, testC, testNW)
@@ -524,7 +535,6 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		map[string]string{},
 		[]int32{80}, map[string]string{constants.GatewayNameLabel: "namespace-wide"}, "10.0.0.2")
 	s.assertUnorderedEvent(t, s.podXdsName("waypoint-ns-pod"), s.svcXdsName("waypoint-ns"))
-	s.clearEvents()
 	selectorPolicyName := "selector"
 
 	// Test that PeerAuthentications are added to the ambient index
@@ -534,7 +544,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			Mode: auth.PeerAuthentication_MutualTLS_PERMISSIVE,
 		}
 	})
-	s.clearEvents()
+	s.assertEvent(t, XDS_CONVERTED_STATIC_STRICT)
 
 	s.addPolicy(t, "namespace", testNS, nil, gvk.PeerAuthentication, func(c controllers.Object) {
 		pol := c.(*clientsecurityv1beta1.PeerAuthentication)
@@ -547,7 +557,6 @@ func TestAmbientIndex_Policy(t *testing.T) {
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{fmt.Sprintf("istio-system/%s", staticStrictPolicyName)})
-	s.clearEvents()
 
 	s.addPolicy(t, selectorPolicyName, testNS, map[string]string{"app": "a"}, gvk.PeerAuthentication, func(c controllers.Object) {
 		pol := c.(*clientsecurityv1beta1.PeerAuthentication)
@@ -584,8 +593,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			},
 		}
 	})
-	s.assertEvent(t, s.podXdsName("pod1")) // Selector policy should be added back since there is now a STRICT exception
-	time.Sleep(time.Second)
+	s.assertEvent(t, s.podXdsName("pod1"), XDS_CONVERTED_PEER_AUTH_SELECTOR) // Selector policy should be added back since there is now a STRICT exception
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{fmt.Sprintf("ns1/%s", model.GetAmbientPolicyConfigName(model.ConfigKey{
@@ -643,7 +651,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		}
 	})
 	// There should be an event since effective policy moves to PERMISSIVE
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), XDS_CONVERTED_PEER_AUTH_SELECTOR)
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		nil)
@@ -689,7 +697,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			},
 		}
 	})
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2")) // Matching pods receive an event
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), XDS_CONVERTED_PEER_AUTH_SELECTOR) // Matching pods receive an event
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{fmt.Sprintf("ns1/%s", model.GetAmbientPolicyConfigName(model.ConfigKey{
@@ -709,6 +717,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		}
 	})
 	// The policy should still be added since the effective policy is PERMISSIVE
+	s.assertEvent(t, XDS_CONVERTED_PEER_AUTH_SELECTOR)
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{fmt.Sprintf("ns1/%s", model.GetAmbientPolicyConfigName(model.ConfigKey{
@@ -740,7 +749,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			},
 		}
 	})
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2")) // Matching pods receive an event
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), XDS_CONVERTED_PEER_AUTH_SELECTOR) // Matching pods receive an event
 	// The policy should still be added since the effective policy is STRICT
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -752,7 +761,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 
 	// Clear PeerAuthentication from workload
 	s.pa.Delete("selector", testNS)
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod2"), XDS_CONVERTED_PEER_AUTH_SELECTOR)
 	// Effective policy is still STRICT so the static policy should still be set
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -762,18 +771,18 @@ func TestAmbientIndex_Policy(t *testing.T) {
 	s.pa.Delete("namespace", testNS)
 	s.pa.Delete("global", systemNS)
 	s.deletePod(t, "pod2")
-	s.assertEvent(t, s.podXdsName("pod2"), s.podXdsName("pod1"))
-	s.clearEvents()
+	s.assertEvent(t, s.podXdsName("pod2"), s.podXdsName("pod1"), XDS_CONVERTED_STATIC_STRICT, s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"))
 
 	// Test AuthorizationPolicies
 	s.addPolicy(t, "global", systemNS, nil, gvk.AuthorizationPolicy, nil)
 	s.addPolicy(t, "namespace", testNS, nil, gvk.AuthorizationPolicy, nil)
+	s.assertEvent(t, XDS_GLOBAL, XDS_NAMESPACE)
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		nil)
 
 	s.addPolicy(t, selectorPolicyName, testNS, map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
-	s.assertEvent(t, s.podXdsName("pod1"))
+	s.assertEvent(t, s.podXdsName("pod1"), XDS_SELECTOR)
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{"ns1/selector"})
@@ -793,7 +802,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		[]string{"ns1/selector"})
 
 	s.addPolicy(t, "global-selector", systemNS, map[string]string{"app": "a"}, gvk.AuthorizationPolicy, nil)
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), XDS_GLOBAL_SELECTOR)
 
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -801,7 +810,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 
 	// Update selector to not select
 	s.addPolicy(t, "global-selector", systemNS, map[string]string{"app": "not-a"}, gvk.AuthorizationPolicy, nil)
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), XDS_GLOBAL_SELECTOR)
 
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -815,7 +824,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		}
 	})
 	// Every workload should receive an event
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"), XDS_CONVERTED_STATIC_STRICT)
 	// Static STRICT policy should be sent
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -854,8 +863,6 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		}
 	})
 
-	// No event because there's effectively no change
-
 	// Static STRICT policy should disappear
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -873,7 +880,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			},
 		}
 	})
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3")) // Matching workloads should receive an event
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), XDS_CONVERTED_PEER_AUTH_SELECTOR_STRICT) // Matching workloads should receive an event
 	// Workload policy should be added since there's a port level exclusion
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -902,9 +909,10 @@ func TestAmbientIndex_Policy(t *testing.T) {
 			Name:      "selector-strict",
 			Namespace: "ns1",
 		}))})
+	s.assertEvent(t, XDS_SELECTOR)
 
 	s.authz.Delete("selector", testNS)
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), XDS_SELECTOR)
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		[]string{fmt.Sprintf("ns1/%s", model.GetAmbientPolicyConfigName(model.ConfigKey{
@@ -915,7 +923,7 @@ func TestAmbientIndex_Policy(t *testing.T) {
 
 	// Delete selector policy
 	s.pa.Delete("selector-strict", testNS)
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3")) // Matching workloads should receive an event
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), XDS_CONVERTED_PEER_AUTH_SELECTOR_STRICT) // Matching workloads should receive an event
 	// Static STRICT policy should now be sent because of the global policy
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
@@ -924,13 +932,12 @@ func TestAmbientIndex_Policy(t *testing.T) {
 	// Delete global policy
 	s.pa.Delete("strict", systemNS)
 	// Every workload should receive an event
-	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"))
+	s.assertEvent(t, s.podXdsName("pod1"), s.podXdsName("pod3"), s.podXdsName("waypoint-ns-pod"), s.podXdsName("waypoint2-sa"), XDS_CONVERTED_STATIC_STRICT)
 	// Now no policies are in effect
 	assert.Equal(t,
 		s.lookup(s.addrXdsName("127.0.0.1"))[0].Address.GetWorkload().AuthorizationPolicies,
 		nil)
 
-	s.clearEvents()
 	s.addPolicy(t, "gateway-targeted", testNS, nil, gvk.AuthorizationPolicy, func(o controllers.Object) {
 		p := o.(*clientsecurityv1beta1.AuthorizationPolicy)
 		p.Spec.TargetRef = &v1beta1.PolicyTargetReference{


### PR DESCRIPTION
fixes #50175 

```shell
$ stress ./ambient.test -test.v -test.run TestAmbientIndex_Policy
...
10m0s: 3571 runs so far, 0 failures
```