### PR TITLE
Add ProxyConfig to list of non-stable resources

### DIFF
--- a/manifests/charts/base/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/base/templates/validatingadmissionpolicy.yaml
@@ -24,11 +24,14 @@ spec:
       expression: "object.kind == 'EnvoyFilter'"
     - name: isWasmPlugin
       expression: "object.kind == 'WasmPlugin'"
+    - name: isProxyConfig
+      expression: "object.kind == 'ProxyConfig'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
+    - expression: "!variables.isProxyConfig"
     - expression: |
         !(
           variables.isTelemetry && (

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingadmissionpolicy.yaml
@@ -30,11 +30,14 @@ spec:
       expression: "object.kind == 'EnvoyFilter'"
     - name: isWasmPlugin
       expression: "object.kind == 'WasmPlugin'"
+    - name: isProxyConfig
+      expression: "object.kind == 'ProxyConfig'"
     - name: isTelemetry
       expression: "object.kind == 'Telemetry'"
   validations:
     - expression: "!variables.isEnvoyFilter"
     - expression: "!variables.isWasmPlugin"
+    - expression: "!variables.isProxyConfig"
     - expression: |
         !(
           variables.isTelemetry && (


### PR DESCRIPTION
**Please provide a description of this PR:**

Adds ProxyConfig to the validating admission policy so that the ProxyConfig is unsupported when using the stable admission policy.

Resolves #50734 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
