### PR TITLE
Add one/many path templating support for AuthPolicy

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
@@ -30,7 +30,7 @@ spec:
             notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
             notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
             notPorts: ["8000", "9000"]
-            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "{**}/not-path/template"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "/{**}/not-path/template"]
       when:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
@@ -26,7 +26,7 @@ spec:
             methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
             hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
             ports: ["80", "90"]
-            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "{**}/path/template"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "/{**}/path/template"]
             notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
             notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
             notPorts: ["8000", "9000"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-in.yaml
@@ -26,11 +26,11 @@ spec:
             methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
             hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
             ports: ["80", "90"]
-            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "{**}/path/template"]
             notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
             notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
             notPorts: ["8000", "9000"]
-            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "{**}/not-path/template"]
       when:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -98,6 +98,14 @@ typedConfig:
                     path:
                       safeRegex:
                         regex: .+
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: "/path/template/*"
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: "**/path/template"
             - notRule:
                 orRules:
                   rules:
@@ -114,6 +122,14 @@ typedConfig:
                       path:
                         safeRegex:
                           regex: .+
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: "/not-path/template/*"
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: "**/not-path/template"
             - orRules:
                 rules:
                 - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -101,11 +101,11 @@ typedConfig:
                 - uriTemplate:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: "/path/template/*"
+                      pathTemplate: /path/template/*
                 - uriTemplate:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: "**/path/template"
+                      pathTemplate: '**/path/template'
             - notRule:
                 orRules:
                   rules:
@@ -125,11 +125,11 @@ typedConfig:
                   - uriTemplate:
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: "/not-path/template/*"
+                        pathTemplate: /not-path/template/*
                   - uriTemplate:
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: "**/not-path/template"
+                        pathTemplate: '**/not-path/template'
             - orRules:
                 rules:
                 - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -107,7 +107,7 @@ typedConfig:
                     name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: '**/path/template'
+                      pathTemplate: /**/path/template
             - notRule:
                 orRules:
                   rules:

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -133,7 +133,7 @@ typedConfig:
                       name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: '**/not-path/template'
+                        pathTemplate: /**/not-path/template
             - orRules:
                 rules:
                 - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -99,10 +99,12 @@ typedConfig:
                       safeRegex:
                         regex: .+
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: /path/template/*
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: '**/path/template'
@@ -123,10 +125,12 @@ typedConfig:
                         safeRegex:
                           regex: .+
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: /not-path/template/*
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: '**/not-path/template'

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
@@ -12,4 +12,4 @@ spec:
     - to:
         - operation:
             paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "{**}/path/template"]
-            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "{**}/not-path/template"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "/{**}/not-path/template"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
@@ -11,5 +11,5 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
-            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "{**}/path/template"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "{**}/not-path/template"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-in.yaml
@@ -11,5 +11,5 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "{**}/path/template"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*", "/path/template/{*}", "/{**}/path/template"]
             notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*", "/not-path/template/{*}", "/{**}/not-path/template"]

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -57,7 +57,7 @@ typedConfig:
                       name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: '**/not-path/template'
+                        pathTemplate: /**/not-path/template
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -23,10 +23,12 @@ typedConfig:
                       safeRegex:
                         regex: .+
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: /path/template/*
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: '**/path/template'
@@ -47,10 +49,12 @@ typedConfig:
                         safeRegex:
                           regex: .+
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: /not-path/template/*
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: '**/not-path/template'

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -22,6 +22,14 @@ typedConfig:
                     path:
                       safeRegex:
                         regex: .+
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: "/path/template/*"
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: "**/path/template"
             - notRule:
                 orRules:
                   rules:
@@ -38,6 +46,14 @@ typedConfig:
                       path:
                         safeRegex:
                           regex: .+
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: "/not-path/template/*"
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: "**/not-path/template"
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -25,11 +25,11 @@ typedConfig:
                 - uriTemplate:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: "/path/template/*"
+                      pathTemplate: /path/template/*
                 - uriTemplate:
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: "**/path/template"
+                      pathTemplate: '**/path/template'
             - notRule:
                 orRules:
                   rules:
@@ -49,11 +49,11 @@ typedConfig:
                   - uriTemplate:
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: "/not-path/template/*"
+                        pathTemplate: /not-path/template/*
                   - uriTemplate:
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: "**/not-path/template"
+                        pathTemplate: '**/not-path/template'
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-path-out.yaml
@@ -31,7 +31,7 @@ typedConfig:
                     name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: '**/path/template'
+                      pathTemplate: /**/path/template
             - notRule:
                 orRules:
                   rules:

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -107,7 +107,7 @@ typedConfig:
                     name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: '**/path/template'
+                      pathTemplate: /**/path/template
             - notRule:
                 orRules:
                   rules:

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -133,7 +133,7 @@ typedConfig:
                       name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: '**/not-path/template'
+                        pathTemplate: /**/not-path/template
             - orRules:
                 rules:
                 - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -98,6 +98,14 @@ typedConfig:
                     path:
                       safeRegex:
                         regex: .+
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: /path/template/*
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: '**/path/template'
             - notRule:
                 orRules:
                   rules:
@@ -114,6 +122,14 @@ typedConfig:
                       path:
                         safeRegex:
                           regex: .+
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: /not-path/template/*
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: '**/not-path/template'
             - orRules:
                 rules:
                 - destinationPort: 80

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-full-rule-out.yaml
@@ -99,10 +99,12 @@ typedConfig:
                       safeRegex:
                         regex: .+
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: /path/template/*
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: '**/path/template'
@@ -123,10 +125,12 @@ typedConfig:
                         safeRegex:
                           regex: .+
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: /not-path/template/*
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: '**/not-path/template'

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
@@ -57,7 +57,7 @@ typedConfig:
                       name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                        pathTemplate: '**/not-path/template'
+                        pathTemplate: /**/not-path/template
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
@@ -22,6 +22,14 @@ typedConfig:
                     path:
                       safeRegex:
                         regex: .+
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: /path/template/*
+                - uriTemplate:
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                      pathTemplate: '**/path/template'
             - notRule:
                 orRules:
                   rules:
@@ -38,6 +46,14 @@ typedConfig:
                       path:
                         safeRegex:
                           regex: .+
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: /not-path/template/*
+                  - uriTemplate:
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+                        pathTemplate: '**/not-path/template'
         principals:
         - andIds:
             ids:

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
@@ -23,10 +23,12 @@ typedConfig:
                       safeRegex:
                         regex: .+
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: /path/template/*
                 - uriTemplate:
+                    name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                       pathTemplate: '**/path/template'
@@ -47,10 +49,12 @@ typedConfig:
                         safeRegex:
                           regex: .+
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: /not-path/template/*
                   - uriTemplate:
+                      name: uri-template
                       typedConfig:
                         '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
                         pathTemplate: '**/not-path/template'

--- a/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/extended-allow-path-out.yaml
@@ -31,7 +31,7 @@ typedConfig:
                     name: uri-template
                     typedConfig:
                       '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
-                      pathTemplate: '**/path/template'
+                      pathTemplate: /**/path/template
             - notRule:
                 orRules:
                   rules:

--- a/pilot/pkg/security/authz/matcher/template.go
+++ b/pilot/pkg/security/authz/matcher/template.go
@@ -20,18 +20,18 @@ import (
 	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
 )
 
-// TODO(jaellio): Define elsewhere? In utils?
 var matchOneTemplate = "{*}"
 var matchAnyTemplate = "{**}"
 
-// PatherTemplateMatcher creates a URI path matcher for path.
+// PatherTemplateMatcher creates a URI template matcher for path.
 func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {
 	return &uri_template.UriTemplateMatchConfig{
 		PathTemplate: sanitizePathTemplate(path),
 	}
 }
 
-// TODO(jaellio): add description
+// sanitizePathTemplate converts the path template into a valid envoy uri template.
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto
 // If path contains "{*}", it will be replaced with "*".
 // If path contains "{**}", it will be replaced with "**".
 // If the path already contained "*" or "**", they will be left as is.
@@ -45,7 +45,7 @@ func sanitizePathTemplate(path string) string {
 	return path
 }
 
-// TODO(jaellio): should this go in util and be exported? Need a comment?
+// IsPathTemplate returns true if the path contains a valid path template.
 func IsPathTemplate(value string) bool {
 	return strings.Contains(value, matchOneTemplate) || strings.Contains(value, matchAnyTemplate)
 }

--- a/pilot/pkg/security/authz/matcher/template.go
+++ b/pilot/pkg/security/authz/matcher/template.go
@@ -22,6 +22,8 @@ import (
 	"istio.io/istio/pkg/config/security"
 )
 
+var replacer = strings.NewReplacer(security.MatchOneTemplate, "*", security.MatchAnyTemplate, "**")
+
 // PatherTemplateMatcher creates a URI template matcher for path.
 func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {
 	return &uri_template.UriTemplateMatchConfig{
@@ -35,11 +37,5 @@ func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {
 // If path contains "{**}", it will be replaced with "**".
 // If the path already contained "*" or "**", they will be left as is.
 func sanitizePathTemplate(path string) string {
-	if strings.Contains(path, security.MatchOneTemplate) {
-		path = strings.ReplaceAll(path, security.MatchOneTemplate, "*")
-	}
-	if strings.Contains(path, security.MatchAnyTemplate) {
-		path = strings.ReplaceAll(path, security.MatchAnyTemplate, "**")
-	}
-	return path
+	return replacer.Replace(path)
 }

--- a/pilot/pkg/security/authz/matcher/template.go
+++ b/pilot/pkg/security/authz/matcher/template.go
@@ -20,8 +20,10 @@ import (
 	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
 )
 
-var matchOneTemplate = "{*}"
-var matchAnyTemplate = "{**}"
+var (
+	matchOneTemplate = "{*}"
+	matchAnyTemplate = "{**}"
+)
 
 // PatherTemplateMatcher creates a URI template matcher for path.
 func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {

--- a/pilot/pkg/security/authz/matcher/template.go
+++ b/pilot/pkg/security/authz/matcher/template.go
@@ -1,0 +1,51 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"strings"
+
+	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
+)
+
+// TODO(jaellio): Define elsewhere? In utils?
+var matchOneTemplate = "{*}"
+var matchAnyTemplate = "{**}"
+
+// PatherTemplateMatcher creates a URI path matcher for path.
+func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {
+	return &uri_template.UriTemplateMatchConfig{
+		PathTemplate: sanitizePathTemplate(path),
+	}
+}
+
+// TODO(jaellio): add description
+// If path contains "{*}", it will be replaced with "*".
+// If path contains "{**}", it will be replaced with "**".
+// If the path already contained "*" or "**", they will be left as is.
+func sanitizePathTemplate(path string) string {
+	if strings.Contains(path, matchOneTemplate) {
+		path = strings.ReplaceAll(path, matchOneTemplate, "*")
+	}
+	if strings.Contains(path, matchAnyTemplate) {
+		path = strings.ReplaceAll(path, matchAnyTemplate, "**")
+	}
+	return path
+}
+
+// TODO(jaellio): should this go in util and be exported? Need a comment?
+func IsPathTemplate(value string) bool {
+	return strings.Contains(value, matchOneTemplate) || strings.Contains(value, matchAnyTemplate)
+}

--- a/pilot/pkg/security/authz/matcher/template.go
+++ b/pilot/pkg/security/authz/matcher/template.go
@@ -18,11 +18,8 @@ import (
 	"strings"
 
 	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
-)
 
-var (
-	matchOneTemplate = "{*}"
-	matchAnyTemplate = "{**}"
+	"istio.io/istio/pkg/config/security"
 )
 
 // PatherTemplateMatcher creates a URI template matcher for path.
@@ -38,16 +35,11 @@ func PathTemplateMatcher(path string) *uri_template.UriTemplateMatchConfig {
 // If path contains "{**}", it will be replaced with "**".
 // If the path already contained "*" or "**", they will be left as is.
 func sanitizePathTemplate(path string) string {
-	if strings.Contains(path, matchOneTemplate) {
-		path = strings.ReplaceAll(path, matchOneTemplate, "*")
+	if strings.Contains(path, security.MatchOneTemplate) {
+		path = strings.ReplaceAll(path, security.MatchOneTemplate, "*")
 	}
-	if strings.Contains(path, matchAnyTemplate) {
-		path = strings.ReplaceAll(path, matchAnyTemplate, "**")
+	if strings.Contains(path, security.MatchAnyTemplate) {
+		path = strings.ReplaceAll(path, security.MatchAnyTemplate, "**")
 	}
 	return path
-}
-
-// IsPathTemplate returns true if the path contains a valid path template.
-func IsPathTemplate(value string) bool {
-	return strings.Contains(value, matchOneTemplate) || strings.Contains(value, matchAnyTemplate)
 }

--- a/pilot/pkg/security/authz/matcher/template_test.go
+++ b/pilot/pkg/security/authz/matcher/template_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package matcher
 
 import (
@@ -6,6 +20,7 @@ import (
 	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
+
 	"istio.io/istio/pkg/test/util/assert"
 )
 

--- a/pilot/pkg/security/authz/matcher/template_test.go
+++ b/pilot/pkg/security/authz/matcher/template_test.go
@@ -37,16 +37,16 @@ func TestPathTemplateMatcher(t *testing.T) {
 		},
 		{
 			name: "matchAnyOnly",
-			path: "/foo/{**}/bar.tmp",
+			path: "/foo/{**}/bar",
 			want: &uri_template.UriTemplateMatchConfig{
-				PathTemplate: "/foo/**/bar.tmp",
+				PathTemplate: "/foo/**/bar",
 			},
 		},
 		{
 			name: "matchAnyAndOne",
-			path: "/{*}/foo/{**}/bar.tmp",
+			path: "/{*}/foo/{**}/bar",
 			want: &uri_template.UriTemplateMatchConfig{
-				PathTemplate: "/*/foo/**/bar.tmp",
+				PathTemplate: "/*/foo/**/bar",
 			},
 		},
 		{

--- a/pilot/pkg/security/authz/matcher/template_test.go
+++ b/pilot/pkg/security/authz/matcher/template_test.go
@@ -30,23 +30,30 @@ func TestPathTemplateMatcher(t *testing.T) {
 	}{
 		{
 			name: "matchOneOnly",
-			path: "foo/bar/{*}",
+			path: "/foo/bar/{*}",
 			want: &uri_template.UriTemplateMatchConfig{
-				PathTemplate: "foo/bar/*",
+				PathTemplate: "/foo/bar/*",
 			},
 		},
 		{
 			name: "matchAnyOnly",
-			path: "foo/{**}/bar.tmp",
+			path: "/foo/{**}/bar.tmp",
 			want: &uri_template.UriTemplateMatchConfig{
-				PathTemplate: "foo/**/bar.tmp",
+				PathTemplate: "/foo/**/bar.tmp",
 			},
 		},
 		{
 			name: "matchAnyAndOne",
-			path: "{*}/foo/{**}/bar.tmp",
+			path: "/{*}/foo/{**}/bar.tmp",
 			want: &uri_template.UriTemplateMatchConfig{
-				PathTemplate: "*/foo/**/bar.tmp",
+				PathTemplate: "/*/foo/**/bar.tmp",
+			},
+		},
+		{
+			name: "matchAnyAndMultipleOnes",
+			path: "/{*}/{*}/foo/{**}/bar",
+			want: &uri_template.UriTemplateMatchConfig{
+				PathTemplate: "/*/*/foo/**/bar",
 			},
 		},
 	}

--- a/pilot/pkg/security/authz/matcher/template_test.go
+++ b/pilot/pkg/security/authz/matcher/template_test.go
@@ -20,8 +20,6 @@ import (
 	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-
-	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestPathTemplateMatcher(t *testing.T) {
@@ -59,47 +57,6 @@ func TestPathTemplateMatcher(t *testing.T) {
 			if !cmp.Equal(got, tc.want, protocmp.Transform()) {
 				t.Errorf("want %v but got %v", tc.want, got)
 			}
-		})
-	}
-}
-
-func TestIsPathTemplate(t *testing.T) {
-	testCases := []struct {
-		name           string
-		path           string
-		isPathTemplate bool
-	}{
-		{
-			name:           "matchOneOnly",
-			path:           "foo/bar/{*}",
-			isPathTemplate: true,
-		},
-		{
-			name:           "matchOneOnly",
-			path:           "foo/{**}/bar",
-			isPathTemplate: true,
-		},
-		{
-			name:           "matchAnyAndOne",
-			path:           "{*}/bar/{**}",
-			isPathTemplate: true,
-		},
-		{
-			name:           "stringMatch",
-			path:           "foo/bar/*",
-			isPathTemplate: false,
-		},
-		{
-			name:           "namedVariable",
-			path:           "foo/bar/{buzz}",
-			isPathTemplate: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			pathTemplate := IsPathTemplate(tc.path)
-			assert.Equal(t, tc.isPathTemplate, pathTemplate)
 		})
 	}
 }

--- a/pilot/pkg/security/authz/matcher/template_test.go
+++ b/pilot/pkg/security/authz/matcher/template_test.go
@@ -1,0 +1,90 @@
+package matcher
+
+import (
+	"testing"
+
+	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestPathTemplateMatcher(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+		want *uri_template.UriTemplateMatchConfig
+	}{
+		{
+			name: "matchOneOnly",
+			path: "foo/bar/{*}",
+			want: &uri_template.UriTemplateMatchConfig{
+				PathTemplate: "foo/bar/*",
+			},
+		},
+		{
+			name: "matchAnyOnly",
+			path: "foo/{**}/bar.tmp",
+			want: &uri_template.UriTemplateMatchConfig{
+				PathTemplate: "foo/**/bar.tmp",
+			},
+		},
+		{
+			name: "matchAnyAndOne",
+			path: "{*}/foo/{**}/bar.tmp",
+			want: &uri_template.UriTemplateMatchConfig{
+				PathTemplate: "*/foo/**/bar.tmp",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PathTemplateMatcher(tc.path)
+			if !cmp.Equal(got, tc.want, protocmp.Transform()) {
+				t.Errorf("want %v but got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsPathTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		path           string
+		isPathTemplate bool
+	}{
+		{
+			name:           "matchOneOnly",
+			path:           "foo/bar/{*}",
+			isPathTemplate: true,
+		},
+		{
+			name:           "matchOneOnly",
+			path:           "foo/{**}/bar",
+			isPathTemplate: true,
+		},
+		{
+			name:           "matchAnyAndOne",
+			path:           "{*}/bar/{**}",
+			isPathTemplate: true,
+		},
+		{
+			name:           "stringMatch",
+			path:           "foo/bar/*",
+			isPathTemplate: false,
+		},
+		{
+			name:           "namedVariable",
+			path:           "foo/bar/{buzz}",
+			isPathTemplate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pathTemplate := IsPathTemplate(tc.path)
+			assert.Equal(t, tc.isPathTemplate, pathTemplate)
+		})
+	}
+}

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -399,6 +399,17 @@ func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permi
 		return nil, fmt.Errorf("%q is HTTP only", key)
 	}
 
+	// TODO(jaellio): Should we interpret the path as a PathMatcher if it is an invalid or unsupported by Istio PathTemplate?
+	// Or should we error?
+	// Ex: "/foo/{*" is not a valid PathTemplate.
+	// Ex: "/foo/{bar}" is an unsupported PathTemplate.
+	//
+	// Should we disallow the use of `*` and `**` in the path if it is a PathTemplate (the path contains `{*}` or `{**}`, and `*` or `**`)?
+	if matcher.IsPathTemplate(value) {
+		m := matcher.PathTemplateMatcher(value)
+		return permissionPathTemplate(m), nil
+	}
+
 	m := matcher.PathMatcher(value)
 	return permissionPath(m), nil
 }

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -400,7 +400,7 @@ func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permi
 		return nil, fmt.Errorf("%q is HTTP only", key)
 	}
 
-	if security.IsPathTemplate(value) {
+	if security.ContainsPathTemplate(value) {
 		m := matcher.PathTemplateMatcher(value)
 		return permissionPathTemplate(m), nil
 	}

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authz/matcher"
 	"istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/config/security"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -399,7 +400,7 @@ func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permi
 		return nil, fmt.Errorf("%q is HTTP only", key)
 	}
 
-	if matcher.IsPathTemplate(value) {
+	if security.IsPathTemplate(value) {
 		m := matcher.PathTemplateMatcher(value)
 		return permissionPathTemplate(m), nil
 	}

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -399,12 +399,6 @@ func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permi
 		return nil, fmt.Errorf("%q is HTTP only", key)
 	}
 
-	// TODO(jaellio): Should we interpret the path as a PathMatcher if it is an invalid or unsupported by Istio PathTemplate?
-	// Or should we error?
-	// Ex: "/foo/{*" is not a valid PathTemplate.
-	// Ex: "/foo/{bar}" is an unsupported PathTemplate.
-	//
-	// Should we disallow the use of `*` and `**` in the path if it is a PathTemplate (the path contains `{*}` or `{**}`, and `*` or `**`)?
 	if matcher.IsPathTemplate(value) {
 		m := matcher.PathTemplateMatcher(value)
 		return permissionPathTemplate(m), nil

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -525,10 +525,6 @@ func TestGenerator(t *testing.T) {
 				if gotYaml, err = protomarshal.ToYAML(gotProto); err != nil {
 					t.Fatalf("%s: failed to parse yaml: %s", tc.name, err)
 				}
-				p := &rbacpb.Permission{}
-				if err := protomarshal.ApplyYAML(gotYaml, p); err != nil {
-					t.Fatalf("failed to parse yaml: %s", err)
-				}
 				t.Errorf("got:\n %v\n but want:\n %v", gotYaml, tc.want)
 			}
 		})

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -477,6 +477,7 @@ func TestGenerator(t *testing.T) {
 			value: "/abc/{*}",
 			want: yamlPermission(t, `
          uriTemplate:
+           name: uri-template
            typedConfig:
             '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
             pathTemplate: /abc/*`),

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -472,6 +472,16 @@ func TestGenerator(t *testing.T) {
             exact: /abc`),
 		},
 		{
+			name:  "pathGenerator-template",
+			g:     pathGenerator{},
+			value: "/abc/{*}",
+			want: yamlPermission(t, `
+         uriTemplate:
+           typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+            pathTemplate: /abc/*`),
+		},
+		{
 			name:  "methodGenerator",
 			g:     methodGenerator{},
 			value: "GET",
@@ -514,6 +524,10 @@ func TestGenerator(t *testing.T) {
 				}
 				if gotYaml, err = protomarshal.ToYAML(gotProto); err != nil {
 					t.Fatalf("%s: failed to parse yaml: %s", tc.name, err)
+				}
+				p := &rbacpb.Permission{}
+				if err := protomarshal.ApplyYAML(gotYaml, p); err != nil {
+					t.Fatalf("failed to parse yaml: %s", err)
 				}
 				t.Errorf("got:\n %v\n but want:\n %v", gotYaml, tc.want)
 			}

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -112,6 +112,7 @@ func permissionPathTemplate(path *uri_template.UriTemplateMatchConfig) *rbacpb.P
 	return &rbacpb.Permission{
 		Rule: &rbacpb.Permission_UriTemplate{
 			UriTemplate: &core.TypedExtensionConfig{
+				Name:        "uri-template",
 				TypedConfig: protoconv.MessageToAny(path),
 			},
 		},

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -18,7 +18,10 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	uri_template "github.com/envoyproxy/go-control-plane/envoy/extensions/path/match/uri_template/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+
+	"istio.io/istio/pilot/pkg/util/protoconv"
 )
 
 func permissionAny() *rbacpb.Permission {
@@ -101,6 +104,16 @@ func permissionPath(path *matcher.PathMatcher) *rbacpb.Permission {
 	return &rbacpb.Permission{
 		Rule: &rbacpb.Permission_UrlPath{
 			UrlPath: path,
+		},
+	}
+}
+
+func permissionPathTemplate(path *uri_template.UriTemplateMatchConfig) *rbacpb.Permission {
+	return &rbacpb.Permission{
+		Rule: &rbacpb.Permission_UriTemplate{
+			UriTemplate: &core.TypedExtensionConfig{
+				TypedConfig: protoconv.MessageToAny(path),
+			},
 		},
 	}
 }

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pilot/pkg/security/authz/matcher"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
@@ -56,6 +58,10 @@ const (
 	attrConnSNI          = "connection.sni"         // server name indication, e.g. "www.example.com".
 	attrExperimental     = "experimental.envoy.filters."
 )
+
+// Matches on named variables {namedvar=*}, named variables {namedvar}, empty braces {}, wildcard /*,
+// and double wildcard /**
+var unsupportedPathTempRegex = regexp.MustCompile(`\/{\w+\=\*[*]?\}|{\w*\}|\/\*[*]?|\*[*]?\/`)
 
 // ParseJwksURI parses the input URI and returns the corresponding hostname, port, and whether SSL is used.
 // URI must start with "http://" or "https://", which corresponding to "http" or "https" scheme.
@@ -95,6 +101,18 @@ func CheckEmptyValues(key string, values []string) error {
 	for _, value := range values {
 		if value == "" {
 			return fmt.Errorf("empty value not allowed, found in %s", key)
+		}
+	}
+	return nil
+}
+
+func CheckValidPathTemplate(key string, paths []string) error {
+	for _, path := range paths {
+		// If the path is a path template it must be supported.
+		// It must not contain named variables, `*`, or `**`.
+		// Ex: "/{*}/foo/{bar}" is an unsupported PathTemplate.
+		if matcher.IsPathTemplate(path) && unsupportedPathTempRegex.MatchString(path) {
+			return fmt.Errorf("invalid or unsupported path template, found in %s", key)
 		}
 	}
 	return nil

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -107,20 +107,23 @@ func CheckEmptyValues(key string, values []string) error {
 
 func CheckValidPathTemplate(key string, paths []string) error {
 	for _, path := range paths {
-		// If path does not contain any path templates, skip the check.
-		if !ContainsPathTemplate(path) {
-			continue
-		}
+		containsPathTemplate := ContainsPathTemplate(path)
 		globs := strings.Split(path, "/")
 		for _, glob := range globs {
 			// If glob is a supported path template, skip the check.
 			if glob == MatchAnyTemplate || glob == MatchOneTemplate {
 				continue
 			}
-			// If glob is not a supported path template and contains `*`, `{`, or `}` it is invalid.
-			if strings.ContainsAny(glob, "{}*") {
-				return fmt.Errorf("invalid or unsupported path template %s, found in %s."+
-					"Contains '*', '{', or '}' beyond a supported path template", path, key)
+			// If glob is not a supported path template and contains `{`, or `}` it is invalid.
+			if strings.ContainsAny(glob, "{}") {
+				return fmt.Errorf("invalid or unsupported path %s, found in %s."+
+					"Contains '{' or '}' beyond a supported path template", path, key)
+			}
+			// If glob contains `*`, is not a supported path template and
+			// the path contains a supported path template, it is invalid.
+			if strings.Contains(glob, "*") && containsPathTemplate {
+				return fmt.Errorf("invalid or unsupported path %s, found in %s."+
+					"Contains '*' beyond a supported path template", path, key)
 			}
 		}
 	}

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -61,9 +60,6 @@ const (
 var (
 	MatchOneTemplate = "{*}"
 	MatchAnyTemplate = "{**}"
-	// Matches on named variables {namedvar=*}, named variables {namedvar}, empty braces {}, wildcard /*,
-	// and double wildcard /**
-	unsupportedPathTempRegex = regexp.MustCompile(`\/{\w+\=\*[*]?\}|{\w*\}|\/\*[*]?|\*[*]?\/`)
 )
 
 // ParseJwksURI parses the input URI and returns the corresponding hostname, port, and whether SSL is used.
@@ -121,9 +117,10 @@ func CheckValidPathTemplate(key string, paths []string) error {
 			if glob == MatchAnyTemplate || glob == MatchOneTemplate {
 				continue
 			}
-			// If glob is not a supported path template and contains `*`, `{`, or `} it is invalid.
+			// If glob is not a supported path template and contains `*`, `{`, or `}` it is invalid.
 			if strings.ContainsAny(glob, "{}*") {
-				return fmt.Errorf("invalid or unsupported path template %s, found in %s", path, key)
+				return fmt.Errorf("invalid or unsupported path template %s, found in %s."+
+					"Contains '*', '{', or '}' beyond a supported path template", path, key)
 			}
 		}
 	}

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -115,7 +115,7 @@ func CheckValidPathTemplate(key string, paths []string) error {
 		// It must not contain named variables, `*`, or `**`.
 		// Ex: "/{*}/foo/{bar}" is an unsupported PathTemplate.
 		if IsPathTemplate(path) && unsupportedPathTempRegex.MatchString(path) {
-			return fmt.Errorf("invalid or unsupported path template, found in %s", key)
+			return fmt.Errorf("invalid or unsupported path template %s, found in %s", path, key)
 		}
 	}
 	return nil

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -235,6 +235,15 @@ func TestCheckValidPathTemplate(t *testing.T) {
 			values: []string{"/foo/{**}/bar"},
 		},
 		{
+			name:   "valid path template - matchAnyTemplate at end",
+			values: []string{"/foo/bar/{**}"},
+		},
+		{
+			name:      "valid path template - matchAnyTemplate with additional chars",
+			values:    []string{"/foo/{**}buzz/bar"},
+			wantError: true,
+		},
+		{
 			name:      "invalid path template - empty curly braces",
 			values:    []string{"/{*}/foo/{}/bar"},
 			wantError: true,
@@ -251,17 +260,42 @@ func TestCheckValidPathTemplate(t *testing.T) {
 		},
 		{
 			name:      "unsupported path template - matchAnyTemplate with named var: {buzz}",
-			values:    []string{"/foo/{buzz}/bar/{**}.txt"},
+			values:    []string{"/foo/{buzz}/bar/{**}"},
 			wantError: true,
 		},
 		{
 			name:      "unsupported path template - matchAnyTemplate with named var: {buzz=*}",
-			values:    []string{"/foo/{buzz=*}/bar/{**}.txt"},
+			values:    []string{"/foo/{buzz=*}/bar/{**}"},
 			wantError: true,
 		},
 		{
 			name:      "unsupported path template - matchAnyTemplate with named var: {buzz=**}",
 			values:    []string{"/{*}/foo/{buzz=**}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchAnyTemplate with additional chars at end",
+			values:    []string{"/{*}/foo/{**}bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with file extension",
+			values:    []string{"/{*}/foo/{*}.txt"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with unmatched open curly brace",
+			values:    []string{"/{*}/foo/{temp"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with unmatched closed curly brace",
+			values:    []string{"/{*}/foo/temp}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with unmatched closed curly brace and `*`",
+			values:    []string{"/{*}/foo/temp}/*"},
 			wantError: true,
 		},
 	}
@@ -273,7 +307,7 @@ func TestCheckValidPathTemplate(t *testing.T) {
 	}
 }
 
-func TestIsPathTemplate(t *testing.T) {
+func TestContainsPathTemplate(t *testing.T) {
 	testCases := []struct {
 		name           string
 		path           string
@@ -308,7 +342,7 @@ func TestIsPathTemplate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pathTemplate := security.IsPathTemplate(tc.path)
+			pathTemplate := security.ContainsPathTemplate(tc.path)
 			assert.Equal(t, tc.isPathTemplate, pathTemplate)
 		})
 	}

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -285,7 +285,7 @@ func TestIsPathTemplate(t *testing.T) {
 			isPathTemplate: true,
 		},
 		{
-			name:           "matchOneOnly",
+			name:           "matchAnyOnly",
 			path:           "foo/{**}/bar",
 			isPathTemplate: true,
 		},

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/config/security"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestParseJwksURI(t *testing.T) {
@@ -269,5 +270,46 @@ func TestCheckValidPathTemplate(t *testing.T) {
 		if c.wantError == (err == nil) {
 			t.Fatalf("CheckValidPathTemplate(%s): want error (%v) but got (%v)", c.name, c.wantError, err)
 		}
+	}
+}
+
+func TestIsPathTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		path           string
+		isPathTemplate bool
+	}{
+		{
+			name:           "matchOneOnly",
+			path:           "foo/bar/{*}",
+			isPathTemplate: true,
+		},
+		{
+			name:           "matchOneOnly",
+			path:           "foo/{**}/bar",
+			isPathTemplate: true,
+		},
+		{
+			name:           "matchAnyAndOne",
+			path:           "{*}/bar/{**}",
+			isPathTemplate: true,
+		},
+		{
+			name:           "stringMatch",
+			path:           "foo/bar/*",
+			isPathTemplate: false,
+		},
+		{
+			name:           "namedVariable",
+			path:           "foo/bar/{buzz}",
+			isPathTemplate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pathTemplate := security.IsPathTemplate(tc.path)
+			assert.Equal(t, tc.isPathTemplate, pathTemplate)
+		})
 	}
 }

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -239,12 +239,12 @@ func TestCheckValidPathTemplate(t *testing.T) {
 			values: []string{"/foo/bar/{**}"},
 		},
 		{
-			name:      "valid path template - matchAnyTemplate with additional chars",
+			name:      "unsupported path template - matchAnyTemplate with additional chars",
 			values:    []string{"/foo/{**}buzz/bar"},
 			wantError: true,
 		},
 		{
-			name:      "invalid path template - empty curly braces",
+			name:      "unsupported path template - empty curly braces",
 			values:    []string{"/{*}/foo/{}/bar"},
 			wantError: true,
 		},
@@ -256,6 +256,16 @@ func TestCheckValidPathTemplate(t *testing.T) {
 		{
 			name:      "unsupported path template - matchOneTemplate with `**`",
 			values:    []string{"/foo/{*}/bar/**/buzz"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path/path template - named var: {buzz}",
+			values:    []string{"/foo/{buzz}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path/path template - only named var: {buzz}",
+			values:    []string{"/{buzz}"},
 			wantError: true,
 		},
 		{

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -218,3 +218,56 @@ func TestValidateCondition(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckValidPathTemplate(t *testing.T) {
+	cases := []struct {
+		name      string
+		values    []string
+		wantError bool
+	}{
+		{
+			name:   "valid path template - matchOneTemplate",
+			values: []string{"/{*}/foo"},
+		},
+		{
+			name:   "valid path template - matchAnyTemplate",
+			values: []string{"/foo/{**}/bar"},
+		},
+		{
+			name:      "invalid path template - empty curly braces",
+			values:    []string{"/{*}/foo/{}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with `*`",
+			values:    []string{"/foo/{*}/bar/*"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchOneTemplate with `**`",
+			values:    []string{"/foo/{*}/bar/**/buzz"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchAnyTemplate with named var: {buzz}",
+			values:    []string{"/foo/{buzz}/bar/{**}.txt"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchAnyTemplate with named var: {buzz=*}",
+			values:    []string{"/foo/{buzz=*}/bar/{**}.txt"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchAnyTemplate with named var: {buzz=**}",
+			values:    []string{"/{*}/foo/{buzz=**}/bar"},
+			wantError: true,
+		},
+	}
+	for _, c := range cases {
+		err := security.CheckValidPathTemplate(c.name, c.values)
+		if c.wantError == (err == nil) {
+			t.Fatalf("CheckValidPathTemplate(%s): want error (%v) but got (%v)", c.name, c.wantError, err)
+		}
+	}
+}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1319,6 +1319,8 @@ var ValidateAuthorizationPolicy = RegisterValidateFunc("ValidateAuthorizationPol
 					errs = appendErrors(errs, security.CheckEmptyValues("NotMethods", op.NotMethods))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotPaths", op.NotPaths))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotHosts", op.NotHosts))
+					errs = appendErrors(errs, security.CheckValidPathTemplate("Paths", op.Paths))
+					errs = appendErrors(errs, security.CheckValidPathTemplate("NotPaths", op.NotPaths))
 					if op.Ports != nil || op.NotPorts != nil {
 						tcpRulesInTo = true
 					}

--- a/releasenotes/notes/16585.yaml
+++ b/releasenotes/notes/16585.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 16585
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Added** support for path templating in AuthorizationPolicy.

--- a/releasenotes/notes/16585.yaml
+++ b/releasenotes/notes/16585.yaml
@@ -8,4 +8,4 @@ issue:
 # release notes.
 releaseNotes:
 - |
-  **Added** support for path templating in AuthorizationPolicy.
+  **Added** support for path templating in AuthorizationPolicy. See Envoy uri template docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -976,16 +976,18 @@ func TestAuthz_PathTemplating(t *testing.T) {
 						path  string
 						allow allowValue
 					}{
+						// Test matches for `/allow/admin/{**}`
 						{
-							path:  "/allow/admin",
+							path:  "/allow/admin/",
 							allow: true,
 						},
 						{
-							path:  "/allow/admin2",
+							// When `**` is the last segment and operator in the template, the path must have a trailing `/` to match.
+							path:  "/allow/admin",
 							allow: false,
 						},
 						{
-							path:  "/allow/user",
+							path:  "/allow/user/",
 							allow: false,
 						},
 						{
@@ -1007,6 +1009,23 @@ func TestAuthz_PathTemplating(t *testing.T) {
 						{
 							path:  "/allow/admin/foo/temp.txt",
 							allow: true,
+						},
+						// Test matches for `/foo/{*}/bar/{**}.txt`
+						{
+							path:  "/foo/buzz/bar/bat.txt",
+							allow: true,
+						},
+						{
+							path:  "/foo/buzz/bar/bat/fuzz.txt",
+							allow: true,
+						},
+						{
+							path:  "/foo/bar/bat.txt",
+							allow: false,
+						},
+						{
+							path:  "/foo/buzz/bar/bat",
+							allow: false,
 						},
 					}
 

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -982,7 +982,7 @@ func TestAuthz_PathTemplating(t *testing.T) {
 							allow: true,
 						},
 						{
-							// When `**` is the last segment and operator in the template, the path must have a trailing `/` to match.
+							// When `**` is the last segment and operator in the template, the path must have a trailing `/` to match
 							path:  "/allow/admin",
 							allow: false,
 						},
@@ -1024,7 +1024,20 @@ func TestAuthz_PathTemplating(t *testing.T) {
 							allow: false,
 						},
 						{
+							path:  "/foo//bar/bat.txt",
+							allow: false,
+						},
+						{
 							path:  "/foo/buzz/bar/bat",
+							allow: false,
+						},
+						// Test matches for `/store/{**}/cart`
+						{
+							path:  "/store//cart",
+							allow: true,
+						},
+						{
+							path:  "/store/cart",
 							allow: false,
 						},
 					}

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1016,6 +1016,10 @@ func TestAuthz_PathTemplating(t *testing.T) {
 							allow: true,
 						},
 						{
+							path:  "/foo/buzz/bar/bat.temp.txt",
+							allow: true,
+						},
+						{
 							path:  "/foo/buzz/bar/bat/fuzz.txt",
 							allow: true,
 						},

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1010,7 +1010,7 @@ func TestAuthz_PathTemplating(t *testing.T) {
 							path:  "/allow/admin/foo/temp.txt",
 							allow: true,
 						},
-						// Test matches for `/foo/{*}/bar/{**}.txt`
+						// Test matches for `/foo/{*}/bar/{**}`
 						{
 							path:  "/foo/buzz/bar/bat.txt",
 							allow: true,
@@ -1033,7 +1033,7 @@ func TestAuthz_PathTemplating(t *testing.T) {
 						},
 						{
 							path:  "/foo/buzz/bar/bat",
-							allow: false,
+							allow: true,
 						},
 						// Test matches for `/store/{**}/cart`
 						{

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -954,6 +954,78 @@ func TestAuthz_PathPrecedence(t *testing.T) {
 		})
 }
 
+func TestAuthz_PathTemplating(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			from := apps.Ns1.A
+			fromMatch := match.ServiceName(from.NamespacedName())
+			toMatch := match.Not(fromMatch)
+			to := toMatch.GetServiceMatches(apps.Ns1.All)
+			fromAndTo := to.Instances().Append(from)
+
+			config.New(t).
+				Source(config.File("testdata/authz/path-templating.yaml.tmpl")).
+				BuildAll(nil, to).
+				Apply()
+
+			newTrafficTest(t, fromAndTo).
+				FromMatch(fromMatch).
+				ToMatch(toMatch).
+				Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
+					cases := []struct {
+						path  string
+						allow allowValue
+					}{
+						{
+							path:  "/allow/admin",
+							allow: true,
+						},
+						{
+							path:  "/allow/admin2",
+							allow: false,
+						},
+						{
+							path:  "/allow/user",
+							allow: false,
+						},
+						{
+							path:  "/allow/admin?param=value",
+							allow: false,
+						},
+						{
+							path:  "/allow",
+							allow: false,
+						},
+						{
+							path:  "/allow/admin/temp",
+							allow: true,
+						},
+						{
+							path:  "/allow/admin/temp.txt",
+							allow: true,
+						},
+						{
+							path:  "/allow/admin/foo/temp.txt",
+							allow: true,
+						},
+					}
+
+					for _, c := range cases {
+						c := c
+						testName := fmt.Sprintf("%s(%s)/http", c.path, c.allow)
+						t.NewSubTest(testName).Run(func(t framework.TestContext) {
+							newAuthzTest().
+								From(from).
+								To(to).
+								Allow(c.allow).
+								Path(c.path).
+								BuildAndRunForPorts(t, ports.HTTP, ports.HTTP2)
+						})
+					}
+				})
+		})
+}
+
 func TestAuthz_IngressGateway(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(t framework.TestContext) {

--- a/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
@@ -10,4 +10,4 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/allow/admin/{**}", "/foo/{*}/bar/{**}.txt"]
+            paths: ["/allow/admin/{**}", "/foo/{*}/bar/{**}.txt", "/store/{**}/cart"]

--- a/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
@@ -10,4 +10,4 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/allow/admin/{**}"]
+            paths: ["/allow/admin/{**}", "/foo/{*}/bar/{**}.txt"]

--- a/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
@@ -10,4 +10,4 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/allow/admin/{**}", "/foo/{*}/bar/{**}.txt", "/store/{**}/cart"]
+            paths: ["/allow/admin/{**}", "/foo/{*}/bar/{**}", "/store/{**}/cart"]

--- a/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/path-templating.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .To.ServiceName }}
+spec:
+  selector:
+    matchLabels:
+      "app": "{{ .To.ServiceName }}"
+  action: ALLOW
+  rules:
+    - to:
+        - operation:
+            paths: ["/allow/admin/{**}"]


### PR DESCRIPTION
**Please provide a description of this PR:**

Updates `paths` and `notPaths` in the AuthorizationPolicy resource to support a limited set of templating based on envoy's [uri templating](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/path/match/uri_template/v3/uri_template_match.proto). 

https://github.com/istio/istio/issues/16585

Adds support for:
- `{*}`
- `{**}` 

If a path contains `{*}` or `{**}` it will be interpreted as a uri template rather than a string match. `{*}` will be converted to `*` and `{**}`  will be convert to `**` when applied in the envoy config.

Open questions: 
1. If a path contains an invalid template (ie. `{}`, `{*`, etc) should we return an error or interpret the path as a string match?
2. If a path contains `*` or `**` (invalid chars in uris, but valid for paths and notPaths) and supported templates (`{*}` and `{**}`), should we return an error, interpret the path as a string match, or interpret the path as a uri template (which might result in unintended behavior since `*` and `**` will be interpreted as uri templates)?

Todo:

- [x]  Write integration tests
- [ ]  Update analyzer support (if applicable) 
- [x] Add path validation