### PR TITLE
ambient: fix node filter

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -138,7 +138,10 @@ func New(options Options) Index {
 	GatewayClasses := krt.WrapClient[*v1beta1.GatewayClass](gatewayClassClient, krt.WithName("GatewayClasses"))
 
 	Services := krt.NewInformerFiltered[*v1.Service](options.Client, filter, krt.WithName("Services"))
-	Nodes := krt.NewInformerFiltered[*v1.Node](options.Client, filter, krt.WithName("Nodes"))
+	Nodes := krt.NewInformerFiltered[*v1.Node](options.Client, kclient.Filter{
+		ObjectFilter:    options.Client.ObjectFilter(),
+		ObjectTransform: kubeclient.StripNodeUnusedFields,
+	}, krt.WithName("Nodes"))
 	Pods := krt.NewInformerFiltered[*v1.Pod](options.Client, kclient.Filter{
 		ObjectFilter:    options.Client.ObjectFilter(),
 		ObjectTransform: kubeclient.StripPodUnusedFields,


### PR DESCRIPTION
We have test assertion that ensures we use the same filter everywhere;
make sure we use it here as well.

See
https://storage.googleapis.com/istio-prow/logs/integ-assertion_istio_postsubmit/1777414345316110336/artifacts/ambient-e522794887874c3bb2a1d78/_suite_context/istio-state-1166045208/primary-0/istiod-764d6c499b-wmqfc_discovery.previous.log
