### PR TITLE
test: fix CNI Version Skew test

### DIFF
--- a/tests/integration/pilot/cni/cniversionskew_test.go
+++ b/tests/integration/pilot/cni/cniversionskew_test.go
@@ -111,5 +111,6 @@ func installCNIOrFail(t framework.TestContext, ver string) {
 	if err != nil {
 		t.Fatalf("Failed to read CNI manifest %v", err)
 	}
+	config = strings.ReplaceAll(config, "kube-system", i.Settings().SystemNamespace)
 	t.ConfigIstio().YAML("", config).ApplyOrFail(t)
 }


### PR DESCRIPTION
https://prow.istio.io/view/gs/istio-prow/logs/integ-cni_istio_postsubmit/1788646342856282112

(should we be testing CNI from 1.11 "N-1"? Probably not)
