### PR TITLE
Fix usage of infrastructure labels/annotations on gateway

### DIFF
--- a/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
@@ -13,6 +13,7 @@ metadata:
     foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -31,6 +32,7 @@ metadata:
     foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default
@@ -54,6 +56,7 @@ spec:
       labels:
         foo: bar
         gateway.networking.k8s.io/gateway-name: default
+        istio.io/dataplane-mode: none
         istio.io/gateway-name: default
         service.istio.io/canonical-name: default-istio
         service.istio.io/canonical-revision: latest
@@ -228,6 +231,7 @@ metadata:
     foo: bar
     gateway.istio.io/managed: istio.io-gateway-controller
     gateway.networking.k8s.io/gateway-name: default
+    istio.io/dataplane-mode: none
     istio.io/gateway-name: default
   name: default-istio
   namespace: default


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/50983, I think

Basically, we have logic to use `infra.Labels || meta.Labels`. We modify
meta.Labels.

This is wrong, we should modify AFTER we pick which set of labels to
use.

Also, we need to deepcopy anything we mutate since its accessing a
shared object cache
