### PR TITLE
validation of waypoint name for istioctl

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -67,6 +67,8 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		// If a user sets the waypoint name to an empty string, set it to the default namespace waypoint name.
 		if waypointName == "" {
 			waypointName = constants.DefaultNamespaceWaypoint
+		} else if waypointName == "none" {
+			return nil, fmt.Errorf("invalid name provided for waypoint, 'none' is a reserved value")
 		}
 		gw := gateway.Gateway{
 			TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**Please provide a description of this PR:**

adds a check for the waypoint name to ensure user doesn't create a waypoint named `none`

fixes #50873

example output:

```
$ out/linux_amd64/istioctl x waypoint apply --name none
Error: failed to create gateway: invalid name provided for waypoint, 'none' is a reserved value
```