### PR TITLE
Increase getAddressTimeout to avoid flaky result when running on openshift

### DIFF
--- a/pkg/test/framework/components/istio/ingress.go
+++ b/pkg/test/framework/components/istio/ingress.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	getAddressTimeout = retry.Timeout(3 * time.Minute)
+	getAddressTimeout = retry.Timeout(4 * time.Minute)
 	getAddressDelay   = retry.BackoffDelay(500 * time.Millisecond)
 
 	_ ingress.Instance = &ingressImpl{}


### PR DESCRIPTION
We need to increase at least 1 min the getAddressTimeout to avoid flaky results when the test is running on the openshift cluster. 