### PR TITLE
injection: use values default as base

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -316,7 +316,7 @@ func ProxyImage(values *opconfig.Values, image *proxyConfig.ProxyImage, annotati
 		tag = fmt.Sprintf("%v", global.GetTag().AsInterface())
 	}
 
-	imageType := ""
+	imageType := global.GetVariant()
 	if image != nil {
 		imageType = image.ImageType
 	}


### PR DESCRIPTION
This is typically handled during install, where `.Values.global.variant`
automatically configures mesh config.

But to be more robust, also handle the case its set here directly
