### PR TITLE
Enable kube.Client to create informers for registered types

### DIFF
--- a/pkg/config/schema/kubeclient/common.go
+++ b/pkg/config/schema/kubeclient/common.go
@@ -170,7 +170,7 @@ func stripUnusedFields(obj any) (any, error) {
 	return obj, nil
 }
 
-var registerType []any = make([]any, 0)
+var registerType = make([]any, 0)
 
 // Register provides the TypeRegistration to the underlying
 // store to enable dynamic object translation
@@ -189,11 +189,12 @@ type TypeRegistration[T runtime.Object] interface {
 	ListWatch(c ClientGetter, opts ktypes.InformerOptions) cache.ListerWatcher
 }
 
-type gvrMatch interface {
-	GetGVR() schema.GroupVersionResource
-}
-
-func NewTypeRegistration[T runtime.Object](gvr schema.GroupVersionResource, gvk config.GroupVersionKind, obj T, lw func(c ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher) TypeRegistration[T] {
+func NewTypeRegistration[T runtime.Object](
+	gvr schema.GroupVersionResource,
+	gvk config.GroupVersionKind,
+	obj T,
+	lw func(c ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher,
+) TypeRegistration[T] {
 	return &internalTypeReg[T]{
 		gvr: gvr,
 		gvk: gvk,

--- a/pkg/config/schema/kubeclient/common.go
+++ b/pkg/config/schema/kubeclient/common.go
@@ -31,6 +31,7 @@ import (
 
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	"istio.io/istio/pilot/pkg/util/informermetric"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/kubetypes"
 	"istio.io/istio/pkg/kube/informerfactory"
 	ktypes "istio.io/istio/pkg/kube/kubetypes"
@@ -61,6 +62,23 @@ type ClientGetter interface {
 }
 
 func GetInformerFiltered[T runtime.Object](c ClientGetter, opts ktypes.InformerOptions) informerfactory.StartableInformer {
+	for _, reg := range registerType {
+		if tr, ok := reg.(TypeRegistration[T]); ok {
+			return c.Informers().InformerFor(tr.GetGVR(), opts, func() cache.SharedIndexInformer {
+				inf := cache.NewSharedIndexInformer(
+					&cache.ListWatch{
+						ListFunc:  tr.ListWatchFunc(c, opts).ListFunc,
+						WatchFunc: tr.ListWatchFunc(c, opts).WatchFunc,
+					},
+					tr.Object(),
+					0,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				)
+				setupInformer(opts, inf)
+				return inf
+			})
+		}
+	}
 	return GetInformerFilteredFromGVR(c, opts, kubetypes.GetGVR[T]())
 }
 
@@ -153,4 +171,62 @@ func stripUnusedFields(obj any) (any, error) {
 	// ManagedFields is large and we never use it
 	t.GetObjectMeta().SetManagedFields(nil)
 	return obj, nil
+}
+
+var registerType []any = make([]any, 0)
+
+// Register provides the TypeRegistration to the underlying
+// store to enable dynamic object translation
+func Register[T runtime.Object](reg TypeRegistration[T]) {
+	kubetypes.Register[T](reg)
+	registerType = append(registerType, reg)
+}
+
+// TypeRegistration represents the necessary methods
+// to provide a custom type to the kubeclient informer mechanism
+type TypeRegistration[T runtime.Object] interface {
+	kubetypes.RegisterType[T]
+
+	// ListWatchFunc provides the necessary methods for list and
+	// watch for the informer
+	ListWatchFunc(c ClientGetter, opts ktypes.InformerOptions) cache.ListWatch
+
+	// Object provides the runtime.Object for this TypeRegistration
+	Object() T
+}
+
+type gvrMatch interface {
+	GetGVR() schema.GroupVersionResource
+}
+
+func NewTypeRegistration[T runtime.Object](gvr schema.GroupVersionResource, gvk config.GroupVersionKind, obj T, lw func(c ClientGetter, o ktypes.InformerOptions) cache.ListWatch) TypeRegistration[T] {
+	return &internalTypeReg[T]{
+		gvr: gvr,
+		gvk: gvk,
+		obj: obj,
+		lw:  lw,
+	}
+}
+
+type internalTypeReg[T runtime.Object] struct {
+	lw  func(c ClientGetter, o ktypes.InformerOptions) cache.ListWatch
+	gvr schema.GroupVersionResource
+	gvk config.GroupVersionKind
+	obj T
+}
+
+func (t *internalTypeReg[T]) GetGVK() config.GroupVersionKind {
+	return t.gvk
+}
+
+func (t *internalTypeReg[T]) GetGVR() schema.GroupVersionResource {
+	return t.gvr
+}
+
+func (t *internalTypeReg[T]) ListWatchFunc(c ClientGetter, o ktypes.InformerOptions) cache.ListWatch {
+	return t.lw(c, o)
+}
+
+func (t *internalTypeReg[T]) Object() T {
+	return t.obj
 }

--- a/pkg/config/schema/kubeclient/common.go
+++ b/pkg/config/schema/kubeclient/common.go
@@ -187,9 +187,6 @@ type TypeRegistration[T runtime.Object] interface {
 	// ListWatchFunc provides the necessary methods for list and
 	// watch for the informer
 	ListWatch(c ClientGetter, opts ktypes.InformerOptions) cache.ListerWatcher
-
-	// Object provides the runtime.Object for this TypeRegistration
-	Object() T
 }
 
 type gvrMatch interface {

--- a/pkg/config/schema/kubeclient/common_test.go
+++ b/pkg/config/schema/kubeclient/common_test.go
@@ -1,0 +1,52 @@
+package kubeclient
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/kube"
+	ktypes "istio.io/istio/pkg/kube/kubetypes"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestCustomRegistration(t *testing.T) {
+	Register[*v1.NetworkPolicy](NewTypeRegistration[*v1.NetworkPolicy](
+		schema.GroupVersionResource{},
+		config.GroupVersionKind{},
+		&v1.NetworkPolicy{},
+		func(c ClientGetter, o ktypes.InformerOptions) cache.ListWatch {
+			return cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = o.FieldSelector
+					options.LabelSelector = o.LabelSelector
+					return c.Kube().NetworkingV1().NetworkPolicies(o.Namespace).List(context.Background(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = o.FieldSelector
+					options.LabelSelector = o.LabelSelector
+					return c.Kube().NetworkingV1().NetworkPolicies(o.Namespace).Watch(context.Background(), options)
+				},
+				DisableChunking: true,
+			}
+		},
+	))
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "funkyns"}}
+
+	client := kube.NewFakeClient(ns)
+
+	inf := GetInformerFiltered[*v1.NetworkPolicy](client, ktypes.InformerOptions{})
+	if inf.Informer == nil {
+		t.Errorf("Expected valid informer, got empty")
+	}
+}
+
+var _ TypeRegistration[*v1.NetworkPolicy] = (*internalTypeReg[*v1.NetworkPolicy])(nil)

--- a/pkg/config/schema/kubeclient/common_test.go
+++ b/pkg/config/schema/kubeclient/common_test.go
@@ -22,17 +22,18 @@ func TestCustomRegistration(t *testing.T) {
 		schema.GroupVersionResource{},
 		config.GroupVersionKind{},
 		&v1.NetworkPolicy{},
-		func(c ClientGetter, o ktypes.InformerOptions) cache.ListWatch {
-			return cache.ListWatch{
+		func(c ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher {
+			np := c.Kube().NetworkingV1().NetworkPolicies(o.Namespace)
+			return &cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 					options.FieldSelector = o.FieldSelector
 					options.LabelSelector = o.LabelSelector
-					return c.Kube().NetworkingV1().NetworkPolicies(o.Namespace).List(context.Background(), options)
+					return np.List(context.Background(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					options.FieldSelector = o.FieldSelector
 					options.LabelSelector = o.LabelSelector
-					return c.Kube().NetworkingV1().NetworkPolicies(o.Namespace).Watch(context.Background(), options)
+					return np.Watch(context.Background(), options)
 				},
 				DisableChunking: true,
 			}

--- a/pkg/config/schema/kubeclient/common_test.go
+++ b/pkg/config/schema/kubeclient/common_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubeclient
 
 import (
@@ -5,16 +19,16 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube"
 	ktypes "istio.io/istio/pkg/kube/kubetypes"
-	v1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 func TestCustomRegistration(t *testing.T) {

--- a/pkg/config/schema/kubetypes/common.go
+++ b/pkg/config/schema/kubetypes/common.go
@@ -61,7 +61,7 @@ func GvkFromObject(obj runtime.Object) config.GroupVersionKind {
 	return getGvk(obj)
 }
 
-var registeredTypes []any = make([]any, 0)
+var registeredTypes = make([]any, 0)
 
 func Register[T runtime.Object](reg RegisterType[T]) {
 	registeredTypes = append(registeredTypes, reg)

--- a/pkg/config/schema/kubetypes/common.go
+++ b/pkg/config/schema/kubetypes/common.go
@@ -48,6 +48,15 @@ func GetGVK[T runtime.Object]() (cfg config.GroupVersionKind) {
 	return getGvk(ptr.Empty[T]())
 }
 
+func MustToGVR[T runtime.Object](cfg config.GroupVersionKind) schema.GroupVersionResource {
+	for _, k := range registeredTypes {
+		if t, ok := k.(RegisterType[T]); ok {
+			return t.GetGVR()
+		}
+	}
+	return gvk.MustToGVR(cfg)
+}
+
 func GvkFromObject(obj runtime.Object) config.GroupVersionKind {
 	return getGvk(obj)
 }
@@ -61,4 +70,5 @@ func Register[T runtime.Object](reg RegisterType[T]) {
 type RegisterType[T runtime.Object] interface {
 	GetGVK() config.GroupVersionKind
 	GetGVR() schema.GroupVersionResource
+	Object() T
 }

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pkg/config/schema/gvk"
 	istiogvr "istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/config/schema/kubeclient"
 	types "istio.io/istio/pkg/config/schema/kubetypes"
@@ -210,7 +209,7 @@ func New[T controllers.ComparableObject](c kube.Client) Client[T] {
 // This means there must only be one filter configuration for a given type using the same kube.Client.
 // Use with caution.
 func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) Client[T] {
-	gvr := gvk.MustToGVR(types.GetGVK[T]())
+	gvr := types.MustToGVR[T](types.GetGVK[T]())
 	inf := kubeclient.GetInformerFiltered[T](c, ToOpts(c, gvr, filter))
 	return &fullClient[T]{
 		writeClient: writeClient[T]{client: c},

--- a/pkg/kube/krt/informer_test.go
+++ b/pkg/kube/krt/informer_test.go
@@ -25,13 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
-	ktypes "istio.io/istio/pkg/kube/kubetypes"
-
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/kubeclient"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
+	ktypes "istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"

--- a/pkg/kube/krt/informer_test.go
+++ b/pkg/kube/krt/informer_test.go
@@ -15,11 +15,20 @@
 package krt_test
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 
+	ktypes "istio.io/istio/pkg/kube/kubetypes"
+
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/kubeclient"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
@@ -78,4 +87,43 @@ func TestNewInformer(t *testing.T) {
 
 	cmt.Delete(cmB.Name, cmB.Namespace)
 	tt.WaitOrdered("delete/ns/b")
+}
+
+func TestUnregisteredTypeCollection(t *testing.T) {
+	np := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "netpol",
+			Namespace: "default",
+		},
+	}
+	c := kube.NewFakeClient(np)
+
+	kubeclient.Register[*v1.NetworkPolicy](kubeclient.NewTypeRegistration[*v1.NetworkPolicy](
+		v1.SchemeGroupVersion.WithResource("networkpolicies"),
+		config.GroupVersionKind{
+			Group:   v1.SchemeGroupVersion.Group,
+			Version: v1.SchemeGroupVersion.Version,
+			Kind:    "NetworkPolicy",
+		},
+		&v1.NetworkPolicy{},
+		func(c kubeclient.ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher {
+			np := c.Kube().NetworkingV1().NetworkPolicies(o.Namespace)
+			return &cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = o.FieldSelector
+					options.LabelSelector = o.LabelSelector
+					return np.List(context.Background(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = o.FieldSelector
+					options.LabelSelector = o.LabelSelector
+					return np.Watch(context.Background(), options)
+				},
+				DisableChunking: true,
+			}
+		},
+	))
+	npcoll := krt.NewInformer[*v1.NetworkPolicy](c)
+	c.RunAndWait(test.NewStop(t))
+	assert.Equal(t, npcoll.List(""), []*v1.NetworkPolicy{np})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Provide a mechanism within `kube.Client` to create informers for arbitrary types. This enables `krt.Collection` resources to be created from informers on types not registered in `resources.gen.go`