### PR TITLE
Drop legacy references to 1.22

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -68,13 +68,10 @@ spec:
             "istio.io/gateway-name" .Name
           ) | nindent 8 }}
     spec:
-      {{- if ge .KubeVersion 122 }}
-      {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
           value: "0"
-      {{- end }}
       serviceAccountName: {{.ServiceAccount | quote}}
       containers:
       - name: istio-proxy
@@ -89,8 +86,6 @@ spec:
         {{- end }}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         securityContext:
-        {{- if ge .KubeVersion 122 }}
-          # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
           capabilities:
             drop:
             - ALL
@@ -100,18 +95,6 @@ spec:
           runAsUser: {{ .ProxyUID | default "1337" }}
           runAsGroup: {{ .ProxyGID | default "1337" }}
           runAsNonRoot: true
-        {{- else }}
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE
-          runAsUser: 0
-          runAsGroup: 1337
-          runAsNonRoot: false
-          allowPrivilegeEscalation: true
-          readOnlyRootFilesystem: true
-        {{- end }}
         ports:
         - containerPort: 15021
           name: status-port

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1554,13 +1554,10 @@ templates:
                 "istio.io/gateway-name" .Name
               ) | nindent 8 }}
         spec:
-          {{- if ge .KubeVersion 122 }}
-          {{/* safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326. */}}
           securityContext:
             sysctls:
             - name: net.ipv4.ip_unprivileged_port_start
               value: "0"
-          {{- end }}
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
@@ -1575,8 +1572,6 @@ templates:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             securityContext:
-            {{- if ge .KubeVersion 122 }}
-              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
               capabilities:
                 drop:
                 - ALL
@@ -1586,18 +1581,6 @@ templates:
               runAsUser: {{ .ProxyUID | default "1337" }}
               runAsGroup: {{ .ProxyGID | default "1337" }}
               runAsNonRoot: true
-            {{- else }}
-              capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-              runAsUser: 0
-              runAsGroup: 1337
-              runAsNonRoot: false
-              allowPrivilegeEscalation: true
-              readOnlyRootFilesystem: true
-            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port


### PR DESCRIPTION
For https://github.com/istio/istio/issues/51114.
1.22 is out of support