### PR TITLE
data seems to not get unmarshalled correctly

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -31,14 +31,26 @@ type ConfigWriter struct {
 }
 
 // Prime loads the config dump into the writer ready for printing
+// func (c *ConfigWriter) Prime(b []byte) error {
+// 	cd := ZtunnelDump{}
+// 	// TODO(fisherxu): migrate this to jsonpb when issue fixed in golang
+// 	// Issue to track -> https://github.com/golang/protobuf/issues/632
+// 	err := json.Unmarshal(b, &cd)
+// 	if err != nil {
+// 		return fmt.Errorf("error unmarshalling config dump response from ztunnel: %v", err)
+// 	}
+// 	c.ztunnelDump = &cd
+// 	return nil
+// }
+
 func (c *ConfigWriter) Prime(b []byte) error {
+	fmt.Println("Raw JSON data:", string(b))
 	cd := ZtunnelDump{}
-	// TODO(fisherxu): migrate this to jsonpb when issue fixed in golang
-	// Issue to track -> https://github.com/golang/protobuf/issues/632
 	err := json.Unmarshal(b, &cd)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling config dump response from ztunnel: %v", err)
 	}
+	fmt.Printf("Unmarshalled Data: %+v\n", cd)
 	c.ztunnelDump = &cd
 	return nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
A draft while I'm investigating a possible issue/regression(?) that I'm encountering now with `istioctl x ztunnel-config workload` and other related commands.

This code will print out the data before we unmarshal and after; we can see that the data gets lost in the process. Prime is necessary for `setupConfigdumpZtunnelConfigWriter` otherwise the data won't end up in ztunnelDump. And this will effect commands like `istioctl x zc all` or `istioctl x zc w -ojson`.

e.g. 
```
azureuser@dev-2024:~/istio$ ik x zc w -ojson                                                                                     []
```

**How to reproduce?**

Checkout this branch locally, run make istioctl. Then use this version of istioctl on a working ambient cluster. And run those commands above (other zc commands are effected as well, likely all of them accept for `istioctl x zc all -ojson` so far that I've noticed)