### PR TITLE
change #none to none for use-waypoint

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1319,7 +1319,7 @@ func TestUpdateWaypointForWorkload(t *testing.T) {
 	s.assertWaypointAddressForPod(t, "pod1", "10.0.0.2")
 
 	// assert local waypoint opt-out works as expected
-	s.labelPod(t, "pod1", testNS, map[string]string{constants.AmbientUseWaypointLabel: "#none"})
+	s.labelPod(t, "pod1", testNS, map[string]string{constants.AmbientUseWaypointLabel: "none"})
 	s.assertEvent(t, s.podXdsName("pod1"))
 	// assert that we're using no waypoint
 	s.assertWaypointAddressForPod(t, "pod1", "")

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -214,7 +214,7 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,
 			Labels: map[string]string{
-				constants.AmbientUseWaypointLabel: "#none",
+				constants.AmbientUseWaypointLabel: "none",
 			},
 		},
 	})

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -146,6 +146,8 @@ func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[W
 // defaultNamespace avoids the need to infer when object meta from a namespace was given
 func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt.Named, isNone bool) {
 	if labelValue, ok := meta.Labels[constants.AmbientUseWaypointLabel]; ok {
+		// NOTE: this means Istio reserves the word "none" in this field with a special meaning
+		//   a waypoint named "none" cannot be used and will be ignored
 		if labelValue == "none" {
 			return nil, true
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -146,7 +146,7 @@ func fetchWaypointForWorkload(ctx krt.HandlerContext, Waypoints krt.Collection[W
 // defaultNamespace avoids the need to infer when object meta from a namespace was given
 func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt.Named, isNone bool) {
 	if labelValue, ok := meta.Labels[constants.AmbientUseWaypointLabel]; ok {
-		if labelValue == "#none" || labelValue == "~" {
+		if labelValue == "none" {
 			return nil, true
 		}
 		namespacedName := strings.Split(labelValue, "/")

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -148,7 +148,9 @@ func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt
 	if labelValue, ok := meta.Labels[constants.AmbientUseWaypointLabel]; ok {
 		// NOTE: this means Istio reserves the word "none" in this field with a special meaning
 		//   a waypoint named "none" cannot be used and will be ignored
-		if labelValue == "none" {
+		//   also reserve a lnything with suffix "/none" to prevent use of "namespace/none" as a work around
+		// ~ is used in other portions of the API, reserve it with special meaning although it's unlikely to be documented
+		if labelValue == "none" || labelValue == "~" || strings.HasSuffix(labelValue, "/none") {
 			return nil, true
 		}
 		namespacedName := strings.Split(labelValue, "/")

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -148,7 +148,7 @@ func getUseWaypoint(meta metav1.ObjectMeta, defaultNamespace string) (named *krt
 	if labelValue, ok := meta.Labels[constants.AmbientUseWaypointLabel]; ok {
 		// NOTE: this means Istio reserves the word "none" in this field with a special meaning
 		//   a waypoint named "none" cannot be used and will be ignored
-		//   also reserve a lnything with suffix "/none" to prevent use of "namespace/none" as a work around
+		//   also reserve anything with suffix "/none" to prevent use of "namespace/none" as a work around
 		// ~ is used in other portions of the API, reserve it with special meaning although it's unlikely to be documented
 		if labelValue == "none" || labelValue == "~" || strings.HasSuffix(labelValue, "/none") {
 			return nil, true

--- a/releasenotes/notes/49700.yaml
+++ b/releasenotes/notes/49700.yaml
@@ -31,7 +31,7 @@ issue:
 # release notes.
 releaseNotes:
 - |
-  **Added** capability to annotate pods, services, namespaces and other similar kinds with an annotation, `istio.io/use-waypoint`, to specify a waypoint in the form `[<namespace name>]/<waypoint name>`. This replaces the old requirement for waypoints either being scoped to the entire namespace or to a single service account. Opting out of a waypoint can also be done with a value of `#none` to allow a namespace-wide waypoint where specific pods or services are not guarded by a waypoint allowing greater flexibility in waypoint specification and use.
+  **Added** capability to annotate pods, services, namespaces and other similar kinds with an annotation, `istio.io/use-waypoint`, to specify a waypoint in the form `[<namespace name>]/<waypoint name>`. This replaces the old requirement for waypoints either being scoped to the entire namespace or to a single service account. Opting out of a waypoint can also be done with a value of `none` to allow a namespace-wide waypoint where specific pods or services are not guarded by a waypoint allowing greater flexibility in waypoint specification and use.
      
 
 # upgradeNotes is a markdown listing of any changes that will affect the upgrade


### PR DESCRIPTION
**Please provide a description of this PR:**
fixes #50841 

changes `#none` to `none` for use-waypoint
removes the totally undocumented `~` optional alias for opting out of a waypoint
updates original release note to include correct information about how this feature will function