### PR TITLE
Add warning messages for stackdriver tracer removed

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -50,6 +50,10 @@ For further documentation see https://istio.io website
     "global.tracer.datadog.address" "meshConfig.defaultConfig.tracing.datadog.address"
     "global.meshExpansion.enabled" "Gateway and other Istio networking resources, such as in samples/multicluster/"
     "istiocoredns.enabled" "the in-proxy DNS capturing (ISTIO_META_DNS_CAPTURE)"
+    "meshConfig.defaultConfig.tracing.stackdriver.debug" "Istio supported tracers"
+    "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAttributes" "Istio supported tracers"
+    "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAnnotations" "Istio supported tracers"
+    "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfMessageEvents" "Istio supported tracers"
 }}
 {{- range $dep, $replace := $deps }}
 {{- /* Complex logic to turn the string above into a null-safe traversal like ((.Values.global).certificates */}}

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -135,6 +135,10 @@ func checkDeprecatedSettings(iop *v1alpha1.IstioOperatorSpec) (util.Errors, []st
 		{"telemetry.v2.stackdriver.configOverride", "custom configuration", nil},
 		{"telemetry.v2.stackdriver.disableOutbound", "custom configuration", nil},
 		{"telemetry.v2.stackdriver.outboundAccessLogging", "custom configuration", nil},
+		{"meshConfig.defaultConfig.tracing.stackdriver.debug", "Istio supported tracers", false},
+		{"meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAttributes", "Istio supported tracers", 0},
+		{"meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAnnotations", "Istio supported tracers", 0},
+		{"meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfMessageEvents", "Istio supported tracers", 0},
 	}
 
 	for _, d := range warningSettings {


### PR DESCRIPTION
**Please provide a description of this PR:**

Add warning messages for stackdriver tracer removed. This PR is a follow-up for https://github.com/istio/istio/pull/51078.