### PR TITLE
ztunnel: drop default requests

### DIFF
--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -32,8 +32,10 @@ defaults:
   # Pod resource configuration
   resources:
     requests:
-      cpu: 500m
-      memory: 2048Mi
+      cpu: 200m
+      # Ztunnel memory scales with the size of the cluster and traffic load
+      # While there are many factors, this is enough for ~200k pod cluster or 100k concurrently open connections.
+      memory: 512Mi
 
   # List of secret names to add to the service account as image pull secrets
   imagePullSecrets: []


### PR DESCRIPTION
CPU is more debatable, but the memory requests is egregiously large
based on current performance tests.
