### PR TITLE
CNI: enable sidecars in istio-system

### DIFF
--- a/manifests/charts/base/files/profile-ambient.yaml
+++ b/manifests/charts/base/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/base/files/profile-openshift.yaml
+++ b/manifests/charts/base/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/default/files/profile-ambient.yaml
+++ b/manifests/charts/default/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/default/files/profile-openshift.yaml
+++ b/manifests/charts/default/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/gateway/files/profile-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/gateway/files/profile-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/istio-cni/files/profile-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/istio-cni/files/profile-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -27,7 +27,6 @@ defaults:
 
 
     excludeNamespaces:
-      - istio-system
       - kube-system
 
     # Allows user to set custom affinity for the DaemonSet

--- a/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/istio-operator/files/profile-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/istio-operator/files/profile-openshift.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/istiod-remote/files/profile-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/istiod-remote/files/profile-openshift.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/charts/ztunnel/files/profile-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-ambient.yaml
@@ -24,9 +24,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -15,8 +15,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/charts/ztunnel/files/profile-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift.yaml
@@ -9,9 +9,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/manifests/helm-profiles/ambient.yaml
+++ b/manifests/helm-profiles/ambient.yaml
@@ -20,9 +20,5 @@ cni:
   ambient:
     enabled: true
 
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
-
 # Ztunnel doesn't use a namespace, so everything here is mostly for ztunnel
 variant: distroless

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -11,8 +11,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - kube-system
   logLevel: info
   privileged: true
   provider: "multus"

--- a/manifests/helm-profiles/openshift.yaml
+++ b/manifests/helm-profiles/openshift.yaml
@@ -5,9 +5,6 @@ cni:
   cniConfDir: /etc/cni/multus/net.d
   chained: false
   cniConfFileName: "istio-cni.conf"
-  excludeNamespaces:
-    - istio-system
-    - kube-system
   logLevel: info
   provider: "multus"
 global:

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -100,10 +100,6 @@ cni:
   privileged: true
   ambient:
     enabled: true
-
-  # Default excludes istio-system; its actually fine to redirect there since we opt-out istiod, ztunnel, and istio-cni
-  excludeNamespaces:
-    - kube-system
 `
 )
 


### PR DESCRIPTION
This opt out is not required; all Istio components already label
themselves as not injected to avoid circular dependencies. The injector
already injects these.

What ends up happening is CNI skips, then later repairs. This is a bit
silly -- we should just properly let CNI run.
