### PR TITLE
support for disabling metrics endpoint from outside of pod

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -511,7 +511,6 @@ type PrometheusScrapeConfiguration struct {
 // Note that we do not return any errors here. If we do, we will drop metrics. For example, the app may be having issues,
 // but we still want Envoy metrics. Instead, errors are tracked in the failed scrape metrics/logs.
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	log.Debugf("MetricsLocalhostAccessOnly is: %v", MetricsLocalhostAccessOnly)
 	if MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
 		http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
 		return

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -98,7 +98,7 @@ var (
 		"If enabled, readiness probes will keep the connection from pilot-agent to the application alive. "+
 			"This mirrors older Istio versions' behaviors, but not kubelet's.").Get()
 
-	MetricsLocalhostAccessOnly = env.Register("METRICS_LOCALHOST_ACCESS_ONLY", false,
+	MetricsLocalhostAccessOnly = env.Register("PROXY_METRICS_LOCALHOST_ACCESS_ONLY", false,
 		"This will disable proxy metrics endpoint from outside of the pod, allow only localhost access.").Get()
 )
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pkg/config"
 	dnsProto "istio.io/istio/pkg/dns/proto"
 	"istio.io/istio/pkg/env"
+	commonFeatures "istio.io/istio/pkg/features"
 	"istio.io/istio/pkg/kube/apimirror"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/model"
@@ -97,9 +98,6 @@ var (
 	ProbeKeepaliveConnections = env.Register("ENABLE_PROBE_KEEPALIVE_CONNECTIONS", false,
 		"If enabled, readiness probes will keep the connection from pilot-agent to the application alive. "+
 			"This mirrors older Istio versions' behaviors, but not kubelet's.").Get()
-
-	MetricsLocalhostAccessOnly = env.Register("PROXY_METRICS_LOCALHOST_ACCESS_ONLY", false,
-		"This will disable proxy metrics endpoint from outside of the pod, allowing only localhost access.").Get()
 )
 
 // KubeAppProbers holds the information about a Kubernetes pod prober.
@@ -511,7 +509,7 @@ type PrometheusScrapeConfiguration struct {
 // Note that we do not return any errors here. If we do, we will drop metrics. For example, the app may be having issues,
 // but we still want Envoy metrics. Instead, errors are tracked in the failed scrape metrics/logs.
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
-	if MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
+	if commonFeatures.MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
 		http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
 		return
 	}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -99,7 +99,7 @@ var (
 			"This mirrors older Istio versions' behaviors, but not kubelet's.").Get()
 
 	MetricsLocalhostAccessOnly = env.Register("PROXY_METRICS_LOCALHOST_ACCESS_ONLY", false,
-		"This will disable proxy metrics endpoint from outside of the pod, allow only localhost access.").Get()
+		"This will disable proxy metrics endpoint from outside of the pod, allowing only localhost access.").Get()
 )
 
 // KubeAppProbers holds the information about a Kubernetes pod prober.

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -75,7 +75,6 @@ func addMonitor(mux *http.ServeMux) error {
 
 func metricsMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Debugf("MetricsLocalhostAccessOnly is: %v", features.MetricsLocalhostAccessOnly)
 		if features.MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
 			http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
 			return

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"istio.io/istio/pilot/pkg/features"
+	commonFeatures "istio.io/istio/pkg/features"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/monitoring"
 	istioNetUtil "istio.io/istio/pkg/util/net"
@@ -75,7 +75,7 @@ func addMonitor(mux *http.ServeMux) error {
 
 func metricsMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if features.MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
+		if commonFeatures.MetricsLocalhostAccessOnly && !istioNetUtil.IsRequestFromLocalhost(r) {
 			http.Error(w, "Only requests from localhost are allowed", http.StatusForbidden)
 			return
 		}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -60,7 +60,7 @@ var (
 	PilotCertProvider = env.Register("PILOT_CERT_PROVIDER", constants.CertProviderIstiod,
 		"The provider of Pilot DNS certificate.").Get()
 
-	MetricsLocalhostAccessOnly = env.Register("METRICS_LOCALHOST_ACCESS_ONLY", false,
+	MetricsLocalhostAccessOnly = env.Register("PILOT_METRICS_LOCALHOST_ACCESS_ONLY", false,
 		"This will disable pilot metrics endpoint from outside of the pod, allow only localhost access.").Get()
 
 	ClusterName = env.Register("CLUSTER_ID", constants.DefaultClusterName,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -60,9 +60,6 @@ var (
 	PilotCertProvider = env.Register("PILOT_CERT_PROVIDER", constants.CertProviderIstiod,
 		"The provider of Pilot DNS certificate.").Get()
 
-	MetricsLocalhostAccessOnly = env.Register("PILOT_METRICS_LOCALHOST_ACCESS_ONLY", false,
-		"This will disable pilot metrics endpoint from outside of the pod, allowing only localhost access.").Get()
-
 	ClusterName = env.Register("CLUSTER_ID", constants.DefaultClusterName,
 		"Defines the cluster and service registry that this Istiod instance belongs to").Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -60,6 +60,9 @@ var (
 	PilotCertProvider = env.Register("PILOT_CERT_PROVIDER", constants.CertProviderIstiod,
 		"The provider of Pilot DNS certificate.").Get()
 
+	MetricsLocalhostAccessOnly = env.Register("METRICS_LOCALHOST_ACCESS_ONLY", false,
+		"This will disable pilot metrics endpoint from outside of the pod, allow only localhost access.").Get()
+
 	ClusterName = env.Register("CLUSTER_ID", constants.DefaultClusterName,
 		"Defines the cluster and service registry that this Istiod instance belongs to").Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -61,7 +61,7 @@ var (
 		"The provider of Pilot DNS certificate.").Get()
 
 	MetricsLocalhostAccessOnly = env.Register("PILOT_METRICS_LOCALHOST_ACCESS_ONLY", false,
-		"This will disable pilot metrics endpoint from outside of the pod, allow only localhost access.").Get()
+		"This will disable pilot metrics endpoint from outside of the pod, allowing only localhost access.").Get()
 
 	ClusterName = env.Register("CLUSTER_ID", constants.DefaultClusterName,
 		"Defines the cluster and service registry that this Istiod instance belongs to").Get()

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -113,7 +113,8 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 		option.DiscoveryHost(discHost),
 		option.Metadata(cfg.Metadata),
 		option.XdsType(xdsType),
-		option.MetadataDiscovery(bool(metadataDiscovery)))
+		option.MetadataDiscovery(bool(metadataDiscovery)),
+		option.MetricsLocalhostAccessOnly(cfg.Metadata.ProxyConfig.ProxyMetadata))
 
 	// Add GCPProjectNumber to access in bootstrap template.
 	md := cfg.Metadata.PlatformMetadata
@@ -162,12 +163,14 @@ func (cfg Config) toTemplateParams() (map[string]any, error) {
 			if ipFamily == network.IPv6 {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv6),
+					option.AdditionalLocalhost(option.LocalhostIPv4),
 					option.Wildcard(option.WildcardIPv6),
 					option.AdditionalWildCard(option.WildcardIPv4),
 					option.DNSLookupFamily(option.DNSLookupFamilyIPS))
 			} else {
 				opts = append(opts,
 					option.Localhost(option.LocalhostIPv4),
+					option.AdditionalLocalhost(option.LocalhostIPv6),
 					option.Wildcard(option.WildcardIPv4),
 					option.AdditionalWildCard(option.WildcardIPv6),
 					option.DNSLookupFamily(option.DNSLookupFamilyIPS))

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -101,6 +101,10 @@ func Localhost(value LocalhostValue) Instance {
 	return newOption("localhost", value)
 }
 
+func AdditionalLocalhost(value LocalhostValue) Instance {
+	return newOption("additional_localhost", value)
+}
+
 func Wildcard(value WildcardValue) Instance {
 	return newOption("wildcard", value)
 }
@@ -263,6 +267,14 @@ func DiscoveryHost(value string) Instance {
 
 func MetadataDiscovery(value bool) Instance {
 	return newOption("metadata_discovery", value)
+}
+
+func MetricsLocalhostAccessOnly(proxyMetadata map[string]string) Instance {
+	value, ok := proxyMetadata["PROXY_METRICS_LOCALHOST_ACCESS_ONLY"]
+	if ok && value == "true" {
+		return newOption("metrics_localhost_access_only", true)
+	}
+	return newOption("metrics_localhost_access_only", false)
 }
 
 func LoadStatsConfigJSONStr(node *model.Node) Instance {

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -270,7 +270,7 @@ func MetadataDiscovery(value bool) Instance {
 }
 
 func MetricsLocalhostAccessOnly(proxyMetadata map[string]string) Instance {
-	value, ok := proxyMetadata["PROXY_METRICS_LOCALHOST_ACCESS_ONLY"]
+	value, ok := proxyMetadata["METRICS_LOCALHOST_ACCESS_ONLY"]
 	if ok && value == "true" {
 		return newOption("metrics_localhost_access_only", true)
 	}

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -404,6 +404,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -351,6 +351,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -348,6 +348,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -348,6 +348,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -404,6 +404,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -404,6 +404,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -404,6 +404,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -404,6 +404,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -414,6 +414,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -342,6 +342,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -350,6 +350,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -344,6 +344,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -344,6 +344,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -343,6 +343,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -320,6 +320,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
+            
             "port_value": 15090
           }
         },

--- a/pkg/features/telemetry.go
+++ b/pkg/features/telemetry.go
@@ -1,0 +1,25 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	"istio.io/istio/pkg/env"
+)
+
+// Define common telemetry feature flags shared among the Istio components.
+var (
+	MetricsLocalhostAccessOnly = env.Register("METRICS_LOCALHOST_ACCESS_ONLY", false,
+		"This will disable metrics endpoint from outside of the pod, allowing only localhost access.").Get()
+)

--- a/pkg/util/net/ip.go
+++ b/pkg/util/net/ip.go
@@ -87,7 +87,7 @@ func ParseIPsSplitToV4V6(ips []string) (ipv4 []netip.Addr, ipv6 []netip.Addr) {
 	return
 }
 
-// IsRequestFromLocalhost returns true slice of ipv4 and ipv6 netip.Addr.
+// IsRequestFromLocalhost returns true if request is from localhost address.
 func IsRequestFromLocalhost(r *http.Request) bool {
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/pkg/util/net/ip.go
+++ b/pkg/util/net/ip.go
@@ -15,6 +15,8 @@
 package net
 
 import (
+	"net"
+	"net/http"
 	"net/netip"
 
 	"istio.io/istio/pkg/log"
@@ -83,4 +85,15 @@ func ParseIPsSplitToV4V6(ips []string) (ipv4 []netip.Addr, ipv6 []netip.Addr) {
 		}
 	}
 	return
+}
+
+// IsRequestFromLocalhost returns true slice of ipv4 and ipv6 netip.Addr.
+func IsRequestFromLocalhost(r *http.Request) bool {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+
+	userIP := net.ParseIP(ip)
+	return userIP.IsLoopback()
 }

--- a/pkg/util/net/ip_test.go
+++ b/pkg/util/net/ip_test.go
@@ -401,7 +401,6 @@ func TestIsRequestFromLocalhost(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			req := httptest.NewRequest("GET", "/", nil)
 			req.RemoteAddr = tc.remoteAddr
 

--- a/pkg/util/net/ip_test.go
+++ b/pkg/util/net/ip_test.go
@@ -15,6 +15,7 @@
 package net
 
 import (
+	"net/http/httptest"
 	"net/netip"
 	"reflect"
 	"testing"
@@ -360,6 +361,53 @@ func TestParseIPsSplitToV4V61(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotIpv6, tt.wantIpv6) {
 				t.Errorf("ParseIPsSplitToV4V6() gotIpv6 = %v, want %v", gotIpv6, tt.wantIpv6)
+			}
+		})
+	}
+}
+
+func TestIsRequestFromLocalhost(t *testing.T) {
+	testCases := []struct {
+		name       string
+		remoteAddr string
+		expected   bool
+	}{
+		{
+			name:       "Localhost IPv4",
+			remoteAddr: "127.0.0.1:8080",
+			expected:   true,
+		},
+		{
+			name:       "Localhost IPv6",
+			remoteAddr: "[::1]:8080",
+			expected:   true,
+		},
+		{
+			name:       "Private IPv4",
+			remoteAddr: "192.168.1.100:8080",
+			expected:   false,
+		},
+		{
+			name:       "Public IPv4",
+			remoteAddr: "8.8.8.8:8080",
+			expected:   false,
+		},
+		{
+			name:       "Invalid Remote Address",
+			remoteAddr: "invalid",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+
+			result := IsRequestFromLocalhost(req)
+			if result != tc.expected {
+				t.Errorf("IsRequestFromLocalhost expected %t for %s, but got %t", tc.expected, tc.remoteAddr, result)
 			}
 		})
 	}

--- a/releasenotes/notes/50728.yaml
+++ b/releasenotes/notes/50728.yaml
@@ -4,7 +4,7 @@ area: security
 
 releaseNotes:
 - |
-  **Added** Environment variables PILOT_METRICS_LOCALHOST_ACCESS_ONLY and PROXY_METRICS_LOCALHOST_ACCESS_ONLY for disabling 
+  **Added** An environment variable METRICS_LOCALHOST_ACCESS_ONLY for disabling 
   metrics endpoint from outside of the pod, to allow only localhost access. User can use set this with command
-  `--set values.pilot.env.PILOT_METRICS_LOCALHOST_ACCESS_ONLY=true` for Control plane and  
-  `--set meshConfig.defaultConfig.proxyMetadata.PROXY_METRICS_LOCALHOST_ACCESS_ONLY=true` for proxy while istioctl installation.
+  `--set values.pilot.env.METRICS_LOCALHOST_ACCESS_ONLY=true` for Control plane and  
+  `--set meshConfig.defaultConfig.proxyMetadata.METRICS_LOCALHOST_ACCESS_ONLY=true` for proxy while istioctl installation.

--- a/releasenotes/notes/50728.yaml
+++ b/releasenotes/notes/50728.yaml
@@ -4,7 +4,7 @@ area: security
 
 releaseNotes:
 - |
-  **Added** An environment variable METRICS_LOCALHOST_ACCESS_ONLY for disabling metrics endpoint 
-  from outside of the pod, to allow only localhost access. User can use set this with command
-  `--set values.pilot.env.METRICS_LOCALHOST_ACCESS_ONLY=true` for Control plane and  
-  `--set meshConfig.defaultConfig.proxyMetadata.METRICS_LOCALHOST_ACCESS_ONLY=true` for proxy while istioctl installation.
+  **Added** Environment variables PILOT_METRICS_LOCALHOST_ACCESS_ONLY and PROXY_METRICS_LOCALHOST_ACCESS_ONLY for disabling 
+  metrics endpoint from outside of the pod, to allow only localhost access. User can use set this with command
+  `--set values.pilot.env.PILOT_METRICS_LOCALHOST_ACCESS_ONLY=true` for Control plane and  
+  `--set meshConfig.defaultConfig.proxyMetadata.PROXY_METRICS_LOCALHOST_ACCESS_ONLY=true` for proxy while istioctl installation.

--- a/releasenotes/notes/50728.yaml
+++ b/releasenotes/notes/50728.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+releaseNotes:
+- |
+  **Added** An environment variable METRICS_LOCALHOST_ACCESS_ONLY for disabling metrics endpoint 
+  from outside of the pod, to allow only localhost access. User can use set this with command
+  `--set values.pilot.env.METRICS_LOCALHOST_ACCESS_ONLY=true` for Control plane and  
+  `--set meshConfig.defaultConfig.proxyMetadata.METRICS_LOCALHOST_ACCESS_ONLY=true` for proxy while istioctl installation.

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -513,7 +513,11 @@
         "address": {
           "socket_address": {
             "protocol": "TCP",
+            {{- if .metrics_localhost_access_only }}
+            "address": "{{ .localhost }}",
+            {{ else }}
             "address": "{{ .wildcard }}",
+            {{ end }}
             "port_value": {{ .envoy_prometheus_port }}
           }
         },
@@ -523,7 +527,11 @@
             "address": {
               "socket_address": {
                 "protocol": "TCP",
+                {{- if .metrics_localhost_access_only }}
+                "address": "{{ .additional_localhost }}",
+                {{ else }}
                 "address": "{{ .additional_wildcard }}",
+                {{ end }}
                 "port_value": {{ .envoy_prometheus_port }}
               }
             }


### PR DESCRIPTION
**description**
support for disabling metrics endpoint from outside of pod. Currently we can't have encrypted metrics from sidecar and istiod, we are trying to have one solution using collector sidecar which can fetch metrics and encrypt them before exporting outside of the pod. For this solution we are adding a way to disable plain text access from outside for proxy and control plane.