### PR TITLE
Refactor ztunnel architecture doc

### DIFF
--- a/architecture/ambient/ztunnel.md
+++ b/architecture/ambient/ztunnel.md
@@ -67,7 +67,7 @@ The address type has the following goals:
   * Specifically, ztunnel should be able to send a request to the control plane to answer "I got a request to send traffic to 1.1.1.1, what is 1.1.1.1?"
   * While this is not needed for small scales, this is important for the long tail of massive clusters (think 1 million endpoints), where the entire set of endpoints cannot reasonably be replicated to each ztunnel.
 * It should not be client-specific.
-  * In Istio sidecars, historically we had a lot of client-specific XDS. For example, putting the XDS-client's IP back into the XDS response. This makes efficient control plane implementation (most notably, caching), extremely challenging.
+  * In Istio sidecars, historically we had a lot of client-specific xDS. For example, putting the xDS-client's IP back into the xDS response. This makes efficient control plane implementation (most notably, caching), extremely challenging.
   * In practice, this largely means that references are fully qualified in the API. IP Addresses (generally) have a network associated with them, node names have a cluster associated with them, etc.
 
 See the [XDS Evolution](https://docs.google.com/document/d/1V5wkeBHbLSLMzAMbwFlFZNHdZPyUEspG4lHbnB0UaCg/edit) document for more history and details.
@@ -243,7 +243,7 @@ This CA enforcement is done by Istio's CA, and is a requirement for any alternat
 Note: Ztunnel authenticates to the CA with a Kubernetes Service Account JWT token, which encodes the pod information, which is what enables this.
 
 Ztunnel will request certificates for all identities on the node.
-It determines this based on the Workload XDS configuration it receives.
+It determines this based on the Workload xDS configuration it receives.
 When a new identity is discovered on the node, it will be enqueued for fetching at a low priority, as an optimization.
 However, if a request needs a certain identity that we have not fetched yet, it will be immediately requested.
 

--- a/architecture/ambient/ztunnel.md
+++ b/architecture/ambient/ztunnel.md
@@ -12,7 +12,7 @@ However, this has one glaring issue: how do we get the traffic to the remote pro
 
 A secondary goal was to enable a smoother on-ramp from "Zero" to "Getting some value".
 Historically, Istio had to really be consumed all-or-nothing for things to work as expected.
-In particular, an easy answer to "I just want to get have mTLS everywhere, then I can think about adopting the rest of service mesh" was desired.
+In particular, an easy answer to "I just want to have mTLS everywhere, then I can think about adopting the rest of service mesh" was desired.
 
 ## Goals
 

--- a/architecture/ambient/ztunnel.md
+++ b/architecture/ambient/ztunnel.md
@@ -76,7 +76,7 @@ The `Workload` aims to represent everything about a workload (generally a `Pod` 
 This includes things like its IP address, identity, metadata (name, namespace, app, version, etc), and whether it has a waypoint proxy associated.
 
 The `Service` aims to represent everything about a service (generally a `Service` or `ServiceEntry`).
-This includes things like its IP addresses and ports.
+This includes things like its IP addresses, ports and an associated waypoint proxy if it has one.
 
 ### Authorization Type
 


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR does some refactoring of the Ztunnel documentation that I noticed while going through it recently.
- grammatical error
- inconsistent references to xDS and XDS
- updated information about what service proto definition has given the [recent changes](https://github.com/istio/ztunnel/pull/823) I added to the API to support waypoint capture