### PR TITLE
`use-waypoint` is user intent, so should be label

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -207,14 +207,14 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "waypoint %v/%v applied\n", gw.Namespace, gw.Name)
 
-			// If a user decides to enroll their namespace with a waypoint, annotate the namespace with the waypoint name
+			// If a user decides to enroll their namespace with a waypoint, label the namespace with the waypoint name
 			// after the waypoint has been applied.
 			if enrollNamespace {
 				err = labelNamespaceWithWaypoint(kubeClient, ns)
 				if err != nil {
-					return fmt.Errorf("failed to annotate namespace with waypoint: %v", err)
+					return fmt.Errorf("failed to label namespace with waypoint: %v", err)
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v annotated with waypoint %v\n", ctx.NamespaceOrDefault(ctx.Namespace()), gw.Name)
+				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v labeled with waypoint %v\n", ctx.NamespaceOrDefault(ctx.Namespace()), gw.Name)
 			}
 			return nil
 		},
@@ -226,7 +226,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 	)
 
 	waypointApplyCmd.PersistentFlags().BoolVarP(&enrollNamespace, "enroll-namespace", "", false,
-		"If set, the namespace will be annotated with the waypoint name")
+		"If set, the namespace will be labeled with the waypoint name")
 
 	waypointDeleteCmd := &cobra.Command{
 		Use:   "delete",

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -210,7 +210,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			// If a user decides to enroll their namespace with a waypoint, annotate the namespace with the waypoint name
 			// after the waypoint has been applied.
 			if enrollNamespace {
-				err = annotateNamespaceWithWaypoint(kubeClient, ns)
+				err = labelNamespaceWithWaypoint(kubeClient, ns)
 				if err != nil {
 					return fmt.Errorf("failed to annotate namespace with waypoint: %v", err)
 				}
@@ -417,17 +417,17 @@ func deleteWaypoints(cmd *cobra.Command, kubeClient kube.CLIClient, namespace st
 	return multiErr.ErrorOrNil()
 }
 
-func annotateNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
+func labelNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
 	nsObj, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return fmt.Errorf("namespace: %s not found", ns)
 	} else if err != nil {
 		return fmt.Errorf("failed to get namespace %s: %v", ns, err)
 	}
-	if nsObj.Annotations == nil {
-		nsObj.Annotations = map[string]string{}
+	if nsObj.Labels == nil {
+		nsObj.Labels = map[string]string{}
 	}
-	nsObj.Annotations[constants.AmbientUseWaypoint] = waypointName
+	nsObj.Labels[constants.AmbientUseWaypoint] = waypointName
 	if _, err := kubeClient.Kube().CoreV1().Namespaces().Update(context.Background(), nsObj, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update namespace %s: %v", ns, err)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -150,13 +150,13 @@ func TestAmbientIndex_WaypointForWorkloadTraffic(t *testing.T) {
 				[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
 			s.assertEvent(t, s.svcXdsName("svc1"), s.podXdsName("pod1"))
 
-			// Annotate the pod and check that the correct event is produced.
-			s.annotatePod(t, "pod1", testNS,
-				map[string]string{constants.AmbientUseWaypoint: "test-wp"})
+			// Label the pod and check that the correct event is produced.
+			s.labelPod(t, "pod1", testNS,
+				map[string]string{"app": "a", constants.AmbientUseWaypoint: "test-wp"})
 			c.podAssertion(s)
 
-			// Annotate the service and check that the correct event is produced.
-			s.annotateService(t, "svc1", testNS,
+			// Label the service and check that the correct event is produced.
+			s.labelService(t, "svc1", testNS,
 				map[string]string{constants.AmbientUseWaypoint: "test-wp"})
 			c.svcAssertion(s)
 
@@ -1645,6 +1645,19 @@ func (s *ambientTestServer) annotatePod(t *testing.T, name, ns string, annotatio
 	s.pc.Update(p)
 }
 
+// just overwrites the labels
+// nolint: unparam
+func (s *ambientTestServer) labelPod(t *testing.T, name, ns string, labels map[string]string) {
+	t.Helper()
+
+	p := s.pc.Get(name, ns)
+	if p == nil {
+		return
+	}
+	p.ObjectMeta.Labels = labels
+	s.pc.Update(p)
+}
+
 // just overwrites the annotations
 // nolint: unparam
 func (s *ambientTestServer) annotateService(t *testing.T, name, ns string, annotations map[string]string) {
@@ -1655,6 +1668,19 @@ func (s *ambientTestServer) annotateService(t *testing.T, name, ns string, annot
 		return
 	}
 	svc.ObjectMeta.Annotations = annotations
+	s.sc.Update(svc)
+}
+
+// just overwrites the labels
+// nolint: unparam
+func (s *ambientTestServer) labelService(t *testing.T, name, ns string, labels map[string]string) {
+	t.Helper()
+
+	svc := s.sc.Get(name, testNS)
+	if svc == nil {
+		return
+	}
+	svc.ObjectMeta.Labels = labels
 	s.sc.Update(svc)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -376,10 +376,10 @@ func TestAmbientIndex_WaypointConfiguredOnlyWhenReady(t *testing.T) {
 	s.addWaypoint(t, "10.0.0.2", "waypoint-sa2", constants.WorkloadTraffic, true)
 	s.assertEvent(t, s.podXdsName("pod2"))
 
-	// // make waypoint-sa1 ready
-	// s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", constants.WorkloadTraffic, true)
-	// // if waypoint-sa1 was configured when not ready "pod2" assertions should skip the "pod1" xds event and this should fail
-	// s.assertEvent(t, s.podXdsName("pod1"))
+	// make waypoint-sa1 ready
+	s.addWaypoint(t, "10.0.0.1", "waypoint-sa1", constants.WorkloadTraffic, true)
+	// if waypoint-sa1 was configured when not ready "pod2" assertions should skip the "pod1" xds event and this should fail
+	s.assertEvent(t, s.podXdsName("pod1"))
 }
 
 func TestAmbientIndex_WaypointAddressAddedToWorkloads(t *testing.T) {
@@ -1627,19 +1627,6 @@ func (s *ambientTestServer) addPods(t *testing.T, ip string, name, sa string, la
 	} else {
 		s.pc.Update(pod)
 	}
-}
-
-// just overwrites the annotations
-// nolint: unparam
-func (s *ambientTestServer) annotatePod(t *testing.T, name, ns string, annotations map[string]string) {
-	t.Helper()
-
-	p := s.pc.Get(name, ns)
-	if p == nil {
-		return
-	}
-	p.ObjectMeta.Annotations = annotations
-	s.pc.Update(p)
 }
 
 // just overwrites the labels

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1658,19 +1658,6 @@ func (s *ambientTestServer) labelPod(t *testing.T, name, ns string, labels map[s
 	s.pc.Update(p)
 }
 
-// just overwrites the annotations
-// nolint: unparam
-func (s *ambientTestServer) annotateService(t *testing.T, name, ns string, annotations map[string]string) {
-	t.Helper()
-
-	svc := s.sc.Get(name, testNS)
-	if svc == nil {
-		return
-	}
-	svc.ObjectMeta.Annotations = annotations
-	s.sc.Update(svc)
-}
-
 // just overwrites the labels
 // nolint: unparam
 func (s *ambientTestServer) labelService(t *testing.T, name, ns string, labels map[string]string) {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1299,7 +1299,7 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 	s.assertWaypointAddressForPod(t, "pod1", "")
 
 	// annotate pod2 to use a waypoint
-	s.annotatePod(t, "pod1", testNS, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa1"})
+	s.labelPod(t, "pod1", testNS, map[string]string{constants.AmbientUseWaypoint: "waypoint-sa1"})
 	s.assertEvent(t, s.podXdsName("pod1"))
 	// assert that the correct waypoint was configured
 	s.assertWaypointAddressForPod(t, "pod1", "10.0.0.2")
@@ -1374,7 +1374,7 @@ func TestWorkloadsForWaypoint(t *testing.T) {
 	assertWaypoint(t, testNW, "10.0.0.1", s.podXdsName("pod2"))
 
 	// Revert back
-	s.annotatePod(t, "pod1", testNS, map[string]string{})
+	s.labelPod(t, "pod1", testNS, map[string]string{})
 	s.assertEvent(t, s.podXdsName("pod1"))
 
 	assertWaypoint(t, testNW, "10.0.0.1", s.podXdsName("pod1"), s.podXdsName("pod2"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1455,7 +1455,6 @@ type ambientTestServer struct {
 	fx        *xdsfake.Updater
 	pc        clienttest.TestClient[*corev1.Pod]
 	sc        clienttest.TestClient[*corev1.Service]
-	nc        clienttest.TestWriter[*corev1.Node]
 	ns        clienttest.TestWriter[*corev1.Namespace]
 	grc       clienttest.TestWriter[*k8sbeta.Gateway]
 	gwcls     clienttest.TestWriter[*k8sbeta.GatewayClass]
@@ -1511,7 +1510,6 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 		pc:        clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
 		sc:        clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
 		ns:        clienttest.NewWriter[*corev1.Namespace](t, cl),
-		nc:        clienttest.NewWriter[*corev1.Node](t, cl),
 		grc:       clienttest.NewWriter[*k8sbeta.Gateway](t, cl),
 		gwcls:     clienttest.NewWriter[*k8sbeta.GatewayClass](t, cl),
 		se:        clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
@@ -1536,12 +1534,6 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   testNS,
 			Labels: map[string]string{"istio.io/dataplane-mode": "ambient"},
-		},
-	})
-
-	a.nc.Create(&corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node1",
 		},
 	})
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -265,10 +265,7 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
 	s.assertEvent(t, s.podXdsName("pod1"), s.svcXdsName("svc1"))
 
-	s.addService(t, "svc1",
-		map[string]string{},
-		map[string]string{constants.AmbientUseWaypoint: "test-wp"},
-		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.1")
+	s.labelService(t, "svc1", testNS, map[string]string{constants.AmbientUseWaypoint: "test-wp"})
 	s.assertEvent(t, s.svcXdsName("svc1"))
 	s.assertNoEvent(t)
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1458,6 +1458,7 @@ type ambientTestServer struct {
 	fx        *xdsfake.Updater
 	pc        clienttest.TestClient[*corev1.Pod]
 	sc        clienttest.TestClient[*corev1.Service]
+	nc        clienttest.TestWriter[*corev1.Node]
 	ns        clienttest.TestWriter[*corev1.Namespace]
 	grc       clienttest.TestWriter[*k8sbeta.Gateway]
 	gwcls     clienttest.TestWriter[*k8sbeta.GatewayClass]
@@ -1513,6 +1514,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 		pc:        clienttest.NewDirectClient[*corev1.Pod, corev1.Pod, *corev1.PodList](t, cl),
 		sc:        clienttest.NewDirectClient[*corev1.Service, corev1.Service, *corev1.ServiceList](t, cl),
 		ns:        clienttest.NewWriter[*corev1.Namespace](t, cl),
+		nc:        clienttest.NewWriter[*corev1.Node](t, cl),
 		grc:       clienttest.NewWriter[*k8sbeta.Gateway](t, cl),
 		gwcls:     clienttest.NewWriter[*k8sbeta.GatewayClass](t, cl),
 		se:        clienttest.NewWriter[*apiv1alpha3.ServiceEntry](t, cl),
@@ -1537,6 +1539,12 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   testNS,
 			Labels: map[string]string{"istio.io/dataplane-mode": "ambient"},
+		},
+	})
+
+	a.nc.Create(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node1",
 		},
 	})
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -138,7 +138,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	s.ns.CreateOrUpdate(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				constants.AmbientUseWaypoint: "waypoint-ns",
 			},
 		},
@@ -213,7 +213,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	s.ns.Update(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				constants.AmbientUseWaypoint: "#none",
 			},
 		},

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -141,15 +141,15 @@ func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[W
 }
 
 // getUseWaypoint takes objectMeta and a defaultNamespace
-// it looks for the istio.io/use-waypoint annotation and parses it
-// if there is no namespace provided in the annotation the default namespace will be used
+// it looks for the istio.io/use-waypoint label and parses it
+// if there is no namespace provided in the label the default namespace will be used
 // defaultNamespace avoids the need to infer when object meta from a namespace was given
 func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt.Named, isNone bool) {
-	if annotationValue, ok := meta.Annotations[constants.AmbientUseWaypoint]; ok {
-		if annotationValue == "#none" || annotationValue == "~" {
+	if labelValue, ok := meta.Labels[constants.AmbientUseWaypoint]; ok {
+		if labelValue == "#none" || labelValue == "~" {
 			return nil, true
 		}
-		namespacedName := strings.Split(annotationValue, "/")
+		namespacedName := strings.Split(labelValue, "/")
 		switch len(namespacedName) {
 		case 1:
 			return &krt.Named{
@@ -162,8 +162,8 @@ func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt
 				Namespace: namespacedName[0],
 			}, false
 		default:
-			// malformed annotation error
-			log.Errorf("%s/%s, has a malformed %s annotation, value found: %s", meta.GetNamespace(), meta.GetName(), constants.AmbientUseWaypoint, annotationValue)
+			// malformed label error
+			log.Errorf("%s/%s, has a malformed %s label, value found: %s", meta.GetNamespace(), meta.GetName(), constants.AmbientUseWaypoint, labelValue)
 			return nil, false
 		}
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -197,7 +197,7 @@ const (
 	// AmbientRedirectionDisabled is an opt-out, configured by user.
 	AmbientRedirectionDisabled = "disabled"
 
-	// AmbientUseWaypoint is the annotation used to specify which waypoint should be used for a given pod, service, etc...
+	// AmbientUseWaypoint is the label used to specify which waypoint should be used for a given pod, service, etc...
 	AmbientUseWaypoint = "istio.io/use-waypoint"
 	// AmbientWaypointForTrafficType is the annotation used to specify which traffic is allowed through the Waypoint.
 	// This annotation is applied to the Waypoint. Valid traffic types are "service", "workload", "all", and "none".

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -167,7 +167,7 @@ func SetWaypointForService(t framework.TestContext, ns namespace.Instance, servi
 		if err != nil {
 			t.Fatalf("error getting svc %s, err %v", service, err)
 		}
-		oldLabels := oldSvc.ObjectMeta.GetAnnotations()
+		oldLabels := oldSvc.ObjectMeta.GetLabels()
 		if oldLabels == nil {
 			oldLabels = make(map[string]string, 1)
 		}

--- a/pkg/test/framework/components/ambient/waypoint.go
+++ b/pkg/test/framework/components/ambient/waypoint.go
@@ -167,33 +167,33 @@ func SetWaypointForService(t framework.TestContext, ns namespace.Instance, servi
 		if err != nil {
 			t.Fatalf("error getting svc %s, err %v", service, err)
 		}
-		oldAnnotations := oldSvc.ObjectMeta.GetAnnotations()
-		if oldAnnotations == nil {
-			oldAnnotations = make(map[string]string, 1)
+		oldLabels := oldSvc.ObjectMeta.GetAnnotations()
+		if oldLabels == nil {
+			oldLabels = make(map[string]string, 1)
 		}
-		newAnnotations := maps.Clone(oldAnnotations)
+		newLabels := maps.Clone(oldLabels)
 		if waypoint != "" {
-			newAnnotations[constants.AmbientUseWaypoint] = waypoint
+			newLabels[constants.AmbientUseWaypoint] = waypoint
 		} else {
-			delete(newAnnotations, constants.AmbientUseWaypoint)
+			delete(newLabels, constants.AmbientUseWaypoint)
 		}
 
-		doAnnotate := func(annotations map[string]string) error {
+		doLabel := func(labels map[string]string) error {
 			// update needs the latest version
 			svc, err := c.Kube().CoreV1().Services(ns.Name()).Get(t.Context(), service, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			svc.ObjectMeta.SetAnnotations(annotations)
+			svc.ObjectMeta.SetLabels(labels)
 			_, err = c.Kube().CoreV1().Services(ns.Name()).Update(t.Context(), svc, metav1.UpdateOptions{})
 			return err
 		}
 
-		if err = doAnnotate(newAnnotations); err != nil {
+		if err = doLabel(newLabels); err != nil {
 			t.Fatalf("error updating svc %s, err %v", service, err)
 		}
 		t.Cleanup(func() {
-			if err := doAnnotate(oldAnnotations); err != nil {
+			if err := doLabel(oldLabels); err != nil {
 				scopes.Framework.Errorf("failed resetting waypoint for %s/%s; this will likely break other tests", ns.Name(), service)
 			}
 		})
@@ -233,10 +233,10 @@ func RemoveWaypointFromService(t framework.TestContext, ns namespace.Instance, s
 			if err != nil {
 				t.Fatalf("error getting svc %s, err %v", service, err)
 			}
-			annotations := oldSvc.ObjectMeta.GetAnnotations()
-			if annotations != nil {
-				delete(annotations, constants.AmbientUseWaypoint)
-				oldSvc.ObjectMeta.SetAnnotations(annotations)
+			labels := oldSvc.ObjectMeta.GetLabels()
+			if labels != nil {
+				delete(labels, constants.AmbientUseWaypoint)
+				oldSvc.ObjectMeta.SetLabels(labels)
 			}
 			_, err = c.Kube().CoreV1().Services(ns.Name()).Update(t.Context(), oldSvc, metav1.UpdateOptions{})
 			if err != nil {

--- a/pkg/test/framework/components/echo/annotations.go
+++ b/pkg/test/framework/components/echo/annotations.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 )
 
+// TODO BML this entire file feels like we're overcomplicating map[string]string
 type AnnotationType string
 
 const (
@@ -49,7 +50,6 @@ var (
 	SidecarInjectTemplates         = workloadAnnotation(annotation.InjectTemplates.Name, "")
 	SidecarStatsHistogramBuckets   = workloadAnnotation(annotation.SidecarStatsHistogramBuckets.Name, "")
 	AmbientType                    = workloadAnnotation(constants.AmbientRedirection, "")
-	AmbientUseWaypoint             = workloadAnnotation(constants.AmbientUseWaypoint, "")
 )
 
 type AnnotationValue struct {

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -124,6 +124,9 @@ type Config struct {
 	// ServiceAnnotations is annotations on service object.
 	ServiceAnnotations Annotations
 
+	// ServiceLabels is the labels on service object.
+	ServiceLabels map[string]string
+
 	// ReadinessTimeout specifies the timeout that we wait the application to
 	// become ready.
 	ReadinessTimeout time.Duration

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -358,8 +358,8 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 
 	if cfg.WorkloadWaypointProxy != "" {
 		for _, subset := range cfg.Subsets {
-			if subset.Annotations == nil {
-				subset.Annotations = echo.NewAnnotations()
+			if subset.Labels == nil {
+				subset.Labels = make(map[string]string)
 			}
 			subset.Labels[constants.AmbientUseWaypoint] = cfg.WorkloadWaypointProxy
 		}
@@ -420,8 +420,8 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 
 func serviceParams(cfg echo.Config) map[string]any {
 	if cfg.ServiceWaypointProxy != "" {
-		if cfg.ServiceAnnotations == nil {
-			cfg.ServiceAnnotations = echo.NewAnnotations()
+		if cfg.ServiceLabels == nil {
+			cfg.ServiceLabels = make(map[string]string)
 		}
 		cfg.ServiceLabels[constants.AmbientUseWaypoint] = cfg.ServiceWaypointProxy
 	}
@@ -430,7 +430,7 @@ func serviceParams(cfg echo.Config) map[string]any {
 		"Headless":           cfg.Headless,
 		"ServiceAccount":     cfg.ServiceAccount,
 		"ServicePorts":       cfg.Ports.GetServicePorts(),
-		"ServiceAnnotations": cfg.ServiceAnnotations,
+		"ServiceLabels":      cfg.ServiceLabels,
 		"IPFamilies":         cfg.IPFamilies,
 		"IPFamilyPolicy":     cfg.IPFamilyPolicy,
 	}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -361,7 +361,7 @@ func deploymentParams(ctx resource.Context, cfg echo.Config, settings *resource.
 			if subset.Annotations == nil {
 				subset.Annotations = echo.NewAnnotations()
 			}
-			subset.Annotations.Set(echo.AmbientUseWaypoint, cfg.WorkloadWaypointProxy)
+			subset.Labels[constants.AmbientUseWaypoint] = cfg.WorkloadWaypointProxy
 		}
 	}
 
@@ -423,7 +423,7 @@ func serviceParams(cfg echo.Config) map[string]any {
 		if cfg.ServiceAnnotations == nil {
 			cfg.ServiceAnnotations = echo.NewAnnotations()
 		}
-		cfg.ServiceAnnotations.Set(echo.AmbientUseWaypoint, cfg.ServiceWaypointProxy)
+		cfg.ServiceLabels[constants.AmbientUseWaypoint] = cfg.ServiceWaypointProxy
 	}
 	return map[string]any{
 		"Service":            cfg.Service,

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -426,13 +426,13 @@ func serviceParams(cfg echo.Config) map[string]any {
 		cfg.ServiceLabels[constants.AmbientUseWaypoint] = cfg.ServiceWaypointProxy
 	}
 	return map[string]any{
-		"Service":            cfg.Service,
-		"Headless":           cfg.Headless,
-		"ServiceAccount":     cfg.ServiceAccount,
-		"ServicePorts":       cfg.Ports.GetServicePorts(),
-		"ServiceLabels":      cfg.ServiceLabels,
-		"IPFamilies":         cfg.IPFamilies,
-		"IPFamilyPolicy":     cfg.IPFamilyPolicy,
+		"Service":        cfg.Service,
+		"Headless":       cfg.Headless,
+		"ServiceAccount": cfg.ServiceAccount,
+		"ServicePorts":   cfg.Ports.GetServicePorts(),
+		"ServiceLabels":  cfg.ServiceLabels,
+		"IPFamilies":     cfg.IPFamilies,
+		"IPFamilyPolicy": cfg.IPFamilyPolicy,
 	}
 }
 

--- a/pkg/test/framework/components/echo/kube/templates/service.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/service.yaml
@@ -9,7 +9,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Service }}
-  labels:
 {{- if .ServiceLabels }}
   labels:
     app: {{ .Service }}

--- a/pkg/test/framework/components/echo/kube/templates/service.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/service.yaml
@@ -10,7 +10,16 @@ kind: Service
 metadata:
   name: {{ .Service }}
   labels:
+{{- if .ServiceLabels }}
+  labels:
     app: {{ .Service }}
+{{- range $name, $value := .ServiceLabels }}
+    {{ $name.Name }}: {{ printf "%q" $value.Value }}
+{{- end }}
+{{- else}}
+  labels:
+    app: {{ .Service }}
+{{- end }}
 {{- if .ServiceAnnotations }}
   annotations:
 {{- range $name, $value := .ServiceAnnotations }}

--- a/pkg/test/framework/components/echo/kube/templates/service.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app: {{ .Service }}
 {{- range $name, $value := .ServiceLabels }}
-    {{ $name.Name }}: {{ printf "%q" $value.Value }}
+    {{$name}}: "{{$value}}"
 {{- end }}
 {{- else}}
   labels:

--- a/releasenotes/notes/50572.yaml
+++ b/releasenotes/notes/50572.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 50572
+releaseNotes:
+- |
+  **Fixed** `use-waypoint` should be a label, for consistency

--- a/tests/integration/ambient/gateway_conformance_test.go
+++ b/tests/integration/ambient/gateway_conformance_test.go
@@ -158,12 +158,12 @@ func TestGatewayConformance(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				annotations := ns.Annotations
-				if annotations == nil {
-					annotations = make(map[string]string)
+				labels := ns.Labels
+				if labels == nil {
+					labels = make(map[string]string)
 				}
-				annotations[constants.AmbientUseWaypoint] = "namespace"
-				ns.Annotations = annotations
+				labels[constants.AmbientUseWaypoint] = "namespace"
+				ns.Labels = labels
 				k.Kube().CoreV1().Namespaces().Update(ctx.Context(), ns, metav1.UpdateOptions{})
 			}
 

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -182,11 +182,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Labels: map[string]string{
 						"app":     WorkloadAddressedWaypoint,
 						"version": "v1",
-					},
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.AmbientUseWaypoint: {
-							Value: "waypoint",
-						},
+						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
 				{
@@ -195,11 +191,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Labels: map[string]string{
 						"app":     WorkloadAddressedWaypoint,
 						"version": "v2",
-					},
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.AmbientUseWaypoint: {
-							Value: "waypoint",
-						},
+						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
 			},
@@ -208,7 +200,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			Service:              ServiceAddressedWaypoint,
 			Namespace:            apps.Namespace,
 			Ports:                ports.All(),
-			ServiceAnnotations:   echo.NewAnnotations().Set(echo.AmbientUseWaypoint, "waypoint"),
+			ServiceLabels:   map[string]string{constants.AmbientUseWaypoint: "waypoint"},
 			ServiceAccount:       true,
 			ServiceWaypointProxy: "waypoint",
 			Subsets: []echo.SubsetConfig{
@@ -218,11 +210,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Labels: map[string]string{
 						"app":     ServiceAddressedWaypoint,
 						"version": "v1",
-					},
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.AmbientUseWaypoint: {
-							Value: "waypoint",
-						},
+						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
 				{
@@ -231,11 +219,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Labels: map[string]string{
 						"app":     ServiceAddressedWaypoint,
 						"version": "v2",
-					},
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.AmbientUseWaypoint: {
-							Value: "waypoint",
-						},
+						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
 			},

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -180,8 +180,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v1",
 					Labels: map[string]string{
-						"app":     WorkloadAddressedWaypoint,
-						"version": "v1",
+						"app":                        WorkloadAddressedWaypoint,
+						"version":                    "v1",
 						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
@@ -189,8 +189,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v2",
 					Labels: map[string]string{
-						"app":     WorkloadAddressedWaypoint,
-						"version": "v2",
+						"app":                        WorkloadAddressedWaypoint,
+						"version":                    "v2",
 						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
@@ -200,7 +200,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			Service:              ServiceAddressedWaypoint,
 			Namespace:            apps.Namespace,
 			Ports:                ports.All(),
-			ServiceLabels:   map[string]string{constants.AmbientUseWaypoint: "waypoint"},
+			ServiceLabels:        map[string]string{constants.AmbientUseWaypoint: "waypoint"},
 			ServiceAccount:       true,
 			ServiceWaypointProxy: "waypoint",
 			Subsets: []echo.SubsetConfig{
@@ -208,8 +208,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v1",
 					Labels: map[string]string{
-						"app":     ServiceAddressedWaypoint,
-						"version": "v1",
+						"app":                        ServiceAddressedWaypoint,
+						"version":                    "v1",
 						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},
@@ -217,8 +217,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v2",
 					Labels: map[string]string{
-						"app":     ServiceAddressedWaypoint,
-						"version": "v2",
+						"app":                        ServiceAddressedWaypoint,
+						"version":                    "v2",
 						constants.AmbientUseWaypoint: "waypoint",
 					},
 				},

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -336,9 +336,9 @@ func SetWaypoint(t framework.TestContext, svc string, waypoint string) {
 			} else {
 				waypoint = fmt.Sprintf("%q", waypoint)
 			}
-			annotation := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":%s}}}`,
+			label := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":%s}}}`,
 				constants.AmbientUseWaypoint, waypoint))
-			_, err := client.Patch(context.TODO(), svc, types.MergePatchType, annotation, metav1.PatchOptions{})
+			_, err := client.Patch(context.TODO(), svc, types.MergePatchType, label, metav1.PatchOptions{})
 			return err
 		}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This changes `istio.io/use-waypoint`  to be a label, and not an annotation.

Why? 

1. It's not consistent with the other ambient labels, which feels weird:
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    istio.io/use-waypoint: waypoint
  creationTimestamp: "2024-04-04T18:13:55Z"
  labels:
    istio.io/dataplane-mode: ambient
    kubernetes.io/metadata.name: default
```

vs

```
apiVersion: v1
kind: Namespace
metadata:
  creationTimestamp: "2024-04-04T18:13:55Z"
  labels:
    istio.io/use-waypoint: waypoint
    istio.io/dataplane-mode: ambient
    kubernetes.io/metadata.name: default
```

2. In general, following a maxim of "labels are for user intent, annotations are for status" gets more consistent results.

3. We will probably want to query this (since it is user intent), and labels are better for queries.

4. If we don't change it now, we never can, so change it now.

Actual change is trivial, most of the diff is test rigging (which is weird TBH)