### PR TITLE
Add missing affinity to ztunnel

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+{{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | trim | indent 8 }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -28,6 +28,33 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | trim | indent 8 }}
+{{- else }}
+{{ if .Values.excludeNodes }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: ztunnel
+                operator: NotIn
+                values:
+                - "{{ .Values.excludeNodes }}"
+{{- end }}
+{{ if .Values.includeNodes }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: ztunnel
+                operator: In
+                values:
+                - "{{ .Values.includeNodes }}"
+{{- end }}
+{{- end }}
       serviceAccountName: ztunnel
       tolerations:
         - effect: NoSchedule

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -31,29 +31,6 @@ spec:
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | trim | indent 8 }}
-{{- else }}
-{{ if .Values.excludeNodes }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: ztunnel
-                operator: NotIn
-                values:
-                - "{{ .Values.excludeNodes }}"
-{{- end }}
-{{ if .Values.includeNodes }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: ztunnel
-                operator: In
-                values:
-                - "{{ .Values.includeNodes }}"
-{{- end }}
 {{- end }}
       serviceAccountName: ztunnel
       tolerations:


### PR DESCRIPTION
Change-Id: Ie51df7029ce8798785f5e5d68fa31221de474abd

**Please provide a description of this PR:**

All other charts support affinity - this allows installing ztunnel on select nodes, CNI has a similar option.

I added 2 extra options - if controversial will remove, otherwise will add the same to cni chart. 
This makes it easier to install on nodes with a specific label - I used 'ztunnel' as in the developer guide, but 
probably should istio.io/mode or something similar. The end goal is to be able to designate a node as 'canary'
and have a new version of cni/ztunnel run only there. It doesn't fully work with helm - will need more work
to not re-create the service account and rbac. 