### PR TITLE
Increase get address timeout to avoid flaky result when the test are executed on Openshift clusters

### DIFF
--- a/manifests/charts/gateway/README.md
+++ b/manifests/charts/gateway/README.md
@@ -54,7 +54,7 @@ That is, `--set some.field=true` should be passed, not `--set defaults.some.fiel
 When deploying the gateway in an OpenShift cluster, use the `openshift` profile to override the default values, for example:
 
 ```console
-helm install istio-ingressgateway istio/gateway -- set profile=openshift
+helm install istio-ingressgateway istio/gateway --set profile=openshift
 ```
 
 ### `image: auto` Information

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -64,8 +64,10 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
+            {{- if not (and .Values.global (eq .Values.global.platform "openshift")) }}
             runAsUser: 1337
             runAsGroup: 1337
+            {{- end }}
             runAsNonRoot: true
           {{- end }}
           env:

--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	getAddressTimeout = retry.Timeout(3 * time.Minute)
+	getAddressTimeout = retry.Timeout(4 * time.Minute)
 	getAddressDelay   = retry.BackoffDelay(500 * time.Millisecond)
 
 	_ ingress.Instance = &ingressImpl{}


### PR DESCRIPTION
We need to increase the getAddressTimeout because we are having flaky results on the setup of the TestSuite when the test runs over the openshift cluster. This will not affect test run over kind because on kind works as expected and take less time to get ready the service