### PR TITLE
xds: push CDS on AUTO_PASSTHROUGH Gateway change

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -563,7 +563,10 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 	if node.Type != Router {
 		return
 	}
-	prevMergedGateway := *node.MergedGateway
+	var prevMergedGateway MergedGateway
+	if node.MergedGateway != nil {
+		prevMergedGateway = *node.MergedGateway
+	}
 	node.MergedGateway = ps.mergeGateways(node)
 	if prevMergedGateway.ContainsAutoPassthroughGateways {
 		node.PrevMergedGateway = &PrevMergedGateway{

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -568,11 +568,9 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 		prevMergedGateway = *node.MergedGateway
 	}
 	node.MergedGateway = ps.mergeGateways(node)
-	if prevMergedGateway.ContainsAutoPassthroughGateways {
-		node.PrevMergedGateway = &PrevMergedGateway{
-			ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
-			AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
-		}
+	node.PrevMergedGateway = &PrevMergedGateway{
+		ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
+		AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
 	}
 }
 

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -570,7 +570,8 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 	node.MergedGateway = ps.mergeGateways(node)
 	if prevMergedGateway.ContainsAutoPassthroughGateways {
 		node.PrevMergedGateway = &PrevMergedGateway{
-			AutoPassthroughSNIHosts: prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
+			ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
+			AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
 		}
 	}
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -361,6 +361,9 @@ type Proxy struct {
 	// The merged gateways associated with the proxy if this is a Router
 	MergedGateway *MergedGateway
 
+	// PrevMergedGateway contains information about merged gateway associated with the proxy previously
+	PrevMergedGateway *PrevMergedGateway
+
 	// ServiceTargets contains a list of all Services associated with the proxy, contextualized for this particular proxy.
 	// These are unique to this proxy, as the port information is specific to it - while a ServicePort is shared with the
 	// service, the target port may be distinct per-endpoint. So this maintains a view specific to this proxy.
@@ -560,7 +563,13 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 	if node.Type != Router {
 		return
 	}
+	prevMergedGateway := *node.MergedGateway
 	node.MergedGateway = ps.mergeGateways(node)
+	if prevMergedGateway.ContainsAutoPassthroughGateways {
+		node.PrevMergedGateway = &PrevMergedGateway{
+			AutoPassthroughSNIHosts: prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
+		}
+	}
 }
 
 func (node *Proxy) SetServiceTargets(serviceDiscovery ServiceDiscovery) {

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -92,8 +92,13 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 		return true
 	}
 	for config := range req.ConfigsUpdated {
-		if features.FilterGatewayClusterConfig && proxy.Type == model.Router {
-			if _, f := pushCdsGatewayConfig[config.Kind]; f {
+		if proxy.Type == model.Router {
+			if features.FilterGatewayClusterConfig {
+				if _, f := pushCdsGatewayConfig[config.Kind]; f {
+					return true
+				}
+			}
+			if proxy.MergedGateway.ContainsAutoPassthroughGateways && config.Kind == kind.Gateway {
 				return true
 			}
 		}

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -98,8 +98,13 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 					return true
 				}
 			}
-			if proxy.MergedGateway != nil && proxy.MergedGateway.ContainsAutoPassthroughGateways && config.Kind == kind.Gateway {
-				return true
+			if config.Kind == kind.Gateway {
+				if proxy.MergedGateway.HasAutoPassthroughGateways() != proxy.PrevMergedGateway.HasAutoPassthroughGateway() {
+					return true
+				}
+				if !proxy.MergedGateway.GetAutoPassthrughGatewaySNIHosts().Equals(proxy.PrevMergedGateway.GetAutoPassthroughSNIHosts()) {
+					return true
+				}
 			}
 		}
 

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -98,7 +98,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 					return true
 				}
 			}
-			if proxy.MergedGateway.ContainsAutoPassthroughGateways && config.Kind == kind.Gateway {
+			if proxy.MergedGateway != nil && proxy.MergedGateway.ContainsAutoPassthroughGateways && config.Kind == kind.Gateway {
 				return true
 			}
 		}

--- a/releasenotes/notes/push-cds-on-auto-passthrough-gateway-change.yaml
+++ b/releasenotes/notes/push-cds-on-auto-passthrough-gateway-change.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** returning 503 errors by auto-passthrough gateways created after enabling mTLS.


### PR DESCRIPTION
**Please provide a description of this PR:**

I noticed that auto-passthrough gateways created after enabling mTLS return 503 errors due to missing clusters. After investigating the implementation, I noticed that SNI DNAT clusters (in format `outbound_.<port>_.<subset>_.<hostname>`) are returned only when they are referenced by listeners, and at the same time a Gateway change triggered only LDS update. This means that mTLS must be created after creating a Gateway or the Gateway deployment must be restarted after enabling mTLS to pull all XDS resources.

**How to reproduce this issue:**
```
cat <<EOF >> istio.yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  name: control-plane
spec:
  profile: minimal
  meshConfig:
    accessLogFile: /dev/stdout
  values:
    global:
      network: network-1
  components:
    ingressGateways:
    - name: istio-eastwestgateway
      label:
        istio: eastwestgateway
        app: istio-eastwestgateway
        topology.istio.io/network: network-1
      enabled: true
      k8s:
        env:
        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
          value: network-1
        service:
          ports:
          - name: status-port
            port: 15021
            targetPort: 15021
          - name: tls
            port: 15443
            targetPort: 15443
          - name: tls-istiod
            port: 15012
            targetPort: 15012
          - name: tls-webhook
            port: 15017
            targetPort: 15017
EOF
cat <<EOF >> mtls.yaml
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
metadata:
  name: default
spec:
  mtls:
    mode: STRICT
EOF
cat <<EOF >> auto-passthrough-gateway.yaml
apiVersion: networking.istio.io/v1beta1
kind: Gateway
metadata:
  name: istio-eastwestgateway
spec:
  selector:
    istio: eastwestgateway
  servers:
  - port:
      number: 15443
      name: tls
      protocol: TLS
    hosts:
    - "httpbin.default.svc.cluster.local"
    tls:
      mode: AUTO_PASSTHROUGH
EOF
```
```
kind create cluster --name test
istioctl install -y -f istio.yaml
kubectl label namespaces default istio-injection=enabled
kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.21/samples/httpbin/httpbin.yaml
kubectl apply -f auto-passthrough-gateway.yaml -n istio-system
kubectl apply -f mtls.yaml -n istio-system
```
Now check clusters in the east-west gateway:
```
istioctl pc clusters deploy/istio-eastwestgateway -n istio-system
```
You should see:
```
SERVICE FQDN                                                                PORT      SUBSET     DIRECTION     TYPE           DESTINATION RULE
httpbin.default.svc.cluster.local                                           8000      -          outbound      EDS            
outbound_.8000_._.httpbin.default.svc.cluster.local                         -         -          -             EDS
```
Now, delete the gateway, disable mTLS and apply these resources in the reverse order:
```
kubectl delete peerauthentication default -n istio-system
kubectl delete gateway istio-eastwestgateway -n istio-system
kubectl apply -f mtls.yaml -n istio-system
kubectl apply -f auto-passthrough-gateway.yaml -n istio-system
```
Check clusters again and you shouldn't see `outbound_.*` clusters.