### PR TITLE
Add keepalives to waypoint HBONE endpoint to mimic ztunnel

### DIFF
--- a/releasenotes/notes/50737.yaml
+++ b/releasenotes/notes/50737.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 50737
+releaseNotes:
+- |
+  **Fixed** added serverside keepalives to waypoint HBONE endpoints

--- a/releasenotes/notes/50737.yaml
+++ b/releasenotes/notes/50737.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: networking
+area: traffic-management
 issue:
   - 50737
 releaseNotes:


### PR DESCRIPTION
**Please provide a description of this PR:**

In https://github.com/istio/ztunnel/pull/931 we added keepalives to the serverside of the HBONE tunnel to work around a hyper client bug: https://github.com/hyperium/hyper/pull/3647

This just adds the same things to the waypoint, for the same reasons.

IMO keepalives are probably worth having even if the hyper client bug is fixed, as a safety valve to keep misbehaving clients (even if they are ours) from hanging connections.