### PR TITLE
iptables: remove a few panics instead of errors

### DIFF
--- a/cni/pkg/plugin/sidecar_iptables_linux.go
+++ b/cni/pkg/plugin/sidecar_iptables_linux.go
@@ -53,7 +53,9 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	cfg.CaptureAllDNS = rdrct.dnsRedirect
 	cfg.DropInvalid = rdrct.invalidDrop
 	cfg.DualStack = rdrct.dualStack
-	cfg.FillConfigFromEnvironment()
+	if err := cfg.FillConfigFromEnvironment(); err != nil {
+		return err
+	}
 
 	netNs, err := getNs(netns)
 	if err != nil {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -151,7 +151,9 @@ func GetCommand(logOpts *log.Options) *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg.FillConfigFromEnvironment()
+			if err := cfg.FillConfigFromEnvironment(); err != nil {
+				handleErrorWithCode(err, 1)
+			}
 			if err := cfg.Validate(); err != nil {
 				handleErrorWithCode(err, 1)
 			}


### PR DESCRIPTION
Panic is ~ok for a CLI, but terrible for a long-running daemon (CNI).
Replace with proper error handling.

We did this for most `panic` in the past ,but missed these Fatal calls
