### PR TITLE
Default variant can't be installed

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -70,6 +70,8 @@ spec:
         - name: install-cni
 {{- if contains "/" .Values.cni.image }}
           image: "{{ .Values.cni.image }}"
+{{- else if eq .Values.cni.variant "default" }}
+          image: "{{ .Values.cni.hub | default .Values.global.hub }}/{{ .Values.cni.image | default "install-cni" }}:{{ .Values.cni.tag | default .Values.global.tag }}"
 {{- else }}
           image: "{{ .Values.cni.hub | default .Values.global.hub }}/{{ .Values.cni.image | default "install-cni" }}:{{ .Values.cni.tag | default .Values.global.tag }}{{with (.Values.cni.variant | default .Values.global.variant)}}-{{.}}{{end}}"
 {{- end }}


### PR DESCRIPTION
Change-Id: I020824c2464d139776ddf5dbbceb3ff03fb52c8a

**Please provide a description of this PR:**

Recent change to add distroless made it impossible to install default ( it is built as ":latest" - not ":latest-default" ).

We may change the build to produce ":latest-xxx" - but we've been using this pattern since 1.0. 

Alternative is to use the same style we use for -revision ( instead of "with" ). 