### PR TITLE
slices: remove redundant zeroing in Delete

### DIFF
--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -99,10 +99,8 @@ func Clone[S ~[]E, E any](s S) S {
 
 // Delete removes the element i from s, returning the modified slice.
 func Delete[S ~[]E, E any](s S, i int) S {
-	// "If those elements contain pointers you might consider zeroing those elements
-	// so that objects they reference can be garbage collected."
-	var empty E
-	s[i] = empty
+	// Since Go 1.22, "slices.Delete zeroes the elements s[len(s)-(j-i):len(s)]"
+	// (no memory leak)
 	return slices.Delete(s, i, i+1)
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Hi, this very small cleanup is removing the explicit zeroing `s[i] = empty` in `slices.Delete`.

2 good reasons to do this:

- The stdlib `slices.Delete` does now zero/nil out the obsolete elements, since Go 1.22 ([1](https://github.com/golang/go/issues/63393), [2](https://go.dev/cl/541477), [3](https://go.dev/blog/generic-slice-functions)).  No need to have `istio.io/istio/pkg/slices` do the zeroing anymore.
  - istio's `go.mod` specifies `go 1.22.0` so we can move forward
- Zeroing the correct elements is a subtle exercise. The former code was zeroing at the index being deleted (overwritten), which is not what we wanted. We wanted to zero the now-obsolete element **at the end** of the slice. The test `TestDelete` did check if the deleted element was garbage collected, but passed "by chance" because the deleted index happened to be last in the slice. In general, the elements leaking were not necessarily the elements being deleted.

No change to the unit tests is needed.