### PR TITLE
revised tests to account for removal of hairpin

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "ZTUNNEL_REPO_SHA",
     "repoName": "ztunnel",
     "file": "",
-    "lastStableSHA": "c52dc8b583294ea77fcd953c0ffd767383acf65e"
+    "lastStableSHA": "4f17630b6922ee1b77110c98ae736647477c0356"
   }
 ]

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -195,15 +195,19 @@ func TestPodIP(t *testing.T) {
 								if src.Config().HasSidecar() {
 									t.Skip("not supported yet")
 								}
-								if src.Config().IsUncaptured() && dst.Config().HasWorkloadAddressedWaypointProxy() {
-									t.Skip("https://github.com/istio/istio/issues/44530")
-								}
 								for _, opt := range callOptions {
 									opt := opt.DeepCopy()
 									selfSend := dstWl.Address() == srcWl.Address()
 									if supportsL7(opt, src, dst) {
 										opt.Check = httpValidator
 									} else {
+										opt.Check = tcpValidator
+									}
+
+									if src.Config().IsUncaptured() && dst.Config().HasAnyWaypointProxy() {
+										// hairpinning isn't going to be implemented AND
+										// waypoint requirements are expressed via L4 policy which is not in place for this test:
+										// expected result is a plaintext passthrough by ztunnel
 										opt.Check = tcpValidator
 									}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Adjust tests to account for removal of hairpin logic from ztunnel in https://github.com/istio/ztunnel/pull/913