### PR TITLE
tests: make security timeout test more resiliant

### DIFF
--- a/tests/integration/security/testdata/requestauthn/timeout.yaml.tmpl
+++ b/tests/integration/security/testdata/requestauthn/timeout.yaml.tmpl
@@ -8,7 +8,7 @@ spec:
       app: {{ .To.ServiceName }}
   jwtRules:
   - issuer: "test-issuer-1@istio.io"
-    jwksUri: "{{ .JWTServer.JwksURI }}?delay=30ms"
+    jwksUri: "{{ .JWTServer.JwksURI }}?delay=500ms"
     outputPayloadToHeader: "x-test-payload"
     forwardOriginalToken: true
     timeout: "10ms"


### PR DESCRIPTION
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/batch/integ-security_istio/1778890737706864640

I think the tight window on the timeout may trigger it to occasionally
work unexpectedly (Envoy gets paused for ~20ms, etc)
