### PR TITLE
Removed SkipIf Condition according to Issue #50336

### DIFF
--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -19,7 +19,6 @@ package untaint
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,9 +42,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireMinVersion(24).
-		SkipIf("https://github.com/istio/istio/issues/43243", func(ctx resource.Context) bool {
-			return strings.Contains(ctx.Settings().Image.Tag, "distroless")
-		}).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/41008
 		Setup(func(t resource.Context) error {
 			t.Settings().Ambient = true


### PR DESCRIPTION
This pull request addresses issue #50336 by removing the workaround from tests/integration/ambient/main_test.go, while keeping it unchanged in tests/integration/ambient/untaint/main_test.go. This PR fixes the issue by removing it from tests/integration/ambient/untaint/main_test.go.