### PR TITLE
krt: various micro-optimizations

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1021,7 +1021,7 @@ func (i *WorkloadInfo) Clone() *WorkloadInfo {
 	}
 }
 
-func (i *WorkloadInfo) ResourceName() string {
+func (i WorkloadInfo) ResourceName() string {
 	return workloadResourceName(i.Workload)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -292,6 +292,7 @@ func (a *index) podWorkloadBuilder(
 
 		// enforce traversing waypoints
 		policies = append(policies, implicitWaypointPolicies(ctx, Waypoints, targetWaypoint, services)...)
+		log.Errorf("howardjohn: %v %v", len(auths), len(policies))
 
 		w := &workloadapi.Workload{
 			Uid:                   a.generatePodUID(p),
@@ -497,10 +498,21 @@ func implicitWaypointPolicies(ctx krt.HandlerContext, Waypoints krt.Collection[W
 		}
 		return ptr.Of(si.Waypoint)
 	})
+	//if len(serviceWaypointKeys) == 0 {
+	//	if waypoint != nil {
+	//		n := implicitWaypointPolicyName(waypoint)
+	//		if n != "" {
+	//			return []string{waypoint.Namespace + "/" + n}
+	//		}
+	//	}
+	//	return nil
+	//}
 	waypoints := krt.Fetch(ctx, Waypoints, krt.FilterKeys(serviceWaypointKeys...))
 	if waypoint != nil {
 		waypoints = append(waypoints, *waypoint)
 	}
+	//log.Errorf("howardjohn: waypoints: %v"
+	log.Errorf("howardjohn: fetch %v %v: %v", serviceWaypointKeys, waypoint!=nil, len(waypoints))
 
 	return slices.MapFilter(waypoints, func(w Waypoint) *string {
 		policy := implicitWaypointPolicyName(&w)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -422,7 +422,9 @@ func constructServices(p *v1.Pod, services []model.ServiceInfo) map[string]*work
 	res := map[string]*workloadapi.PortList{}
 	for _, svc := range services {
 		n := namespacedHostname(svc.Namespace, svc.Hostname)
-		pl := &workloadapi.PortList{}
+		pl := &workloadapi.PortList{
+			Ports: make([]*workloadapi.Port, 0, len(svc.Ports)),
+		}
 		res[n] = pl
 		for _, port := range svc.Ports {
 			targetPort := port.TargetPort

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -292,7 +292,6 @@ func (a *index) podWorkloadBuilder(
 
 		// enforce traversing waypoints
 		policies = append(policies, implicitWaypointPolicies(ctx, Waypoints, targetWaypoint, services)...)
-		log.Errorf("howardjohn: %v %v", len(auths), len(policies))
 
 		w := &workloadapi.Workload{
 			Uid:                   a.generatePodUID(p),
@@ -498,21 +497,19 @@ func implicitWaypointPolicies(ctx krt.HandlerContext, Waypoints krt.Collection[W
 		}
 		return ptr.Of(si.Waypoint)
 	})
-	//if len(serviceWaypointKeys) == 0 {
-	//	if waypoint != nil {
-	//		n := implicitWaypointPolicyName(waypoint)
-	//		if n != "" {
-	//			return []string{waypoint.Namespace + "/" + n}
-	//		}
-	//	}
-	//	return nil
-	//}
+	if len(serviceWaypointKeys) == 0 {
+		if waypoint != nil {
+			n := implicitWaypointPolicyName(waypoint)
+			if n != "" {
+				return []string{waypoint.Namespace + "/" + n}
+			}
+		}
+		return nil
+	}
 	waypoints := krt.Fetch(ctx, Waypoints, krt.FilterKeys(serviceWaypointKeys...))
 	if waypoint != nil {
 		waypoints = append(waypoints, *waypoint)
 	}
-	//log.Errorf("howardjohn: waypoints: %v"
-	log.Errorf("howardjohn: fetch %v %v: %v", serviceWaypointKeys, waypoint!=nil, len(waypoints))
 
 	return slices.MapFilter(waypoints, func(w Waypoint) *string {
 		policy := implicitWaypointPolicyName(&w)

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -693,7 +693,9 @@ func (s *Controller) ResyncEDS() {
 	s.edsUpdate(allInstances)
 	// HACK to workaround Service syncing after WorkloadEntry: https://github.com/istio/istio/issues/45114
 	s.workloadInstances.ForEach(func(wi *model.WorkloadInstance) {
-		s.NotifyWorkloadInstanceHandlers(wi, model.EventAdd)
+		if wi.Kind == model.WorkloadEntryKind {
+			s.NotifyWorkloadInstanceHandlers(wi, model.EventAdd)
+		}
 	})
 }
 

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -338,7 +338,7 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 	h := &manyCollection[I, O]{
 		transformation:         hf,
 		collectionName:         opts.name,
-		id:                     nextUid(),
+		id:                     nextUID(),
 		log:                    log.WithLabels("owner", opts.name),
 		parent:                 c,
 		collectionDependencies: sets.New[collectionUID](),

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -125,7 +125,7 @@ func (h *manyCollection[I, O]) dump() {
 	h.log.Errorf(">>> BEGIN DUMP")
 	for k, deps := range h.objectDependencies {
 		for _, dep := range deps {
-			h.log.Errorf("Dependencies for: %v: %v (%v)", k, dep.id, dep.filter)
+			h.log.Errorf("Dependencies for: %v: %v (%v)", k, dep.collectionName, dep.filter)
 		}
 	}
 	for i, os := range h.collectionState.mappings {
@@ -557,7 +557,7 @@ func (i *collectionDependencyTracker[I, O]) registerDependency(
 
 	// For any new collections we depend on, start watching them if its the first time we have watched them.
 	if !i.collectionDependencies.InsertContains(d.id) {
-		i.log.WithLabels("collection", d.id).Debugf("register new dependency")
+		i.log.WithLabels("collection", d.collectionName).Debugf("register new dependency")
 		syncer.WaitUntilSynced(i.stop)
 		register(func(o []Event[any], initialSync bool) {
 			i.onSecondaryDependencyEvent(d.id, o)

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -37,6 +37,7 @@ import (
 type manyCollection[I, O any] struct {
 	// collectionName provides the collectionName for this collection.
 	collectionName string
+	id             collectionUid
 	// parent is the input collection we are building off of.
 	parent Collection[I]
 
@@ -52,11 +53,11 @@ type manyCollection[I, O any] struct {
 	mu              sync.Mutex
 	collectionState multiIndex[I, O]
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
-	// These are keyed by the internal hash() function on collections.
+	// These are keyed by the internal uid() function on collections.
 	// Note this does not include `parent`, which is the *primary* dependency declared outside of transformation functions.
-	collectionDependencies sets.Set[untypedCollection]
+	collectionDependencies sets.Set[collectionUid]
 	// Stores a map of I -> secondary dependencies (added via Fetch)
-	objectDependencies map[Key[I]][]dependency
+	objectDependencies map[Key[I]][]*dependency
 
 	// eventHandlers is a list of event handlers registered for the collection. On any changes, each will be notified.
 	eventHandlers *handlers[O]
@@ -124,7 +125,7 @@ func (h *manyCollection[I, O]) dump() {
 	h.log.Errorf(">>> BEGIN DUMP")
 	for k, deps := range h.objectDependencies {
 		for _, dep := range deps {
-			h.log.Errorf("Dependencies for: %v: %v (%v)", k, dep.collection.name, dep.filter)
+			h.log.Errorf("Dependencies for: %v: %v (%v)", k, dep.id, dep.filter)
 		}
 	}
 	for i, os := range h.collectionState.mappings {
@@ -339,10 +340,11 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 	h := &manyCollection[I, O]{
 		transformation:         hf,
 		collectionName:         opts.name,
+		id:                     nextUid(),
 		log:                    log.WithLabels("owner", opts.name),
 		parent:                 c,
-		collectionDependencies: sets.New[any](),
-		objectDependencies:     map[Key[I]][]dependency{},
+		collectionDependencies: sets.New[collectionUid](),
+		objectDependencies:     map[Key[I]][]*dependency{},
 		collectionState: multiIndex[I, O]{
 			inputs:   map[Key[I]]I{},
 			outputs:  map[Key[O]]O{},
@@ -388,7 +390,7 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 
 // Handler is called when a dependency changes. We will take as inputs the item that changed.
 // Then we find all of our own values (I) that changed and onPrimaryInputEvent() them
-func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection any, events []Event[any]) {
+func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection collectionUid, events []Event[any]) {
 	h.recomputeMu.Lock()
 	defer h.recomputeMu.Unlock()
 	// A secondary dependency changed...
@@ -441,15 +443,16 @@ func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection any, 
 	h.onPrimaryInputEventLocked(toRun)
 }
 
-func (h *manyCollection[I, O]) objectChanged(iKey Key[I], dependencies []dependency, sourceCollection any, ev Event[any]) bool {
+func (h *manyCollection[I, O]) objectChanged(iKey Key[I], dependencies []*dependency, sourceCollection collectionUid, ev Event[any]) bool {
 	for _, dep := range dependencies {
-		if dep.collection.original != sourceCollection {
+		id := dep.id
+		if id != sourceCollection {
 			continue
 		}
 		// For each input, we will check if it depends on this event.
 		// We use Items() to check both the old and new object; we will recompute if either matched
-		for _, item := range ev.Items() {
-			match := dep.filter.Matches(item, false)
+		for _, item := range ev.Items2() {
+			match := dep.filter.Matches2(item, false)
 			if h.log.DebugEnabled() {
 				h.log.WithLabels("item", iKey, "match", match).Debugf("dependency change for collection %T", sourceCollection)
 			}
@@ -522,6 +525,10 @@ func (h *manyCollection[I, O]) name() string {
 	return h.collectionName
 }
 
+func (h *manyCollection[I, O]) uid() collectionUid {
+	return h.id
+}
+
 // collectionDependencyTracker tracks, for a single transformation call, all dependencies registered.
 // These are inserted on each call to Fetch().
 // Once the transformation function is complete, the set of dependencies for the provided input will be replaced
@@ -531,7 +538,7 @@ func (h *manyCollection[I, O]) name() string {
 // for a given transformation call at once, then apply it in a single transaction to the manyCollection.
 type collectionDependencyTracker[I, O any] struct {
 	*manyCollection[I, O]
-	d   []dependency
+	d   []*dependency
 	key Key[I]
 }
 
@@ -541,15 +548,15 @@ func (i *collectionDependencyTracker[I, O]) name() string {
 
 // registerDependency track a dependency. This is in the context of a specific input I type, as we create a collectionDependencyTracker
 // per I.
-func (i *collectionDependencyTracker[I, O]) registerDependency(d dependency) {
+func (i *collectionDependencyTracker[I, O]) registerDependency(d *dependency, ec *erasedCollection) {
 	i.d = append(i.d, d)
 
 	// For any new collections we depend on, start watching them if its the first time we have watched them.
-	if !i.collectionDependencies.InsertContains(d.collection.original) {
-		i.log.WithLabels("collection", d.collection.name).Debugf("register new dependency")
-		d.collection.synced.WaitUntilSynced(i.stop)
-		d.collection.register(func(o []Event[any], initialSync bool) {
-			i.onSecondaryDependencyEvent(d.collection.original, o)
+	if !i.collectionDependencies.InsertContains(d.id) {
+		i.log.WithLabels("collection", ec.name).Debugf("register new dependency")
+		ec.synced.WaitUntilSynced(i.stop)
+		ec.register(func(o []Event[any], initialSync bool) {
+			i.onSecondaryDependencyEvent(ec.id, o)
 		})
 	}
 }

--- a/pkg/kube/krt/collection.go
+++ b/pkg/kube/krt/collection.go
@@ -37,7 +37,7 @@ import (
 type manyCollection[I, O any] struct {
 	// collectionName provides the collectionName for this collection.
 	collectionName string
-	id             collectionUid
+	id             collectionUID
 	// parent is the input collection we are building off of.
 	parent Collection[I]
 
@@ -55,7 +55,7 @@ type manyCollection[I, O any] struct {
 	// collectionDependencies specifies the set of collections we depend on from within the transformation functions (via Fetch).
 	// These are keyed by the internal uid() function on collections.
 	// Note this does not include `parent`, which is the *primary* dependency declared outside of transformation functions.
-	collectionDependencies sets.Set[collectionUid]
+	collectionDependencies sets.Set[collectionUID]
 	// Stores a map of I -> secondary dependencies (added via Fetch)
 	objectDependencies map[Key[I]][]*dependency
 
@@ -97,8 +97,6 @@ func (o *handlers[O]) Get() []func(o []Event[O], initialSync bool) {
 	defer o.mu.RUnlock()
 	return slices.Clone(o.h)
 }
-
-type untypedCollection = any
 
 // multiIndex stores input and output objects.
 // Each input and output can be looked up by its key.
@@ -343,7 +341,7 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 		id:                     nextUid(),
 		log:                    log.WithLabels("owner", opts.name),
 		parent:                 c,
-		collectionDependencies: sets.New[collectionUid](),
+		collectionDependencies: sets.New[collectionUID](),
 		objectDependencies:     map[Key[I]][]*dependency{},
 		collectionState: multiIndex[I, O]{
 			inputs:   map[Key[I]]I{},
@@ -390,7 +388,7 @@ func newManyCollection[I, O any](cc Collection[I], hf TransformationMulti[I, O],
 
 // Handler is called when a dependency changes. We will take as inputs the item that changed.
 // Then we find all of our own values (I) that changed and onPrimaryInputEvent() them
-func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection collectionUid, events []Event[any]) {
+func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection collectionUID, events []Event[any]) {
 	h.recomputeMu.Lock()
 	defer h.recomputeMu.Unlock()
 	// A secondary dependency changed...
@@ -443,7 +441,7 @@ func (h *manyCollection[I, O]) onSecondaryDependencyEvent(sourceCollection colle
 	h.onPrimaryInputEventLocked(toRun)
 }
 
-func (h *manyCollection[I, O]) objectChanged(iKey Key[I], dependencies []*dependency, sourceCollection collectionUid, ev Event[any]) bool {
+func (h *manyCollection[I, O]) objectChanged(iKey Key[I], dependencies []*dependency, sourceCollection collectionUID, ev Event[any]) bool {
 	for _, dep := range dependencies {
 		id := dep.id
 		if id != sourceCollection {
@@ -525,7 +523,8 @@ func (h *manyCollection[I, O]) name() string {
 	return h.collectionName
 }
 
-func (h *manyCollection[I, O]) uid() collectionUid {
+// nolint: unused // (not true, its to implement an interface)
+func (h *manyCollection[I, O]) uid() collectionUID {
 	return h.id
 }
 

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -109,17 +109,6 @@ func (e Event[T]) Items() []T {
 	return res
 }
 
-func (e Event[T]) Items2() []*T {
-	res := make([]*T, 0, 2)
-	if e.Old != nil {
-		res = append(res, e.Old)
-	}
-	if e.New != nil {
-		res = append(res, e.New)
-	}
-	return res
-}
-
 // Latest returns only the latest object (New for add/update, Old for delete).
 func (e Event[T]) Latest() T {
 	if e.New != nil {

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -69,7 +69,7 @@ type internalCollection[T any] interface {
 	// Note this may not be universally unique
 	name() string
 	// Uid is an internal unique ID for this collection. MUST be globally unique
-	uid() collectionUid
+	uid() collectionUID
 
 	dump()
 

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -68,6 +68,8 @@ type internalCollection[T any] interface {
 	// Name is a human facing name for this collection.
 	// Note this may not be universally unique
 	name() string
+	// Uid is an internal unique ID for this collection. MUST be globally unique
+	uid() collectionUid
 
 	dump()
 
@@ -103,6 +105,17 @@ func (e Event[T]) Items() []T {
 	}
 	if e.New != nil {
 		res = append(res, *e.New)
+	}
+	return res
+}
+
+func (e Event[T]) Items2() []*T {
+	res := make([]*T, 0, 2)
+	if e.Old != nil {
+		res = append(res, e.Old)
+	}
+	if e.New != nil {
+		res = append(res, e.New)
 	}
 	return res
 }

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -52,6 +52,11 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 				list = append(list, *i)
 			}
 		}
+	} else if d.filter.key != "" {
+		list = make([]T, 0, 1)
+			if i := c.GetKey(Key[T](d.filter.key)); i != nil {
+				list = append(list, *i)
+			}
 	} else if d.filter.listFromIndex != nil {
 		// Otherwise from an index; fetch from there. Often this is a list of a namespace
 		list = d.filter.listFromIndex().([]T)

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -54,18 +54,13 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	// Compute our list of all possible objects that can match. Then we will filter them later.
 	// This pre-filtering upfront avoids extra work
 	var list []T
-	if d.filter.keys != nil {
+	if !d.filter.keys.IsEmpty() {
 		// If they fetch a set of keys, directly Get these. Usually this is a single resource.
-		list = make([]T, 0, len(d.filter.keys))
-		for k := range d.filter.keys {
+		list = make([]T, 0, d.filter.keys.Len())
+		for _, k := range d.filter.keys.List() {
 			if i := c.GetKey(Key[T](k)); i != nil {
 				list = append(list, *i)
 			}
-		}
-	} else if d.filter.key != "" {
-		list = make([]T, 0, 1)
-		if i := c.GetKey(Key[T](d.filter.key)); i != nil {
-			list = append(list, *i)
 		}
 	} else if d.filter.listFromIndex != nil {
 		// Otherwise from an index; fetch from there. Often this is a list of a namespace

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -34,9 +34,9 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	h := ctx.(registerDependency)
 	c := cc.(internalCollection[T])
 	d := &dependency{
-		id:     c.uid(),
+		id:             c.uid(),
 		collectionName: c.name(),
-		filter: &filter{},
+		filter:         &filter{},
 	}
 	for _, o := range opts {
 		o(d)
@@ -55,7 +55,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	// Compute our list of all possible objects that can match. Then we will filter them later.
 	// This pre-filtering upfront avoids extra work
 	var list []T
-	if !d.filter.keys.IsEmpty() {
+	if !d.filter.keys.IsNil() {
 		// If they fetch a set of keys, directly Get these. Usually this is a single resource.
 		list = make([]T, 0, d.filter.keys.Len())
 		for _, k := range d.filter.keys.List() {
@@ -70,12 +70,10 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 		// Otherwise get everything
 		list = c.List()
 	}
-	log.Errorf("howardjohn: LIST PRE: %v %v", len(list), cap(list))
 	list = slices.FilterInPlace(list, func(i T) bool {
 		o := c.augment(i)
 		return d.filter.Matches(o, true)
 	})
-	log.Errorf("howardjohn: LIST POST: %v %v", len(list), cap(list))
 	if log.DebugEnabled() {
 		log.WithLabels(
 			"parent", h.name(),

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -35,6 +35,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 	c := cc.(internalCollection[T])
 	d := &dependency{
 		id:     c.uid(),
+		collectionName: c.name(),
 		filter: &filter{},
 	}
 	for _, o := range opts {
@@ -69,10 +70,12 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 		// Otherwise get everything
 		list = c.List()
 	}
+	log.Errorf("howardjohn: LIST PRE: %v %v", len(list), cap(list))
 	list = slices.FilterInPlace(list, func(i T) bool {
 		o := c.augment(i)
 		return d.filter.Matches(o, true)
 	})
+	log.Errorf("howardjohn: LIST POST: %v %v", len(list), cap(list))
 	if log.DebugEnabled() {
 		log.WithLabels(
 			"parent", h.name(),

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -39,7 +39,7 @@ type filter struct {
 
 func (f *filter) String() string {
 	attrs := []string{}
-	if !f.keys.IsEmpty() {
+	if !f.keys.IsNil() {
 		attrs = append(attrs, "keys="+f.keys.String())
 	}
 	if f.selectsNonEmpty != nil {
@@ -126,7 +126,7 @@ func (f *filter) Matches(object any, forList bool) bool {
 	if !forList {
 		// First, lookup directly by key. This is cheap
 		// an empty set will match none
-		if !f.keys.IsEmpty() && !f.keys.Contains(string(GetKey[any](object))) {
+		if !f.keys.IsNil() && !f.keys.Contains(string(GetKey[any](object))) {
 			if log.DebugEnabled() {
 				log.Debugf("no match key: %q vs %q", f.keys, string(GetKey[any](object)))
 			}

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -25,7 +25,7 @@ import (
 )
 
 type filter struct {
-	key string
+	key  string
 	keys sets.String
 
 	// selectsNonEmpty is like selects, but it treats an empty selector as not matching
@@ -38,7 +38,7 @@ type filter struct {
 	indexMatches  func(any) bool
 }
 
-func (f filter) String() string {
+func (f *filter) String() string {
 	attrs := []string{}
 	if !f.keys.IsEmpty() {
 		attrs = append(attrs, "keys="+f.keys.String())
@@ -121,7 +121,66 @@ func FilterGeneric(f func(any) bool) FetchOption {
 	}
 }
 
-func (f filter) Matches(object any, forList bool) bool {
+func (f *filter) Matches2(objectp *any, forList bool) bool {
+	object := *objectp
+	// Check each of our defined filters to see if the object matches
+	// This function is called very often and is important to keep fast
+	// Cheaper checks should come earlier to avoid additional work and short circuit early
+
+	// If we are listing, we already did this. Do not redundantly check.
+	if !forList {
+		// First, lookup directly by key. This is cheap
+		// an empty set will match none
+		if f.keys != nil && !f.keys.Contains(string(GetKey[any](object))) {
+			if log.DebugEnabled() {
+				log.Debugf("no match key: %q vs %q", f.keys, string(GetKey[any](object)))
+			}
+			return false
+		}
+		if f.key != "" && f.key != string(GetKey[any](object)) {
+			if log.DebugEnabled() {
+				log.Debugf("no match key: %q vs %q", f.keys, string(GetKey[any](object)))
+			}
+			return false
+		}
+		// Index is also cheap, and often used to filter namespaces out. Make sure we do this early
+		if f.indexMatches != nil && !f.indexMatches(object) {
+			if log.DebugEnabled() {
+				log.Debugf("no match index")
+			}
+			return false
+		}
+	}
+
+	// Rest is expensive
+	if f.selects != nil && !labels.Instance(getLabelSelector(object)).SubsetOf(f.selects) {
+		if log.DebugEnabled() {
+			log.Debugf("no match selects: %q vs %q", f.selects, getLabelSelector(object))
+		}
+		return false
+	}
+	if f.selectsNonEmpty != nil && !labels.Instance(getLabelSelector(object)).Match(f.selectsNonEmpty) {
+		if log.DebugEnabled() {
+			log.Debugf("no match selectsNonEmpty: %q vs %q", f.selectsNonEmpty, getLabelSelector(object))
+		}
+		return false
+	}
+	if f.labels != nil && !labels.Instance(f.labels).SubsetOf(getLabels(object)) {
+		if log.DebugEnabled() {
+			log.Debugf("no match labels: %q vs %q", f.labels, getLabels(object))
+		}
+		return false
+	}
+	if f.generic != nil && !f.generic(object) {
+		if log.DebugEnabled() {
+			log.Debugf("no match generic")
+		}
+		return false
+	}
+	return true
+}
+
+func (f *filter) Matches(object any, forList bool) bool {
 	// Check each of our defined filters to see if the object matches
 	// This function is called very often and is important to keep fast
 	// Cheaper checks should come earlier to avoid additional work and short circuit early

--- a/pkg/kube/krt/helpers.go
+++ b/pkg/kube/krt/helpers.go
@@ -16,6 +16,8 @@ package krt
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/kube/controllers"
+	"k8s.io/client-go/tools/cache"
 	"reflect"
 	"strings"
 	"time"
@@ -33,6 +35,13 @@ func GetKey[O any](a O) Key[O] {
 		return k
 	}
 
+	// Kubernetes types are pointers, which means our types would be double pointers
+	// Allow flattening
+	ao, ok := any(&a).(controllers.Object)
+	if ok {
+		k, _ := cache.MetaNamespaceKeyFunc(ao)
+		return Key[O](k)
+	}
 	panic(fmt.Sprintf("Cannot get Key, got %T", a))
 }
 

--- a/pkg/kube/krt/helpers.go
+++ b/pkg/kube/krt/helpers.go
@@ -16,15 +16,15 @@ package krt
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/kube/controllers"
-	"k8s.io/client-go/tools/cache"
 	"reflect"
 	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	acmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/ptr"
 )
 

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -68,6 +68,7 @@ func (i *informer[I]) name() string {
 	return i.collectionName
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (i *informer[I]) uid() collectionUID {
 	return i.id
 }
@@ -147,7 +148,7 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 		inf:            c,
 		log:            log.WithLabels("owner", o.name),
 		collectionName: o.name,
-		id:             nextUid(),
+		id:             nextUID(),
 		eventHandlers:  &handlers[I]{},
 		augmentation:   o.augmentation,
 		synced:         make(chan struct{}),

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -33,6 +33,7 @@ type informer[I controllers.ComparableObject] struct {
 	inf            kclient.Informer[I]
 	log            *istiolog.Scope
 	collectionName string
+	id             collectionUid
 
 	eventHandlers *handlers[I]
 	augmentation  func(a any) any
@@ -65,6 +66,10 @@ func (i *informer[I]) dump() {
 
 func (i *informer[I]) name() string {
 	return i.collectionName
+}
+
+func (i *informer[I]) uid() collectionUid {
+	return i.id
 }
 
 func (i *informer[I]) List() []I {
@@ -142,6 +147,7 @@ func WrapClient[I controllers.ComparableObject](c kclient.Informer[I], opts ...C
 		inf:            c,
 		log:            log.WithLabels("owner", o.name),
 		collectionName: o.name,
+		id:             nextUid(),
 		eventHandlers:  &handlers[I]{},
 		augmentation:   o.augmentation,
 		synced:         make(chan struct{}),

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -33,7 +33,7 @@ type informer[I controllers.ComparableObject] struct {
 	inf            kclient.Informer[I]
 	log            *istiolog.Scope
 	collectionName string
-	id             collectionUid
+	id             collectionUID
 
 	eventHandlers *handlers[I]
 	augmentation  func(a any) any
@@ -68,7 +68,7 @@ func (i *informer[I]) name() string {
 	return i.collectionName
 }
 
-func (i *informer[I]) uid() collectionUid {
+func (i *informer[I]) uid() collectionUID {
 	return i.id
 }
 

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -203,6 +203,6 @@ type collectionUID uint64
 
 var globalUIDCounter = atomic.NewUint64(1)
 
-func nextUid() collectionUID {
+func nextUID() collectionUID {
 	return collectionUID(globalUIDCounter.Inc())
 }

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/ptr"
-	"istio.io/istio/pkg/slices"
 )
 
 // registerHandlerAsBatched is a helper to register the provided handler as a batched handler. This allows collections to
@@ -38,36 +37,6 @@ func registerHandlerAsBatched[T any](c internalCollection[T], f func(o Event[T])
 			f(o)
 		}
 	}, true)
-}
-
-// erasedCollection is a Collection[T] that has been type-erased so it can be stored in collections
-// that do not have type information.
-type erasedCollection struct {
-	// registerFunc registers any Event[any] handler. These will be mapped to Event[T] when connected to the original collection.
-	registerFunc func(f func(o []Event[any], initialSync bool))
-	name         string
-	id           collectionUid
-	synced       Syncer
-}
-
-func (e erasedCollection) register(f func(o []Event[any], initialSync bool)) {
-	e.registerFunc(f)
-}
-
-func eraseCollection[T any](c internalCollection[T]) *erasedCollection {
-	return &erasedCollection{
-		name:   c.name(),
-		id:     c.uid(),
-		synced: c.Synced(),
-		registerFunc: func(f func(o []Event[any], initialSync bool)) {
-			ff := func(o []Event[T], initialSync bool) {
-				f(slices.Map(o, castEvent[T, any]), initialSync)
-			}
-			// Skip calling all the existing state for secondary dependencies, otherwise we end up with a deadlock due to
-			// rerunning the same collection's recomputation at the same time (once for the initial event, then for the initial registration).
-			c.RegisterBatch(ff, false)
-		},
-	}
 }
 
 // castEvent converts an Event[I] to Event[O].
@@ -113,11 +82,13 @@ type dependency struct {
 	filter *filter
 }
 
+type erasedEventHandler = func(o []Event[any], initialSync bool)
+
 // registerDependency is an internal interface for things that can register dependencies.
 // This is called from Fetch to Collections, generally.
 type registerDependency interface {
 	// Registers a dependency, returning true if it is finalized
-	registerDependency(*dependency, *erasedCollection)
+	registerDependency(*dependency, Syncer, func(f erasedEventHandler))
 	name() string
 }
 

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -76,8 +76,6 @@ type collectionOptions struct {
 // dependency is a specific thing that can be depended on
 type dependency struct {
 	id collectionUid
-	// The actual collection containing this
-	// collection *erasedCollection
 	// Filter over the collection
 	filter *filter
 }

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -75,7 +75,7 @@ type collectionOptions struct {
 
 // dependency is a specific thing that can be depended on
 type dependency struct {
-	id collectionUid
+	id             collectionUID
 	collectionName string
 	// Filter over the collection
 	filter *filter
@@ -199,10 +199,10 @@ func equal[O any](a, b O) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-type collectionUid uint64
+type collectionUID uint64
 
-var globalUidCounter = atomic.NewUint64(1)
+var globalUIDCounter = atomic.NewUint64(1)
 
-func nextUid() collectionUid {
-	return collectionUid(globalUidCounter.Inc())
+func nextUid() collectionUID {
+	return collectionUID(globalUIDCounter.Inc())
 }

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -76,6 +76,7 @@ type collectionOptions struct {
 // dependency is a specific thing that can be depended on
 type dependency struct {
 	id collectionUid
+	collectionName string
 	// Filter over the collection
 	filter *filter
 }

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -23,6 +23,7 @@ import (
 
 type join[T any] struct {
 	collectionName string
+	id             collectionUid
 	collections    []internalCollection[T]
 	merge          func(ts []T) T
 	synced         <-chan struct{}
@@ -78,6 +79,9 @@ func (j *join[T]) augment(a any) any {
 func (j *join[T]) name() string { return j.collectionName }
 
 // nolint: unused // (not true, its to implement an interface)
+func (j *join[T]) uid() collectionUid { return j.id }
+
+// nolint: unused // (not true, its to implement an interface)
 func (j *join[I]) dump() {
 	log.Errorf("> BEGIN DUMP (join %v)", j.collectionName)
 	for _, c := range j.collections {
@@ -116,6 +120,7 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 	}()
 	return &join[T]{
 		collectionName: o.name,
+		id:             nextUid(),
 		synced:         synced,
 		collections:    c,
 		merge: func(ts []T) T {

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -117,7 +117,7 @@ func JoinCollection[T any](cs []Collection[T], opts ...CollectionOption) Collect
 	// TODO: in the future, we could have a custom merge function. For now, since we just take the first, we optimize around that case
 	return &join[T]{
 		collectionName: o.name,
-		id:             nextUid(),
+		id:             nextUID(),
 		synced:         synced,
 		collections:    c,
 	}

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -16,10 +16,10 @@ package krt
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/util/sets"
 
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type join[T any] struct {

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -24,7 +24,7 @@ import (
 
 type join[T any] struct {
 	collectionName string
-	id             collectionUid
+	id             collectionUID
 	collections    []internalCollection[T]
 	synced         <-chan struct{}
 }
@@ -75,7 +75,7 @@ func (j *join[T]) augment(a any) any {
 func (j *join[T]) name() string { return j.collectionName }
 
 // nolint: unused // (not true, its to implement an interface)
-func (j *join[T]) uid() collectionUid { return j.id }
+func (j *join[T]) uid() collectionUID { return j.id }
 
 // nolint: unused // (not true, its to implement an interface)
 func (j *join[I]) dump() {

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -38,7 +38,7 @@ func NewStatic[T any](initial *T) StaticSingleton[T] {
 	val.Store(initial)
 	x := &static[T]{
 		val:           val,
-		id:            nextUid(),
+		id:            nextUID(),
 		eventHandlers: &handlers[T]{},
 	}
 	return collectionAdapter[T]{x}

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -38,6 +38,7 @@ func NewStatic[T any](initial *T) StaticSingleton[T] {
 	val.Store(initial)
 	x := &static[T]{
 		val:           val,
+		id:            nextUid(),
 		eventHandlers: &handlers[T]{},
 	}
 	return collectionAdapter[T]{x}
@@ -46,6 +47,7 @@ func NewStatic[T any](initial *T) StaticSingleton[T] {
 // static represents a Collection of a single static value. This can be explicitly Set() to override it
 type static[T any] struct {
 	val           *atomic.Pointer[T]
+	id            collectionUid
 	eventHandlers *handlers[T]
 }
 
@@ -107,6 +109,11 @@ func (d *static[T]) augment(a any) any {
 // nolint: unused // (not true, its to implement an interface)
 func (d *static[T]) name() string {
 	return "static"
+}
+
+// nolint: unused // (not true, its to implement an interface)
+func (d *static[T]) uid() collectionUid {
+	return d.id
 }
 
 func toEvent[T any](old, now *T) Event[T] {

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -47,7 +47,7 @@ func NewStatic[T any](initial *T) StaticSingleton[T] {
 // static represents a Collection of a single static value. This can be explicitly Set() to override it
 type static[T any] struct {
 	val           *atomic.Pointer[T]
-	id            collectionUid
+	id            collectionUID
 	eventHandlers *handlers[T]
 }
 
@@ -112,7 +112,7 @@ func (d *static[T]) name() string {
 }
 
 // nolint: unused // (not true, its to implement an interface)
-func (d *static[T]) uid() collectionUid {
+func (d *static[T]) uid() collectionUID {
 	return d.id
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -32,7 +32,7 @@ func NewStaticCollection[T any](vals []T) Collection[T] {
 	}
 	return &staticList[T]{
 		vals: res,
-		id:   nextUid(),
+		id:   nextUID(),
 	}
 }
 
@@ -48,6 +48,7 @@ func (s *staticList[T]) name() string {
 	return "staticList"
 }
 
+// nolint: unused // (not true, its to implement an interface)
 func (s *staticList[T]) uid() collectionUID {
 	return s.id
 }

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -22,7 +22,7 @@ import (
 
 type staticList[T any] struct {
 	vals map[Key[T]]T
-	id   collectionUid
+	id   collectionUID
 }
 
 func NewStaticCollection[T any](vals []T) Collection[T] {
@@ -48,7 +48,7 @@ func (s *staticList[T]) name() string {
 	return "staticList"
 }
 
-func (s *staticList[T]) uid() collectionUid {
+func (s *staticList[T]) uid() collectionUID {
 	return s.id
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -22,6 +22,7 @@ import (
 
 type staticList[T any] struct {
 	vals map[Key[T]]T
+	id   collectionUid
 }
 
 func NewStaticCollection[T any](vals []T) Collection[T] {
@@ -29,7 +30,10 @@ func NewStaticCollection[T any](vals []T) Collection[T] {
 	for _, v := range vals {
 		res[GetKey(v)] = v
 	}
-	return &staticList[T]{res}
+	return &staticList[T]{
+		vals: res,
+		id:   nextUid(),
+	}
 }
 
 func (s *staticList[T]) GetKey(k Key[T]) *T {
@@ -42,6 +46,10 @@ func (s *staticList[T]) GetKey(k Key[T]) *T {
 // nolint: unused // (not true, its to implement an interface)
 func (s *staticList[T]) name() string {
 	return "staticList"
+}
+
+func (s *staticList[T]) uid() collectionUid {
+	return s.id
 }
 
 // nolint: unused // (not true, its to implement an interface)

--- a/pkg/kube/krt/testing.go
+++ b/pkg/kube/krt/testing.go
@@ -24,7 +24,7 @@ type TestingDummyContext struct{}
 func (t TestingDummyContext) _internalHandler() {
 }
 
-func (t TestingDummyContext) registerDependency(d dependency) {
+func (t TestingDummyContext) registerDependency(d *dependency, collection *erasedCollection) {
 }
 
 func (t TestingDummyContext) name() string {

--- a/pkg/kube/krt/testing.go
+++ b/pkg/kube/krt/testing.go
@@ -24,7 +24,7 @@ type TestingDummyContext struct{}
 func (t TestingDummyContext) _internalHandler() {
 }
 
-func (t TestingDummyContext) registerDependency(d *dependency, collection *erasedCollection) {
+func (t TestingDummyContext) registerDependency(d *dependency, s Syncer, f func(f erasedEventHandler)) {
 }
 
 func (t TestingDummyContext) name() string {

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -175,6 +175,9 @@ func FilterInPlace[E any](s []E, f func(E) bool) []E {
 // FilterDuplicatesPresorted retains all unique elements in []E.
 // The slices MUST be pre-sorted.
 func FilterDuplicatesPresorted[E comparable](s []E) []E {
+	if len(s) <= 1 {
+		return s
+	}
 	n := 1
 	for i := 1; i < len(s); i++ {
 		val := s[i]

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -145,6 +145,10 @@ func Reverse[E any](r []E) []E {
 	return r
 }
 
+func BinarySearch[S ~[]E, E cmp.Ordered](x S, target E) (int, bool) {
+	return slices.BinarySearch(x, target)
+}
+
 // FilterInPlace retains all elements in []E that f(E) returns true for.
 // The array is *mutated in place* and returned.
 // Use Filter to avoid mutation

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -172,6 +172,29 @@ func FilterInPlace[E any](s []E, f func(E) bool) []E {
 	return s
 }
 
+// FilterDuplicatesPresorted retains all unique elements in []E.
+// The slices MUST be pre-sorted.
+func FilterDuplicatesPresorted[E comparable](s []E) []E {
+	n := 1
+	for i := 1; i < len(s); i++ {
+		val := s[i]
+		if val != s[i-1] {
+			s[n] = val
+			n++
+		}
+	}
+
+	// If those elements contain pointers you might consider zeroing those elements
+	// so that objects they reference can be garbage collected."
+	var empty E
+	for i := n; i < len(s); i++ {
+		s[i] = empty
+	}
+
+	s = s[:n]
+	return s
+}
+
 // Filter retains all elements in []E that f(E) returns true for.
 // A new slice is created and returned. Use FilterInPlace to perform in-place
 func Filter[E any](s []E, f func(E) bool) []E {

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -873,10 +873,10 @@ func BenchmarkEqualUnordered(b *testing.B) {
 }
 
 func TestFilterDuplicates(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		name string
-		in []string
-		out []string
+		in   []string
+		out  []string
 	}{
 		{
 			name: "empty",
@@ -900,20 +900,20 @@ func TestFilterDuplicates(t *testing.T) {
 		},
 		{
 			name: "dupes last",
-			in:   []string{"a", "a", "c", "c"},
-			out:  []string{"a", "b", "C"},
+			in:   []string{"a", "b", "c", "c"},
+			out:  []string{"a", "b", "c"},
 		},
 		{
 			name: "dupes middle",
 			in:   []string{"a", "b", "b", "c"},
-			out:  []string{"a", "b", "C"},
+			out:  []string{"a", "b", "c"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := FilterDuplicatesPresorted(tt.in)
 			assert.Equal(t, tt.out, got)
-			assert.Equal(t, tt.out, tt.in)
+			assert.Equal(t, tt.out, tt.in[:len(tt.out)])
 		})
 	}
 }

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -871,3 +871,49 @@ func BenchmarkEqualUnordered(b *testing.B) {
 		EqualUnordered(l, notEqual)
 	}
 }
+
+func TestFilterDuplicates(t *testing.T) {
+	tests := []struct{
+		name string
+		in []string
+		out []string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			out:  nil,
+		},
+		{
+			name: "one",
+			in:   []string{"a"},
+			out:  []string{"a"},
+		},
+		{
+			name: "no dupes",
+			in:   []string{"a", "b", "c", "d"},
+			out:  []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "dupes first",
+			in:   []string{"a", "a", "c", "d"},
+			out:  []string{"a", "c", "d"},
+		},
+		{
+			name: "dupes last",
+			in:   []string{"a", "a", "c", "c"},
+			out:  []string{"a", "b", "C"},
+		},
+		{
+			name: "dupes middle",
+			in:   []string{"a", "b", "b", "c"},
+			out:  []string{"a", "b", "C"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterDuplicatesPresorted(tt.in)
+			assert.Equal(t, tt.out, got)
+			assert.Equal(t, tt.out, tt.in)
+		})
+	}
+}

--- a/pkg/util/smallset/smallset.go
+++ b/pkg/util/smallset/smallset.go
@@ -109,6 +109,14 @@ func (s Set[T]) IsEmpty() bool {
 	return len(s.items) == 0
 }
 
+// IsNil indicates whether the set is nil. This is different from an empty set.
+// 'var smallset.Set': nil
+// smallset.New(): nil
+// smallset.New(emptyList...): not nil
+func (s Set[T]) IsNil() bool {
+	return s.items == nil
+}
+
 // String returns a string representation of the set.
 // Use it only for debugging and logging.
 func (s Set[T]) String() string {

--- a/pkg/util/smallset/smallset.go
+++ b/pkg/util/smallset/smallset.go
@@ -1,0 +1,110 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smallset
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/constraints"
+
+	"istio.io/istio/pkg/slices"
+)
+
+// Set is an immutable set optimized for *small number of items*. For general purposes, Sets is likely better
+//
+// *Set construction*: sets is roughly 1kb allocations per 250 items. smallsets is 0.
+// *Contains* sets is O(1). smallsets is O(logn). smallsets is typically faster up to about 5 elements.
+//
+//	At 1000 items, it is roughly 5x slower (30ns vs 5ns).
+type Set[T constraints.Ordered] struct {
+	items []T
+}
+
+// NewPresorted creates a new Set with the given items.
+// If items is not sorted, this gives undefined behavior; use New instead.
+func NewPresorted[T constraints.Ordered](items ...T) Set[T] {
+	return Set[T]{items: items}
+}
+
+// New creates a new Set with the given items.
+func New[T constraints.Ordered](items ...T) Set[T] {
+	slices.Sort(items)
+	return Set[T]{items: items}
+}
+
+// CopyAndInsert builds a *new* with all the current items plus new items
+func (s Set[T]) CopyAndInsert(items ...T) Set[T] {
+	slices.Sort(items)
+	// This is basically the 'merge' part of merge sort.
+	a := s.items
+	b := items
+	nl := make([]T, 0, len(a)+len(b))
+	i, j := 0, 0
+	appendIfUnique := func(t T) []T {
+		l := len(nl)
+		if l == 0 {
+			nl = append(nl, t)
+		} else {
+			last := nl[l-1]
+			if last != t {
+				nl = append(nl, t)
+			}
+		}
+		return nl
+	}
+	for i < len(a) && j < len(b) {
+		if a[i] < b[j] {
+			nl = appendIfUnique(a[i])
+			i++
+		} else {
+			nl = appendIfUnique(b[j])
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		nl = appendIfUnique(a[i])
+	}
+	for ; j < len(b); j++ {
+		nl = appendIfUnique(b[j])
+	}
+	return New(nl...)
+}
+
+// List returns the underlying slice. Must not be modified
+func (s Set[T]) List() []T {
+	return s.items
+}
+
+// Contains returns whether the given item is in the set.
+func (s Set[T]) Contains(item T) bool {
+	_, f := slices.BinarySearch(s.items, item)
+	return f
+}
+
+// Len returns the number of elements in this Set.
+func (s Set[T]) Len() int {
+	return len(s.items)
+}
+
+// IsEmpty indicates whether the set is the empty set.
+func (s Set[T]) IsEmpty() bool {
+	return len(s.items) == 0
+}
+
+// String returns a string representation of the set.
+// Use it only for debugging and logging.
+func (s Set[T]) String() string {
+	return fmt.Sprintf("%v", s.items)
+}

--- a/pkg/util/smallset/smallset.go
+++ b/pkg/util/smallset/smallset.go
@@ -33,14 +33,19 @@ type Set[T constraints.Ordered] struct {
 }
 
 // NewPresorted creates a new Set with the given items.
-// If items is not sorted, this gives undefined behavior; use New instead.
+// If items is not sorted or contains duplicates, this gives undefined behavior; use New instead.
 func NewPresorted[T constraints.Ordered](items ...T) Set[T] {
 	return Set[T]{items: items}
 }
 
 // New creates a new Set with the given items.
+// Duplicates are removed
 func New[T constraints.Ordered](items ...T) Set[T] {
+	if len(items) == 1 {
+		return NewPresorted(items...)
+	}
 	slices.Sort(items)
+	items = slices.FilterDuplicatesPresorted(items)
 	return Set[T]{items: items}
 }
 

--- a/pkg/util/smallset/smallset.go
+++ b/pkg/util/smallset/smallset.go
@@ -42,7 +42,7 @@ func NewPresorted[T constraints.Ordered](items ...T) Set[T] {
 // Duplicates are removed
 func New[T constraints.Ordered](items ...T) Set[T] {
 	if len(items) == 1 {
-		return NewPresorted(items...)
+		return Set[T]{items: items}
 	}
 	slices.Sort(items)
 	items = slices.FilterDuplicatesPresorted(items)
@@ -84,7 +84,8 @@ func (s Set[T]) CopyAndInsert(items ...T) Set[T] {
 	for ; j < len(b); j++ {
 		nl = appendIfUnique(b[j])
 	}
-	return New(nl...)
+	// we already know they are sorted+unique
+	return Set[T]{items: nl}
 }
 
 // List returns the underlying slice. Must not be modified

--- a/pkg/util/smallset/smallset_test.go
+++ b/pkg/util/smallset/smallset_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestSet(t *testing.T) {
-	elements := []string{"d", "b", "a"}
+	elements := []string{"d", "b", "a", "d"}
 	set := smallset.New(elements...)
 
-	assert.Equal(t, set.Len(), len(elements))
+	assert.Equal(t, set.Len(), 3)
 	assert.Equal(t, set.List(), []string{"a", "b", "d"})
 
 	assert.Equal(t, set.Contains("a"), true)

--- a/pkg/util/smallset/smallset_test.go
+++ b/pkg/util/smallset/smallset_test.go
@@ -49,6 +49,18 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, nset.Contains("z"), true)
 }
 
+func TestNew(t *testing.T) {
+	var uninit smallset.Set[string]
+	assert.Equal(t, uninit.IsNil(), true)
+	assert.Equal(t, uninit.IsEmpty(), true)
+	empty := smallset.New[string]()
+	assert.Equal(t, empty.IsNil(), true)
+	assert.Equal(t, empty.IsEmpty(), true)
+	empty2 := smallset.New[string]([]string{}...)
+	assert.Equal(t, empty2.IsNil(), false)
+	assert.Equal(t, empty2.IsEmpty(), true)
+}
+
 func BenchmarkSet(b *testing.B) {
 	items1000 := []string{}
 	for i := 0; i < 1000; i++ {

--- a/pkg/util/smallset/smallset_test.go
+++ b/pkg/util/smallset/smallset_test.go
@@ -1,0 +1,121 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smallset_test
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/util/smallset"
+)
+
+func TestSet(t *testing.T) {
+	elements := []string{"d", "b", "a"}
+	set := smallset.New(elements...)
+
+	assert.Equal(t, set.Len(), len(elements))
+	assert.Equal(t, set.List(), []string{"a", "b", "d"})
+
+	assert.Equal(t, set.Contains("a"), true)
+	assert.Equal(t, set.Contains("b"), true)
+	assert.Equal(t, set.Contains("c"), false)
+	assert.Equal(t, set.Contains("d"), true)
+	assert.Equal(t, set.Contains("e"), false)
+
+	nset := set.CopyAndInsert("z", "c", "a")
+	// Should not mutate original set
+	assert.Equal(t, set.List(), []string{"a", "b", "d"})
+	assert.Equal(t, nset.List(), []string{"a", "b", "c", "d", "z"})
+
+	assert.Equal(t, nset.Contains("a"), true)
+	assert.Equal(t, nset.Contains("b"), true)
+	assert.Equal(t, nset.Contains("c"), true)
+	assert.Equal(t, nset.Contains("d"), true)
+	assert.Equal(t, nset.Contains("e"), false)
+	assert.Equal(t, nset.Contains("z"), true)
+}
+
+func BenchmarkSet(b *testing.B) {
+	items1000 := []string{}
+	for i := 0; i < 1000; i++ {
+		items1000 = append(items1000, fmt.Sprint(i))
+	}
+	items100 := []string{}
+	for i := 0; i < 100; i++ {
+		items100 = append(items100, fmt.Sprint(i))
+	}
+	items2 := []string{}
+	for i := 0; i < 2; i++ {
+		items2 = append(items2, fmt.Sprint(i))
+	}
+	// rand.Shuffle(elements)
+	b.Run("Set", func(b *testing.B) {
+		set1000 := sets.New(items1000...)
+		set100 := sets.New(items100...)
+		set2 := sets.New(items2...)
+		b.Run("New/1000", func(b *testing.B) {
+			for range b.N {
+				_ = sets.New(items100...)
+			}
+		})
+		b.Run("Contains/1000", func(b *testing.B) {
+			for range b.N {
+				_ = set1000.Contains("456")
+			}
+		})
+		b.Run("Contains/100", func(b *testing.B) {
+			for range b.N {
+				_ = set100.Contains("45")
+			}
+		})
+		b.Run("Contains/2", func(b *testing.B) {
+			for range b.N {
+				_ = set2.Contains("2")
+			}
+		})
+	})
+	b.Run("SmallSet", func(b *testing.B) {
+		set1000 := smallset.New(items1000...)
+		set100 := smallset.New(items100...)
+		set2 := smallset.New(items2...)
+		b.Run("New/1000", func(b *testing.B) {
+			for range b.N {
+				_ = smallset.New(items1000...)
+			}
+		})
+		b.Run("NewPresorted/1000", func(b *testing.B) {
+			for range b.N {
+				_ = smallset.New(items1000...)
+			}
+		})
+		b.Run("Contains/1000", func(b *testing.B) {
+			for range b.N {
+				_ = set1000.Contains("456")
+			}
+		})
+		b.Run("Contains/100", func(b *testing.B) {
+			for range b.N {
+				_ = set100.Contains("45")
+			}
+		})
+		b.Run("Contains/4", func(b *testing.B) {
+			for range b.N {
+				_ = set2.Contains("2")
+			}
+		})
+	})
+}

--- a/pkg/util/smallset/smallset_test.go
+++ b/pkg/util/smallset/smallset_test.go
@@ -74,7 +74,6 @@ func BenchmarkSet(b *testing.B) {
 	for i := 0; i < 2; i++ {
 		items2 = append(items2, fmt.Sprint(i))
 	}
-	// rand.Shuffle(elements)
 	b.Run("Set", func(b *testing.B) {
 		set1000 := sets.New(items1000...)
 		set100 := sets.New(items100...)

--- a/pkg/util/smallset/smallset_test.go
+++ b/pkg/util/smallset/smallset_test.go
@@ -67,24 +67,33 @@ func BenchmarkSet(b *testing.B) {
 		set1000 := sets.New(items1000...)
 		set100 := sets.New(items100...)
 		set2 := sets.New(items2...)
+		b.Run("New/1", func(b *testing.B) {
+			for range b.N {
+				_ = sets.New("a")
+			}
+		})
 		b.Run("New/1000", func(b *testing.B) {
 			for range b.N {
-				_ = sets.New(items100...)
+				_ = sets.New(items1000...)
 			}
 		})
 		b.Run("Contains/1000", func(b *testing.B) {
 			for range b.N {
+				// Check an item in and out of the set
 				_ = set1000.Contains("456")
+				_ = set1000.Contains("abc")
 			}
 		})
 		b.Run("Contains/100", func(b *testing.B) {
 			for range b.N {
 				_ = set100.Contains("45")
+				_ = set100.Contains("abc")
 			}
 		})
 		b.Run("Contains/2", func(b *testing.B) {
 			for range b.N {
-				_ = set2.Contains("2")
+				_ = set2.Contains("1")
+				_ = set2.Contains("abc")
 			}
 		})
 	})
@@ -92,6 +101,11 @@ func BenchmarkSet(b *testing.B) {
 		set1000 := smallset.New(items1000...)
 		set100 := smallset.New(items100...)
 		set2 := smallset.New(items2...)
+		b.Run("New/1", func(b *testing.B) {
+			for range b.N {
+				_ = smallset.New("a")
+			}
+		})
 		b.Run("New/1000", func(b *testing.B) {
 			for range b.N {
 				_ = smallset.New(items1000...)
@@ -99,22 +113,28 @@ func BenchmarkSet(b *testing.B) {
 		})
 		b.Run("NewPresorted/1000", func(b *testing.B) {
 			for range b.N {
-				_ = smallset.New(items1000...)
+				_ = smallset.NewPresorted(items1000...)
 			}
 		})
 		b.Run("Contains/1000", func(b *testing.B) {
 			for range b.N {
+				// Check an item in and out of the set
 				_ = set1000.Contains("456")
+				_ = set1000.Contains("abc")
 			}
 		})
 		b.Run("Contains/100", func(b *testing.B) {
 			for range b.N {
+				// Check an item in and out of the set
 				_ = set100.Contains("45")
+				_ = set100.Contains("abc")
 			}
 		})
-		b.Run("Contains/4", func(b *testing.B) {
+		b.Run("Contains/2", func(b *testing.B) {
 			for range b.N {
-				_ = set2.Contains("2")
+				// Check an item in and out of the set
+				_ = set2.Contains("1")
+				_ = set2.Contains("abc")
 			}
 		})
 	})


### PR DESCRIPTION
For the same test workload:
Old: 9.5s, 290mb used, 22M objects allocated
Now: 7s, 250mb used, 12M objects allocated

Optimizations include:
* Introduce a new `smallset`, optimized for sets with very few items. This has huge improvements in memory and CPU for small sets. 1-2 elements are WAY faster in CPU, and memory usage is much smaller even for larger ones. In krt, the set I replaced is often 1 item so this gives big wins
* Remove erasedCollection and pass params directly. Avoid storing +comparing the full collection (expensive!) and instead give each collection a UID to compare cheaply.