### PR TITLE
download script should fail early when the download failed

### DIFF
--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 ##############################################################################
 
+set -e
+
 # Separate downloader for istioctl
 #
 # You can fetch the istioctl file using:


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently, when the `curl -fsL -o "${tmp}/${filename}" "$ARCH_URL"` failed, the download will continue with msg `istioctl-xxx download complete!` and exit successfully. This behavior reports a successful download even when it failed.