### PR TITLE
Default revision message: just state what we did, rather than why

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -412,8 +412,7 @@ func detectDefaultWebhookChange(p Printer, client kube.CLIClient, iop *v1alpha12
 	// If there is no default webhook but a revisioned default webhook exists,
 	// and we are installing a new IOP with default semantics, the default webhook shifts.
 	if exists && len(mwhs.Items) == 0 && iop.Spec.GetRevision() == "" {
-		p.Println("This installation will make default injection and validation pointing to the default revision, and " +
-			"originally it was pointing to the revisioned one.")
+		p.Println("The default revision has been updated to point to this installation.")
 	}
 	return nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

I had a hard time understanding what this message was trying to tell me - the pertinent information is that the default revision has been updated - why it was updated is somewhat moot by the time you get to this point in the installation.