### PR TITLE
use SpawnUpstreamSpan instead of startChildSpan

### DIFF
--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -367,7 +367,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 
 	accessLogBuilder.setHTTPAccessLog(lb.push, lb.node, connectionManager, httpOpts.class)
 
-	startChildSpan, reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
+	reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
 
 	filters := []*hcm.HttpFilter{}
 	if !httpOpts.isWaypoint {
@@ -415,7 +415,6 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 		filters = append(filters, xdsfilters.EmptySessionFilter)
 	}
 	filters = append(filters, xdsfilters.BuildRouterFilter(xdsfilters.RouterFilterContext{
-		StartChildSpan:       startChildSpan,
 		SuppressDebugHeaders: httpOpts.suppressEnvoyDebugHeaders,
 	}))
 

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -59,19 +59,17 @@ func TestConfigureTracing(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name               string
-		opts               gatewayListenerOpts
-		inSpec             *model.TracingConfig
-		want               *hcm.HttpConnectionManager_Tracing
-		wantStartChildSpan bool
-		wantReqIDExtCtx    *requestidextension.UUIDRequestIDExtensionContext
+		name            string
+		opts            gatewayListenerOpts
+		inSpec          *model.TracingConfig
+		want            *hcm.HttpConnectionManager_Tracing
+		wantReqIDExtCtx *requestidextension.UUIDRequestIDExtensionContext
 	}{
 		{
-			name:               "no telemetry api",
-			opts:               fakeOptsNoTelemetryAPI(),
-			want:               fakeTracingConfigNoProvider(55.55, 13, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    nil,
+			name:            "no telemetry api",
+			opts:            fakeOptsNoTelemetryAPI(),
+			want:            fakeTracingConfigNoProvider(55.55, 13, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: nil,
 		},
 		{
 			name: "default providers",
@@ -83,113 +81,103 @@ func TestConfigureTracing(t *testing.T) {
 					Provider: fakeZipkin(),
 				},
 			},
-			opts:               fakeOptsWithDefaultProviders(),
-			want:               fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 55.5, 256, defaultTracingTags()),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &requestidextension.UUIDRequestIDExtensionContext{},
+			opts:            fakeOptsWithDefaultProviders(),
+			want:            fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 55.5, 256, defaultTracingTags()),
+			wantReqIDExtCtx: &requestidextension.UUIDRequestIDExtensionContext{},
 		},
 		{
-			name:               "no telemetry api and nil custom tag",
-			opts:               fakeOptsNoTelemetryAPIWithNilCustomTag(),
-			want:               fakeTracingConfigNoProvider(55.55, 13, defaultTracingTags()),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    nil,
+			name:            "no telemetry api and nil custom tag",
+			opts:            fakeOptsNoTelemetryAPIWithNilCustomTag(),
+			want:            fakeTracingConfigNoProvider(55.55, 13, defaultTracingTags()),
+			wantReqIDExtCtx: nil,
 		},
 		{
-			name:               "only telemetry api (no provider)",
-			inSpec:             fakeTracingSpecNoProvider(99.999, false, true),
-			opts:               fakeOptsOnlyZipkinTelemetryAPI(),
-			want:               fakeTracingConfigNoProvider(99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "only telemetry api (no provider)",
+			inSpec:          fakeTracingSpecNoProvider(99.999, false, true),
+			opts:            fakeOptsOnlyZipkinTelemetryAPI(),
+			want:            fakeTracingConfigNoProvider(99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "only telemetry api (no provider) with nil custom tag",
-			inSpec:             fakeTracingSpecNoProviderWithNilCustomTag(99.999, false, true),
-			opts:               fakeOptsOnlyZipkinTelemetryAPI(),
-			want:               fakeTracingConfigNoProvider(99.999, 0, defaultTracingTags()),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:   "only telemetry api (no provider) with nil custom tag",
+			inSpec: fakeTracingSpecNoProviderWithNilCustomTag(99.999, false, true),
+			opts:   fakeOptsOnlyZipkinTelemetryAPI(),
+			want:   fakeTracingConfigNoProvider(99.999, 0, defaultTracingTags()),
+
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "only telemetry api (with provider)",
-			inSpec:             fakeTracingSpec(fakeZipkin(), 99.999, false, true),
-			opts:               fakeOptsOnlyZipkinTelemetryAPI(),
-			want:               fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "only telemetry api (with provider)",
+			inSpec:          fakeTracingSpec(fakeZipkin(), 99.999, false, true),
+			opts:            fakeOptsOnlyZipkinTelemetryAPI(),
+			want:            fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "zipkin enable 64bit trace id",
-			inSpec:             fakeTracingSpec(fakeZipkinEnable64bitTraceID(), 99.999, false, true),
-			opts:               fakeOptsOnlyZipkinTelemetryAPI(),
-			want:               fakeTracingConfig(fakeZipkinProvider(clusterName, authority, false), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "zipkin enable 64bit trace id",
+			inSpec:          fakeTracingSpec(fakeZipkinEnable64bitTraceID(), 99.999, false, true),
+			opts:            fakeOptsOnlyZipkinTelemetryAPI(),
+			want:            fakeTracingConfig(fakeZipkinProvider(clusterName, authority, false), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "both tracing enabled (no provider)",
-			inSpec:             fakeTracingSpecNoProvider(99.999, false, true),
-			opts:               fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
-			want:               fakeTracingConfigNoProvider(99.999, 13, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "both tracing enabled (no provider)",
+			inSpec:          fakeTracingSpecNoProvider(99.999, false, true),
+			opts:            fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
+			want:            fakeTracingConfigNoProvider(99.999, 13, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "both tracing disabled (no provider)",
-			inSpec:             fakeTracingSpecNoProvider(99.999, false, true),
-			opts:               fakeOptsMeshAndTelemetryAPI(false /* no enable tracing */),
-			want:               fakeTracingConfigNoProvider(99.999, 13, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "both tracing disabled (no provider)",
+			inSpec:          fakeTracingSpecNoProvider(99.999, false, true),
+			opts:            fakeOptsMeshAndTelemetryAPI(false /* no enable tracing */),
+			want:            fakeTracingConfigNoProvider(99.999, 13, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "both tracing enabled (with provider)",
-			inSpec:             fakeTracingSpec(fakeZipkin(), 99.999, false, true),
-			opts:               fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
-			want:               fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "both tracing enabled (with provider)",
+			inSpec:          fakeTracingSpec(fakeZipkin(), 99.999, false, true),
+			opts:            fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
+			want:            fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "both tracing disabled (with provider)",
-			inSpec:             fakeTracingSpec(fakeZipkin(), 99.999, false, true),
-			opts:               fakeOptsMeshAndTelemetryAPI(false /* no enable tracing */),
-			want:               fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:   "both tracing disabled (with provider)",
+			inSpec: fakeTracingSpec(fakeZipkin(), 99.999, false, true),
+			opts:   fakeOptsMeshAndTelemetryAPI(false /* no enable tracing */),
+			want:   fakeTracingConfig(fakeZipkinProvider(clusterName, authority, true), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "basic config (with datadog provider)",
-			inSpec:             fakeTracingSpec(fakeDatadog(), 99.999, false, true),
-			opts:               fakeOptsOnlyDatadogTelemetryAPI(),
-			want:               fakeTracingConfig(fakeDatadogProvider("fake-cluster", "testhost", clusterName), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:   "basic config (with datadog provider)",
+			inSpec: fakeTracingSpec(fakeDatadog(), 99.999, false, true),
+			opts:   fakeOptsOnlyDatadogTelemetryAPI(),
+			want:   fakeTracingConfig(fakeDatadogProvider("fake-cluster", "testhost", clusterName), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "basic config (with skywalking provider)",
-			inSpec:             fakeTracingSpec(fakeSkywalking(), 99.999, false, false),
-			opts:               fakeOptsOnlySkywalkingTelemetryAPI(),
-			want:               fakeTracingConfig(fakeSkywalkingProvider(clusterName, authority), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: true,
-			wantReqIDExtCtx:    &requestidextension.UUIDRequestIDExtensionContext{UseRequestIDForTraceSampling: false},
+			name:            "basic config (with skywalking provider)",
+			inSpec:          fakeTracingSpec(fakeSkywalking(), 99.999, false, false),
+			opts:            fakeOptsOnlySkywalkingTelemetryAPI(),
+			want:            fakeTracingConfigForSkywalking(fakeSkywalkingProvider(clusterName, authority), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &requestidextension.UUIDRequestIDExtensionContext{UseRequestIDForTraceSampling: false},
 		},
 		{
-			name:               "basic config (with opentelemetry provider via grpc)",
-			inSpec:             fakeTracingSpec(fakeOpenTelemetryGrpc(), 99.999, false, true),
-			opts:               fakeOptsOnlyOpenTelemetryGrpcTelemetryAPI(),
-			want:               fakeTracingConfig(fakeOpenTelemetryGrpcProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:   "basic config (with opentelemetry provider via grpc)",
+			inSpec: fakeTracingSpec(fakeOpenTelemetryGrpc(), 99.999, false, true),
+			opts:   fakeOptsOnlyOpenTelemetryGrpcTelemetryAPI(),
+			want:   fakeTracingConfig(fakeOpenTelemetryGrpcProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "basic config (with opentelemetry provider via http)",
-			inSpec:             fakeTracingSpec(fakeOpenTelemetryHTTP(), 99.999, false, true),
-			opts:               fakeOptsOnlyOpenTelemetryHTTPTelemetryAPI(),
-			want:               fakeTracingConfig(fakeOpenTelemetryHTTPProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+			name:            "basic config (with opentelemetry provider via http)",
+			inSpec:          fakeTracingSpec(fakeOpenTelemetryHTTP(), 99.999, false, true),
+			opts:            fakeOptsOnlyOpenTelemetryHTTPTelemetryAPI(),
+			want:            fakeTracingConfig(fakeOpenTelemetryHTTPProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
 			name:   "basic config (with opentelemetry provider with resource detectors)",
@@ -197,44 +185,40 @@ func TestConfigureTracing(t *testing.T) {
 			opts:   fakeOptsOnlyOpenTelemetryResourceDetectorsTelemetryAPI(),
 			want: fakeTracingConfig(
 				fakeOpenTelemetryResourceDetectorsProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    &defaultUUIDExtensionCtx,
+
+			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 		{
-			name:               "client-only config for server",
-			inSpec:             fakeClientOnlyTracingSpec(fakeSkywalking(), 99.999, false, false),
-			opts:               fakeInboundOptsOnlySkywalkingTelemetryAPI(),
-			want:               nil,
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    nil,
+			name:            "client-only config for server",
+			inSpec:          fakeClientOnlyTracingSpec(fakeSkywalking(), 99.999, false, false),
+			opts:            fakeInboundOptsOnlySkywalkingTelemetryAPI(),
+			want:            nil,
+			wantReqIDExtCtx: nil,
 		},
 		{
-			name:               "server-only config for server",
-			inSpec:             fakeServerOnlyTracingSpec(fakeSkywalking(), 99.999, false, false),
-			opts:               fakeInboundOptsOnlySkywalkingTelemetryAPI(),
-			want:               fakeTracingConfig(fakeSkywalkingProvider(clusterName, authority), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
-			wantStartChildSpan: true,
-			wantReqIDExtCtx:    &requestidextension.UUIDRequestIDExtensionContext{UseRequestIDForTraceSampling: false},
+			name:            "server-only config for skywalking server",
+			inSpec:          fakeServerOnlyTracingSpec(fakeSkywalking(), 99.999, false, false),
+			opts:            fakeInboundOptsOnlySkywalkingTelemetryAPI(),
+			want:            fakeTracingConfigForSkywalking(fakeSkywalkingProvider(clusterName, authority), 99.999, 0, append(defaultTracingTags(), fakeEnvTag)),
+			wantReqIDExtCtx: &requestidextension.UUIDRequestIDExtensionContext{UseRequestIDForTraceSampling: false},
 		},
 		{
-			name:               "invalid provider",
-			inSpec:             fakeTracingSpec(fakePrometheus(), 99.999, false, true),
-			opts:               fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
-			want:               nil,
-			wantStartChildSpan: false,
-			wantReqIDExtCtx:    nil,
+			name:            "invalid provider",
+			inSpec:          fakeTracingSpec(fakePrometheus(), 99.999, false, true),
+			opts:            fakeOptsMeshAndTelemetryAPI(true /* enable tracing */),
+			want:            nil,
+			wantReqIDExtCtx: nil,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			hcm := &hcm.HttpConnectionManager{}
-			startChildSpan, gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.opts.push, tc.opts.proxy, hcm, 0)
+			gotReqIDExtCtx := configureTracingFromTelemetry(tc.inSpec, tc.opts.push, tc.opts.proxy, hcm, 0)
 			if diff := cmp.Diff(tc.want, hcm.Tracing, protocmp.Transform()); diff != "" {
 				t.Fatalf("configureTracing returned unexpected diff (-want +got):\n%s", diff)
 			}
 			assert.Equal(t, tc.want, hcm.Tracing)
-			assert.Equal(t, startChildSpan, tc.wantStartChildSpan)
 			assert.Equal(t, tc.wantReqIDExtCtx, gotReqIDExtCtx)
 		})
 	}
@@ -1063,6 +1047,12 @@ func fakeTracingConfig(provider *tracingcfg.Tracing_Http, randomSampling float64
 		t.Provider = provider
 	}
 	return t
+}
+
+func fakeTracingConfigForSkywalking(provider *tracingcfg.Tracing_Http, randomSampling float64, maxLen uint32, tags []*tracing.CustomTag) *hcm.HttpConnectionManager_Tracing {
+	cfg := fakeTracingConfig(provider, randomSampling, maxLen, tags)
+	cfg.SpawnUpstreamSpan = wrapperspb.Bool(true)
+	return cfg
 }
 
 var fakeEnvTag = &tracing.CustomTag{

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -1049,6 +1049,7 @@ func fakeTracingConfig(provider *tracingcfg.Tracing_Http, randomSampling float64
 	return t
 }
 
+// nolint: lll
 func fakeTracingConfigForSkywalking(provider *tracingcfg.Tracing_Http, randomSampling float64, maxLen uint32, tags []*tracing.CustomTag) *hcm.HttpConnectionManager_Tracing {
 	cfg := fakeTracingConfig(provider, randomSampling, maxLen, tags)
 	cfg.SpawnUpstreamSpan = wrapperspb.Bool(true)


### PR DESCRIPTION
**Please provide a description of this PR:**

xref: https://github.com/envoyproxy/envoy/pull/29659


TODO: consider enable `SpawnUpstreamSpan` for all trace provider?