### PR TITLE
tf: allow dumping resources from container tests

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -250,6 +250,10 @@ func (t *testAnalyzer) Features(feats ...features.Feature) Test {
 	return t
 }
 
+func (t *testAnalyzer) TopLevel() Test {
+	return t
+}
+
 func addFeatureLabels(featureLabels map[features.Feature][]string, feats ...features.Feature) error {
 	c, err := features.BuildChecker(env.IstioSrc + "/pkg/test/framework/features/features.yaml")
 	if err != nil {

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -42,6 +42,8 @@ type scope struct {
 
 	closeChan chan struct{}
 
+	topLevel bool
+
 	skipDump bool
 
 	// Mutex to lock changes to resources, children, and closers that can be done concurrently
@@ -180,6 +182,12 @@ func (s *scope) skipDumping() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.skipDump = true
+}
+
+func (s *scope) markTopLevel() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.topLevel = true
 }
 
 func (s *scope) dump(ctx resource.Context, recursive bool) {

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -87,6 +87,7 @@ func newSuiteContext(s *resource.Settings, envFn resource.EnvironmentFactory, la
 		contextNames: sets.New[string](),
 		dumpCount:    atomic.NewUint64(0),
 	}
+	c.globalScope.markTopLevel()
 
 	env, err := envFn(c)
 	if err != nil {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -56,6 +56,9 @@ type Test interface {
 	//
 	// Deprecated: Tests should not make assumptions regarding number of networks.
 	RequiresSingleNetwork() Test
+	// TopLevel marks a test as a "top-level test" meaning a container test that has many subtests.
+	// Resources created at this level will be in-scope for dumping when any descendant test fails.
+	TopLevel() Test
 	// Run the test, supplied as a lambda.
 	Run(fn func(t TestContext))
 	// RunParallel runs this test in parallel with other children of the same parent test/suite. Under the hood,
@@ -123,6 +126,7 @@ type testImpl struct {
 	requireLocalIstiod   bool
 	requireSingleNetwork bool
 	minIstioVersion      string
+	topLevel             bool
 
 	ctx *testContext
 	tc  context2.Context
@@ -164,6 +168,11 @@ func (t *testImpl) Features(feats ...features.Feature) Test {
 		// test runs shouldn't fail
 		log.Error(err)
 	}
+	return t
+}
+
+func (t *testImpl) TopLevel() Test {
+	t.topLevel = true
 	return t
 }
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -145,6 +145,10 @@ func newTestContext(test *testImpl, goTest *testing.T, s *suiteContext, parentSc
 		FileWriter: yml.NewFileWriter(workDir),
 	}
 
+	if test.topLevel {
+		ctx.scope.markTopLevel()
+	}
+
 	// Register the cleanup handler for the context.
 	goTest.Cleanup(ctx.close)
 
@@ -298,11 +302,28 @@ func (c *testContext) CleanupStrategy(strategy cleanup.Strategy, fn func()) {
 	}
 }
 
+// topLevelScopes walks up the tree to find all "top level" or "container"
+// scopes. We always want to dump the resources created at the "top level" when
+// their descendant scopes fail.
+func (c *testContext) topLevelScopes() []*scope {
+	var out []*scope
+	current := c.scope.parent
+	for current != nil {
+		if current.topLevel {
+			out = append(out, current)
+		}
+		current = current.parent
+	}
+	return out
+}
+
 func (c *testContext) dump() {
 	if c.suite.RequestTestDump() {
 		scopes.Framework.Debugf("Begin dumping testContext: %q", c.id)
-		// make sure we dump suite-level resources, but don't dump sibling tests or their children
-		rt.DumpCustom(c, false)
+		// make sure we dump suite-level/top-level resources, but don't dump sibling tests or their children
+		for _, scope := range c.topLevelScopes() {
+			scope.dump(c, false)
+		}
 		c.scope.dump(c, true)
 		scopes.Framework.Debugf("Completed dumping testContext: %q", c.id)
 	} else {

--- a/tests/integration/ambient/traffic_test.go
+++ b/tests/integration/ambient/traffic_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestTraffic(t *testing.T) {
 	framework.NewTest(t).
+		TopLevel().
 		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
 		Run(func(t framework.TestContext) {
 			apps := deployment.NewOrFail(t, t, deployment.Config{


### PR DESCRIPTION
```go
 framework.NewTest(t).
    TopLevel().
		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
		Run(func(t framework.TestContext) {
			apps := deployment.NewOrFail(t, t, deployment.Config{
				NoExternalNamespace: true,
				IncludeExtAuthz:     false,
			})
			common.RunAllTrafficTests(t, i, apps.SingleNamespaceView())
		})
```

Marking this test  means any descendent `this_test/subtest_group/individual_case` will dump the resources created at this level. Previously we had this behavior for `Suite` level resources. For tests like this that are essentially suites, we should get the same behavior. 

fixes #50238 
