### PR TITLE
bootstrap: interpolate HOST_IP like we do for native traces

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -15,6 +15,7 @@
 package envoy
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -143,7 +144,7 @@ func (e *envoy) args(fname string, overrideFname string) []string {
 	startupArgs = append(startupArgs, e.extraArgs...)
 
 	if overrideFname != "" {
-		s, err := readToJSON(overrideFname)
+		s, err := readBootstrapToJSON(overrideFname)
 		if err != nil {
 			log.Warnf("Failed to read bootstrap override: %v", err)
 		} else {
@@ -159,14 +160,19 @@ func (e *envoy) args(fname string, overrideFname string) []string {
 	return startupArgs
 }
 
-// readToJSON reads a config file, in YAML or JSON, and returns JSON string
-func readToJSON(fname string) (string, error) {
-	bytes, err := os.ReadFile(fname)
+var HostIP = os.Getenv("HOST_IP")
+
+// readBootstrapToJSON reads a config file, in YAML or JSON, and returns JSON string
+func readBootstrapToJSON(fname string) (string, error) {
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %s, %v", fname, err)
 	}
 
-	converted, err := yaml.YAMLToJSON(bytes)
+	// Replace host with HOST_IP env var if it is "$(HOST_IP)".
+	// This is to support some tracer setting (Datadog, Zipkin), where "$(HOST_IP)" is used for address.
+	b = bytes.ReplaceAll(b, []byte("$(HOST_IP)"), []byte(HostIP))
+	converted, err := yaml.YAMLToJSON(b)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert to JSON: %s, %v", fname, err)
 	}

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -72,13 +72,13 @@ func TestEnvoyArgs(t *testing.T) {
 }
 
 func TestReadToJSON(t *testing.T) {
-	got, err := readToJSON("testdata/bootstrap.yaml")
+	got, err := readBootstrapToJSON("testdata/bootstrap.yaml")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	want := `{"key":"value"}`
 	if got != want {
-		t.Errorf("readToJSON() => got:\n%v,\nwant:\n%v", got, want)
+		t.Errorf("readBootstrapToJSON() => got:\n%v,\nwant:\n%v", got, want)
 	}
 }
 


### PR DESCRIPTION
We already have this logic on other code paths.

This allows a config like:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: dog-statsd
data:
  custom_bootstrap.json: |
    {
      "statsSinks": [
        {
          "name": "envoy.stat_sinks.dog_statsd",
          "typedConfig": {
            "@type": "type.googleapis.com/envoy.config.metrics.v3.DogStatsdSink",
            "address": {
              "socketAddress": {
                "address": "$(HOST_IP)",
                "portValue": 1231
              }
            }
          }
        }
      ]
    }
```
