### PR TITLE
istioctl: we should warn when namespace is not labeled ambient

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -148,8 +148,8 @@ func Cmd(ctx cli.Context) *cobra.Command {
 					return fmt.Errorf("failed to check if namespace is labeled ambient: %v", err)
 				}
 				if !namespaceIsLabeledAmbient {
-					fmt.Fprintln(cmd.OutOrStdout(), "Warning: namespace is not enrolled in ambient. Consider running\t"+
-						"`"+"kubectl label namespace default istio.io/dataplane-mode=ambient"+"`")
+					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace is not enrolled in ambient. Consider running\t"+
+						"`"+"kubectl label namespace %s istio.io/dataplane-mode=ambient"+"`", ns)
 					return nil
 				}
 			}

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -142,6 +142,12 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			}
 			ns := ctx.NamespaceOrDefault(ctx.Namespace())
 			// If a user decides to enroll their namespace with a waypoint, verify that they have labeled their namespace as ambient.
+			// If they don't, the user will be warned and be presented with the command to label their namespace as ambient if they
+			// choose to do so.
+			//
+			// NOTE: This is a warning and not an error because the user may not intend to label their namespace as ambient.
+			//
+			// e.g. Users are handling ambient redirection per workload rather than at the namespace level.
 			if enrollNamespace {
 				namespaceIsLabeledAmbient, err := namespaceIsLabeledAmbient(kubeClient, ns)
 				if err != nil {
@@ -149,8 +155,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				}
 				if !namespaceIsLabeledAmbient {
 					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace is not enrolled in ambient. Consider running\t"+
-						"`"+"kubectl label namespace %s istio.io/dataplane-mode=ambient"+"`", ns)
-					return nil
+						"`"+"kubectl label namespace %s istio.io/dataplane-mode=ambient"+"`\n", ns)
 				}
 			}
 			gw, err := makeGateway(true)

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -439,8 +439,5 @@ func namespaceIsLabeledAmbient(kubeClient kube.CLIClient, ns string) (bool, erro
 	if nsObj.Labels == nil {
 		return false, nil
 	}
-	if nsObj.Labels[constants.DataplaneMode] == constants.DataplaneModeAmbient {
-		return true, nil
-	}
-	return false, nil
+	return nsObj.Labels[constants.DataplaneMode] == constants.DataplaneModeAmbient, nil
 }

--- a/releasenotes/notes/50395.yaml
+++ b/releasenotes/notes/50395.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 50396
+releaseNotes:
+- |
+  **Added** Warn user in standard out when `x waypoint apply --enroll-namespace` is called and namespace is not labeled ambient.

--- a/releasenotes/notes/50395.yaml
+++ b/releasenotes/notes/50395.yaml
@@ -5,4 +5,4 @@ issue:
   - 50396
 releaseNotes:
 - |
-  **Added** Warn user in standard out when `x waypoint apply --enroll-namespace` is called and namespace is not labeled ambient.
+  **Added** Warn user in standard out when `istioctl experimental waypoint apply --enroll-namespace` is called and namespace is not labeled ambient.


### PR DESCRIPTION
**Please provide a description of this PR:**
Resolves: #50396

We are not checking if a namespace is labeled ambient before we enroll a waypoint with a namespace. This PR adds that check that returns early before we apply the waypoint if `--enroll-namespace` flag is used and the namespace does not have that `ambient` label.

This is what the UX will look like now:

```
azureuser@dev-2024:~/istio$ istioctl x waypoint apply --enroll-namespace                                            
Warning: namespace is not enrolled in ambient. Consider running `kubectl label namespace default istio.io/dataplane-mode=ambient`     

azureuser@dev-2024:~/istio$ istioctl x waypoint apply --enroll-namespace                                            
Warning: namespace is not enrolled in ambient. Consider running `kubectl label namespace default istio.io/dataplane-mode=ambient`     

azureuser@dev-2024:~/istio$ istioctl x waypoint apply --enroll-namespace                                         
Warning: namespace is not enrolled in ambient. Consider running `kubectl label namespace default istio.io/dataplane-mode=ambient`     

azureuser@dev-2024:~/istio$ kubectl label namespace default istio.io/dataplane-mode=ambient                                           
namespace/default labeled

azureuser@dev-2024:~/istio$ istioctl x waypoint apply --enroll-namespace                        
waypoint default/default-namespace applied
namespace default annotated with waypoint default-namespace  
```