### PR TITLE
Add retry on EXIT_ON_ZERO_ACTIVE_CONNECTIONS loop

### DIFF
--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -236,7 +236,7 @@ func (a *Agent) terminate() {
 func (a *Agent) activeProxyConnections() (int, error) {
 	adminHost := net.JoinHostPort(a.localhost, strconv.Itoa(a.adminPort))
 	activeConnectionsURL := fmt.Sprintf("http://%s/stats?usedonly&filter=downstream_cx_active$", adminHost)
-	stats, err := http.DoHTTPGet(activeConnectionsURL)
+	stats, err := http.DoHTTPGetWithTimeout(activeConnectionsURL, 2*time.Second)
 	if err != nil {
 		return -1, fmt.Errorf("unable to get listener stats from Envoy : %v", err)
 	}

--- a/pkg/envoy/agent.go
+++ b/pkg/envoy/agent.go
@@ -171,7 +171,6 @@ func (a *Agent) terminate() {
 		defer ticker.Stop()
 
 		retryCount := 0
-		retryBackoffTime := 1 * time.Second
 	graceful_loop:
 		for range ticker.C {
 			ac, err := a.activeProxyConnections()
@@ -191,8 +190,6 @@ func (a *Agent) terminate() {
 						break graceful_loop
 					}
 					log.Warnf("Retrying (%d attempt) to obtain active connections...", retryCount)
-					time.Sleep(retryBackoffTime)
-					retryBackoffTime *= 2 // Exponentially increase the retry backoff time.
 					continue graceful_loop
 				}
 				if ac == -1 {
@@ -207,9 +204,8 @@ func (a *Agent) terminate() {
 					break graceful_loop
 				}
 				log.Infof("There are still %d active connections", ac)
-				// reset retry count and backoff time
+				// reset retry count
 				retryCount = 0
-				retryBackoffTime = 1 * time.Second
 			}
 		}
 	} else {

--- a/releasenotes/notes/50596.yaml
+++ b/releasenotes/notes/50596.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 50596
+
+releaseNotes:
+- |
+  **Fixed** Added retry logic to make getting envoy metrics more safety on EXIT_ON_ZERO_ACTIVE_CONNECTIONS mode.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixed (#50596)

I turned on the exit on zero active connection feature in istio 1.19. I've been waiting for this feature because the preStop loop we implemented was hacky
After applying the feature, it worked well for a while. We received a report from engineer that the application was occasionally crashing when it terminated. The following error logs were captured:

...
2024-04-17 17:22:36.687	2024-04-17T08:22:36.687060Z	info	There are still 5630 active connections
2024-04-17 17:22:37.376	2024-04-17T08:22:37.376249Z	warn	Envoy proxy is NOT ready: server is not live, current state is: DRAINING
2024-04-17 17:22:38.608	2024-04-17T08:22:38.608674Z	error	**unable to get listener stats from Envoy : Get "http://127.0.0.1:15000/stats?usedonly&filter=downstream_cx_active$": context deadline exceeded** (Client.Timeout exceeded while awaiting headers)
2024-04-17 17:22:38.608	2024-04-17T08:22:38.608701Z	warn	Aborting proxy
2024-04-17 17:22:38.608	2024-04-17T08:22:38.608787Z	info	Envoy aborted normally
2024-04-17 17:22:38.610	2024-04-17T08:22:38.609975Z	info	Agent has successfully terminated
...

Abnormal termination even though there were many active connections. The network can fail at any time, so i thought we needed a retry count as a Safety net.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
