### PR TITLE
Fix bug causing Pods to show up in k8s store as WE

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -693,7 +693,9 @@ func (s *Controller) ResyncEDS() {
 	s.edsUpdate(allInstances)
 	// HACK to workaround Service syncing after WorkloadEntry: https://github.com/istio/istio/issues/45114
 	s.workloadInstances.ForEach(func(wi *model.WorkloadInstance) {
-		s.NotifyWorkloadInstanceHandlers(wi, model.EventAdd)
+		if wi.Kind == model.WorkloadEntryKind {
+			s.NotifyWorkloadInstanceHandlers(wi, model.EventAdd)
+		}
 	})
 }
 


### PR DESCRIPTION
This only impacts test, as ResyncEDS is a test only function