### PR TITLE
sds: do not send empty responses

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -336,6 +336,8 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		return false
 	}
 
+	deltaLog.Debugf("ADS:%s REQUEST %v: sub:%v unsub:%v initial:%v", stype, con.conID,
+		request.ResourceNamesSubscribe, request.ResourceNamesUnsubscribe, request.InitialResourceVersions)
 	previousInfo := con.proxy.GetWatchedResource(request.TypeUrl)
 
 	// This can happen in two cases:

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -138,7 +138,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, w *model.WatchedResource, req *
 	// SDS flow. The pilotSDSCertificateErrors metric and logs handle visibility into invalid references.
 	resources := filterAuthorizedResources(s.parseResources(w.ResourceNames, proxy), proxy, proxyClusterSecrets)
 
-	results := model.Resources{}
+	var results model.Resources
 	cached, regenerated := 0, 0
 	for _, sr := range resources {
 		if updatedSecrets != nil {

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -51,6 +51,9 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(c resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
+  global:
+    logging:
+      level: delta:debug
   pilot: 
     env: 
       PILOT_JWT_ENABLE_REMOTE_JWKS: true


### PR DESCRIPTION
Related to https://github.com/istio/istio/issues/50361; I am not sure if
its a fix or not.

This mirrors EDS and RDS. When we have nothing to push, do not respond
rather than an empty response.
