### PR TITLE
fix port merge of kubernetes services in sidecar

### DIFF
--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -595,6 +595,56 @@ var (
 		},
 	}
 
+	configs23 = &config.Config{
+		Meta: config.Meta{
+			Name: "sidecar-scope-with-multiple-ports",
+		},
+		Spec: &networking.Sidecar{
+			Egress: []*networking.IstioEgressListener{
+				{
+					Port: &networking.SidecarPort{
+						Number:   8031,
+						Protocol: "TCP",
+						Name:     "tcp-ipc1",
+					},
+					Hosts: []string{"ns1/foobar.svc.cluster.local"},
+				},
+				{
+					Port: &networking.SidecarPort{
+						Number:   8032,
+						Protocol: "TCP",
+						Name:     "tcp-ipc2",
+					},
+					Hosts: []string{"ns1/foobar.svc.cluster.local"},
+				},
+				{
+					Port: &networking.SidecarPort{
+						Number:   8033,
+						Protocol: "TCP",
+						Name:     "tcp-ipc3",
+					},
+					Hosts: []string{"ns1/foobar.svc.cluster.local"},
+				},
+				{
+					Port: &networking.SidecarPort{
+						Number:   8034,
+						Protocol: "TCP",
+						Name:     "tcp-ipc4",
+					},
+					Hosts: []string{"ns1/foobar.svc.cluster.local"},
+				},
+				{
+					Port: &networking.SidecarPort{
+						Number:   8035,
+						Protocol: "TCP",
+						Name:     "tcp-ipc5",
+					},
+					Hosts: []string{"ns1/foobar.svc.cluster.local"},
+				},
+			},
+		},
+	}
+
 	services1 = []*Service{
 		{
 			Hostname: "bar",
@@ -1101,6 +1151,18 @@ var (
 			Attributes: ServiceAttributes{
 				Name:            "baz",
 				Namespace:       "ns3",
+				ServiceRegistry: provider.Kubernetes,
+			},
+		},
+	}
+
+	services26 = []*Service{
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port803x,
+			Attributes: ServiceAttributes{
+				Name:            "foo",
+				Namespace:       "ns1",
 				ServiceRegistry: provider.Kubernetes,
 			},
 		},
@@ -2180,6 +2242,21 @@ func TestCreateSidecarScope(t *testing.T) {
 			name:          "multi-port-merge",
 			sidecarConfig: configs22,
 			services:      services23,
+			expectedServices: []*Service{
+				{
+					Hostname: "foobar.svc.cluster.local",
+					Ports:    port803x,
+					Attributes: ServiceAttributes{
+						Name:      "foo",
+						Namespace: "ns1",
+					},
+				},
+			},
+		},
+		{
+			name:          "multi-port-merge-in-same-namespace",
+			sidecarConfig: configs23,
+			services:      services26,
 			expectedServices: []*Service{
 				{
 					Hostname: "foobar.svc.cluster.local",

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -78,6 +78,19 @@ var (
 		},
 	}
 
+	port744x = []*Port{
+		{
+			Port:     7443,
+			Protocol: "GRPC",
+			Name:     "service-grpc-tls",
+		},
+		{
+			Port:     7442,
+			Protocol: "HTTP",
+			Name:     "http-tls",
+		},
+	}
+
 	port803x = []*Port{
 		{
 			Port:     8031,
@@ -566,7 +579,7 @@ var (
 					Port: &networking.SidecarPort{
 						Number:   8034,
 						Protocol: "TCP",
-						Name:     "tcp-ipc4",
+						Name:     "rmi-ipc4",
 					},
 					Hosts: []string{"*/foobar.svc.cluster.local"},
 				},
@@ -1015,24 +1028,9 @@ var (
 			Hostname: "foobar.svc.cluster.local",
 			Ports:    port803x,
 			Attributes: ServiceAttributes{
-				Name:      "foo",
-				Namespace: "ns1",
-			},
-		},
-		{
-			Hostname: "foobar.svc.cluster.local",
-			Ports:    port8000,
-			Attributes: ServiceAttributes{
-				Name:      "foo",
-				Namespace: "ns2",
-			},
-		},
-		{
-			Hostname: "foobar.svc.cluster.local",
-			Ports:    port7443,
-			Attributes: ServiceAttributes{
-				Name:      "baz",
-				Namespace: "ns3",
+				Name:            "foo",
+				Namespace:       "ns1",
+				ServiceRegistry: provider.Kubernetes,
 			},
 		},
 	}
@@ -2061,56 +2059,6 @@ func TestCreateSidecarScope(t *testing.T) {
 			},
 		},
 		{
-			name: "k8s service no merge",
-			sidecarConfig: &config.Config{
-				Meta: config.Meta{
-					Name:      "default",
-					Namespace: "default",
-				},
-				Spec: &networking.Sidecar{},
-			},
-			services: []*Service{
-				{
-					Hostname: "proxy",
-					Ports:    port7000,
-					Attributes: ServiceAttributes{
-						Name:            "s1",
-						Namespace:       "default",
-						ServiceRegistry: provider.Kubernetes,
-					},
-				},
-				{
-					Hostname: "proxy",
-					Ports:    port7443,
-					Attributes: ServiceAttributes{
-						Name:            "s2",
-						Namespace:       "default",
-						ServiceRegistry: provider.Kubernetes,
-					},
-				},
-				{
-					Hostname: "proxy",
-					Ports:    port7442,
-					Attributes: ServiceAttributes{
-						Name:            "s3",
-						Namespace:       "default",
-						ServiceRegistry: provider.Kubernetes,
-					},
-				},
-			},
-			expectedServices: []*Service{
-				{
-					Hostname: "proxy",
-					Ports:    port7000,
-					Attributes: ServiceAttributes{
-						Name:            "s1",
-						Namespace:       "default",
-						ServiceRegistry: provider.Kubernetes,
-					},
-				},
-			},
-		},
-		{
 			name: "k8s service take precedence over external service",
 			sidecarConfig: &config.Config{
 				Meta: config.Meta{
@@ -2201,7 +2149,7 @@ func TestCreateSidecarScope(t *testing.T) {
 			expectedServices: []*Service{
 				{
 					Hostname: "proxy",
-					Ports:    port7443,
+					Ports:    port744x,
 					Attributes: ServiceAttributes{
 						Name:            "s2",
 						Namespace:       "default",

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -579,7 +579,7 @@ var (
 					Port: &networking.SidecarPort{
 						Number:   8034,
 						Protocol: "TCP",
-						Name:     "rmi-ipc4",
+						Name:     "tcp-ipc4",
 					},
 					Hosts: []string{"*/foobar.svc.cluster.local"},
 				},
@@ -1030,6 +1030,24 @@ var (
 			Attributes: ServiceAttributes{
 				Name:            "foo",
 				Namespace:       "ns1",
+				ServiceRegistry: provider.Kubernetes,
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port8000,
+			Attributes: ServiceAttributes{
+				Name:            "foo",
+				Namespace:       "ns2",
+				ServiceRegistry: provider.Kubernetes,
+			},
+		},
+		{
+			Hostname: "foobar.svc.cluster.local",
+			Ports:    port7443,
+			Attributes: ServiceAttributes{
+				Name:            "baz",
+				Namespace:       "ns3",
 				ServiceRegistry: provider.Kubernetes,
 			},
 		},

--- a/releasenotes/notes/sidecar-port-merge.yaml
+++ b/releasenotes/notes/sidecar-port-merge.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** a bug when a Sidecar is resource is defined with multiple egress listeners with different ports 
+  of a Kubernetes service, does not merge the ports correctly. This leads to creating only one Cluster with 
+  the first port and second port is ignored.


### PR DESCRIPTION
K8s servie merge in sidecar is broken since https://github.com/istio/istio/pull/48896. When a sidecar is defined with two egress listeners  pointing to two ports, the port merge does not happen

```
  egress:
  - hosts:
    - '*/foo.svc.cluster.local'
    port:
      name: tcp-port1
      number: 7443
      protocol: TCP
  - hosts:
    - '*/foo.svc.cluster.local'
    port:
      name: tcp-port2
      number: 7442
      protocol: TCP
```

With the above sidecar, the merged service will only have one port and hence only cluster is created.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure