### PR TITLE
cni: enable pprof, stop memory spikes

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -42,7 +42,11 @@ import (
 
 var (
 	logOptions   = log.DefaultOptions()
-	ctrlzOptions = ctrlz.DefaultOptions()
+	ctrlzOptions = func() *ctrlz.Options {
+		o := ctrlz.DefaultOptions()
+		o.EnablePprof = true
+		return o
+	}()
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/ctrlz/options.go
+++ b/pkg/ctrlz/options.go
@@ -25,6 +25,9 @@ type Options struct {
 
 	// The IP address to listen on for ctrlz.
 	Address string
+
+	// If true, pprof will be enabled
+	EnablePprof bool
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults

--- a/releasenotes/notes/cni-pprof.yaml
+++ b/releasenotes/notes/cni-pprof.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 49053
+
+releaseNotes:
+  - |
+    **Added** `pprof` endpoints to profile the CNI pod (on port 9867).
+  - |
+    **Improved** CNI memory usage by avoiding keeping large files in memory.


### PR DESCRIPTION
Turns out once you can see whats going on, its really simple to optimize
functions that are obviously inefficient and have been around for ~5
years!

Fixes https://github.com/istio/istio/issues/49053
