### PR TITLE
ambient: test `targetRefs` instead of singular

### DIFF
--- a/pilot/pkg/model/policyattachment_test.go
+++ b/pilot/pkg/model/policyattachment_test.go
@@ -79,7 +79,7 @@ func TestGetPolicyMatcher(t *testing.T) {
 	tests := []struct {
 		name                   string
 		opts                   WorkloadSelectionOpts
-		policy                 policyTargetGetter
+		policy                 PolicyTargetGetter
 		expected               policyMatch
 		enableSelectorPolicies bool
 	}{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/api/security/v1beta1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
@@ -343,11 +342,9 @@ func convertPeerAuthentication(rootNamespace string, cfg *securityclient.PeerAut
 func convertAuthorizationPolicy(rootns string, obj *securityclient.AuthorizationPolicy) *security.Authorization {
 	pol := &obj.Spec
 
-	polTargetRef := pol.GetTargetRef()
-	if polTargetRef != nil &&
-		polTargetRef.Group == gvk.KubernetesGateway.Group &&
-		polTargetRef.Kind == gvk.KubernetesGateway.Kind {
-		// we have a policy targeting a gateway, do not configure a WDS authorization
+	polTargetRef := model.GetTargetRefs(pol)
+	if len(polTargetRef) > 0 {
+		// TargetRef is not intended for ztunnel
 		return nil
 	}
 

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -713,8 +713,8 @@ kind: AuthorizationPolicy
 metadata:
   name: policy-waypoint
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
 `+policySpec+`
@@ -759,8 +759,8 @@ kind: AuthorizationPolicy
 metadata:
   name: policy-waypoint
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
 `+policySpec).ApplyOrFail(t)
@@ -1020,8 +1020,8 @@ kind: AuthorizationPolicy
 metadata:
   name: policy-waypoint
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
 `+policySpec+`
@@ -1041,8 +1041,8 @@ kind: AuthorizationPolicy
 metadata:
   name: deny-policy-waypoint
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
 `+denySpec).ApplyOrFail(t)

--- a/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
+++ b/tests/integration/ambient/testdata/requestauthn/waypoint-jwt.yaml.tmpl
@@ -3,8 +3,8 @@ kind: RequestAuthentication
 metadata:
   name: default-{{ .To.ServiceName }}
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
   jwtRules:
@@ -30,8 +30,8 @@ kind: AuthorizationPolicy
 metadata:
   name: authz-gateway-{{ .To.ServiceName }}
 spec:
-  targetRef:
-    kind: Gateway
+  targetRefs:
+  - kind: Gateway
     group: gateway.networking.k8s.io
     name: waypoint
   rules:


### PR DESCRIPTION
We expect to push all users to use targetRefs in all cases. Both work,
but uses copy+paste from tests so its best to use best practices here.

Unit tests provide sufficient coverage that singular and plural are the
same.
