### PR TITLE
Test the Telemetry API Access logging match feature

### DIFF
--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -685,6 +685,15 @@ func TestTelemetryFilters(t *testing.T) {
 			},
 		},
 	}
+	clientLogging := &tpb.Telemetry{
+		AccessLogging: []*tpb.AccessLogging{
+			{
+				Match: &tpb.AccessLogging_LogSelector{
+					Mode: tpb.WorkloadMode_CLIENT,
+				},
+			},
+		},
+	}
 	emptyLogging := &tpb.Telemetry{
 		AccessLogging: []*tpb.AccessLogging{
 			{},
@@ -1148,6 +1157,17 @@ func TestTelemetryFilters(t *testing.T) {
 			map[string]string{
 				"istio.stackdriver": `{"access_logging":"ERRORS_ONLY","metric_expiry_duration":"3600s"}`,
 			},
+		},
+		{
+			"stackdriver client logging",
+			[]config.Config{
+				newTelemetry("default", clientLogging),
+			},
+			sidecar,
+			networking.ListenerClassSidecarOutbound,
+			networking.ListenerProtocolHTTP,
+			nil,
+			map[string]string{},
 		},
 		{
 			"stackdriver logging default provider",


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR tests [AccessLogging.Match ](https://istio.io/latest/docs/reference/config/telemetry/#AccessLogging)

Part of #46720 