### PR TITLE
Add --for to waypoint generate to allow preview of yaml

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -126,6 +126,11 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return nil
 		},
 	}
+	waypointGenerateCmd.PersistentFlags().StringVar(&trafficType,
+		"for",
+		"service",
+		fmt.Sprintf("Specify the traffic type %s for the waypoint", sets.SortedList(validTrafficTypes)),
+	)
 	waypointApplyCmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply a waypoint configuration",

--- a/releasenotes/notes/50791.yaml
+++ b/releasenotes/notes/50791.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 50790
+releaseNotes:
+- |
+  **Added** Add --for flag to istioctl x waypoint generate command so that the user can preview the yaml before they apply it.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #50790 

Adds the `--for` flag to the waypoint generate command so that users can preview what the flag does before they run it. It should show what the update looks like with the `istio.io/waypoint-for` annotation updated. Ran it locally to confirm (reviewer can reproduce this the same way):

Create local istioctl build with this change:
```
azureuser@dev-2024:~/istio$ make istioctl 
azureuser@dev-2024:~/istio$ alias ik=./out/linux_amd64/istioctl                                                                    
azureuser@dev-2024:~/istio$ ik
```

Ran the command for the different options and got the following expected results:

**Not an existing option:**
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for foobar                                                                    
Error: failed to create gateway: invalid traffic type: foobar. Valid options are: [service workload all none]     
```

**Flag with no option provided:**
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for                                                                           
Error: flag needs an argument: --for
```

Generate with no use of flag (should default to service):
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate
```
```yaml                                                                                 
apiVersion: gateway.networking.k8s.io/v1                                                                                           
kind: Gateway                                                                                                                      
metadata:                                                                                                                            
    labels:                                                                                                                              
        istio.io/waypoint-for: service                                                                                                   
    name: waypoint                                                                                                                   
spec:                                                                                                                                
    gatewayClassName: istio-waypoint                                                                                                   
    listeners:                                                                                                                         
    - name: mesh                                                                                                                         
      port: 15008                                                                                                                        
      protocol: HBONE
```

Generate with none when specifying none:
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for none
```
```yaml                                                                                 
apiVersion: gateway.networking.k8s.io/v1                                                                                           
kind: Gateway                                                                                                                      
metadata:                                                                                                                            
    labels:                                                                                                                              
        istio.io/waypoint-for: none
    name: waypoint                                                                                                                   
spec:                                                                                                                                
    gatewayClassName: istio-waypoint                                                                                                   
    listeners:                                                                                                                         
    - name: mesh                                                                                                                         
      port: 15008                                                                                                                        
      protocol: HBONE
```

Generate with service when specifying service:
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for service
```
```yaml                                                                                 
apiVersion: gateway.networking.k8s.io/v1                                                                                           
kind: Gateway                                                                                                                      
metadata:                                                                                                                            
    labels:                                                                                                                              
        istio.io/waypoint-for: service
    name: waypoint                                                                                                                   
spec:                                                                                                                                
    gatewayClassName: istio-waypoint                                                                                                   
    listeners:                                                                                                                         
    - name: mesh                                                                                                                         
      port: 15008                                                                                                                        
      protocol: HBONE
```

Generate with all when specifying all:
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for all
```
```yaml                                                                                 
apiVersion: gateway.networking.k8s.io/v1                                                                                           
kind: Gateway                                                                                                                      
metadata:                                                                                                                            
    labels:                                                                                                                              
        istio.io/waypoint-for: all
    name: waypoint                                                                                                                   
spec:                                                                                                                                
    gatewayClassName: istio-waypoint                                                                                                   
    listeners:                                                                                                                         
    - name: mesh                                                                                                                         
      port: 15008                                                                                                                        
      protocol: HBONE
```


Generate with workload when specifying workload:
```bash
azureuser@dev-2024:~/istio$ ik x waypoint generate --for workload
```
```yaml                                                                                 
apiVersion: gateway.networking.k8s.io/v1                                                                                           
kind: Gateway                                                                                                                      
metadata:                                                                                                                            
    labels:                                                                                                                              
        istio.io/waypoint-for: workload
    name: waypoint                                                                                                                   
spec:                                                                                                                                
    gatewayClassName: istio-waypoint                                                                                                   
    listeners:                                                                                                                         
    - name: mesh                                                                                                                         
      port: 15008                                                                                                                        
      protocol: HBONE
```