### PR TITLE
istioctl: update ztunnel log examples and config dump API

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/api.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/api.go
@@ -21,22 +21,28 @@ type Locality struct {
 }
 
 type ZtunnelWorkload struct {
-	WorkloadIPs       []string  `json:"workloadIps"`
-	Waypoint          *Waypoint `json:"waypoint"`
-	Protocol          string    `json:"protocol"`
-	Name              string    `json:"name"`
-	Namespace         string    `json:"namespace"`
-	ServiceAccount    string    `json:"serviceAccount"`
-	WorkloadName      string    `json:"workloadName"`
-	WorkloadType      string    `json:"workloadType"`
-	CanonicalName     string    `json:"canonicalName"`
-	CanonicalRevision string    `json:"canonicalRevision"`
-	ClusterID         string    `json:"clusterId"`
-	TrustDomain       string    `json:"trustDomain,omitempty"`
-	Locality          Locality  `json:"locality,omitempty"`
-	Node              string    `json:"node"`
-	Network           string    `json:"network,omitempty"`
-	Status            string    `json:"status"`
+	WorkloadIPs       []string          `json:"workloadIps"`
+	Waypoint          *Waypoint         `json:"waypoint,omitempty"`
+	Protocol          string            `json:"protocol"`
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	ServiceAccount    string            `json:"serviceAccount"`
+	WorkloadName      string            `json:"workloadName"`
+	WorkloadType      string            `json:"workloadType"`
+	CanonicalName     string            `json:"canonicalName"`
+	CanonicalRevision string            `json:"canonicalRevision"`
+	ClusterID         string            `json:"clusterId"`
+	TrustDomain       string            `json:"trustDomain,omitempty"`
+	Locality          Locality          `json:"locality,omitempty"`
+	Node              string            `json:"node"`
+	Network           string            `json:"network,omitempty"`
+	Status            string            `json:"status"`
+	ApplicationTunnel ApplicationTunnel `json:"applicationTunnel,omitempty"`
+}
+
+type ApplicationTunnel struct {
+	Protocol string  `json:"protocol"`
+	Port     *uint16 `json:"port,omitempty"`
 }
 
 type Waypoint struct {

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -395,10 +395,10 @@ func logCmd(ctx cli.Context) *cobra.Command {
  istioctl ztunnel-config log
 
  # Update levels of the all loggers for a specific Ztunnel pod
- istioctl ztunnel-config log <pod-name[.namespace]> --level none
+ istioctl ztunnel-config log <pod-name[.namespace]> --level off
 
  # Update levels of the specified loggers for all Ztunnl pods
- istioctl ztunnel-config log --level http:debug,redis:debug
+ istioctl ztunnel-config log --level access:debug,info
 
  # Reset levels of all the loggers to default value (warning)  for a specific Ztunnel pod.
  istioctl ztunnel-config log <pod-name[.namespace]> -r


### PR DESCRIPTION
The log examples were invalid/misleading, and config dump was missing a
field.
