### PR TITLE
Fix ambient cni on OpenShift

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -216,12 +216,17 @@ func doAddRun(args *skel.CmdArgs, conf *Config, kClient kubernetes.Interface, ru
 		if err != nil {
 			log.Errorf("istio-cni cmdAdd failed to check ambient: %s", err)
 		}
-		prevResult := conf.PrevResult.(*cniv1.Result)
+
+		var prevResIps []*cniv1.IPConfig
+		if conf.PrevResult != nil {
+			prevResult := conf.PrevResult.(*cniv1.Result)
+			prevResIps = prevResult.IPs
+		}
 
 		// Only send event if this pod "would be" an ambient-watched pod - otherwise skip
 		if podIsAmbient {
 			cniClient := newCNIClient(conf.CNIEventAddress, constants.CNIAddEventPath)
-			if err = PushCNIEvent(cniClient, args, prevResult.IPs, podName, podNamespace); err != nil {
+			if err = PushCNIEvent(cniClient, args, prevResIps, podName, podNamespace); err != nil {
 				log.Errorf("istio-cni cmdAdd failed to signal node Istio CNI agent: %s", err)
 				return err
 			}

--- a/cni/pkg/plugin/plugin_test.go
+++ b/cni/pkg/plugin/plugin_test.go
@@ -529,6 +529,7 @@ func TestCmdAddNoPrevResult(t *testing.T) {
          "sampleconfig": []
     },
     "loglevel": "debug",
+	"ambient_enabled": %t,
     "kubernetes": {
         "k8sapiroot": "APIRoot",
         "kubeconfig": "testK8sConfig",
@@ -539,7 +540,8 @@ func TestCmdAddNoPrevResult(t *testing.T) {
     }`
 
 	pod, ns := buildFakePodAndNSForClient()
-	testDoAddRun(t, confNoPrevResult, testNSName, pod, ns)
+	testDoAddRun(t, fmt.Sprintf(confNoPrevResult, false), testNSName, pod, ns)
+	testDoAddRun(t, fmt.Sprintf(confNoPrevResult, true), testNSName, pod, ns)
 }
 
 func TestCmdAddEnableDualStack(t *testing.T) {


### PR DESCRIPTION
This change handles the case where `PrevResult` is `nil`, as in the case when using `Multus`, e.g. on OpenShift.

Before this fix, we get this error:
```
error adding container to network "istio-cni": istio-cni panicked during cmdAdd: interface conversion: types.Result is nil, not *types100.Result
```
