### PR TITLE
[Release Channels] Implement with a ValidatingAdmissionPolicy

### DIFF
--- a/manifests/charts/base/files/profile-stable.yaml
+++ b/manifests/charts/base/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,61 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "stable-channel-policy.istio.io"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+        - security.istio.io
+        - networking.istio.io
+        - telemetry.istio.io
+        - extensions.istio.io
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  variables:
+    - name: isVirtualService
+      expression: "object.kind == 'VirtualService'"
+    - name: isDestinationRule
+      expression: "object.kind == 'DestinationRule'"
+    - name: isIstioGateway
+      expression: "object.kind == 'Gateway'"
+    - name: isServiceEntry
+      expression: "object.kind == 'ServiceEntry'"
+    - name: isEnvoyFilter
+      expression: "object.kind == 'EnvoyFilter'"
+    - name: isAuthorizationPolicy
+      expression: "object.kind == 'AuthorizationPolicy'"
+    - name: isPeerAuthentication
+      expression: "object.kind == 'PeerAuthentication'"
+    - name: isRequestAuthentication
+      expression: "object.kind == 'RequestAuthentication'"
+    - name: isWorkloadEntry
+      expression: "object.kind == 'WorkloadEntry'"
+    - name: isWorkloadGroup
+      expression: "object.kind == 'WorkloadGroup'"
+    - name: isSidecar
+      expression: "object.kind == 'Sidecar'"
+    - name: isWasmPlugin
+      expression: "object.kind == 'WasmPlugin'"
+    - name: isTelemetry
+      expression: "object.kind == 'Telemetry'"
+    - name: isProxyConfig
+      expression: "object.kind == 'ProxyConfig'"
+  validations:
+    - expression: |
+      isTelemetry &&
+        (
+          object.spec.tracing.exists(t, has(t.useRequestIdForTraceSampling)) ||
+          object.spec.metrics.exists(m, has(m.reportingInterval)) ||
+          object.spec.accessLogging.exists(l, has(l.filter))
+        )
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "stable-channel-policy-binding.istio.io"
+spec:
+  policyName: "stable-channel-policy.istio.io"
+  validationActions: [Deny]

--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -19,10 +19,6 @@ spec:
       apiVersions: ["*"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["*"]
-    namespaceSelector:
-      matchExpressions:
-        - key: istio.io/rev
-          operator: DoesNotExist
   variables:
     - name: isVirtualService
       expression: "object.kind == 'VirtualService'"
@@ -53,15 +49,28 @@ spec:
     - name: isProxyConfig
       expression: "object.kind == 'ProxyConfig'"
   validations:
+    - expression: "!variables.isEnvoyFilter"
+    - expression: "!variables.isWasmPlugin"
     - expression: |
-        isTelemetry &&
+        variables.isVirtualService        ||
+        variables.isDestinationRule       ||
+        variables.isIstioGateway          ||
+        variables.isServiceEntry          ||
+        variables.isAuthorizationPolicy   ||
+        variables.isPeerAuthentication    ||
+        variables.isRequestAuthentication ||
+        variables.isWorkloadEntry         ||
+        variables.isWorkloadGroup         ||
+        variables.isSidecar               ||
+        variables.isProxyConfig           ||
+        (
+          variables.isTelemetry &&
           (
-            object.spec.tracing.exists(t, has(t.useRequestIdForTraceSampling)) ||
-            object.spec.metrics.exists(m, has(m.reportingInterval)) ||
-            object.spec.accessLogging.exists(l, has(l.filter))
+            (has(object.spec.tracing) && object.spec.tracing.all(t, !has(t.useRequestIdForTraceSampling))) ||
+            (has(object.spec.metrics) && object.spec.metrics.all(m, !has(m.reportingInterval))) ||
+            (has(object.spec.accessLogging) && object.spec.accessLogging.all(l, !has(l.filter)))
           )
-    - expression: "isEnvoyFilter"
-    - expression: "isWasmPlugin"
+        )
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding

--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -38,7 +38,7 @@ spec:
           )
         )
 ---
-apiVersion: admissionregistration.k8s.io/v1b
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "stable-channel-default-policy-binding.istio.io"

--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -20,55 +20,21 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["*"]
   variables:
-    - name: isVirtualService
-      expression: "object.kind == 'VirtualService'"
-    - name: isDestinationRule
-      expression: "object.kind == 'DestinationRule'"
-    - name: isIstioGateway
-      expression: "object.kind == 'Gateway'"
-    - name: isServiceEntry
-      expression: "object.kind == 'ServiceEntry'"
     - name: isEnvoyFilter
       expression: "object.kind == 'EnvoyFilter'"
-    - name: isAuthorizationPolicy
-      expression: "object.kind == 'AuthorizationPolicy'"
-    - name: isPeerAuthentication
-      expression: "object.kind == 'PeerAuthentication'"
-    - name: isRequestAuthentication
-      expression: "object.kind == 'RequestAuthentication'"
-    - name: isWorkloadEntry
-      expression: "object.kind == 'WorkloadEntry'"
-    - name: isWorkloadGroup
-      expression: "object.kind == 'WorkloadGroup'"
-    - name: isSidecar
-      expression: "object.kind == 'Sidecar'"
     - name: isWasmPlugin
       expression: "object.kind == 'WasmPlugin'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
-    - name: isProxyConfig
-      expression: "object.kind == 'ProxyConfig'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
     - expression: |
-        variables.isVirtualService        ||
-        variables.isDestinationRule       ||
-        variables.isIstioGateway          ||
-        variables.isServiceEntry          ||
-        variables.isAuthorizationPolicy   ||
-        variables.isPeerAuthentication    ||
-        variables.isRequestAuthentication ||
-        variables.isWorkloadEntry         ||
-        variables.isWorkloadGroup         ||
-        variables.isSidecar               ||
-        variables.isProxyConfig           ||
-        (
-          variables.isTelemetry &&
-          (
-            (has(object.spec.tracing) && object.spec.tracing.all(t, !has(t.useRequestIdForTraceSampling))) ||
-            (has(object.spec.metrics) && object.spec.metrics.all(m, !has(m.reportingInterval))) ||
-            (has(object.spec.accessLogging) && object.spec.accessLogging.all(l, !has(l.filter)))
+        !(
+          variables.isTelemetry && (
+            (has(object.spec.tracing) ? object.spec.tracing : {}).exists(t, has(t.useRequestIdForTraceSampling)) ||
+            (has(object.spec.metrics) ? object.spec.metrics : {}).exists(m, has(m.reportingInterval)) ||
+            (has(object.spec.accessLogging) ? object.spec.accessLogging : {}).exists(l, has(l.filter))
           )
         )
 ---

--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.experimental.stableValidationPolicy (not (eq .Values.defaultRevision "")) }}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "stable-channel-default-policy.istio.io"
@@ -38,7 +38,7 @@ spec:
           )
         )
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1b
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "stable-channel-default-policy-binding.istio.io"

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -36,3 +36,5 @@ defaults:
     enableIstioConfigCRDs: true
 
   defaultRevision: "default"
+  experimental:
+    stableValidationPolicy: false

--- a/manifests/charts/default/files/profile-stable.yaml
+++ b/manifests/charts/default/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/gateway/files/profile-stable.yaml
+++ b/manifests/charts/gateway/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/gateways/istio-egress/files/profile-stable.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-stable.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/istio-cni/files/profile-stable.yaml
+++ b/manifests/charts/istio-cni/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-stable.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -15,7 +15,7 @@ spec:
       apiVersions: ["*"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["*"]
-    namespaceSelector:
+    objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
@@ -25,7 +25,7 @@ spec:
           {{- else }}
           - "{{ .Values.revision }}"
           {{- end }}
-    variables:
+  variables:
     - name: isVirtualService
       expression: "object.kind == 'VirtualService'"
     - name: isDestinationRule
@@ -55,15 +55,28 @@ spec:
     - name: isProxyConfig
       expression: "object.kind == 'ProxyConfig'"
   validations:
+    - expression: "!variables.isEnvoyFilter"
+    - expression: "!variables.isWasmPlugin"
     - expression: |
-        isTelemetry &&
+        variables.isVirtualService        ||
+        variables.isDestinationRule       ||
+        variables.isIstioGateway          ||
+        variables.isServiceEntry          ||
+        variables.isAuthorizationPolicy   ||
+        variables.isPeerAuthentication    ||
+        variables.isRequestAuthentication ||
+        variables.isWorkloadEntry         ||
+        variables.isWorkloadGroup         ||
+        variables.isSidecar               ||
+        variables.isProxyConfig           ||
+        (
+          variables.isTelemetry &&
           (
-            object.spec.tracing.exists(t, has(t.useRequestIdForTraceSampling)) ||
-            object.spec.metrics.exists(m, has(m.reportingInterval)) ||
-            object.spec.accessLogging.exists(l, has(l.filter))
+            (has(object.spec.tracing) && object.spec.tracing.all(t, !has(t.useRequestIdForTraceSampling))) ||
+            (has(object.spec.metrics) && object.spec.metrics.all(m, !has(m.reportingInterval))) ||
+            (has(object.spec.accessLogging) && object.spec.accessLogging.all(l, !has(l.filter)))
           )
-    - expression: "isEnvoyFilter"
-    - expression: "isWasmPlugin"
+        )
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -1,12 +1,8 @@
-{{- if and .Values.experimental.stableValidationPolicy (not (eq .Values.defaultRevision "")) }}
+{{- if .Values.experimental.stableValidationPolicy }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: "stable-channel-default-policy.istio.io"
-  labels:
-    release: {{ .Release.Name }}
-    istio: istiod
-    istio.io/rev: {{ .Values.defaultRevision }}
+  name: "stable-channel-policy{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -22,8 +18,14 @@ spec:
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
-          operator: DoesNotExist
-  variables:
+          operator: In
+          values:
+          {{- if (eq .Values.revision "") }}
+          - "default"
+          {{- else }}
+          - "{{ .Values.revision }}"
+          {{- end }}
+    variables:
     - name: isVirtualService
       expression: "object.kind == 'VirtualService'"
     - name: isDestinationRule
@@ -66,8 +68,8 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: "stable-channel-default-policy-binding.istio.io"
+  name: "stable-channel-policy-binding{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"
 spec:
-  policyName: "stable-channel-default-policy.istio.io"
+  policyName: "stable-channel-policy{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"
   validationActions: [Deny]
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.experimental.stableValidationPolicy }}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "stable-channel-policy{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"
@@ -44,7 +44,7 @@ spec:
           )
         )
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "stable-channel-policy-binding{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Values.global.istioNamespace }}.istio.io"

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -26,55 +26,21 @@ spec:
           - "{{ .Values.revision }}"
           {{- end }}
   variables:
-    - name: isVirtualService
-      expression: "object.kind == 'VirtualService'"
-    - name: isDestinationRule
-      expression: "object.kind == 'DestinationRule'"
-    - name: isIstioGateway
-      expression: "object.kind == 'Gateway'"
-    - name: isServiceEntry
-      expression: "object.kind == 'ServiceEntry'"
     - name: isEnvoyFilter
       expression: "object.kind == 'EnvoyFilter'"
-    - name: isAuthorizationPolicy
-      expression: "object.kind == 'AuthorizationPolicy'"
-    - name: isPeerAuthentication
-      expression: "object.kind == 'PeerAuthentication'"
-    - name: isRequestAuthentication
-      expression: "object.kind == 'RequestAuthentication'"
-    - name: isWorkloadEntry
-      expression: "object.kind == 'WorkloadEntry'"
-    - name: isWorkloadGroup
-      expression: "object.kind == 'WorkloadGroup'"
-    - name: isSidecar
-      expression: "object.kind == 'Sidecar'"
     - name: isWasmPlugin
       expression: "object.kind == 'WasmPlugin'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
-    - name: isProxyConfig
-      expression: "object.kind == 'ProxyConfig'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
     - expression: |
-        variables.isVirtualService        ||
-        variables.isDestinationRule       ||
-        variables.isIstioGateway          ||
-        variables.isServiceEntry          ||
-        variables.isAuthorizationPolicy   ||
-        variables.isPeerAuthentication    ||
-        variables.isRequestAuthentication ||
-        variables.isWorkloadEntry         ||
-        variables.isWorkloadGroup         ||
-        variables.isSidecar               ||
-        variables.isProxyConfig           ||
-        (
-          variables.isTelemetry &&
-          (
-            (has(object.spec.tracing) && object.spec.tracing.all(t, !has(t.useRequestIdForTraceSampling))) ||
-            (has(object.spec.metrics) && object.spec.metrics.all(m, !has(m.reportingInterval))) ||
-            (has(object.spec.accessLogging) && object.spec.accessLogging.all(l, !has(l.filter)))
+        !(
+          variables.isTelemetry && (
+            (has(object.spec.tracing) ? object.spec.tracing : {}).exists(t, has(t.useRequestIdForTraceSampling)) ||
+            (has(object.spec.metrics) ? object.spec.metrics : {}).exists(m, has(m.reportingInterval)) ||
+            (has(object.spec.accessLogging) ? object.spec.accessLogging : {}).exists(l, has(l.filter))
           )
         )
 ---

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -199,6 +199,9 @@ defaults:
   meshConfig:
     enablePrometheusMerge: true
 
+  experimental:
+    stableValidationPolicy: false
+
   global:
     # Used to locate istiod.
     istioNamespace: istio-system

--- a/manifests/charts/istio-operator/files/profile-stable.yaml
+++ b/manifests/charts/istio-operator/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/istiod-remote/files/profile-stable.yaml
+++ b/manifests/charts/istiod-remote/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -165,6 +165,8 @@ defaults:
   # See https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options
   meshConfig:
     enablePrometheusMerge: true
+  experimental:
+    stableValidationPolicy: false
   global:
     # Used to locate istiod.
     istioNamespace: istio-system

--- a/manifests/charts/ztunnel/files/profile-stable.yaml
+++ b/manifests/charts/ztunnel/files/profile-stable.yaml
@@ -1,0 +1,8 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/helm-profiles/stable.yaml
+++ b/manifests/helm-profiles/stable.yaml
@@ -1,0 +1,4 @@
+# The stable profile deploys admission control to ensure that only stable resources and fields are used
+# THIS IS CURRENTLY EXPERIMENTAL AND SUBJECT TO CHANGE
+experimental:
+  stableValidationPolicy: true

--- a/manifests/profiles/stable.yaml
+++ b/manifests/profiles/stable.yaml
@@ -1,0 +1,5 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    profile: stable

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -5166,6 +5166,8 @@ type Values struct {
 	// Specifies the compatibility version to use. When this is set, the control plane will
 	// be configured with the same defaults as the specified version.
 	CompatibilityVersion string `protobuf:"bytes,43,opt,name=compatibilityVersion,proto3" json:"compatibilityVersion,omitempty"`
+	// Specifies experimental helm fields that could be removed or changed in the future
+	Experimental *ExperimentalConfig `protobuf:"bytes,44,opt,name=experimental,proto3" json:"experimental,omitempty"`
 }
 
 func (x *Values) Reset() {
@@ -5320,6 +5322,13 @@ func (x *Values) GetCompatibilityVersion() string {
 	return ""
 }
 
+func (x *Values) GetExperimental() *ExperimentalConfig {
+	if x != nil {
+		return x.Experimental
+	}
+	return nil
+}
+
 // ZeroVPNConfig enables cross-cluster access using SNI matching.
 type ZeroVPNConfig struct {
 	state         protoimpl.MessageState
@@ -5377,6 +5386,55 @@ func (x *ZeroVPNConfig) GetSuffix() string {
 	return ""
 }
 
+// ExperimentalConfig is a placeholder for experimental installation features.
+type ExperimentalConfig struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Controls whether the experimental feature is enabled.
+	StableValidationPolicy *wrapperspb.BoolValue `protobuf:"bytes,1,opt,name=stableValidationPolicy,proto3" json:"stableValidationPolicy,omitempty"`
+}
+
+func (x *ExperimentalConfig) Reset() {
+	*x = ExperimentalConfig{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ExperimentalConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExperimentalConfig) ProtoMessage() {}
+
+func (x *ExperimentalConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExperimentalConfig.ProtoReflect.Descriptor instead.
+func (*ExperimentalConfig) Descriptor() ([]byte, []int) {
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ExperimentalConfig) GetStableValidationPolicy() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.StableValidationPolicy
+	}
+	return nil
+}
+
 // IntOrString is a type that can hold an int32 or a string.  When used in
 // JSON or YAML marshalling and unmarshalling, it produces or consumes the
 // inner type.  This allows you to have, for example, a JSON field that can
@@ -5399,7 +5457,7 @@ type IntOrString struct {
 func (x *IntOrString) Reset() {
 	*x = IntOrString{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+		mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5412,7 +5470,7 @@ func (x *IntOrString) String() string {
 func (*IntOrString) ProtoMessage() {}
 
 func (x *IntOrString) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47]
+	mi := &file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5425,7 +5483,7 @@ func (x *IntOrString) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntOrString.ProtoReflect.Descriptor instead.
 func (*IntOrString) Descriptor() ([]byte, []int) {
-	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{47}
+	return file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *IntOrString) GetType() int64 {
@@ -6538,7 +6596,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x6a, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x50, 0x61, 0x74, 0x68, 0x12, 0x2c, 0x0a, 0x11, 0x69,
 	0x6e, 0x6a, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x41, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65,
 	0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x11, 0x69, 0x6e, 0x6a, 0x65, 0x63, 0x74, 0x69, 0x6f,
-	0x6e, 0x43, 0x41, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x22, 0xbb, 0x06, 0x0a, 0x06, 0x56, 0x61,
+	0x6e, 0x43, 0x41, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65, 0x22, 0xfd, 0x06, 0x0a, 0x06, 0x56, 0x61,
 	0x6c, 0x75, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x03, 0x63, 0x6e, 0x69, 0x18, 0x02, 0x20, 0x01, 0x28,
 	0x0b, 0x32, 0x13, 0x2e, 0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2e, 0x43, 0x4e, 0x49,
 	0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x03, 0x63, 0x6e, 0x69, 0x12, 0x34, 0x0a, 0x08, 0x67,
@@ -6590,36 +6648,47 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x69, 0x6c, 0x65, 0x12, 0x32, 0x0a, 0x14, 0x63, 0x6f, 0x6d, 0x70, 0x61, 0x74, 0x69, 0x62, 0x69,
 	0x6c, 0x69, 0x74, 0x79, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x2b, 0x20, 0x01, 0x28,
 	0x09, 0x52, 0x14, 0x63, 0x6f, 0x6d, 0x70, 0x61, 0x74, 0x69, 0x62, 0x69, 0x6c, 0x69, 0x74, 0x79,
-	0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x5d, 0x0a, 0x0d, 0x5a, 0x65, 0x72, 0x6f, 0x56,
-	0x50, 0x4e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e, 0x61, 0x62,
-	0x6c, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
-	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c,
-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64, 0x12, 0x16,
-	0x0a, 0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06,
-	0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x22, 0x8c, 0x01, 0x0a, 0x0b, 0x49, 0x6e, 0x74, 0x4f, 0x72,
-	0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
-	0x20, 0x01, 0x28, 0x03, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x33, 0x0a, 0x06, 0x69, 0x6e,
-	0x74, 0x56, 0x61, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f,
-	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x49, 0x6e, 0x74,
-	0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x69, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x12,
-	0x34, 0x0a, 0x06, 0x73, 0x74, 0x72, 0x56, 0x61, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32,
-	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
-	0x66, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73,
-	0x74, 0x72, 0x56, 0x61, 0x6c, 0x2a, 0x4a, 0x0a, 0x15, 0x69, 0x6e, 0x67, 0x72, 0x65, 0x73, 0x73,
-	0x43, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x6c, 0x65, 0x72, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x0f,
-	0x0a, 0x0b, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12,
-	0x0b, 0x0a, 0x07, 0x44, 0x45, 0x46, 0x41, 0x55, 0x4c, 0x54, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06,
-	0x53, 0x54, 0x52, 0x49, 0x43, 0x54, 0x10, 0x02, 0x12, 0x07, 0x0a, 0x03, 0x4f, 0x46, 0x46, 0x10,
-	0x03, 0x2a, 0x60, 0x0a, 0x06, 0x74, 0x72, 0x61, 0x63, 0x65, 0x72, 0x12, 0x0a, 0x0a, 0x06, 0x7a,
-	0x69, 0x70, 0x6b, 0x69, 0x6e, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x6c, 0x69, 0x67, 0x68, 0x74,
-	0x73, 0x74, 0x65, 0x70, 0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07, 0x64, 0x61, 0x74, 0x61, 0x64, 0x6f,
-	0x67, 0x10, 0x02, 0x12, 0x0f, 0x0a, 0x0b, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x64, 0x72, 0x69, 0x76,
-	0x65, 0x72, 0x10, 0x03, 0x12, 0x13, 0x0a, 0x0f, 0x6f, 0x70, 0x65, 0x6e, 0x43, 0x65, 0x6e, 0x73,
-	0x75, 0x73, 0x41, 0x67, 0x65, 0x6e, 0x74, 0x10, 0x04, 0x12, 0x08, 0x0a, 0x04, 0x6e, 0x6f, 0x6e,
-	0x65, 0x10, 0x05, 0x42, 0x31, 0x5a, 0x2f, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2e, 0x69, 0x6f, 0x2f,
-	0x69, 0x73, 0x74, 0x69, 0x6f, 0x2f, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2f, 0x70,
-	0x6b, 0x67, 0x2f, 0x61, 0x70, 0x69, 0x73, 0x2f, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2f, 0x76, 0x31,
-	0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x40, 0x0a, 0x0c, 0x65, 0x78, 0x70, 0x65, 0x72,
+	0x69, 0x6d, 0x65, 0x6e, 0x74, 0x61, 0x6c, 0x18, 0x2c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e,
+	0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2e, 0x45, 0x78, 0x70, 0x65, 0x72, 0x69, 0x6d,
+	0x65, 0x6e, 0x74, 0x61, 0x6c, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x0c, 0x65, 0x78, 0x70,
+	0x65, 0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74, 0x61, 0x6c, 0x22, 0x5d, 0x0a, 0x0d, 0x5a, 0x65, 0x72,
+	0x6f, 0x56, 0x50, 0x4e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e,
+	0x61, 0x62, 0x6c, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f,
+	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f,
+	0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64,
+	0x12, 0x16, 0x0a, 0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x06, 0x73, 0x75, 0x66, 0x66, 0x69, 0x78, 0x22, 0x68, 0x0a, 0x12, 0x45, 0x78, 0x70, 0x65,
+	0x72, 0x69, 0x6d, 0x65, 0x6e, 0x74, 0x61, 0x6c, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x52,
+	0x0a, 0x16, 0x73, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+	0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x16, 0x73, 0x74, 0x61, 0x62,
+	0x6c, 0x65, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x50, 0x6f, 0x6c, 0x69,
+	0x63, 0x79, 0x22, 0x8c, 0x01, 0x0a, 0x0b, 0x49, 0x6e, 0x74, 0x4f, 0x72, 0x53, 0x74, 0x72, 0x69,
+	0x6e, 0x67, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03,
+	0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x33, 0x0a, 0x06, 0x69, 0x6e, 0x74, 0x56, 0x61, 0x6c,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61,
+	0x6c, 0x75, 0x65, 0x52, 0x06, 0x69, 0x6e, 0x74, 0x56, 0x61, 0x6c, 0x12, 0x34, 0x0a, 0x06, 0x73,
+	0x74, 0x72, 0x56, 0x61, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f,
+	0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74,
+	0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73, 0x74, 0x72, 0x56, 0x61,
+	0x6c, 0x2a, 0x4a, 0x0a, 0x15, 0x69, 0x6e, 0x67, 0x72, 0x65, 0x73, 0x73, 0x43, 0x6f, 0x6e, 0x74,
+	0x72, 0x6f, 0x6c, 0x6c, 0x65, 0x72, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x0f, 0x0a, 0x0b, 0x55, 0x4e,
+	0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07, 0x44,
+	0x45, 0x46, 0x41, 0x55, 0x4c, 0x54, 0x10, 0x01, 0x12, 0x0a, 0x0a, 0x06, 0x53, 0x54, 0x52, 0x49,
+	0x43, 0x54, 0x10, 0x02, 0x12, 0x07, 0x0a, 0x03, 0x4f, 0x46, 0x46, 0x10, 0x03, 0x2a, 0x60, 0x0a,
+	0x06, 0x74, 0x72, 0x61, 0x63, 0x65, 0x72, 0x12, 0x0a, 0x0a, 0x06, 0x7a, 0x69, 0x70, 0x6b, 0x69,
+	0x6e, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x6c, 0x69, 0x67, 0x68, 0x74, 0x73, 0x74, 0x65, 0x70,
+	0x10, 0x01, 0x12, 0x0b, 0x0a, 0x07, 0x64, 0x61, 0x74, 0x61, 0x64, 0x6f, 0x67, 0x10, 0x02, 0x12,
+	0x0f, 0x0a, 0x0b, 0x73, 0x74, 0x61, 0x63, 0x6b, 0x64, 0x72, 0x69, 0x76, 0x65, 0x72, 0x10, 0x03,
+	0x12, 0x13, 0x0a, 0x0f, 0x6f, 0x70, 0x65, 0x6e, 0x43, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x41, 0x67,
+	0x65, 0x6e, 0x74, 0x10, 0x04, 0x12, 0x08, 0x0a, 0x04, 0x6e, 0x6f, 0x6e, 0x65, 0x10, 0x05, 0x42,
+	0x31, 0x5a, 0x2f, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2e, 0x69, 0x6f, 0x2f, 0x69, 0x73, 0x74, 0x69,
+	0x6f, 0x2f, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61,
+	0x70, 0x69, 0x73, 0x2f, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2f, 0x76, 0x31, 0x61, 0x6c, 0x70, 0x68,
+	0x61, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -6635,7 +6704,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_rawDescGZIP() []byte {
 }
 
 var file_pkg_apis_istio_v1alpha1_values_types_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
 	(IngressControllerMode)(0),               // 0: v1alpha1.ingressControllerMode
 	(Tracer)(0),                              // 1: v1alpha1.tracer
@@ -6687,215 +6756,218 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_goTypes = []interface{}{
 	(*IstiodRemoteConfig)(nil),               // 47: v1alpha1.IstiodRemoteConfig
 	(*Values)(nil),                           // 48: v1alpha1.Values
 	(*ZeroVPNConfig)(nil),                    // 49: v1alpha1.ZeroVPNConfig
-	(*IntOrString)(nil),                      // 50: v1alpha1.IntOrString
-	nil,                                      // 51: v1alpha1.Resources.LimitsEntry
-	nil,                                      // 52: v1alpha1.Resources.RequestsEntry
-	nil,                                      // 53: v1alpha1.EgressGatewayConfig.LabelsEntry
-	nil,                                      // 54: v1alpha1.IngressGatewayConfig.LabelsEntry
-	(*wrapperspb.BoolValue)(nil),             // 55: google.protobuf.BoolValue
-	(*structpb.Value)(nil),                   // 56: google.protobuf.Value
-	(*v1.Affinity)(nil),                      // 57: k8s.io.api.core.v1.Affinity
-	(*structpb.Struct)(nil),                  // 58: google.protobuf.Struct
-	(*v1.SeccompProfile)(nil),                // 59: k8s.io.api.core.v1.SeccompProfile
-	(*v11.LabelSelector)(nil),                // 60: k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	(*v1.Toleration)(nil),                    // 61: k8s.io.api.core.v1.Toleration
-	(*durationpb.Duration)(nil),              // 62: google.protobuf.Duration
-	(*v1.TopologySpreadConstraint)(nil),      // 63: k8s.io.api.core.v1.TopologySpreadConstraint
-	(*v1.VolumeMount)(nil),                   // 64: k8s.io.api.core.v1.VolumeMount
-	(*v1.Volume)(nil),                        // 65: k8s.io.api.core.v1.Volume
-	(*v1.Lifecycle)(nil),                     // 66: k8s.io.api.core.v1.Lifecycle
-	(*wrapperspb.Int32Value)(nil),            // 67: google.protobuf.Int32Value
-	(*wrapperspb.StringValue)(nil),           // 68: google.protobuf.StringValue
+	(*ExperimentalConfig)(nil),               // 50: v1alpha1.ExperimentalConfig
+	(*IntOrString)(nil),                      // 51: v1alpha1.IntOrString
+	nil,                                      // 52: v1alpha1.Resources.LimitsEntry
+	nil,                                      // 53: v1alpha1.Resources.RequestsEntry
+	nil,                                      // 54: v1alpha1.EgressGatewayConfig.LabelsEntry
+	nil,                                      // 55: v1alpha1.IngressGatewayConfig.LabelsEntry
+	(*wrapperspb.BoolValue)(nil),             // 56: google.protobuf.BoolValue
+	(*structpb.Value)(nil),                   // 57: google.protobuf.Value
+	(*v1.Affinity)(nil),                      // 58: k8s.io.api.core.v1.Affinity
+	(*structpb.Struct)(nil),                  // 59: google.protobuf.Struct
+	(*v1.SeccompProfile)(nil),                // 60: k8s.io.api.core.v1.SeccompProfile
+	(*v11.LabelSelector)(nil),                // 61: k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	(*v1.Toleration)(nil),                    // 62: k8s.io.api.core.v1.Toleration
+	(*durationpb.Duration)(nil),              // 63: google.protobuf.Duration
+	(*v1.TopologySpreadConstraint)(nil),      // 64: k8s.io.api.core.v1.TopologySpreadConstraint
+	(*v1.VolumeMount)(nil),                   // 65: k8s.io.api.core.v1.VolumeMount
+	(*v1.Volume)(nil),                        // 66: k8s.io.api.core.v1.Volume
+	(*v1.Lifecycle)(nil),                     // 67: k8s.io.api.core.v1.Lifecycle
+	(*wrapperspb.Int32Value)(nil),            // 68: google.protobuf.Int32Value
+	(*wrapperspb.StringValue)(nil),           // 69: google.protobuf.StringValue
 }
 var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
-	55,  // 0: v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 1: v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
-	57,  // 2: v1alpha1.CNIConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	58,  // 3: v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
+	56,  // 0: v1alpha1.CNIConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 1: v1alpha1.CNIConfig.tag:type_name -> google.protobuf.Value
+	58,  // 2: v1alpha1.CNIConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	59,  // 3: v1alpha1.CNIConfig.podAnnotations:type_name -> google.protobuf.Struct
 	7,   // 4: v1alpha1.CNIConfig.repair:type_name -> v1alpha1.CNIRepairConfig
-	55,  // 5: v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
+	56,  // 5: v1alpha1.CNIConfig.chained:type_name -> google.protobuf.BoolValue
 	8,   // 6: v1alpha1.CNIConfig.resource_quotas:type_name -> v1alpha1.ResourceQuotas
 	10,  // 7: v1alpha1.CNIConfig.resources:type_name -> v1alpha1.Resources
-	55,  // 8: v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
-	59,  // 9: v1alpha1.CNIConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	56,  // 8: v1alpha1.CNIConfig.privileged:type_name -> google.protobuf.BoolValue
+	60,  // 9: v1alpha1.CNIConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
 	6,   // 10: v1alpha1.CNIConfig.ambient:type_name -> v1alpha1.CNIAmbientConfig
-	50,  // 11: v1alpha1.CNIConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	55,  // 12: v1alpha1.CNIUsageConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 13: v1alpha1.CNIUsageConfig.chained:type_name -> google.protobuf.BoolValue
-	55,  // 14: v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 15: v1alpha1.CNIAmbientConfig.dnsCapture:type_name -> google.protobuf.BoolValue
-	55,  // 16: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 17: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
-	55,  // 18: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
-	51,  // 19: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
-	52,  // 20: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
-	58,  // 21: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
-	55,  // 22: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
+	51,  // 11: v1alpha1.CNIConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	56,  // 12: v1alpha1.CNIUsageConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 13: v1alpha1.CNIUsageConfig.chained:type_name -> google.protobuf.BoolValue
+	56,  // 14: v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 15: v1alpha1.CNIAmbientConfig.dnsCapture:type_name -> google.protobuf.BoolValue
+	56,  // 16: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 17: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
+	56,  // 18: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
+	52,  // 19: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
+	53,  // 20: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
+	59,  // 21: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
+	56,  // 22: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
 	37,  // 23: v1alpha1.DefaultResourcesConfig.requests:type_name -> v1alpha1.ResourcesRequestsConfig
-	55,  // 24: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	56,  // 24: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
 	9,   // 25: v1alpha1.EgressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
 	9,   // 26: v1alpha1.EgressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	55,  // 27: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	55,  // 28: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 29: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
-	53,  // 30: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
-	58,  // 31: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	58,  // 32: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	60,  // 33: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 34: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	56,  // 27: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 28: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 29: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
+	54,  // 30: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
+	59,  // 31: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 32: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 33: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 34: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
 	33,  // 35: v1alpha1.EgressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
 	10,  // 36: v1alpha1.EgressGatewayConfig.resources:type_name -> v1alpha1.Resources
 	39,  // 37: v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	58,  // 38: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	59,  // 38: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
 	49,  // 39: v1alpha1.EgressGatewayConfig.zvpn:type_name -> v1alpha1.ZeroVPNConfig
-	61,  // 40: v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	50,  // 41: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	50,  // 42: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	58,  // 43: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	58,  // 44: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	55,  // 45: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	62,  // 40: v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	51,  // 41: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 42: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	59,  // 43: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	59,  // 44: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	56,  // 45: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
 	11,  // 46: v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
 	14,  // 47: v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> v1alpha1.EgressGatewayConfig
-	55,  // 48: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 48: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
 	20,  // 49: v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> v1alpha1.IngressGatewayConfig
 	3,   // 50: v1alpha1.GlobalConfig.arch:type_name -> v1alpha1.ArchConfig
-	55,  // 51: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
-	58,  // 52: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
+	56,  // 51: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
+	59,  // 52: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
 	12,  // 53: v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> v1alpha1.DefaultPodDisruptionBudgetConfig
 	13,  // 54: v1alpha1.GlobalConfig.defaultResources:type_name -> v1alpha1.DefaultResourcesConfig
-	61,  // 55: v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
-	55,  // 56: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
+	62,  // 55: v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 56: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
 	19,  // 57: v1alpha1.GlobalConfig.logging:type_name -> v1alpha1.GlobalLoggingConfig
-	58,  // 58: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
+	59,  // 58: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
 	22,  // 59: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
-	55,  // 60: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
-	55,  // 61: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
+	56,  // 60: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
+	56,  // 61: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
 	34,  // 62: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
 	36,  // 63: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
 	38,  // 64: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
-	56,  // 65: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
+	57,  // 65: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
 	41,  // 66: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
-	55,  // 67: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
+	56,  // 67: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
 	18,  // 68: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
 	17,  // 69: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
-	55,  // 70: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
-	55,  // 71: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
-	55,  // 72: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
-	55,  // 73: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
-	55,  // 74: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	55,  // 75: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	56,  // 70: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
+	56,  // 71: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
+	56,  // 72: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
+	56,  // 73: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
+	56,  // 74: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	56,  // 75: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
 	9,   // 76: v1alpha1.IngressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
 	9,   // 77: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	55,  // 78: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	55,  // 79: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	58,  // 80: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	54,  // 81: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
-	58,  // 82: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	58,  // 83: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	60,  // 84: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	56,  // 78: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 79: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 80: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	55,  // 81: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
+	59,  // 82: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 83: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 84: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
 	33,  // 86: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	58,  // 87: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	59,  // 87: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
 	39,  // 88: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	58,  // 89: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	59,  // 89: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
 	21,  // 90: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
-	50,  // 91: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	50,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	61,  // 93: v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	58,  // 94: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	58,  // 95: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	58,  // 96: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	55,  // 97: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	51,  // 91: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	62,  // 93: v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	59,  // 94: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	59,  // 95: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	59,  // 96: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	56,  // 97: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
 	11,  // 98: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	55,  // 99: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 100: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 101: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	56,  // 99: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 100: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 101: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
 	2,   // 102: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
-	55,  // 103: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 104: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	58,  // 105: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
+	56,  // 103: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 104: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	59,  // 105: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
 	10,  // 106: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
 	9,   // 107: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	58,  // 108: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	62,  // 109: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	58,  // 110: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	58,  // 111: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	55,  // 112: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	55,  // 113: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
-	58,  // 114: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	57,  // 115: v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	50,  // 116: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	50,  // 117: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	61,  // 118: v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	55,  // 119: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
-	55,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
-	58,  // 121: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	58,  // 122: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	58,  // 123: v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
+	59,  // 108: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	63,  // 109: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	59,  // 110: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	59,  // 111: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	56,  // 112: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	56,  // 113: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
+	59,  // 114: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	58,  // 115: v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	51,  // 116: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 117: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	62,  // 118: v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 119: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
+	56,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
+	59,  // 121: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	59,  // 122: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	59,  // 123: v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
 	32,  // 124: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
-	56,  // 125: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	59,  // 126: v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
-	63,  // 127: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	58,  // 128: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
-	64,  // 129: v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
-	65,  // 130: v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
+	57,  // 125: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	60,  // 126: v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	64,  // 127: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	59,  // 128: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
+	65,  // 129: v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
+	66,  // 130: v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
 	9,   // 131: v1alpha1.PilotConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
 	5,   // 132: v1alpha1.PilotConfig.cni:type_name -> v1alpha1.CNIUsageConfig
 	25,  // 133: v1alpha1.PilotConfig.taint:type_name -> v1alpha1.PilotTaintControllerConfig
 	0,   // 134: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
-	55,  // 135: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 136: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 135: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 136: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
 	29,  // 137: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
-	55,  // 138: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 138: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
 	30,  // 139: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
 	31,  // 140: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
-	55,  // 141: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 142: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	55,  // 143: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	55,  // 144: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	56,  // 141: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 142: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 143: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	56,  // 144: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
 	35,  // 145: v1alpha1.ProxyConfig.startupProbe:type_name -> v1alpha1.StartupProbe
 	10,  // 146: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
 	1,   // 147: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
-	66,  // 148: v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
-	55,  // 149: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	55,  // 150: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	67,  // 148: v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
+	56,  // 149: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	56,  // 150: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
 	10,  // 151: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
-	58,  // 152: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	55,  // 153: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	60,  // 154: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	60,  // 155: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	55,  // 156: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	58,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	58,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
-	58,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	55,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	59,  // 152: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	56,  // 153: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	61,  // 154: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 155: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	56,  // 156: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	59,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	59,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
+	59,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	56,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
 	42,  // 161: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
 	43,  // 162: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
 	44,  // 163: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
 	45,  // 164: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	55,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	55,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	55,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	55,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	56,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	56,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	56,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	56,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
 	4,   // 169: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
 	15,  // 170: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
 	16,  // 171: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
 	24,  // 172: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	56,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	57,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
 	28,  // 174: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
 	40,  // 175: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
 	5,   // 176: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
-	56,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	57,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
 	46,  // 178: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
 	47,  // 179: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	55,  // 180: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	67,  // 181: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	68,  // 182: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	183, // [183:183] is the sub-list for method output_type
-	183, // [183:183] is the sub-list for method input_type
-	183, // [183:183] is the sub-list for extension type_name
-	183, // [183:183] is the sub-list for extension extendee
-	0,   // [0:183] is the sub-list for field type_name
+	50,  // 180: v1alpha1.Values.experimental:type_name -> v1alpha1.ExperimentalConfig
+	56,  // 181: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 182: v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
+	68,  // 183: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	69,  // 184: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	185, // [185:185] is the sub-list for method output_type
+	185, // [185:185] is the sub-list for method input_type
+	185, // [185:185] is the sub-list for extension type_name
+	185, // [185:185] is the sub-list for extension extendee
+	0,   // [0:185] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }
@@ -7469,6 +7541,18 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			}
 		}
 		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ExperimentalConfig); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_pkg_apis_istio_v1alpha1_values_types_proto_msgTypes[48].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IntOrString); i {
 			case 0:
 				return &v.state
@@ -7487,7 +7571,7 @@ func file_pkg_apis_istio_v1alpha1_values_types_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc,
 			NumEnums:      3,
-			NumMessages:   52,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -1426,6 +1426,9 @@ message Values {
   // Specifies the compatibility version to use. When this is set, the control plane will
   // be configured with the same defaults as the specified version.
   string compatibilityVersion = 43;
+
+  // Specifies experimental helm fields that could be removed or changed in the future
+  ExperimentalConfig experimental = 44;
 }
 
 // ZeroVPNConfig enables cross-cluster access using SNI matching.
@@ -1434,6 +1437,12 @@ message ZeroVPNConfig {
   google.protobuf.BoolValue enabled = 1;
 
   string suffix = 2;
+}
+
+// ExperimentalConfig is a placeholder for experimental installation features.
+message ExperimentalConfig {
+  // Controls whether the experimental feature is enabled.
+  google.protobuf.BoolValue stableValidationPolicy = 1;
 }
 
 // IntOrString is a type that can hold an int32 or a string.  When used in

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -2,6 +2,10 @@
 # This should be used to create K8s clusters with versions >= 1.23
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  ValidatingAdmissionPolicy: true
+runtimeConfig:
+  "admissionregistration.k8s.io/v1beta1": true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -2,10 +2,6 @@
 # This should be used to create K8s clusters with versions >= 1.23
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  ValidatingAdmissionPolicy: true
-runtimeConfig:
-  "admissionregistration.k8s.io/v1beta1": true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/releasenotes/notes/release-channels.yaml
+++ b/releasenotes/notes/release-channels.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- https://github.com/istio/enhancements/issues/173
+releaseNotes:
+- |
+  **Added** a new, optional experimental admission policy that only allows stable features/fields to be used in Istio APIs

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -155,14 +155,14 @@ func performInPlaceUpgradeFunc(previousVersion string, isAmbient bool) func(fram
 		}
 		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, prevVariant, "", isAmbient)
 		helmtest.InstallIstio(t, cs, h, overrideValuesFile, previousVersion, true, isAmbient, nsConfig)
-		helmtest.VerifyInstallation(t, cs, nsConfig, true, isAmbient)
+		helmtest.VerifyInstallation(t, cs, nsConfig, true, isAmbient, "")
 
 		_, oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t, "")
 		sanitycheck.RunTrafficTestClientServer(t, oldClient, oldServer)
 
 		overrideValuesFile = helmtest.GetValuesOverrides(t, s.Image.Hub, s.Image.Tag, s.Image.Variant, "", isAmbient)
 		upgradeCharts(t, h, overrideValuesFile, nsConfig, isAmbient)
-		helmtest.VerifyInstallation(t, cs, nsConfig, true, isAmbient)
+		helmtest.VerifyInstallation(t, cs, nsConfig, true, isAmbient, "")
 
 		_, newClient, newServer := sanitycheck.SetupTrafficTest(t, t, "")
 		sanitycheck.RunTrafficTestClientServer(t, newClient, newServer)
@@ -192,14 +192,14 @@ func performCanaryUpgradeFunc(nsConfig helmtest.NamespaceConfig, previousVersion
 		s := t.Settings()
 		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, s.Image.Variant, "", false)
 		helmtest.InstallIstio(t, cs, h, overrideValuesFile, previousVersion, false, false, helmtest.DefaultNamespaceConfig)
-		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false)
+		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 
 		_, oldClient, oldServer := sanitycheck.SetupTrafficTest(t, t, "")
 		sanitycheck.RunTrafficTestClientServer(t, oldClient, oldServer)
 
 		overrideValuesFile = helmtest.GetValuesOverrides(t, s.Image.Hub, s.Image.Tag, s.Image.Variant, canaryTag, false)
 		helmtest.InstallIstioWithRevision(t, cs, h, "", canaryTag, overrideValuesFile, true, false)
-		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false)
+		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 
 		// now that we've installed with a revision we have a new mutating webhook
 		helmtest.VerifyMutatingWebhookConfigurations(t, cs, []string{
@@ -243,7 +243,7 @@ func performRevisionTagsUpgradeFunc(previousVersion string) func(framework.TestC
 		previousRevision := strings.ReplaceAll(previousVersion, ".", "-")
 		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, s.Image.Variant, previousRevision, false)
 		helmtest.InstallIstioWithRevision(t, cs, h, previousVersion, previousRevision, overrideValuesFile, false, true)
-		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false)
+		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 
 		// helm template istiod-1-15-0 istio/istiod --version 1.15.0 -s templates/revision-tags.yaml --set revision=1-15-0 --set revisionTags={prod}
 		helmtest.SetRevisionTagWithVersion(t, h, previousRevision, prodTag, previousVersion)
@@ -261,7 +261,7 @@ func performRevisionTagsUpgradeFunc(previousVersion string) func(framework.TestC
 		// helm install istiod-latest ../manifests/charts/istio-control/istio-discovery -f values.yaml
 		overrideValuesFile = helmtest.GetValuesOverrides(t, s.Image.Hub, s.Image.Tag, s.Image.Variant, latestRevisionTag, false)
 		helmtest.InstallIstioWithRevision(t, cs, h, "", latestRevisionTag, overrideValuesFile, true, false)
-		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false)
+		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 
 		// helm template istiod-latest ../manifests/charts/istio-control/istio-discovery --namespace istio-system
 		//    -s templates/revision-tags.yaml --set revision=latest --set revisionTags={canary}

--- a/tests/integration/helm/util.go
+++ b/tests/integration/helm/util.go
@@ -83,6 +83,49 @@ global:
   variant: %q
 profile: ambient
 `
+	sampleEnvoyFilter = `
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: sample
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
+      proxy:
+        proxyVersion: ^1\.19.*
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
+      proxy:
+        proxyVersion: ^1\.19.*
+  priority: -1
+`
+
+	extendedTelemetry = `
+apiVersion: v1
+kind: Telemetry
+metadata:
+	name: metrics-reporting-interval
+spec:
+	metrics:
+		- providers:
+			- name: prometheus
+		reportingInterval: 10s
+`
 )
 
 // ManifestsChartPath is path of local Helm charts used for testing.


### PR DESCRIPTION
**Please provide a description of this PR:**
Use a ValidatingAdmissionPolicy as an iterative implementation of the release channels proposal. We largely take the same approach as we've done with the validating webhook: one version for revisions and one for non-revisioned resources. Right now, the only extended fields are the 3 telemetry fields and the only extended resources are WasmPlugin and EnvoyFillter. 

The policy is authored manually for now and care will need to be taken to ensure it is updated for each extended field/resource being added in the future. Automation can/will be added in a follow up PR