### PR TITLE
Optimize service sorting

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1615,16 +1615,15 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 // SortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
 func SortServicesByCreationTime(services []*Service) []*Service {
 	slices.SortStableFunc(services, func(a, b *Service) int {
-		r := a.CreationTime.Compare(b.CreationTime)
+		if r := a.CreationTime.Compare(b.CreationTime); r != 0 {
+			return r
+		}
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.
-		if r == 0 {
-			an := a.Attributes.Name + "." + a.Attributes.Namespace
-			bn := b.Attributes.Name + "." + b.Attributes.Namespace
-			return cmp.Compare(an, bn)
-		}
-		return r
+		an := a.Attributes.Name + "." + a.Attributes.Namespace
+		bn := b.Attributes.Name + "." + b.Attributes.Namespace
+		return cmp.Compare(an, bn)
 	})
 	return services
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1614,16 +1614,17 @@ func resolveServiceAliases(allServices []*Service, configsUpdated sets.Set[Confi
 
 // SortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
 func SortServicesByCreationTime(services []*Service) []*Service {
-	sort.SliceStable(services, func(i, j int) bool {
+	slices.SortStableFunc(services, func(a, b *Service) int {
+		r := a.CreationTime.Compare(b.CreationTime)
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
 		// CreationTimestamp is stored in seconds, so this is not uncommon.
-		if services[i].CreationTime.Equal(services[j].CreationTime) {
-			in := services[i].Attributes.Name + "." + services[i].Attributes.Namespace
-			jn := services[j].Attributes.Name + "." + services[j].Attributes.Namespace
-			return in < jn
+		if r == 0 {
+			an := a.Attributes.Name + "." + a.Attributes.Namespace
+			bn := b.Attributes.Name + "." + b.Attributes.Namespace
+			return cmp.Compare(an, bn)
 		}
-		return services[i].CreationTime.Before(services[j].CreationTime)
+		return r
 	})
 	return services
 }

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -3368,20 +3368,3 @@ func BenchmarkInitServiceAccounts(b *testing.B) {
 		ps.initServiceAccounts(env, services)
 	}
 }
-
-func BenchmarkSortServicesByCreationTime(b *testing.B) {
-	cs := make([]*Service, 0, 1000)
-	for i := 0; i < 1000; i++ {
-		cs = append(cs, &Service{
-			CreationTime: time.Now().Add(time.Duration(i)),
-			Attributes: ServiceAttributes{
-				Name:      fmt.Sprintf("name%d", i),
-				Namespace: "default",
-			},
-		})
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		SortServicesByCreationTime(cs)
-	}
-}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -3368,3 +3368,20 @@ func BenchmarkInitServiceAccounts(b *testing.B) {
 		ps.initServiceAccounts(env, services)
 	}
 }
+
+func BenchmarkSortServicesByCreationTime(b *testing.B) {
+	cs := make([]*Service, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		cs = append(cs, &Service{
+			CreationTime: time.Now().Add(time.Duration(i)),
+			Attributes: ServiceAttributes{
+				Name:      fmt.Sprintf("name%d", i),
+				Namespace: "default",
+			},
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SortServicesByCreationTime(cs)
+	}
+}

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -70,15 +70,13 @@ func SortFunc[E any](x []E, less func(a, b E) int) []E {
 }
 
 // SortStableFunc sorts the slice x while keeping the original order of equal element.
-// cmp(a, b) should return a negative number when a < b, a positive number when
-// a > b and zero when a == b.
 // The slice is modified in place but returned.
-// If E is not a pointer type, sort.SliceStable may be more efficient.
-func SortStableFunc[E any](x []E, cmp func(a, b E) int) []E {
+// Please refer to SortFunc for usage instructions.
+func SortStableFunc[E any](x []E, less func(a, b E) int) []E {
 	if len(x) <= 1 {
 		return x
 	}
-	slices.SortStableFunc(x, cmp)
+	slices.SortStableFunc(x, less)
 	return x
 }
 

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -69,6 +69,19 @@ func SortFunc[E any](x []E, less func(a, b E) int) []E {
 	return x
 }
 
+// SortStableFunc sorts the slice x while keeping the original order of equal element.
+// cmp(a, b) should return a negative number when a < b, a positive number when
+// a > b and zero when a == b.
+// The slice is modified in place but returned.
+// If E is not a pointer type, sort.SliceStable may be more efficient.
+func SortStableFunc[E any](x []E, cmp func(a, b E) int) []E {
+	if len(x) <= 1 {
+		return x
+	}
+	slices.SortStableFunc(x, cmp)
+	return x
+}
+
 // SortBy is a helper to sort a slice by some value. Typically, this would be sorting a struct
 // by a single field. If you need to have multiple fields, see the ExampleSort.
 func SortBy[E any, A constraints.Ordered](x []E, extract func(a E) A) []E {

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -787,7 +787,7 @@ func makeRandomStructs(n int) []*myStruct {
 const N = 100_000
 
 func BenchmarkSort(b *testing.B) {
-	b.Run("bool", func(b *testing.B) {
+	b.Run("SortFunc", func(b *testing.B) {
 		cmpFunc := func(a, b *myStruct) int { return a.n - b.n }
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
@@ -796,7 +796,16 @@ func BenchmarkSort(b *testing.B) {
 			SortFunc(ss, cmpFunc)
 		}
 	})
-	b.Run("by", func(b *testing.B) {
+	b.Run("SortStableFunc", func(b *testing.B) {
+		cmpFunc := func(a, b *myStruct) int { return a.n - b.n }
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			ss := makeRandomStructs(N)
+			b.StartTimer()
+			SortStableFunc(ss, cmpFunc)
+		}
+	})
+	b.Run("SortBy", func(b *testing.B) {
 		cmpFunc := func(a *myStruct) int { return a.n }
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()


### PR DESCRIPTION
Changed `sort.SliceStable` to `slices.SortStableFunc`.

```
goos: darwin
goarch: arm64
pkg: istio.io/istio/pilot/pkg/model
                             │   old.txt   │              new.txt               │
                             │   sec/op    │   sec/op     vs base               │
SortServicesByCreationTime-8   8.795µ ± 2%   5.005µ ± 1%  -43.10% (p=0.002 n=6)

                             │  old.txt   │              new.txt              │
                             │    B/op    │   B/op     vs base                │
SortServicesByCreationTime-8   56.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)

                             │  old.txt   │              new.txt               │
                             │ allocs/op  │ allocs/op   vs base                │
SortServicesByCreationTime-8   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
```