### PR TITLE
Simplify dynamic informer registration

### DIFF
--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -396,6 +396,14 @@ func (g GroupVersionKind) GroupVersion() string {
 	return g.Group + "/" + g.Version
 }
 
+func FromKubernetesGVK(gvk schema.GroupVersionKind) GroupVersionKind {
+	return GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
+}
+
 // Kubernetes returns the same GVK, using the Kubernetes object type
 func (g GroupVersionKind) Kubernetes() schema.GroupVersionKind {
 	return schema.GroupVersionKind{

--- a/pkg/config/schema/codegen/templates/types.go.tmpl
+++ b/pkg/config/schema/codegen/templates/types.go.tmpl
@@ -15,17 +15,17 @@ import (
 	apiistioioapitelemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 )
 
-func getGvk(obj any) config.GroupVersionKind {
+func getGvk(obj any) (config.GroupVersionKind, bool) {
 	switch obj.(type) {
 {{- range .Entries }}
 	case *{{ .ClientImport }}.{{ .Resource.Kind }}:
-		return gvk.{{ .Resource.Identifier }}
+		return gvk.{{ .Resource.Identifier }}, true
 	{{- if and (not (eq .ClientImport .IstioAwareClientImport)) (not .Resource.Synthetic) }}
 	case *{{ .IstioAwareClientImport }}.{{ .Resource.Kind }}:
-		return gvk.{{ .Resource.Identifier }}
+		return gvk.{{ .Resource.Identifier }}, true
     {{- end }}
 {{- end }}
   default:
-    panic(fmt.Sprintf("Unknown type %T", obj))
+    return config.GroupVersionKind{}, false
 	}
 }

--- a/pkg/config/schema/kubeclient/common_test.go
+++ b/pkg/config/schema/kubeclient/common_test.go
@@ -22,37 +22,23 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
 
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube"
 	ktypes "istio.io/istio/pkg/kube/kubetypes"
 )
 
 func TestCustomRegistration(t *testing.T) {
-	Register[*v1.NetworkPolicy](NewTypeRegistration[*v1.NetworkPolicy](
-		schema.GroupVersionResource{},
-		config.GroupVersionKind{},
-		&v1.NetworkPolicy{},
-		func(c ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher {
-			np := c.Kube().NetworkingV1().NetworkPolicies(o.Namespace)
-			return &cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					options.FieldSelector = o.FieldSelector
-					options.LabelSelector = o.LabelSelector
-					return np.List(context.Background(), options)
-				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					options.FieldSelector = o.FieldSelector
-					options.LabelSelector = o.LabelSelector
-					return np.Watch(context.Background(), options)
-				},
-				DisableChunking: true,
-			}
+	Register[*v1.NetworkPolicy](
+		v1.SchemeGroupVersion.WithResource("networkpolicies"),
+		v1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+		func(c ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
+			return c.Kube().NetworkingV1().NetworkPolicies(namespace).List(context.Background(), o)
 		},
-	))
+		func(c ClientGetter, namespace string, o metav1.ListOptions) (watch.Interface, error) {
+			return c.Kube().NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), o)
+		},
+	)
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "funkyns"}}
 

--- a/pkg/config/schema/kubetypes/resources.gen.go
+++ b/pkg/config/schema/kubetypes/resources.gen.go
@@ -3,8 +3,6 @@
 package kubetypes
 
 import (
-	"fmt"
-
 	k8sioapiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	k8sioapiappsv1 "k8s.io/api/apps/v1"
 	k8sioapicertificatesv1 "k8s.io/api/certificates/v1"
@@ -32,123 +30,123 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
-func getGvk(obj any) config.GroupVersionKind {
+func getGvk(obj any) (config.GroupVersionKind, bool) {
 	switch obj.(type) {
 	case *istioioapisecurityv1beta1.AuthorizationPolicy:
-		return gvk.AuthorizationPolicy
+		return gvk.AuthorizationPolicy, true
 	case *apiistioioapisecurityv1beta1.AuthorizationPolicy:
-		return gvk.AuthorizationPolicy
+		return gvk.AuthorizationPolicy, true
 	case *k8sioapicertificatesv1.CertificateSigningRequest:
-		return gvk.CertificateSigningRequest
+		return gvk.CertificateSigningRequest, true
 	case *k8sioapicorev1.ConfigMap:
-		return gvk.ConfigMap
+		return gvk.ConfigMap, true
 	case *k8sioapiextensionsapiserverpkgapisapiextensionsv1.CustomResourceDefinition:
-		return gvk.CustomResourceDefinition
+		return gvk.CustomResourceDefinition, true
 	case *k8sioapiappsv1.DaemonSet:
-		return gvk.DaemonSet
+		return gvk.DaemonSet, true
 	case *k8sioapiappsv1.Deployment:
-		return gvk.Deployment
+		return gvk.Deployment, true
 	case *istioioapinetworkingv1alpha3.DestinationRule:
-		return gvk.DestinationRule
+		return gvk.DestinationRule, true
 	case *apiistioioapinetworkingv1alpha3.DestinationRule:
-		return gvk.DestinationRule
+		return gvk.DestinationRule, true
 	case *k8sioapidiscoveryv1.EndpointSlice:
-		return gvk.EndpointSlice
+		return gvk.EndpointSlice, true
 	case *k8sioapicorev1.Endpoints:
-		return gvk.Endpoints
+		return gvk.Endpoints, true
 	case *istioioapinetworkingv1alpha3.EnvoyFilter:
-		return gvk.EnvoyFilter
+		return gvk.EnvoyFilter, true
 	case *apiistioioapinetworkingv1alpha3.EnvoyFilter:
-		return gvk.EnvoyFilter
+		return gvk.EnvoyFilter, true
 	case *sigsk8siogatewayapiapisv1.GRPCRoute:
-		return gvk.GRPCRoute
+		return gvk.GRPCRoute, true
 	case *istioioapinetworkingv1alpha3.Gateway:
-		return gvk.Gateway
+		return gvk.Gateway, true
 	case *apiistioioapinetworkingv1alpha3.Gateway:
-		return gvk.Gateway
+		return gvk.Gateway, true
 	case *sigsk8siogatewayapiapisv1beta1.GatewayClass:
-		return gvk.GatewayClass
+		return gvk.GatewayClass, true
 	case *sigsk8siogatewayapiapisv1beta1.HTTPRoute:
-		return gvk.HTTPRoute
+		return gvk.HTTPRoute, true
 	case *k8sioapinetworkingv1.Ingress:
-		return gvk.Ingress
+		return gvk.Ingress, true
 	case *k8sioapinetworkingv1.IngressClass:
-		return gvk.IngressClass
+		return gvk.IngressClass, true
 	case *sigsk8siogatewayapiapisv1beta1.Gateway:
-		return gvk.KubernetesGateway
+		return gvk.KubernetesGateway, true
 	case *k8sioapicoordinationv1.Lease:
-		return gvk.Lease
+		return gvk.Lease, true
 	case *istioioapimeshv1alpha1.MeshConfig:
-		return gvk.MeshConfig
+		return gvk.MeshConfig, true
 	case *istioioapimeshv1alpha1.MeshNetworks:
-		return gvk.MeshNetworks
+		return gvk.MeshNetworks, true
 	case *k8sioapiadmissionregistrationv1.MutatingWebhookConfiguration:
-		return gvk.MutatingWebhookConfiguration
+		return gvk.MutatingWebhookConfiguration, true
 	case *k8sioapicorev1.Namespace:
-		return gvk.Namespace
+		return gvk.Namespace, true
 	case *k8sioapicorev1.Node:
-		return gvk.Node
+		return gvk.Node, true
 	case *istioioapisecurityv1beta1.PeerAuthentication:
-		return gvk.PeerAuthentication
+		return gvk.PeerAuthentication, true
 	case *apiistioioapisecurityv1beta1.PeerAuthentication:
-		return gvk.PeerAuthentication
+		return gvk.PeerAuthentication, true
 	case *k8sioapicorev1.Pod:
-		return gvk.Pod
+		return gvk.Pod, true
 	case *istioioapinetworkingv1beta1.ProxyConfig:
-		return gvk.ProxyConfig
+		return gvk.ProxyConfig, true
 	case *apiistioioapinetworkingv1beta1.ProxyConfig:
-		return gvk.ProxyConfig
+		return gvk.ProxyConfig, true
 	case *sigsk8siogatewayapiapisv1beta1.ReferenceGrant:
-		return gvk.ReferenceGrant
+		return gvk.ReferenceGrant, true
 	case *istioioapisecurityv1beta1.RequestAuthentication:
-		return gvk.RequestAuthentication
+		return gvk.RequestAuthentication, true
 	case *apiistioioapisecurityv1beta1.RequestAuthentication:
-		return gvk.RequestAuthentication
+		return gvk.RequestAuthentication, true
 	case *k8sioapicorev1.Secret:
-		return gvk.Secret
+		return gvk.Secret, true
 	case *k8sioapicorev1.Service:
-		return gvk.Service
+		return gvk.Service, true
 	case *k8sioapicorev1.ServiceAccount:
-		return gvk.ServiceAccount
+		return gvk.ServiceAccount, true
 	case *istioioapinetworkingv1alpha3.ServiceEntry:
-		return gvk.ServiceEntry
+		return gvk.ServiceEntry, true
 	case *apiistioioapinetworkingv1alpha3.ServiceEntry:
-		return gvk.ServiceEntry
+		return gvk.ServiceEntry, true
 	case *istioioapinetworkingv1alpha3.Sidecar:
-		return gvk.Sidecar
+		return gvk.Sidecar, true
 	case *apiistioioapinetworkingv1alpha3.Sidecar:
-		return gvk.Sidecar
+		return gvk.Sidecar, true
 	case *k8sioapiappsv1.StatefulSet:
-		return gvk.StatefulSet
+		return gvk.StatefulSet, true
 	case *sigsk8siogatewayapiapisv1alpha2.TCPRoute:
-		return gvk.TCPRoute
+		return gvk.TCPRoute, true
 	case *sigsk8siogatewayapiapisv1alpha2.TLSRoute:
-		return gvk.TLSRoute
+		return gvk.TLSRoute, true
 	case *istioioapitelemetryv1alpha1.Telemetry:
-		return gvk.Telemetry
+		return gvk.Telemetry, true
 	case *apiistioioapitelemetryv1alpha1.Telemetry:
-		return gvk.Telemetry
+		return gvk.Telemetry, true
 	case *sigsk8siogatewayapiapisv1alpha2.UDPRoute:
-		return gvk.UDPRoute
+		return gvk.UDPRoute, true
 	case *k8sioapiadmissionregistrationv1.ValidatingWebhookConfiguration:
-		return gvk.ValidatingWebhookConfiguration
+		return gvk.ValidatingWebhookConfiguration, true
 	case *istioioapinetworkingv1alpha3.VirtualService:
-		return gvk.VirtualService
+		return gvk.VirtualService, true
 	case *apiistioioapinetworkingv1alpha3.VirtualService:
-		return gvk.VirtualService
+		return gvk.VirtualService, true
 	case *istioioapiextensionsv1alpha1.WasmPlugin:
-		return gvk.WasmPlugin
+		return gvk.WasmPlugin, true
 	case *apiistioioapiextensionsv1alpha1.WasmPlugin:
-		return gvk.WasmPlugin
+		return gvk.WasmPlugin, true
 	case *istioioapinetworkingv1alpha3.WorkloadEntry:
-		return gvk.WorkloadEntry
+		return gvk.WorkloadEntry, true
 	case *apiistioioapinetworkingv1alpha3.WorkloadEntry:
-		return gvk.WorkloadEntry
+		return gvk.WorkloadEntry, true
 	case *istioioapinetworkingv1alpha3.WorkloadGroup:
-		return gvk.WorkloadGroup
+		return gvk.WorkloadGroup, true
 	case *apiistioioapinetworkingv1alpha3.WorkloadGroup:
-		return gvk.WorkloadGroup
+		return gvk.WorkloadGroup, true
 	default:
-		panic(fmt.Sprintf("Unknown type %T", obj))
+		return config.GroupVersionKind{}, false
 	}
 }

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -209,7 +209,7 @@ func New[T controllers.ComparableObject](c kube.Client) Client[T] {
 // This means there must only be one filter configuration for a given type using the same kube.Client.
 // Use with caution.
 func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) Client[T] {
-	gvr := types.MustToGVR[T](types.GetGVK[T]())
+	gvr := types.MustToGVR[T](types.MustGVKFromType[T]())
 	inf := kubeclient.GetInformerFiltered[T](c, ToOpts(c, gvr, filter))
 	return &fullClient[T]{
 		writeClient: writeClient[T]{client: c},

--- a/pkg/kube/krt/informer_test.go
+++ b/pkg/kube/krt/informer_test.go
@@ -23,14 +23,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
 
-	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/kubeclient"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/kube/krt"
-	ktypes "istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
@@ -97,31 +94,16 @@ func TestUnregisteredTypeCollection(t *testing.T) {
 	}
 	c := kube.NewFakeClient(np)
 
-	kubeclient.Register[*v1.NetworkPolicy](kubeclient.NewTypeRegistration[*v1.NetworkPolicy](
+	kubeclient.Register[*v1.NetworkPolicy](
 		v1.SchemeGroupVersion.WithResource("networkpolicies"),
-		config.GroupVersionKind{
-			Group:   v1.SchemeGroupVersion.Group,
-			Version: v1.SchemeGroupVersion.Version,
-			Kind:    "NetworkPolicy",
+		v1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
+			return c.Kube().NetworkingV1().NetworkPolicies(namespace).List(context.Background(), o)
 		},
-		&v1.NetworkPolicy{},
-		func(c kubeclient.ClientGetter, o ktypes.InformerOptions) cache.ListerWatcher {
-			np := c.Kube().NetworkingV1().NetworkPolicies(o.Namespace)
-			return &cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					options.FieldSelector = o.FieldSelector
-					options.LabelSelector = o.LabelSelector
-					return np.List(context.Background(), options)
-				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					options.FieldSelector = o.FieldSelector
-					options.LabelSelector = o.LabelSelector
-					return np.Watch(context.Background(), options)
-				},
-				DisableChunking: true,
-			}
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (watch.Interface, error) {
+			return c.Kube().NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), o)
 		},
-	))
+	)
 	npcoll := krt.NewInformer[*v1.NetworkPolicy](c)
 	c.RunAndWait(test.NewStop(t))
 	assert.Equal(t, npcoll.List(), []*v1.NetworkPolicy{np})

--- a/pkg/typemap/map.go
+++ b/pkg/typemap/map.go
@@ -1,0 +1,44 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typemap
+
+import (
+	"reflect"
+
+	"istio.io/istio/pkg/ptr"
+)
+
+// TypeMap provides a map that holds a map of Type -> Value. There can be only a single value per type.
+// The value stored for a type must be of the same type as the key.
+type TypeMap struct {
+	inner map[reflect.Type]any
+}
+
+func NewTypeMap() TypeMap {
+	return TypeMap{make(map[reflect.Type]any)}
+}
+
+func Set[T any](t TypeMap, v T) {
+	interfaceType := reflect.TypeOf((*T)(nil)).Elem()
+	t.inner[interfaceType] = v
+}
+
+func Get[T any](t TypeMap) *T {
+	v, f := t.inner[reflect.TypeFor[T]()]
+	if f {
+		return ptr.Of(v.(T))
+	}
+	return nil
+}

--- a/pkg/typemap/map_test.go
+++ b/pkg/typemap/map_test.go
@@ -1,0 +1,52 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typemap_test
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/typemap"
+)
+
+type TestStruct struct {
+	Field string
+}
+
+type TestInterface[T any] interface {
+	Foo() T
+}
+
+func (t TestStruct) Foo() string {
+	return t.Field
+}
+
+func TestTypeMap(t *testing.T) {
+	tm := typemap.NewTypeMap()
+	typemap.Set(tm, 1)
+	typemap.Set(tm, int32(2))
+	typemap.Set(tm, "old")
+	typemap.Set(tm, "string")
+	typemap.Set(tm, TestStruct{Field: "inner"})
+	typemap.Set(tm, &TestStruct{Field: "pointer"})
+	typemap.Set[TestInterface[string]](tm, TestStruct{Field: "interface"})
+
+	assert.Equal(t, typemap.Get[int](tm), ptr.Of(1))
+	assert.Equal(t, typemap.Get[int32](tm), ptr.Of(int32(2)))
+	assert.Equal(t, typemap.Get[string](tm), ptr.Of("string"))
+	assert.Equal(t, typemap.Get[*TestStruct](tm), ptr.Of(&TestStruct{Field: "pointer"}))
+	assert.Equal(t, typemap.Get[TestInterface[string]](tm), ptr.Of(TestInterface[string](TestStruct{Field: "interface"})))
+}


### PR DESCRIPTION
1. Use a map for lookup instead of O(1) lookup
2. Check the core types first, to favor performance of core types over extended. This is likely a trivial difference
3. Pass list and watch instead of ListWatch so the common library can set the standard fields.


cc @jmcshane lmk what you think. Ill un-draft once yours merges