### PR TITLE
helm: support configurable automountServiceAccountToken

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
       {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 8 }}

--- a/manifests/charts/gateway/templates/serviceaccount.yaml
+++ b/manifests/charts/gateway/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "gateway.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -197,6 +197,9 @@
             }
           }
         },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
         "serviceAccount": {
           "type": "object",
           "properties": {
@@ -207,6 +210,9 @@
               "type": "string"
             },
             "create": {
+              "type": "boolean"
+            },
+            "automountServiceAccountToken": {
               "type": "boolean"
             }
           }

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -10,6 +10,9 @@ defaults:
 
   kind: Deployment
 
+  # Automounting API credentials for the pods.
+  automountServiceAccountToken: true
+
   rbac:
     # If enabled, roles will be created to enable accessing certificates from Gateways. This is not needed
     # when using http://gateway-api.org/.
@@ -18,6 +21,8 @@ defaults:
   serviceAccount:
     # If set, a service account will be created. Otherwise, the default is used
     create: true
+    # Automount API credentials for a Service Account, defaults to true.
+    automountServiceAccountToken: true
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -75,6 +75,7 @@ spec:
 {{- toYaml . | nindent 8 }}
 {{- end }}
       serviceAccountName: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+      automountServiceAccountToken: {{ .Values.pilot.automountServiceAccountToken | default true }}
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.pilot.serviceAccountAutomountServiceAccountToken | default true }}
   {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range .Values.global.imagePullSecrets }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -53,10 +53,14 @@ defaults:
     # Additional volumes to the istiod pod
     volumes: []
 
+    # Configurable automountServiceAccountToken field for the deployment
+    automountServiceAccountToken: true
     nodeSelector: {}
     podAnnotations: {}
     serviceAnnotations: {}
     serviceAccountAnnotations: {}
+    # Automount the ServiceAccount token, defaults to true
+    serviceAccountAutomountServiceAccountToken: true
 
     topologySpreadConstraints: []
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Keeps the `automountServiceAccountToken` defaulting to `true` just as before for ServiceAccounts/Deployments.

It makes it configurable though for cases such as with Azure AKS Security policy which scans for any pod/SA that have it set to `true` and instead recommended as part of their security benchmarks to disable auto-mounting and injecting the service account tokens as extra volumes/volumeMounts explicitly for each workload that requires it: [Kubernetes clusters should disable automounting API credentials](https://portal.azure.com/#blade/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2F423dd1ba-798e-40e4-9c4d-b6902674b423)

A similar [thread](https://github.com/cert-manager/cert-manager/issues/5254) on this from `cert-manager` and [hardened values](https://cert-manager.io/docs/installation/best-practice/#best-practice-helm-chart-values) for such setups & [rationale](https://cert-manager.io/docs/installation/best-practice/#restrict-auto-mount-of-service-account-tokens) behind it.