### PR TITLE
istioctl: avoid parsing strings to ints or floats for string fields

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/common.go
+++ b/operator/pkg/apis/istio/v1alpha1/common.go
@@ -15,6 +15,12 @@
 package v1alpha1
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"istio.io/api/operator/v1alpha1"
 )
 
@@ -49,4 +55,58 @@ func SetNamespace(iops *v1alpha1.IstioOperatorSpec, namespace string) {
 		iops.Namespace = namespace
 	}
 	// TODO implement
+}
+
+// GetFieldType uses reflection to retrieve the reflect.Type of a nested field
+// As the IstioOperator type only uses a map[string]any for values, it will
+// traverse either IstioOperatorSpec or Values depending on the given path
+func GetFieldType(path string) (reflect.Type, error) {
+	titleCaser := cases.Title(language.English, cases.NoLower)
+	iopSpec := v1alpha1.IstioOperatorSpec{}
+	values := Values{}
+	path = strings.TrimPrefix(path, "spec.")
+	pathParts := strings.Split(path, ".")
+	var currentNode reflect.Type
+	// traverse either values or iopSpec
+	currentPath := "spec"
+	if len(pathParts) > 0 && pathParts[0] == "values" {
+		currentNode = reflect.TypeOf(&values).Elem()
+		pathParts = pathParts[1:]
+		currentPath += ".values"
+	} else {
+		currentNode = reflect.TypeOf(&iopSpec).Elem()
+	}
+	for _, part := range pathParts {
+		// remove any slice brackets from the path
+		if sliceBrackets := strings.Index(part, "["); sliceBrackets > 0 {
+			part = part[:sliceBrackets]
+		}
+		currentPath += "." + part
+		nextNode, found := currentNode.FieldByName(titleCaser.String(part))
+		if !found {
+			// iterate over fields to compare against json tags
+			for i := 0; i < currentNode.NumField(); i++ {
+				f := currentNode.Field(i)
+				if strings.Contains(f.Tag.Get("protobuf"), "json="+part+",") {
+					nextNode = f
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("failed to identify type of %s: field %s does not exist", path, currentPath)
+			}
+		}
+		if nextNode.Type.Kind() == reflect.Slice || nextNode.Type.Kind() == reflect.Pointer {
+			currentNode = nextNode.Type.Elem()
+		} else if nextNode.Type.Kind() == reflect.Map {
+			currentNode = nextNode.Type.Elem()
+		} else {
+			currentNode = nextNode.Type
+		}
+		if currentNode.Kind() != reflect.Struct {
+			break
+		}
+	}
+	return currentNode, nil
 }

--- a/releasenotes/notes/50990.yaml
+++ b/releasenotes/notes/50990.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+- 50990
+releaseNotes:
+- |
+  **Fixed** a bug in istioctl where it would parse a field value into a non-string type which then failed to be assigned to the string field.


### PR DESCRIPTION
**Please provide a description of this PR:**

This uses reflection to check field types of our values. The performance hit should be negligible as this only runs as part of istioctl. The function turned out to be a bit more complex because we a) use a map for values instead of the struct in our IstioOperator CRD and b) protoc-gen-go does not generate proper json tags.

Fixes #50990