### PR TITLE
Fix incorrect memory access in assertion

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -295,12 +295,9 @@ func (s *DiscoveryServer) globalPushContext() *model.PushContext {
 // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
 func (s *DiscoveryServer) ConfigUpdate(req *model.PushRequest) {
 	if features.EnableUnsafeAssertions {
-		// This operation is really slow, which makes tests fail for unrelated reasons, so we process it async.
-		go func() {
-			if model.HasConfigsOfKind(req.ConfigsUpdated, kind.Service) {
-				panic("assertion failed kind.Service can not be set in ConfigKey")
-			}
-		}()
+		if model.HasConfigsOfKind(req.ConfigsUpdated, kind.Service) {
+			panic("assertion failed kind.Service can not be set in ConfigKey")
+		}
 	}
 	if model.HasConfigsOfKind(req.ConfigsUpdated, kind.Address) {
 		// This is a bit like clearing EDS cache on EndpointShard update. Because Address


### PR DESCRIPTION
This impacts the assertion mode only, not prod. We do async, but the set
has ownership passed. We later call .Merge on it which panics
(https://storage.googleapis.com/istio-prow/logs/integ-assertion_istio_postsubmit/1790807913632108544/artifacts/ambient-92275c91ed104daaaebed49/TestDirect/waypoint/Pod_IP_destination/_test_context/istio-state3742125984/primary-0/istiod-6765f4447f-47zxm_discovery.previous.log).

The reason we `go` here is because we copied some other code that does
it; that other code takes ~1s per operation, so it makes sense to do
async. Here, the operation is ~100ns so no need to do async. This also
avoids modifying it after we have passed "ownership".
