### PR TITLE
Change bookinfo gateway Port to 80 from 8080

### DIFF
--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -9,7 +9,7 @@ spec:
     istio: ingressgateway # use istio default controller
   servers:
   - port:
-      number: 8080
+      number: 80
       name: http
       protocol: HTTP
     hosts:


### PR DESCRIPTION
**Please provide a description of this PR:**
The sample [bookinfo example](https://istio.io/latest/docs/examples/bookinfo/#determine-the-ingress-ip-and-port) doesn't work with the istio-ingressgateway and bookinfo gateway because of port mismatch.

istio-ingressgateway.yaml
```
  - name: http2
    nodePort: 31156
    port: 80
    protocol: TCP
    targetPort: 80
```

bookinfo.gateway
```
    port:
      name: http
      number: 8080
      protocol: HTTP
```

This will cause error when accessing locally. (mac+minikube) 
```
curl http://localhost:80/productpage
curl: (56) Recv failure: Connection reset by peer
```

Changing to port 80 works as expected.
bookinfo.gateway
```
    port:
      name: http
      number: 80
      protocol: HTTP
```
```
curl -s "http://localhost:80/productpage" | grep -o "<title>.*</title>"
<title>Simple Bookstore App</title>
```
This is causing issues while testing out the sample bookinfo and the documentation doesn't provide anything to fix the issue.