### PR TITLE
ambient: rename default waypoint (again)

### DIFF
--- a/istioctl/pkg/waypoint/testdata/waypoint/all-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/all-gateway
@@ -1,3 +1,3 @@
-NAMESPACE     NAME                  REVISION     PROGRAMMED
-default       default-namespace     default      True
-fake          default-namespace     default      True
+NAMESPACE     NAME         REVISION     PROGRAMMED
+default       waypoint     default      True
+fake          waypoint     default      True

--- a/istioctl/pkg/waypoint/testdata/waypoint/combined-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/combined-gateway
@@ -2,5 +2,5 @@ NAMESPACE     NAME                   REVISION     PROGRAMMED
 bookinfo      bookinfo-rev           rev1         True
 bookinfo      bookinfo-valid         default      True
 default       bookinfo               default      False
-default       default-namespace      default      False
 default       no-name-convention     default      True
+default       waypoint               default      False

--- a/istioctl/pkg/waypoint/testdata/waypoint/default-gateway
+++ b/istioctl/pkg/waypoint/testdata/waypoint/default-gateway
@@ -1,2 +1,2 @@
-NAME                  REVISION     PROGRAMMED
-default-namespace     default      True
+NAME         REVISION     PROGRAMMED
+waypoint     default      True

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1998,7 +1998,7 @@ func convertGateways(r configContext) ([]config.Config, map[parentKey][]*parentI
 		servers := []*istio.Server{}
 
 		// Extract the addresses. A gateway will bind to a specific Service
-		gatewayServices, err := extractGatewayServices(r.GatewayResources, kgw, obj)
+		gatewayServices, err := extractGatewayServices(r.GatewayResources, kgw, obj, classInfo)
 		if len(gatewayServices) == 0 && err != nil {
 			// Short circuit if its a hard failure
 			reportGatewayStatus(r, obj, classInfo, gatewayServices, servers, err)
@@ -2264,9 +2264,9 @@ func IsManaged(gw *k8s.GatewaySpec) bool {
 	return false
 }
 
-func extractGatewayServices(r GatewayResources, kgw *k8s.GatewaySpec, obj config.Config) ([]string, *ConfigError) {
+func extractGatewayServices(r GatewayResources, kgw *k8s.GatewaySpec, obj config.Config, info classInfo) ([]string, *ConfigError) {
 	if IsManaged(kgw) {
-		name := model.GetOrDefault(obj.Annotations[gatewayNameOverride], getDefaultName(obj.Name, kgw, false))
+		name := model.GetOrDefault(obj.Annotations[gatewayNameOverride], getDefaultName(obj.Name, kgw, info.disableNameSuffix))
 		return []string{fmt.Sprintf("%s.%s.svc.%v", name, obj.Namespace, r.Domain)}, nil
 	}
 	gatewayServices := []string{}

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1962,7 +1962,10 @@ func filteredReferences(parents []routeParentReference) []routeParentReference {
 	return ret
 }
 
-func getDefaultName(name string, kgw *k8s.GatewaySpec) string {
+func getDefaultName(name string, kgw *k8s.GatewaySpec, disableNameSuffix bool) string {
+	if disableNameSuffix {
+		return name
+	}
 	return fmt.Sprintf("%v-%v", name, kgw.GatewayClassName)
 }
 
@@ -2263,7 +2266,7 @@ func IsManaged(gw *k8s.GatewaySpec) bool {
 
 func extractGatewayServices(r GatewayResources, kgw *k8s.GatewaySpec, obj config.Config) ([]string, *ConfigError) {
 	if IsManaged(kgw) {
-		name := model.GetOrDefault(obj.Annotations[gatewayNameOverride], getDefaultName(obj.Name, kgw))
+		name := model.GetOrDefault(obj.Annotations[gatewayNameOverride], getDefaultName(obj.Name, kgw, false))
 		return []string{fmt.Sprintf("%s.%s.svc.%v", name, obj.Namespace, r.Domain)}, nil
 	}
 	gatewayServices := []string{}

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -1451,7 +1451,7 @@ func TestExtractGatewayServices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gatewayServices, err := extractGatewayServices(tt.r, tt.kgw, tt.obj)
+			gatewayServices, err := extractGatewayServices(tt.r, tt.kgw, tt.obj, classInfo{})
 			assert.Equal(t, gatewayServices, tt.gatewayServices)
 			assert.Equal(t, err, tt.err)
 		})

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -112,6 +112,9 @@ type classInfo struct {
 	// disableRouteGeneration, if set, will make it so the controller ignores this class.
 	disableRouteGeneration bool
 
+	// disableNameSuffix, if set, will avoid appending -<class> to names
+	disableNameSuffix bool
+
 	// addressType is the default address type to report
 	addressType gateway.AddressType
 }
@@ -161,6 +164,7 @@ func getClassInfos() map[gateway.GatewayController]classInfo {
 			controller:         constants.ManagedGatewayMeshController,
 			description:        "The default Istio waypoint GatewayClass",
 			templates:          "waypoint",
+			disableNameSuffix:  true,
 			defaultServiceType: corev1.ServiceTypeClusterIP,
 			addressType:        gateway.IPAddressType,
 		}
@@ -335,7 +339,7 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	proxyUID, proxyGID := inject.GetProxyIDs(ns)
 
-	defaultName := getDefaultName(gw.Name, &gw.Spec)
+	defaultName := getDefaultName(gw.Name, &gw.Spec, gi.disableNameSuffix)
 
 	serviceType := gi.defaultServiceType
 	if o, f := gw.Annotations[serviceTypeOverride]; f {

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -13,7 +13,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -30,7 +30,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -53,7 +53,7 @@ spec:
         gateway.istio.io/managed: istio.io-mesh-controller
         gateway.networking.k8s.io/gateway-name: namespace
         istio.io/gateway-name: namespace
-        service.istio.io/canonical-name: namespace-istio-waypoint
+        service.istio.io/canonical-name: namespace
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
         topology.istio.io/network: network-1
@@ -65,7 +65,7 @@ spec:
         - --domain
         - $(POD_NAMESPACE).svc.<no value>
         - --serviceCluster
-        - namespace-istio-waypoint.$(POD_NAMESPACE)
+        - namespace.$(POD_NAMESPACE)
         - --proxyLogLevel
         - <nil>
         - --proxyComponentLogLevel
@@ -127,9 +127,9 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_WORKLOAD_NAME
-          value: namespace-istio-waypoint
+          value: namespace
         - name: ISTIO_META_OWNER
-          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace-istio-waypoint
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         image: test/proxyv2:test
@@ -188,7 +188,7 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
-      serviceAccountName: namespace-istio-waypoint
+      serviceAccountName: namespace
       terminationGracePeriodSeconds: 2
       volumes:
       - emptyDir: {}
@@ -232,7 +232,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -13,7 +13,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -30,7 +30,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -53,7 +53,7 @@ spec:
         gateway.istio.io/managed: istio.io-mesh-controller
         gateway.networking.k8s.io/gateway-name: namespace
         istio.io/gateway-name: namespace
-        service.istio.io/canonical-name: namespace-istio-waypoint
+        service.istio.io/canonical-name: namespace
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
         topology.istio.io/network: network-1
@@ -65,7 +65,7 @@ spec:
         - --domain
         - $(POD_NAMESPACE).svc.<no value>
         - --serviceCluster
-        - namespace-istio-waypoint.$(POD_NAMESPACE)
+        - namespace.$(POD_NAMESPACE)
         - --proxyLogLevel
         - <nil>
         - --proxyComponentLogLevel
@@ -127,9 +127,9 @@ spec:
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         - name: ISTIO_META_WORKLOAD_NAME
-          value: namespace-istio-waypoint
+          value: namespace
         - name: ISTIO_META_OWNER
-          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace-istio-waypoint
+          value: kubernetes://apis/apps/v1/namespaces/default/deployments/namespace
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         image: test/proxyv2:test
@@ -188,7 +188,7 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
-      serviceAccountName: namespace-istio-waypoint
+      serviceAccountName: namespace
       terminationGracePeriodSeconds: 2
       volumes:
       - emptyDir: {}
@@ -232,7 +232,7 @@ metadata:
     gateway.networking.k8s.io/gateway-name: namespace
     istio.io/gateway-name: namespace
     topology.istio.io/network: network-1
-  name: namespace-istio-waypoint
+  name: namespace
   namespace: default
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1beta1

--- a/pilot/pkg/config/kube/gateway/testdata/waypoint.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/waypoint.status.yaml.golden
@@ -13,7 +13,7 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: 'Failed to assign to any requested addresses: hostname "namespace-istio-waypoint.ns.svc.domain.suffix"
+    message: 'Failed to assign to any requested addresses: hostname "namespace.ns.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
     status: "False"
@@ -59,7 +59,7 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: fake
-    message: 'Failed to assign to any requested addresses: hostname "invalid-istio-waypoint.ns.svc.domain.suffix"
+    message: 'Failed to assign to any requested addresses: hostname "invalid.ns.svc.domain.suffix"
       not found'
     reason: AddressNotUsable
     status: "False"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -98,7 +98,7 @@ const (
 	IstioMeshGateway = "mesh"
 
 	// DefaultNamespaceWaypoint is the default name for a waypoint in a namespace.
-	DefaultNamespaceWaypoint = "default-namespace"
+	DefaultNamespaceWaypoint = "waypoint"
 
 	// The data name in the ConfigMap of each namespace storing the root cert of non-Kube CA.
 	CACertNamespaceConfigMapDataName = "root-cert.pem"

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -700,7 +700,7 @@ spec:
   rules:
   - from:
     - source:
-        principals: ["cluster.local/ns/{{.Namespace}}/sa/{{.Source}}", "cluster.local/ns/{{.Namespace}}/sa/{{.WaypointName}}-istio-waypoint"]
+        principals: ["cluster.local/ns/{{.Namespace}}/sa/{{.Source}}", "cluster.local/ns/{{.Namespace}}/sa/{{.WaypointName}}"]
 `
 				t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 					"Destination":  dst.Config().Service,
@@ -996,7 +996,7 @@ spec:
   rules:
   - from:
     - source:
-        principals: ["cluster.local/ns/{{.Namespace}}/sa/{{.WaypointName}}-istio-waypoint"]
+        principals: ["cluster.local/ns/{{.Namespace}}/sa/{{.WaypointName}}"]
 `
 			}
 			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/http/headers"
 	"istio.io/istio/pkg/ptr"
 	echot "istio.io/istio/pkg/test/echo"
@@ -2211,7 +2210,7 @@ func buildQuery(src, dst echo.Instance) prometheus.Query {
 		"destination_canonical_service":  dst.ServiceName(),
 		"destination_canonical_revision": dst.Config().Version,
 		"destination_service":            fmt.Sprintf("%s.%s.svc.cluster.local", dst.Config().Service, destns),
-		"destination_principal":          fmt.Sprintf("spiffe://cluster.local/ns/%v/sa/%v-%v", destns, "waypoint", constants.WaypointGatewayClassName),
+		"destination_principal":          fmt.Sprintf("spiffe://cluster.local/ns/%v/sa/%v", destns, "waypoint"),
 		"destination_service_name":       dst.Config().Service,
 		"destination_workload":           deployName(dst),
 		"destination_workload_namespace": destns,


### PR DESCRIPTION
Before: `default-namespace`, which ends up suffixing to `default-namespace-istio-waypoint`

Now: `waypoint`, with suffix disabled. So its just `waypoint`.

From discussion with @louiscryan 