### PR TITLE
Fix service entry merge

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -100,7 +101,8 @@ func (es *EndpointShards) CopyEndpoints(portMap map[string]int) map[int][]*Istio
 	res := map[int][]*IstioEndpoint{}
 	for _, v := range es.Shards {
 		for _, ep := range v {
-			portNum, f := portMap[ep.ServicePortName]
+			k := ptr.NonEmptyOrDefault(ep.ServicePortNameKey, ep.ServicePortName)
+			portNum, f := portMap[k]
 			if !f {
 				continue
 			}

--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -101,7 +101,8 @@ func (es *EndpointShards) CopyEndpoints(portMap map[string]int) map[int][]*Istio
 	res := map[int][]*IstioEndpoint{}
 	for _, v := range es.Shards {
 		for _, ep := range v {
-			k := ptr.NonEmptyOrDefault(ep.ServicePortNameKey, ep.ServicePortName)
+			// use the port name as the key, unless LegacyClusterPortKey is set and takes precedence
+			k := ptr.NonEmptyOrDefault(ep.LegacyClusterPortKey, ep.ServicePortName)
 			portNum, f := portMap[k]
 			if !f {
 				continue

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1446,7 +1446,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 	for _, s := range allServices {
 		portMap := map[string]int{}
 		for _, port := range s.Ports {
-			portMap[port.Name] = port.Port
+			portMap[fmt.Sprintf("%s~%d", port.Name, port.Port)] = port.Port
 		}
 
 		svcKey := s.Key()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1446,7 +1447,8 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 	for _, s := range allServices {
 		portMap := map[string]int{}
 		for _, port := range s.Ports {
-			portMap[fmt.Sprintf("%s~%d", port.Name, port.Port)] = port.Port
+			// In EDS we match on port *name*. But for historical reasons, we match on port number for CDS.
+			portMap[strconv.Itoa(port.Port)] = port.Port
 		}
 
 		svcKey := s.Key()

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1446,9 +1445,10 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 
 	for _, s := range allServices {
 		portMap := map[string]int{}
+		ports := sets.New[int]()
 		for _, port := range s.Ports {
-			// In EDS we match on port *name*. But for historical reasons, we match on port number for CDS.
-			portMap[strconv.Itoa(port.Port)] = port.Port
+			portMap[port.Name] = port.Port
+			ports.Insert(port.Port)
 		}
 
 		svcKey := s.Key()
@@ -1457,7 +1457,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment, configsUpdate sets.
 		}
 		shards, ok := env.EndpointIndex.ShardsForService(string(s.Hostname), s.Attributes.Namespace)
 		if ok {
-			instancesByPort := shards.CopyEndpoints(portMap)
+			instancesByPort := shards.CopyEndpoints(portMap, ports)
 			// Iterate over the instances and add them to the service index to avoid overiding the existing port instances.
 			for port, instances := range instancesByPort {
 				ps.ServiceIndex.instancesByPort[svcKey][port] = instances

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -485,8 +485,11 @@ type IstioEndpoint struct {
 	Address string
 
 	// ServicePortName tracks the name of the port, this is used to select the IstioEndpoint by service port.
-	ServicePortName    string
-	ServicePortNameKey string
+	ServicePortName string
+	// LegacyClusterPortKey provides an alternative key from ServicePortName to support legacy quirks in the API.
+	// Basically, EDS merges by port name, but CDS historically ignored port name and matched on number.
+	// Note that for Kubernetes Service, this is identical - its only ServiceEntry where these checks can differ
+	LegacyClusterPortKey string
 
 	// ServiceAccount holds the associated service account.
 	ServiceAccount string

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -489,7 +489,7 @@ type IstioEndpoint struct {
 	// LegacyClusterPortKey provides an alternative key from ServicePortName to support legacy quirks in the API.
 	// Basically, EDS merges by port name, but CDS historically ignored port name and matched on number.
 	// Note that for Kubernetes Service, this is identical - its only ServiceEntry where these checks can differ
-	LegacyClusterPortKey string
+	LegacyClusterPortKey int
 
 	// ServiceAccount holds the associated service account.
 	ServiceAccount string

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -485,7 +485,8 @@ type IstioEndpoint struct {
 	Address string
 
 	// ServicePortName tracks the name of the port, this is used to select the IstioEndpoint by service port.
-	ServicePortName string
+	ServicePortName    string
+	ServicePortNameKey string
 
 	// ServiceAccount holds the associated service account.
 	ServiceAccount string

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -16,7 +16,6 @@ package serviceentry
 
 import (
 	"net/netip"
-	"strconv"
 	"strings"
 	"time"
 
@@ -286,7 +285,7 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 			EndpointPort:    instancePort,
 			ServicePortName: servicePort.Name,
 
-			LegacyClusterPortKey: strconv.Itoa(int(servicePort.Number)),
+			LegacyClusterPortKey: int(servicePort.Number),
 			Network:              network.ID(wle.Network),
 			Locality: model.Locality{
 				Label:     locality,
@@ -347,7 +346,7 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 						Address:              string(service.Hostname),
 						EndpointPort:         endpointPort,
 						ServicePortName:      serviceEntryPort.Name,
-						LegacyClusterPortKey: strconv.Itoa(int(serviceEntryPort.Number)),
+						LegacyClusterPortKey: int(serviceEntryPort.Number),
 						Labels:               nil,
 						TLSMode:              model.DisabledTLSModeLabel,
 					},
@@ -399,7 +398,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			}
 			ep := workloadInstance.Endpoint.ShallowCopy()
 			ep.ServicePortName = serviceEntryPort.Name
-			ep.LegacyClusterPortKey = strconv.Itoa(int(serviceEntryPort.Number))
+			ep.LegacyClusterPortKey = int(serviceEntryPort.Number)
 
 			ep.EndpointPort = targetPort
 			out = append(out, &model.ServiceInstance{

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -285,6 +285,8 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 			Address:         addr,
 			EndpointPort:    instancePort,
 			ServicePortName: servicePort.Name,
+
+			ServicePortNameKey: fmt.Sprintf("%s~%d", servicePort.Name, servicePort.Number),
 			Network:         network.ID(wle.Network),
 			Locality: model.Locality{
 				Label:     locality,
@@ -397,6 +399,8 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			}
 			ep := workloadInstance.Endpoint.ShallowCopy()
 			ep.ServicePortName = serviceEntryPort.Name
+			ep.ServicePortNameKey = fmt.Sprintf("%s~%d", serviceEntryPort.Name, serviceEntryPort.Number)
+
 			ep.EndpointPort = targetPort
 			out = append(out, &model.ServiceInstance{
 				Endpoint:    ep,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -15,6 +15,7 @@
 package serviceentry
 
 import (
+	"fmt"
 	"net/netip"
 	"strings"
 	"time"
@@ -341,11 +342,12 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 				}
 				out = append(out, &model.ServiceInstance{
 					Endpoint: &model.IstioEndpoint{
-						Address:         string(service.Hostname),
-						EndpointPort:    endpointPort,
-						ServicePortName: serviceEntryPort.Name,
-						Labels:          nil,
-						TLSMode:         model.DisabledTLSModeLabel,
+						Address:            string(service.Hostname),
+						EndpointPort:       endpointPort,
+						ServicePortName:    serviceEntryPort.Name,
+						ServicePortNameKey: fmt.Sprintf("%s~%d", serviceEntryPort.Name, serviceEntryPort.Number),
+						Labels:             nil,
+						TLSMode:            model.DisabledTLSModeLabel,
 					},
 					Service:     service,
 					ServicePort: convertPort(serviceEntryPort),

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -15,8 +15,8 @@
 package serviceentry
 
 import (
-	"fmt"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
 
@@ -286,8 +286,8 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 			EndpointPort:    instancePort,
 			ServicePortName: servicePort.Name,
 
-			ServicePortNameKey: fmt.Sprintf("%s~%d", servicePort.Name, servicePort.Number),
-			Network:         network.ID(wle.Network),
+			LegacyClusterPortKey: strconv.Itoa(int(servicePort.Number)),
+			Network:              network.ID(wle.Network),
 			Locality: model.Locality{
 				Label:     locality,
 				ClusterID: clusterID,
@@ -344,12 +344,12 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 				}
 				out = append(out, &model.ServiceInstance{
 					Endpoint: &model.IstioEndpoint{
-						Address:            string(service.Hostname),
-						EndpointPort:       endpointPort,
-						ServicePortName:    serviceEntryPort.Name,
-						ServicePortNameKey: fmt.Sprintf("%s~%d", serviceEntryPort.Name, serviceEntryPort.Number),
-						Labels:             nil,
-						TLSMode:            model.DisabledTLSModeLabel,
+						Address:              string(service.Hostname),
+						EndpointPort:         endpointPort,
+						ServicePortName:      serviceEntryPort.Name,
+						LegacyClusterPortKey: strconv.Itoa(int(serviceEntryPort.Number)),
+						Labels:               nil,
+						TLSMode:              model.DisabledTLSModeLabel,
 					},
 					Service:     service,
 					ServicePort: convertPort(serviceEntryPort),
@@ -399,7 +399,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadIn
 			}
 			ep := workloadInstance.Endpoint.ShallowCopy()
 			ep.ServicePortName = serviceEntryPort.Name
-			ep.ServicePortNameKey = fmt.Sprintf("%s~%d", serviceEntryPort.Name, serviceEntryPort.Number)
+			ep.LegacyClusterPortKey = strconv.Itoa(int(serviceEntryPort.Number))
 
 			ep.EndpointPort = targetPort
 			out = append(out, &model.ServiceInstance{

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -617,11 +617,12 @@ func makeInstance(cfg *config.Config, address string, port int,
 	return &model.ServiceInstance{
 		Service: svc,
 		Endpoint: &model.IstioEndpoint{
-			Address:         address,
-			EndpointPort:    uint32(port),
-			ServicePortName: svcPort.Name,
-			Labels:          svcLabels,
-			TLSMode:         tlsMode,
+			Address:              address,
+			EndpointPort:         uint32(port),
+			ServicePortName:      svcPort.Name,
+			LegacyClusterPortKey: int(svcPort.Number),
+			Labels:               svcLabels,
+			TLSMode:              tlsMode,
 		},
 		ServicePort: &model.Port{
 			Name:     svcPort.Name,

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -259,7 +259,21 @@ spec:
   - name: port1
     number: 8080
     protocol: HTTP
-  resolution: DNS`})
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se3
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: port1
+    number: 80
+    protocol: HTTP
+  resolution: DNS
+`})
 	res := xdstest.ExtractClusterEndpoints(s.Clusters(s.SetupProxy(nil)))
 	assert.Equal(t, res, map[string][]string{
 		"outbound|8080||example.com": {"example.com:8080"},

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -273,10 +273,43 @@ spec:
     number: 80
     protocol: HTTP
   resolution: DNS
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se4
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: port1
+    number: 80
+    targetPort: 1234
+    protocol: HTTP
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: se5
+spec:
+  hosts:
+  - example.com
+  ports:
+  - name: port1
+    number: 80
+    protocol: HTTP
+  resolution: DNS
+  endpoints:
+  - address: not.example.com
+    ports:
+      port1: 2345
 `})
 	res := xdstest.ExtractClusterEndpoints(s.Clusters(s.SetupProxy(nil)))
 	assert.Equal(t, res, map[string][]string{
 		"outbound|8080||example.com": {"example.com:8080"},
-		"outbound|80||example.com":   {"example.com:80"},
+		// Kind of weird to have multiple here, but it is what it is...
+		// If we had targetPort, etc, set here this would be required
+		"outbound|80||example.com":   { "example.com:1234", "example.com:80", "example.com:80",},
 	})
 }

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -298,10 +298,12 @@ spec:
   ports:
   - name: port1
     number: 80
+    targetPort: 999
     protocol: HTTP
   resolution: DNS
   endpoints:
-  - address: not.example.com
+  - address: endpoint.example.com
+  - address: endpoint-port-override.example.com
     ports:
       port1: 2345
 `})
@@ -310,6 +312,12 @@ spec:
 		"outbound|8080||example.com": {"example.com:8080"},
 		// Kind of weird to have multiple here, but it is what it is...
 		// If we had targetPort, etc, set here this would be required
-		"outbound|80||example.com":   { "example.com:1234", "example.com:80", "example.com:80",},
+		"outbound|80||example.com":   {
+			"example.com:1234",
+			"example.com:80",
+			"example.com:80",
+			"endpoint.example.com:999",
+			"endpoint-port-override.example.com:2345",
+		},
 	})
 }

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -307,17 +308,20 @@ spec:
     ports:
       port1: 2345
 `})
+
 	res := xdstest.ExtractClusterEndpoints(s.Clusters(s.SetupProxy(nil)))
+	// TODO(https://github.com/istio/istio/issues/50749) order should be deterministic
+	slices.Sort(res["outbound|80||example.com"])
 	assert.Equal(t, res, map[string][]string{
 		"outbound|8080||example.com": {"example.com:8080"},
 		// Kind of weird to have multiple here, but it is what it is...
 		// If we had targetPort, etc, set here this would be required
-		"outbound|80||example.com":   {
+		"outbound|80||example.com": {
+			"endpoint-port-override.example.com:2345",
+			"endpoint.example.com:999",
 			"example.com:1234",
 			"example.com:80",
 			"example.com:80",
-			"endpoint.example.com:999",
-			"endpoint-port-override.example.com:2345",
 		},
 	})
 }

--- a/releasenotes/notes/se-conflict.yaml
+++ b/releasenotes/notes/se-conflict.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 50478
+releaseNotes:
+  - |
+    **Fixed** a behavioral change in Istio 1.20 that caused merging of ServiceEntries with the same hostname and port names
+    to give unexpected results.

--- a/releasenotes/notes/se-conflict.yaml
+++ b/releasenotes/notes/se-conflict.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
   - 50478
 releaseNotes:


### PR DESCRIPTION
Throwing in my attempt at fixing https://github.com/istio/istio/issues/50478.
Note this pairs well with https://github.com/istio/istio/pull/50690 to fix the EDS issue (https://github.com/istio/istio/issues/50688). With both PRs, all known issues are fixed.

There are a few approaches here:

## Approach 1

Up to 1.19.8 the created clusters are one per port without LB between ports:
```
outbound|80||news.google.com::172.217.22.110:80
outbound|8080||news.google.com::172.217.22.110:8080
```

This behavior is, IMO, what a user expects. While the port names are colliding, user probably doesn't really care -- they care about the number. This also is the behavior if the port names did not collide.

This was the behavior in 1.19 **and what I implemented here**.

## Approach 2

Cross product the ports:

```
outbound|80||news.google.com::172.217.22.110:80
outbound|80||news.google.com::172.217.22.110:8080
outbound|8080||news.google.com::172.217.22.110:80
outbound|8080||news.google.com::172.217.22.110:8080
```

I don't see a good reason to ever want this approach

### Approach 3

Merge down to a single service port, but with an endpoint per port. Implemented in https://github.com/istio/istio/pull/50691

```
outbound|80||news.google.com::172.217.22.110:80
outbound|80||news.google.com::172.217.22.110:8080
```

---

The difference from 1 and 3 comes down to how we intepret them. In a `Service`, they key could logically be considered the name OR the number; because they must be distinct, there is never any difference between those. We happen to use name throughout Istio, but that is an internal detail.

This PR takes the opposite approach and makes the number effectively the key. 

Note: I 100% agree the approach here is incredibly hacky. If we want to go down this route, I will try to make it suck less and add tests.