### PR TITLE
Sort values for validTrafficType

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -203,7 +203,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 	waypointApplyCmd.PersistentFlags().StringVar(&trafficType,
 		"for",
 		"service",
-		fmt.Sprintf("Specify the traffic type %s for the waypoint", validTrafficTypes.String()),
+		fmt.Sprintf("Specify the traffic type %s for the waypoint", sets.SortedList(validTrafficTypes)),
 	)
 
 	waypointApplyCmd.PersistentFlags().BoolVarP(&enrollNamespace, "enroll-namespace", "", false,


### PR DESCRIPTION
**Please provide a description of this PR:**
Sort the values to stop randomly updating the reference docs.

Looking at https://github.com/istio/istio.io/pull/14879/files, we will routinely update the reference docs as the validTrafficTypes.String() is random:
```
// String returns a string representation of the set.
// Be aware that the order of elements is random so the string representation may vary.

```