### PR TITLE
ambient: fix nil pointer when pod cache is stale

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -188,9 +188,9 @@ func (s *CniPluginServer) ReconcileCNIAddEvent(ctx context.Context, addCmd CNIPl
 }
 
 func (s *CniPluginServer) getPodWithRetry(log *istiolog.Scope, name, namespace string) (*corev1.Pod, error) {
-	log.Debugf("Checking pod: %s in ns: %s is enabled for ambient", name, namespace)
-	maxStaleRetries := 10
-	msInterval := 10
+	log.Debugf("Checking if pod %s/%s is enabled for ambient", namespace, name)
+	const maxStaleRetries = 10
+	const msInterval = 10
 	retries := 0
 	var ambientPod *corev1.Pod
 	var err error

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -82,12 +82,19 @@ func setupHandlers(ctx context.Context, kubeClient kube.Client, dataplane MeshDa
 	return s
 }
 
+// GetPodIfAmbient looks up a pod. It returns:
+// * An error if the pod cannot be found
+// * nil if the pod is found, but does not have ambient enabled
+// * the pod, if it is found and ambient is enabled
 func (s *InformerHandlers) GetPodIfAmbient(podName, podNamespace string) (*corev1.Pod, error) {
 	ns := s.namespaces.Get(podNamespace, "")
 	if ns == nil {
 		return nil, fmt.Errorf("failed to find namespace %v", ns)
 	}
 	pod := s.pods.Get(podName, podNamespace)
+	if pod == nil {
+		return nil, fmt.Errorf("failed to find pod %v", ns)
+	}
 	if util.PodRedirectionEnabled(ns, pod) {
 		return pod, nil
 	}


### PR DESCRIPTION
I ran into this in an *extremely* bespoke and unsupported environment,
but I think it could occur in real world. We are looping outside of
GetPodIfAmbient for the pod to show up, but if it fails we panic. We
want to instead get an error.
