### PR TITLE
Fix bug when virtual services overwrites routes

### DIFF
--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -17,7 +17,6 @@ package core
 import (
 	"encoding/binary"
 	"fmt"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -51,6 +50,7 @@ import (
 	"istio.io/istio/pkg/config/security"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/hash"
 	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/istio/pkg/util/sets"

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -17,6 +17,7 @@ package core
 import (
 	"encoding/binary"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -480,8 +481,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 						}
 					}
 					newVHost := &route.VirtualHost{
-						Name:                       util.DomainName(string(hostname), port),
-						Domains:                    []string{hostname.String()},
+						Name:    util.DomainName(string(hostname), port),
+						Domains: []string{hostname.String()},
 						// Route will be appended to during deduplication, so make sure we are operating on a copy
 						Routes:                     slices.Clone(routes),
 						TypedPerFilterConfig:       perRouteFilters,

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -482,7 +482,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 					newVHost := &route.VirtualHost{
 						Name:                       util.DomainName(string(hostname), port),
 						Domains:                    []string{hostname.String()},
-						Routes:                     routes,
+						Routes:                     append([]*route.Route{}, routes...),
 						TypedPerFilterConfig:       perRouteFilters,
 						IncludeRequestAttemptCount: ph.IncludeRequestAttemptCount,
 					}

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -482,7 +482,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 					newVHost := &route.VirtualHost{
 						Name:                       util.DomainName(string(hostname), port),
 						Domains:                    []string{hostname.String()},
-						Routes:                     append([]*route.Route{}, routes...),
+						// Route will be appended to during deduplication, so make sure we are operating on a copy
+						Routes:                     slices.Clone(routes),
 						TypedPerFilterConfig:       perRouteFilters,
 						IncludeRequestAttemptCount: ph.IncludeRequestAttemptCount,
 					}

--- a/releasenotes/notes/vs-overwrite-fix.yaml
+++ b/releasenotes/notes/vs-overwrite-fix.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: []
+releaseNotes:
+- |
+  **Fixed** an issue causing routes to be overwritten by other virtual services.


### PR DESCRIPTION
Make sure that each host has its own slice of routes to not overwrite routes added by other virtual services.

**Please provide a description of this PR:**
In the test case the `foobar-vs` will allocate memory to hold 4 routes, but will only be using 3. The same slice will be used for both hosts when added to the `vHostDedupMap`.

`foo-vs` and `bar-vs` virtual services will both append to the same slice resulting in that the last of the two (`bar-vs`) will overwrite the path already added by `foo-vs`.

This will result in that the path added by `foo-vs` will be lost and the path added by `bar-vs` will be added to both hosts.

This change will create a copy of the  routes slice for each host so that subsequential appends to the slice only affects the current host.