### PR TITLE
ambient: fix flake on waypoint

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -48,6 +48,7 @@ type Index interface {
 	ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo
 	Waypoint(network, address string) []netip.Addr
 	SyncAll()
+	HasSynced() bool
 	model.AmbientIndexes
 }
 
@@ -466,6 +467,13 @@ func (a *index) AdditionalPodSubscriptions(
 
 func (a *index) SyncAll() {
 	a.networkUpdateTrigger.TriggerRecomputation()
+}
+
+func (a *index) HasSynced() bool {
+	return a.services.Synced().HasSynced() &&
+		a.workloads.Synced().HasSynced() &&
+		a.waypoints.Synced().HasSynced() &&
+		a.authorizationPolicies.Synced().HasSynced()
 }
 
 type LookupNetwork func(endpointIP string, labels labels.Instance) network.ID

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1241,7 +1241,8 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 		assert.Equal(t, wl, expected)
 	}
 	s.addWaypoint(t, "10.0.0.1", "waypoint", "", true)
-
+	// Wait until waypoint is available
+	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List("")) }, 1)
 	// expected order is pod3, pod1, pod2, which is the order of creation
 	s.addPods(t,
 		"127.0.0.3",

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -578,6 +578,9 @@ func (c *Controller) HasSynced() bool {
 }
 
 func (c *Controller) informersSynced() bool {
+	if c.ambientIndex != nil && !c.ambientIndex.HasSynced() {
+		return false
+	}
 	return c.namespaces.HasSynced() &&
 		c.services.HasSynced() &&
 		c.endpoints.slices.HasSynced() &&

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -117,6 +117,8 @@ func (h *manyCollection[I, O]) Synced() Syncer {
 
 // nolint: unused // (not true, its to implement an interface)
 func (h *manyCollection[I, O]) dump() {
+	h.recomputeMu.Lock()
+	defer h.recomputeMu.Unlock()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.log.Errorf(">>> BEGIN DUMP")


### PR DESCRIPTION
Example
https://prow.istio.io/view/gs/istio-prow/logs/unit-tests_istio_postsubmit/1775278590686924800

3 issues:
* Race on Dump()
* Failure in the test
* Lack of syncing leads to flakes

Failure comes from not waiting for the waypoint to be applied yet

Also fixes https://github.com/istio/istio/issues/50192
