### PR TITLE
istioctl: fix certificate view

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/certificates.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/certificates.go
@@ -63,20 +63,17 @@ func (c *ConfigWriter) PrintSecretSummary() error {
 			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 				secret.Identity, valueOrNA(""), secret.State, false, valueOrNA(""), valueOrNA(""), valueOrNA(""))
 		} else {
-			// get the CA value and remove it from the cert chain slice so it's not printed twice
-			ca := secret.CertChain[0]
-			secret.CertChain = secret.CertChain[1:]
-			n := new(big.Int)
-			n, _ = n.SetString(ca.SerialNumber, 10)
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%x\t%v\t%v\n",
-				secret.Identity, "CA", secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
-
-			// print the rest of the cert chain
-			for _, ca := range secret.CertChain {
+			for i, ca := range secret.CertChain {
+				t := "Intermediate"
+				if i == 0 {
+					t = "Leaf"
+				} else if i == len(secret.CertChain)-1 {
+					t = "Root"
+				}
 				n := new(big.Int)
 				n, _ = n.SetString(ca.SerialNumber, 10)
 				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%x\t%v\t%v\n",
-					secret.Identity, "Cert Chain", secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
+					secret.Identity, t, secret.State, certNotExpired(ca), n, valueOrNA(ca.ExpirationTime), valueOrNA(ca.ValidFrom))
 			}
 		}
 	}

--- a/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
+++ b/istioctl/pkg/writer/ztunnel/configdump/testdata/secretsummary.txt
@@ -1,6 +1,6 @@
-CERTIFICATE NAME                                         TYPE           STATUS           VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
-spiffe://cluster.local/ns/istio-system/sa/istiod         CA             Available        true           e5dfb59150b2ba7f108d93dcec5aa613     2033-03-22T13:04:57Z     2023-03-21T13:02:57Z
-spiffe://cluster.local/ns/istio-system/sa/istiod         Cert Chain     Available        false          8a516645c40ce76c2c0d27ab4e2461c1     2022-03-18T13:04:49Z     2022-03-21T13:04:49Z
-spiffe://cluster.local/ns/istio-system/sa/ztunnel        NA             Initializing     false          NA                                   NA                       NA
-spiffe://cluster.local/ns/istio-system/sa/another-sa     NA             Unavailable      false          NA                                   NA                       NA
-spiffe://cluster.local/ns/istio-system/sa/istiod         NA             Unavailable      false          NA                                   NA                       NA
+CERTIFICATE NAME                                         TYPE     STATUS           VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
+spiffe://cluster.local/ns/istio-system/sa/istiod         Leaf     Available        true           e5dfb59150b2ba7f108d93dcec5aa613     2033-03-22T13:04:57Z     2023-03-21T13:02:57Z
+spiffe://cluster.local/ns/istio-system/sa/istiod         Root     Available        false          8a516645c40ce76c2c0d27ab4e2461c1     2022-03-18T13:04:49Z     2022-03-21T13:04:49Z
+spiffe://cluster.local/ns/istio-system/sa/ztunnel        NA       Initializing     false          NA                                   NA                       NA
+spiffe://cluster.local/ns/istio-system/sa/another-sa     NA       Unavailable      false          NA                                   NA                       NA
+spiffe://cluster.local/ns/istio-system/sa/istiod         NA       Unavailable      false          NA                                   NA                       NA


### PR DESCRIPTION
We were showing the leaf as "CA", and intermediates as "CA".

Now show them properly: Root, Intermediate(s), Leaf
