### PR TITLE
Ambient: individual pods can enroll using label `istio.io/dataplane-mode=ambient`

### DIFF
--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -44,8 +44,9 @@ var annotationRemovePatch = []byte(fmt.Sprintf(
 // PodRedirectionEnabled determines if a pod should or should not be configured
 // to have traffic redirected thru the node proxy.
 func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
-	if namespace.GetLabels()[constants.DataplaneMode] != constants.DataplaneModeAmbient {
-		// Namespace does not have ambient mode enabled
+	if namespace.GetLabels()[constants.DataplaneMode] != constants.DataplaneModeAmbient &&
+		pod.GetLabels()[constants.DataplaneMode] != constants.DataplaneModeAmbient {
+		// Neither namespcape nor pod has ambient mode enabled
 		return false
 	}
 	if podHasSidecar(pod) {

--- a/releasenotes/notes/50355.yaml
+++ b/releasenotes/notes/50355.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 50355
+releaseNotes:
+- |
+  **Added** functionality to enroll individual pods into ambient by labelling them with `istio.io/dataplane-mode=ambient`


### PR DESCRIPTION
**Please provide a description of this PR:**

/closes #50355

This change enables individual pods to enroll in ambient when labelled `istio.io/dataplane-mode=ambient`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
