### PR TITLE
Split istioctl pc ztunnel info into zc

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -48,6 +48,7 @@ import (
 	"istio.io/istio/istioctl/pkg/wait"
 	"istio.io/istio/istioctl/pkg/waypoint"
 	"istio.io/istio/istioctl/pkg/workload"
+	"istio.io/istio/istioctl/pkg/ztunnelconfig"
 	"istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/collateral"
@@ -184,6 +185,7 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(experimentalCmd)
 	rootCmd.AddCommand(proxyconfig.ProxyConfig(ctx))
+	rootCmd.AddCommand(ztunnelconfig.ZtunnelConfig(ctx))
 	rootCmd.AddCommand(admin.Cmd(ctx))
 	experimentalCmd.AddCommand(injector.Cmd(ctx))
 

--- a/istioctl/pkg/proxyconfig/proxyconfig_test.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig_test.go
@@ -48,7 +48,6 @@ func TestProxyConfig(t *testing.T) {
 	loggingConfig := map[string][]byte{
 		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile(t, "../writer/envoy/logging/testdata/logging.txt"),
 		"httpbin-794b576b6c-qx6pf":    []byte("{}"),
-		"ztunnel-9v7nw":               []byte("current log level is debug"),
 	}
 	cases := []execTestCase{
 		{
@@ -87,23 +86,11 @@ func TestProxyConfig(t *testing.T) {
 			expectedString:   "unrecognized logger name: xxx",
 			wantException:    true,
 		},
-		{ // logger name invalid when namespacing is used improperly
-			execClientConfig: loggingConfig,
-			args:             strings.Split("log ztunnel-9v7nw --level ztunnel:::pool:debug", " "),
-			expectedString:   "unrecognized logging level: pool:debug",
-			wantException:    true,
-		},
 		{ // logger name valid, but logging level invalid
 			execClientConfig: loggingConfig,
 			args:             strings.Split("log details-v1-5b7f94f9bc-wp5tb --level http:yyy", " "),
 			expectedString:   "unrecognized logging level: yyy",
 			wantException:    true,
-		},
-		{ // logger name valid and logging level valid
-			execClientConfig: loggingConfig,
-			args:             strings.Split("log ztunnel-9v7nw --level ztunnel::pool:debug", " "),
-			expectedString:   "",
-			wantException:    false,
 		},
 		{ // both logger name and logging level invalid
 			execClientConfig: loggingConfig,
@@ -175,12 +162,6 @@ func TestProxyConfig(t *testing.T) {
 			args:             strings.Split("route httpbin-794b576b6c-qx6pf", " "),
 			expectedString:   `config dump has no configuration type`,
 			wantException:    true,
-		},
-		{ // set ztunnel logging level
-			execClientConfig: loggingConfig,
-			args:             strings.Split("log ztunnel-9v7nw --level debug", " "),
-			expectedString:   "current log level is debug",
-			wantException:    false,
 		},
 	}
 

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ztunnelconfig
 
 import (
@@ -12,6 +26,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+
 	"istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/completion"
 	"istio.io/istio/istioctl/pkg/kubeinject"
@@ -43,8 +58,6 @@ var (
 	configDumpFile string
 
 	labelSelector = ""
-
-	loggerName string
 )
 
 func ZtunnelConfig(ctx cli.Context) *cobra.Command {
@@ -263,7 +276,7 @@ func logCmd(ctx cli.Context) *cobra.Command {
 				}
 			}
 			for _, pod := range podNames {
-				loggerName, err = setupEnvoyLogConfig(kubeClient, "", pod, podNamespace)
+				_, err = setupEnvoyLogConfig(kubeClient, "", pod, podNamespace)
 				if err != nil {
 					return err
 				}

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -1,0 +1,473 @@
+package ztunnelconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"istio.io/istio/istioctl/pkg/cli"
+	"istio.io/istio/istioctl/pkg/completion"
+	"istio.io/istio/istioctl/pkg/kubeinject"
+	ambientutil "istio.io/istio/istioctl/pkg/util/ambient"
+	ztunnelDump "istio.io/istio/istioctl/pkg/writer/ztunnel/configdump"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	jsonOutput    = "json"
+	yamlOutput    = "yaml"
+	summaryOutput = "short"
+
+	defaultProxyAdminPort = 15000
+)
+
+var (
+	workloadsNamespace string
+	verboseProxyConfig bool
+
+	address, node string
+
+	// output format (json, yaml or short)
+	outputFormat string
+
+	proxyAdminPort int
+
+	configDumpFile string
+
+	labelSelector = ""
+
+	loggerName string
+)
+
+func ZtunnelConfig(ctx cli.Context) *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "ztunnel-config",
+		Short: "Retrieve information about ztunnel configuration.",
+		Long:  "A group of commands used to retrieve information about Ztunnel configuration from a Ztunnel instance.",
+		Example: `  # Retrieve summary about workload configuration for a given ztunnel.
+	istioctl ztunnel-config <workload> <ztunnel-name[.namespace]>`,
+		Aliases: []string{"zc"},
+	}
+
+	configCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	configCmd.PersistentFlags().IntVar(&proxyAdminPort, "proxy-admin-port", defaultProxyAdminPort, "Envoy proxy admin port")
+
+	configCmd.AddCommand(logCmd(ctx))
+	configCmd.AddCommand(workloadConfigCmd(ctx))
+
+	return configCmd
+}
+
+func workloadConfigCmd(ctx cli.Context) *cobra.Command {
+	var podName, podNamespace string
+
+	workloadConfigCmd := &cobra.Command{
+		Use:   "workload [<type>/]<name>[.<namespace>]",
+		Short: "Retrieves workload configuration for the specified ztunnel pod",
+		Long:  `Retrieve information about workload configuration for the ztunnel instance.`,
+		Example: `  # Retrieve summary about workload configuration for a given ztunnel.
+  istioctl proxy-config workload <ztunnel-name[.namespace]>
+
+  # Retrieve summary of workloads on node XXXX for a given ztunnel instance.
+  istioctl proxy-config workload <ztunnel-name[.namespace]> --node ambient-worker
+
+  # Retrieve full workload dump of workloads with address XXXX for a given ztunnel
+  istioctl proxy-config workload <ztunnel-name[.namespace]> --address 0.0.0.0 -o json
+
+  # Retrieve workload summary
+  kubectl exec -it $ZTUNNEL -n istio-system -- curl localhost:15000/config_dump > ztunnel-config.json
+  istioctl proxy-config workloads --file ztunnel-config.json
+
+  # Retrieve workload summary for a specific namespace
+  istioctl proxy-config workloads <ztunnel-name[.namespace]> --workloads-namespace foo
+`,
+		Aliases: []string{"workloads", "w"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if (len(args) == 1) != (configDumpFile == "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("workload requires pod name or --file parameter")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			kubeClient, err := ctx.CLIClient()
+			if err != nil {
+				return err
+			}
+			var configWriter *ztunnelDump.ConfigWriter
+			if len(args) == 1 {
+				if podName, podNamespace, err = getComponentPodName(ctx, args[0]); err != nil {
+					return err
+				}
+				ztunnelPod := ambientutil.IsZtunnelPod(kubeClient, podName, podNamespace)
+				if !ztunnelPod {
+					return fmt.Errorf("workloads command is only supported by ztunnel proxies: %v", podName)
+				}
+				configWriter, err = setupZtunnelConfigDumpWriter(kubeClient, podName, podNamespace, c.OutOrStdout())
+			} else {
+				configWriter, err = setupFileZtunnelConfigdumpWriter(configDumpFile, c.OutOrStdout())
+			}
+			if err != nil {
+				return err
+			}
+			filter := ztunnelDump.WorkloadFilter{
+				Namespace: workloadsNamespace,
+				Address:   address,
+				Node:      node,
+				Verbose:   verboseProxyConfig,
+			}
+
+			switch outputFormat {
+			case summaryOutput:
+				return configWriter.PrintWorkloadSummary(filter)
+			case jsonOutput, yamlOutput:
+				return configWriter.PrintWorkloadDump(filter, outputFormat)
+			default:
+				return fmt.Errorf("output format %q not supported", outputFormat)
+			}
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ValidPodsNameArgs(cmd, ctx, args, toComplete)
+		},
+	}
+
+	workloadConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	workloadConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter workloads by address field")
+	workloadConfigCmd.PersistentFlags().StringVar(&node, "node", "", "Filter workloads by node field")
+	workloadConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
+	workloadConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
+		"Ztunnel config dump JSON file")
+	workloadConfigCmd.PersistentFlags().StringVar(&workloadsNamespace, "workloads-namespace", "",
+		"Filter workloads by namespace field")
+
+	return workloadConfigCmd
+}
+
+// Level is an enumeration of all supported log levels.
+type Level int
+
+const (
+	defaultLoggerName       = "level"
+	defaultEnvoyOutputLevel = WarningLevel
+)
+
+const (
+	// OffLevel disables logging
+	OffLevel Level = iota
+	// CriticalLevel enables critical level logging
+	CriticalLevel
+	// ErrorLevel enables error level logging
+	ErrorLevel
+	// WarningLevel enables warning level logging
+	WarningLevel
+	// InfoLevel enables info level logging
+	InfoLevel
+	// DebugLevel enables debug level logging
+	DebugLevel
+	// TraceLevel enables trace level logging
+	TraceLevel
+)
+
+var levelToString = map[Level]string{
+	TraceLevel:    "trace",
+	DebugLevel:    "debug",
+	InfoLevel:     "info",
+	WarningLevel:  "warning",
+	ErrorLevel:    "error",
+	CriticalLevel: "critical",
+	OffLevel:      "off",
+}
+
+var stringToLevel = map[string]Level{
+	"trace":    TraceLevel,
+	"debug":    DebugLevel,
+	"info":     InfoLevel,
+	"warning":  WarningLevel,
+	"warn":     WarningLevel,
+	"error":    ErrorLevel,
+	"critical": CriticalLevel,
+	"off":      OffLevel,
+}
+
+var (
+	loggerLevelString = ""
+	reset             = false
+)
+
+func ztunnelLogLevel(level string) string {
+	switch level {
+	case "warning":
+		return "warn"
+	case "critical":
+		return "error"
+	default:
+		return level
+	}
+}
+
+func logCmd(ctx cli.Context) *cobra.Command {
+	var podNamespace string
+	var podNames []string
+
+	logCmd := &cobra.Command{
+		Use:   "log [<type>/]<name>[.<namespace>]",
+		Short: "Retrieves logging levels of the Envoy in the specified pod",
+		Long:  "Retrieve information about logging levels of the Envoy instance in the specified pod, and update optionally",
+		Example: `  # Retrieve information about logging levels for a given pod from Envoy.
+  istioctl proxy-config log <pod-name[.namespace]>
+
+  # Update levels of the all loggers
+  istioctl proxy-config log <pod-name[.namespace]> --level none
+
+  # Update levels of the specified loggers.
+  istioctl proxy-config log <pod-name[.namespace]> --level http:debug,redis:debug
+
+  # Reset levels of all the loggers to default value (warning).
+  istioctl proxy-config log <pod-name[.namespace]> -r
+`,
+		Aliases: []string{"o"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if labelSelector == "" && len(args) < 1 {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("log requires pod name or --selector")
+			}
+			if reset && loggerLevelString != "" {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("--level cannot be combined with --reset")
+			}
+			if outputFormat != "" && outputFormat != summaryOutput {
+				return fmt.Errorf("--output is not applicable for this command")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			kubeClient, err := ctx.CLIClient()
+			if err != nil {
+				return err
+			}
+			if labelSelector != "" {
+				if podNames, podNamespace, err = getPodNameBySelector(ctx, kubeClient, labelSelector); err != nil {
+					return err
+				}
+			} else {
+				if podNames, podNamespace, err = getPodNames(ctx, args[0], ctx.Namespace()); err != nil {
+					return err
+				}
+			}
+			for _, pod := range podNames {
+				loggerName, err = setupEnvoyLogConfig(kubeClient, "", pod, podNamespace)
+				if err != nil {
+					return err
+				}
+			}
+
+			destLoggerLevels := map[string]Level{}
+			if reset {
+				// reset logging level to `defaultOutputLevel`, and ignore the `level` option
+				levelString, _ := getLogLevelFromConfigMap(ctx)
+				level, ok := stringToLevel[levelString]
+				if ok {
+					destLoggerLevels[defaultLoggerName] = level
+				} else {
+					log.Warn("unable to get logLevel from ConfigMap istio-sidecar-injector, using default value \"info\" for ztunnel")
+				}
+			} else if loggerLevelString != "" {
+				levels := strings.Split(loggerLevelString, ",")
+				for _, ol := range levels {
+					if !strings.Contains(ol, ":") && !strings.Contains(ol, "=") {
+						level, ok := stringToLevel[ol]
+						if ok {
+							destLoggerLevels = map[string]Level{
+								defaultLoggerName: level,
+							}
+						} else {
+							return fmt.Errorf("unrecognized logging level: %v", ol)
+						}
+					} else {
+						logParts := strings.Split(ol, "::") // account for any specified namespace
+						loggerAndLevelOnly := logParts[len(logParts)-1]
+						loggerLevel := regexp.MustCompile(`[:=]`).Split(loggerAndLevelOnly, 2)
+						// TODO validate ztunnel logger name when available: https://github.com/istio/ztunnel/issues/426
+						level, ok := stringToLevel[loggerLevel[1]]
+						if !ok {
+							return fmt.Errorf("unrecognized logging level: %v", loggerLevel[1])
+						}
+						destLoggerLevels[loggerLevel[0]] = level
+					}
+				}
+			}
+
+			var errs *multierror.Error
+			for _, podName := range podNames {
+				q := "level=" + ztunnelLogLevel(loggerLevelString)
+				if reset {
+					q += "&reset"
+				}
+				resp, err := setupEnvoyLogConfig(kubeClient, q, podName, podNamespace)
+				if err == nil {
+					_, _ = fmt.Fprintf(c.OutOrStdout(), "%v.%v:\n%v\n", podName, podNamespace, resp)
+				} else {
+					errs = multierror.Append(fmt.Errorf("%v.%v: %v", podName, podNamespace, err))
+				}
+			}
+			if err := multierror.Flatten(errs.ErrorOrNil()); err != nil {
+				return err
+			}
+			return nil
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.ValidPodsNameArgs(cmd, ctx, args, toComplete)
+		},
+	}
+
+	levelListString := fmt.Sprintf("[%s, %s, %s, %s, %s, %s, %s]",
+		levelToString[TraceLevel],
+		levelToString[DebugLevel],
+		levelToString[InfoLevel],
+		levelToString[WarningLevel],
+		levelToString[ErrorLevel],
+		levelToString[CriticalLevel],
+		levelToString[OffLevel])
+
+	logCmd.PersistentFlags().BoolVarP(&reset, "reset", "r", reset, "Reset levels to default value (warning).")
+	logCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
+	logCmd.PersistentFlags().StringVar(&loggerLevelString, "level", loggerLevelString,
+		fmt.Sprintf("Comma-separated minimum per-logger level of messages to output, in the form of"+
+			" [<logger>:]<level>,[<logger>:]<level>,... or <level> to change all active loggers, "+
+			"where logger components can be listed by running \"istioctl proxy-config log <pod-name[.namespace]>\""+
+			"or referred from https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h, and level can be one of %s", levelListString))
+	return logCmd
+}
+
+func setupEnvoyLogConfig(kubeClient kube.CLIClient, param, podName, podNamespace string) (string, error) {
+	path := "logging"
+	if param != "" {
+		path = path + "?" + param
+	}
+	result, err := kubeClient.EnvoyDoWithPort(context.TODO(), podName, podNamespace, "POST", path, proxyAdminPort)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute command on Envoy: %v", err)
+	}
+	return string(result), nil
+}
+
+func getLogLevelFromConfigMap(ctx cli.Context) (string, error) {
+	valuesConfig, err := kubeinject.GetValuesFromConfigMap(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	var values struct {
+		SidecarInjectorWebhook struct {
+			Global struct {
+				Proxy struct {
+					LogLevel string `json:"logLevel"`
+				} `json:"proxy"`
+			} `json:"global"`
+		} `json:"sidecarInjectorWebhook"`
+	}
+	if err := yaml.Unmarshal([]byte(valuesConfig), &values); err != nil {
+		return "", fmt.Errorf("failed to parse values config: %v [%v]", err, valuesConfig)
+	}
+	return values.SidecarInjectorWebhook.Global.Proxy.LogLevel, nil
+}
+
+func getPodNames(ctx cli.Context, podflag, ns string) ([]string, string, error) {
+	podNames, ns, err := ctx.InferPodsFromTypedResource(podflag, ns)
+	if err != nil {
+		log.Errorf("pods lookup failed")
+		return []string{}, "", err
+	}
+	return podNames, ns, nil
+}
+
+func getPodNameBySelector(ctx cli.Context, kubeClient kube.CLIClient, labelSelector string) ([]string, string, error) {
+	var (
+		podNames []string
+		ns       string
+	)
+	pl, err := kubeClient.PodsForSelector(context.TODO(), ctx.NamespaceOrDefault(ctx.Namespace()), labelSelector)
+	if err != nil {
+		return nil, "", fmt.Errorf("not able to locate pod with selector %s: %v", labelSelector, err)
+	}
+	if len(pl.Items) < 1 {
+		return nil, "", errors.New("no pods found")
+	}
+	for _, pod := range pl.Items {
+		podNames = append(podNames, pod.Name)
+	}
+	ns = pl.Items[0].Namespace
+	return podNames, ns, nil
+}
+
+// getComponentPodName returns the pod name and namespace of the Istio component
+func getComponentPodName(ctx cli.Context, podflag string) (string, string, error) {
+	return getPodNameWithNamespace(ctx, podflag, ctx.IstioNamespace())
+}
+
+func getPodNameWithNamespace(ctx cli.Context, podflag, ns string) (string, string, error) {
+	var podName, podNamespace string
+	podName, podNamespace, err := ctx.InferPodInfoFromTypedResource(podflag, ns)
+	if err != nil {
+		return "", "", err
+	}
+	return podName, podNamespace, nil
+}
+
+func setupZtunnelConfigDumpWriter(kubeClient kube.CLIClient, podName, podNamespace string, out io.Writer) (*ztunnelDump.ConfigWriter, error) {
+	debug, err := extractZtunnelConfigDump(kubeClient, podName, podNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return setupConfigdumpZtunnelConfigWriter(debug, out)
+}
+
+func readFile(filename string) ([]byte, error) {
+	file := os.Stdin
+	if filename != "-" {
+		var err error
+		file, err = os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Errorf("failed to close %s: %s", filename, err)
+		}
+	}()
+	return io.ReadAll(file)
+}
+
+func extractZtunnelConfigDump(kubeClient kube.CLIClient, podName, podNamespace string) ([]byte, error) {
+	path := "config_dump"
+	debug, err := kubeClient.EnvoyDoWithPort(context.TODO(), podName, podNamespace, "GET", path, 15000)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute command on %s.%s ztunnel: %v", podName, podNamespace, err)
+	}
+	return debug, err
+}
+
+func setupConfigdumpZtunnelConfigWriter(debug []byte, out io.Writer) (*ztunnelDump.ConfigWriter, error) {
+	cw := &ztunnelDump.ConfigWriter{Stdout: out}
+	err := cw.Prime(debug)
+	if err != nil {
+		return nil, err
+	}
+	return cw, nil
+}
+
+func setupFileZtunnelConfigdumpWriter(filename string, out io.Writer) (*ztunnelDump.ConfigWriter, error) {
+	data, err := readFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return setupConfigdumpZtunnelConfigWriter(data, out)
+}

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -246,6 +246,10 @@ func logCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"o"},
 		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("--level needs a value")
+			}
 			if reset && loggerLevelString != "" {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("--level cannot be combined with --reset")

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig_test.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig_test.go
@@ -49,7 +49,7 @@ func TestProxyConfig(t *testing.T) {
 	cases := []execTestCase{
 		{
 			args:           []string{},
-			expectedString: "A group of commands used to retrieve information about",
+			expectedString: "A group of commands used to update or retrieve Ztunnel",
 		},
 		{ // logger name invalid when namespacing is used improperly
 			execClientConfig: loggingConfig,

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig_test.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig_test.go
@@ -1,0 +1,131 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ztunnelconfig
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"istio.io/istio/istioctl/pkg/cli"
+	"istio.io/istio/pkg/kube"
+)
+
+type execTestCase struct {
+	execClientConfig map[string][]byte
+	args             []string
+
+	// Typically use one of the three
+	expectedOutput string // Expected constant output
+	expectedString string // String output is expected to contain
+
+	wantException bool
+}
+
+func TestProxyConfig(t *testing.T) {
+	loggingConfig := map[string][]byte{
+		"ztunnel-9v7nw": []byte("current log level is debug"),
+	}
+	cases := []execTestCase{
+		{
+			args:           []string{},
+			expectedString: "A group of commands used to retrieve information about",
+		},
+		{ // logger name invalid when namespacing is used improperly
+			execClientConfig: loggingConfig,
+			args:             strings.Split("log ztunnel-9v7nw --level ztunnel:::pool:debug", " "),
+			expectedString:   "unrecognized logging level: pool:debug",
+			wantException:    true,
+		},
+		{ // logger name valid and logging level valid
+			execClientConfig: loggingConfig,
+			args:             strings.Split("log ztunnel-9v7nw --level ztunnel::pool:debug", " "),
+			expectedString:   "",
+			wantException:    false,
+		},
+		{ // set ztunnel logging level
+			execClientConfig: loggingConfig,
+			args:             strings.Split("log ztunnel-9v7nw --level debug", " "),
+			expectedString:   "current log level is debug",
+			wantException:    false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
+			verifyExecTestOutput(t, ZtunnelConfig(cli.NewFakeContext(&cli.NewFakeContextOption{
+				Results:   c.execClientConfig,
+				Namespace: "default",
+			})), c)
+		})
+	}
+}
+
+func verifyExecTestOutput(t *testing.T, cmd *cobra.Command, c execTestCase) {
+	t.Helper()
+
+	var out bytes.Buffer
+	cmd.SetArgs(c.args)
+	cmd.SilenceUsage = true
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	fErr := cmd.Execute()
+	output := out.String()
+
+	if c.expectedOutput != "" && c.expectedOutput != output {
+		t.Fatalf("Unexpected output for 'istioctl %s'\n got: %q\nwant: %q", strings.Join(c.args, " "), output, c.expectedOutput)
+	}
+
+	if c.expectedString != "" && !strings.Contains(output, c.expectedString) {
+		t.Fatalf("Output didn't match for '%s %s'\n got %v\nwant: %v", cmd.Name(), strings.Join(c.args, " "), output, c.expectedString)
+	}
+
+	if c.wantException {
+		if fErr == nil {
+			t.Fatalf("Wanted an exception for 'istioctl %s', didn't get one, output was %q",
+				strings.Join(c.args, " "), output)
+		}
+	} else {
+		if fErr != nil {
+			t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(c.args, " "), fErr)
+		}
+	}
+}
+
+func init() {
+	cli.MakeKubeFactory = func(k kube.CLIClient) cmdutil.Factory {
+		tf := cmdtesting.NewTestFactory()
+		_, _, codec := cmdtesting.NewExternalScheme()
+		tf.UnstructuredClient = &fake.RESTClient{
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+			Resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     cmdtesting.DefaultHeader(),
+				Body: cmdtesting.ObjBody(codec,
+					cmdtesting.NewInternalType("", "", "foo")),
+			},
+		}
+		return tf
+	}
+}

--- a/releasenotes/notes/50347.yaml
+++ b/releasenotes/notes/50347.yaml
@@ -2,7 +2,7 @@ apiVersion: release-notes/v2
 kind: feature
 area: istioctl
 issue:
-  - 50347
+  - 49841
 releaseNotes:
 - |
   **Added** Add ztunnel-config istioctl command. Allow users to view Ztunnel configuration information through istioctl via ztunnel-config workload flag. 

--- a/releasenotes/notes/50347.yaml
+++ b/releasenotes/notes/50347.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 50347
+releaseNotes:
+- |
+  **Added** Add ztunnel-config istioctl command. Allow users to view Ztunnel configuration information through istioctl via ztunnel-config workload flag. 
+  **Removed** Remove workload flag from proxy-config command. Users must use ztunnel-config command to view Ztunnel configuration information.


### PR DESCRIPTION
**Please provide a description of this PR:**
Resolves: #49841 

Removes the workload command from `istioctl proxy-config` and puts it in a new command called `istioctl ztunnel-config`.

`istioctl proxy-config` and `istioctl pc` no longer work when calling `w` or `workload`:

e.g.
```
azureuser@dev-2024:~/istio$ ./out/linux_amd64/istioctl pc w ztunnel-5kq4t -n istio-system
A group of commands used to retrieve information about proxy configuration from the Envoy config dump

Usage:
  istioctl proxy-config [command]
```

`istioctl ztunnel-config` and `istioctl zc` now take its place for getting ztunnel info (`w` or `workload`):

**short (or no -o provided) snippet:**
```
azureuser@dev-2024:~/istio$ ./out/linux_amd64/istioctl zc w ztunnel-5kq4t -n istio-system
NAMESPACE          NAME                                            NETWORK IP          NODE                        WAYPOINT                PROTOCOL
echo-1-36960       captured-v1-bcf9f6948-jfsfp                             10.244.0.13 istio-testing-control-plane waypoint-istio-waypoint HBONE
```

**yaml snippet:**
```
azureuser@dev-2024:~/istio$ ./out/linux_amd64/istioctl zc w ztunnel-5kq4t -n istio-system -oyaml
- canonicalName: ztunnel
  canonicalRevision: latest
  gatewayIp: null
  name: ztunnel-5kq4t
  namespace: istio-system
  nativeHbone: false
  node: istio-testing-control-plane
  protocol: TCP
  serviceAccount: ztunnel
  waypoint: null
  workloadIps:
  - 10.244.0.10
  workloadName: ztunnel-5kq4t
  workloadType: pod
  ```

**json snippet:**
```
azureuser@dev-2024:~/istio$ ./out/linux_amd64/istioctl zc w ztunnel-5kq4t -n istio-system -ojson
[
    {
        "workloadIps": [
            "10.244.0.8"
        ],
        "waypoint": null,
        "gatewayIp": null,
        "protocol": "TCP",
        "name": "istio-egressgateway-75789864dc-r49zt",
        "namespace": "istio-system",
        "serviceAccount": "istio-egressgateway-service-account",
        "workloadName": "istio-egressgateway",
        "workloadType": "deployment",
        "canonicalName": "istio-egressgateway",
        "canonicalRevision": "latest",
        "node": "istio-testing-control-plane",
        "nativeHbone": false
    },
```