### PR TITLE
istioctl: add enrolled namespace flag for users to enroll waypoints for a namespace

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -408,7 +408,7 @@ func annotateNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
 	if nsObj.Annotations == nil {
 		nsObj.Annotations = map[string]string{}
 	}
-	nsObj.Annotations[constants.AmbientUseWaypoint] = constants.WaypointGatewayClassName
+	nsObj.Annotations[constants.AmbientUseWaypoint] = waypointName
 	if _, err := kubeClient.Kube().CoreV1().Namespaces().Update(context.Background(), nsObj, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update namespace %s: %v", ns, err)
 	}

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -84,14 +84,12 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		if waypointName == "" {
 			waypointName = constants.DefaultNamespaceWaypoint
 		}
-		// If a user decides to enroll their namespace with a waypoint, annotate the namespace with the waypoint name
+		// If a user decides to enroll their namespace with a waypoint, annotate the namespace with the waypoint name.
 		if enrollNamespace {
 			kubeClient, err := ctx.CLIClient()
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
 			}
-			// If waypoint should be enrolled into specific namespace, annotate that namespace with the waypoint;
-			// otherwise, the default is to enroll the waypoint into the default namespace.
 			err = annotateNamespaceWithWaypoint(kubeClient, ns)
 			if err != nil {
 				return nil, fmt.Errorf("failed to annotate namespace with waypoint: %v", err)

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -195,8 +195,8 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to annotate namespace with waypoint: %v", err)
 				}
+				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v annotated with waypoint %v\n", ctx.NamespaceOrDefault(ctx.Namespace()), gw.Name)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "namespace %v annotated with waypoint %v\n", ctx.NamespaceOrDefault(ctx.Namespace()), gw.Name)
 			return nil
 		},
 	}

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -100,9 +100,6 @@ const (
 	// DefaultNamespaceWaypoint is the default name for a waypoint in a namespace.
 	DefaultNamespaceWaypoint = "default-namespace"
 
-	// DefaultEnrolledNamespace is the default namespace for waypoint enrollment.
-	DefaultEnrolledNamespace = "default"
-
 	// The data name in the ConfigMap of each namespace storing the root cert of non-Kube CA.
 	CACertNamespaceConfigMapDataName = "root-cert.pem"
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -100,6 +100,9 @@ const (
 	// DefaultNamespaceWaypoint is the default name for a waypoint in a namespace.
 	DefaultNamespaceWaypoint = "default-namespace"
 
+	// DefaultEnrolledNamespace is the default namespace for waypoint enrollment.
+	DefaultEnrolledNamespace = "default"
+
 	// The data name in the ConfigMap of each namespace storing the root cert of non-Kube CA.
 	CACertNamespaceConfigMapDataName = "root-cert.pem"
 

--- a/releasenotes/notes/50221.yaml
+++ b/releasenotes/notes/50221.yaml
@@ -6,5 +6,5 @@ issue:
   - 50173
 releaseNotes:
 - |
-  **Added** Allow user to name their waypoint throught istioctl via --name flag on the waypoint cmd.
+  **Added** Allow user to name their waypoint through istioctl via --name flag on the waypoint cmd.
   **Removed** Remove ability for user to specify service account for the waypoint by deleting the --service-account flag on the waypoint cmd

--- a/releasenotes/notes/50267.yaml
+++ b/releasenotes/notes/50267.yaml
@@ -5,4 +5,4 @@ issue:
   - 50248
 releaseNotes:
 - |
-  **Added** Allow user to enroll their waypoint in a specific namespace through istioctl via --enroll-namespace flag on the waypoint cmd.
+  **Added** Allow user to enroll their waypoint in the waypoint's namespace through istioctl via --enroll-namespace flag on the waypoint cmd.

--- a/releasenotes/notes/50267.yaml
+++ b/releasenotes/notes/50267.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 50248
+releaseNotes:
+- |
+  **Added** Allow user to enroll their waypoint in a specific namespace through istioctl via --enroll-namespace flag on the waypoint cmd.

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -96,7 +96,7 @@ func TestWaypoint(t *testing.T) {
 				"--wait",
 			})
 
-			nameSet := []string{"", "w1", "w2", "w3"}
+			nameSet := []string{"", "w1", "w2"}
 			for _, name := range nameSet {
 				istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 					"x",
@@ -109,6 +109,20 @@ func TestWaypoint(t *testing.T) {
 					"--wait",
 				})
 			}
+
+			istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
+				"x",
+				"waypoint",
+				"apply",
+				"--namespace",
+				nsConfig.Name(),
+				"--name",
+				"w3",
+				"--enroll-namespace",
+				"true",
+				"--wait",
+			})
+			nameSet = append(nameSet, "w3")
 
 			output, _ := istioctl.NewOrFail(t, t, istioctl.Config{}).InvokeOrFail(t, []string{
 				"x",


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds an istioctl flag for enrolling a namespace for a specific waypoint. This was done in addition to a few other things that in order to clean up the istioctl waypoint logic:
- Add `--enroll-namespace` flag with default value set. A user can now specify a namespace to enroll with the waypoint when they create/update a waypoint.
- `trafficType` and `waypointName` had default checks where if it wasn't set and `makeGateway` was called it would get set to the default values specified in `constants.go`. This PR initializes those variables ahead of time and lets the user override them but if the flag is never used, we already have the default value set.
- `waypointName` flag should have an accurate default value in it's flag description (e.g. the default waypoint name constant which is `default-namespace` instead of the technically incorrect `default`)

Resolves: #50248