### PR TITLE
Use label istio.io/dataplane-mode=disabled for pod-level ambient opt-out

### DIFF
--- a/cni/README.md
+++ b/cni/README.md
@@ -63,9 +63,9 @@ Istio CNI injection is currently based on the same Pod annotations used in init-
 
 - plugin config "exclude namespaces" applies first
 - ambient is enabled if:
-    - namespace label "istio.io/dataplane-mode" == "ambient" is required (may change for 'on-by-default' mode)
+    - namespace label "istio.io/dataplane-mode" == "ambient", and/or pod label "istio.io/dataplane-mode" == "ambient"
     - "sidecar.istio.io/status" annotation is not present on the pod (created by injection of sidecar)
-    - "ambient.istio.io/redirection" is not "disabled"
+    - pod label "istio.io/dataplane-mode" is not "none"
 - sidecar interception is enabled if:
     - "istio-init" container is not present in the pod.
     - istio-proxy container exists and

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -207,13 +207,10 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		}
 		wasAnnotated := oldPod.Annotations != nil && oldPod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled
 		isAnnotated := newPod.Annotations != nil && newPod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled
-		isOpOut := newPod.Annotations != nil && newPod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionDisabled
 		shouldBeEnabled := util.PodRedirectionEnabled(ns, newPod)
 
 		// We should check the latest annotation vs desired status
 		changeNeeded := isAnnotated != shouldBeEnabled
-		// Also need change for case user manually rolls out the pods
-		changeNeeded = changeNeeded || (wasAnnotated && isOpOut && !shouldBeEnabled)
 
 		log.Debugf("Pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), oldPod(%+v), newPod(%+v)",
 			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, oldPod, newPod)

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -371,7 +371,7 @@ func TestExistingPodRemovedWhenPodAnnotated(t *testing.T) {
 
 	// label the pod for exclusion
 	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
-		constants.DataplaneMode, constants.DataplaneModeNone))
+		constants.DataplaneModeLabel, constants.DataplaneModeNone))
 	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
 		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
@@ -452,7 +452,7 @@ func TestAmbientEnabledReturnsNoPodIfNotEnabled(t *testing.T) {
 			Name:      "test",
 			Namespace: "test",
 			UID:       "1234",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeNone},
+			Labels:    map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: NodeName,
@@ -496,7 +496,7 @@ func TestAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {
 			Name:      "test",
 			Namespace: "test",
 			UID:       "1234",
-			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeNone},
+			Labels:    map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: NodeName,

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -369,11 +369,11 @@ func TestExistingPodRemovedWhenPodAnnotated(t *testing.T) {
 		mock.Anything,
 	).Once().Return(nil)
 
-	// annotate the pod
-	annotationsPatch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`,
-		constants.AmbientRedirection, constants.AmbientRedirectionDisabled))
+	// label the pod for exclusion
+	labelsPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+		constants.DataplaneMode, constants.DataplaneModeNone))
 	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
-		types.MergePatchType, annotationsPatch, metav1.PatchOptions{})
+		types.MergePatchType, labelsPatch, metav1.PatchOptions{})
 	assert.NoError(t, err)
 
 	// wait for an update events
@@ -384,7 +384,7 @@ func TestExistingPodRemovedWhenPodAnnotated(t *testing.T) {
 
 	assertPodNotAnnotated(t, client, pod)
 
-	// patch a test label to emulate a non-annotation POD update event
+	// patch a test label to emulate a POD update event
 	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
 		types.MergePatchType, []byte(`{"metadata":{"labels":{"test":"update"}}}`), metav1.PatchOptions{})
 	assert.NoError(t, err)
@@ -449,10 +449,10 @@ func TestAmbientEnabledReturnsNoPodIfNotEnabled(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test",
-			Namespace:   "test",
-			UID:         "1234",
-			Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+			Name:      "test",
+			Namespace: "test",
+			UID:       "1234",
+			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeNone},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: NodeName,
@@ -493,10 +493,10 @@ func TestAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test",
-			Namespace:   "test",
-			UID:         "1234",
-			Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+			Name:      "test",
+			Namespace: "test",
+			UID:       "1234",
+			Labels:    map[string]string{constants.DataplaneMode: constants.DataplaneModeNone},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: NodeName,

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -297,7 +297,7 @@ func TestCmdAddPodWithGenericSidecar(t *testing.T) {
 	assert.Equal(t, wasCalled, true)
 }
 
-func TestCmdAddPodDisabledAnnotation(t *testing.T) {
+func TestCmdAddPodDisabledLabel(t *testing.T) {
 	url, serverClose := setupCNIEventClientWithMockServer(false)
 
 	cniConf := buildMockConf(true, url)
@@ -312,7 +312,7 @@ func TestCmdAddPodDisabledAnnotation(t *testing.T) {
 	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
 	wasCalled := serverClose()
-	// Pod has an explicit opt-out annotation, should not be added to ambient mesh
+	// Pod has an explicit opt-out label, should not be added to ambient mesh
 	assert.Equal(t, wasCalled, false)
 }
 
@@ -324,7 +324,7 @@ func TestCmdAddPodEnabledNamespaceDisabled(t *testing.T) {
 	pod, ns := buildFakePodAndNSForClient()
 
 	app := corev1.Container{Name: "app"}
-	pod.ObjectMeta.Annotations = map[string]string{constants.DataplaneModeLabel: constants.AmbientRedirectionEnabled}
+	pod.ObjectMeta.Labels = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient}
 	pod.Spec.Containers = []corev1.Container{app}
 
 	testDoAddRun(t, cniConf, testNSName, pod, ns)
@@ -332,7 +332,7 @@ func TestCmdAddPodEnabledNamespaceDisabled(t *testing.T) {
 	wasCalled := serverClose()
 	// Currently, we do not allow individual pod opt-in to ambient if namespace is not labeled, so pod
 	// shouls not be added to ambient
-	assert.Equal(t, wasCalled, false)
+	assert.Equal(t, wasCalled, true)
 }
 
 func TestCmdAddPodInExcludedNamespace(t *testing.T) {

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -330,8 +330,6 @@ func TestCmdAddPodEnabledNamespaceDisabled(t *testing.T) {
 	testDoAddRun(t, cniConf, testNSName, pod, ns)
 
 	wasCalled := serverClose()
-	// Currently, we do not allow individual pod opt-in to ambient if namespace is not labeled, so pod
-	// shouls not be added to ambient
 	assert.Equal(t, wasCalled, true)
 }
 

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -305,8 +305,8 @@ func TestCmdAddPodDisabledAnnotation(t *testing.T) {
 	pod, ns := buildFakePodAndNSForClient()
 
 	app := corev1.Container{Name: "app"}
-	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneModeLabel: constants.AmbientRedirectionEnabled}
-	pod.ObjectMeta.Annotations = map[string]string{constants.DataplaneModeLabel: constants.AmbientRedirectionDisabled}
+	ns.ObjectMeta.Labels = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient}
+	pod.ObjectMeta.Labels = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone}
 	pod.Spec.Containers = []corev1.Container{app}
 
 	testDoAddRun(t, cniConf, testNSName, pod, ns)

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -40,7 +40,6 @@ var annotationRemovePatch = []byte(fmt.Sprintf(
 	constants.AmbientRedirection,
 ))
 
-// TODO: we should use the upstream istio version of this function.
 // PodRedirectionEnabled determines if a pod should or should not be configured
 // to have traffic redirected thru the node proxy.
 func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
@@ -53,10 +52,8 @@ func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
 		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
 		return false
 	}
-	// TODO: delete this block when there is a way for users to signal the intent to exclude
-	// a pod from ambient that does not require the use of this annotation
-	if pod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionDisabled {
-		// Pod explicitly asked to not have redirection enabled
+	if pod.GetLabels()[constants.DataplaneMode] == constants.DataplaneModeNone {
+		// Pod explicitly asked to not have ambient redirection enabled
 		return false
 	}
 	return true

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -52,7 +52,7 @@ func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
 		// Ztunnel and sidecar for a single pod is currently not supported; opt out.
 		return false
 	}
-	if pod.GetLabels()[constants.DataplaneMode] == constants.DataplaneModeNone {
+	if pod.GetLabels()[constants.DataplaneModeLabel] == constants.DataplaneModeNone {
 		// Pod explicitly asked to not have ambient redirection enabled
 		return false
 	}

--- a/cni/pkg/util/podutil_test.go
+++ b/cni/pkg/util/podutil_test.go
@@ -80,9 +80,9 @@ func TestGetPodIPsIfNoPodIPPresent(t *testing.T) {
 
 func TestPodRedirectionEnabled(t *testing.T) {
 	var (
-		ambientEnabledLabel       = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient}
-		ambientDisabledAnnotation = map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled}
-		sidecarStatusAnnotation   = map[string]string{annotation.SidecarStatus.Name: "test"}
+		ambientEnabledLabel     = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient}
+		ambientDisabledLabel    = map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone}
+		sidecarStatusAnnotation = map[string]string{annotation.SidecarStatus.Name: "test"}
 
 		namespaceWithAmbientEnabledLabel = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -120,22 +120,14 @@ func TestPodRedirectionEnabled(t *testing.T) {
 			},
 		}
 
-		podWithAmbientDisabledAnnotation = &corev1.Pod{
+		podWithAmbientDisabledLabel = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "test",
-				Namespace:   "test",
-				Annotations: ambientDisabledAnnotation,
+				Name:      "test",
+				Namespace: "test",
+				Labels:    ambientDisabledLabel,
 			},
 		}
 
-		podWithAmbientEnabledLabelAndAmbientDisabledAnnotation = &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "test",
-				Namespace:   "test",
-				Labels:      ambientEnabledLabel,
-				Annotations: ambientDisabledAnnotation,
-			},
-		}
 		podWithSidecarAndAmbientEnabledLabel = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "test",
@@ -195,23 +187,11 @@ func TestPodRedirectionEnabled(t *testing.T) {
 			},
 			want: false,
 		},
-		// TODO: when there exists a means for users to signal the intent to exclude a pod from ambient without requiring the use of
-		// the ambient redirection annotation, this annotation should no longer be checked by this function and this case should return 'true'
 		{
-			name: "pod has annotation to disable ambient redirection",
+			name: "pod has label to disable ambient redirection",
 			args: args{
 				namespace: namespaceWithAmbientEnabledLabel,
-				pod:       podWithAmbientDisabledAnnotation,
-			},
-			want: false,
-		},
-		// TODO: when there exists a means for users to signal the intent to exclude a pod from ambient without requiring the use of
-		// the ambient redirection annotation, this annotation should no longer be checked by this function and this case should return 'true'
-		{
-			name: "pod has label to enable ambient mode and annotation to disable ambient redirection",
-			args: args{
-				namespace: namespaceWithAmbientEnabledLabel,
-				pod:       podWithAmbientEnabledLabelAndAmbientDisabledAnnotation,
+				pod:       podWithAmbientDisabledLabel,
 			},
 			want: false,
 		},

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -30,9 +30,9 @@ spec:
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
+        istio.io/dataplane-mode: none
       annotations:
         sidecar.istio.io/inject: "false"
-        ambient.istio.io/redirection: disabled
         # Add Prometheus Scrape annotations
         prometheus.io/scrape: 'true'
         prometheus.io/port: "15014"

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -52,7 +52,6 @@ spec:
           (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
           (strdict "istio.io/rev" (.Revision | default "default"))
           (strdict
-            "ambient.istio.io/redirection" "disabled"
             "prometheus.io/path" "/stats/prometheus"
             "prometheus.io/port" "15020"
             "prometheus.io/scrape" "true"
@@ -61,6 +60,7 @@ spec:
         {{- toJsonMap
           (strdict
             "sidecar.istio.io/inject" "false"
+            "istio.io/dataplane-mode" "none"
             "service.istio.io/canonical-name" .DeploymentName
             "service.istio.io/canonical-revision" "latest"
            )

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -47,12 +47,12 @@ spec:
         {{- range $key, $val := .Values.pilot.podLabels }}
         {{ $key }}: "{{ $val }}"
         {{- end }}
+        istio.io/dataplane-mode: none
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         {{- end }}
-        ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
         {{- if .Values.pilot.podAnnotations }}
 {{ toYaml .Values.pilot.podAnnotations | indent 8 }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -19,10 +19,10 @@ spec:
     metadata:
       labels:
         sidecar.istio.io/inject: "false"
+        istio.io/dataplane-mode: none
         app: ztunnel
 {{ with .Values.podLabels -}}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
-        ambient.istio.io/redirection: disabled
         sidecar.istio.io/inject: "false"
 {{ with .Values.podAnnotations -}}{{ toYaml . | indent 8 }}{{ end }}
     spec:

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -361,11 +361,11 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	// TODO this sprays ambient annotations/labels all over EVER gateway resource (serviceaccts, services, etc)
 	// where they have no meaning/are not used/are ignored. We really only need them on the deployment podspec.
 	var hasAmbientLabel bool
-	if _, ok := gw.Labels[constants.DataplaneMode]; ok {
+	if _, ok := gw.Labels[constants.DataplaneModeLabel]; ok {
 		hasAmbientLabel = true
 	}
 	if gw.Spec.Infrastructure != nil {
-		if _, ok := gw.Spec.Infrastructure.Labels[constants.DataplaneMode]; ok {
+		if _, ok := gw.Spec.Infrastructure.Labels[constants.DataplaneModeLabel]; ok {
 			hasAmbientLabel = true
 		}
 	}
@@ -374,7 +374,7 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		if gw.Labels == nil {
 			gw.Labels = make(map[string]string)
 		}
-		gw.Labels[constants.DataplaneMode] = constants.DataplaneModeNone
+		gw.Labels[constants.DataplaneModeLabel] = constants.DataplaneModeNone
 	}
 
 	input := TemplateInput{

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -358,21 +358,23 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		gw.Labels[label.TopologyNetwork.Name] = d.injectConfig().Values.Struct().GetGlobal().GetNetwork()
 	}
 
-	// Disable ambient redirection for kube-gateway if there is no explicit setting
-	var hasAmbientAnnotation bool
-	if _, ok := gw.Annotations[constants.AmbientRedirection]; ok {
-		hasAmbientAnnotation = true
+	// TODO this sprays ambient annotations/labels all over EVER gateway resource (serviceaccts, services, etc)
+	// where they have no meaning/are not used/are ignored. We really only need them on the deployment podspec.
+	var hasAmbientLabel bool
+	if _, ok := gw.Labels[constants.DataplaneMode]; ok {
+		hasAmbientLabel = true
 	}
 	if gw.Spec.Infrastructure != nil {
-		if _, ok := gw.Spec.Infrastructure.Annotations[constants.AmbientRedirection]; ok {
-			hasAmbientAnnotation = true
+		if _, ok := gw.Spec.Infrastructure.Labels[constants.DataplaneMode]; ok {
+			hasAmbientLabel = true
 		}
 	}
-	if features.EnableAmbientWaypoints && !isWaypointGateway && !hasAmbientAnnotation {
-		if gw.Annotations == nil {
-			gw.Annotations = make(map[string]string)
+	// If no ambient redirection label is set explicitly, explicitly disable.
+	if features.EnableAmbientWaypoints && !isWaypointGateway && !hasAmbientLabel {
+		if gw.Labels == nil {
+			gw.Labels = make(map[string]string)
 		}
-		gw.Annotations[constants.AmbientRedirection] = constants.AmbientRedirectionDisabled
+		gw.Labels[constants.DataplaneMode] = constants.DataplaneModeNone
 	}
 
 	input := TemplateInput{

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -308,8 +308,9 @@ func TestConfigureIstioGateway(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
-					Annotations: map[string]string{
-						"ambient.istio.io/redirection": "enabled",
+					// TODO why are we setting this on gateways?
+					Labels: map[string]string{
+						constants.DataplaneMode: constants.DataplaneModeAmbient,
 					},
 				},
 				Spec: k8s.GatewaySpec{
@@ -328,8 +329,9 @@ func TestConfigureIstioGateway(t *testing.T) {
 				Spec: k8s.GatewaySpec{
 					GatewayClassName: k8s.ObjectName(features.GatewayAPIDefaultGatewayClass),
 					Infrastructure: &k8s.GatewayInfrastructure{
-						Annotations: map[k8s.AnnotationKey]k8s.AnnotationValue{
-							"ambient.istio.io/redirection": "enabled",
+						// TODO why are we setting this on gateways?
+						Labels: map[k8s.AnnotationKey]k8s.AnnotationValue{
+							constants.DataplaneMode: constants.DataplaneModeAmbient,
 						},
 					},
 				},

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -310,7 +310,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 					Namespace: "default",
 					// TODO why are we setting this on gateways?
 					Labels: map[string]string{
-						constants.DataplaneMode: constants.DataplaneModeAmbient,
+						constants.DataplaneModeLabel: constants.DataplaneModeAmbient,
 					},
 				},
 				Spec: k8s.GatewaySpec{
@@ -331,7 +331,7 @@ func TestConfigureIstioGateway(t *testing.T) {
 					Infrastructure: &k8s.GatewayInfrastructure{
 						// TODO why are we setting this on gateways?
 						Labels: map[k8s.AnnotationKey]k8s.AnnotationValue{
-							constants.DataplaneMode: constants.DataplaneModeAmbient,
+							constants.DataplaneModeLabel: constants.DataplaneModeAmbient,
 						},
 					},
 				},

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -8,11 +8,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -26,11 +26,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default
   namespace: default
@@ -46,7 +46,6 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         networking.istio.io/service-type: ClusterIP
         prometheus.io/path: /stats/prometheus
@@ -54,6 +53,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
@@ -223,11 +223,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     networking.istio.io/service-type: ClusterIP
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-custom
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-custom
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-custom
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-custom
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: enabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: ambient
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: enabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: ambient
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: enabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: ambient
     istio.io/gateway-name: default
   name: default-istio
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: custom-sa
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     topology.istio.io/network: network-1
   name: default-istio
@@ -25,11 +25,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     topology.istio.io/network: network-1
   name: default
@@ -46,13 +46,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default
         service.istio.io/canonical-revision: latest
@@ -226,11 +226,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     topology.istio.io/network: network-1
   name: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -24,11 +24,11 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -44,13 +44,13 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -219,11 +219,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    ambient.istio.io/redirection: disabled
+  annotations: {}
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -8,11 +8,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     should: see
   name: default-istio
@@ -27,11 +27,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     should: see
   name: default-istio
@@ -48,7 +48,6 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
@@ -56,6 +55,7 @@ spec:
         should: see
       labels:
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -226,11 +226,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    ambient.istio.io/redirection: disabled
     should: see
   labels:
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
     should: see
   name: default-istio

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -44,7 +44,6 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
@@ -52,6 +51,7 @@ spec:
       labels:
         gateway.istio.io/managed: istio.io-mesh-controller
         gateway.networking.k8s.io/gateway-name: namespace
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: namespace
         service.istio.io/canonical-name: namespace
         service.istio.io/canonical-revision: latest

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -44,7 +44,6 @@ spec:
   template:
     metadata:
       annotations:
-        ambient.istio.io/redirection: disabled
         istio.io/rev: default
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
@@ -52,6 +51,7 @@ spec:
       labels:
         gateway.istio.io/managed: istio.io-mesh-controller
         gateway.networking.k8s.io/gateway-name: namespace
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: namespace
         service.istio.io/canonical-name: namespace
         service.istio.io/canonical-revision: latest

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -185,17 +185,22 @@ const (
 	ListenerModeOption          = "gateway.istio.io/listener-protocol"
 	ListenerModeAutoPassthrough = "auto-passthrough"
 
-	// DataplaneModeLabel namespace label for determining ambient mesh behavior
-	DataplaneModeLabel   = "istio.io/dataplane-mode"
+	// DataplaneMode namespace label for determining ambient mesh behavior
+	DataplaneModeLabel = "istio.io/dataplane-mode"
+	// Set by users to indicate that the (namespace|pod) should be captured for ambient
 	DataplaneModeAmbient = "ambient"
+	// Set by users to indicate that the (namespace|pod) should NOT be captured for ambient
+	DataplaneModeNone    = "none"
+	DataplaneModeInherit = "inherit" // TODO do we need this atm
 
 	// AmbientRedirection specifies whether a pod has ambient redirection (to ztunnel) configured.
 	AmbientRedirection = "ambient.istio.io/redirection"
-	// AmbientRedirectionEnabled indicates redirection is configured. This is set by the CNI when it
-	// actually sets up redirection, rather than by the user.
+	// AmbientRedirectionEnabled indicates redirection is configured. This is set by the CNI on pods
+	// when it actually has successfully set up pod redirection, rather than by the user.
+	//
+	// The presence of this annotation with this specific value indicates the pod is captured.
+	// Anything else indicates it is not.
 	AmbientRedirectionEnabled = "enabled"
-	// AmbientRedirectionDisabled is an opt-out, configured by user.
-	AmbientRedirectionDisabled = "disabled"
 
 	// AmbientUseWaypointLabelLabel is the label used to specify which waypoint should be used for a given pod, service, etc...
 	AmbientUseWaypointLabel = "istio.io/use-waypoint"

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.37.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.44.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.44.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.40.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1230,7 +1230,6 @@ templates:
               (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version")
               (strdict "istio.io/rev" (.Revision | default "default"))
               (strdict
-                "ambient.istio.io/redirection" "disabled"
                 "prometheus.io/path" "/stats/prometheus"
                 "prometheus.io/port" "15020"
                 "prometheus.io/scrape" "true"
@@ -1239,6 +1238,7 @@ templates:
             {{- toJsonMap
               (strdict
                 "sidecar.istio.io/inject" "false"
+                "istio.io/dataplane-mode" "none"
                 "service.istio.io/canonical-name" .DeploymentName
                 "service.istio.io/canonical-revision" "latest"
                )

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -243,8 +243,8 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			{
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
 				Labels: map[string]string{
-					label.SidecarInject.Name: "false",
-					constants.DataplaneMode:  constants.DataplaneModeNone,
+					label.SidecarInject.Name:     "false",
+					constants.DataplaneModeLabel: constants.DataplaneModeNone,
 				},
 			},
 		},
@@ -257,7 +257,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 		Subsets: []echo.SubsetConfig{{
 			Annotations: map[string]string{annotation.SidecarInterceptionMode.Name: "TPROXY"},
 			Labels: map[string]string{
-				constants.DataplaneMode: constants.DataplaneModeNone,
+				constants.DataplaneModeLabel: constants.DataplaneModeNone,
 			},
 		}},
 		IncludeExtAuthz: c.IncludeExtAuthz,

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -243,8 +243,8 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			{
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
 				Labels: map[string]string{
-					label.SidecarInject.Name:     "false",
-					constants.AmbientRedirection: constants.AmbientRedirectionDisabled,
+					label.SidecarInject.Name: "false",
+					constants.DataplaneMode:  constants.DataplaneModeNone,
 				},
 			},
 		},
@@ -257,7 +257,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 		Subsets: []echo.SubsetConfig{{
 			Annotations: map[string]string{annotation.SidecarInterceptionMode.Name: "TPROXY"},
 			Labels: map[string]string{
-				constants.AmbientRedirection: constants.AmbientRedirectionDisabled,
+				constants.DataplaneMode: constants.DataplaneModeNone,
 			},
 		}},
 		IncludeExtAuthz: c.IncludeExtAuthz,

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -365,7 +365,7 @@ func (c Config) HasSidecar() bool {
 
 func (c Config) IsUncaptured() bool {
 	// TODO this can be more robust to not require labeling initial echo config (check namespace + isWaypoint + not sidecar)
-	return len(c.Subsets) > 0 && c.Subsets[0].Annotations != nil && c.Subsets[0].Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionDisabled
+	return len(c.Subsets) > 0 && c.Subsets[0].Labels != nil && c.Subsets[0].Labels[constants.DataplaneModeLabel] == constants.DataplaneModeNone
 }
 
 func (c Config) HasProxyCapabilities() bool {
@@ -413,7 +413,7 @@ func (c Config) WaypointClient() bool {
 func (c Config) ZTunnelCaptured() bool {
 	haveSubsets := len(c.Subsets) > 0
 	if c.Namespace.IsAmbient() && haveSubsets &&
-		c.Subsets[0].Annotations[constants.AmbientRedirection] != constants.AmbientRedirectionDisabled &&
+		c.Subsets[0].Labels[constants.DataplaneModeLalbe] != constants.DataplaneModeNone &&
 		!c.HasSidecar() {
 		return true
 	}

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -413,7 +413,7 @@ func (c Config) WaypointClient() bool {
 func (c Config) ZTunnelCaptured() bool {
 	haveSubsets := len(c.Subsets) > 0
 	if c.Namespace.IsAmbient() && haveSubsets &&
-		c.Subsets[0].Labels[constants.DataplaneModeLalbe] != constants.DataplaneModeNone &&
+		c.Subsets[0].Labels[constants.DataplaneModeLabel] != constants.DataplaneModeNone &&
 		!c.HasSidecar() {
 		return true
 	}

--- a/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
+++ b/pkg/test/framework/components/echo/kube/templates/vm_deployment.yaml
@@ -16,12 +16,12 @@ spec:
       annotations:
         # Sidecar is inside the pod to simulate VMs - do not inject
         sidecar.istio.io/inject: "false"
-        # HBONE enabled proxy lives inside the VM. Don't use CNI to redirect.
-        ambient.istio.io/redirection: disabled
       labels:
         # Label should not be selected. We will create a workload entry instead
         istio.io/test-vm: {{ $.Service }}
         istio.io/test-vm-version: {{ $subset.Version }}
+        # HBONE enabled proxy lives inside the VM. Don't use CNI to redirect.
+        istio.io/dataplane-mode: none
     spec:
       # Disable kube-dns, to mirror VM
       # we set policy to none and explicitly provide a set of invalid values

--- a/releasenotes/notes/50804.yaml
+++ b/releasenotes/notes/50804.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 50736
+releaseNotes:
+- |
+  **Added** Allow pods to be opted out of ambient capture using the `istio.io/dataplane-mode=none` label.
+  **Removed** the ability to opt-out pods from ambient capture using the `ambient.istio.io/redirection=disabled` annotation, as that is a status annotation reserved for the CNI.

--- a/tests/integration/ambient/cnirepair/main_test.go
+++ b/tests/integration/ambient/cnirepair/main_test.go
@@ -162,16 +162,16 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v1",
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "true",
-						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
+						"sidecar.istio.io/inject":    "true",
+						constants.DataplaneModeLabel: constants.DataplaneModeNone,
 					},
 				},
 				{
 					Replicas: 1,
 					Version:  "v2",
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "true",
-						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
+						"sidecar.istio.io/inject":    "true",
+						constants.DataplaneModeLabel: constants.DataplaneModeNone,
 					},
 				},
 			},

--- a/tests/integration/ambient/cnirepair/main_test.go
+++ b/tests/integration/ambient/cnirepair/main_test.go
@@ -141,14 +141,14 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			ServiceAccount: true,
 			Subsets: []echo.SubsetConfig{
 				{
-					Replicas:    1,
-					Version:     "v1",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v1",
+					Labels:   map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 				},
 				{
-					Replicas:    1,
-					Version:     "v2",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v2",
+					Labels:   map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 				},
 			},
 		}).
@@ -159,19 +159,19 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			ServiceAccount: true,
 			Subsets: []echo.SubsetConfig{
 				{
-					Replicas:    1,
-					Version:     "v1",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v1",
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "true",
+						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
 					},
 				},
 				{
-					Replicas:    1,
-					Version:     "v2",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v2",
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "true",
+						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
 					},
 				},
 			},

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -328,16 +328,16 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 					Replicas: 1,
 					Version:  "v1",
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "true",
-						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
+						"sidecar.istio.io/inject":    "true",
+						constants.DataplaneModeLabel: constants.DataplaneModeNone,
 					},
 				},
 				{
 					Replicas: 1,
 					Version:  "v2",
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "true",
-						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
+						"sidecar.istio.io/inject":    "true",
+						constants.DataplaneModeLabel: constants.DataplaneModeNone,
 					},
 				},
 			},

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -251,14 +251,14 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			ServiceAccount: true,
 			Subsets: []echo.SubsetConfig{
 				{
-					Replicas:    1,
-					Version:     "v1",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v1",
+					Labels:   map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 				},
 				{
-					Replicas:    1,
-					Version:     "v2",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v2",
+					Labels:   map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeNone},
 				},
 			},
 		})
@@ -325,19 +325,19 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			ServiceAccount: true,
 			Subsets: []echo.SubsetConfig{
 				{
-					Replicas:    1,
-					Version:     "v1",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v1",
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "true",
+						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
 					},
 				},
 				{
-					Replicas:    1,
-					Version:     "v2",
-					Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionDisabled},
+					Replicas: 1,
+					Version:  "v2",
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "true",
+						constants.DataplaneModeLabel:   constants.DataplaneModeNone,
 					},
 				},
 			},

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -217,10 +217,11 @@ kind: Gateway
 metadata:
   name: simple-http-waypoint
   namespace: {{.Namespace}}
+  labels:
+    istio.io/dataplane-mode: ambient
   annotations:
     networking.istio.io/address-type: IPAddress
     networking.istio.io/service-type: ClusterIP
-    ambient.istio.io/redirection: enabled
 spec:
   gatewayClassName: istio
   listeners:


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/50736

- Deprecates the use of the annotation `ambient.istio.io/redirection: false` as a user-facing means to opt-out pods from capture.
- Instead, uses the label `istio.io/dataplane-mode=none` as the means to do this - same label to opt-in and opt-out and signal user intent, which makes more sense.
- The annotation `ambient.istio.io/redirection: true` is set by CNI when pods are successfully enrolled (as triggered based on this label), and that annotation status should be what we check to know if a pod is enrolled or not.


Almost all of this is test boilerplate, the relevant logic changes are in `informers.go` (which actually got a bit simpler) and `podutil.go`

~(leaving as WIP to sort out any straggling integ test failures, I bet there will be some)~


~Apparently we have some integ tests that test capturing gateways, which seems a bit odd to me.~

Actually it turns out that a positive consequence of https://github.com/istio/istio/pull/50683 is that capturing gateways for sandwiching isn't as hacky, which is good.