### PR TITLE
Remove Istio stackdriver metrics from XDS

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -1052,7 +1052,6 @@ func generateSDConfig(class networking.ListenerClass, telemetryConfig telemetryF
 		cfg.DisableServerAccessLogging = true // nolint: staticcheck
 	}
 
-	cfg.MetricExpiryDuration = durationpb.New(1 * time.Hour)
 	cfg.EnableAuditLog = features.StackdriverAuditLog
 	// In WASM we are not actually processing protobuf at all, so we need to encode this to JSON
 	cfgJSON, _ := protomarshal.MarshalProtoNames(&cfg)

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -620,48 +620,6 @@ func TestTelemetryFilters(t *testing.T) {
 		},
 	}
 	overridesStackdriver := &tpb.Telemetry{
-		Metrics: []*tpb.Metrics{
-			{
-				Providers: []*tpb.ProviderRef{{Name: "stackdriver"}},
-				Overrides: overrides,
-			},
-		},
-		AccessLogging: []*tpb.AccessLogging{
-			{
-				Providers: []*tpb.ProviderRef{{Name: "stackdriver"}},
-				Filter: &tpb.AccessLogging_Filter{
-					Expression: `response.code >= 500 && response.code <= 800`,
-				},
-			},
-		},
-	}
-	overridesAllMetricsStackdriver := &tpb.Telemetry{
-		Metrics: []*tpb.Metrics{
-			{
-				Providers: []*tpb.ProviderRef{{Name: "stackdriver"}},
-				Overrides: []*tpb.MetricsOverrides{
-					{
-						TagOverrides: map[string]*tpb.MetricsOverrides_TagOverride{
-							"destination_service": {
-								Value: "fake_dest",
-							},
-						},
-					},
-					{
-						Match: &tpb.MetricSelector{
-							MetricMatch: &tpb.MetricSelector_Metric{
-								Metric: tpb.MetricSelector_REQUEST_COUNT,
-							},
-						},
-						TagOverrides: map[string]*tpb.MetricsOverrides_TagOverride{
-							"destination_service": {
-								Value: "fake_dest_override",
-							},
-						},
-					},
-				},
-			},
-		},
 		AccessLogging: []*tpb.AccessLogging{
 			{
 				Providers: []*tpb.ProviderRef{{Name: "stackdriver"}},
@@ -1034,7 +992,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true}`,
 			},
 		},
 		{
@@ -1045,50 +1003,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800",` +
-					`"metric_expiry_duration":"3600s","metrics_overrides":{"client/request_count":{"tag_overrides":{"add":"bar"}}}}`,
-			},
-		},
-		{
-			"overrides all metrics stackdriver/client",
-			[]config.Config{newTelemetry("istio-system", overridesAllMetricsStackdriver)},
-			sidecar,
-			networking.ListenerClassSidecarOutbound,
-			networking.ListenerProtocolHTTP,
-			nil,
-			map[string]string{
-				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800",` +
-					`"metric_expiry_duration":"3600s","metrics_overrides":{` +
-					`"client/connection_close_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/connection_open_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/received_bytes_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/request_bytes":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/request_count":{"tag_overrides":{"destination_service":"fake_dest_override"}},` +
-					`"client/response_bytes":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/response_latencies":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"client/sent_bytes_count":{"tag_overrides":{"destination_service":"fake_dest"}}` +
-					`}}`,
-			},
-		},
-		{
-			"overrides all metrics stackdriver/server",
-			[]config.Config{newTelemetry("istio-system", overridesAllMetricsStackdriver)},
-			sidecar,
-			networking.ListenerClassSidecarInbound,
-			networking.ListenerProtocolHTTP,
-			nil,
-			map[string]string{
-				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging_filter_expression":"response.code >= 500 && response.code <= 800",` +
-					`"metric_expiry_duration":"3600s","metrics_overrides":{` +
-					`"server/connection_close_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/connection_open_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/received_bytes_count":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/request_bytes":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/request_count":{"tag_overrides":{"destination_service":"fake_dest_override"}},` +
-					`"server/response_bytes":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/response_latencies":{"tag_overrides":{"destination_service":"fake_dest"}},` +
-					`"server/sent_bytes_count":{"tag_overrides":{"destination_service":"fake_dest"}}` +
-					`}}`,
+				"istio.stackdriver": `{"access_logging_filter_expression":"response.code >= 500 && response.code <= 800"}`,
 			},
 		},
 		{

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -1017,7 +1017,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true}`,
 			},
 		},
 		{
@@ -1057,7 +1057,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			&meshconfig.MeshConfig_DefaultProviders{Metrics: []string{"prometheus"}},
 			map[string]string{
-				"istio.stackdriver": `{"disable_server_access_logging":true,"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true}`,
 			},
 		},
 		{
@@ -1070,7 +1070,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			nil,
 			map[string]string{
-				"istio.stackdriver": `{"access_logging":"ERRORS_ONLY","metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"access_logging":"ERRORS_ONLY"}`,
 			},
 		},
 		{
@@ -1094,7 +1094,7 @@ func TestTelemetryFilters(t *testing.T) {
 			networking.ListenerProtocolHTTP,
 			&meshconfig.MeshConfig_DefaultProviders{AccessLogging: []string{"stackdriver"}},
 			map[string]string{
-				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL","metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL"}`,
 			},
 		},
 		{
@@ -1108,7 +1108,7 @@ func TestTelemetryFilters(t *testing.T) {
 				AccessLogging: []string{"stackdriver"},
 			},
 			map[string]string{
-				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL","metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_host_header_fallback":true,"access_logging":"FULL"}`,
 			},
 		},
 		{
@@ -1122,7 +1122,7 @@ func TestTelemetryFilters(t *testing.T) {
 				AccessLogging: []string{"stackdriver"},
 			},
 			map[string]string{
-				"istio.stackdriver": `{"disable_server_access_logging":true,"disable_host_header_fallback":true,"metric_expiry_duration":"3600s"}`,
+				"istio.stackdriver": `{"disable_server_access_logging":true,"disable_host_header_fallback":true}`,
 			},
 		},
 	}

--- a/releasenotes/notes/51044.yaml
+++ b/releasenotes/notes/51044.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 50808
+releaseNotes:
+  - |
+    **Removed** Istio Stackdriver metrics from XDS.


### PR DESCRIPTION
**Please provide a description of this PR:**

Istio Stackdriver metrics are implemented using the OpenCensus SDK. As OpenCensus is deprecated, this PR removes the XDS programming of the Istio Stackdriver metrics from Istio. 

Istio Stackdriver logs are not implemented using the OpenCensus SDK and are not removed in this PR.

Related issue: https://github.com/istio/istio/issues/50808.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ X] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure