### PR TITLE
Opt ServiceEntry validate message

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2701,7 +2701,8 @@ var ValidateServiceEntry = RegisterValidateFunc("ValidateServiceEntry",
 			}
 			if len(serviceEntry.Addresses) == 0 {
 				if port.Protocol == "" || port.Protocol == "TCP" {
-					errs = AppendValidation(errs, WrapWarning(fmt.Errorf("addresses are required for ports serving TCP (or unset) protocol")))
+					errs = AppendValidation(errs, WrapWarning(fmt.Errorf(
+						"addresses are required for ports serving TCP (or unset) protocol, if dns auto allocate and cache is not enabled")))
 				}
 			}
 			errs = AppendValidation(errs,


### PR DESCRIPTION
**Please provide a description of this PR:**







"If we enable DNS auto allocation and cache, addresses are not required for the ServiceEntry of the TCP. Although we cannot determine whether the relevant configuration is enabled during the validation, including this information in the warn message  is still very helpful to users."