### PR TITLE
remove max drain duration

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -68,8 +68,6 @@ const (
 	// nolint: revive
 	connectTimeoutMin = time.Millisecond
 
-	drainTimeMax = time.Hour
-
 	// UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
 	// ServiceEntry.Endpoint.Address message.
 	UnixAddressPrefix = "unix://"

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1390,10 +1390,6 @@ func ValidateDrainDuration(drainTime *durationpb.Duration) (errs error) {
 			errors.New("drain time only supports durations to seconds precision"))
 	}
 
-	if drainDuration > drainTimeMax {
-		errs = multierror.Append(errs,
-			fmt.Errorf("drain time %v must be <%v", drainDuration.String(), drainTimeMax.String()))
-	}
 	return
 }
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -291,10 +291,6 @@ func TestValidateDrainDuration(t *testing.T) {
 			Drain: &durationpb.Duration{Seconds: -1},
 			Valid: false,
 		},
-		{
-			Drain: &durationpb.Duration{Seconds: 1 + int64(time.Hour/time.Second)},
-			Valid: false,
-		},
 	}
 	for _, combo := range combinations {
 		if got := ValidateDrainDuration(combo.Drain); (got == nil) != combo.Valid {


### PR DESCRIPTION
Some protocols needs more drain duration it seems https://github.com/istio/istio/discussions/50477. Envoy does not have max - So not sure if we should have one

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure