### PR TITLE
Explicitly fail when we are asked to add a duplicate ip to the ipset

### DIFF
--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -231,8 +231,8 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) erro
 
 	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
 	if openNetns == nil {
-		log.Warn("failed to find pod netns")
-		return fmt.Errorf("failed to find pod netns")
+		log.Warn("failed to find pod netns during removal")
+		return fmt.Errorf("failed to find pod netns during removal")
 	}
 	// pod is removed from the mesh, but is still running. remove iptables rules
 	log.Debugf("calling DeleteInpodRules.")
@@ -312,11 +312,17 @@ func addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr, hostsideProbeSet 
 	for _, pip := range podIPs {
 		// Add to host ipset
 		log.Debugf("adding pod %s probe to ipset %s with ip %s", pod.Name, hostsideProbeSet.Prefix, pip)
-		// Add IP/port combo to set. Note that we set Replace to true - a pod ip/port combo already being
-		// in the set is perfectly fine, and something we can always safely overwrite, so we will.
-		if err := hostsideProbeSet.AddIP(pip, ipProto, podUID, true); err != nil {
+		// Add IP/port combo to set. Note that we set Replace to false here - we _did_ previously
+		// set it to true, but in theory that could mask weird scenarios where K8S triggers events out of order ->
+		// an add(sameIPreused) then delete(originalIP).
+		// Which will result in the new pod starting to fail healthchecks.
+		//
+		// Since we purge on restart of CNI, and remove pod IPs from the set on every pod removal/deletion,
+		// we _shouldn't_ get any overwrite/overlap, unless something is wrong and we are asked to add
+		// a pod by an IP we already have in the set (which will give an error, which we want).
+		if err := hostsideProbeSet.AddIP(pip, ipProto, podUID, false); err != nil {
 			ipsetAddrErrs = append(ipsetAddrErrs, err)
-			log.Warnf("failed adding pod %s to ipset %s with ip %s, error was %s",
+			log.Errorf("failed adding pod %s to ipset %s with ip %s, error was %s",
 				pod.Name, hostsideProbeSet.Prefix, pip, err)
 		}
 	}

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -156,7 +156,7 @@ func TestServerAddPod(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
-		true,
+		false,
 	).Return(nil)
 
 	err := netServer.AddPodToMesh(ctx, &corev1.Pod{ObjectMeta: podMeta}, podIPs, "fakenetns")
@@ -253,7 +253,7 @@ func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podMeta metav1.Obje
 		netip.MustParseAddr("99.9.9.9"),
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
-		true,
+		false,
 	).Return(nil)
 }
 
@@ -371,7 +371,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -379,7 +379,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
@@ -402,7 +402,7 @@ func TestAddPodToHostNSIPSetsV6(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -410,7 +410,7 @@ func TestAddPodToHostNSIPSetsV6(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")}
@@ -433,7 +433,7 @@ func TestAddPodToHostNSIPSetsDualstack(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -441,7 +441,7 @@ func TestAddPodToHostNSIPSetsDualstack(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("99.9.9.9")}
@@ -451,7 +451,7 @@ func TestAddPodToHostNSIPSetsDualstack(t *testing.T) {
 	fakeIPSetDeps.AssertExpectations(t)
 }
 
-func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
+func TestAddPodIPToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 	pod := buildConvincingPod(false)
 
 	var podUID string = string(pod.ObjectMeta.UID)
@@ -464,7 +464,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -472,7 +472,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(errors.New("bwoah"))
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
@@ -483,7 +483,7 @@ func TestAddPodProbePortsToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 	fakeIPSetDeps.AssertExpectations(t)
 }
 
-func TestRemovePodProbePortsFromHostNSIPSets(t *testing.T) {
+func TestRemovePodIPFromHostNSIPSets(t *testing.T) {
 	pod := buildConvincingPod(false)
 
 	fakeIPSetDeps := ipset.FakeNLDeps()
@@ -522,7 +522,7 @@ func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fixture.ipsetDeps.On("addIP",
@@ -530,7 +530,7 @@ func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fixture.ipsetDeps.On("listEntriesByIP",
@@ -584,7 +584,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	fixture.ipsetDeps.On("addIP",
@@ -592,7 +592,7 @@ func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		true,
+		false,
 	).Return(nil)
 
 	// List should return one IP not in our "pod snapshot", which means we prune

--- a/releasenotes/notes/51081.yaml
+++ b/releasenotes/notes/51081.yaml
@@ -1,0 +1,29 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: bug-fix
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: traffic-management
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+- |
+  **Fixed** Explicitly fail to add pod to host ipset if ip already exists, rather than silently overwrite


### PR DESCRIPTION
A user is (somehow) able to produce a scenario where, without `istio-cni` restarting, a pod IP goes `missing` from the host node ipset, causing an active pod to begin failing host node healthchecks.

Since we destructively mutate the ipset contents in _exactly_ 3 spots:

1. Flush on `istio-cni` startup
2. Flush/destroy on `istio-cni` shutdown
3. Removing pod IPs on K8S pod unlabel/delete events

and no `istio-cni` restart happens as per logs, that leaves (3) as the only way this could manifest, barring outside interference with the contents of the ipset.

The only scenario where I can imagine this happening is if 
- two pods reuse the same IP relatively close to each other on the same node.
- K8S `pod add` and `pod remove` events for those two pods both overlap, and come in to us out-of-order - we `add` the new pod with the reused IP, and then somehow _later_ get a `remove` event for the old pod with the original use of the IP, leading to the set being out of sync.

This PR changes the `addPodIPToIpset` logic, so that if we try to add a pod IP that is already there, we log/return an error - previously, we would silently overwrite the existing entry.

This will at least help us see if the above happens and cause the pod with the overlapping IP to fail to start - otherwise we should never legitimately have an overwrite.

(We might have missed this in testing months back because we were using `ip:port` maps, and the odds of two pods using the same IP AND the same ports is even tinier)