### PR TITLE
helm upgrade tests: Upgrade from latest patch release

### DIFF
--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -195,7 +195,15 @@ func baseSetup(overrideValuesStr string, isAmbient bool, config NamespaceConfig,
 		cs := t.Clusters().Default().(*kubecluster.Cluster)
 		h := helm.New(cs.Filename())
 		s := t.Settings()
-		overrideValues := fmt.Sprintf(overrideValuesStr, s.Image.Hub, s.Image.Tag, s.Image.Variant)
+
+		// Some templates contain a tag definition, in which we just replace %s it with the tag value,
+		// others just contain a %s placeholder for the whole tag: line
+		tag := s.Image.Tag
+		if !strings.Contains(overrideValuesStr, "tag: ") {
+			tag = "tag: " + tag
+		}
+		overrideValues := fmt.Sprintf(overrideValuesStr, s.Image.Hub, tag, s.Image.Variant)
+
 		overrideValuesFile := filepath.Join(workDir, "values.yaml")
 		if err := os.WriteFile(overrideValuesFile, []byte(overrideValues), os.ModePerm); err != nil {
 			t.Fatalf("failed to write iop cr file: %v", err)

--- a/tests/integration/helm/upgrade/helm_upgrade_test.go
+++ b/tests/integration/helm/upgrade/helm_upgrade_test.go
@@ -60,14 +60,6 @@ func initVersions(ctx resource.Context) error {
 	nMinusTwoVersion = semver.New(previousVersion.Major(), previousVersion.Minor()-1, previousVersion.Patch(),
 		previousVersion.Prerelease(), previousVersion.Metadata()).String()
 
-	// Workaround publish issues
-	if previousSupportedVersion == "1.17.0" {
-		previousSupportedVersion = "1.17.1"
-	}
-	if nMinusTwoVersion == "1.17.0" {
-		nMinusTwoVersion = "1.17.1"
-	}
-
 	return nil
 }
 

--- a/tests/integration/helm/upgrade/util.go
+++ b/tests/integration/helm/upgrade/util.go
@@ -153,7 +153,7 @@ func performInPlaceUpgradeFunc(previousVersion string, isAmbient bool) func(fram
 		if isAmbient {
 			prevVariant = "debug"
 		}
-		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, prevVariant, "", isAmbient)
+		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, "", prevVariant, "", isAmbient)
 		helmtest.InstallIstio(t, cs, h, overrideValuesFile, previousVersion, true, isAmbient, nsConfig)
 		helmtest.VerifyInstallation(t, cs, nsConfig, true, isAmbient, "")
 
@@ -190,7 +190,7 @@ func performCanaryUpgradeFunc(nsConfig helmtest.NamespaceConfig, previousVersion
 		})
 
 		s := t.Settings()
-		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, s.Image.Variant, "", false)
+		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, "", s.Image.Variant, "", false)
 		helmtest.InstallIstio(t, cs, h, overrideValuesFile, previousVersion, false, false, helmtest.DefaultNamespaceConfig)
 		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 
@@ -241,7 +241,7 @@ func performRevisionTagsUpgradeFunc(previousVersion string) func(framework.TestC
 		// helm install istio-base istio/base --version 1.15.0 --namespace istio-system -f values.yaml
 		// helm install istiod-1-15 istio/istiod --version 1.15.0 -f values.yaml
 		previousRevision := strings.ReplaceAll(previousVersion, ".", "-")
-		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, previousVersion, s.Image.Variant, previousRevision, false)
+		overrideValuesFile := helmtest.GetValuesOverrides(t, gcrHub, "", s.Image.Variant, previousRevision, false)
 		helmtest.InstallIstioWithRevision(t, cs, h, previousVersion, previousRevision, overrideValuesFile, false, true)
 		helmtest.VerifyInstallation(t, cs, helmtest.DefaultNamespaceConfig, false, false, "")
 


### PR DESCRIPTION
Instead of upgrading from `.0`. For instance, if latest `N-1` release is 1.21.2, the test deploys Istio 1.21.2 (not 1.21.0 as it does today) and then performs an upgrade to the current dev version.

For this we make use of the `~` in the version parameter of `helm install`. Instead of invoking e.g., `helm install  --version 1.21.0`, we use `helm install --version ~1.21.0`. This instructs helm to install the latest patch release in 1.21.x: https://helm.sh/docs/chart_best_practices/dependencies/#versions

While on it, removed the workaround for 1.17. It's EOL.
