### PR TITLE
Ambient - propagate IPV6 config correctly to CNI agent

### DIFF
--- a/cni/README.md
+++ b/cni/README.md
@@ -53,6 +53,7 @@ Additionally, it does not require any network rules/routing/config in the host n
 | Env Var            | Default         | Purpose                                                                                                                                       |
 |--------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | HOST_PROBE_SNAT_IP | "169.254.7.127" | Applied to SNAT host probe packets, so they can be identified/skipped podside. Any link-local address in the 169.254.0.0/16 block can be used |
+| HOST_PROBE_SNAT_IPV6 | "fd16:9254:7127:1337:ffff:ffff:ffff:ffff" | IPv6 link local ranges are designed to be collision-resistant by default, and so this probably never needs to be overridden |
 
 ## Sidecar Mode Implementation Details
 

--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -100,6 +100,7 @@ var rootCmd = &cobra.Command{
 					Revision:        nodeagent.Revision,
 					ServerSocket:    cfg.InstallConfig.ZtunnelUDSAddress,
 					DNSCapture:      cfg.InstallConfig.AmbientDNSCapture,
+					EnableIPv6:      cfg.InstallConfig.AmbientIPv6,
 				})
 			if err != nil {
 				return fmt.Errorf("failed to create ambient nodeagent service: %v", err)
@@ -266,6 +267,7 @@ func constructConfig() (*config.Config, error) {
 
 		AmbientEnabled:    viper.GetBool(constants.AmbientEnabled),
 		AmbientDNSCapture: viper.GetBool(constants.AmbientDNSCapture),
+		AmbientIPv6:       viper.GetBool(constants.AmbientIPv6),
 	}
 
 	if len(installCfg.K8sNodeName) == 0 {

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -82,6 +82,9 @@ type InstallConfig struct {
 
 	// Whether ambient DNS capture is enabled
 	AmbientDNSCapture bool
+
+	// Whether ipv6 is enabled for ambient capture
+	AmbientIPv6 bool
 }
 
 // RepairConfig struct defines the Istio CNI race repair configuration
@@ -142,6 +145,7 @@ func (c InstallConfig) String() string {
 
 	b.WriteString("AmbientEnabled: " + fmt.Sprint(c.AmbientEnabled) + "\n")
 	b.WriteString("AmbientDNSCapture: " + fmt.Sprint(c.AmbientDNSCapture) + "\n")
+	b.WriteString("AmbientIPv6: " + fmt.Sprint(c.AmbientIPv6) + "\n")
 
 	return b.String()
 }

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -34,6 +34,7 @@ const (
 	CNIEventAddress      = "cni-event-address"
 	AmbientEnabled       = "ambient-enabled"
 	AmbientDNSCapture    = "ambient-dns-capture"
+	AmbientIPv6          = "ambient-ipv6"
 
 	// Repair
 	RepairEnabled            = "repair-enabled"

--- a/cni/pkg/ipset/ipset.go
+++ b/cni/pkg/ipset/ipset.go
@@ -33,7 +33,7 @@ const (
 )
 
 type NetlinkIpsetDeps interface {
-	ipsetIPPortCreate(name string) error
+	ipsetIPHashCreate(name string, v6 bool) error
 	destroySet(name string) error
 	addIP(name string, ip netip.Addr, ipProto uint8, comment string, replace bool) error
 	deleteIP(name string, ip netip.Addr, ipProto uint8) error
@@ -58,10 +58,10 @@ func NewIPSet(name string, v6 bool, deps NetlinkIpsetDeps) (IPSet, error) {
 		Deps:   deps,
 		Prefix: name,
 	}
-	err = deps.ipsetIPPortCreate(set.V4Name)
+	err = deps.ipsetIPHashCreate(set.V4Name, false)
 	if v6 {
 		set.V6Name = fmt.Sprintf(V6Name, name)
-		v6err := deps.ipsetIPPortCreate(set.V6Name)
+		v6err := deps.ipsetIPHashCreate(set.V6Name, true)
 		err = errors.Join(err, v6err)
 	}
 	return set, err

--- a/cni/pkg/ipset/ipset.go
+++ b/cni/pkg/ipset/ipset.go
@@ -16,57 +16,124 @@ package ipset
 
 import (
 	"net/netip"
+	"fmt"
+	"errors"
 )
 
 type IPSet struct {
-	Name string
+	V4Name string
+	V6Name string
 	Deps NetlinkIpsetDeps
 }
 
+const v4Name = "%s-v4"
+const v6Name = "%s-v6"
+
 type NetlinkIpsetDeps interface {
 	ipsetIPPortCreate(name string) error
+	ipsetIPPortCreateMultiFamily(name string) error
 	destroySet(name string) error
 	addIP(name string, ip netip.Addr, ipProto uint8, comment string, replace bool) error
 	deleteIP(name string, ip netip.Addr, ipProto uint8) error
 	flush(name string) error
-	clearEntriesWithComment(name, comment string) error
+	clearEntriesWithComment(name string, comment string) error
 	clearEntriesWithIP(name string, ip netip.Addr) error
 	listEntriesByIP(name string) ([]netip.Addr, error)
 }
 
-func NewIPSet(name string, deps NetlinkIpsetDeps) (IPSet, error) {
+// TODO this should actually create v6 and v6 subsets of type `hash:ip`, add them both to a
+// superset of type `list:set` - we can then query the superset directly in iptables (with the same rule),
+// and iptables will be smart enough to pick the correct underlying set (v4 or v6, based on context),
+// reducing the # of rules we need.
+//
+// BUT netlink lib doesn't support adding things to `list:set` types yet, and current tagged release
+// doesn't support creating `list:set` types yet (is in main branch tho)
+func NewIPSet(name string, v6 bool, deps NetlinkIpsetDeps) (IPSet, error) {
+	var err error;
 	set := IPSet{
-		Name: name,
+		V4Name: fmt.Sprintf(v4Name, name),
 		Deps: deps,
 	}
-	err := deps.ipsetIPPortCreate(name)
+	if v6 {
+		set.V6Name = fmt.Sprintf(v6Name, name)
+		err = deps.ipsetIPPortCreate(set.V6Name)
+	}
+	err = deps.ipsetIPPortCreate(set.V4Name)
 	return set, err
 }
 
 func (m *IPSet) DestroySet() error {
-	return m.Deps.destroySet(m.Name)
+	var err error
+	err = m.Deps.destroySet(m.V4Name)
+
+	if m.V6Name != "" {
+		v6err := m.Deps.destroySet(m.V6Name)
+		err = errors.Join(err, v6err)
+	}
+
+	return err
 }
 
 func (m *IPSet) AddIP(ip netip.Addr, ipProto uint8, comment string, replace bool) error {
-	return m.Deps.addIP(m.Name, ip, ipProto, comment, replace)
+	ipToInsert := ip.Unmap()
+
+	// We have already Unmap'd, so we can do a simple IsV6 y/n check now
+	if ipToInsert.Is6() {
+		return m.Deps.addIP(m.V6Name, ipToInsert, ipProto, comment, replace)
+	}
+	return m.Deps.addIP(m.V4Name, ipToInsert, ipProto, comment, replace)
 }
 
 func (m *IPSet) DeleteIP(ip netip.Addr, ipProto uint8) error {
-	return m.Deps.deleteIP(m.Name, ip, ipProto)
+	ipToDel := ip.Unmap()
+
+	// We have already Unmap'd, so we can do a simple IsV6 y/n check now
+	if ipToDel.Is6() {
+		return m.Deps.deleteIP(m.V6Name, ipToDel, ipProto)
+	}
+	return m.Deps.deleteIP(m.V4Name, ipToDel, ipProto)
 }
 
 func (m *IPSet) Flush() error {
-	return m.Deps.flush(m.Name)
+	var err error
+	err = m.Deps.flush(m.V4Name)
+
+	if m.V6Name != "" {
+		v6err := m.Deps.flush(m.V6Name)
+		err = errors.Join(err, v6err)
+	}
+	return err
 }
 
 func (m *IPSet) ClearEntriesWithComment(comment string) error {
-	return m.Deps.clearEntriesWithComment(m.Name, comment)
+	var err error
+	err = m.Deps.clearEntriesWithComment(m.V4Name, comment)
+
+	if m.V6Name != "" {
+		v6err := m.Deps.clearEntriesWithComment(m.V6Name, comment)
+		err = errors.Join(err, v6err)
+	}
+	return err
 }
 
 func (m *IPSet) ClearEntriesWithIP(ip netip.Addr) error {
-	return m.Deps.clearEntriesWithIP(m.Name, ip)
+	ipToClear := ip.Unmap()
+
+	if ipToClear.Is6() {
+		return m.Deps.clearEntriesWithIP(m.V6Name, ipToClear)
+	}
+	return m.Deps.clearEntriesWithIP(m.V4Name, ipToClear)
 }
 
 func (m *IPSet) ListEntriesByIP() ([]netip.Addr, error) {
-	return m.Deps.listEntriesByIP(m.Name)
+	var err error
+	var set []netip.Addr
+	set, err = m.Deps.listEntriesByIP(m.V4Name)
+
+	if m.V6Name != "" {
+		v6set, v6err := m.Deps.listEntriesByIP(m.V6Name)
+		err = errors.Join(err, v6err)
+		set = append(set, v6set...)
+	}
+	return set, err
 }

--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 func RealNlDeps() NetlinkIpsetDeps {
@@ -30,11 +31,19 @@ func RealNlDeps() NetlinkIpsetDeps {
 
 type realDeps struct{}
 
-func (m *realDeps) ipsetIPPortCreate(name string) error {
-	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true})
+func (m *realDeps) ipsetIPHashCreate(name string, v6 bool) error {
+	var family uint8
+
+	if v6 {
+		family = unix.AF_INET6
+	} else {
+		family = unix.AF_INET
+	}
+	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Family: family})
 	if ipsetErr, ok := err.(nl.IPSetError); ok && ipsetErr == nl.IPSET_ERR_EXIST {
 		return nil
 	}
+
 	return err
 }
 

--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -46,7 +46,7 @@ func (m *realDeps) destroySet(name string) error {
 func (m *realDeps) addIP(name string, ip netip.Addr, ipProto uint8, comment string, replace bool) error {
 	err := netlink.IpsetAdd(name, &netlink.IPSetEntry{
 		Comment:  comment,
-		IP:       net.IP(ip.Unmap().AsSlice()),
+		IP:       net.IP(ip.AsSlice()),
 		Protocol: &ipProto,
 		Replace:  replace,
 	})
@@ -58,7 +58,7 @@ func (m *realDeps) addIP(name string, ip netip.Addr, ipProto uint8, comment stri
 
 func (m *realDeps) deleteIP(name string, ip netip.Addr, ipProto uint8) error {
 	err := netlink.IpsetDel(name, &netlink.IPSetEntry{
-		IP:       net.IP(ip.Unmap().AsSlice()),
+		IP:       net.IP(ip.AsSlice()),
 		Protocol: &ipProto,
 	})
 	if err != nil {
@@ -100,7 +100,7 @@ func (m *realDeps) clearEntriesWithComment(name, comment string) error {
 }
 
 func (m *realDeps) clearEntriesWithIP(name string, ip netip.Addr) error {
-	delIP := net.IP(ip.Unmap().AsSlice())
+	delIP := net.IP(ip.AsSlice())
 	res, err := netlink.IpsetList(name)
 	if err != nil {
 		return fmt.Errorf("failed to list ipset %s: %w", name, err)

--- a/cni/pkg/ipset/nldeps_mock.go
+++ b/cni/pkg/ipset/nldeps_mock.go
@@ -28,8 +28,8 @@ func FakeNLDeps() *MockedIpsetDeps {
 	return &MockedIpsetDeps{}
 }
 
-func (m *MockedIpsetDeps) ipsetIPPortCreate(name string) error {
-	args := m.Called(name)
+func (m *MockedIpsetDeps) ipsetIPHashCreate(name string, v6 bool) error {
+	args := m.Called(name, v6)
 	return args.Error(0)
 }
 

--- a/cni/pkg/ipset/nldeps_unspecified.go
+++ b/cni/pkg/ipset/nldeps_unspecified.go
@@ -28,7 +28,7 @@ func RealNlDeps() NetlinkIpsetDeps {
 
 type realDeps struct{}
 
-func (m *realDeps) ipsetIPPortCreate(name string) error {
+func (m *realDeps) ipsetIPHashCreate(name string, v6 bool) error {
 	return errors.New("not implemented on this platform")
 }
 

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -446,11 +446,15 @@ func (cfg *IptablesConfigurator) CreateHostRulesForHealthChecks(hostSNATIP *neti
 	builder := cfg.appendHostRules(hostSNATIP)
 
 	log.Info("Adding host netnamespace iptables rules")
+
+	// TODO BML work around no ipv6 ipset
+	hackGrab := cfg.cfg.EnableInboundIPv6
+	cfg.cfg.EnableInboundIPv6 = false
 	if err := cfg.executeCommands(builder); err != nil {
 		log.Errorf("failed to add host netnamespace iptables rules: %v", err)
 		return err
 	}
-
+	cfg.cfg.EnableInboundIPv6 = hackGrab
 	return nil
 }
 

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -52,7 +52,7 @@ var log = istiolog.RegisterScope("iptables", "iptables helper")
 type Config struct {
 	RestoreFormat     bool `json:"RESTORE_FORMAT"`
 	TraceLogging      bool `json:"IPTABLES_TRACE_LOGGING"`
-	EnableInboundIPv6 bool `json:"ENABLE_INBOUND_IPV6"`
+	EnableIPv6 bool `json:"ENABLE_INBOUND_IPV6"`
 	RedirectDNS       bool `json:"REDIRECT_DNS"`
 }
 
@@ -68,7 +68,7 @@ func ipbuildConfig(c *Config) *iptablesconfig.Config {
 	return &iptablesconfig.Config{
 		RestoreFormat:     c.RestoreFormat,
 		TraceLogging:      c.TraceLogging,
-		EnableInboundIPv6: c.EnableInboundIPv6,
+		EnableIPv6: c.EnableIPv6,
 		RedirectDNS:       c.RedirectDNS,
 	}
 }
@@ -147,7 +147,7 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 	iptablesVariant := []dep.IptablesVersion{}
 	iptablesVariant = append(iptablesVariant, cfg.iptV)
 
-	if cfg.cfg.EnableInboundIPv6 {
+	if cfg.cfg.EnableIPv6 {
 		iptablesVariant = append(iptablesVariant, cfg.ipt6V)
 	}
 
@@ -379,7 +379,7 @@ func (cfg *IptablesConfigurator) executeCommands(iptablesBuilder *builder.Iptabl
 		// Execute iptables-restore
 		execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(iptablesBuilder, &cfg.iptV, true))
 		// Execute ip6tables-restore
-		if cfg.cfg.EnableInboundIPv6 {
+		if cfg.cfg.EnableIPv6 {
 			execErrs = append(execErrs, cfg.executeIptablesRestoreCommand(iptablesBuilder, &cfg.ipt6V, false))
 		}
 	} else {
@@ -387,7 +387,7 @@ func (cfg *IptablesConfigurator) executeCommands(iptablesBuilder *builder.Iptabl
 		execErrs = append(execErrs,
 			cfg.executeIptablesCommands(&cfg.iptV, iptablesBuilder.BuildV4()))
 		// Execute ip6tables commands
-		if cfg.cfg.EnableInboundIPv6 {
+		if cfg.cfg.EnableIPv6 {
 			execErrs = append(execErrs,
 				cfg.executeIptablesCommands(&cfg.ipt6V, iptablesBuilder.BuildV6()))
 		}
@@ -448,13 +448,13 @@ func (cfg *IptablesConfigurator) CreateHostRulesForHealthChecks(hostSNATIP *neti
 	log.Info("Adding host netnamespace iptables rules")
 
 	// TODO BML work around no ipv6 ipset
-	hackGrab := cfg.cfg.EnableInboundIPv6
-	cfg.cfg.EnableInboundIPv6 = false
+	hackGrab := cfg.cfg.EnableIPv6
+	cfg.cfg.EnableIPv6 = false
 	if err := cfg.executeCommands(builder); err != nil {
 		log.Errorf("failed to add host netnamespace iptables rules: %v", err)
 		return err
 	}
-	cfg.cfg.EnableInboundIPv6 = hackGrab
+	cfg.cfg.EnableIPv6 = hackGrab
 	return nil
 }
 
@@ -478,7 +478,7 @@ func (cfg *IptablesConfigurator) executeHostDeleteCommands() {
 	iptablesVariant := []dep.IptablesVersion{}
 	iptablesVariant = append(iptablesVariant, cfg.iptV)
 
-	if cfg.cfg.EnableInboundIPv6 {
+	if cfg.cfg.EnableIPv6 {
 		iptablesVariant = append(iptablesVariant, cfg.ipt6V)
 	}
 	for _, iptVer := range iptablesVariant {

--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -39,7 +39,7 @@ func DelInpodMarkIPRule(cfg *Config) error {
 func forEachInpodMarkIPRule(cfg *Config, f func(*netlink.Rule) error) error {
 	var rules []*netlink.Rule
 	families := []int{unix.AF_INET}
-	if cfg.EnableInboundIPv6 {
+	if cfg.EnableIPv6 {
 		families = append(families, unix.AF_INET6)
 	}
 	for _, family := range families {
@@ -85,7 +85,7 @@ func forEachLoopbackRoute(cfg *Config, f func(*netlink.Route) error) error {
 
 	// Set up netlink routes for localhost
 	cidrs := []string{"0.0.0.0/0"}
-	if cfg.EnableInboundIPv6 {
+	if cfg.EnableIPv6 {
 		cidrs = append(cidrs, "0::0/0")
 	}
 	for _, fullCIDR := range cidrs {

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -76,7 +76,7 @@ func TestIptablesHostRules(t *testing.T) {
 		},
 	}
 	probeSNATipv4 := netip.MustParseAddr("169.254.7.127")
-	probeSNATipv6 := netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")
+	probeSNATipv6 := netip.MustParseAddr("fd16:9254:7127:1337:ffff:ffff:ffff:ffff")
 
 	for _, tt := range cases {
 		for _, ipv6 := range []bool{false, true} {
@@ -86,13 +86,7 @@ func TestIptablesHostRules(t *testing.T) {
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
 				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
-				var probeIP *netip.Addr
-				if ipv6 {
-					probeIP = &probeSNATipv6
-				} else {
-					probeIP = &probeSNATipv4
-				}
-				err := iptConfigurator.CreateHostRulesForHealthChecks(probeIP)
+				err := iptConfigurator.CreateHostRulesForHealthChecks(&probeSNATipv4, &probeSNATipv6)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -43,7 +43,7 @@ func TestIptables(t *testing.T) {
 		for _, ipv6 := range []bool{false, true} {
 			t.Run(tt.name+"_"+ipstr(ipv6), func(t *testing.T) {
 				cfg := constructTestConfig()
-				cfg.EnableInboundIPv6 = ipv6
+				cfg.EnableIPv6 = ipv6
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
 				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
@@ -82,7 +82,7 @@ func TestIptablesHostRules(t *testing.T) {
 		for _, ipv6 := range []bool{false, true} {
 			t.Run(tt.name+"_"+ipstr(ipv6), func(t *testing.T) {
 				cfg := constructTestConfig()
-				cfg.EnableInboundIPv6 = ipv6
+				cfg.EnableIPv6 = ipv6
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
 				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())

--- a/cni/pkg/iptables/testdata/hostprobe.golden
+++ b/cni/pkg/iptables/testdata/hostprobe.golden
@@ -1,3 +1,3 @@
 iptables -t nat -N ISTIO_POSTRT
 iptables -t nat -A POSTROUTING -j ISTIO_POSTRT
-iptables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes dst -j SNAT --to-source 169.254.7.127
+iptables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v4 dst -j SNAT --to-source 169.254.7.127

--- a/cni/pkg/iptables/testdata/hostprobe_ipv6.golden
+++ b/cni/pkg/iptables/testdata/hostprobe_ipv6.golden
@@ -1,6 +1,6 @@
 iptables -t nat -N ISTIO_POSTRT
 iptables -t nat -A POSTROUTING -j ISTIO_POSTRT
-iptables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes dst -j SNAT --to-source e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164
+iptables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v4 dst -j SNAT --to-source 169.254.7.127
 ip6tables -t nat -N ISTIO_POSTRT
 ip6tables -t nat -A POSTROUTING -j ISTIO_POSTRT
-ip6tables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes dst -j SNAT --to-source e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164
+ip6tables -t nat -A ISTIO_POSTRT -m owner --socket-exists -p tcp -m set --match-set istio-inpod-probes-v6 dst -j SNAT --to-source fd16:9254:7127:1337:ffff:ffff:ffff:ffff

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -311,13 +311,13 @@ func addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr, hostsideProbeSet 
 	// For each pod IP
 	for _, pip := range podIPs {
 		// Add to host ipset
-		log.Debugf("adding pod %s probe to ipset %s with ip %s", pod.Name, hostsideProbeSet.Name, pip)
+		log.Debugf("adding pod %s probe to ipset %s with ip %s", pod.Name, hostsideProbeSet.Prefix, pip)
 		// Add IP/port combo to set. Note that we set Replace to true - a pod ip/port combo already being
 		// in the set is perfectly fine, and something we can always safely overwrite, so we will.
 		if err := hostsideProbeSet.AddIP(pip, ipProto, podUID, true); err != nil {
 			ipsetAddrErrs = append(ipsetAddrErrs, err)
 			log.Warnf("failed adding pod %s to ipset %s with ip %s, error was %s",
-				pod.Name, hostsideProbeSet.Name, pip, err)
+				pod.Name, hostsideProbeSet.Prefix, pip, err)
 		}
 	}
 
@@ -330,7 +330,7 @@ func removePodFromHostNSIpset(pod *corev1.Pod, hostsideProbeSet *ipset.IPSet) er
 		if err := hostsideProbeSet.ClearEntriesWithIP(pip); err != nil {
 			return err
 		}
-		log.Debugf("removed pod name %s with UID %s from host ipset %s by ip %s", pod.Name, pod.UID, hostsideProbeSet.Name, pip)
+		log.Debugf("removed pod name %s with UID %s from host ipset %s by ip %s", pod.Name, pod.UID, hostsideProbeSet.Prefix, pip)
 	}
 
 	return nil
@@ -349,7 +349,7 @@ func pruneHostIPset(expected sets.Set[netip.Addr], hostsideProbeSet *ipset.IPSet
 		if err := hostsideProbeSet.ClearEntriesWithIP(staleIP); err != nil {
 			return err
 		}
-		log.Debugf("removed stale ip %s from host ipset %s", staleIP, hostsideProbeSet.Name)
+		log.Debugf("removed stale ip %s from host ipset %s", staleIP, hostsideProbeSet.Prefix)
 	}
 	return nil
 }

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -113,14 +113,14 @@ func buildConvincingPod(v6IP bool) *corev1.Pod {
 	var podStatus corev1.PodStatus
 	if v6IP {
 		podStatus = corev1.PodStatus{
-				PodIP:  "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164",
-				PodIPs: []corev1.PodIP{{IP: "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"}, {IP: "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3165"}},
-			}
+			PodIP:  "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164",
+			PodIPs: []corev1.PodIP{{IP: "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"}, {IP: "e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3165"}},
+		}
 	} else {
 		podStatus = corev1.PodStatus{
-				PodIP:  "2.2.2.2",
-				PodIPs: []corev1.PodIP{{IP: "2.2.2.2"}, {IP: "3.3.3.3"}},
-			}
+			PodIP:  "2.2.2.2",
+			PodIPs: []corev1.PodIP{{IP: "2.2.2.2"}, {IP: "3.3.3.3"}},
+		}
 	}
 
 	return &corev1.Pod{

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -62,7 +62,7 @@ func getTestFixure(ctx context.Context) netTestFixture {
 	ztunnelServer := &fakeZtunnel{}
 
 	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{Name: "foo", Deps: fakeIPSetDeps}
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 	netServer := newNetServer(ztunnelServer, podNsMap, iptablesConfigurator, NewPodNetnsProcFinder(fakeFs()), set)
 
 	netServer.netnsRunner = func(fdable NetnsFd, toRun func() error) error {
@@ -353,7 +353,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 
 	var podUID string = string(pod.ObjectMeta.UID)
 	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{Name: "foo", Deps: fakeIPSetDeps}
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 	ipProto := uint8(unix.IPPROTO_TCP)
 
 	fakeIPSetDeps.On("addIP",
@@ -384,7 +384,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 
 	var podUID string = string(pod.ObjectMeta.UID)
 	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{Name: "foo", Deps: fakeIPSetDeps}
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 	ipProto := uint8(unix.IPPROTO_TCP)
 
 	fakeIPSetDeps.On("addIP",
@@ -415,7 +415,7 @@ func TestRemovePodProbePortsFromHostNSIPSets(t *testing.T) {
 	pod := buildConvincingPod()
 
 	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{Name: "foo", Deps: fakeIPSetDeps}
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	fakeIPSetDeps.On("clearEntriesWithIP",
 		"foo",

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -142,7 +142,7 @@ func TestServerAddPod(t *testing.T) {
 	podIPs := []netip.Addr{podIP}
 
 	fixture.ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("99.9.9.9"),
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
@@ -239,7 +239,7 @@ func TestServerDeletePod(t *testing.T) {
 
 func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podMeta metav1.ObjectMeta) {
 	ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("99.9.9.9"),
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
@@ -338,7 +338,7 @@ func TestConstructInitialSnap(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: podMeta}
 
 	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo",
+		"foo-v4",
 	).Return([]netip.Addr{}, nil)
 
 	err := netServer.ConstructInitialSnapshot([]*corev1.Pod{pod})
@@ -357,7 +357,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 	ipProto := uint8(unix.IPPROTO_TCP)
 
 	fakeIPSetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
@@ -365,7 +365,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
@@ -388,7 +388,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 	ipProto := uint8(unix.IPPROTO_TCP)
 
 	fakeIPSetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
@@ -396,7 +396,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
@@ -418,12 +418,12 @@ func TestRemovePodProbePortsFromHostNSIPSets(t *testing.T) {
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	fakeIPSetDeps.On("clearEntriesWithIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("3.3.3.3"),
 	).Return(nil)
 
 	fakeIPSetDeps.On("clearEntriesWithIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
 	).Return(nil)
 
@@ -446,7 +446,7 @@ func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 
 	// expectations
 	fixture.ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
@@ -454,7 +454,7 @@ func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 	).Return(nil)
 
 	fixture.ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
@@ -462,7 +462,7 @@ func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 	).Return(nil)
 
 	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo",
+		"foo-v4",
 	).Return([]netip.Addr{}, nil)
 
 	netServer := fixture.netServer
@@ -485,7 +485,7 @@ func TestSyncHostIPSetsAddsNothingIfPodHasNoIPs(t *testing.T) {
 	setupLogging()
 
 	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo",
+		"foo-v4",
 	).Return([]netip.Addr{}, nil)
 
 	netServer := fixture.netServer
@@ -508,7 +508,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 
 	// expectations
 	fixture.ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
@@ -516,7 +516,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 	).Return(nil)
 
 	fixture.ipsetDeps.On("addIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
@@ -525,7 +525,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 
 	// List should return one IP not in our "pod snapshot", which means we prune
 	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo",
+		"foo-v4",
 	).Return([]netip.Addr{
 		netip.MustParseAddr("2.2.2.2"),
 		netip.MustParseAddr("6.6.6.6"),
@@ -533,7 +533,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 	}, nil)
 
 	fixture.ipsetDeps.On("clearEntriesWithIP",
-		"foo",
+		"foo-v4",
 		netip.MustParseAddr("6.6.6.6"),
 	).Return(nil)
 

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -48,4 +48,5 @@ type AmbientArgs struct {
 	KubeConfig      string
 	ServerSocket    string
 	DNSCapture      bool
+	EnableIPv6      bool
 }

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -22,20 +22,24 @@ import (
 )
 
 var (
-	PodNamespace    = env.RegisterStringVar("SYSTEM_NAMESPACE", constants.IstioSystemNamespace, "pod's namespace").Get()
-	PodName         = env.RegisterStringVar("POD_NAME", "", "").Get()
-	NodeName        = env.RegisterStringVar("NODE_NAME", "", "").Get()
-	Revision        = env.RegisterStringVar("REVISION", "", "").Get()
-	HostProbeSNATIP = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
+	PodNamespace      = env.RegisterStringVar("SYSTEM_NAMESPACE", constants.IstioSystemNamespace, "pod's namespace").Get()
+	PodName           = env.RegisterStringVar("POD_NAME", "", "").Get()
+	NodeName          = env.RegisterStringVar("NODE_NAME", "", "").Get()
+	Revision          = env.RegisterStringVar("REVISION", "", "").Get()
+	HostProbeSNATIP   = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
+	HostProbeSNATIPV6 = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IPV6", DefaultHostProbeSNATIPV6, "").Get())
 )
 
 const (
 	// to reliably identify kubelet healthprobes from inside the pod (versus standard kube-proxy traffic,
-	// since the IP is normally the same), we SNAT identified host probes in the host netns to a fixed APIPA IP.
+	// since the IP is normally the same), we SNAT identified host probes in the host netns to a fixed
+	// APIPA/"link-local" IP.
 	//
 	// It doesn't matter what this IP is, so long as it's not routable and doesn't collide with anything else.
-	// (Can be ipv6)
-	DefaultHostProbeSNATIP = "169.254.7.127"
+	//
+	// IPv6 link local ranges are designed to be collision-resistant by default, and so probably never need to be overridden
+	DefaultHostProbeSNATIP   = "169.254.7.127"
+	DefaultHostProbeSNATIPV6 = "fd16:9254:7127:1337:ffff:ffff:ffff:ffff"
 )
 
 type AmbientArgs struct {

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -68,7 +68,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	cfg := &iptables.Config{
 		RestoreFormat: true,
 		RedirectDNS:   args.DNSCapture,
-		EnableIPv6:    true,
+		EnableIPv6:    args.EnableIPv6,
 	}
 
 	log.Debug("creating ipsets in the node netns")

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -65,8 +65,14 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 		return nil, fmt.Errorf("error initializing kube client: %w", err)
 	}
 
+	cfg := &iptables.Config{
+		RestoreFormat:     true,
+		RedirectDNS:       args.DNSCapture,
+		EnableIPv6: true,
+	}
+
 	log.Debug("creating ipsets in the node netns")
-	set, err := createHostsideProbeIpset()
+	set, err := createHostsideProbeIpset(cfg.EnableIPv6)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing hostside probe ipset: %w", err)
 	}
@@ -75,12 +81,6 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	ztunnelServer, err := newZtunnelServer(args.ServerSocket, podNsMap)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing the ztunnel server: %w", err)
-	}
-
-	cfg := &iptables.Config{
-		RestoreFormat:     true,
-		RedirectDNS:       args.DNSCapture,
-		EnableInboundIPv6: true,
 	}
 
 	iptablesConfigurator, err := iptables.NewIptablesConfigurator(cfg, realDependencies(), iptables.RealNlDeps())
@@ -153,9 +153,9 @@ func buildKubeClient(kubeConfig string) (kube.Client, error) {
 // Note that if the ipset already exist by name, Create will not return an error.
 //
 // We will unconditionally flush our set before use here, so it shouldn't matter.
-func createHostsideProbeIpset() (ipset.IPSet, error) {
+func createHostsideProbeIpset(isV6 bool) (ipset.IPSet, error) {
 	linDeps := ipset.RealNlDeps()
-	probeSet, err := ipset.NewIPSet(iptables.ProbeIPSet, linDeps)
+	probeSet, err := ipset.NewIPSet(iptables.ProbeIPSet, isV6, linDeps)
 	if err != nil {
 		return probeSet, err
 	}

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -66,9 +66,9 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	}
 
 	cfg := &iptables.Config{
-		RestoreFormat:     true,
-		RedirectDNS:       args.DNSCapture,
-		EnableIPv6: true,
+		RestoreFormat: true,
+		RedirectDNS:   args.DNSCapture,
+		EnableIPv6:    true,
 	}
 
 	log.Debug("creating ipsets in the node netns")
@@ -92,7 +92,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	// Later we will reuse this same configurator inside the pod netns for adding other rules
 	iptablesConfigurator.DeleteHostRules()
 
-	if err := iptablesConfigurator.CreateHostRulesForHealthChecks(&HostProbeSNATIP); err != nil {
+	if err := iptablesConfigurator.CreateHostRulesForHealthChecks(&HostProbeSNATIP, &HostProbeSNATIPV6); err != nil {
 		return nil, fmt.Errorf("error initializing the host rules for health checks: %w", err)
 	}
 

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -78,8 +78,9 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	}
 
 	cfg := &iptables.Config{
-		RestoreFormat: true,
-		RedirectDNS:   args.DNSCapture,
+		RestoreFormat:     true,
+		RedirectDNS:       args.DNSCapture,
+		EnableInboundIPv6: true,
 	}
 
 	iptablesConfigurator, err := iptables.NewIptablesConfigurator(cfg, realDependencies(), iptables.RealNlDeps())

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stoewer/go-strcase v1.3.0
 	github.com/stretchr/testify v1.9.0
-	github.com/vishvananda/netlink v1.2.1-beta.2
+	github.com/vishvananda/netlink v1.2.1-beta.2.0.20240411215012-578e95cc3190
 	github.com/vishvananda/netns v0.0.4
 	github.com/yl2chen/cidranger v1.0.2
 	go.opentelemetry.io/otel v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -732,6 +732,8 @@ github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8ok
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20240411215012-578e95cc3190 h1:G9ovFHG2n9BlIxcwYufO4UVMCS9WnjyvGvjRv0Ckbhk=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20240411215012-578e95cc3190/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
@@ -947,6 +949,7 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=

--- a/go.sum
+++ b/go.sum
@@ -730,8 +730,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
-github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netlink v1.2.1-beta.2.0.20240411215012-578e95cc3190 h1:G9ovFHG2n9BlIxcwYufO4UVMCS9WnjyvGvjRv0Ckbhk=
 github.com/vishvananda/netlink v1.2.1-beta.2.0.20240411215012-578e95cc3190/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
@@ -924,7 +922,6 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201118182958-a01c418693c7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -133,10 +133,6 @@ spec:
               value: "{{ .Values.cni.chained }}"
             - name: REPAIR_ENABLED
               value: "{{ .Values.cni.repair.enabled }}"
-{{- if .Values.cni.ambient.enabled }}
-            - name: AMBIENT_DNS_CAPTURE
-              value: "{{ .Values.cni.ambient.dnsCapture }}"
-{{- end }}
             - name: REPAIR_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -165,10 +161,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: LOG_LEVEL
               value: {{ .Values.cni.logLevel | quote }}
-            {{- if .Values.cni.ambient.enabled }}
+{{- if .Values.cni.ambient.enabled }}
             - name: AMBIENT_ENABLED
               value: "true"
-            {{- end }}
+            - name: AMBIENT_IPV6
+              value: "{{ .Values.cni.ambient.ipv6 }}"
+            - name: AMBIENT_DNS_CAPTURE
+              value: "{{ .Values.cni.ambient.dnsCapture }}"
+{{- end }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -51,6 +51,8 @@ defaults:
       configDir: ""
       # If enabled, and ambient is enabled, DNS redirection will be enabled
       dnsCapture: false
+      # UNSTABLE: If enabled, and ambient is enabled, enables ipv6 support
+      ipv6: false
 
 
     repair:

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -638,6 +638,8 @@ type CNIAmbientConfig struct {
 	ConfigDir string `protobuf:"bytes,3,opt,name=configDir,proto3" json:"configDir,omitempty"`
 	// If enabled, and ambient is enabled, DNS redirection will be enabled.
 	DnsCapture *wrapperspb.BoolValue `protobuf:"bytes,5,opt,name=dnsCapture,proto3" json:"dnsCapture,omitempty"`
+	// UNSTABLE: If enabled, and ambient is enabled, enables ipv6 support
+	Ipv6 *wrapperspb.BoolValue `protobuf:"bytes,7,opt,name=ipv6,proto3" json:"ipv6,omitempty"`
 }
 
 func (x *CNIAmbientConfig) Reset() {
@@ -689,6 +691,13 @@ func (x *CNIAmbientConfig) GetConfigDir() string {
 func (x *CNIAmbientConfig) GetDnsCapture() *wrapperspb.BoolValue {
 	if x != nil {
 		return x.DnsCapture
+	}
+	return nil
+}
+
+func (x *CNIAmbientConfig) GetIpv6() *wrapperspb.BoolValue {
+	if x != nil {
+		return x.Ipv6
 	}
 	return nil
 }
@@ -5612,7 +5621,7 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65,
 	0x42, 0x02, 0x18, 0x01, 0x52, 0x07, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x65, 0x64, 0x12, 0x1a, 0x0a,
 	0x08, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x08, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x22, 0xa2, 0x01, 0x0a, 0x10, 0x43, 0x4e,
+	0x08, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x22, 0xd2, 0x01, 0x0a, 0x10, 0x43, 0x4e,
 	0x49, 0x41, 0x6d, 0x62, 0x69, 0x65, 0x6e, 0x74, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x34,
 	0x0a, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
 	0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
@@ -5622,7 +5631,10 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_rawDesc = []byte{
 	0x69, 0x72, 0x12, 0x3a, 0x0a, 0x0a, 0x64, 0x6e, 0x73, 0x43, 0x61, 0x70, 0x74, 0x75, 0x72, 0x65,
 	0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c,
-	0x75, 0x65, 0x52, 0x0a, 0x64, 0x6e, 0x73, 0x43, 0x61, 0x70, 0x74, 0x75, 0x72, 0x65, 0x22, 0xad,
+	0x75, 0x65, 0x52, 0x0a, 0x64, 0x6e, 0x73, 0x43, 0x61, 0x70, 0x74, 0x75, 0x72, 0x65, 0x12, 0x2e,
+	0x0a, 0x04, 0x69, 0x70, 0x76, 0x36, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67,
+	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x42,
+	0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x04, 0x69, 0x70, 0x76, 0x36, 0x22, 0xad,
 	0x03, 0x0a, 0x0f, 0x43, 0x4e, 0x49, 0x52, 0x65, 0x70, 0x61, 0x69, 0x72, 0x43, 0x6f, 0x6e, 0x66,
 	0x69, 0x67, 0x12, 0x34, 0x0a, 0x07, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x64, 0x18, 0x01, 0x20,
 	0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
@@ -6794,180 +6806,181 @@ var file_pkg_apis_istio_v1alpha1_values_types_proto_depIdxs = []int32{
 	56,  // 13: v1alpha1.CNIUsageConfig.chained:type_name -> google.protobuf.BoolValue
 	56,  // 14: v1alpha1.CNIAmbientConfig.enabled:type_name -> google.protobuf.BoolValue
 	56,  // 15: v1alpha1.CNIAmbientConfig.dnsCapture:type_name -> google.protobuf.BoolValue
-	56,  // 16: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
-	57,  // 17: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
-	56,  // 18: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
-	52,  // 19: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
-	53,  // 20: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
-	59,  // 21: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
-	56,  // 22: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
-	37,  // 23: v1alpha1.DefaultResourcesConfig.requests:type_name -> v1alpha1.ResourcesRequestsConfig
-	56,  // 24: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 25: v1alpha1.EgressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
-	9,   // 26: v1alpha1.EgressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	56,  // 27: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	56,  // 28: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	59,  // 29: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
-	54,  // 30: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
-	59,  // 31: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	59,  // 32: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	61,  // 33: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	61,  // 34: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	33,  // 35: v1alpha1.EgressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	10,  // 36: v1alpha1.EgressGatewayConfig.resources:type_name -> v1alpha1.Resources
-	39,  // 37: v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	59,  // 38: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	49,  // 39: v1alpha1.EgressGatewayConfig.zvpn:type_name -> v1alpha1.ZeroVPNConfig
-	62,  // 40: v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	51,  // 41: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 42: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	59,  // 43: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	59,  // 44: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	56,  // 45: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 46: v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	14,  // 47: v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> v1alpha1.EgressGatewayConfig
-	56,  // 48: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
-	20,  // 49: v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> v1alpha1.IngressGatewayConfig
-	3,   // 50: v1alpha1.GlobalConfig.arch:type_name -> v1alpha1.ArchConfig
-	56,  // 51: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
-	59,  // 52: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
-	12,  // 53: v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> v1alpha1.DefaultPodDisruptionBudgetConfig
-	13,  // 54: v1alpha1.GlobalConfig.defaultResources:type_name -> v1alpha1.DefaultResourcesConfig
-	62,  // 55: v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
-	56,  // 56: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
-	19,  // 57: v1alpha1.GlobalConfig.logging:type_name -> v1alpha1.GlobalLoggingConfig
-	59,  // 58: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
-	22,  // 59: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
-	56,  // 60: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
-	56,  // 61: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
-	34,  // 62: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
-	36,  // 63: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
-	38,  // 64: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
-	57,  // 65: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
-	41,  // 66: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
-	56,  // 67: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
-	18,  // 68: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
-	17,  // 69: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
-	56,  // 70: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
-	56,  // 71: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
-	56,  // 72: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
-	56,  // 73: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
-	56,  // 74: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
-	56,  // 75: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	9,   // 76: v1alpha1.IngressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
-	9,   // 77: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	56,  // 78: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
-	56,  // 79: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
-	59,  // 80: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
-	55,  // 81: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
-	59,  // 82: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
-	59,  // 83: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
-	61,  // 84: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	61,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	33,  // 86: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
-	59,  // 87: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
-	39,  // 88: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
-	59,  // 89: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	21,  // 90: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
-	51,  // 91: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	62,  // 93: v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	59,  // 94: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
-	59,  // 95: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
-	59,  // 96: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
-	56,  // 97: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
-	11,  // 98: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
-	56,  // 99: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 100: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 101: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
-	2,   // 102: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
-	56,  // 103: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 104: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
-	59,  // 105: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
-	10,  // 106: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
-	9,   // 107: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
-	59,  // 108: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
-	63,  // 109: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
-	59,  // 110: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
-	59,  // 111: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
-	56,  // 112: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
-	56,  // 113: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
-	59,  // 114: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
-	58,  // 115: v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
-	51,  // 116: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
-	51,  // 117: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
-	62,  // 118: v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
-	56,  // 119: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
-	56,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
-	59,  // 121: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
-	59,  // 122: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
-	59,  // 123: v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
-	32,  // 124: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
-	57,  // 125: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
-	60,  // 126: v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
-	64,  // 127: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
-	59,  // 128: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
-	65,  // 129: v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
-	66,  // 130: v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
-	9,   // 131: v1alpha1.PilotConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
-	5,   // 132: v1alpha1.PilotConfig.cni:type_name -> v1alpha1.CNIUsageConfig
-	25,  // 133: v1alpha1.PilotConfig.taint:type_name -> v1alpha1.PilotTaintControllerConfig
-	0,   // 134: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
-	56,  // 135: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 136: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
-	29,  // 137: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
-	56,  // 138: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
-	30,  // 139: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
-	31,  // 140: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
-	56,  // 141: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 142: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 143: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
-	56,  // 144: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
-	35,  // 145: v1alpha1.ProxyConfig.startupProbe:type_name -> v1alpha1.StartupProbe
-	10,  // 146: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
-	1,   // 147: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
-	67,  // 148: v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
-	56,  // 149: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
-	56,  // 150: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
-	10,  // 151: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
-	59,  // 152: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
-	56,  // 153: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
-	61,  // 154: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	61,  // 155: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
-	56,  // 156: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
-	59,  // 157: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
-	59,  // 158: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
-	59,  // 159: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
-	56,  // 160: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
-	42,  // 161: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
-	43,  // 162: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
-	44,  // 163: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
-	45,  // 164: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
-	56,  // 165: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
-	56,  // 166: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
-	56,  // 167: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
-	56,  // 168: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
-	4,   // 169: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
-	15,  // 170: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
-	16,  // 171: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
-	24,  // 172: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
-	57,  // 173: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
-	28,  // 174: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
-	40,  // 175: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
-	5,   // 176: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
-	57,  // 177: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
-	46,  // 178: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
-	47,  // 179: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
-	50,  // 180: v1alpha1.Values.experimental:type_name -> v1alpha1.ExperimentalConfig
-	56,  // 181: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
-	56,  // 182: v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
-	68,  // 183: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
-	69,  // 184: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
-	185, // [185:185] is the sub-list for method output_type
-	185, // [185:185] is the sub-list for method input_type
-	185, // [185:185] is the sub-list for extension type_name
-	185, // [185:185] is the sub-list for extension extendee
-	0,   // [0:185] is the sub-list for field type_name
+	56,  // 16: v1alpha1.CNIAmbientConfig.ipv6:type_name -> google.protobuf.BoolValue
+	56,  // 17: v1alpha1.CNIRepairConfig.enabled:type_name -> google.protobuf.BoolValue
+	57,  // 18: v1alpha1.CNIRepairConfig.tag:type_name -> google.protobuf.Value
+	56,  // 19: v1alpha1.ResourceQuotas.enabled:type_name -> google.protobuf.BoolValue
+	52,  // 20: v1alpha1.Resources.limits:type_name -> v1alpha1.Resources.LimitsEntry
+	53,  // 21: v1alpha1.Resources.requests:type_name -> v1alpha1.Resources.RequestsEntry
+	59,  // 22: v1alpha1.ServiceAccount.annotations:type_name -> google.protobuf.Struct
+	56,  // 23: v1alpha1.DefaultPodDisruptionBudgetConfig.enabled:type_name -> google.protobuf.BoolValue
+	37,  // 24: v1alpha1.DefaultResourcesConfig.requests:type_name -> v1alpha1.ResourcesRequestsConfig
+	56,  // 25: v1alpha1.EgressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	9,   // 26: v1alpha1.EgressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
+	9,   // 27: v1alpha1.EgressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
+	56,  // 28: v1alpha1.EgressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 29: v1alpha1.EgressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 30: v1alpha1.EgressGatewayConfig.env:type_name -> google.protobuf.Struct
+	54,  // 31: v1alpha1.EgressGatewayConfig.labels:type_name -> v1alpha1.EgressGatewayConfig.LabelsEntry
+	59,  // 32: v1alpha1.EgressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 33: v1alpha1.EgressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 34: v1alpha1.EgressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 35: v1alpha1.EgressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	33,  // 36: v1alpha1.EgressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
+	10,  // 37: v1alpha1.EgressGatewayConfig.resources:type_name -> v1alpha1.Resources
+	39,  // 38: v1alpha1.EgressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
+	59,  // 39: v1alpha1.EgressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	49,  // 40: v1alpha1.EgressGatewayConfig.zvpn:type_name -> v1alpha1.ZeroVPNConfig
+	62,  // 41: v1alpha1.EgressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	51,  // 42: v1alpha1.EgressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 43: v1alpha1.EgressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	59,  // 44: v1alpha1.EgressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	59,  // 45: v1alpha1.EgressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	56,  // 46: v1alpha1.EgressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	11,  // 47: v1alpha1.EgressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
+	14,  // 48: v1alpha1.GatewaysConfig.istio_egressgateway:type_name -> v1alpha1.EgressGatewayConfig
+	56,  // 49: v1alpha1.GatewaysConfig.enabled:type_name -> google.protobuf.BoolValue
+	20,  // 50: v1alpha1.GatewaysConfig.istio_ingressgateway:type_name -> v1alpha1.IngressGatewayConfig
+	3,   // 51: v1alpha1.GlobalConfig.arch:type_name -> v1alpha1.ArchConfig
+	56,  // 52: v1alpha1.GlobalConfig.configValidation:type_name -> google.protobuf.BoolValue
+	59,  // 53: v1alpha1.GlobalConfig.defaultNodeSelector:type_name -> google.protobuf.Struct
+	12,  // 54: v1alpha1.GlobalConfig.defaultPodDisruptionBudget:type_name -> v1alpha1.DefaultPodDisruptionBudgetConfig
+	13,  // 55: v1alpha1.GlobalConfig.defaultResources:type_name -> v1alpha1.DefaultResourcesConfig
+	62,  // 56: v1alpha1.GlobalConfig.defaultTolerations:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 57: v1alpha1.GlobalConfig.logAsJson:type_name -> google.protobuf.BoolValue
+	19,  // 58: v1alpha1.GlobalConfig.logging:type_name -> v1alpha1.GlobalLoggingConfig
+	59,  // 59: v1alpha1.GlobalConfig.meshNetworks:type_name -> google.protobuf.Struct
+	22,  // 60: v1alpha1.GlobalConfig.multiCluster:type_name -> v1alpha1.MultiClusterConfig
+	56,  // 61: v1alpha1.GlobalConfig.omitSidecarInjectorConfigMap:type_name -> google.protobuf.BoolValue
+	56,  // 62: v1alpha1.GlobalConfig.operatorManageWebhooks:type_name -> google.protobuf.BoolValue
+	34,  // 63: v1alpha1.GlobalConfig.proxy:type_name -> v1alpha1.ProxyConfig
+	36,  // 64: v1alpha1.GlobalConfig.proxy_init:type_name -> v1alpha1.ProxyInitConfig
+	38,  // 65: v1alpha1.GlobalConfig.sds:type_name -> v1alpha1.SDSConfig
+	57,  // 66: v1alpha1.GlobalConfig.tag:type_name -> google.protobuf.Value
+	41,  // 67: v1alpha1.GlobalConfig.tracer:type_name -> v1alpha1.TracerConfig
+	56,  // 68: v1alpha1.GlobalConfig.useMCP:type_name -> google.protobuf.BoolValue
+	18,  // 69: v1alpha1.GlobalConfig.istiod:type_name -> v1alpha1.IstiodConfig
+	17,  // 70: v1alpha1.GlobalConfig.sts:type_name -> v1alpha1.STSConfig
+	56,  // 71: v1alpha1.GlobalConfig.mountMtlsCerts:type_name -> google.protobuf.BoolValue
+	56,  // 72: v1alpha1.GlobalConfig.externalIstiod:type_name -> google.protobuf.BoolValue
+	56,  // 73: v1alpha1.GlobalConfig.configCluster:type_name -> google.protobuf.BoolValue
+	56,  // 74: v1alpha1.GlobalConfig.autoscalingv2API:type_name -> google.protobuf.BoolValue
+	56,  // 75: v1alpha1.IstiodConfig.enableAnalysis:type_name -> google.protobuf.BoolValue
+	56,  // 76: v1alpha1.IngressGatewayConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	9,   // 77: v1alpha1.IngressGatewayConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
+	9,   // 78: v1alpha1.IngressGatewayConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
+	56,  // 79: v1alpha1.IngressGatewayConfig.customService:type_name -> google.protobuf.BoolValue
+	56,  // 80: v1alpha1.IngressGatewayConfig.enabled:type_name -> google.protobuf.BoolValue
+	59,  // 81: v1alpha1.IngressGatewayConfig.env:type_name -> google.protobuf.Struct
+	55,  // 82: v1alpha1.IngressGatewayConfig.labels:type_name -> v1alpha1.IngressGatewayConfig.LabelsEntry
+	59,  // 83: v1alpha1.IngressGatewayConfig.nodeSelector:type_name -> google.protobuf.Struct
+	59,  // 84: v1alpha1.IngressGatewayConfig.podAnnotations:type_name -> google.protobuf.Struct
+	61,  // 85: v1alpha1.IngressGatewayConfig.podAntiAffinityLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 86: v1alpha1.IngressGatewayConfig.podAntiAffinityTermLabelSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	33,  // 87: v1alpha1.IngressGatewayConfig.ports:type_name -> v1alpha1.PortsConfig
+	59,  // 88: v1alpha1.IngressGatewayConfig.resources:type_name -> google.protobuf.Struct
+	39,  // 89: v1alpha1.IngressGatewayConfig.secretVolumes:type_name -> v1alpha1.SecretVolume
+	59,  // 90: v1alpha1.IngressGatewayConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	21,  // 91: v1alpha1.IngressGatewayConfig.zvpn:type_name -> v1alpha1.IngressGatewayZvpnConfig
+	51,  // 92: v1alpha1.IngressGatewayConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 93: v1alpha1.IngressGatewayConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	62,  // 94: v1alpha1.IngressGatewayConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	59,  // 95: v1alpha1.IngressGatewayConfig.ingressPorts:type_name -> google.protobuf.Struct
+	59,  // 96: v1alpha1.IngressGatewayConfig.additionalContainers:type_name -> google.protobuf.Struct
+	59,  // 97: v1alpha1.IngressGatewayConfig.configVolumes:type_name -> google.protobuf.Struct
+	56,  // 98: v1alpha1.IngressGatewayConfig.runAsRoot:type_name -> google.protobuf.BoolValue
+	11,  // 99: v1alpha1.IngressGatewayConfig.serviceAccount:type_name -> v1alpha1.ServiceAccount
+	56,  // 100: v1alpha1.IngressGatewayZvpnConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 101: v1alpha1.MultiClusterConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 102: v1alpha1.MultiClusterConfig.includeEnvoyFilter:type_name -> google.protobuf.BoolValue
+	2,   // 103: v1alpha1.OutboundTrafficPolicyConfig.mode:type_name -> v1alpha1.OutboundTrafficPolicyConfig.Mode
+	56,  // 104: v1alpha1.PilotConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 105: v1alpha1.PilotConfig.autoscaleEnabled:type_name -> google.protobuf.BoolValue
+	59,  // 106: v1alpha1.PilotConfig.autoscaleBehavior:type_name -> google.protobuf.Struct
+	10,  // 107: v1alpha1.PilotConfig.resources:type_name -> v1alpha1.Resources
+	9,   // 108: v1alpha1.PilotConfig.cpu:type_name -> v1alpha1.TargetUtilizationConfig
+	59,  // 109: v1alpha1.PilotConfig.nodeSelector:type_name -> google.protobuf.Struct
+	63,  // 110: v1alpha1.PilotConfig.keepaliveMaxServerConnectionAge:type_name -> google.protobuf.Duration
+	59,  // 111: v1alpha1.PilotConfig.deploymentLabels:type_name -> google.protobuf.Struct
+	59,  // 112: v1alpha1.PilotConfig.podLabels:type_name -> google.protobuf.Struct
+	56,  // 113: v1alpha1.PilotConfig.configMap:type_name -> google.protobuf.BoolValue
+	56,  // 114: v1alpha1.PilotConfig.useMCP:type_name -> google.protobuf.BoolValue
+	59,  // 115: v1alpha1.PilotConfig.env:type_name -> google.protobuf.Struct
+	58,  // 116: v1alpha1.PilotConfig.affinity:type_name -> k8s.io.api.core.v1.Affinity
+	51,  // 117: v1alpha1.PilotConfig.rollingMaxSurge:type_name -> v1alpha1.IntOrString
+	51,  // 118: v1alpha1.PilotConfig.rollingMaxUnavailable:type_name -> v1alpha1.IntOrString
+	62,  // 119: v1alpha1.PilotConfig.tolerations:type_name -> k8s.io.api.core.v1.Toleration
+	56,  // 120: v1alpha1.PilotConfig.enableProtocolSniffingForOutbound:type_name -> google.protobuf.BoolValue
+	56,  // 121: v1alpha1.PilotConfig.enableProtocolSniffingForInbound:type_name -> google.protobuf.BoolValue
+	59,  // 122: v1alpha1.PilotConfig.podAnnotations:type_name -> google.protobuf.Struct
+	59,  // 123: v1alpha1.PilotConfig.serviceAnnotations:type_name -> google.protobuf.Struct
+	59,  // 124: v1alpha1.PilotConfig.serviceAccountAnnotations:type_name -> google.protobuf.Struct
+	32,  // 125: v1alpha1.PilotConfig.configSource:type_name -> v1alpha1.PilotConfigSource
+	57,  // 126: v1alpha1.PilotConfig.tag:type_name -> google.protobuf.Value
+	60,  // 127: v1alpha1.PilotConfig.seccompProfile:type_name -> k8s.io.api.core.v1.SeccompProfile
+	64,  // 128: v1alpha1.PilotConfig.topologySpreadConstraints:type_name -> k8s.io.api.core.v1.TopologySpreadConstraint
+	59,  // 129: v1alpha1.PilotConfig.extraContainerArgs:type_name -> google.protobuf.Struct
+	65,  // 130: v1alpha1.PilotConfig.volumeMounts:type_name -> k8s.io.api.core.v1.VolumeMount
+	66,  // 131: v1alpha1.PilotConfig.volumes:type_name -> k8s.io.api.core.v1.Volume
+	9,   // 132: v1alpha1.PilotConfig.memory:type_name -> v1alpha1.TargetUtilizationConfig
+	5,   // 133: v1alpha1.PilotConfig.cni:type_name -> v1alpha1.CNIUsageConfig
+	25,  // 134: v1alpha1.PilotConfig.taint:type_name -> v1alpha1.PilotTaintControllerConfig
+	0,   // 135: v1alpha1.PilotIngressConfig.ingressControllerMode:type_name -> v1alpha1.ingressControllerMode
+	56,  // 136: v1alpha1.PilotPolicyConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 137: v1alpha1.TelemetryConfig.enabled:type_name -> google.protobuf.BoolValue
+	29,  // 138: v1alpha1.TelemetryConfig.v2:type_name -> v1alpha1.TelemetryV2Config
+	56,  // 139: v1alpha1.TelemetryV2Config.enabled:type_name -> google.protobuf.BoolValue
+	30,  // 140: v1alpha1.TelemetryV2Config.prometheus:type_name -> v1alpha1.TelemetryV2PrometheusConfig
+	31,  // 141: v1alpha1.TelemetryV2Config.stackdriver:type_name -> v1alpha1.TelemetryV2StackDriverConfig
+	56,  // 142: v1alpha1.TelemetryV2PrometheusConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 143: v1alpha1.TelemetryV2StackDriverConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 144: v1alpha1.ProxyConfig.enableCoreDump:type_name -> google.protobuf.BoolValue
+	56,  // 145: v1alpha1.ProxyConfig.privileged:type_name -> google.protobuf.BoolValue
+	35,  // 146: v1alpha1.ProxyConfig.startupProbe:type_name -> v1alpha1.StartupProbe
+	10,  // 147: v1alpha1.ProxyConfig.resources:type_name -> v1alpha1.Resources
+	1,   // 148: v1alpha1.ProxyConfig.tracer:type_name -> v1alpha1.tracer
+	67,  // 149: v1alpha1.ProxyConfig.lifecycle:type_name -> k8s.io.api.core.v1.Lifecycle
+	56,  // 150: v1alpha1.ProxyConfig.holdApplicationUntilProxyStarts:type_name -> google.protobuf.BoolValue
+	56,  // 151: v1alpha1.StartupProbe.enabled:type_name -> google.protobuf.BoolValue
+	10,  // 152: v1alpha1.ProxyInitConfig.resources:type_name -> v1alpha1.Resources
+	59,  // 153: v1alpha1.SDSConfig.token:type_name -> google.protobuf.Struct
+	56,  // 154: v1alpha1.SidecarInjectorConfig.enableNamespacesByDefault:type_name -> google.protobuf.BoolValue
+	61,  // 155: v1alpha1.SidecarInjectorConfig.neverInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	61,  // 156: v1alpha1.SidecarInjectorConfig.alwaysInjectSelector:type_name -> k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector
+	56,  // 157: v1alpha1.SidecarInjectorConfig.rewriteAppHTTPProbe:type_name -> google.protobuf.BoolValue
+	59,  // 158: v1alpha1.SidecarInjectorConfig.injectedAnnotations:type_name -> google.protobuf.Struct
+	59,  // 159: v1alpha1.SidecarInjectorConfig.objectSelector:type_name -> google.protobuf.Struct
+	59,  // 160: v1alpha1.SidecarInjectorConfig.templates:type_name -> google.protobuf.Struct
+	56,  // 161: v1alpha1.SidecarInjectorConfig.useLegacySelectors:type_name -> google.protobuf.BoolValue
+	42,  // 162: v1alpha1.TracerConfig.datadog:type_name -> v1alpha1.TracerDatadogConfig
+	43,  // 163: v1alpha1.TracerConfig.lightstep:type_name -> v1alpha1.TracerLightStepConfig
+	44,  // 164: v1alpha1.TracerConfig.zipkin:type_name -> v1alpha1.TracerZipkinConfig
+	45,  // 165: v1alpha1.TracerConfig.stackdriver:type_name -> v1alpha1.TracerStackdriverConfig
+	56,  // 166: v1alpha1.TracerStackdriverConfig.debug:type_name -> google.protobuf.BoolValue
+	56,  // 167: v1alpha1.BaseConfig.enableCRDTemplates:type_name -> google.protobuf.BoolValue
+	56,  // 168: v1alpha1.BaseConfig.enableIstioConfigCRDs:type_name -> google.protobuf.BoolValue
+	56,  // 169: v1alpha1.BaseConfig.validateGateway:type_name -> google.protobuf.BoolValue
+	4,   // 170: v1alpha1.Values.cni:type_name -> v1alpha1.CNIConfig
+	15,  // 171: v1alpha1.Values.gateways:type_name -> v1alpha1.GatewaysConfig
+	16,  // 172: v1alpha1.Values.global:type_name -> v1alpha1.GlobalConfig
+	24,  // 173: v1alpha1.Values.pilot:type_name -> v1alpha1.PilotConfig
+	57,  // 174: v1alpha1.Values.ztunnel:type_name -> google.protobuf.Value
+	28,  // 175: v1alpha1.Values.telemetry:type_name -> v1alpha1.TelemetryConfig
+	40,  // 176: v1alpha1.Values.sidecarInjectorWebhook:type_name -> v1alpha1.SidecarInjectorConfig
+	5,   // 177: v1alpha1.Values.istio_cni:type_name -> v1alpha1.CNIUsageConfig
+	57,  // 178: v1alpha1.Values.meshConfig:type_name -> google.protobuf.Value
+	46,  // 179: v1alpha1.Values.base:type_name -> v1alpha1.BaseConfig
+	47,  // 180: v1alpha1.Values.istiodRemote:type_name -> v1alpha1.IstiodRemoteConfig
+	50,  // 181: v1alpha1.Values.experimental:type_name -> v1alpha1.ExperimentalConfig
+	56,  // 182: v1alpha1.ZeroVPNConfig.enabled:type_name -> google.protobuf.BoolValue
+	56,  // 183: v1alpha1.ExperimentalConfig.stableValidationPolicy:type_name -> google.protobuf.BoolValue
+	68,  // 184: v1alpha1.IntOrString.intVal:type_name -> google.protobuf.Int32Value
+	69,  // 185: v1alpha1.IntOrString.strVal:type_name -> google.protobuf.StringValue
+	186, // [186:186] is the sub-list for method output_type
+	186, // [186:186] is the sub-list for method input_type
+	186, // [186:186] is the sub-list for extension type_name
+	186, // [186:186] is the sub-list for extension extendee
+	0,   // [0:186] is the sub-list for field type_name
 }
 
 func init() { file_pkg_apis_istio_v1alpha1_values_types_proto_init() }

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -152,6 +152,9 @@ message CNIAmbientConfig {
 
   // If enabled, and ambient is enabled, DNS redirection will be enabled.
   google.protobuf.BoolValue dnsCapture = 5;
+
+  // UNSTABLE: If enabled, and ambient is enabled, enables ipv6 support
+  google.protobuf.BoolValue ipv6 = 7;
 }
 
 message CNIRepairConfig {

--- a/pkg/workloadapi/security/authorization.pb.go
+++ b/pkg/workloadapi/security/authorization.pb.go
@@ -21,12 +21,11 @@
 package security
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/pkg/workloadapi/security/authorization.pb.go
+++ b/pkg/workloadapi/security/authorization.pb.go
@@ -21,11 +21,12 @@
 package security
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/releasenotes/notes/50747.yaml
+++ b/releasenotes/notes/50747.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 50162
+releaseNotes:
+- |
+  **Fixed** Allow ipv6 config to be propagated to ambient CNI. Note that IPv6 support is still unstable.

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -93,7 +93,7 @@ func (rb *IptablesRuleBuilder) InsertRuleV4(command log.Command, chain string, t
 }
 
 func (rb *IptablesRuleBuilder) InsertRuleV6(command log.Command, chain string, table string, position int, params ...string) *IptablesRuleBuilder {
-	if !rb.cfg.EnableInboundIPv6 {
+	if !rb.cfg.EnableIPv6 {
 		return rb
 	}
 	return rb.insertInternal(&rb.rules.rulesv6, command, chain, table, position, params...)
@@ -142,7 +142,7 @@ func (rb *IptablesRuleBuilder) AppendRule(command log.Command, chain string, tab
 }
 
 func (rb *IptablesRuleBuilder) AppendRuleV6(command log.Command, chain string, table string, params ...string) *IptablesRuleBuilder {
-	if !rb.cfg.EnableInboundIPv6 {
+	if !rb.cfg.EnableIPv6 {
 		return rb
 	}
 	return rb.appendInternal(&rb.rules.rulesv6, command, chain, table, params...)

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -161,7 +161,7 @@ func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
 }
 
 var IPv6Config = &config.Config{
-	EnableInboundIPv6: true,
+	EnableIPv6: true,
 }
 
 func TestBuildV6InsertSingleRule(t *testing.T) {

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -257,7 +257,7 @@ func ignoreExists(err error) error {
 // in the 127.x.y.z range, while IPv6 defaults to `prefixlen 128` which allows binding only to ::1.
 // Equivalent to `ip -6 addr add "::6/128" dev lo`
 func configureIPv6Addresses(cfg *config.Config) error {
-	if !cfg.EnableInboundIPv6 {
+	if !cfg.EnableIPv6 {
 		return nil
 	}
 	link, err := netlink.LinkByName("lo")
@@ -292,7 +292,7 @@ func (cfg *IptablesConfigurator) Run() error {
 	defer func() {
 		// Best effort since we don't know if the commands exist
 		_ = cfg.ext.Run(constants.IPTablesSave, &iptVer, nil)
-		if cfg.cfg.EnableInboundIPv6 {
+		if cfg.cfg.EnableIPv6 {
 			_ = cfg.ext.Run(constants.IPTablesSave, &ipt6Ver, nil)
 		}
 	}()

--- a/tools/istio-iptables/pkg/capture/run_linux.go
+++ b/tools/istio-iptables/pkg/capture/run_linux.go
@@ -46,7 +46,7 @@ func configureTProxyRoutes(cfg *config.Config) error {
 			// Route all packets marked in chain ISTIODIVERT using routing table ${INBOUND_TPROXY_ROUTE_TABLE}.
 			// Equivalent to `ip rule add fwmark <tproxyMark> lookup <tproxyTable>`
 			families := []int{unix.AF_INET}
-			if cfg.EnableInboundIPv6 {
+			if cfg.EnableIPv6 {
 				families = append(families, unix.AF_INET6)
 			}
 			for _, family := range families {
@@ -62,7 +62,7 @@ func configureTProxyRoutes(cfg *config.Config) error {
 			// the loopback interface.
 			// Equivalent to `ip route add local default dev lo table <table>`
 			cidrs := []string{"0.0.0.0/0"}
-			if cfg.EnableInboundIPv6 {
+			if cfg.EnableIPv6 {
 				cidrs = append(cidrs, "0::0/0")
 			}
 			for _, fullCIDR := range cidrs {

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -51,7 +51,7 @@ func TestIptables(t *testing.T) {
 			"ipv6-empty-inbound-ports",
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = ""
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestIptables(t *testing.T) {
 				cfg.OutboundIPRangesInclude = "9.9.0.0/16"
 				cfg.DryRun = true
 				cfg.RedirectDNS = true
-				cfg.EnableInboundIPv6 = false
+				cfg.EnableIPv6 = false
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
 				cfg.DNSServersV4 = []string{"127.0.0.53"}
@@ -80,14 +80,14 @@ func TestIptables(t *testing.T) {
 				cfg.ProxyGID = "1337"
 				cfg.ProxyUID = "1337"
 				cfg.ExcludeInterfaces = "not-istio-nic"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
 			"ipv6-inbound-ports",
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = "4000,5000"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
@@ -95,7 +95,7 @@ func TestIptables(t *testing.T) {
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = "4000,5000"
 				cfg.KubeVirtInterfaces = "eth0,eth1"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func TestIptables(t *testing.T) {
 				cfg.KubeVirtInterfaces = "eth0,eth1"
 				cfg.OutboundIPRangesExclude = "2001:db8::/32"
 				cfg.OutboundIPRangesInclude = "2001:db8::/32"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
@@ -117,7 +117,7 @@ func TestIptables(t *testing.T) {
 				cfg.KubeVirtInterfaces = "eth0,eth1"
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 				cfg.OutboundIPRangesExclude = "2001:db8::/32"
 				cfg.OutboundIPRangesInclude = "2001:db8::/32"
 			},
@@ -127,7 +127,7 @@ func TestIptables(t *testing.T) {
 			func(cfg *config.Config) {
 				cfg.InboundPortsInclude = ""
 				cfg.OutboundPortsInclude = "32000,31000"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
@@ -188,13 +188,13 @@ func TestIptables(t *testing.T) {
 				cfg.DNSServersV6 = []string{"::127.0.0.53"}
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 			},
 		},
 		{
 			"ipv6-dns-uid-gid",
 			func(cfg *config.Config) {
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 				cfg.RedirectDNS = true
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
@@ -215,7 +215,7 @@ func TestIptables(t *testing.T) {
 		{
 			"ipv6-dns-outbound-owner-groups",
 			func(cfg *config.Config) {
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 				cfg.RedirectDNS = true
 				cfg.OwnerGroupsInclude = "java,202"
 			},
@@ -223,7 +223,7 @@ func TestIptables(t *testing.T) {
 		{
 			"ipv6-dns-outbound-owner-groups-exclude",
 			func(cfg *config.Config) {
-				cfg.EnableInboundIPv6 = true
+				cfg.EnableIPv6 = true
 				cfg.RedirectDNS = true
 				cfg.OwnerGroupsExclude = "888,ftp"
 			},
@@ -241,7 +241,7 @@ func TestIptables(t *testing.T) {
 				cfg.DryRun = true
 				cfg.RedirectDNS = true
 				cfg.DNSServersV4 = []string{"127.0.0.53"}
-				cfg.EnableInboundIPv6 = false
+				cfg.EnableIPv6 = false
 				cfg.ProxyGID = "1,2"
 				cfg.ProxyUID = "3,4"
 			},

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	RedirectDNS             bool          `json:"REDIRECT_DNS"`
 	DropInvalid             bool          `json:"DROP_INVALID"`
 	CaptureAllDNS           bool          `json:"CAPTURE_ALL_DNS"`
-	EnableIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
+	EnableIPv6              bool          `json:"ENABLE_INBOUND_IPV6"`
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -116,7 +116,12 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_INCLUDE=%s\n", c.OutboundPortsInclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_EXCLUDE=%s\n", c.OutboundPortsExclude))
 	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces))
+	// TODO consider renaming this env var to ENABLE_IPV6 - nothing about it is specific to "INBOUND"
 	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableIPv6))
+	// TODO remove this flag - "dual stack" should just mean
+	// - supports IPv6
+	// - supports pods with more than one podIP
+	// The former already has a flag, the latter is something we should do by default and is a bug where we do not
 	b.WriteString(fmt.Sprintf("DUAL_STACK=%t\n", c.DualStack))
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
 	b.WriteString(fmt.Sprintf("DROP_INVALID=%t\n", c.DropInvalid))
@@ -162,6 +167,7 @@ func (c *Config) FillConfigFromEnvironment() error {
 		c.ProxyGID = c.ProxyUID
 	}
 	// Detect whether IPv6 is enabled by checking if the pod's IP address is IPv4 or IPv6.
+	// TODO remove this check, it will break with more than one pod IP
 	hostIP, isIPv6, err := getLocalIP(c.DualStack)
 	if err != nil {
 		return err

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	RedirectDNS             bool          `json:"REDIRECT_DNS"`
 	DropInvalid             bool          `json:"DROP_INVALID"`
 	CaptureAllDNS           bool          `json:"CAPTURE_ALL_DNS"`
-	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
+	EnableIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
@@ -116,7 +116,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_INCLUDE=%s\n", c.OutboundPortsInclude))
 	b.WriteString(fmt.Sprintf("OUTBOUND_PORTS_EXCLUDE=%s\n", c.OutboundPortsExclude))
 	b.WriteString(fmt.Sprintf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces))
-	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableInboundIPv6))
+	b.WriteString(fmt.Sprintf("ENABLE_INBOUND_IPV6=%t\n", c.EnableIPv6))
 	b.WriteString(fmt.Sprintf("DUAL_STACK=%t\n", c.DualStack))
 	b.WriteString(fmt.Sprintf("DNS_CAPTURE=%t\n", c.RedirectDNS))
 	b.WriteString(fmt.Sprintf("DROP_INVALID=%t\n", c.DropInvalid))
@@ -168,7 +168,7 @@ func (c *Config) FillConfigFromEnvironment() error {
 	}
 
 	c.HostIP = hostIP
-	c.EnableInboundIPv6 = isIPv6
+	c.EnableIPv6 = isIPv6
 
 	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
 	// case where reading /etc/resolv.conf could fail.

--- a/tools/istio-iptables/pkg/config/config_test.go
+++ b/tools/istio-iptables/pkg/config/config_test.go
@@ -96,7 +96,7 @@ func TestGetLocalIP(t *testing.T) {
 				t.Errorf("getLocalIP err: %s", err)
 			}
 			if isV6 != tt.expected {
-				t.Errorf("unexpected EnableInboundIPv6 result, expected: %t got: %t", tt.expected, isV6)
+				t.Errorf("unexpected EnableIPv6 result, expected: %t got: %t", tt.expected, isV6)
 			}
 		})
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

This should fix https://github.com/istio/istio/issues/50162 and other related issues around IPV6 and our use of ipsets in ambient, namely

- Actually propagate the config from the pod manifest to the ambient CNI node agent (we have ipv6 rules, but they never got used due to this)
- Properly handle IPv4/V6 ipsets (Ideally we should be using `list:set` type ipsets for this, but `vishvananda/netlink` doesn't fully support those yet, so did it manually)

(note that ipv6 support in general (ambient && sidecar) is still unstable, but at least in terms of _traffic capture/redirection in ambient CNI_, it should not be broken/should work with this)