### PR TITLE
clarify zc output by adding type info to headers

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/certificates.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/certificates.go
@@ -53,7 +53,7 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 	}
 	secretDump := c.ztunnelDump.Certificates
 	w := new(tabwriter.Writer).Init(c.Stdout, 0, 8, 5, ' ', 0)
-	fmt.Fprintln(w, "NAME\tTYPE\tSTATUS\tVALID CERT\tSERIAL NUMBER\tNOT AFTER\tNOT BEFORE")
+	fmt.Fprintln(w, "CERTIFICATE NAME\tTYPE\tSTATUS\tVALID CERT\tSERIAL NUMBER\tNOT AFTER\tNOT BEFORE")
 
 	for _, secret := range secretDump {
 		if strings.Contains(secret.State, "Unavailable") {

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -51,7 +51,7 @@ func (c *ConfigWriter) PrintBootstrapDump(outputFormat string) error {
 
 func (c *ConfigWriter) PrintFullSummary() error {
 	_, _ = c.Stdout.Write([]byte("\n"))
-	if err := c.PrintWorkloadSummary(WorkloadFilter{}); err != nil {
+	if err := c.PrintWorkloadSummary(WorkloadFilter{Verbose: true}); err != nil {
 		return err
 	}
 	_, _ = c.Stdout.Write([]byte("\n"))

--- a/istioctl/pkg/writer/ztunnel/configdump/policies.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/policies.go
@@ -54,7 +54,7 @@ func (c *ConfigWriter) PrintPolicySummary(filter PolicyFilter) error {
 		}
 		return cmp.Compare(a.Name, b.Name)
 	})
-	fmt.Fprintln(w, "NAMESPACE\tNAME\tACTION\tSCOPE")
+	fmt.Fprintln(w, "NAMESPACE\tPOLICY NAME\tACTION\tSCOPE")
 
 	for _, pol := range pols {
 		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n",

--- a/istioctl/pkg/writer/ztunnel/configdump/services.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/services.go
@@ -57,7 +57,7 @@ func (c *ConfigWriter) PrintServiceSummary(filter ServiceFilter) error {
 		}
 		return cmp.Compare(a.Hostname, b.Hostname)
 	})
-	fmt.Fprintln(w, "NAMESPACE\tNAME\tIP\tWAYPOINT")
+	fmt.Fprintln(w, "NAMESPACE\tSERVICE NAME\tSERVICE VIP\tWAYPOINT")
 
 	for _, svc := range svcs {
 		var ip string

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
@@ -1,4 +1,4 @@
-NAME                                                     TYPE           STATUS           VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
+CERTIFICATE NAME                                         TYPE           STATUS           VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
 spiffe://cluster.local/ns/istio-system/sa/istiod         CA             Available        true           e5dfb59150b2ba7f108d93dcec5aa613     2033-03-22T13:04:57Z     2023-03-21T13:02:57Z
 spiffe://cluster.local/ns/istio-system/sa/istiod         Cert Chain     Available        false          8a516645c40ce76c2c0d27ab4e2461c1     2022-03-18T13:04:49Z     2022-03-21T13:04:49Z
 spiffe://cluster.local/ns/istio-system/sa/ztunnel        NA             Initializing     false          NA                                   NA                       NA

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/workloadsummary.txt
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/workloadsummary.txt
@@ -1,4 +1,4 @@
-NAMESPACE          NAME                                                 IP          NODE                  WAYPOINT                            PROTOCOL
+NAMESPACE          POD NAME                                             IP          NODE                  WAYPOINT                            PROTOCOL
 bookinfo           bookinfo-productpage-istio-waypoint-5cdd6745d5-rc2gg 10.244.2.59 ambient-worker2       None                                TCP
 bookinfo           details-v1-698d88b-dqrbr                             10.244.2.51 ambient-worker2       namespace-istio-waypoint            HBONE
 bookinfo           namespace-istio-waypoint-d94944bf6-z89g2             10.244.2.52 ambient-worker2       None                                TCP

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/workloadsummary_default.txt
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/workloadsummary_default.txt
@@ -1,4 +1,4 @@
-NAMESPACE NAME                           IP          NODE            WAYPOINT PROTOCOL
+NAMESPACE POD NAME                       IP          NODE            WAYPOINT PROTOCOL
 default   details-v1-698d88b-krdw7       10.244.2.55 ambient-worker2 None     HBONE
 default   httpbin-7447985f87-t8hv7       10.244.1.40 ambient-worker  None     TCP
 default   productpage-v1-675fc69cf-kkrm2 10.244.2.56 ambient-worker2 None     HBONE

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -86,9 +86,9 @@ func (c *ConfigWriter) PrintWorkloadSummary(filter WorkloadFilter) error {
 	})
 
 	if filter.Verbose {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tIP\tNODE\tWAYPOINT\tPROTOCOL")
+		fmt.Fprintln(w, "NAMESPACE\tPOD NAME\tIP\tNODE\tWAYPOINT\tPROTOCOL")
 	} else {
-		fmt.Fprintln(w, "NAMESPACE\tNAME\tIP\tNODE")
+		fmt.Fprintln(w, "NAMESPACE\tPOD NAME\tIP\tNODE")
 	}
 
 	for _, wl := range verifiedWorkloads {


### PR DESCRIPTION
**Please provide a description of this PR:**

fixes #50573 

This PR attempts to clarify the output of `istioctl c ztunnel-config all` by adding type information to the name column header. It also adds verbose workload output so that waypoint and protocol are visible.

new output looks like:
```shell
❯ ./out/linux_amd64/istioctl x zc all

NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
default            details-v1-f556b5996-vs7dk              10.244.2.13 ambient-worker2       None     HBONE
default            notsleep-847d8464fc-h9vmn               10.244.2.14 ambient-worker2       None     HBONE
default            productpage-v1-65cd959b64-p6xzq         10.244.2.15 ambient-worker2       waypoint HBONE
default            ratings-v1-5c4f69595-5ggbp              10.244.2.16 ambient-worker2       None     HBONE
default            reviews-v1-55d887669b-wbrmd             10.244.2.18 ambient-worker2       None     HBONE
default            reviews-v2-85cdbdf489-lnj54             10.244.2.19 ambient-worker2       None     HBONE
default            reviews-v3-65cd7d4c6b-rnq57             10.244.2.20 ambient-worker2       None     HBONE
default            sleep-7689f89688-46hmt                  10.244.2.21 ambient-worker2       None     HBONE
default            waypoint-778c79b66-dz8kc                10.244.2.22 ambient-worker2       None     TCP
istio-system       istio-ingressgateway-799494bdbc-bc2zk   10.244.2.23 ambient-worker2       None     TCP
istio-system       istiod-db4b8bd8c-csswr                  10.244.2.24 ambient-worker2       None     TCP
istio-system       ztunnel-bccf5                           10.244.1.11 ambient-worker        None     TCP
istio-system       ztunnel-qpcvh                           10.244.2.12 ambient-worker2       None     TCP
istio-system       ztunnel-t825t                           10.244.0.6  ambient-control-plane None     TCP
kube-system        coredns-787d4945fb-8b2tp                10.244.0.3  ambient-control-plane None     TCP
kube-system        coredns-787d4945fb-jn7sl                10.244.0.2  ambient-control-plane None     TCP
local-path-storage local-path-provisioner-75f5b54ffd-98nt7 10.244.0.5  ambient-control-plane None     TCP

NAMESPACE    SERVICE NAME         SERVICE VIP   WAYPOINT
default      details              10.96.205.225 None
default      kubernetes           10.96.0.1     None
default      notsleep             10.96.50.231  None
default      productpage          10.96.65.99   None
default      ratings              10.96.204.187 None
default      reviews              10.96.141.167 None
default      sleep                10.96.173.76  None
default      waypoint             10.96.218.119 None
istio-system istio-ingressgateway 10.96.28.22   None
istio-system istiod               10.96.60.31   None
kube-system  kube-dns             10.96.0.10    None

NAMESPACE POLICY NAME                           ACTION SCOPE
default   istio_allow_waypoint_default_waypoint Allow  WorkloadSelector

CERTIFICATE NAME     TYPE     STATUS     VALID CERT     SERIAL NUMBER     NOT AFTER     NOT BEFORE

```