### PR TITLE
generate implicit policies to allow from waypoint

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -45,16 +45,10 @@ var (
 		false, false,
 		"If enabled, HBONE will be preferred when sending to destinations. ")
 
-	DefaultAllowFromWaypoint = func() bool {
-		v := env.Register(
-			"PILOT_DEFAULT_ENFORCE_FROM_WAYPOINT",
-			false,
-			"If enabled, zTunnels will enforce that incoming traffic has traversed a Waypoint if traffic to an endpoint may traverse one.").Get()
-		if v && !EnableAmbient {
-			log.Fatalf("PILOT_ENABLE_AMBIENT_WAYPOINTS requires PILOT_ENABLE_AMBIENT_CONTROLLERS")
-		}
-		return v
-	}()
+	DefaultAllowFromWaypoint = registerAmbient(
+		"PILOT_DEFAULT_ENFORCE_FROM_WAYPOINT",
+		true, false,
+		"If enabled, zTunnels will enforce that incoming traffic has traversed a Waypoint if traffic to an endpoint may traverse one.")
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -44,6 +44,17 @@ var (
 		"PILOT_PREFER_SENDING_HBONE",
 		false, false,
 		"If enabled, HBONE will be preferred when sending to destinations. ")
+
+	DefaultAllowFromWaypoint = func() bool {
+		v := env.Register(
+			"PILOT_DEFAULT_ENFORCE_FROM_WAYPOINT",
+			false,
+			"If enabled, zTunnels will enforce that incoming traffic has traversed a Waypoint if traffic to an endpoint may traverse one.").Get()
+		if v && !EnableAmbient {
+			log.Fatalf("PILOT_ENABLE_AMBIENT_WAYPOINTS requires PILOT_ENABLE_AMBIENT_CONTROLLERS")
+		}
+		return v
+	}()
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -962,7 +962,7 @@ type ServiceInfo struct {
 	PortNames map[int32]ServicePortName
 	// Source is the type that introduced this service.
 	Source kind.Kind
-	// Waypoint attached to the Service
+	// Waypoint that clients should use when addressing traffic to this Service.
 	Waypoint string
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -962,6 +962,8 @@ type ServiceInfo struct {
 	PortNames map[int32]ServicePortName
 	// Source is the type that introduced this service.
 	Source kind.Kind
+  // Waypoint attached to the Service
+  Waypoint string
 }
 
 func (i ServiceInfo) NamespacedName() types.NamespacedName {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -962,8 +962,8 @@ type ServiceInfo struct {
 	PortNames map[int32]ServicePortName
 	// Source is the type that introduced this service.
 	Source kind.Kind
-  // Waypoint attached to the Service
-  Waypoint string
+	// Waypoint attached to the Service
+	Waypoint string
 }
 
 func (i ServiceInfo) NamespacedName() types.NamespacedName {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -150,10 +150,10 @@ func New(options Options) Index {
 	Namespaces := krt.NewInformer[*v1.Namespace](options.Client, krt.WithName("Namespaces"))
 
 	MeshConfig := MeshConfigCollection(ConfigMaps, options)
-	Waypoints := WaypointsCollection(Gateways, GatewayClasses)
+	Waypoints := WaypointsCollection(Gateways, GatewayClasses, Pods)
 
 	// AllPolicies includes peer-authentication converted policies
-	AuthorizationPolicies, AllPolicies := PolicyCollections(AuthzPolicies, PeerAuths, MeshConfig)
+	AuthorizationPolicies, AllPolicies := PolicyCollections(AuthzPolicies, PeerAuths, MeshConfig, Waypoints, Pods)
 	AllPolicies.RegisterBatch(PushXds(a.XDSUpdater, func(i model.WorkloadAuthorization) model.ConfigKey {
 		return model.ConfigKey{Kind: kind.AuthorizationPolicy, Name: i.Authorization.Name, Namespace: i.Authorization.Namespace}
 	}), false)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -166,7 +166,7 @@ func New(options Options) Index {
 		if s.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
 			return nil
 		}
-		waypoint := s.Waypoint
+		waypoint := s.Service.Waypoint
 		if waypoint == nil {
 			return nil
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1082,7 +1082,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 	s := newAmbientTestServer(t, testC, testNW)
 	setupPolicyTest(t, s)
 
-	t.Run("generate policy", func(t *testing.T) {
+	t.Run("policy with service accounts", func(t *testing.T) {
 		assert.EventuallyEqual(t, func() []string {
 			waypointPolicy := s.authorizationPolicies.GetKey(krt.Key[model.WorkloadAuthorization]("ns1/" + policyName))
 			if waypointPolicy == nil {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -617,10 +617,10 @@ const (
 	xdsSelector                        = "selector"
 )
 
-// TODO(nmittler): Consider splitting this into multiple, smaller tests.
-func TestAmbientIndex_Policy(t *testing.T) {
-	s := newAmbientTestServer(t, testC, testNW)
-
+// app a has one pod
+// the waypoint has two pods with different service accounts
+// the waypoint is namespace attached
+func setupPolicyTest(t *testing.T, s *ambientTestServer) {
 	s.addPods(t, "127.0.0.1", "pod1", "sa1", map[string]string{"app": "a"}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("pod1"))
 	s.addPods(t, "127.0.0.200", "waypoint-ns-pod", "namespace-wide",
@@ -630,7 +630,10 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		}, nil, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint-ns-pod"))
 	s.addPods(t, "127.0.0.201", "waypoint2-sa", "waypoint-sa",
-		map[string]string{constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel},
+		map[string]string{
+			constants.ManagedGatewayLabel: constants.ManagedGatewayMeshControllerLabel,
+			constants.GatewayNameLabel:    "waypoint-ns",
+		},
 		map[string]string{}, true, corev1.PodRunning)
 	s.assertEvent(t, s.podXdsName("waypoint2-sa"))
 	s.addWaypoint(t, "10.0.0.2", "waypoint-ns", constants.AllTraffic, true)
@@ -648,6 +651,13 @@ func TestAmbientIndex_Policy(t *testing.T) {
 		map[string]string{},
 		[]int32{80}, map[string]string{constants.GatewayNameLabel: "waypoint-ns"}, "10.0.0.2")
 	s.assertUnorderedEvent(t, s.podXdsName("waypoint-ns-pod"), s.svcXdsName("waypoint-ns"))
+}
+
+// TODO(nmittler): Consider splitting this into multiple, smaller tests.
+func TestAmbientIndex_Policy(t *testing.T) {
+	s := newAmbientTestServer(t, testC, testNW)
+	setupPolicyTest(t, s)
+
 	selectorPolicyName := "selector"
 
 	// Test that PeerAuthentications are added to the ambient index
@@ -1062,6 +1072,40 @@ func TestAmbientIndex_Policy(t *testing.T) {
 	// there should be no event for creation of a gateway-targeted policy because we should not configure WDS with a policy
 	// when expressed user intent is specifically to have that policy enforced by a gateway
 	s.assertNoEvent(t)
+}
+
+func TestDefaultAllowWaypointPolicy(t *testing.T) {
+	// while the Waypoint is in testNS, the policies live in the Pods' namespaces
+	policyName := "istio_allow_waypoint_" + testNS + "_" + "waypoint-ns"
+	test.SetForTest(t, &features.DefaultAllowFromWaypoint, true)
+
+	s := newAmbientTestServer(t, testC, testNW)
+	setupPolicyTest(t, s)
+
+	t.Run("generate policy", func(t *testing.T) {
+		assert.EventuallyEqual(t, func() []string {
+			waypointPolicy := s.authorizationPolicies.GetKey(krt.Key[model.WorkloadAuthorization]("ns1/" + policyName))
+			if waypointPolicy == nil {
+				return nil
+			}
+			match := waypointPolicy.Authorization.GetGroups()[0].GetRules()[0].GetMatches()[0]
+			return slices.Map(match.Principals, func(sm *security.StringMatch) string {
+				return sm.GetExact()
+			})
+		}, []string{
+			"spiffe://cluster.local/ns/ns1/sa/namespace-wide",
+			"spiffe://cluster.local/ns/ns1/sa/waypoint-sa",
+		})
+	})
+
+	t.Run("attach policy to workload", func(t *testing.T) {
+		assert.EventuallyEqual(t,
+			func() []string {
+				return s.lookup(s.addrXdsName("127.0.0.1"))[0].GetWorkload().GetAuthorizationPolicies()
+			},
+			[]string{policyName},
+		)
+	})
 }
 
 func TestPodLifecycleWorkloadGates(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/policies.go
@@ -16,6 +16,8 @@
 package ambient
 
 import (
+	v1 "k8s.io/api/core/v1"
+
 	securityclient "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -23,7 +25,6 @@ import (
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/workloadapi/security"
-	"k8s.io/api/core/v1"
 )
 
 func PolicyCollections(

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/workloadapi"
 )
 
@@ -52,6 +53,12 @@ type Waypoint struct {
 	// TrafficType controls whether Service or Workload can reference this
 	// waypoint. Must be one of "all", "service", "workload".
 	TrafficType string
+
+	// ServiceAccounts from instances of the waypoint.
+	// This only handles Pods. If we wish to support non-pod waypoints, we'll
+	// want to index ServiceEntry/WorkloadEntry or possibly allow specifying
+	// the ServiceAccounts directly on a Gateway resource.
+	ServiceAccounts []string
 }
 
 // fetchWaypointForInstance attempts to find a Waypoint a given object is an instance of.
@@ -168,13 +175,22 @@ func (w Waypoint) ResourceName() string {
 	return w.GetNamespace() + "/" + w.GetName()
 }
 
-func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway], GatewayClasses krt.Collection[*v1beta1.GatewayClass]) krt.Collection[Waypoint] {
+func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway], GatewayClasses krt.Collection[*v1beta1.GatewayClass], Pods krt.Collection[*v1.Pod]) krt.Collection[Waypoint] {
+	podsByNamespace := krt.NewNamespaceIndex(Pods)
 	return krt.NewCollection(Gateways, func(ctx krt.HandlerContext, gateway *v1beta1.Gateway) *Waypoint {
 		if len(gateway.Status.Addresses) == 0 {
 			// gateway.Status.Addresses should only be populated once the Waypoint's deployment has at least 1 ready pod, it should never be removed after going ready
 			// ignore Kubernetes Gateways which aren't waypoints
 			return nil
 		}
+
+		instances := krt.Fetch(ctx, Pods, krt.FilterLabel(map[string]string{
+			constants.GatewayNameLabel: gateway.Name,
+		}), krt.FilterIndex(podsByNamespace, gateway.Namespace))
+
+		serviceAccounts := slices.Map(instances, func(p *v1.Pod) string {
+			return p.Spec.ServiceAccountName
+		})
 
 		gatewayClass := ptr.OrEmpty(krt.FetchOne(ctx, GatewayClasses, krt.FilterKey(string(gateway.Spec.GatewayClassName))))
 		if gatewayClass == nil {
@@ -183,14 +199,14 @@ func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway], GatewayClass
 
 		// Check for a declared traffic type that is allowed to pass through the Waypoint
 		if tt, found := gateway.Annotations[constants.AmbientWaypointForTrafficType]; found {
-			return makeWaypoint(gateway, gatewayClass, tt)
+			return makeWaypoint(gateway, gatewayClass, serviceAccounts, tt)
 		}
 		// If a value is not declared on a Gateway or its associated GatewayClass
 		// then the network layer should default to service when redirecting traffic.
 		//
 		// This is a safety measure to ensure that the Gateway is not misconfigured, but
 		// we will likely not hit this case as the CLI will validate the traffic type.
-		return makeWaypoint(gateway, gatewayClass, constants.ServiceTraffic)
+		return makeWaypoint(gateway, gatewayClass, serviceAccounts, constants.ServiceTraffic)
 	}, krt.WithName("Waypoints"))
 }
 
@@ -240,12 +256,18 @@ func makeInboundBinding(gatewayClass *v1beta1.GatewayClass) InboundBinding {
 	}
 }
 
-func makeWaypoint(gateway *v1beta1.Gateway, gatewayClass *v1beta1.GatewayClass, trafficType string) *Waypoint {
+func makeWaypoint(
+	gateway *v1beta1.Gateway,
+	gatewayClass *v1beta1.GatewayClass,
+	serviceAccounts []string,
+	trafficType string,
+) *Waypoint {
 	return &Waypoint{
-		Named:          krt.NewNamed(gateway),
-		Addresses:      getGatewayAddrs(gateway),
-		DefaultBinding: makeInboundBinding(gatewayClass),
-		TrafficType:    trafficType,
+		Named:           krt.NewNamed(gateway),
+		Addresses:       getGatewayAddrs(gateway),
+		DefaultBinding:  makeInboundBinding(gatewayClass),
+		TrafficType:     trafficType,
+		ServiceAccounts: slices.Sort(serviceAccounts),
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -175,7 +175,11 @@ func (w Waypoint) ResourceName() string {
 	return w.GetNamespace() + "/" + w.GetName()
 }
 
-func WaypointsCollection(Gateways krt.Collection[*v1beta1.Gateway], GatewayClasses krt.Collection[*v1beta1.GatewayClass], Pods krt.Collection[*v1.Pod]) krt.Collection[Waypoint] {
+func WaypointsCollection(
+	Gateways krt.Collection[*v1beta1.Gateway],
+	GatewayClasses krt.Collection[*v1beta1.GatewayClass],
+	Pods krt.Collection[*v1.Pod],
+) krt.Collection[Waypoint] {
 	podsByNamespace := krt.NewNamespaceIndex(Pods)
 	return krt.NewCollection(Gateways, func(ctx krt.HandlerContext, gateway *v1beta1.Gateway) *Waypoint {
 		if len(gateway.Status.Addresses) == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -85,6 +85,8 @@ func (a *index) WorkloadsCollection(
 			// Not ready yet
 			return nil
 		}
+		services := []model.ServiceInfo{*svc}
+
 		for _, p := range se.Spec.Endpoints {
 			meshCfg := krt.FetchOne(ctx, MeshConfig.AsCollection())
 			// We need to filter from the policies that are present, which apply to us.
@@ -109,10 +111,11 @@ func (a *index) WorkloadsCollection(
 			var waypointAddress *workloadapi.GatewayAddress
 			if waypoint != nil {
 				waypointAddress = a.getWaypointAddress(waypoint)
-				if waypointPolicy := implicitWaypointPolicyName(waypoint); waypointPolicy != "" {
-					policies = append(policies, waypointPolicy)
-				}
 			}
+
+			// enforce traversing waypoints
+			policies = append(policies, implicitWaypointPolicies(ctx, Waypoints, waypoint, services)...)
+
 			a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
 			network := a.Network(p.Address, p.Labels).String()
 			if p.Network != "" {
@@ -125,7 +128,7 @@ func (a *index) WorkloadsCollection(
 				Network:               network,
 				ClusterId:             string(a.ClusterID),
 				ServiceAccount:        p.ServiceAccount,
-				Services:              constructServicesFromWorkloadEntry(p, []model.ServiceInfo{*svc}),
+				Services:              constructServicesFromWorkloadEntry(p, services),
 				AuthorizationPolicies: policies,
 				Status:                workloadapi.WorkloadStatus_HEALTHY, // TODO: WE can be unhealthy
 				Waypoint:              waypointAddress,
@@ -181,9 +184,6 @@ func (a *index) workloadEntryWorkloadBuilder(
 		var waypointAddress *workloadapi.GatewayAddress
 		if waypoint != nil {
 			waypointAddress = a.getWaypointAddress(waypoint)
-			if waypointPolicy := implicitWaypointPolicyName(waypoint); waypointPolicy != "" {
-				policies = append(policies, waypointPolicy)
-			}
 		}
 		fo := []krt.FetchOption{krt.FilterIndex(WorkloadServicesNamespaceIndex, p.Namespace), krt.FilterSelectsNonEmpty(p.GetLabels())}
 		if !features.EnableK8SServiceSelectWorkloadEntries {
@@ -197,6 +197,10 @@ func (a *index) workloadEntryWorkloadBuilder(
 		if p.Spec.Network != "" {
 			network = p.Spec.Network
 		}
+
+		// enforce traversing waypoints
+		policies = append(policies, implicitWaypointPolicies(ctx, Waypoints, waypoint, services)...)
+
 		w := &workloadapi.Workload{
 			Uid:                   a.generateWorkloadEntryUID(p.Namespace, p.Name),
 			Name:                  p.Name,
@@ -276,7 +280,7 @@ func (a *index) podWorkloadBuilder(
 		network := a.Network(p.Status.PodIP, p.Labels).String()
 
 		var appTunnel *workloadapi.ApplicationTunnel
-		var targetWaypoint *workloadapi.GatewayAddress
+		var targetWaypoint *Waypoint
 		if instancedWaypoint := fetchWaypointForInstance(ctx, Waypoints, p.ObjectMeta); instancedWaypoint != nil {
 			// we're an instance of a waypoint, set inbound tunnel info
 			appTunnel = &workloadapi.ApplicationTunnel{
@@ -285,11 +289,11 @@ func (a *index) podWorkloadBuilder(
 			}
 		} else if waypoint := fetchWaypointForWorkload(ctx, Waypoints, Namespaces, p.ObjectMeta); waypoint != nil {
 			// there is a workload-attached waypoint, point there with a GatewayAddress
-			targetWaypoint = a.getWaypointAddress(waypoint)
-			if waypointPolicy := implicitWaypointPolicyName(waypoint); waypointPolicy != "" {
-				policies = append(policies, waypointPolicy)
-			}
+			targetWaypoint = waypoint
 		}
+
+		// enforce traversing waypoints
+		policies = append(policies, implicitWaypointPolicies(ctx, Waypoints, targetWaypoint, services)...)
 
 		w := &workloadapi.Workload{
 			Uid:                   a.generatePodUID(p),
@@ -299,7 +303,7 @@ func (a *index) podWorkloadBuilder(
 			ClusterId:             string(a.ClusterID),
 			Addresses:             [][]byte{podIP.AsSlice()},
 			ServiceAccount:        p.Spec.ServiceAccountName,
-			Waypoint:              targetWaypoint,
+			Waypoint:              a.getWaypointAddress(targetWaypoint),
 			Node:                  p.Spec.NodeName,
 			ApplicationTunnel:     appTunnel,
 			Services:              constructServices(p, services),
@@ -481,4 +485,28 @@ func getWorkloadEntryLocality(p *networkingv1alpha3.WorkloadEntry) *workloadapi.
 		Zone:    zone,
 		Subzone: subzone,
 	}
+}
+
+func implicitWaypointPolicies(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint], waypoint *Waypoint, services []model.ServiceInfo) []string {
+	if !features.DefaultAllowFromWaypoint {
+		return nil
+	}
+	serviceWaypointKeys := slices.MapFilter(services, func(si model.ServiceInfo) *string {
+		if si.Waypoint == "" || (waypoint != nil && waypoint.ResourceName() == si.Waypoint) {
+			return nil
+		}
+		return ptr.Of(si.Waypoint)
+	})
+	waypoints := krt.Fetch(ctx, Waypoints, krt.FilterKeys(serviceWaypointKeys...))
+	if waypoint != nil {
+		waypoints = append(waypoints, *waypoint)
+	}
+
+	return slices.MapFilter(waypoints, func(w Waypoint) *string {
+		policy := implicitWaypointPolicyName(&w)
+		if policy == "" {
+			return nil
+		}
+		return &policy
+	})
 }

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -118,7 +118,8 @@ func FilterGeneric(f func(any) bool) FetchOption {
 }
 
 func (f filter) Matches(object any, forList bool) bool {
-	if !f.keys.IsEmpty() && f.keys.Contains(string(GetKey[any](object))) {
+	// an empty set will match none
+	if f.keys != nil && !f.keys.Contains(string(GetKey[any](object))) {
 		if log.DebugEnabled() {
 			log.Debugf("no match key: %q vs %q", f.keys, string(GetKey[any](object)))
 		}


### PR DESCRIPTION
When the feature flag is enabled, automatically add an ALLOW policy to attached to workloads that _could_ flow through the Waypoint. This includes Workloads that are part of a Service that has a Waypoint. 