### PR TITLE
Gateway v1.1: support gRPC route v1

### DIFF
--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -68,6 +68,8 @@ if [ -z "${GATEWAY_VERSION}" ]; then
   fail "Unable to retrieve the gateway-api version from go.mod file. Not updating the CRD file.";
 fi
 
+# TODO(https://github.com/kubernetes-sigs/gateway-api/pull/3022) add this back
+exit 0
 echo "# Generated with \`kubectl kustomize \"https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_VERSION}\"\`" > "${API_TMP}/gateway-api-crd.yaml"
 if ! kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_VERSION}" >> "${API_TMP}/gateway-api-crd.yaml"; then
   fail "Unable to generate the CRDs for ${GATEWAY_VERSION}. Not updating the CRD file.";

--- a/bin/update_crds.sh
+++ b/bin/update_crds.sh
@@ -68,8 +68,6 @@ if [ -z "${GATEWAY_VERSION}" ]; then
   fail "Unable to retrieve the gateway-api version from go.mod file. Not updating the CRD file.";
 fi
 
-# TODO(https://github.com/kubernetes-sigs/gateway-api/pull/3022) add this back
-exit 0
 echo "# Generated with \`kubectl kustomize \"https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_VERSION}\"\`" > "${API_TMP}/gateway-api-crd.yaml"
 if ! kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_VERSION}" >> "${API_TMP}/gateway-api-crd.yaml"; then
   fail "Unable to generate the CRDs for ${GATEWAY_VERSION}. Not updating the CRD file.";

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda
 	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda
-	google.golang.org/grpc v1.63.0
+	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -118,7 +118,7 @@ require (
 	k8s.io/kubectl v0.30.0
 	k8s.io/utils v0.0.0-20240310230437-4693a0247e57
 	sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01
-	sigs.k8s.io/gateway-api v1.0.1-0.20240418002011-7f9f51098f40
+	sigs.k8s.io/gateway-api v1.1.0-rc1
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	k8s.io/kubectl v0.30.0
 	k8s.io/utils v0.0.0-20240310230437-4693a0247e57
 	sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01
-	sigs.k8s.io/gateway-api v1.1.0-rc1
+	sigs.k8s.io/gateway-api v1.1.0-rc1.0.20240425002700-732025730290
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1045,8 +1045,8 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.63.0 h1:WjKe+dnvABXyPJMD7KDNLxtoGk5tgk+YFWN6cBWjZE8=
-google.golang.org/grpc v1.63.0/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
+google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
+google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1159,8 +1159,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01 h1:YIERVtPSYjTgFZSJEs4JlsTmS9UYtsDF5RHwbLiwwy8=
 sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01/go.mod h1:qnlXuoQTuzXfYBI1t3qz6oc85Ce+QPAqEcHkQBggWQI=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v1.0.1-0.20240418002011-7f9f51098f40 h1:gH4Z10+yqcxTJ52r1Spk8rhj3Kv0IevbdPPvPgEcqbA=
-sigs.k8s.io/gateway-api v1.0.1-0.20240418002011-7f9f51098f40/go.mod h1:pOW7gKjeVN1xDfoPYkzI1b3v0XtgTcIx/CJ8cQAbOCA=
+sigs.k8s.io/gateway-api v1.1.0-rc1 h1:xyMnxvlN7FoDuk5ZDbJIZPK/zxObFsOgGmQIk25kAdU=
+sigs.k8s.io/gateway-api v1.1.0-rc1/go.mod h1:l6CLPHMssBJ+FGeSqxZGuy/RsyDUXjbc0QAmgkUiRoc=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/go.sum
+++ b/go.sum
@@ -1159,8 +1159,8 @@ sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gE
 sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01 h1:YIERVtPSYjTgFZSJEs4JlsTmS9UYtsDF5RHwbLiwwy8=
 sigs.k8s.io/controller-runtime v0.17.1-0.20240412100902-45e166d1fd01/go.mod h1:qnlXuoQTuzXfYBI1t3qz6oc85Ce+QPAqEcHkQBggWQI=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/gateway-api v1.1.0-rc1 h1:xyMnxvlN7FoDuk5ZDbJIZPK/zxObFsOgGmQIk25kAdU=
-sigs.k8s.io/gateway-api v1.1.0-rc1/go.mod h1:l6CLPHMssBJ+FGeSqxZGuy/RsyDUXjbc0QAmgkUiRoc=
+sigs.k8s.io/gateway-api v1.1.0-rc1.0.20240425002700-732025730290 h1:Z0My9zcCWwJOzXFB7uhE3jVyckfjflZ2BWAp2btS8h4=
+sigs.k8s.io/gateway-api v1.1.0-rc1.0.20240425002700-732025730290/go.mod h1:l6CLPHMssBJ+FGeSqxZGuy/RsyDUXjbc0QAmgkUiRoc=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/atomic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/pkg/consts"
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -49,7 +50,13 @@ func makeClient(t *testing.T, schemas collection.Schemas, f kubetypes.DynamicObj
 		kube.SetObjectFilter(fake, f)
 	}
 	for _, s := range schemas.All() {
-		clienttest.MakeCRD(t, fake, s.GroupVersionResource())
+		var annotations map[string]string
+		if s.Group() == gvk.KubernetesGateway.Group {
+			annotations = map[string]string{
+				consts.BundleVersionAnnotation: consts.BundleVersion,
+			}
+		}
+		clienttest.MakeCRDWithAnnotations(t, fake, s.GroupVersionResource(), annotations)
 	}
 	stop := test.NewStop(t)
 	config := New(fake, Option{})

--- a/pkg/config/schema/codegen/templates/collections.go.tmpl
+++ b/pkg/config/schema/codegen/templates/collections.go.tmpl
@@ -77,15 +77,13 @@ var (
 		Build()
 
 	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
-    // TODO: add GPRCRoute
 	pilotStableGatewayAPI = collection.NewSchemasBuilder().
 	{{- range .Entries }}
 		{{- if or
        (contains .Resource.Group "istio.io")
        (and
           (contains .Resource.Group "gateway.networking.k8s.io")
-          (not (contains .Resource.Version "alpha"))
-          (not (contains .Resource.Kind "GRPCRoute")))
+          (not (contains .Resource.Version "alpha")))
     }}
 		MustAdd({{ .Resource.Identifier }}).
 		{{- end}}

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -345,7 +345,6 @@ var (
 			Build()
 
 	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
-	// TODO: add GPRCRoute
 	pilotStableGatewayAPI = collection.NewSchemasBuilder().
 				MustAdd(AuthorizationPolicy).
 				MustAdd(DestinationRule).

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -860,11 +860,11 @@ var (
 			Build()
 
 	// PilotStableGatewayAPI contains only collections used by Pilot, including beta+ Gateway API.
-	// TODO: add GPRCRoute
 	pilotStableGatewayAPI = collection.NewSchemasBuilder().
 				MustAdd(AuthorizationPolicy).
 				MustAdd(DestinationRule).
 				MustAdd(EnvoyFilter).
+				MustAdd(GRPCRoute).
 				MustAdd(Gateway).
 				MustAdd(GatewayClass).
 				MustAdd(HTTPRoute).

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1204,9 +1204,9 @@ func istioScheme() *runtime.Scheme {
 	utilruntime.Must(clientsecurity.AddToScheme(scheme))
 	utilruntime.Must(clienttelemetry.AddToScheme(scheme))
 	utilruntime.Must(clientextensions.AddToScheme(scheme))
-	utilruntime.Must(gatewayapi.AddToScheme(scheme))
-	utilruntime.Must(gatewayapibeta.AddToScheme(scheme))
-	utilruntime.Must(gatewayapiv1.AddToScheme(scheme))
+	utilruntime.Must(gatewayapi.Install(scheme))
+	utilruntime.Must(gatewayapibeta.Install(scheme))
+	utilruntime.Must(gatewayapiv1.Install(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	return scheme
 }

--- a/pkg/kube/kclient/crdwatcher.go
+++ b/pkg/kube/kclient/crdwatcher.go
@@ -91,6 +91,13 @@ func minimumVersionFilter(t any) bool {
 		log.Errorf("CRD %v version %v invalid; ignoring: %v", crd.Name, bv, err)
 		return false
 	}
+	// Ignore RC tags, etc. We 'round up' those.
+	nv, err := fv.SetPrerelease("")
+	if err != nil {
+		log.Errorf("CRD %v version %v invalid; ignoring: %v", crd.Name, bv, err)
+		return false
+	}
+	fv = &nv
 	if fv.LessThan(mv) {
 		log.Infof("CRD %v version %v is below minimum version %v, ignoring", crd.Name, fv, mv)
 		return false

--- a/pkg/kube/kclient/crdwatcher.go
+++ b/pkg/kube/kclient/crdwatcher.go
@@ -18,9 +18,11 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/Masterminds/semver/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/pkg/consts"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/schema/gvr"
@@ -54,9 +56,46 @@ func newCrdWatcher(client kube.Client) kubetypes.CrdWatcher {
 
 	c.queue = controllers.NewQueue("crd watcher",
 		controllers.WithReconciler(c.Reconcile))
-	c.crds = NewMetadata(client, gvr.CustomResourceDefinition, Filter{})
+	c.crds = NewMetadata(client, gvr.CustomResourceDefinition, Filter{
+		ObjectFilter: kubetypes.NewStaticObjectFilter(minimumVersionFilter),
+	})
 	c.crds.AddEventHandler(controllers.ObjectHandler(c.queue.AddObject))
 	return c
+}
+
+var minimumCRDVersions = map[string]*semver.Version{
+	"grpcroutes.gateway.networking.k8s.io": semver.New(1, 1, 0, "", ""),
+}
+
+// minimumVersionFilter filters CRDs that do not meet a minimum "version".
+// Currently, we use this only for Gateway API CRD's, so we hardcode their versioning scheme.
+// The problem we are trying to solve is:
+// * User installs CRDs with Foo v1alpha1
+// * Istio vNext starts watching Foo at v1
+// * user upgrades to Istio vNext. It sees Foo exists, and tries to watch v1. This fails.
+// The user may have opted into using an experimental CRD, but not to experimental usage *in Istio* so this isn't acceptable.
+func minimumVersionFilter(t any) bool {
+	// Setup a filter
+	crd := t.(*metav1.PartialObjectMetadata)
+	mv, f := minimumCRDVersions[crd.Name]
+	if !f {
+		return true
+	}
+	bv, f := crd.Annotations[consts.BundleVersionAnnotation]
+	if !f {
+		log.Errorf("CRD %v expected to have a %v annotation, but none found; ignoring", crd.Name, consts.BundleVersion)
+		return false
+	}
+	fv, err := semver.NewVersion(bv)
+	if err != nil {
+		log.Errorf("CRD %v version %v invalid; ignoring: %v", crd.Name, bv, err)
+		return false
+	}
+	if fv.LessThan(mv) {
+		log.Infof("CRD %v version %v is below minimum version %v, ignoring", crd.Name, fv, mv)
+		return false
+	}
+	return true
 }
 
 // HasSynced returns whether the underlying cache has synced and the callback has been called at least once.

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -107,10 +107,10 @@ func TestGatewayConformance(t *testing.T) {
 				UsableNetworkAddresses:   []v1.GatewayAddress{{Value: "infra-backend-v1.gateway-conformance-infra.svc.cluster.local", Type: &hostnameType}},
 				UnusableNetworkAddresses: []v1.GatewayAddress{{Value: "foo", Type: &hostnameType}},
 				ConformanceProfiles: k8ssets.New(
-					suite.HTTPConformanceProfile.Name,
-					suite.TLSConformanceProfile.Name,
-					suite.GRPCConformanceProfile.Name,
-					suite.MeshConformanceProfile.Name,
+					suite.GatewayHTTPConformanceProfileName,
+					suite.GatewayTLSConformanceProfileName,
+					suite.GatewayGRPCConformanceProfileName,
+					suite.MeshHTTPConformanceProfileName,
 				),
 				Implementation: confv1.Implementation{
 					Organization: "istio",

--- a/tests/integration/pilot/gateway_conformance_test.go
+++ b/tests/integration/pilot/gateway_conformance_test.go
@@ -118,10 +118,10 @@ func TestGatewayConformance(t *testing.T) {
 				UsableNetworkAddresses:   []v1.GatewayAddress{{Value: "infra-backend-v1.gateway-conformance-infra.svc.cluster.local", Type: &hostnameType}},
 				UnusableNetworkAddresses: []v1.GatewayAddress{{Value: "foo", Type: &hostnameType}},
 				ConformanceProfiles: k8ssets.New(
-					suite.HTTPConformanceProfile.Name,
-					suite.TLSConformanceProfile.Name,
-					suite.GRPCConformanceProfile.Name,
-					suite.MeshConformanceProfile.Name,
+					suite.GatewayHTTPConformanceProfileName,
+					suite.GatewayTLSConformanceProfileName,
+					suite.GatewayGRPCConformanceProfileName,
+					suite.MeshHTTPConformanceProfileName,
 				),
 				Implementation: confv1.Implementation{
 					Organization: "istio",

--- a/tests/integration/pilot/testdata/gateway-api-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-crd.yaml
@@ -1,3 +1,4 @@
+# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=7320257302905254dcebf4f5c424741cf1556c06"`
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/tests/integration/pilot/testdata/gateway-api-crd.yaml
+++ b/tests/integration/pilot/testdata/gateway-api-crd.yaml
@@ -1,10 +1,9 @@
-# Generated with `kubectl kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=7f9f51098f405344a3a7eb13c55895c77919f706"`
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   labels:
@@ -27,7 +26,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha2
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         description: |-
@@ -54,9 +53,9 @@ spec:
           spec:
             description: Spec defines the desired state of BackendTLSPolicy.
             properties:
-              targetRef:
+              targetRefs:
                 description: |-
-                  TargetRef identifies an API object to apply the policy to.
+                  TargetRefs identifies an API object to apply the policy to.
                   Only Services have Extended support. Implementations MAY support
                   additional objects, with Implementation Specific support.
                   Note that this config applies to the entire referenced resource
@@ -68,69 +67,83 @@ spec:
 
 
                   Support: Implementation-specific for any other resource
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              validation:
+                description: Validation contains backend TLS validation configuration.
                 properties:
-                  group:
-                    description: Group is the group of the target resource.
-                    maxLength: 253
-                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  kind:
-                    description: Kind is kind of the target resource.
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                    type: string
-                  name:
-                    description: Name is the name of the target resource.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  sectionName:
+                  caCertificateRefs:
                     description: |-
-                      SectionName is the name of a section within the target resource. When
-                      unspecified, this targetRef targets the entire resource. In the following
-                      resources, SectionName is interpreted as the following:
-
-
-                      * Gateway: Listener name
-                      * HTTPRoute: HTTPRouteRule name
-                      * Service: Port name
-
-
-                      If a SectionName is specified, but does not exist on the targeted object,
-                      the Policy must fail to attach, and the policy implementation should record
-                      a `ResolvedRefs` or similar Condition in the Policy's status.
-                    maxLength: 253
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                required:
-                - group
-                - kind
-                - name
-                type: object
-              tls:
-                description: TLS contains backend TLS policy configuration.
-                properties:
-                  caCertRefs:
-                    description: |-
-                      CACertRefs contains one or more references to Kubernetes objects that
+                      CACertificateRefs contains one or more references to Kubernetes objects that
                       contain a PEM-encoded TLS CA certificate bundle, which is used to
                       validate a TLS handshake between the Gateway and backend Pod.
 
 
-                      If CACertRefs is empty or unspecified, then WellKnownCACerts must be
-                      specified. Only one of CACertRefs or WellKnownCACerts may be specified,
-                      not both. If CACertRefs is empty or unspecified, the configuration for
-                      WellKnownCACerts MUST be honored instead if supported by the
-                      implementation.
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
 
 
                       References to a resource in a different namespace are invalid for the
                       moment, although we will revisit this in the future.
 
 
-                      A single CACertRef to a Kubernetes ConfigMap kind has "Core" support.
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
                       Implementations MAY choose to support attaching multiple certificates to
                       a backend, but this behavior is implementation-specific.
 
@@ -195,16 +208,16 @@ spec:
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
-                  wellKnownCACerts:
+                  wellKnownCACertificates:
                     description: |-
-                      WellKnownCACerts specifies whether system CA certificates may be used in
+                      WellKnownCACertificates specifies whether system CA certificates may be used in
                       the TLS handshake between the gateway and backend pod.
 
 
-                      If WellKnownCACerts is unspecified or empty (""), then CACertRefs must be
-                      specified with at least one entry for a valid configuration. Only one of
-                      CACertRefs or WellKnownCACerts may be specified, not both. If an
-                      implementation does not support the WellKnownCACerts field or the value
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                      implementation does not support the WellKnownCACertificates field or the value
                       supplied is not supported, the Status Conditions on the Policy MUST be
                       updated to include an Accepted: False Condition with Reason: Invalid.
 
@@ -217,15 +230,17 @@ spec:
                 - hostname
                 type: object
                 x-kubernetes-validations:
-                - message: must not contain both CACertRefs and WellKnownCACerts
-                  rule: '!(has(self.caCertRefs) && size(self.caCertRefs) > 0 && has(self.wellKnownCACerts)
-                    && self.wellKnownCACerts != "")'
-                - message: must specify either CACertRefs or WellKnownCACerts
-                  rule: (has(self.caCertRefs) && size(self.caCertRefs) > 0 || has(self.wellKnownCACerts)
-                    && self.wellKnownCACerts != "")
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
             required:
-            - targetRef
-            - tls
+            - targetRefs
+            - validation
             type: object
           status:
             description: Status defines the current state of BackendTLSPolicy.
@@ -588,8 +603,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -1137,8 +1152,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -1663,11 +1678,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -2888,11 +2905,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -3616,8 +3635,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
@@ -5541,6 +5560,106 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
                   type: object
                 maxItems: 16
                 type: array
@@ -7768,6 +7887,106 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
                   type: object
                 maxItems: 16
                 type: array
@@ -8099,8 +8318,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
@@ -10805,6 +11024,106 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
                       description: |+
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -10819,6 +11138,12 @@ spec:
                             BackendRequest specifies a timeout for an individual request from the gateway
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
 
 
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
@@ -10843,6 +11168,12 @@ spec:
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
 
 
                             This timeout is intended to cover as close to the whole request-response transaction
@@ -13918,6 +14249,106 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
                       description: |+
                         Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -13932,6 +14363,12 @@ spec:
                             BackendRequest specifies a timeout for an individual request from the gateway
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
 
 
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
@@ -13956,6 +14393,12 @@ spec:
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
 
 
                             This timeout is intended to cover as close to the whole request-response transaction
@@ -14352,8 +14795,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
@@ -14736,8 +15179,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
@@ -15558,8 +16001,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
@@ -16453,8 +16896,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
-    gateway.networking.k8s.io/bundle-version: v1.0.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0-rc1
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io


### PR DESCRIPTION
This won't work until GW api actually official launches 1.1, where the bundle-version will be "1.1".

Part of https://github.com/istio/istio/issues/50408