### PR TITLE
autoregistration: fix regression in PILOT_ENABLE_WORKLOAD_ENTRY_AUTOREGISTRATION

### DIFF
--- a/pilot/pkg/autoregistration/controller.go
+++ b/pilot/pkg/autoregistration/controller.go
@@ -150,6 +150,8 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.store != nil && c.cleanupQueue != nil {
 		go c.periodicWorkloadEntryCleanup(stop)
 		go c.cleanupQueue.Run(stop)
+	}
+	if features.WorkloadEntryAutoRegistration {
 		go c.lateRegistrationQueue.Run(stop)
 	}
 


### PR DESCRIPTION
This flag would currently cause Istiod to panic if its ever set. Fix it
and add a simple test
