### PR TITLE
Remove istio.io/for-service-account

### DIFF
--- a/istioctl/pkg/waypoint/testdata/waypoint/all-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/all-gateway
@@ -1,3 +1,3 @@
-NAMESPACE     NAME          SERVICE ACCOUNT     REVISION     PROGRAMMED
-default       namespace                         default      True
-fake          namespace                         default      True
+NAMESPACE     NAME          REVISION     PROGRAMMED
+default       namespace     default      True
+fake          namespace     default      True

--- a/istioctl/pkg/waypoint/testdata/waypoint/combined-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/combined-gateway
@@ -1,6 +1,6 @@
-NAMESPACE     NAME                   SERVICE ACCOUNT     REVISION     PROGRAMMED
-bookinfo      bookinfo-rev           bookinfo-rev        rev1         True
-bookinfo      bookinfo-valid         bookinfo-valid      default      True
-default       bookinfo               bookinfo            default      False
-default       namespace                                  default      False
-default       no-name-convention     sa                  default      True
+NAMESPACE     NAME                   REVISION     PROGRAMMED
+bookinfo      bookinfo-rev           rev1         True
+bookinfo      bookinfo-valid         default      True
+default       bookinfo               default      False
+default       namespace              default      False
+default       no-name-convention     default      True

--- a/istioctl/pkg/waypoint/testdata/waypoint/default-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/default-gateway
@@ -1,2 +1,2 @@
-NAME          SERVICE ACCOUNT     REVISION     PROGRAMMED
-namespace                         default      True
+NAME          REVISION     PROGRAMMED
+namespace     default      True

--- a/istioctl/pkg/waypoint/waypoint_test.go
+++ b/istioctl/pkg/waypoint/waypoint_test.go
@@ -48,8 +48,8 @@ func TestWaypointList(t *testing.T) {
 			name: "default namespace gateway",
 			args: strings.Split("list", " "),
 			gateways: []*gateway.Gateway{
-				makeGateway("namespace", "default", "", true, true),
-				makeGateway("namespace", "fake", "", true, true),
+				makeGateway("namespace", "default", true, true),
+				makeGateway("namespace", "fake", true, true),
 			},
 			expectedOutFile: "default-gateway",
 		},
@@ -57,8 +57,8 @@ func TestWaypointList(t *testing.T) {
 			name: "all namespaces gateways",
 			args: strings.Split("list -A", " "),
 			gateways: []*gateway.Gateway{
-				makeGateway("namespace", "default", "", true, true),
-				makeGateway("namespace", "fake", "", true, true),
+				makeGateway("namespace", "default", true, true),
+				makeGateway("namespace", "fake", true, true),
 			},
 			expectedOutFile: "all-gateway",
 		},
@@ -66,12 +66,12 @@ func TestWaypointList(t *testing.T) {
 			name: "have both managed and unmanaged gateways",
 			args: strings.Split("list -A", " "),
 			gateways: []*gateway.Gateway{
-				makeGateway("bookinfo", "default", "bookinfo", false, true),
-				makeGateway("bookinfo-invalid", "fake", "bookinfo", true, false),
-				makeGateway("namespace", "default", "", false, true),
-				makeGateway("bookinfo-valid", "bookinfo", "bookinfo-valid", true, true),
-				makeGateway("no-name-convention", "default", "sa", true, true),
-				makeGatewayWithRevision("bookinfo-rev", "bookinfo", "bookinfo-rev", true, true, "rev1"),
+				makeGateway("bookinfo", "default", false, true),
+				makeGateway("bookinfo-invalid", "fake", true, false),
+				makeGateway("namespace", "default", false, true),
+				makeGateway("bookinfo-valid", "bookinfo", true, true),
+				makeGateway("no-name-convention", "default", true, true),
+				makeGatewayWithRevision("bookinfo-rev", "bookinfo", true, true, "rev1"),
 			},
 			expectedOutFile: "combined-gateway",
 		},
@@ -116,7 +116,7 @@ func TestWaypointList(t *testing.T) {
 	}
 }
 
-func makeGateway(name, namespace, sa string, programmed, isWaypoint bool) *gateway.Gateway {
+func makeGateway(name, namespace string, programmed, isWaypoint bool) *gateway.Gateway {
 	conditions := make([]metav1.Condition, 0)
 	if programmed {
 		conditions = append(conditions, metav1.Condition{
@@ -137,9 +137,6 @@ func makeGateway(name, namespace, sa string, programmed, isWaypoint bool) *gatew
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Annotations: map[string]string{
-				constants.WaypointServiceAccount: sa,
-			},
 		},
 		Spec: gateway.GatewaySpec{
 			GatewayClassName: gateway.ObjectName(className),
@@ -150,8 +147,8 @@ func makeGateway(name, namespace, sa string, programmed, isWaypoint bool) *gatew
 	}
 }
 
-func makeGatewayWithRevision(name, namespace, sa string, programmed, isWaypoint bool, rev string) *gateway.Gateway {
-	gw := makeGateway(name, namespace, sa, programmed, isWaypoint)
+func makeGatewayWithRevision(name, namespace string, programmed, isWaypoint bool, rev string) *gateway.Gateway {
+	gw := makeGateway(name, namespace, programmed, isWaypoint)
 	if gw.Labels == nil {
 		gw.Labels = make(map[string]string)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -134,7 +134,7 @@ func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
 			// It involves creating a waypoint for the specified traffic type
 			// then creating a workload and a service with no annotations set
 			// on these objects yet.
-			s.addWaypoint(t, "10.0.0.10", "test-wp", "default", c.trafficType, true)
+			s.addWaypoint(t, "10.0.0.10", "test-wp", c.trafficType, true)
 			s.addPods(t, "127.0.0.1", "pod1", "sa1",
 				map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 			s.assertEvent(t, s.podXdsName("pod1"))
@@ -251,7 +251,7 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
-	s.addWaypoint(t, "10.0.0.10", "test-wp", "default", "", true)
+	s.addWaypoint(t, "10.0.0.10", "test-wp", "default", true)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
@@ -373,12 +373,12 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 		corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod2"))
 
-	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", "sa1", "", false)
-	s.addWaypoint(t, "10.0.0.2", "waypoint-sa2", "sa2", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", "", false)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-sa2", constants.WorkloadTraffic, true)
 	s.assertEvent(t, s.podXdsName("pod2"))
 
 	// make waypoint-sa1 ready
-	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", "sa1", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", constants.WorkloadTraffic, true)
 	// if waypoint-sa1 was configured when not ready "pod2" assertions should skip the "pod1" xds event and this should fail
 	s.assertEvent(t, s.podXdsName("pod1"))
 }
@@ -413,7 +413,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 		corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod4"))
 
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "", constants.AllTraffic, true)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", constants.AllTraffic, true)
 	// All these workloads updated, so push them
 	s.assertEvent(t, s.podXdsName("pod1"),
 		s.podXdsName("pod2"),
@@ -438,7 +438,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 	)
 	s.assertAddresses(t, "", "pod1", "pod2", "pod3", "pod4", "waypoint-ns", "waypoint-ns-pod")
 
-	s.addWaypoint(t, "10.0.0.3", "waypoint-sa2", "sa2", constants.AllTraffic, true)
+	s.addWaypoint(t, "10.0.0.3", "waypoint-sa2", constants.AllTraffic, true)
 	s.assertEvent(t, s.podXdsName("pod4"))
 	// Add a waypoint proxy pod for sa2
 	s.addPods(t, "127.0.0.250", "waypoint-sa2-pod", "service-account",
@@ -547,7 +547,7 @@ func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
 
 	s.addPods(t, "127.0.0.201", "waypoint2-sa", "waypoint-sa",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
-		map[string]string{constants.WaypointServiceAccount: "sa2"}, true, corev1.PodRunning)
+		map[string]string{}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-sa"))
 	// Unrelated SA should not change anything
 	assert.Equal(t,
@@ -612,9 +612,9 @@ func TestAmbientIndex_Policy(t *testing.T) {
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
 	s.addPods(t, "127.0.0.201", "waypoint2-sa", "waypoint-sa",
 		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
-		map[string]string{constants.WaypointServiceAccount: "sa2"}, true, corev1.PodRunning)
+		map[string]string{}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-sa"))
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "", constants.AllTraffic, true)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", constants.AllTraffic, true)
 	s.ns.Update(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,
@@ -1193,9 +1193,9 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 
 	// add our waypoints but they won't be used until annotations are added
 	// add a new waypoint
-	s.addWaypoint(t, "10.0.0.2", "waypoint-sa1", "sa1", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-sa1", constants.WorkloadTraffic, true)
 	// Add a namespace waypoint to the pod
-	s.addWaypoint(t, "10.0.0.1", "waypoint-ns", "", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.1", "waypoint-ns", constants.WorkloadTraffic, true)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertAddresses(t, "", "pod1")
@@ -1283,8 +1283,8 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 		assert.Equal(t, wl, sets.New(expected...))
 	}
 	// Add a namespace waypoint to the pod
-	s.addWaypoint(t, "10.0.0.1", "waypoint-ns", "", constants.WorkloadTraffic, true)
-	s.addWaypoint(t, "10.0.0.2", "waypoint-sa1", "sa1", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.1", "waypoint-ns", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-sa1", constants.WorkloadTraffic, true)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
@@ -1334,7 +1334,7 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 		}
 		assert.Equal(t, wl, expected)
 	}
-	s.addWaypoint(t, "10.0.0.1", "waypoint", "", constants.WorkloadTraffic, true)
+	s.addWaypoint(t, "10.0.0.1", "waypoint", constants.WorkloadTraffic, true)
 	// Wait until waypoint is available
 	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List("")) }, 1)
 
@@ -1465,7 +1465,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 	return a
 }
 
-func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, sa, trafficType string, ready bool) {
+func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, trafficType string, ready bool) {
 	t.Helper()
 
 	fromSame := k8sv1.NamespacesFromSame
@@ -1498,9 +1498,6 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, sa, trafficType 
 		Status: k8sbeta.GatewayStatus{},
 	}
 	annotations := make(map[string]string, 2)
-	if sa != "" {
-		annotations[constants.WaypointServiceAccount] = sa
-	}
 	if trafficType != "" && validTrafficTypes.Contains(trafficType) {
 		annotations[constants.AmbientWaypointForTrafficType] = trafficType
 	} else {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -134,7 +134,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 		}, nil, true, corev1.PodRunning)
 	s.assertAddresses(t, "", "name1", "name2", "name3", "waypoint-ns-pod")
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
-	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", "", constants.AllTraffic, true)
+	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", constants.AllTraffic, true)
 	s.ns.CreateOrUpdate(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,

--- a/pkg/config/analysis/analyzers/maturity/maturity.go
+++ b/pkg/config/analysis/analyzers/maturity/maturity.go
@@ -73,7 +73,6 @@ var AlwaysIgnoredAnnotations = map[string]bool{
 	// They are added automatically, and should not be alerted on.
 	// Delete these related annotations once they are stable.
 	// Ref: https://github.com/istio/api/pull/2695
-	constants.WaypointServiceAccount:        true,
 	constants.AmbientWaypointForTrafficType: true,
 	constants.AmbientRedirection:            true,
 }

--- a/pkg/config/analysis/analyzers/testdata/misannotated.yaml
+++ b/pkg/config/analysis/analyzers/testdata/misannotated.yaml
@@ -170,7 +170,6 @@ metadata:
   annotations:
     # annotations not set by user, should not warn
     istio.io/rev: rev
-    istio.io/for-service-account: sa
     ambient.istio.io/redirection: enabled
 spec:
   containers:

--- a/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
+++ b/pkg/config/analysis/analyzers/testdata/service-port-name.yaml
@@ -17,8 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    istio.io/for-service-account: reviews
   labels:
     gateway.istio.io/managed: istio.io-mesh-controller
   name: reviews-istio-waypoint

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -163,8 +163,6 @@ const (
 	// testing the validation webhook.
 	AlwaysReject = "internal.istio.io/webhook-always-reject"
 
-	WaypointServiceAccount = "istio.io/for-service-account"
-
 	ManagedGatewayLabel               = "gateway.istio.io/managed"
 	UnmanagedGatewayController        = "istio.io/unmanaged-gateway"
 	ManagedGatewayControllerLabel     = "istio.io-gateway-controller"

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -39,7 +39,6 @@ var _ io.Closer = &kubeComponent{}
 type kubeComponent struct {
 	id resource.ID
 
-	sa       string
 	ns       namespace.Instance
 	inbound  istioKube.PortForwarder
 	outbound istioKube.PortForwarder
@@ -48,10 +47,6 @@ type kubeComponent struct {
 
 func (k kubeComponent) Namespace() namespace.Instance {
 	return k.ns
-}
-
-func (k kubeComponent) ServiceAccount() string {
-	return k.sa
 }
 
 func (k kubeComponent) PodIP() string {
@@ -83,17 +78,15 @@ func (k kubeComponent) Close() error {
 // WaypointProxy describes a waypoint proxy deployment
 type WaypointProxy interface {
 	Namespace() namespace.Instance
-	ServiceAccount() string
 	Inbound() string
 	Outbound() string
 	PodIP() string
 }
 
 // NewWaypointProxy creates a new WaypointProxy.
-func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, sa string) (WaypointProxy, error) {
+func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, name string) (WaypointProxy, error) {
 	server := &kubeComponent{
 		ns: ns,
-		sa: sa,
 	}
 	server.id = ctx.TrackResource(server)
 	if err := crd.DeployGatewayAPI(ctx); err != nil {
@@ -112,8 +105,8 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, sa string) (W
 		"apply",
 		"--namespace",
 		ns.Name(),
-		"--service-account",
-		sa,
+		"--name",
+		name,
 		"--for",
 		constants.AllTraffic,
 	})
@@ -123,7 +116,7 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, sa string) (W
 
 	cls := ctx.Clusters().Kube().Default()
 	// Find the Waypoint pod and service, and start forwarding a local port.
-	fetchFn := testKube.NewSinglePodFetch(cls, ns.Name(), fmt.Sprintf("%s=%s", constants.GatewayNameLabel, sa))
+	fetchFn := testKube.NewSinglePodFetch(cls, ns.Name(), fmt.Sprintf("%s=%s", constants.GatewayNameLabel, name))
 	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err
@@ -152,9 +145,9 @@ func NewWaypointProxy(ctx resource.Context, ns namespace.Instance, sa string) (W
 }
 
 // NewWaypointProxyOrFail calls NewWaypointProxy and fails if an error occurs.
-func NewWaypointProxyOrFail(t framework.TestContext, ns namespace.Instance, sa string) WaypointProxy {
+func NewWaypointProxyOrFail(t framework.TestContext, ns namespace.Instance, name string) WaypointProxy {
 	t.Helper()
-	s, err := NewWaypointProxy(t, ns, sa)
+	s, err := NewWaypointProxy(t, ns, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +187,6 @@ func DeleteWaypoint(t framework.TestContext, ns namespace.Instance, waypoint str
 		"delete",
 		"--namespace",
 		ns.Name(),
-		"--service-account",
 		waypoint,
 	})
 	waypointError := retry.UntilSuccess(func() error {

--- a/releasenotes/notes/50221.yaml
+++ b/releasenotes/notes/50221.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 49915
+  - 50173
+releaseNotes:
+- |
+  **Added** Allow user to name their waypoint throught istioctl via --name flag on the waypoint cmd.
+  **Removed** Remove ability for user to specify service account for the waypoint by deleting the --service-account flag on the waypoint cmd

--- a/samples/ambient-argo/application/details-waypoint.yaml
+++ b/samples/ambient-argo/application/details-waypoint.yaml
@@ -1,8 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  annotations:
-    istio.io/for-service-account: bookinfo-details
   labels:
     istio.io/rev: stable
   name: bookinfo-details

--- a/samples/ambient-argo/application/reviews-waypoint.yaml
+++ b/samples/ambient-argo/application/reviews-waypoint.yaml
@@ -1,8 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  annotations:
-    istio.io/for-service-account: bookinfo-reviews
   labels:
     istio.io/rev: rapid
   name: bookinfo-reviews

--- a/tests/integration/ambient/bookinfo_test.go
+++ b/tests/integration/ambient/bookinfo_test.go
@@ -298,8 +298,6 @@ func TestOtherRevisionIgnored(t *testing.T) {
 				"apply",
 				"--namespace",
 				nsConfig.Name(),
-				"--service-account",
-				"sa",
 				"--revision",
 				"foo",
 			})

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -119,7 +119,7 @@ func TestWaypoint(t *testing.T) {
 			})
 			for _, name := range nameSet {
 				if !strings.Contains(output, name) {
-					t.Fatalf("expect to find %s in output: %s", sa, output)
+					t.Fatalf("expect to find %s in output: %s", name, output)
 				}
 			}
 
@@ -129,9 +129,9 @@ func TestWaypoint(t *testing.T) {
 				"list",
 				"-A",
 			})
-			for _, sa := range saSet {
-				if !strings.Contains(output, sa) {
-					t.Fatalf("expect to find %s in output: %s", sa, output)
+			for _, name := range nameSet {
+				if !strings.Contains(output, name) {
+					t.Fatalf("expect to find %s in output: %s", name, output)
 				}
 			}
 
@@ -141,40 +141,23 @@ func TestWaypoint(t *testing.T) {
 				"-n",
 				nsConfig.Name(),
 				"delete",
+				"w1",
+				"w2",
 			})
 			retry.UntilSuccessOrFail(t, func() error {
-				if err := checkWaypointIsReady(t, nsConfig.Name(), "namespace"); err != nil {
-					if errors.Is(err, kubetest.ErrNoPodsFetched) {
-						return nil
-					}
-					return fmt.Errorf("failed to check gateway status: %v", err)
-				}
-				return fmt.Errorf("failed to clean up gateway in namespace: %s", nsConfig.Name())
-			}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
-
-			istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
-				"x",
-				"waypoint",
-				"-n",
-				nsConfig.Name(),
-				"delete",
-				"sa1",
-				"sa2",
-			})
-			retry.UntilSuccessOrFail(t, func() error {
-				for _, sa := range []string{"sa1", "sa2"} {
-					if err := checkWaypointIsReady(t, nsConfig.Name(), sa); err != nil {
+				for _, name := range []string{"w1", "w2"} {
+					if err := checkWaypointIsReady(t, nsConfig.Name(), name); err != nil {
 						if !errors.Is(err, kubetest.ErrNoPodsFetched) {
 							return fmt.Errorf("failed to check gateway status: %v", err)
 						}
 					} else {
-						return fmt.Errorf("failed to delete multiple gateways: %s not cleaned up", sa)
+						return fmt.Errorf("failed to delete multiple gateways: %s not cleaned up", name)
 					}
 				}
 				return nil
 			}, retry.Timeout(15*time.Second), retry.BackoffDelay(time.Millisecond*100))
 
-			// delete all waypoints in namespace, so sa3 should be deleted
+			// delete all waypoints in namespace, so w3 should be deleted
 			istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 				"x",
 				"waypoint",
@@ -184,7 +167,7 @@ func TestWaypoint(t *testing.T) {
 				"--all",
 			})
 			retry.UntilSuccessOrFail(t, func() error {
-				if err := checkWaypointIsReady(t, nsConfig.Name(), "sa3"); err != nil {
+				if err := checkWaypointIsReady(t, nsConfig.Name(), "w3"); err != nil {
 					if errors.Is(err, kubetest.ErrNoPodsFetched) {
 						return nil
 					}

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -96,16 +96,16 @@ func TestWaypoint(t *testing.T) {
 				"--wait",
 			})
 
-			saSet := []string{"sa1", "sa2", "sa3"}
-			for _, sa := range saSet {
+			nameSet := []string{"w1", "w2", "w3"}
+			for _, name := range nameSet {
 				istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 					"x",
 					"waypoint",
 					"apply",
 					"--namespace",
 					nsConfig.Name(),
-					"--service-account",
-					sa,
+					"--name",
+					name,
 					"--wait",
 				})
 			}
@@ -117,8 +117,8 @@ func TestWaypoint(t *testing.T) {
 				"--namespace",
 				nsConfig.Name(),
 			})
-			for _, sa := range saSet {
-				if !strings.Contains(output, sa) {
+			for _, name := range nameSet {
+				if !strings.Contains(output, name) {
 					t.Fatalf("expect to find %s in output: %s", sa, output)
 				}
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

Closes #50173 - removes unused WaypointServiceAccount concept
Closes #49915 - adds waypoint name to istioctl

With https://github.com/istio/istio/pull/49700, WaypointServiceAccount "istio.io/for-service-account" has been useless, because the annotation is not checked anymore.