### PR TITLE
pilot: fix bug in endpoint updates

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
@@ -323,6 +325,10 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 		for _, nie := range istioEndpoints {
 			if oie, exists := omap[nie.Address]; exists {
 				// If endpoint exists already, we should push if it's health status changes.
+				if !cmp.Equal(oie, nie, nie.CmpOpts()...) {
+					// DO NOT MERGE. Need an optimized equal method. This is just to check in CI
+					needPush = true
+				}
 				if oie.HealthStatus != nie.HealthStatus {
 					needPush = true
 				}
@@ -405,6 +411,8 @@ func updateShardServiceAccount(shards *EndpointShards, serviceName string) bool 
 // EndpointIndexUpdater is an updater that will keep an EndpointIndex in sync. This is intended for tests only.
 type EndpointIndexUpdater struct {
 	Index *EndpointIndex
+	// Optional; if set, we will trigger ConfigUpdates in response to EDS updates as appropriate
+	ConfigUpdateFunc func(req *PushRequest)
 }
 
 var _ XDSUpdater = &EndpointIndexUpdater{}
@@ -416,7 +424,15 @@ func NewEndpointIndexUpdater(ei *EndpointIndex) *EndpointIndexUpdater {
 func (f *EndpointIndexUpdater) ConfigUpdate(*PushRequest) {}
 
 func (f *EndpointIndexUpdater) EDSUpdate(shard ShardKey, serviceName string, namespace string, eps []*IstioEndpoint) {
-	f.Index.UpdateServiceEndpoints(shard, serviceName, namespace, eps)
+	pushType := f.Index.UpdateServiceEndpoints(shard, serviceName, namespace, eps)
+	if f.ConfigUpdateFunc != nil && pushType == IncrementalPush || pushType == FullPush {
+		// Trigger a push
+		f.ConfigUpdateFunc(&PushRequest{
+			Full:           pushType == FullPush,
+			ConfigsUpdated: sets.New(ConfigKey{Kind: kind.ServiceEntry, Name: serviceName, Namespace: namespace}),
+			Reason:         NewReasonStats(EndpointUpdate),
+		})
+	}
 }
 
 func (f *EndpointIndexUpdater) EDSCacheUpdate(shard ShardKey, serviceName string, namespace string, eps []*IstioEndpoint) {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1374,6 +1374,56 @@ func (ep *IstioEndpoint) ShallowCopy() *IstioEndpoint {
 	return &cpy
 }
 
+// Equals checks whether the attributes are equal from the passed in service.
+func (ep *IstioEndpoint) Equals(other *IstioEndpoint) bool {
+	if ep == nil {
+		return other == nil
+	}
+	if other == nil {
+		return ep == nil
+	}
+
+	// Check things we can directly compare...
+	eq := ep.Address == other.Address &&
+		ep.ServicePortName == other.ServicePortName &&
+		ep.LegacyClusterPortKey == other.LegacyClusterPortKey &&
+		ep.ServiceAccount == other.ServiceAccount &&
+		ep.Network == other.Network &&
+		ep.Locality == other.Locality &&
+		ep.EndpointPort == other.EndpointPort &&
+		ep.LbWeight == other.LbWeight &&
+		ep.TLSMode == other.TLSMode &&
+		ep.Namespace == other.Namespace &&
+		ep.WorkloadName == other.WorkloadName &&
+		ep.HostName == other.HostName &&
+		ep.SubDomain == other.SubDomain &&
+		ep.HealthStatus == other.HealthStatus &&
+		ep.NodeName == other.NodeName
+	if !eq {
+		return false
+	}
+
+	// check everything else
+	if !maps.Equal(ep.Labels, other.Labels) {
+		return false
+	}
+
+	// Compare discoverability by name
+	var epp string
+	if ep.DiscoverabilityPolicy != nil {
+		epp = ep.DiscoverabilityPolicy.String()
+	}
+	var op string
+	if other.DiscoverabilityPolicy != nil {
+		op = other.DiscoverabilityPolicy.String()
+	}
+	if epp != op {
+		return false
+	}
+
+	return true
+}
+
 func copyInternal(v any) any {
 	copied, err := copystructure.Copy(v)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -242,10 +242,13 @@ func TestWorkloadInstances(t *testing.T) {
 		makePod(t, kube, pod)
 		createEndpoints(t, kube, service.Name, namespace, []v1.EndpointPort{{Name: "http", Port: 80}}, []string{pod.Status.PodIP})
 		fx.WaitOrFail(t, "eds")
+		// Endpoint update is triggered since its a brand new service
+		if ev := fx.WaitOrFail(t, "xds full"); !ev.Reason.Has(model.EndpointUpdate) {
+			t.Fatalf("xds push reason does not contain %v: %v", model.EndpointUpdate, ev)
+		}
 		// headless service update must trigger nds push, so we trigger a full push.
-		ev := fx.WaitOrFail(t, "xds full")
-		if !ev.Reason.Has(model.HeadlessEndpointUpdate) {
-			t.Fatalf("xds push reason does not contain %v", model.HeadlessEndpointUpdate)
+		if ev := fx.WaitOrFail(t, "xds full"); !ev.Reason.Has(model.HeadlessEndpointUpdate) {
+			t.Fatalf("xds push reason does not contain %v: %v", model.HeadlessEndpointUpdate, ev)
 		}
 
 		// pure HTTP headless services should not need a full push since they do not
@@ -264,10 +267,13 @@ func TestWorkloadInstances(t *testing.T) {
 		makePod(t, kube, pod)
 		createEndpoints(t, kube, service.Name, namespace, []v1.EndpointPort{{Name: "tcp", Port: 70}}, []string{pod.Status.PodIP})
 		fx.WaitOrFail(t, "eds")
-		ev := fx.WaitOrFail(t, "xds full")
-		// headless service update must trigger nds push.
-		if !ev.Reason.Has(model.HeadlessEndpointUpdate) {
-			t.Fatalf("xds push reason does not contain %v", model.HeadlessEndpointUpdate)
+		// Endpoint update is triggered since its a brand new service
+		if ev := fx.WaitOrFail(t, "xds full"); !ev.Reason.Has(model.EndpointUpdate) {
+			t.Fatalf("xds push reason does not contain %v: %v", model.EndpointUpdate, ev)
+		}
+		// headless service update must trigger nds push, so we trigger a full push.
+		if ev := fx.WaitOrFail(t, "xds full"); !ev.Reason.Has(model.HeadlessEndpointUpdate) {
+			t.Fatalf("xds push reason does not contain %v: %v", model.HeadlessEndpointUpdate, ev)
 		}
 		instances := []EndpointResponse{{
 			Address: pod.Status.PodIP,
@@ -499,7 +505,7 @@ func TestWorkloadInstances(t *testing.T) {
 		fx.Clear()
 		// Update the port
 		newWorkloadEntry := workloadEntry.DeepCopy()
-		spec := workloadEntry.Spec.(*networking.WorkloadEntry)
+		spec := workloadEntry.Spec.(*networking.WorkloadEntry).DeepCopy()
 		spec.Ports = map[string]uint32{
 			"http": 1234,
 		}


### PR DESCRIPTION
TBH I am not sure how this isn't a bigger issue. Currently if an
endpoint changes we are not triggering a push at all. In this case, it
was port number, but could be others.

Implementation is *bad* right now, but if this is desired we can swap
for an optimized Equals implementation
