### PR TITLE
waypoint-for switched from annotation to label

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -92,10 +92,10 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return nil, fmt.Errorf("invalid traffic type: %s. Valid options are: %s", trafficType, validTrafficTypes.String())
 		}
 
-		if gw.Annotations == nil {
-			gw.Annotations = map[string]string{}
+		if gw.Labels == nil {
+			gw.Labels = map[string]string{}
 		}
-		gw.Annotations[constants.AmbientWaypointForTrafficType] = trafficType
+		gw.Labels[constants.AmbientWaypointForTrafficType] = trafficType
 
 		if revision != "" {
 			gw.Labels = map[string]string{label.IoIstioRev.Name: revision}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1572,13 +1572,13 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, trafficType stri
 		Spec:   gatewaySpec,
 		Status: k8sbeta.GatewayStatus{},
 	}
-	annotations := make(map[string]string, 2)
+	labels := make(map[string]string, 2)
 	if trafficType != "" && validTrafficTypes.Contains(trafficType) {
-		annotations[constants.AmbientWaypointForTrafficType] = trafficType
+		labels[constants.AmbientWaypointForTrafficType] = trafficType
 	} else {
-		annotations[constants.AmbientWaypointForTrafficType] = constants.ServiceTraffic
+		labels[constants.AmbientWaypointForTrafficType] = constants.ServiceTraffic
 	}
-	gateway.Annotations = annotations
+	gateway.Labels = labels
 
 	if ready {
 		addrType := k8sbeta.IPAddressType

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -202,7 +202,7 @@ func WaypointsCollection(
 		}
 
 		// Check for a declared traffic type that is allowed to pass through the Waypoint
-		if tt, found := gateway.Annotations[constants.AmbientWaypointForTrafficType]; found {
+		if tt, found := gateway.Labels[constants.AmbientWaypointForTrafficType]; found {
 			return makeWaypoint(gateway, gatewayClass, serviceAccounts, tt)
 		}
 		// If a value is not declared on a Gateway or its associated GatewayClass

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -199,8 +199,8 @@ const (
 
 	// AmbientUseWaypoint is the label used to specify which waypoint should be used for a given pod, service, etc...
 	AmbientUseWaypoint = "istio.io/use-waypoint"
-	// AmbientWaypointForTrafficType is the annotation used to specify which traffic is allowed through the Waypoint.
-	// This annotation is applied to the Waypoint. Valid traffic types are "service", "workload", "all", and "none".
+	// AmbientWaypointForTrafficType is the label used to specify which traffic is allowed through the Waypoint.
+	// This label is applied to the Waypoint. Valid traffic types are "service", "workload", "all", and "none".
 	AmbientWaypointForTrafficType = "istio.io/waypoint-for"
 
 	// AmbientWaypointInboundBinding has the format `<protocol>` or `<protocol>/<port>`. If the waypoint is


### PR DESCRIPTION
**Please provide a description of this PR:**

Use a label for defining what kinds of traffic a waypoint will accept because it is an expression of user-intent and not a status.

fixes #50606