### PR TITLE
add "app.kubernetes.io/name" to gateway.podlabels

### DIFF
--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -30,6 +30,7 @@ app.kubernetes.io/name: {{ include "gateway.name" . }}
 
 {{- define "gateway.podLabels" -}}
 {{ include "gateway.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "gateway.name" . }}
 {{- range $key, $val := .Values.labels }}
 {{- if not (or (eq $key "app") (eq $key "istio")) }}
 {{ $key | quote }}: {{ $val | quote }}

--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -31,6 +31,9 @@ app.kubernetes.io/name: {{ include "gateway.name" . }}
 {{- define "gateway.podLabels" -}}
 {{ include "gateway.selectorLabels" . }}
 app.kubernetes.io/name: {{ include "gateway.name" . }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
 {{- with .Values.revision }}
 istio.io/rev: {{ . | quote }}
 {{- end }}

--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -31,6 +31,9 @@ app.kubernetes.io/name: {{ include "gateway.name" . }}
 {{- define "gateway.podLabels" -}}
 {{ include "gateway.selectorLabels" . }}
 app.kubernetes.io/name: {{ include "gateway.name" . }}
+{{- with .Values.revision }}
+istio.io/rev: {{ . | quote }}
+{{- end }}
 {{- range $key, $val := .Values.labels }}
 {{- if not (or (eq $key "app") (eq $key "istio")) }}
 {{ $key | quote }}: {{ $val | quote }}

--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -7,7 +7,7 @@
 {{- end }}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create chart name and version as used by the helm.sh/chart label.
 */}}
 {{- define "gateway.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
@@ -15,38 +15,30 @@ Create chart name and version as used by the chart label.
 
 {{- define "gateway.labels" -}}
 helm.sh/chart: {{ include "gateway.chart" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ include "gateway.podLabels" . }}
-{{- end }}
-
-{{- define "gateway.podLabels" -}}
 {{ include "gateway.selectorLabels" . }}
 app.kubernetes.io/name: {{ include "gateway.name" . }}
-{{- with .Chart.AppVersion }}
-app.kubernetes.io/version: {{ . | quote }}
-{{- end }}
-{{- with .Values.revision }}
-istio.io/rev: {{ . | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $val := .Values.labels }}
-{{- if not (or (eq $key "app") (eq $key "istio")) }}
+{{- if and (ne $key "app") (ne $key "istio") }}
 {{ $key | quote }}: {{ $val | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
 
 {{- define "gateway.selectorLabels" -}}
-{{- if hasKey .Values.labels "app" }}
-{{- with .Values.labels.app }}app: {{.|quote}}
-{{- end}}
-{{- else }}app: {{ include "gateway.name" . }}
+app: {{ (.Values.labels.app | quote) | default (include "gateway.name" .) }}
+istio: {{ (.Values.labels.istio | quote) | default (include "gateway.name" . | trimPrefix "istio-") }}
 {{- end }}
-{{- if hasKey .Values.labels "istio" }}
-{{- with .Values.labels.istio }}
-istio: {{.|quote}}
-{{- end}}
-{{- else }}
-istio: {{ include "gateway.name" . | trimPrefix "istio-" }}
+
+{{/*
+Keep sidecar injection labels together
+https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
+*/}}
+{{- define "gateway.sidecarInjectionLabels" -}}
+sidecar.istio.io/inject: "true"
+{{- with .Values.revision }}
+istio.io/rev: {{ . | quote }}
 {{- end }}
 {{- end }}
 

--- a/manifests/charts/gateway/templates/_helpers.tpl
+++ b/manifests/charts/gateway/templates/_helpers.tpl
@@ -15,17 +15,8 @@ Create chart name and version as used by the chart label.
 
 {{- define "gateway.labels" -}}
 helm.sh/chart: {{ include "gateway.chart" . }}
-{{ include "gateway.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/name: {{ include "gateway.name" . }}
-{{- range $key, $val := .Values.labels }}
-{{- if not (or (eq $key "app") (eq $key "istio")) }}
-{{ $key | quote }}: {{ $val | quote }}
-{{- end }}
-{{- end }}
+{{ include "gateway.podLabels" . }}
 {{- end }}
 
 {{- define "gateway.podLabels" -}}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -23,8 +23,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        sidecar.istio.io/inject: "true"
-        {{- include "gateway.podLabels" . | nindent 8 }}
+        {{- include "gateway.sidecarInjectionLabels" . | nindent 8 }}
+        {{- include "gateway.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "gateway.name" . }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+        {{- range $key, $val := .Values.labels }}
+        {{- if and (ne $key "app") (ne $key "istio") }}
+        {{ $key | quote }}: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -24,9 +24,6 @@ spec:
       {{- end }}
       labels:
         sidecar.istio.io/inject: "true"
-        {{- with .Values.revision }}
-        istio.io/rev: {{ . | quote }}
-        {{- end }}
         {{- include "gateway.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
**Please provide a description of this PR:**

Two commits to squash or keep the _main_ only

- main (separate commit)
> add "app.kubernetes.io/name" to `gateway.podLabels`
>
> Goal: to have matching "app.kubernetes.io/name" label and value for on `deployment` and `pod` for metrics.
>
>Using `.Values.labels` for that will lead to duplicate "app.kubernetes.io/name" labels.

- https://helm.sh/docs/chart_best_practices/labels/#standard-labels
- https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

---
- optional (cleanup as separate commit)

> move `istio.io/rev` label to `gateway.podLabels` (not-functional change)