### PR TITLE
We only support Helm APIv2

### DIFF
--- a/manifests/charts/base/Chart.yaml
+++ b/manifests/charts/base/Chart.yaml
@@ -1,14 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 name: base
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
 version: 1.0.0
 appVersion: 1.0.0
-tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio cluster resources and CRDs
 keywords:
   - istio
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/default/Chart.yaml
+++ b/manifests/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: istio-default
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
@@ -9,5 +9,4 @@ keywords:
   - istio
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/gateways/istio-egress/Chart.yaml
+++ b/manifests/charts/gateways/istio-egress/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: istio-egress
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
@@ -11,5 +11,4 @@ keywords:
   - gateways
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/gateways/istio-ingress/Chart.yaml
+++ b/manifests/charts/gateways/istio-ingress/Chart.yaml
@@ -1,10 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 name: istio-ingress
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
 version: 1.0.0
 appVersion: 1.0.0
-tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio gateways
 keywords:
   - istio
@@ -12,5 +11,4 @@ keywords:
   - gateways
 sources:
   - http://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/istio-cni/Chart.yaml
+++ b/manifests/charts/istio-cni/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: cni
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
@@ -10,5 +10,4 @@ keywords:
   - istio
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/istio-control/istio-discovery/Chart.yaml
+++ b/manifests/charts/istio-control/istio-discovery/Chart.yaml
@@ -1,10 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 name: istiod
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
 version: 1.0.0
 appVersion: 1.0.0
-tillerVersion: ">=2.7.2"
 description: Helm chart for istio control plane
 keywords:
   - istio
@@ -12,5 +11,4 @@ keywords:
   - istio-discovery
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/istio-operator/Chart.yaml
+++ b/manifests/charts/istio-operator/Chart.yaml
@@ -1,15 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 name: istio-operator
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
 version: 1.0.0
 appVersion: 1.0.0
-tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:
   - istio
   - operator
 sources:
   - https://github.com/istio/istio/tree/master/operator
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/istiod-remote/Chart.yaml
+++ b/manifests/charts/istiod-remote/Chart.yaml
@@ -1,15 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 name: istiod-remote
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
 version: 1.0.0
 appVersion: 1.0.0
-tillerVersion: ">=2.7.2"
 description: Helm chart for a remote cluster using an external istio control plane
 keywords:
   - istio
   - external-istiod
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png

--- a/manifests/charts/ztunnel/Chart.yaml
+++ b/manifests/charts/ztunnel/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: ztunnel
 # This version is never actually shipped. istio/release-builder will replace it at build-time
 # with the appropriate version
@@ -10,5 +10,4 @@ keywords:
   - istio
 sources:
   - https://github.com/istio/istio
-engine: gotpl
 icon: https://istio.io/latest/favicons/android-192x192.png


### PR DESCRIPTION
**Please provide a description of this PR:**

Drop pre-Helm 3 cruft - we don't support or recommend or document use of pre-Helm-3 versions anyway.