### PR TITLE
analyzer: do not depend on local network

### DIFF
--- a/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
+++ b/pkg/config/analysis/analyzers/externalcontrolplane/externalcontrolplane.go
@@ -108,8 +108,6 @@ func (s *ExternalControlPlaneAnalyzer) Analyze(c analysis.Context) {
 type webhookURLResult struct {
 	ip       net.IP
 	hostName string
-
-	resolvesIPs []net.IP
 }
 
 func (r *webhookURLResult) isIP() bool {
@@ -133,14 +131,6 @@ func lintWebhookURL(webhookURL string) (result *webhookURLResult, err error) {
 	}
 
 	result.hostName = parsedHostname
-	ips, err := net.LookupIP(parsedHostname)
-	if err != nil {
-		return result, fmt.Errorf("cannot be resolved via a DNS lookup")
-	}
-	result.resolvesIPs = ips
-	if len(ips) == 0 {
-		return result, fmt.Errorf("resolves with zero IP addresses")
-	}
 
 	return result, nil
 }


### PR DESCRIPTION
This analyzer depending on doing DNS resolution from the analyzer. This is pretty problematic.

1. Analysis is often run locally. Local network != kubernetes network
2. Unbounded outbound network requests from istiod is bad
3. We don't even use the result anyways
4. This makes unit tests depend on network connectivity, which has been causing failures (due to prow cluster networking issues, fwiw)

This PR removes it entirely