### PR TITLE
ambient: fix WasmPlugin bind to Service

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2066,6 +2066,23 @@ func (ps *PushContext) WasmPlugins(proxy *Proxy) map[extensions.PluginPhase][]*W
 	return ps.WasmPluginsByListenerInfo(proxy, anyListener, WasmPluginTypeAny)
 }
 
+func (ps *PushContext) WasmPluginsByName(proxy *Proxy, names []types.NamespacedName) []*WasmPluginWrapper {
+	res := make([]*WasmPluginWrapper, 0, len(names))
+	for _, n := range names {
+		if n.Namespace != proxy.ConfigNamespace && n.Namespace != ps.Mesh.RootNamespace {
+			log.Warnf("proxy requested invalid WASM configuration: %v", n)
+			continue
+		}
+		for _, wsm := range ps.wasmPluginsByNamespace[n.Namespace] {
+			if wsm.Name == n.Name {
+				res = append(res, wsm)
+				break
+			}
+		}
+	}
+	return res
+}
+
 // WasmPluginsByListenerInfo return the WasmPluginWrappers which are matched with TrafficSelector in the given proxy.
 func (ps *PushContext) WasmPluginsByListenerInfo(proxy *Proxy, info WasmPluginListenerInfo,
 	pluginType WasmPluginType,

--- a/pilot/pkg/networking/core/extension/wasmplugin_test.go
+++ b/pilot/pkg/networking/core/extension/wasmplugin_test.go
@@ -125,23 +125,21 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 	})
 	testCases := []struct {
 		name        string
-		wasmPlugins map[extensions.PluginPhase][]*model.WasmPluginWrapper
+		wasmPlugins []*model.WasmPluginWrapper
 		names       []string
 		expectedECs []*core.TypedExtensionConfig
 	}{
 		{
 			name:        "empty",
-			wasmPlugins: map[extensions.PluginPhase][]*model.WasmPluginWrapper{},
+			wasmPlugins: []*model.WasmPluginWrapper{},
 			names:       []string{someAuthNFilter.Name},
 			expectedECs: []*core.TypedExtensionConfig{},
 		},
 		{
 			name: "authn",
-			wasmPlugins: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
-				extensions.PluginPhase_AUTHN: {
-					someAuthNFilter,
-					someAuthZFilter,
-				},
+			wasmPlugins: []*model.WasmPluginWrapper{
+				someAuthNFilter,
+				someAuthZFilter,
 			},
 			names: []string{someAuthNFilter.Namespace + "." + someAuthNFilter.Name},
 			expectedECs: []*core.TypedExtensionConfig{
@@ -153,10 +151,8 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 		},
 		{
 			name: "network",
-			wasmPlugins: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
-				extensions.PluginPhase_AUTHN: {
-					someNetworkFilter,
-				},
+			wasmPlugins: []*model.WasmPluginWrapper{
+				someNetworkFilter,
 			},
 			names: []string{
 				someNetworkFilter.Namespace + "." + someNetworkFilter.Name,
@@ -170,11 +166,9 @@ func TestInsertedExtensionConfigurations(t *testing.T) {
 		},
 		{
 			name: "combination of http and network",
-			wasmPlugins: map[extensions.PluginPhase][]*model.WasmPluginWrapper{
-				extensions.PluginPhase_AUTHN: {
-					someAuthNFilter,
-					someNetworkFilter,
-				},
+			wasmPlugins: []*model.WasmPluginWrapper{
+				someAuthNFilter,
+				someNetworkFilter,
 			},
 			names: []string{
 				someAuthNFilter.Namespace + "." + someAuthNFilter.Name,


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/51014

Need tests

The issue is in the LDS gen we lookup with Service, but in the ECDS request we don't so we don't find it.

Actually, the lookup in ECDS is not needed in general, not just in ambient: the proxy already requested a lsit of names, so we can just return those.

**Please provide a description of this PR:**