### PR TITLE
krt: allow lookup by Index, replace Namespace logic with Index

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -158,8 +158,8 @@ func New(options Options) Index {
 
 	// these are workloadapi-style services combined from kube services and service entries
 	WorkloadServices := a.ServicesCollection(Services, ServiceEntries, Waypoints, Namespaces)
-	ServiceAddressIndex := krt.CreateIndex[model.ServiceInfo, networkAddress](WorkloadServices, networkAddressFromService)
-	ServiceInfosByOwningWaypoint := krt.CreateIndex[model.ServiceInfo, networkAddress](WorkloadServices, func(s model.ServiceInfo) []networkAddress {
+	ServiceAddressIndex := krt.NewIndex[model.ServiceInfo, networkAddress](WorkloadServices, networkAddressFromService)
+	ServiceInfosByOwningWaypoint := krt.NewIndex[model.ServiceInfo, networkAddress](WorkloadServices, func(s model.ServiceInfo) []networkAddress {
 		// Filter out waypoint services
 		if s.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -203,11 +203,11 @@ func New(options Options) Index {
 		AllPolicies,
 		Namespaces,
 	)
-	WorkloadAddressIndex := krt.CreateIndex[model.WorkloadInfo, networkAddress](Workloads, networkAddressFromWorkload)
-	WorkloadServiceIndex := krt.CreateIndex[model.WorkloadInfo, string](Workloads, func(o model.WorkloadInfo) []string {
+	WorkloadAddressIndex := krt.NewIndex[model.WorkloadInfo, networkAddress](Workloads, networkAddressFromWorkload)
+	WorkloadServiceIndex := krt.NewIndex[model.WorkloadInfo, string](Workloads, func(o model.WorkloadInfo) []string {
 		return maps.Keys(o.Services)
 	})
-	WorkloadWaypointIndex := krt.CreateIndex[model.WorkloadInfo, networkAddress](Workloads, func(w model.WorkloadInfo) []networkAddress {
+	WorkloadWaypointIndex := krt.NewIndex[model.WorkloadInfo, networkAddress](Workloads, func(w model.WorkloadInfo) []networkAddress {
 		// Filter out waypoints.
 		if w.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
@@ -324,7 +324,7 @@ func (a *index) All() []model.AddressInfo {
 		index int
 	}
 	addrm := map[netip.Addr]kindindex{}
-	for _, wl := range a.workloads.List("") {
+	for _, wl := range a.workloads.List() {
 		overwrite := -1
 		write := true
 		for _, addr := range wl.Addresses {
@@ -356,7 +356,7 @@ func (a *index) All() []model.AddressInfo {
 			}
 		}
 	}
-	for _, s := range a.services.List("") {
+	for _, s := range a.services.List() {
 		res = append(res, serviceToAddressInfo(s.Service))
 	}
 	return res

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -605,7 +605,7 @@ func TestAmbientIndex_WaypointInboundBinding(t *testing.T) {
 	})
 	s.addWaypoint(t, "1.2.3.4", "proxy-sandwich", constants.AllTraffic, true)
 	// TODO needing this check seems suspicious. We should really wait for up to 2 pod events.
-	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List("")) }, 1)
+	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List()) }, 1)
 
 	s.addPods(t, "10.0.0.1", "proxy-sandwich-instance", "", map[string]string{constants.GatewayNameLabel: "proxy-sandwich"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("proxy-sandwich-instance"))
@@ -1315,7 +1315,7 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 	s.addWaypoint(t, "10.0.0.1", "waypoint-ns", constants.WorkloadTraffic, true)
 	s.addWaypoint(t, "10.0.0.2", "waypoint-sa1", constants.WorkloadTraffic, true)
 	// Wait until waypoints are available
-	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List("")) }, 2)
+	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List()) }, 2)
 
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
@@ -1367,7 +1367,7 @@ func TestWorkloadsForWaypointOrder(t *testing.T) {
 	}
 	s.addWaypoint(t, "10.0.0.1", "waypoint", constants.WorkloadTraffic, true)
 	// Wait until waypoint is available
-	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List("")) }, 1)
+	assert.EventuallyEqual(t, func() int { return len(s.waypoints.List()) }, 1)
 
 	// expected order is pod3, pod1, pod2, which is the order of creation
 	s.addPods(t,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
@@ -20,8 +20,6 @@ import (
 	"strconv"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"istio.io/api/security/v1beta1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
@@ -38,7 +36,7 @@ const (
 
 func (a *index) Policies(requested sets.Set[model.ConfigKey]) []model.WorkloadAuthorization {
 	// TODO: use many Gets instead of List?
-	cfgs := a.authorizationPolicies.List(metav1.NamespaceAll)
+	cfgs := a.authorizationPolicies.List()
 	l := len(cfgs)
 	if len(requested) > 0 {
 		l = len(requested)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/meshconfig.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/meshconfig.go
@@ -18,6 +18,7 @@ package ambient
 import (
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
@@ -44,9 +45,11 @@ func MeshConfigCollection(ConfigMaps krt.Collection[*v1.ConfigMap], options Opti
 			meshCfg := mesh.DefaultMeshConfig()
 			cms := []*v1.ConfigMap{}
 			if features.SharedMeshConfig != "" {
-				cms = AppendNonNil(cms, krt.FetchOne(ctx, ConfigMaps, krt.FilterName(features.SharedMeshConfig, options.SystemNamespace)))
+				cms = AppendNonNil(cms, krt.FetchOne(ctx, ConfigMaps,
+					krt.FilterObjectName(types.NamespacedName{Name: features.SharedMeshConfig, Namespace: options.SystemNamespace})))
 			}
-			cms = AppendNonNil(cms, krt.FetchOne(ctx, ConfigMaps, krt.FilterName(cmName, options.SystemNamespace)))
+			cms = AppendNonNil(cms, krt.FetchOne(ctx, ConfigMaps,
+				krt.FilterObjectName(types.NamespacedName{Name: cmName, Namespace: options.SystemNamespace})))
 
 			for _, c := range cms {
 				n, err := mesh.ApplyMeshConfig(meshConfigMapData(c), meshCfg)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -311,7 +311,8 @@ func TestPodWorkloads(t *testing.T) {
 			Namespaces := krt.NewStaticCollection(extractType[*v1.Namespace](&inputs))
 			Nodes := krt.NewStaticCollection(extractType[*v1.Node](&inputs))
 			assert.Equal(t, len(inputs), 0, fmt.Sprintf("some inputs were not consumed: %v", inputs))
-			builder := a.podWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices, Namespaces, Nodes)
+			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			builder := a.podWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices, WorkloadServicesNamespaceIndex, Namespaces, Nodes)
 			wrapper := builder(krt.TestingDummyContext{}, tt.pod)
 			var res *workloadapi.Workload
 			if wrapper != nil {
@@ -561,7 +562,16 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 			Namespaces := krt.NewStaticCollection(extractType[*v1.Namespace](&inputs))
 			MeshConfig := krt.NewStatic(&MeshConfig{slices.First(extractType[meshapi.MeshConfig](&inputs))})
 			assert.Equal(t, len(inputs), 0, fmt.Sprintf("some inputs were not consumed: %v", inputs))
-			builder := a.workloadEntryWorkloadBuilder(MeshConfig, AuthorizationPolicies, PeerAuths, Waypoints, WorkloadServices, Namespaces)
+			WorkloadServicesNamespaceIndex := krt.NewNamespaceIndex(WorkloadServices)
+			builder := a.workloadEntryWorkloadBuilder(
+				MeshConfig,
+				AuthorizationPolicies,
+				PeerAuths,
+				Waypoints,
+				WorkloadServices,
+				WorkloadServicesNamespaceIndex,
+				Namespaces,
+			)
 			wrapper := builder(krt.TestingDummyContext{}, tt.we)
 			var res *workloadapi.Workload
 			if wrapper != nil {

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -437,7 +437,7 @@ func (h *manyCollection[I, O]) objectChanged(iKey Key[I], dependencies []depende
 		// For each input, we will check if it depends on this event.
 		// We use Items() to check both the old and new object; we will recompute if either matched
 		for _, item := range ev.Items() {
-			match := dep.filter.Matches(item)
+			match := dep.filter.Matches(item, false)
 			if h.log.DebugEnabled() {
 				h.log.WithLabels("item", iKey, "match", match).Debugf("dependency change for collection %T", sourceCollection)
 			}
@@ -463,21 +463,10 @@ func (h *manyCollection[I, O]) GetKey(k Key[O]) (res *O) {
 	return nil
 }
 
-func (h *manyCollection[I, O]) List(namespace string) (res []O) {
+func (h *manyCollection[I, O]) List() (res []O) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if namespace == "" {
-		res = maps.Values(h.collectionState.outputs)
-	} else {
-		// Future improvement: shard outputs by namespace so we can query more efficiently
-		for _, v := range h.collectionState.outputs {
-			if getNamespace(v) == namespace {
-				res = append(res, v)
-			}
-		}
-		return
-	}
-	return
+	return maps.Values(h.collectionState.outputs)
 }
 
 func (h *manyCollection[I, O]) Register(f func(o Event[O])) Syncer {

--- a/pkg/kube/krt/collection_test.go
+++ b/pkg/kube/krt/collection_test.go
@@ -435,7 +435,7 @@ func CompareUnordered(wants ...string) func(s string) bool {
 
 func fetcherSorted[T krt.ResourceNamer](c krt.Collection[T]) func() []T {
 	return func() []T {
-		return slices.SortBy(c.List(""), func(t T) string {
+		return slices.SortBy(c.List(), func(t T) string {
 			return t.ResourceName()
 		})
 	}

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -24,13 +24,12 @@ var log = istiolog.RegisterScope("krt", "")
 // Collection is the core resource type for krt, representing a collection of objects. Items can be listed, or fetched
 // directly. Most importantly, consumers can subscribe to events when objects change.
 type Collection[T any] interface {
-	// GetKey returns an object by it's key, if present. Otherwise, nil is returned.
+	// GetKey returns an object by its key, if present. Otherwise, nil is returned.
 	GetKey(k Key[T]) *T
 
-	// List returns all objects in the queried namespace.
+	// List returns all objects in the collection.
 	// Order of the list is undefined.
-	// Note: not all T types have a "Namespace"; a non-empty namespace is only valid for types that do have a namespace.
-	List(namespace string) []T
+	List() []T
 
 	EventStream[T]
 }

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -40,10 +40,16 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 
 	// Now we can do the real fetching
 	var res []T
-	for _, i := range c.List(d.filter.namespace) {
+	var list []T
+	if d.filter.listFromIndex != nil {
+		list = d.filter.listFromIndex().([]T)
+	} else {
+		list = c.List()
+	}
+	for _, i := range list {
 		i := i
 		o := c.augment(i)
-		if d.filter.Matches(o) {
+		if d.filter.Matches(o, true) {
 			res = append(res, i)
 		}
 	}

--- a/pkg/kube/krt/index_test.go
+++ b/pkg/kube/krt/index_test.go
@@ -1,0 +1,148 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package krt_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestIndex(t *testing.T) {
+	c := kube.NewFakeClient()
+	kpc := kclient.New[*corev1.Pod](c)
+	pc := clienttest.Wrap(t, kpc)
+	pods := krt.WrapClient[*corev1.Pod](kpc)
+	stop := test.NewStop(t)
+	c.RunAndWait(stop)
+	SimplePods := SimplePodCollection(pods)
+	tt := assert.NewTracker[string](t)
+	IPIndex := krt.NewIndex[SimplePod, string](SimplePods, func(o SimplePod) []string {
+		return []string{o.IP}
+	})
+	fetchSorted := func(ip string) []SimplePod {
+		return slices.SortBy(IPIndex.Lookup(ip), func(t SimplePod) string {
+			return t.ResourceName()
+		})
+	}
+
+	SimplePods.Register(TrackerHandler[SimplePod](tt))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
+	}
+	pc.CreateOrUpdateStatus(pod)
+	tt.WaitUnordered("add/namespace/name")
+	assert.Equal(t, fetchSorted("1.2.3.4"), []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.4"}})
+
+	pod.Status.PodIP = "1.2.3.5"
+	pc.UpdateStatus(pod)
+	tt.WaitUnordered("update/namespace/name")
+	assert.Equal(t, fetchSorted("1.2.3.4"), []SimplePod{})
+	assert.Equal(t, fetchSorted("1.2.3.5"), []SimplePod{{NewNamed(pod), Labeled{}, "1.2.3.5"}})
+
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name2",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.5"},
+	}
+	pc.CreateOrUpdateStatus(pod2)
+	tt.WaitUnordered("add/namespace/name2")
+	assert.Equal(t, fetchSorted("1.2.3.5"), []SimplePod{
+		{NewNamed(pod), Labeled{}, "1.2.3.5"},
+		{NewNamed(pod2), Labeled{}, "1.2.3.5"},
+	})
+
+	pc.Delete(pod.Name, pod.Namespace)
+	pc.Delete(pod2.Name, pod2.Namespace)
+	tt.WaitUnordered("delete/namespace/name", "delete/namespace/name2")
+	assert.Equal(t, fetchSorted("1.2.3.4"), []SimplePod{})
+}
+
+func TestIndexCollection(t *testing.T) {
+	c := kube.NewFakeClient()
+	kpc := kclient.New[*corev1.Pod](c)
+	pc := clienttest.Wrap(t, kpc)
+	pods := krt.WrapClient[*corev1.Pod](kpc)
+	stop := test.NewStop(t)
+	c.RunAndWait(stop)
+	SimplePods := SimplePodCollection(pods)
+	tt := assert.NewTracker[string](t)
+	IPIndex := krt.NewIndex[SimplePod, string](SimplePods, func(o SimplePod) []string {
+		return []string{o.IP}
+	})
+	Collection := krt.NewSingleton[string](func(ctx krt.HandlerContext) *string {
+		pods := krt.Fetch(ctx, SimplePods, krt.FilterIndex(IPIndex, "1.2.3.5"))
+		names := slices.Sort(slices.Map(pods, SimplePod.ResourceName))
+		return ptr.Of(strings.Join(names, ","))
+	})
+	Collection.AsCollection().Synced().WaitUntilSynced(stop)
+	fetchSorted := func(ip string) []SimplePod {
+		return slices.SortBy(IPIndex.Lookup(ip), func(t SimplePod) string {
+			return t.ResourceName()
+		})
+	}
+
+	SimplePods.Register(TrackerHandler[SimplePod](tt))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.4"},
+	}
+	pc.CreateOrUpdateStatus(pod)
+	tt.WaitUnordered("add/namespace/name")
+	assert.Equal(t, Collection.Get(), ptr.Of(""))
+
+	pod.Status.PodIP = "1.2.3.5"
+	pc.UpdateStatus(pod)
+	tt.WaitUnordered("update/namespace/name")
+	assert.Equal(t, Collection.Get(), ptr.Of("namespace/name"))
+
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name2",
+			Namespace: "namespace",
+		},
+		Status: corev1.PodStatus{PodIP: "1.2.3.5"},
+	}
+	pc.CreateOrUpdateStatus(pod2)
+	tt.WaitUnordered("add/namespace/name2")
+	assert.Equal(t, Collection.Get(), ptr.Of("namespace/name,namespace/name2"))
+
+	pc.Delete(pod.Name, pod.Namespace)
+	pc.Delete(pod2.Name, pod2.Namespace)
+	tt.WaitUnordered("delete/namespace/name", "delete/namespace/name2")
+	assert.Equal(t, fetchSorted("1.2.3.4"), []SimplePod{})
+}

--- a/pkg/kube/krt/informer_test.go
+++ b/pkg/kube/krt/informer_test.go
@@ -44,7 +44,7 @@ func TestNewInformer(t *testing.T) {
 	tt := assert.NewTracker[string](t)
 	ConfigMaps.Register(TrackerHandler[*corev1.ConfigMap](tt))
 
-	assert.Equal(t, ConfigMaps.List(""), nil)
+	assert.Equal(t, ConfigMaps.List(), nil)
 
 	cmA := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -67,15 +67,15 @@ func TestNewInformer(t *testing.T) {
 	}
 	cmt.Create(cmA)
 	tt.WaitOrdered("add/ns/a")
-	assert.Equal(t, ConfigMaps.List(""), []*corev1.ConfigMap{cmA})
+	assert.Equal(t, ConfigMaps.List(), []*corev1.ConfigMap{cmA})
 
 	cmt.Update(cmA2)
 	tt.WaitOrdered("update/ns/a")
-	assert.Equal(t, ConfigMaps.List(""), []*corev1.ConfigMap{cmA2})
+	assert.Equal(t, ConfigMaps.List(), []*corev1.ConfigMap{cmA2})
 
 	cmt.Create(cmB)
 	tt.WaitOrdered("add/ns/b")
-	assert.Equal(t, slices.SortBy(ConfigMaps.List(""), func(a *corev1.ConfigMap) string { return a.Name }), []*corev1.ConfigMap{cmA2, cmB})
+	assert.Equal(t, slices.SortBy(ConfigMaps.List(), func(a *corev1.ConfigMap) string { return a.Name }), []*corev1.ConfigMap{cmA2, cmB})
 
 	assert.Equal(t, ConfigMaps.GetKey("ns/b"), &cmB)
 	assert.Equal(t, ConfigMaps.GetKey("ns/a"), &cmA2)
@@ -124,5 +124,5 @@ func TestUnregisteredTypeCollection(t *testing.T) {
 	))
 	npcoll := krt.NewInformer[*v1.NetworkPolicy](c)
 	c.RunAndWait(test.NewStop(t))
-	assert.Equal(t, npcoll.List(""), []*v1.NetworkPolicy{np})
+	assert.Equal(t, npcoll.List(), []*v1.NetworkPolicy{np})
 }

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -120,16 +120,6 @@ type registerDependency interface {
 	name() string
 }
 
-// getName returns the name for an object, if possible.
-// Warning: this will panic if the name is not available.
-func getName(a any) string {
-	ak, ok := a.(Namer)
-	if ok {
-		return ak.GetName()
-	}
-	panic(fmt.Sprintf("No Name, got %T %+v", a, a))
-}
-
 // tryGetKey returns the Key for an object. If not possible, returns false
 func tryGetKey[O any](a O) (Key[O], bool) {
 	as, ok := any(a).(string)
@@ -154,20 +144,6 @@ func tryGetKey[O any](a O) (Key[O], bool) {
 		return *ack, true
 	}
 	return "", false
-}
-
-// getNamespace returns the namespace for an object, if possible.
-// Warning: this will panic if the namespace is not available.
-func getNamespace(a any) string {
-	ak, ok := a.(Namespacer)
-	if ok {
-		return ak.GetNamespace()
-	}
-	pk, ok := any(&a).(Namespacer)
-	if ok {
-		return pk.GetNamespace()
-	}
-	panic(fmt.Sprintf("No Namespace, got %T", a))
 }
 
 // getLabels returns the labels for an object, if possible.

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -41,10 +41,10 @@ func (j *join[T]) GetKey(k Key[T]) *T {
 	return ptr.Of(j.merge(found))
 }
 
-func (j *join[T]) List(namespace string) []T {
+func (j *join[T]) List() []T {
 	res := map[Key[T]][]T{}
 	for _, c := range j.collections {
-		for _, i := range c.List(namespace) {
+		for _, i := range c.List() {
 			key := GetKey(i)
 			res[key] = append(res[key], i)
 		}

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -59,7 +59,7 @@ func TestJoinCollection(t *testing.T) {
 	}
 	assert.Equal(
 		t,
-		slices.SortBy(j.List(""), sortf),
+		slices.SortBy(j.List(), sortf),
 		slices.SortBy([]Named{
 			{"c1", "b"},
 			{"c2", "a"},
@@ -90,7 +90,7 @@ func TestCollectionJoin(t *testing.T) {
 	SimpleEndpoints := SimpleEndpointsCollection(AllPods, AllServices)
 
 	fetch := func() []SimpleEndpoint {
-		return slices.SortBy(SimpleEndpoints.List(""), func(s SimpleEndpoint) string { return s.ResourceName() })
+		return slices.SortBy(SimpleEndpoints.List(), func(s SimpleEndpoint) string { return s.ResourceName() })
 	}
 
 	assert.Equal(t, fetch(), nil)

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -53,7 +53,7 @@ func (d *static[T]) GetKey(k Key[T]) *T {
 	return d.val.Load()
 }
 
-func (d *static[T]) List(namespace string) []T {
+func (d *static[T]) List() []T {
 	v := d.val.Load()
 	if v == nil {
 		return nil
@@ -140,7 +140,7 @@ func (c collectionAdapter[T]) Set(t *T) {
 
 func (c collectionAdapter[T]) Get() *T {
 	// Guaranteed to be 0 or 1 len
-	res := c.c.List("")
+	res := c.c.List()
 	if len(res) == 0 {
 		return nil
 	}

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -14,7 +14,11 @@
 
 package krt
 
-import "istio.io/istio/pkg/maps"
+import (
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
+)
 
 type staticList[T any] struct {
 	vals map[Key[T]]T
@@ -49,22 +53,12 @@ func (s *staticList[T]) augment(a any) any {
 	return a
 }
 
-func (s *staticList[T]) List(namespace string) []T {
-	if namespace == "" {
-		return maps.Values(s.vals)
-	}
-	var res []T
-	// Future improvement: shard outputs by namespace so we can query more efficiently
-	for _, v := range s.vals {
-		if getNamespace(v) == namespace {
-			res = append(res, v)
-		}
-	}
-	return res
+func (s *staticList[T]) List() []T {
+	return maps.Values(s.vals)
 }
 
 func (s *staticList[T]) Register(f func(o Event[T])) Syncer {
-	panic("StaticCollection does not support event handlers")
+	return registerHandlerAsBatched(s, f)
 }
 
 func (s *staticList[T]) Synced() Syncer {
@@ -72,7 +66,15 @@ func (s *staticList[T]) Synced() Syncer {
 }
 
 func (s *staticList[T]) RegisterBatch(f func(o []Event[T]), runExistingState bool) Syncer {
-	panic("StaticCollection does not support event handlers")
+	if runExistingState {
+		f(slices.Map(s.List(), func(e T) Event[T] {
+			return Event[T]{
+				New:   &e,
+				Event: controllers.EventAdd,
+			}
+		}))
+	}
+	return alwaysSynced{}
 }
 
 var _ internalCollection[any] = &staticList[any]{}


### PR DESCRIPTION
This PR introduces a few changes:
* Allow Fetching by an Index. This is going to be used directly in some followup work
* Rewrite Namespace lookup/list to use an Index on Namespace. Before, the namespace was just a post-applied filtering anyways. We also didn't use any listing by a certain namespace anyways


A modest perf improvement (though the benchmark doesn't use it as effectively as future PR will, so its not the primary motivation):

```
name                   old time/op    new time/op    delta
Controllers/krt-16       14.7ms ± 4%    12.2ms ± 6%  -17.40%  (p=0.000 n=10+9)

name                   old alloc/op   new alloc/op   delta
Controllers/krt-16       16.0MB ± 0%    14.9MB ± 0%   -6.41%  (p=0.000 n=10+9)

name                   old allocs/op  new allocs/op  delta
Controllers/krt-16         125k ± 0%      122k ± 0%   -2.36%  (p=0.000 n=10+9)

```