### PR TITLE
EnvoyOpenTelemetryLogProvider should set TraceId

### DIFF
--- a/releasenotes/notes/49911.yaml
+++ b/releasenotes/notes/49911.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - 49911
+releaseNotes:
+  - |
+    **Fixed** an issue that TraceId is not propagated when using OpenTelemetry access logger.


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes: #49911 

xref: https://github.com/envoyproxy/envoy/pull/33281

this's fixed on upstream, just add release notes to highligh.

**Should not be backported unless envoy did**