### PR TITLE
Split out HBONE enablement

### DIFF
--- a/manifests/charts/base/files/profile-ambient.yaml
+++ b/manifests/charts/base/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/base/files/profile-ambient.yaml
+++ b/manifests/charts/base/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/base/files/profile-ambient.yaml
+++ b/manifests/charts/base/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/default/files/profile-ambient.yaml
+++ b/manifests/charts/default/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/default/files/profile-ambient.yaml
+++ b/manifests/charts/default/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/default/files/profile-ambient.yaml
+++ b/manifests/charts/default/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateway/files/profile-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateway/files/profile-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/gateway/files/profile-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-cni/files/profile-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-cni/files/profile-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/istio-cni/files/profile-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istio-operator/files/profile-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-operator/files/profile-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/istio-operator/files/profile-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-operator/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/istiod-remote/files/profile-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istiod-remote/files/profile-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/istiod-remote/files/profile-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/charts/ztunnel/files/profile-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-ambient.yaml
@@ -13,7 +13,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/ztunnel/files/profile-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-ambient.yaml
@@ -11,16 +11,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/charts/ztunnel/files/profile-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-ambient.yaml
@@ -11,12 +11,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -24,11 +24,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -24,12 +24,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/manifests/helm-profiles/ambient.yaml
+++ b/manifests/helm-profiles/ambient.yaml
@@ -7,16 +7,13 @@ global:
   variant: distroless
 pilot:
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
-  logLevel: info
   ambient:
     enabled: true
 

--- a/manifests/helm-profiles/ambient.yaml
+++ b/manifests/helm-profiles/ambient.yaml
@@ -7,12 +7,8 @@ global:
   variant: distroless
 pilot:
   env:
-    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
-    PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
+    PILOT_ENABLE_AMBIENT: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 cni:
   ambient:
     enabled: true

--- a/manifests/helm-profiles/ambient.yaml
+++ b/manifests/helm-profiles/ambient.yaml
@@ -9,7 +9,7 @@ pilot:
   env:
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
-    PILOT_ENABLE_LISTENING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -20,11 +20,9 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
-    # Setup more secure default that is off in 'default' only for backwards compatibility
-    VERIFY_CERTIFICATE_AT_CLIENT: "true"
-    ENABLE_AUTO_SNI: "true"
-
-    PILOT_ENABLE_HBONE: "true"
+    # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
+    PILOT_ENABLE_SENDING_HBONE: "true"
+    PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
     PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
     PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -20,12 +20,11 @@ pilot:
     provider: "multus"
   variant: distroless
   env:
+    PILOT_ENABLE_AMBIENT: "true"
     # Allow sidecars/ingress to send/receive HBONE. This is required for interop.
     PILOT_ENABLE_SENDING_HBONE: "true"
     PILOT_ENABLE_SIDECAR_LISTENING_HBONE: "true"
     CA_TRUSTED_NODE_ACCOUNTS: "istio-system/ztunnel,kube-system/ztunnel"
-    PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
-    PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
 variant: distroless
 seLinuxOptions:
   type: spc_t

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -1,0 +1,46 @@
+package features
+
+import (
+	"istio.io/istio/pkg/env"
+	"istio.io/istio/pkg/log"
+)
+
+var (
+	EnableAmbient = env.Register(
+		"PILOT_ENABLE_AMBIENT",
+		false,
+		"If enabled, ambient mode can be used. Individual flags configure fine grained enablement; this must be enabled for any ambient functionality.").Get()
+
+	EnableAmbientWaypoints = registerAmbient("PILOT_ENABLE_AMBIENT_WAYPOINTS",
+		true, false,
+		"If enabled, controllers required for ambient will run. This is required to run ambient mesh.")
+
+	EnableHBONESend = registerAmbient(
+		"PILOT_ENABLE_SENDING_HBONE",
+		true, false,
+		"If enabled, HBONE will be allowed when sending to destinations.")
+
+	EnableSidecarHBONEListening = registerAmbient(
+		"PILOT_ENABLE_SIDECAR_LISTENING_HBONE",
+		true, false,
+		"If enabled, HBONE support can be configured for proxies.")
+
+	// Not required for ambient, so disabled by default
+	PreferHBONESend = registerAmbient(
+		"PILOT_PREFER_SENDING_HBONE",
+		false, false,
+		"If enabled, HBONE will be preferred when sending to destinations. ")
+)
+
+// registerAmbient registers a variable that is allowed only if EnableAmbient is set
+func registerAmbient[T env.Parseable](name string, defaultWithAmbient, defaultWithoutAmbient T, description string) T {
+	if EnableAmbient {
+		return env.Register(name, defaultWithAmbient, description).Get()
+	}
+
+	_, f := env.Register(name, defaultWithoutAmbient, description).Lookup()
+	if f {
+		log.Warnf("ignoring %v; requires PILOT_ENABLE_AMBIENT=true", name)
+	}
+	return defaultWithoutAmbient
+}

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package features
 
 import (

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -165,9 +165,9 @@ var (
 	EnableGatewayAPIGatewayClassController = env.Register("PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER", true,
 		"If this is set to true, istiod will create and manage its default GatewayClasses").Get()
 
-	// EnableHBONEListening provides a global Pilot flag for enabling listening on HBONE.
-	EnableHBONEListening = env.Register(
-		"PILOT_ENABLE_LISTENING_HBONE",
+	// EnableSidecarHBONEListening provides a global Pilot flag for enabling listening on HBONE.
+	EnableSidecarHBONEListening = env.Register(
+		"PILOT_ENABLE_SIDECAR_LISTENING_HBONE",
 		false,
 		"If enabled, HBONE support can be configured for proxies. "+
 			"Note: proxies must opt in on a per-proxy basis with ENABLE_HBONE to actually get HBONE config, in addition to this flag.").Get()

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -165,40 +165,6 @@ var (
 	EnableGatewayAPIGatewayClassController = env.Register("PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER", true,
 		"If this is set to true, istiod will create and manage its default GatewayClasses").Get()
 
-	// EnableSidecarHBONEListening provides a global Pilot flag for enabling listening on HBONE.
-	EnableSidecarHBONEListening = env.Register(
-		"PILOT_ENABLE_SIDECAR_LISTENING_HBONE",
-		false,
-		"If enabled, HBONE support can be configured for proxies. "+
-			"Note: proxies must opt in on a per-proxy basis with ENABLE_HBONE to actually get HBONE config, in addition to this flag.").Get()
-	// PreferHBONESend controls whether HBONE is preferred. If not, if an endpoint supports mTLS and HBONE, mTLS will be used
-	PreferHBONESend = env.Register(
-		"PILOT_PREFER_SENDING_HBONE",
-		false,
-		"If enabled, HBONE will be preferred when sending to destinations. ").Get()
-	// PreferHBONESend controls whether HBONE sending HBONE is allowed.
-	// This is required for ambient to function.
-	EnableHBONESend = env.Register(
-		"PILOT_ENABLE_SENDING_HBONE",
-		false,
-		"If enabled, HBONE will be preferred when sending to destinations. ").Get()
-
-	EnableAmbientControllers = env.Register(
-		"PILOT_ENABLE_AMBIENT_CONTROLLERS",
-		false,
-		"If enabled, controllers required for ambient will run. This is required to run ambient mesh.").Get()
-
-	EnableAmbientWaypoints = func() bool {
-		v := env.Register(
-			"PILOT_ENABLE_AMBIENT_WAYPOINTS",
-			false,
-			"If enabled, controllers required for ambient will run. This is required to run ambient mesh.").Get()
-		if v && !EnableAmbientControllers {
-			log.Fatalf("PILOT_ENABLE_AMBIENT_WAYPOINTS requires PILOT_ENABLE_AMBIENT_CONTROLLERS")
-		}
-		return v
-	}()
-
 	DeltaXds = env.Register("ISTIO_DELTA_XDS", true,
 		"If enabled, pilot will only send the delta configs as opposed to the state of the world on a "+
 			"Resource Request. This feature uses the delta xds api, but does not currently send the actual deltas.").Get()

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -165,15 +165,23 @@ var (
 	EnableGatewayAPIGatewayClassController = env.Register("PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER", true,
 		"If this is set to true, istiod will create and manage its default GatewayClasses").Get()
 
-	// EnableHBONE provides a global Pilot flag for enabling HBONE.
-	// Generally, this could be a per-proxy setting (and is, via ENABLE_HBONE node metadata).
-	// However, there are some code paths that impact all clients, hence the global flag.
-	// Warning: do not enable by default until endpoint_builder.go caching is fixed (and possibly other locations).
-	EnableHBONE = env.Register(
-		"PILOT_ENABLE_HBONE",
+	// EnableHBONEListening provides a global Pilot flag for enabling listening on HBONE.
+	EnableHBONEListening = env.Register(
+		"PILOT_ENABLE_LISTENING_HBONE",
 		false,
 		"If enabled, HBONE support can be configured for proxies. "+
 			"Note: proxies must opt in on a per-proxy basis with ENABLE_HBONE to actually get HBONE config, in addition to this flag.").Get()
+	// PreferHBONESend controls whether HBONE is preferred. If not, if an endpoint supports mTLS and HBONE, mTLS will be used
+	PreferHBONESend = env.Register(
+		"PILOT_PREFER_SENDING_HBONE",
+		false,
+		"If enabled, HBONE will be preferred when sending to destinations. ").Get()
+	// PreferHBONESend controls whether HBONE sending HBONE is allowed.
+	// This is required for ambient to function.
+	EnableHBONESend = env.Register(
+		"PILOT_ENABLE_SENDING_HBONE",
+		false,
+		"If enabled, HBONE will be preferred when sending to destinations. ").Get()
 
 	EnableAmbientControllers = env.Register(
 		"PILOT_ENABLE_AMBIENT_CONTROLLERS",

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -921,7 +921,7 @@ func (node *Proxy) FuzzValidate() bool {
 }
 
 func (node *Proxy) EnableHBONEListen() bool {
-	return node.IsAmbient() || (features.EnableHBONEListening && bool(node.Metadata.EnableHBONE))
+	return node.IsAmbient() || (features.EnableSidecarHBONEListening && bool(node.Metadata.EnableHBONE))
 }
 
 func (node *Proxy) SetWorkloadEntry(name string, create bool) {

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -920,8 +920,8 @@ func (node *Proxy) FuzzValidate() bool {
 	return len(node.IPAddresses) != 0
 }
 
-func (node *Proxy) EnableHBONE() bool {
-	return node.IsAmbient() || (features.EnableHBONE && bool(node.Metadata.EnableHBONE))
+func (node *Proxy) EnableHBONEListen() bool {
+	return node.IsAmbient() || (features.EnableHBONEListening && bool(node.Metadata.EnableHBONE))
 }
 
 func (node *Proxy) SetWorkloadEntry(name string, create bool) {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -28,10 +28,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/mitchellh/copystructure"
@@ -528,18 +526,6 @@ type IstioEndpoint struct {
 
 	// If in k8s, the node where the pod resides
 	NodeName string
-
-	// precomputedEnvoyEndpoint is a cached LbEndpoint, converted from the data, to
-	// avoid recomputation
-	precomputedEnvoyEndpoint atomic.Pointer[endpoint.LbEndpoint]
-}
-
-func (ep *IstioEndpoint) EnvoyEndpoint() *endpoint.LbEndpoint {
-	return ep.precomputedEnvoyEndpoint.Load()
-}
-
-func (ep *IstioEndpoint) ComputeEnvoyEndpoint(now *endpoint.LbEndpoint) {
-	ep.precomputedEnvoyEndpoint.Store(now)
 }
 
 func (ep *IstioEndpoint) SupportsTunnel(tunnelType string) bool {

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -224,7 +224,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, proxy, instances, inboundPatcher)...)
-		if proxy.EnableHBONE() {
+		if proxy.EnableHBONEListen() {
 			clusters = append(clusters, configgen.buildInboundHBONEClusters())
 		}
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
@@ -256,7 +256,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 	}
 
 	// OutboundTunnel cluster is needed for sidecar and gateway.
-	if proxy.EnableHBONE() && proxy.Type != model.Waypoint {
+	if features.EnableHBONESend && proxy.Type != model.Waypoint {
 		clusters = append(clusters, cb.buildConnectOriginate(proxy, req.Push, nil))
 	}
 

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -91,7 +91,7 @@ type ClusterBuilder struct {
 	passThroughBindIPs []string              // Passthrough IPs to be used while building clusters.
 	supportsIPv4       bool                  // Whether Proxy IPs has IPv4 address.
 	supportsIPv6       bool                  // Whether Proxy IPs has IPv6 address.
-	hbone              bool                  // Does the proxy support HBONE
+	sendHbone          bool                  // Does the proxy support HBONE
 	locality           *core.Locality        // Locality information of proxy.
 	proxyLabels        map[string]string     // Proxy labels.
 	proxyView          model.ProxyView       // Proxy view of endpoints.
@@ -114,7 +114,7 @@ func NewClusterBuilder(proxy *model.Proxy, req *model.PushRequest, cache model.X
 		passThroughBindIPs: getPassthroughBindIPs(proxy.GetIPMode()),
 		supportsIPv4:       proxy.SupportsIPv4(),
 		supportsIPv6:       proxy.SupportsIPv6(),
-		hbone:              proxy.EnableHBONE() || proxy.IsWaypointProxy(),
+		sendHbone:          features.EnableHBONESend || proxy.IsWaypointProxy(),
 		locality:           proxy.Locality,
 		proxyLabels:        proxy.Labels,
 		proxyView:          proxy.GetView(),

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -194,7 +194,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		proxyClusterID:  cb.clusterID,
 		proxySidecar:    cb.sidecarProxy(),
 		proxyView:       cb.proxyView,
-		hbone:           cb.hbone,
+		hbone:           cb.sendHbone,
 		http2:           port.Protocol.IsHTTP2(),
 		downstreamAuto:  cb.sidecarProxy() && port.Protocol.IsUnsupported(),
 		supportsIPv4:    cb.supportsIPv4,

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -106,7 +106,7 @@ func (cb *ClusterBuilder) applyUpstreamTLSSettings(
 	}
 	istioAutodetectedMtls := tls != nil && tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL &&
 		mtlsCtxType == autoDetected
-	if cb.hbone {
+	if cb.sendHbone {
 		cb.applyHBONETransportSocketMatches(c.cluster, tls, istioAutodetectedMtls)
 	} else if c.cluster.GetType() != cluster.Cluster_ORIGINAL_DST {
 		// For headless service, discovery type will be `Cluster_ORIGINAL_DST`

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -56,10 +56,7 @@ func (cb *ClusterBuilder) applyTrafficPolicy(opts buildClusterOpts) {
 			tls, mtlsCtxType := cb.buildUpstreamTLSSettings(tls, opts.serviceAccounts, opts.istioMtlsSni,
 				autoMTLSEnabled, opts.meshExternal, opts.serviceMTLSMode)
 			cb.applyUpstreamTLSSettings(&opts, tls, mtlsCtxType)
-			// donot apply proxy protocol for proxy that supports HBONE
-			if !cb.hbone {
-				cb.applyUpstreamProxyProtocol(&opts, proxyProtocol)
-			}
+			cb.applyUpstreamProxyProtocol(&opts, proxyProtocol)
 		}
 	}
 

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -110,7 +110,7 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 
 	builder.patchListeners()
 	l := builder.getListeners()
-	if builder.node.EnableHBONE() && !builder.node.IsWaypointProxy() {
+	if features.EnableHBONESend && !builder.node.IsWaypointProxy() {
 		l = append(l, buildConnectOriginateListener())
 	}
 

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -90,7 +90,7 @@ func NewListenerBuilder(node *model.Proxy, push *model.PushContext) *ListenerBui
 
 func (lb *ListenerBuilder) appendSidecarInboundListeners() *ListenerBuilder {
 	lb.inboundListeners = lb.buildInboundListeners()
-	if lb.node.EnableHBONE() {
+	if lb.node.EnableHBONEListen() {
 		lb.inboundListeners = append(lb.inboundListeners, lb.buildInboundHBONEListeners()...)
 	}
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -54,7 +54,7 @@ type Controller struct {
 }
 
 func (c *Controller) ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo {
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbient {
 		return nil
 	}
 	var res []model.ServiceInfo
@@ -76,7 +76,7 @@ func (c *Controller) WorkloadsForWaypoint(key model.WaypointKey) []model.Workloa
 }
 
 func (c *Controller) AdditionalPodSubscriptions(proxy *model.Proxy, addr, cur sets.String) sets.String {
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbient {
 		return nil
 	}
 	res := sets.New[string]()
@@ -88,7 +88,7 @@ func (c *Controller) AdditionalPodSubscriptions(proxy *model.Proxy, addr, cur se
 
 func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []model.WorkloadAuthorization {
 	var res []model.WorkloadAuthorization
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbient {
 		return res
 	}
 	for _, p := range c.GetRegistries() {
@@ -99,7 +99,7 @@ func (c *Controller) Policies(requested sets.Set[model.ConfigKey]) []model.Workl
 
 func (c *Controller) AddressInformation(addresses sets.String) ([]model.AddressInfo, sets.String) {
 	i := []model.AddressInfo{}
-	if !features.EnableAmbientControllers {
+	if !features.EnableAmbient {
 		return i, nil
 	}
 	removed := sets.String{}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -71,14 +71,12 @@ const (
 
 func init() {
 	features.EnableAmbientWaypoints = true
-	features.EnableAmbientControllers = true
+	features.EnableAmbient = true
 }
 
 var validTrafficTypes = sets.New(constants.ServiceTraffic, constants.WorkloadTraffic, constants.AllTraffic, constants.NoTraffic)
 
 func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
-
 	cases := []struct {
 		name         string
 		trafficType  string
@@ -174,7 +172,6 @@ func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
 }
 
 func TestAmbientIndex_NetworkAndClusterIDs(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	cases := []struct {
 		name    string
 		cluster cluster.ID
@@ -254,7 +251,6 @@ func TestAmbientIndex_LookupWorkloads(t *testing.T) {
 }
 
 func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, testC, testNW)
 
 	s.addWaypoint(t, "10.0.0.10", "test-wp", "default", true)
@@ -1344,7 +1340,6 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 }
 
 func TestWorkloadsForWaypointOrder(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
 	s := newAmbientTestServer(t, "", testNW)
 
 	assertOrderedWaypoint := func(t *testing.T, network, address string, expected ...string) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -284,7 +284,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	})
 	registerHandlers[*v1.Pod](c, c.podsClient, "Pods", c.pods.onEvent, c.pods.labelFilter)
 
-	if features.EnableAmbientControllers {
+	if features.EnableAmbient {
 		c.ambientIndex = ambient.New(ambient.Options{
 			Client:          kubeClient,
 			SystemNamespace: options.SystemNamespace,

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -227,7 +227,7 @@ func addMeshNetworksFromRegistryGateway(t *testing.T, c *FakeController, watcher
 }
 
 func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	testNS := "test"
 	systemNS := "istio-system"
 

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -396,7 +396,6 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			ep := workloadInstance.Endpoint.ShallowCopy()
 			ep.ServicePortName = serviceEntryPort.Name
 			ep.EndpointPort = targetPort
-			ep.ComputeEnvoyEndpoint(nil)
 			out = append(out, &model.ServiceInstance{
 				Endpoint:    ep,
 				Service:     service,

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -875,7 +875,7 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceEndpoints(t, fx, expectedSvc, 80, instances)
 	})
 
-	istiotest.SetForTest(t, &features.EnableHBONE, true)
+	istiotest.SetForTest(t, &features.EnableHBONEListening, true)
 	istiotest.SetForTest(t, &features.EnableAmbientControllers, true)
 	for _, ambient := range []bool{false, true} {
 		name := "disabled"

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -876,7 +876,7 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	istiotest.SetForTest(t, &features.EnableSidecarHBONEListening, true)
-	istiotest.SetForTest(t, &features.EnableAmbientControllers, true)
+	istiotest.SetForTest(t, &features.EnableAmbient, true)
 	for _, ambient := range []bool{false, true} {
 		name := "disabled"
 		if ambient {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -875,7 +875,7 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceEndpoints(t, fx, expectedSvc, 80, instances)
 	})
 
-	istiotest.SetForTest(t, &features.EnableHBONEListening, true)
+	istiotest.SetForTest(t, &features.EnableSidecarHBONEListening, true)
 	istiotest.SetForTest(t, &features.EnableAmbientControllers, true)
 	for _, ambient := range []bool{false, true} {
 		name := "disabled"

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -540,8 +540,8 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection, ident
 	con.conID = connectionID(proxy.ID)
 	con.node = node
 	con.proxy = proxy
-	if proxy.IsZTunnel() && !features.EnableAmbientControllers {
-		return fmt.Errorf("ztunnel requires PILOT_ENABLE_AMBIENT_CONTROLLERS=true")
+	if proxy.IsZTunnel() && !features.EnableAmbient {
+		return fmt.Errorf("ztunnel requires PILOT_ENABLE_AMBIENT=true")
 	}
 
 	// Authorize xds clients

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -316,7 +316,7 @@ func TestDeltaReconnectRequests(t *testing.T) {
 }
 
 func TestDeltaWDS(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	wlA := &model.WorkloadInfo{
 		Workload: &workloadapi.Workload{

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -211,7 +211,7 @@ func (b *EndpointBuilder) WriteHash(h hash.Hash) {
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(b.clusterLocal))
 	h.Write(Separator)
-	if features.EnableHBONEListening && b.proxy != nil {
+	if features.EnableSidecarHBONEListening && b.proxy != nil {
 		h.WriteString(strconv.FormatBool(b.proxy.IsProxylessGrpc()))
 		h.Write(Separator)
 	}

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -211,7 +211,7 @@ func (b *EndpointBuilder) WriteHash(h hash.Hash) {
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(b.clusterLocal))
 	h.Write(Separator)
-	if features.EnableHBONE && b.proxy != nil {
+	if features.EnableHBONEListening && b.proxy != nil {
 		h.WriteString(strconv.FormatBool(b.proxy.IsProxylessGrpc()))
 		h.Write(Separator)
 	}
@@ -319,7 +319,7 @@ func (b *EndpointBuilder) FromServiceEndpoints() []*endpoint.LocalityLbEndpoints
 	}
 	svcEps := b.push.ServiceEndpointsByPort(b.service, b.port, b.subsetLabels)
 	// don't use the pre-computed endpoints for CDS to preserve previous behavior
-	return ExtractEnvoyEndpoints(b.generate(svcEps, true))
+	return ExtractEnvoyEndpoints(b.generate(svcEps))
 }
 
 // BuildClusterLoadAssignment converts the shards for this EndpointBuilder's Service
@@ -342,7 +342,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 		return true
 	})
 
-	localityLbEndpoints := b.generate(svcEps, false)
+	localityLbEndpoints := b.generate(svcEps)
 	if len(localityLbEndpoints) == 0 {
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
@@ -370,8 +370,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 }
 
 // generate endpoints with applies weights, multi-network mapping and other filtering
-// noCache means we will not use or update the IstioEndpoint's precomputedEnvoyEndpoint
-func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint, allowPrecomputed bool) []*LocalityEndpoints {
+func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint) []*LocalityEndpoints {
 	// shouldn't happen here
 	if !b.ServiceFound() {
 		return nil
@@ -383,28 +382,10 @@ func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint, allowPrecomputed 
 
 	localityEpMap := make(map[string]*LocalityEndpoints)
 	for _, ep := range eps {
-		eep := ep.EnvoyEndpoint()
 		mtlsEnabled := b.mtlsChecker.checkMtlsEnabled(ep, b.proxy.IsWaypointProxy())
-		// Determine if we need to build the endpoint. We try to cache it for performance reasons
-		needToCompute := eep == nil
-		if features.EnableHBONE {
-			// Currently the HBONE implementation leads to different endpoint generation depending on if the
-			// client proxy supports HBONE or not. This breaks the cache.
-			// For now, just disable caching if the global HBONE flag is enabled.
-			needToCompute = true
-		}
-		if eep != nil && mtlsEnabled != isMtlsEnabled(eep) {
-			// The mTLS settings may have changed, invalidating the cache endpoint. Rebuild it
-			needToCompute = true
-		}
-		if needToCompute || !allowPrecomputed {
-			eep = buildEnvoyLbEndpoint(b, ep, mtlsEnabled)
-			if eep == nil {
-				continue
-			}
-			if allowPrecomputed {
-				ep.ComputeEnvoyEndpoint(eep)
-			}
+		eep := buildEnvoyLbEndpoint(b, ep, mtlsEnabled)
+		if eep == nil {
+			continue
 		}
 		locLbEps, found := localityEpMap[ep.Locality.Label]
 		if !found {
@@ -651,7 +632,11 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 	}
 	util.AppendLbEndpointMetadata(meta, ep.Metadata)
 
-	if supportTunnel(b, e) {
+	tunnel := supportTunnel(b, e)
+	if mtlsEnabled && !features.PreferHBONESend {
+		tunnel = false
+	}
+	if tunnel {
 		address, port := e.Address, int(e.EndpointPort)
 		// We intentionally do not take into account waypoints here.
 		// 1. Workload waypoints: sidecar/ingress do not support sending traffic directly to workloads, only to services,
@@ -687,10 +672,6 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 func supportTunnel(b *EndpointBuilder, e *model.IstioEndpoint) bool {
 	if b.proxy.IsProxylessGrpc() {
 		// Proxyless client cannot handle tunneling, even if the server can
-		return false
-	}
-
-	if !b.proxy.EnableHBONE() {
 		return false
 	}
 

--- a/pilot/pkg/xds/workload_test.go
+++ b/pilot/pkg/xds/workload_test.go
@@ -87,7 +87,7 @@ func buildExpectAddedAndRemoved(t *testing.T) func(resp *discovery.DeltaDiscover
 }
 
 func TestWorkloadReconnect(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	t.Run("ondemand", func(t *testing.T) {
 		expect := buildExpect(t)
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
@@ -154,7 +154,7 @@ func TestWorkloadReconnect(t *testing.T) {
 }
 
 func TestWorkload(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	t.Run("ondemand", func(t *testing.T) {
 		expect := buildExpect(t)
 		expectRemoved := buildExpectExpectRemoved(t)
@@ -372,7 +372,7 @@ func createService(s *xds.FakeDiscoveryServer, name, namespace string, selector 
 }
 
 func TestWorkloadAuthorizationPolicy(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	expect := buildExpect(t)
 	expectRemoved := buildExpectExpectRemoved(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
@@ -400,7 +400,7 @@ func TestWorkloadAuthorizationPolicy(t *testing.T) {
 }
 
 func TestWorkloadPeerAuthentication(t *testing.T) {
-	test.SetForTest(t, &features.EnableAmbientControllers, true)
+	test.SetForTest(t, &features.EnableAmbient, true)
 	expect := buildExpect(t)
 	expectAddedAndRemoved := buildExpectAddedAndRemoved(t)
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})

--- a/tests/integration/iop-wds.yaml
+++ b/tests/integration/iop-wds.yaml
@@ -11,6 +11,6 @@ spec:
   values:
     pilot:
       env:
-        PILOT_ENABLE_AMBIENT_CONTROLLERS: "true"
+        PILOT_ENABLE_AMBIENT: "true"
         PILOT_ENABLE_AMBIENT_WAYPOINTS: "true"
         PILOT_DISABLE_MX_ALPN: "true"


### PR DESCRIPTION
There are now three properties:
* Allow sending HBONE. This is critical, and required for interop between ingress and sidecars to waypoints/ztunnel.
* Listen on HBONE. This is only needed if we want to allow HBONE from ztunnel to sidecars.
* Prefer to send HBONE. This is experimental and only if we want to use HBONE between sidecars. This is not needed in any way for ambient.

These are now split out to give more operational controls. In particular, users can now configure to not use HBONE between sidecars, which is excessively risky at this point.
