### PR TITLE
Fix CNI installation in namespaces other than kube-system in OpenShift

### DIFF
--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -12,6 +12,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods","nodes","namespaces"]
   verbs: ["get", "list", "watch"]
+{{- if (eq .Values.platform "openshift") }}
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]
+{{- end }}
 ---
 {{- if .Values.cni.repair.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
By adding a special permission to the `ClusterRole` when openshift profile is selected.
