### PR TITLE
ambient: make sandwich test not do double HBONE

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -256,7 +256,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 	}
 
 	// OutboundTunnel cluster is needed for sidecar and gateway.
-	if features.EnableHBONESend && proxy.Type != model.Waypoint {
+	if features.EnableHBONESend && proxy.Type != model.Waypoint && bool(!proxy.Metadata.DisableHBONESend) {
 		clusters = append(clusters, cb.buildConnectOriginate(proxy, req.Push, nil))
 	}
 

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -211,8 +211,10 @@ func (b *EndpointBuilder) WriteHash(h hash.Hash) {
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(b.clusterLocal))
 	h.Write(Separator)
-	if features.EnableSidecarHBONEListening && b.proxy != nil {
+	if b.proxy != nil {
 		h.WriteString(strconv.FormatBool(b.proxy.IsProxylessGrpc()))
+		h.Write(Separator)
+		h.WriteString(strconv.FormatBool(bool(b.proxy.Metadata.DisableHBONESend)))
 		h.Write(Separator)
 	}
 	h.WriteString(util.LocalityToString(b.locality))
@@ -634,6 +636,9 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 
 	tunnel := supportTunnel(b, e)
 	if mtlsEnabled && !features.PreferHBONESend {
+		tunnel = false
+	}
+	if b.proxy.Metadata.DisableHBONESend {
 		tunnel = false
 	}
 	if tunnel {

--- a/pkg/model/proxy.go
+++ b/pkg/model/proxy.go
@@ -291,9 +291,13 @@ type NodeMetadata struct {
 	// This depends on DNSCapture.
 	DNSAutoAllocate StringBool `json:"DNS_AUTO_ALLOCATE,omitempty"`
 
-	// EnableHBONE, if set, will enable generation of HBONE config.
+	// EnableHBONE, if set, will enable generation of HBONE listener config.
 	// Note: this only impacts sidecars; ztunnel and waypoint proxy unconditionally use HBONE.
 	EnableHBONE StringBool `json:"ENABLE_HBONE,omitempty"`
+
+	// DisableHBONESend, will disable sending HBONE.
+	// Warning: If this is enabled, ambient may break; use with caution.
+	DisableHBONESend StringBool `json:"DISABLE_HBONE_SEND,omitempty"`
 
 	// AutoRegister will enable auto registration of the connected endpoint to the service registry using the given WorkloadGroup name
 	AutoRegisterGroup string `json:"AUTO_REGISTER_GROUP,omitempty"`

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -201,6 +201,17 @@ func TestSimpleHTTPSandwich(t *testing.T) {
 		NewTest(t).
 		Run(func(t framework.TestContext) {
 			config := `
+apiVersion: networking.istio.io/v1beta1
+kind: ProxyConfig
+metadata:
+  name: disable-hbone
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: simple-http-waypoint
+  environmentVariables:
+    ISTIO_META_DISABLE_HBONE_SEND: "true"
+---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:


### PR DESCRIPTION
Currently the sandwich is sending waypoint in envoy AND adding another
layer in ztunnel. This lets us disable it
