### PR TITLE
distroless: move to apko/wolfi images

### DIFF
--- a/bin/update_deps.sh
+++ b/bin/update_deps.sh
@@ -40,5 +40,5 @@ chmod +x prow/release-commit.sh
 sed -i '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha proxy)"'"/  }; /ZTUNNEL_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA": "'"$(getSha ztunnel)"'"/  }' istio.deps
 
 # shellcheck disable=SC1001
-LATEST_DEB11_DISTROLESS_SHA256=$(crane digest gcr.io/distroless/static-debian11 | awk -F\: '{print $2}')
-sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_DEB11_DISTROLESS_SHA256}/g" docker/Dockerfile.distroless
+LATEST_DISTROLESS_SHA256=$(crane digest cgr.dev/chainguard/static | awk -F\: '{print $2}')
+sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_DISTROLESS_SHA256}/g" docker/Dockerfile.distroless

--- a/bin/update_deps.sh
+++ b/bin/update_deps.sh
@@ -42,8 +42,3 @@ sed -i '/PROXY_REPO_SHA/,/lastStableSHA/ { s/"lastStableSHA":.*/"lastStableSHA":
 # shellcheck disable=SC1001
 LATEST_DEB11_DISTROLESS_SHA256=$(crane digest gcr.io/distroless/static-debian11 | awk -F\: '{print $2}')
 sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_DEB11_DISTROLESS_SHA256}/g" docker/Dockerfile.distroless
-
-# shellcheck disable=SC1001
-LATEST_IPTABLES_DISTROLESS_SHA256=$(crane digest gcr.io/istio-release/iptables | awk -F\: '{print $2}')
-sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_IPTABLES_DISTROLESS_SHA256}/g" pilot/docker/Dockerfile.proxyv2
-sed -i -E "s/sha256:[a-z0-9]+/sha256:${LATEST_IPTABLES_DISTROLESS_SHA256}/g" pilot/docker/Dockerfile.ztunnel

--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -9,11 +9,7 @@ ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# This image is a custom built debian11 distroless image with multiarchitecture support.
-# It is built on the base distroless image, with iptables binary and libraries added
-# The source can be found at https://github.com/istio/distroless/tree/iptables
-# This version is from commit 86c4972a9f5f245cfb382c8e1e95f176d968c882.
-FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:863a23b9b2d6f3f282e651fb62a47d28a7bd19356839367654254f5677cea6fa as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # prepare a distroless source context to copy files from
-FROM gcr.io/distroless/static-debian11@sha256:9be3fcc6abeaf985b5ecce59451acbcbb15e7be39472320c538d0d55a0834edc as distroless_source
+FROM cgr.dev/chainguard/static@sha256:873e9709e2a83acc995ff24e71c100480f9c0368e0d86eaee9c3c7cb8fb5f0e0 as distroless_source
 
 # prepare a base dev to modify file contents
 FROM ubuntu:noble as ubuntu_source

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -9,11 +9,7 @@ ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# This image is a custom built debian11 distroless image with multiarchitecture support.
-# It is built on the base distroless image, with iptables binary and libraries added
-# The source can be found at https://github.com/istio/distroless/tree/iptables
-# This version is from commit 86c4972a9f5f245cfb382c8e1e95f176d968c882.
-FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:863a23b9b2d6f3f282e651fb62a47d28a7bd19356839367654254f5677cea6fa as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.ztunnel
+++ b/pilot/docker/Dockerfile.ztunnel
@@ -9,11 +9,7 @@ ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# This image is a custom built debian11 distroless image with multiarchitecture support.
-# It is built on the base distroless image, with iptables binary and libraries added
-# The source can be found at https://github.com/istio/distroless/tree/iptables
-# This version is from commit 86c4972a9f5f245cfb382c8e1e95f176d968c882.
-FROM ${ISTIO_BASE_REGISTRY}/iptables@sha256:863a23b9b2d6f3f282e651fb62a47d28a7bd19356839367654254f5677cea6fa as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/releasenotes/notes/apko-distroless.yaml
+++ b/releasenotes/notes/apko-distroless.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Updated** the [`distroless`](/docs/ops/configuration/security/harden-docker-images/) images for Istio CNI, Proxy, and Ztunnel to be based on [Wolfi](https://wolfi.dev).
+    This should have no user facing impact.

--- a/releasenotes/notes/apko-distroless.yaml
+++ b/releasenotes/notes/apko-distroless.yaml
@@ -3,5 +3,5 @@ kind: feature
 area: installation
 releaseNotes:
   - |
-    **Updated** the [`distroless`](/docs/ops/configuration/security/harden-docker-images/) images for Istio CNI, Proxy, and Ztunnel to be based on [Wolfi](https://wolfi.dev).
+    **Updated** the [`distroless`](/docs/ops/configuration/security/harden-docker-images/) images to be based on [Wolfi](https://wolfi.dev).
     This should have no user facing impact.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/44510

This moves our images over to the new images added in https://github.com/istio/istio/pull/50545.

This has 2 commits: 1 replaces just our iptables one, the second replaces the other `static` ones. 

The main value is on the `iptables` one, since that is our fork and has maintenance benefits. I changed `static` as well to align there (why depend on 2 things when we can depend on 1).