### PR TITLE
Idempotency for istio-iptables apply flow

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -424,10 +424,10 @@ func (cfg *IptablesConfigurator) executeCommands(log *istiolog.Scope, iptablesBu
 
 	if cfg.cfg.RestoreFormat {
 		// Execute iptables-restore
-		execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(log, iptablesBuilder, &cfg.iptV, true))
+		execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(log, iptablesBuilder.BuildV4Restore(), &cfg.iptV))
 		// Execute ip6tables-restore
 		if cfg.cfg.EnableIPv6 {
-			execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(log, iptablesBuilder, &cfg.ipt6V, false))
+			execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(log, iptablesBuilder.BuildV6Restore(), &cfg.ipt6V))
 		}
 	} else {
 		// Execute iptables commands
@@ -453,19 +453,10 @@ func (cfg *IptablesConfigurator) executeIptablesCommands(iptVer *dep.IptablesVer
 
 func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(
 	log *istiolog.Scope,
-	iptablesBuilder *builder.IptablesRuleBuilder,
+	data string,
 	iptVer *dep.IptablesVersion,
-	isIpv4 bool,
 ) error {
 	cmd := iptablesconstants.IPTablesRestore
-	var data string
-
-	if isIpv4 {
-		data = iptablesBuilder.BuildV4Restore()
-	} else {
-		data = iptablesBuilder.BuildV6Restore()
-	}
-
 	log.Infof("Running %s with the following input:\n%v", iptVer.CmdToString(cmd), strings.TrimSpace(data))
 	// --noflush to prevent flushing/deleting previous contents from table
 	return cfg.ext.Run(cmd, iptVer, strings.NewReader(data), "--noflush", "-v")

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -234,6 +234,10 @@ func getRules(b []byte) map[string]string {
 	for _, table := range parts {
 		// If table is not empty, get table name from the first line
 		lines := strings.Split(strings.Trim(table, "\n"), "\n")
+		lines = slices.Filter(lines, func(line string) bool {
+			return line != "iptables-save" && line != "ip6tables-save"
+		})
+
 		if len(lines) >= 1 && strings.HasPrefix(lines[0], "* ") {
 			tableName := lines[0][2:]
 			lines = append(lines, "COMMIT")

--- a/releasenotes/notes/50328.yaml
+++ b/releasenotes/notes/50328.yaml
@@ -1,0 +1,18 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issues:
+  - 30393
+  - 42792
+releaseNotes:
+- |
+  **Fixed** Allow for re-executions of istio-iptables by skipping apply step if existing rules are compatible.
+---
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** `--cleanup-only` option to istio-iptables to perform a cleanup of chains/rules without creating new ones.
+- |
+  **Added** `--reconcile` option to reconcile iptables if existing chains/rules are found and a drift with the desired state is detected.

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"strings"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
-	"istio.io/istio/tools/istio-iptables/pkg/log"
+	iptableslog "istio.io/istio/tools/istio-iptables/pkg/log"
 )
 
 // Rule represents iptables rule - chain, table and options
@@ -59,14 +60,14 @@ func NewIptablesRuleBuilder(cfg *config.Config) *IptablesRuleBuilder {
 	}
 }
 
-func (rb *IptablesRuleBuilder) InsertRule(command log.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) InsertRule(command iptableslog.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
 	rb.InsertRuleV4(command, chain, table, position, params...)
 	rb.InsertRuleV6(command, chain, table, position, params...)
 	return rb
 }
 
 // nolint lll
-func (rb *IptablesRuleBuilder) insertInternal(ipt *[]Rule, command log.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) insertInternal(ipt *[]Rule, command iptableslog.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
 	rules := params
 	*ipt = append(*ipt, Rule{
 		chain:  chain,
@@ -74,9 +75,12 @@ func (rb *IptablesRuleBuilder) insertInternal(ipt *[]Rule, command log.Command, 
 		params: append([]string{"-I", chain, fmt.Sprint(position)}, rules...),
 	})
 	idx := indexOf("-j", params)
+	if idx < 0 && !strings.HasPrefix(chain, "ISTIO_") {
+		log.Warnf("Inserting non-jump rule in non-Istio chain (rule: %s) \n", strings.Join(params, " "))
+	}
 	// We have identified the type of command this is and logging is enabled. Insert a rule to log this chain was hit.
 	// Since this is insert we do this *after* the real chain, which will result in it bumping it forward
-	if rb.cfg.TraceLogging && idx >= 0 && command != log.UndefinedCommand {
+	if rb.cfg.TraceLogging && idx >= 0 && command != iptableslog.UndefinedCommand {
 		match := params[:idx]
 		// 1337 group is just a random constant to be matched on the log reader side
 		// Size of 20 allows reading the IPv4 IP header.
@@ -90,11 +94,11 @@ func (rb *IptablesRuleBuilder) insertInternal(ipt *[]Rule, command log.Command, 
 	return rb
 }
 
-func (rb *IptablesRuleBuilder) InsertRuleV4(command log.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) InsertRuleV4(command iptableslog.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
 	return rb.insertInternal(&rb.rules.rulesv4, command, chain, table, position, params...)
 }
 
-func (rb *IptablesRuleBuilder) InsertRuleV6(command log.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) InsertRuleV6(command iptableslog.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
 	if !rb.cfg.EnableIPv6 {
 		return rb
 	}
@@ -110,10 +114,13 @@ func indexOf(element string, data []string) int {
 	return -1 // not found.
 }
 
-func (rb *IptablesRuleBuilder) appendInternal(ipt *[]Rule, command log.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) appendInternal(ipt *[]Rule, command iptableslog.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
 	idx := indexOf("-j", params)
+	if idx < 0 && !strings.HasPrefix(chain, "ISTIO_") {
+		log.Warnf("Appending non-jump rule in non-Istio chain (rule: %s) \n", strings.Join(params, " "))
+	}
 	// We have identified the type of command this is and logging is enabled. Appending a rule to log this chain will be hit
-	if rb.cfg.TraceLogging && idx >= 0 && command != log.UndefinedCommand {
+	if rb.cfg.TraceLogging && idx >= 0 && command != iptableslog.UndefinedCommand {
 		match := params[:idx]
 		// 1337 group is just a random constant to be matched on the log reader side
 		// Size of 20 allows reading the IPv4 IP header.
@@ -133,17 +140,17 @@ func (rb *IptablesRuleBuilder) appendInternal(ipt *[]Rule, command log.Command, 
 	return rb
 }
 
-func (rb *IptablesRuleBuilder) AppendRuleV4(command log.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) AppendRuleV4(command iptableslog.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
 	return rb.appendInternal(&rb.rules.rulesv4, command, chain, table, params...)
 }
 
-func (rb *IptablesRuleBuilder) AppendRule(command log.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) AppendRule(command iptableslog.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
 	rb.AppendRuleV4(command, chain, table, params...)
 	rb.AppendRuleV6(command, chain, table, params...)
 	return rb
 }
 
-func (rb *IptablesRuleBuilder) AppendRuleV6(command log.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
+func (rb *IptablesRuleBuilder) AppendRuleV6(command iptableslog.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
 	if !rb.cfg.EnableIPv6 {
 		return rb
 	}
@@ -172,12 +179,177 @@ func (rb *IptablesRuleBuilder) buildRules(rules []Rule) [][]string {
 	return output
 }
 
+func reverseRules(rules []*Rule) []*Rule {
+	output := make([]*Rule, 0)
+	for _, r := range rules {
+		var modifiedParams []string
+		skip := false
+		insertIndex := -1
+		for i, element := range r.params {
+			// insert index of a previous -I flag must be skipped
+			if insertIndex >= 0 && i == insertIndex+2 {
+				continue
+			}
+			if element == "-A" || element == "--append" {
+				// -A/--append is transformed to -D
+				modifiedParams = append(modifiedParams, "-D")
+			} else if element == "-I" || element == "--insert" {
+				// -I/--insert is transformed to -D, insert index at i+2 must be skipped
+				insertIndex = i
+				modifiedParams = append(modifiedParams, "-D")
+			} else {
+				// Every other flag/value is kept as it is
+				modifiedParams = append(modifiedParams, element)
+			}
+
+			if ((element == "-A" || element == "--append") || (element == "-I" || element == "--insert")) &&
+				i < len(r.params)-1 && strings.HasPrefix(r.params[i+1], "ISTIO_") {
+				// Ignore every non-jump rule in ISTIO_* chains as we will flush the chain anyway
+				skip = true
+			} else if (element == "-j" || element == "--jump") && i < len(r.params)-1 && strings.HasPrefix(r.params[i+1], "ISTIO_") {
+				// Override previous skip if this is a jump-rule
+				skip = false
+			}
+		}
+		if skip {
+			continue
+		}
+
+		output = append(output, &Rule{
+			chain:  r.chain,
+			table:  r.table,
+			params: modifiedParams,
+		})
+	}
+	log.Debugf("Reversed rules to %+v", output)
+	return output
+}
+
+func checkRules(rules []*Rule) []*Rule {
+	output := make([]*Rule, 0)
+	for _, r := range rules {
+		var modifiedParams []string
+		insertIndex := -1
+		for i, element := range r.params {
+			// insert index of a previous -I flag must be skipped
+			if insertIndex >= 0 && i == insertIndex+2 {
+				continue
+			}
+			if element == "-A" || element == "--append" {
+				// -A/--append is transformed to -D
+				modifiedParams = append(modifiedParams, "-C")
+			} else if element == "-I" || element == "--insert" {
+				// -I/--insert is transformed to -D, insert index at i+2 must be skipped
+				insertIndex = i
+				modifiedParams = append(modifiedParams, "-C")
+			} else {
+				// Every other flag/value is kept as it is
+				modifiedParams = append(modifiedParams, element)
+			}
+		}
+		output = append(output, &Rule{
+			chain:  r.chain,
+			table:  r.table,
+			params: modifiedParams,
+		})
+	}
+	log.Debugf("Rules mutated into check-rules %+v", output)
+	return output
+}
+
+func (rb *IptablesRuleBuilder) buildCheckRules(rules []*Rule) [][]string {
+	output := make([][]string, 0)
+	checkRules := checkRules(rules)
+	for _, r := range checkRules {
+		cmd := append([]string{"-t", r.table}, r.params...)
+		output = append(output, cmd)
+	}
+	return output
+}
+
+func (rb *IptablesRuleBuilder) buildCleanupRules(rules []*Rule) [][]string {
+	newRules := make([]*Rule, len(rules))
+	for i := len(rules) - 1; i >= 0; i-- {
+		newRules[len(rules)-1-i] = rules[i]
+	}
+
+	output := make([][]string, 0)
+	reversedRules := reverseRules(newRules)
+	for _, r := range reversedRules {
+		cmd := append([]string{"-t", r.table}, r.params...)
+		output = append(output, cmd)
+	}
+	chainTableLookupSet := sets.New[string]()
+	for _, r := range newRules {
+		chainTable := fmt.Sprintf("%s:%s", r.chain, r.table)
+		// Delete chain if key: `chainTable` isn't present in map
+		if !chainTableLookupSet.Contains(chainTable) {
+			// Don't delete iptables built-in chains
+			if _, present := constants.BuiltInChainsMap[r.chain]; !present {
+				cmd := []string{"-t", r.table, "-F", r.chain}
+				output = append(output, cmd)
+				cmd = []string{"-t", r.table, "-X", r.chain}
+				output = append(output, cmd)
+				chainTableLookupSet.Insert(chainTable)
+			}
+		}
+	}
+	return output
+}
+
+func (rb *IptablesRuleBuilder) buildGuardrails() []*Rule {
+	rules := make([]*Rule, 0)
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.INPUT, constants.FILTER, 1, "-p", "tcp", "-j", "DROP")
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.INPUT, constants.FILTER, 1, "-p", "udp", "-j", "DROP")
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.FORWARD, constants.FILTER, 1, "-p", "tcp", "-j", "DROP")
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.FORWARD, constants.FILTER, 1, "-p", "udp", "-j", "DROP")
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.OUTPUT, constants.FILTER, 1, "-p", "tcp", "-j", "DROP")
+	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.OUTPUT, constants.FILTER, 1, "-p", "udp", "-j", "DROP")
+	return rules
+}
+
 func (rb *IptablesRuleBuilder) BuildV4() [][]string {
 	return rb.buildRules(rb.rules.rulesv4)
 }
 
 func (rb *IptablesRuleBuilder) BuildV6() [][]string {
 	return rb.buildRules(rb.rules.rulesv6)
+}
+
+func (rb *IptablesRuleBuilder) BuildCleanupV4() [][]string {
+	return rb.buildCleanupRules(rb.rules.rulesv4)
+}
+
+func (rb *IptablesRuleBuilder) BuildCleanupV6() [][]string {
+	return rb.buildCleanupRules(rb.rules.rulesv6)
+}
+
+func (rb *IptablesRuleBuilder) BuildCheckV4() [][]string {
+	return rb.buildCheckRules(rb.rules.rulesv4)
+}
+
+func (rb *IptablesRuleBuilder) BuildCheckV6() [][]string {
+	return rb.buildCheckRules(rb.rules.rulesv6)
+}
+
+func (rb *IptablesRuleBuilder) BuildGuardrails() [][]string {
+	rules := rb.buildGuardrails()
+	output := make([][]string, 0)
+	for _, r := range rules {
+		cmd := append([]string{"-t", r.table}, r.params...)
+		output = append(output, cmd)
+	}
+	return output
+}
+
+func (rb *IptablesRuleBuilder) BuildCleanupGuardrails() [][]string {
+	rules := reverseRules(rb.buildGuardrails())
+	output := make([][]string, 0)
+	for _, r := range rules {
+		cmd := append([]string{"-t", r.table}, r.params...)
+		output = append(output, cmd)
+	}
+	return output
 }
 
 func (rb *IptablesRuleBuilder) constructIptablesRestoreContents(tableRulesMap map[string][]string) string {
@@ -229,9 +401,65 @@ func (rb *IptablesRuleBuilder) BuildV6Restore() string {
 	return rb.buildRestore(rb.rules.rulesv6)
 }
 
+// getStateFromSave function takes a string in iptables-restore format and returns a map of the tables, chains, and rules.
+// Note that if this function is used to parse iptables-save output, the rules may have changed since they were first applied
+// as rules do not necessarily undergo a round-trip through the kernel in the same form.
+// Therefore, these rules should not be used for any critical checks.
+func (rb *IptablesRuleBuilder) GetStateFromSave(data string) map[string]map[string][]string {
+	lines := strings.Split(data, "\n")
+	result := make(map[string]map[string][]string)
+	for _, defaultTable := range []string{constants.FILTER, constants.NAT, constants.MANGLE, constants.RAW} {
+		result[defaultTable] = make(map[string][]string)
+	}
+
+	table := ""
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") || line == "COMMIT" {
+			continue
+		}
+		// Found table
+		if strings.HasPrefix(line, "*") {
+			table = strings.TrimSpace(line[1:])
+			continue
+		}
+		// Found chain, setup an empty list for the chain if it is an ISTIO one
+		if strings.HasPrefix(line, ":") {
+			if !strings.HasPrefix(line, ":ISTIO") {
+				continue
+			}
+			chain := strings.Split(line, " ")[0][1:]
+			_, ok := result[table][chain]
+			if !ok {
+				result[table][chain] = []string{}
+			}
+			continue
+		}
+
+		rule := strings.Split(line, " ")
+		ruleChain := ""
+		for i, item := range rule {
+			if (item == "--append" || item == "-A" || item == "--insert" || item == "-I") && i+1 < len(rule) {
+				ruleChain = rule[i+1]
+			}
+		}
+		if ruleChain == "" {
+			continue
+		}
+		_, ok := result[table][ruleChain]
+		if !ok {
+			result[table][ruleChain] = []string{}
+		}
+		result[table][ruleChain] = append(result[table][ruleChain], line)
+	}
+	return result
+}
+
 // AppendVersionedRule is a wrapper around AppendRule that substitutes an ipv4/ipv6 specific value
 // in place in the params. This allows appending a dual-stack rule that has an IP value in it.
-func (rb *IptablesRuleBuilder) AppendVersionedRule(ipv4 string, ipv6 string, command log.Command, chain string, table string, params ...string) {
+func (rb *IptablesRuleBuilder) AppendVersionedRule(ipv4 string, ipv6 string, command iptableslog.Command, chain string, table string, params ...string) {
 	rb.AppendRuleV4(command, chain, table, replaceVersionSpecific(ipv4, params...)...)
 	rb.AppendRuleV6(command, chain, table, replaceVersionSpecific(ipv6, params...)...)
 }

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -184,8 +184,8 @@ func (rb *IptablesRuleBuilder) buildRules(rules []Rule) [][]string {
 // structure of other parameters.
 // Non-jump rules in ISTIO_* chains are skipped as these chains will be flushed, but jump rules are retained to ensure proper reversal.
 // Note: This function does not support converting rules with -D/--delete flags back to -A/-I flags.
-func undoRules(rules []*Rule) []*Rule {
-	output := make([]*Rule, 0)
+func undoRules(rules []Rule) []Rule {
+	output := make([]Rule, 0)
 	for _, r := range rules {
 		var modifiedParams []string
 		skip := false
@@ -220,7 +220,7 @@ func undoRules(rules []*Rule) []*Rule {
 			continue
 		}
 
-		output = append(output, &Rule{
+		output = append(output, Rule{
 			chain:  r.chain,
 			table:  r.table,
 			params: modifiedParams,
@@ -234,8 +234,8 @@ func undoRules(rules []*Rule) []*Rule {
 // The function transforms -A/--append and -I/--insert flags into -C/--check flags while preserving the
 // structure of other parameters.
 // The transformation allows for checking whether the corresponding rules are already present in the iptables configuration.
-func checkRules(rules []*Rule) []*Rule {
-	output := make([]*Rule, 0)
+func checkRules(rules []Rule) []Rule {
+	output := make([]Rule, 0)
 	for _, r := range rules {
 		var modifiedParams []string
 		insertIndex := -1
@@ -256,7 +256,7 @@ func checkRules(rules []*Rule) []*Rule {
 				modifiedParams = append(modifiedParams, element)
 			}
 		}
-		output = append(output, &Rule{
+		output = append(output, Rule{
 			chain:  r.chain,
 			table:  r.table,
 			params: modifiedParams,
@@ -266,7 +266,7 @@ func checkRules(rules []*Rule) []*Rule {
 	return output
 }
 
-func (rb *IptablesRuleBuilder) buildCheckRules(rules []*Rule) [][]string {
+func (rb *IptablesRuleBuilder) buildCheckRules(rules []Rule) [][]string {
 	output := make([][]string, 0)
 	checkRules := checkRules(rules)
 	for _, r := range checkRules {
@@ -276,8 +276,8 @@ func (rb *IptablesRuleBuilder) buildCheckRules(rules []*Rule) [][]string {
 	return output
 }
 
-func (rb *IptablesRuleBuilder) buildCleanupRules(rules []*Rule) [][]string {
-	newRules := make([]*Rule, len(rules))
+func (rb *IptablesRuleBuilder) buildCleanupRules(rules []Rule) [][]string {
+	newRules := make([]Rule, len(rules))
 	for i := len(rules) - 1; i >= 0; i-- {
 		newRules[len(rules)-1-i] = rules[i]
 	}
@@ -306,8 +306,8 @@ func (rb *IptablesRuleBuilder) buildCleanupRules(rules []*Rule) [][]string {
 	return output
 }
 
-func (rb *IptablesRuleBuilder) buildGuardrails() []*Rule {
-	rules := make([]*Rule, 0)
+func (rb *IptablesRuleBuilder) buildGuardrails() []Rule {
+	rules := make([]Rule, 0)
 	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.INPUT, constants.FILTER, 1, "-p", "tcp", "-j", "DROP")
 	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.INPUT, constants.FILTER, 1, "-p", "udp", "-j", "DROP")
 	rb.insertInternal(&rules, iptableslog.UndefinedCommand, constants.FORWARD, constants.FILTER, 1, "-p", "tcp", "-j", "DROP")

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -179,6 +179,11 @@ func (rb *IptablesRuleBuilder) buildRules(rules []Rule) [][]string {
 	return output
 }
 
+// reverseRules generates the minimal set of rules that are necessary to reverse the changes made by the input rules.
+// The function transforms -A/--append and -I/--insert flags into -D/--delete flags while preserving the
+// structure of other parameters.
+// Non-jump rules in ISTIO_* chains are skipped as these chains will be flushed, but jump rules are retained to ensure proper reversal.
+// Note: This function does not support converting -D/--delete flags back to -A/-I flags.
 func reverseRules(rules []*Rule) []*Rule {
 	output := make([]*Rule, 0)
 	for _, r := range rules {
@@ -225,6 +230,10 @@ func reverseRules(rules []*Rule) []*Rule {
 	return output
 }
 
+// checkRules generates a set of iptables rules that are used to verify the existence of the input rules.
+// The function transforms -A/--append and -I/--insert flags into -C/--check flags while preserving the
+// structure of other parameters.
+// The transformation allows for checking whether the corresponding rules are already present in the iptables configuration.
 func checkRules(rules []*Rule) []*Rule {
 	output := make([]*Rule, 0)
 	for _, r := range rules {

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -237,7 +237,7 @@ func TestCheckRulesV4V6(t *testing.T) {
 	}
 }
 
-func TestReverseRulesV4V6(t *testing.T) {
+func TestCleanupRulesV4V6(t *testing.T) {
 	builderConfig := &config.Config{
 		EnableIPv6: true,
 	}

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -856,10 +856,10 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 
 	residueExists, deltaExists := cfg.VerifyIptablesState(iptVer, ipt6Ver)
 	if residueExists && deltaExists && !cfg.cfg.Reconcile {
-		return fmt.Errorf("reconcile is needed but no-reconcile flag is set. Can't recover from this state")
+		log.Warn("reconcile is needed but no-reconcile flag is set. Unexpected behavior may occur due to preexisting iptables rules")
 	}
 	// Cleanup Step
-	if (residueExists && deltaExists) || cfg.cfg.CleanupOnly {
+	if (residueExists && deltaExists && cfg.cfg.Reconcile) || cfg.cfg.CleanupOnly {
 		// Apply safety guardrails
 		if !cfg.cfg.CleanupOnly {
 			log.Info("Setting up guardrails")

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -15,13 +15,21 @@
 package capture
 
 import (
+	"bytes"
 	"net/netip"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
+	_ "github.com/howardjohn/unshare-go/netns"
+	// Create a new user namespace. This will map the current UID/GID to 0.
+	_ "github.com/howardjohn/unshare-go/userns"
+
 	testutil "istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/tools/istio-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
@@ -42,8 +50,11 @@ func constructTestConfig() *config.Config {
 	}
 }
 
-func TestIptables(t *testing.T) {
-	cases := []struct {
+func getCommonTestCases() []struct {
+	name   string
+	config func(cfg *config.Config)
+} {
+	return []struct {
 		name   string
 		config func(cfg *config.Config)
 	}{
@@ -271,7 +282,10 @@ func TestIptables(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range cases {
+}
+
+func TestIptables(t *testing.T) {
+	for _, tt := range getCommonTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := constructTestConfig()
 			tt.config(cfg)
@@ -333,6 +347,159 @@ func TestSeparateV4V6(t *testing.T) {
 			if !reflect.DeepEqual(v6Range, tt.v6) {
 				t.Fatalf("expected %v, got %v", tt.v6, v6Range)
 			}
+		})
+	}
+}
+
+func TestIdempotentEquivalentRerun(t *testing.T) {
+	commonCases := getCommonTestCases()
+	ext := &dep.RealDependencies{
+		HostFilesystemPodNetwork: false,
+		NetworkNamespace:         "",
+	}
+	iptVer, err := ext.DetectIptablesVersion(false)
+	if err != nil {
+		t.Fatalf("Can't detect iptables version")
+	}
+
+	ipt6Ver, err := ext.DetectIptablesVersion(true)
+	if err != nil {
+		t.Fatalf("Can't detect ip6tables version")
+	}
+
+	for _, tt := range commonCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := constructTestConfig()
+			tt.config(cfg)
+			// Override UID and GID otherwise test will fail in the linux namespace from unshare-go lib
+			cfg.ProxyUID = "0"
+			cfg.ProxyGID = "0"
+			if cfg.OwnerGroupsExclude != "" {
+				cfg.OwnerGroupsInclude = "0"
+			}
+			if cfg.OwnerGroupsInclude != "" {
+				cfg.OwnerGroupsInclude = "0"
+			}
+
+			defer func() {
+				// Final Cleanup
+				cfg.CleanupOnly = true
+				cfg.Reconcile = false
+				iptConfigurator := NewIptablesConfigurator(cfg, ext)
+				assert.NoError(t, iptConfigurator.Run())
+				residueExists, deltaExists := iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+				assert.Equal(t, residueExists, false)
+				assert.Equal(t, deltaExists, true)
+			}()
+
+			// First Pass
+			cfg.Reconcile = false
+			iptConfigurator := NewIptablesConfigurator(cfg, ext)
+			assert.NoError(t, iptConfigurator.Run())
+			residueExists, deltaExists := iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+			assert.Equal(t, residueExists, true)
+			assert.Equal(t, deltaExists, false)
+
+			// Second Pass
+			iptConfigurator = NewIptablesConfigurator(cfg, ext)
+			assert.NoError(t, iptConfigurator.Run())
+		})
+	}
+}
+
+func TestIdempotentUnequaledRerun(t *testing.T) {
+	commonCases := getCommonTestCases()
+	ext := &dep.RealDependencies{
+		HostFilesystemPodNetwork: false,
+		NetworkNamespace:         "",
+	}
+	iptVer, err := ext.DetectIptablesVersion(false)
+	if err != nil {
+		t.Fatalf("Can't detect iptables version")
+	}
+
+	ipt6Ver, err := ext.DetectIptablesVersion(true)
+	if err != nil {
+		t.Fatalf("Can't detect ip6tables version")
+	}
+
+	for _, tt := range commonCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := constructTestConfig()
+			tt.config(cfg)
+			// Override UID and GID otherwise test will fail in the linux namespace from unshare-go lib
+			cfg.ProxyUID = "0"
+			cfg.ProxyGID = "0"
+			var stdout, stderr bytes.Buffer
+			if cfg.OwnerGroupsExclude != "" {
+				cfg.OwnerGroupsInclude = "0"
+			}
+			if cfg.OwnerGroupsInclude != "" {
+				cfg.OwnerGroupsInclude = "0"
+			}
+
+			defer func() {
+				// Final Cleanup
+				cfg.CleanupOnly = true
+				cfg.Reconcile = false
+				iptConfigurator := NewIptablesConfigurator(cfg, ext)
+				assert.NoError(t, iptConfigurator.Run())
+				residueExists, deltaExists := iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+				assert.Equal(t, residueExists, true) // residue found due to extra OUTPUT rule
+				assert.Equal(t, deltaExists, true)
+				// Remove additional rule
+				cmd := exec.Command("iptables", "-t", "nat", "-D", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+				if err := cmd.Run(); err != nil {
+					t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
+				}
+				residueExists, deltaExists = iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+				assert.Equal(t, residueExists, false)
+				assert.Equal(t, deltaExists, true)
+			}()
+
+			// First Pass
+			iptConfigurator := NewIptablesConfigurator(cfg, ext)
+			assert.NoError(t, iptConfigurator.Run())
+			residueExists, deltaExists := iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+			assert.Equal(t, residueExists, true)
+			assert.Equal(t, deltaExists, false)
+
+			// Diverge from installation
+			cmd := exec.Command("iptables", "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
+			}
+
+			// Apply not required after tainting non-ISTIO chains with extra rules
+			residueExists, deltaExists = iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+			assert.Equal(t, residueExists, true)
+			assert.Equal(t, deltaExists, false)
+
+			cmd = exec.Command("iptables", "-t", "nat", "-A", "ISTIO_INBOUND", "-p", "tcp", "--dport", "123", "-j", "ACCEPT")
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf("iptables cmd (%s %s) failed: %s", cmd.Path, cmd.Args, stderr.String())
+			}
+
+			// Apply required after tainting ISTIO chains
+			residueExists, deltaExists = iptConfigurator.VerifyIptablesState(&iptVer, &ipt6Ver)
+			assert.Equal(t, residueExists, true)
+			assert.Equal(t, deltaExists, true)
+
+			// Fail is expected if cleanup is skipped
+			cfg.Reconcile = false
+			iptConfigurator = NewIptablesConfigurator(cfg, ext)
+			assert.Error(t, iptConfigurator.Run())
+
+			// Second pass with cleanup
+			cfg.Reconcile = true
+			iptConfigurator = NewIptablesConfigurator(cfg, ext)
+			assert.NoError(t, iptConfigurator.Run())
 		})
 	}
 }

--- a/tools/istio-iptables/pkg/capture/testdata/basic-exclude-nic.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/basic-exclude-nic.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/dns-uid-gid.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/drop-invalid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/drop-invalid.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/empty.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/empty.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/host-ipv4-loopback-cidr.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/inbound-ports-include.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/inbound-ports-include.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/inbound-ports-tproxy.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/inbound-ports-tproxy.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/inbound-ports-wildcard-tproxy.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/inbound-ports-wildcard.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/inbound-ports-wildcard.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ip-range.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ip-range.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipnets.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipnets.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups-exclude.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups-exclude.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-outbound-owner-groups.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-uid-gid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-dns-uid-gid.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-empty-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-empty-inbound-ports.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-inbound-ports.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-inbound-ports.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-ipnets.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-ipnets.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-outbound-ports.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-outbound-ports.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-uid-gid.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-uid-gid.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/ipv6-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/ipv6-virt-interfaces.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/kube-virt-interfaces.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/logging.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/logging.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/loopback-outbound-iprange.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/loopback-outbound-iprange.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/outbound-owner-groups-exclude.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/outbound-owner-groups-exclude.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/outbound-owner-groups.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/outbound-owner-groups.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/outbound-ports-include.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/outbound-ports-include.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/capture/testdata/tproxy.golden
+++ b/tools/istio-iptables/pkg/capture/testdata/tproxy.golden
@@ -1,3 +1,5 @@
+iptables-save
+ip6tables-save
 iptables -t nat -N ISTIO_INBOUND
 iptables -t nat -N ISTIO_REDIRECT
 iptables -t nat -N ISTIO_IN_REDIRECT

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -136,6 +136,12 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 		&cfg.NetworkNamespace)
 
 	flag.BindEnv(fs, constants.CNIMode, "", "Whether to run as CNI plugin.", &cfg.HostFilesystemPodNetwork)
+
+	flag.BindEnv(fs, constants.Reconcile, "", "Reconcile pre-existing and incompatible iptables rules instead of failing if drift is detected",
+		&cfg.Reconcile)
+
+	flag.BindEnv(fs, constants.CleanupOnly, "", "Perform a forced cleanup without creating new iptables chains or rules.",
+		&cfg.CleanupOnly)
 }
 
 func GetCommand(logOpts *log.Options) *cobra.Command {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -90,6 +90,8 @@ type Config struct {
 	DualStack                bool       `json:"DUAL_STACK"`
 	HostIP                   netip.Addr `json:"HOST_IP"`
 	HostIPv4LoopbackCidr     string     `json:"HOST_IPV4_LOOPBACK_CIDR"`
+	Reconcile                bool       `json:"RECONCILE"`
+	CleanupOnly              bool       `json:"CLEANUP_ONLY"`
 }
 
 func (c *Config) String() string {

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -106,6 +106,8 @@ const (
 	CaptureAllDNS             = "capture-all-dns"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
+	Reconcile                 = "reconcile"
+	CleanupOnly               = "cleanup-only"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -15,6 +15,7 @@
 package dependencies
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os/exec"
@@ -218,6 +219,11 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 // Run runs a command
 func (r *RealDependencies) Run(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
 	return r.executeXTables(cmd, iptVer, false, stdin, args...)
+}
+
+// Run runs a command and returns stdout
+func (r *RealDependencies) RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+	return r.executeXTablesWithOutput(cmd, iptVer, false, stdin, args...)
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -203,11 +203,16 @@ func mount(src, dst string) error {
 	return syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_RDONLY, "")
 }
 
-func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion,
+	ignoreErrors bool, stdin io.ReadSeeker, args ...string,
+) (*bytes.Buffer, error) {
 	mode := "without lock"
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
 	cmdBin := iptVer.CmdToString(cmd)
 	if cmdBin == "" {
-		return fmt.Errorf("called without iptables binary, cannot execute!: %+v", iptVer)
+		return stdout, fmt.Errorf("called without iptables binary, cannot execute!: %+v", iptVer)
 	}
 	var c *exec.Cmd
 	needLock := iptVer.IsWriteCmd(cmd) && !iptVer.NoLocks()
@@ -249,10 +254,8 @@ func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *Ipt
 			c = exec.Command(cmdBin, args...)
 		}
 	}
-
 	log.Infof("Running command (%s): %s %s", mode, cmdBin, strings.Join(args, " "))
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
+
 	c.Stdout = stdout
 	c.Stderr = stderr
 	c.Stdin = stdin
@@ -273,5 +276,10 @@ func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *Ipt
 		log.Errorf("Command error output: %v", stderrStr)
 	}
 
+	return stdout, err
+}
+
+func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+	_, err := r.executeXTablesWithOutput(cmd, iptVer, ignoreErrors, stdin, args...)
 	return err
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -18,6 +18,7 @@
 package dependencies
 
 import (
+	"bytes"
 	"errors"
 	"io"
 
@@ -32,7 +33,14 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reade
 }
 
 func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	return ErrNotImplemented
+	_, err := r.executeXTablesWithOutput(cmd, iptVer, ignoreErrors, stdin, args...)
+	return err
+}
+
+func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion,
+	ignoreErrors bool, stdin io.ReadSeeker, args ...string,
+) (*bytes.Buffer, error) {
+	return nil, ErrNotImplemented
 }
 
 func shouldUseBinaryForCurrentContext(iptablesBin string) (IptablesVersion, error) {

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -15,6 +15,7 @@
 package dependencies
 
 import (
+	"bytes"
 	"io"
 
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
@@ -24,6 +25,10 @@ import (
 type Dependencies interface {
 	// Run runs a command
 	Run(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error
+
+	// Run runs a command and get the output
+	RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error)
+
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
 	RunQuietlyAndIgnore(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string)
 

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -16,6 +16,7 @@ package dependencies
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -39,6 +40,12 @@ func (s *DependenciesStub) Run(cmd constants.IptablesCmd, iptVer *IptablesVersio
 	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return nil
+}
+
+func (s *DependenciesStub) RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
+	_ = s.writeAllToDryRunPath()
+	return &bytes.Buffer{}, nil
 }
 
 func (s *DependenciesStub) RunQuietlyAndIgnore(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes #30393 and #42792 .

Current behavior on master will make a re-execution of istio-init container likely to fail due to the possibility of having existing ISTIO_* chains (and/or rules).
If, for whatever reason, the init containers are getting re-executed, we should make sure that they do not fail because the settings are already in effect. This is also one of the recommendation of the k8s doc about init containers:

> Because init containers can be restarted, retried, or re-executed, init container code should be idempotent. In particular, code that writes to files on EmptyDirs should be prepared for the possibility that an output file already exists.
> -- https://kubernetes.io/docs/concepts/workloads/pods/init-containers/



With these changes `pilot-agent ip-tables` will remove rules that would end up being duplicated + existing istio chains.



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
