### PR TITLE
ca: remove legacy-unknown signer, removed in k8s 1.22

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -88,7 +88,6 @@ rules:
     resources:
       - "signers"
     resourceNames:
-    - "kubernetes.io/legacy-unknown"
 {{- range .Values.global.certSigners }}
     - {{ . | quote }}
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -89,7 +89,6 @@ rules:
     resources:
       - "signers"
     resourceNames:
-    - "kubernetes.io/legacy-unknown"
 {{- range .Values.global.certSigners }}
     - {{ . | quote }}
 {{- end }}

--- a/security/pkg/k8s/chiron/utils.go
+++ b/security/pkg/k8s/chiron/utils.go
@@ -66,7 +66,7 @@ func GenKeyCertK8sCA(client clientset.Interface, dnsName,
 		cert.UsageServerAuth,
 	}
 	if signerName == "" {
-		signerName = "kubernetes.io/legacy-unknown"
+		return nil, nil, nil, fmt.Errorf("signerName is required for Kubernetes CA")
 	}
 	certChain, caCert, err := SignCSRK8s(client, csrPEM, signerName, usages, dnsName, caFilePath, approveCsr, true, requestedLifetime)
 


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/22161

This cannot be used in Istio at all, so it is effectively dead
