### PR TITLE
Make validation message clearer when user attempts to set namespace for targetRef

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1165,7 +1165,8 @@ func validatePolicyTargetReference(targetRef *type_beta.PolicyTargetReference) (
 		v = appendErrorf(v, "targetRef name must be set")
 	}
 	if targetRef.Namespace != "" {
-		v = appendErrorf(v, "targetRef namespace must not be set")
+		// cross namespace referencing is currently not supported
+		v = appendErrorf(v, "targetRef namespace must not be set; local namespace is inferred from the policy namespace")
 	}
 
 	canoncalGroup := targetRef.Group

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1166,7 +1166,7 @@ func validatePolicyTargetReference(targetRef *type_beta.PolicyTargetReference) (
 	}
 	if targetRef.Namespace != "" {
 		// cross namespace referencing is currently not supported
-		v = appendErrorf(v, "targetRef namespace must not be set; local namespace is inferred from the policy namespace")
+		v = appendErrorf(v, "targetRef namespace must not be set; cross namespace referencing is not supported")
 	}
 
 	canoncalGroup := targetRef.Group


### PR DESCRIPTION
**Please provide a description of this PR:**
It's not obvious to the user that it is intended for the policy object's namespace to be used and that they shouldn't set the namespace for targetRef. This PR updates the validation message to make this clearer and adds a comment adding context to why we do this.

Notes for reviewer(s):
- message in this PR uses language from the API comment/description of the Namespace field on PolicyTargetReference shown [here](https://github.com/istio/api/blob/aa8be1710a492e2a31cf0949fbe9eae0c14d1a5a/type/v1beta1/selector.pb.go#L263-L265)
- context for why we do [this](https://github.com/istio/istio/pull/46621/files#r1318048974)
- context around [user experience](https://istio.slack.com/archives/C049TCZMPCP/p1716303337650699?thread_ts=1716258271.529259&cid=C049TCZMPCP) that needed some clearing up