### PR TITLE
Support DestinationRule (beyond subsets) in waypoint

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -729,7 +729,8 @@ type buildClusterOpts struct {
 	// Indicates the service registry of the cluster being built.
 	serviceRegistry provider.ID
 	// Indicates if the destinationRule has a workloadSelector
-	isDrWithSelector bool
+	isDrWithSelector      bool
+	credentialSocketExist bool
 }
 
 func applyTCPKeepalive(mesh *meshconfig.MeshConfig, c *cluster.Cluster, tcp *networking.ConnectionPoolSettings_TCPSettings) {

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -221,13 +221,14 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	// merge applicable port level traffic policy settings
 	trafficPolicy, _ := util.GetPortLevelTrafficPolicy(destinationRule.GetTrafficPolicy(), port)
 	opts := buildClusterOpts{
-		mesh:           cb.req.Push.Mesh,
-		serviceTargets: cb.serviceTargets,
-		mutable:        mc,
-		policy:         trafficPolicy,
-		port:           port,
-		clusterMode:    clusterMode,
-		direction:      model.TrafficDirectionOutbound,
+		mesh:                  cb.req.Push.Mesh,
+		serviceTargets:        cb.serviceTargets,
+		mutable:               mc,
+		policy:                trafficPolicy,
+		port:                  port,
+		clusterMode:           clusterMode,
+		direction:             model.TrafficDirectionOutbound,
+		credentialSocketExist: cb.credentialSocketExist,
 	}
 
 	if clusterMode == DefaultClusterMode {
@@ -558,7 +559,7 @@ func http2ProtocolOptions() *core.Http2ProtocolOptions {
 
 // nolint
 // revive:disable-next-line
-func (cb *ClusterBuilder) isHttp2Cluster(mc *clusterWrapper) bool {
+func isHttp2Cluster(mc *clusterWrapper) bool {
 	options := mc.httpProtocolOptions
 	return options != nil && options.GetExplicitHttpConfig().GetHttp2ProtocolOptions() != nil
 }

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -2136,11 +2136,9 @@ func TestIsHttp2Cluster(t *testing.T) {
 		},
 	}
 
-	cb := NewClusterBuilder(newSidecarProxy(), nil, model.DisabledCache{})
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			isHttp2Cluster := cb.isHttp2Cluster(test.cluster) // revive:disable-line
+			isHttp2Cluster := isHttp2Cluster(test.cluster) // revive:disable-line
 			if isHttp2Cluster != test.isHttp2Cluster {
 				t.Errorf("got: %t, want: %t", isHttp2Cluster, test.isHttp2Cluster)
 			}

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/wellknown"
 )
 
 // applyTrafficPolicy applies the trafficPolicy defined within destinationRule,
@@ -489,7 +490,7 @@ func (cb *ClusterBuilder) applyUpstreamProxyProtocol(
 	if c.cluster.TransportSocket != nil {
 		// add an upstream proxy protocol wrapper for transportSocket
 		c.cluster.TransportSocket = &core.TransportSocket{
-			Name: "envoy.transport_sockets.upstream_proxy_protocol",
+			Name: wellknown.TransportSocketPROXY,
 			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&proxyprotocol.ProxyProtocolUpstreamTransport{
 				Config:          &core.ProxyProtocolConfig{Version: core.ProxyProtocolConfig_Version(proxyProtocol.Version)},
 				TransportSocket: c.cluster.TransportSocket,
@@ -500,7 +501,7 @@ func (cb *ClusterBuilder) applyUpstreamProxyProtocol(
 	// add an upstream proxy protocol wrapper for each transportSocket
 	for _, tsm := range c.cluster.TransportSocketMatches {
 		tsm.TransportSocket = &core.TransportSocket{
-			Name: "envoy.transport_sockets.upstream_proxy_protocol",
+			Name: wellknown.TransportSocketPROXY,
 			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&proxyprotocol.ProxyProtocolUpstreamTransport{
 				Config:          &core.ProxyProtocolConfig{Version: core.ProxyProtocolConfig_Version(proxyProtocol.Version)},
 				TransportSocket: tsm.TransportSocket,

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -20,7 +20,9 @@ import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	internalupstream "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
+	proxyprotocol "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/proxy_protocol/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
@@ -29,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -36,10 +39,12 @@ import (
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pilot/pkg/xds/endpoints"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/wellknown"
 )
 
 // buildInternalUpstreamCluster builds a single endpoint cluster to the internal listener.
@@ -78,7 +83,7 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 	// Creates "encap" cluster to route to the encap listener.
 	clusters = append(clusters, MainInternalCluster, EncapCluster)
 	// Creates per-VIP load balancing upstreams.
-	clusters = append(clusters, cb.buildWaypointInboundVIP(proxy, svcs)...)
+	clusters = append(clusters, cb.buildWaypointInboundVIP(proxy, svcs, push.Mesh)...)
 	// Upstream of the "encap" listener.
 	clusters = append(clusters, cb.buildWaypointConnectOriginate(proxy, push))
 
@@ -91,7 +96,15 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 }
 
 // `inbound-vip||hostname|port`. EDS routing to the internal listener for each pod in the VIP.
-func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(proxy *model.Proxy, svc *model.Service, port model.Port, subset string) *clusterWrapper {
+func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(
+	proxy *model.Proxy,
+	svc *model.Service,
+	port model.Port,
+	subset string,
+	mesh *meshconfig.MeshConfig,
+	policy *networking.TrafficPolicy,
+	drConfig *config.Config,
+) *cluster.Cluster {
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, subset, svc.Hostname, port.Port)
 
 	discoveryType := convertResolution(cb.proxyType, svc)
@@ -120,15 +133,108 @@ func (cb *ClusterBuilder) buildWaypointInboundVIPCluster(proxy *model.Proxy, svc
 	svcMetaList := im.Fields["services"].GetListValue()
 	svcMetaList.Values = append(svcMetaList.Values, buildServiceMetadata(svc))
 
+	// Apply DestinationRule configuration for the service
+	connectionPool, outlierDetection, loadBalancer, tls, proxyProtocol := selectTrafficPolicyComponents(policy)
+	// Add applicable metadata to the cluster to identify which config is applied for tooling
+	if policy != nil {
+		util.AddConfigInfoMetadata(localCluster.cluster.Metadata, drConfig.Meta)
+	}
+	if subset != "" {
+		util.AddSubsetToMetadata(localCluster.cluster.Metadata, subset)
+	}
+	if connectionPool == nil {
+		connectionPool = &networking.ConnectionPoolSettings{}
+	}
+
+	// For these policies, we have the standard logic apply
+	cb.applyConnectionPool(mesh, localCluster, connectionPool)
+	cb.applyH2Upgrade(localCluster, &port, mesh, connectionPool)
+	applyOutlierDetection(localCluster.cluster, outlierDetection)
+	applyLoadBalancer(localCluster.cluster, loadBalancer, &port, cb.locality, cb.proxyLabels, mesh)
+
+	// Setup EDS config after apply LoadBalancer, since it can impact the result
+	if localCluster.cluster.GetType() == cluster.Cluster_ORIGINAL_DST {
+		localCluster.cluster.LbPolicy = cluster.Cluster_CLUSTER_PROVIDED
+	}
+	maybeApplyEdsConfig(localCluster.cluster)
+
+	// TLS and PROXY are more involved, since these impact the transport socket which is customized for HBONE.
+	opts := &buildClusterOpts{
+		mesh:           cb.req.Push.Mesh,
+		mutable:        localCluster,
+		policy:         policy,
+		port:           &port,
+		serviceTargets: cb.serviceTargets,
+		clusterMode:    DefaultClusterMode,
+		direction:      model.TrafficDirectionInboundVIP,
+	}
+	transportSocket := util.RawBufferTransport()
+	if tlsContext := buildWaypointTLSContext(opts, tls); tlsContext != nil {
+		transportSocket = &core.TransportSocket{
+			Name: "internal_upstream",
+			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&internalupstream.InternalUpstreamTransport{
+				PassthroughMetadata: util.TunnelHostMetadata,
+				TransportSocket: &core.TransportSocket{
+					Name:       wellknown.TransportSocketTLS,
+					ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(tlsContext)},
+				},
+			})},
+		}
+	}
+	if proxyProtocol != nil {
+		// Wrap the existing transport socket. Note this could be RawBuffer or TLS, depending on other config
+		transportSocket = &core.TransportSocket{
+			Name: wellknown.TransportSocketPROXY,
+			ConfigType: &core.TransportSocket_TypedConfig{
+				TypedConfig: protoconv.MessageToAny(&proxyprotocol.ProxyProtocolUpstreamTransport{
+					Config:          &core.ProxyProtocolConfig{Version: core.ProxyProtocolConfig_Version(proxyProtocol.Version)},
+					TransportSocket: transportSocket,
+				},
+				),
+			},
+		}
+	}
 	// no TLS, we are just going to internal address
 	localCluster.cluster.TransportSocketMatches = nil
-	localCluster.cluster.TransportSocket = util.TunnelHostInternalUpstreamTransportSocket
-	maybeApplyEdsConfig(localCluster.cluster)
-	return localCluster
+	// Wrap the transportSocket with internal listener upstream. Note this could be a raw buffer, PROXY, TLS, etc
+	localCluster.cluster.TransportSocket = util.TunnelHostInternalUpstreamTransportSocket(transportSocket)
+
+	return localCluster.build()
+}
+
+func buildWaypointTLSContext(opts *buildClusterOpts, tls *networking.ClientTLSSettings) *tlsv3.UpstreamTlsContext {
+	if tls == nil {
+		return nil
+	}
+
+	var tlsContext *tlsv3.UpstreamTlsContext
+	var err error
+	switch tls.Mode {
+	case networking.ClientTLSSettings_DISABLE:
+		// nothing needed
+		return nil
+	case networking.ClientTLSSettings_ISTIO_MUTUAL:
+		// not supported (?)
+		return nil
+	case networking.ClientTLSSettings_SIMPLE:
+		tlsContext, err = constructUpstreamTLS(opts, tls, opts.mutable, false)
+
+	case networking.ClientTLSSettings_MUTUAL:
+		tlsContext, err = constructUpstreamTLS(opts, tls, opts.mutable, true)
+	}
+	if err != nil {
+		log.Errorf("failed to build Upstream TLSContext: %s", err.Error())
+		return nil
+	}
+	// Compliance for Envoy TLS upstreams.
+	if tlsContext != nil {
+		sec_model.EnforceCompliance(tlsContext.CommonTlsContext)
+	}
+	return tlsContext
 }
 
 // `inbound-vip|protocol|hostname|port`. EDS routing to the internal listener for each pod in the VIP.
-func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[host.Name]*model.Service) []*cluster.Cluster {
+func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[host.Name]*model.Service, mesh *meshconfig.MeshConfig) []*cluster.Cluster {
 	clusters := []*cluster.Cluster{}
 
 	for _, svc := range svcs {
@@ -136,22 +242,22 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 			if port.Protocol == protocol.UDP {
 				continue
 			}
+			cfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()
+			dr := CastDestinationRule(cfg)
+			policy := dr.GetTrafficPolicy()
 			if port.Protocol.IsUnsupported() || port.Protocol.IsTCP() {
-				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp").build())
+				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp", mesh, policy, cfg))
 			}
 			if port.Protocol.IsUnsupported() || port.Protocol.IsHTTP() {
-				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "http").build())
+				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "http", mesh, policy, cfg))
 			}
-			cfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()
-			if cfg != nil {
-				destinationRule := cfg.Spec.(*networking.DestinationRule)
-				for _, ss := range destinationRule.Subsets {
-					if port.Protocol.IsUnsupported() || port.Protocol.IsTCP() {
-						clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp/"+ss.Name).build())
-					}
-					if port.Protocol.IsUnsupported() || port.Protocol.IsHTTP() {
-						clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "http/"+ss.Name).build())
-					}
+			for _, ss := range dr.GetSubsets() {
+				policy = util.MergeSubsetTrafficPolicy(dr.GetTrafficPolicy(), ss.GetTrafficPolicy(), port)
+				if port.Protocol.IsUnsupported() || port.Protocol.IsTCP() {
+					clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp/"+ss.Name, mesh, policy, cfg))
+				}
+				if port.Protocol.IsUnsupported() || port.Protocol.IsHTTP() {
+					clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "http/"+ss.Name, mesh, policy, cfg))
 				}
 			}
 		}
@@ -173,8 +279,8 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 	validationCtx := ctx.GetCombinedValidationContext().DefaultValidationContext
 	for _, uriSanMatcher := range uriSanMatchers {
 		if uriSanMatcher != nil {
-			validationCtx.MatchTypedSubjectAltNames = append(validationCtx.MatchTypedSubjectAltNames, &tls.SubjectAltNameMatcher{
-				SanType: tls.SubjectAltNameMatcher_URI,
+			validationCtx.MatchTypedSubjectAltNames = append(validationCtx.MatchTypedSubjectAltNames, &tlsv3.SubjectAltNameMatcher{
+				SanType: tlsv3.SubjectAltNameMatcher_URI,
 				Matcher: uriSanMatcher,
 			})
 		}
@@ -206,7 +312,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 		},
 		TransportSocket: &core.TransportSocket{
 			Name: "tls",
-			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&tls.UpstreamTlsContext{
+			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&tlsv3.UpstreamTlsContext{
 				CommonTlsContext: ctx,
 			})},
 		},

--- a/pilot/pkg/networking/util/internal_upstream.go
+++ b/pilot/pkg/networking/util/internal_upstream.go
@@ -44,10 +44,12 @@ var DefaultInternalUpstreamTransportSocket = &core.TransportSocket{
 	})},
 }
 
-var TunnelHostInternalUpstreamTransportSocket = &core.TransportSocket{
-	Name: "internal_upstream",
-	ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&internalupstream.InternalUpstreamTransport{
-		PassthroughMetadata: TunnelHostMetadata,
-		TransportSocket:     RawBufferTransport(),
-	})},
+func TunnelHostInternalUpstreamTransportSocket(inner *core.TransportSocket) *core.TransportSocket {
+	return &core.TransportSocket{
+		Name: "internal_upstream",
+		ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: protoconv.MessageToAny(&internalupstream.InternalUpstreamTransport{
+			PassthroughMetadata: TunnelHostMetadata,
+			TransportSocket:     inner,
+		})},
+	}
 }

--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -113,4 +113,6 @@ const (
 	TransportSocketTLS = "envoy.transport_sockets.tls"
 	// TransportSocket Quic
 	TransportSocketQuic = "envoy.transport_sockets.quic"
+	// TransportSocketPROXY indicates upstream HA-PROXY protocol
+	TransportSocketPROXY = "envoy.transport_sockets.upstream_proxy_protocol"
 )


### PR DESCRIPTION
This PR implements full DestinationRule support in waypoints. Prior to this, only subsets were supported.

As part of this change, some of the sidecar TLS logic is refactored to avoid duplication. Aside from that, the changes should be scoped only to waypoints. Testing coverage includes e2e tests of applying various policies to waypoints

Fixes https://github.com/istio/istio/issues/50215