### PR TITLE
Cleanup trust domain to not use globals

### DIFF
--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/monitoring"
-	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/zdsapi"
 )
 
@@ -278,7 +277,7 @@ func podToWorkload(pod *v1.Pod) *zdsapi.WorkloadInfo {
 	namespace := pod.ObjectMeta.Namespace
 	name := pod.ObjectMeta.Name
 	svcAccount := pod.Spec.ServiceAccountName
-	trustDomain := spiffe.GetTrustDomain()
+	trustDomain := ""
 	return &zdsapi.WorkloadInfo{
 		Namespace:      namespace,
 		Name:           name,

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -178,7 +178,7 @@ func (s *Server) RunCA(grpc *grpc.Server) {
 		// Add a custom authenticator using standard JWT validation, if not running in K8S
 		// When running inside K8S - we can use the built-in validator, which also check pod removal (invalidation).
 		jwtRule := v1beta1.JWTRule{Issuer: iss, Audiences: []string{aud}}
-		oidcAuth, err := authenticate.NewJwtAuthenticator(&jwtRule)
+		oidcAuth, err := authenticate.NewJwtAuthenticator(&jwtRule, nil)
 		if err == nil {
 			s.caServer.Authenticators = append(s.caServer.Authenticators, oidcAuth)
 			log.Info("Using out-of-cluster JWT authentication")

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -576,7 +576,7 @@ func TestInitOIDC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			args := &PilotArgs{JwtRule: tt.jwtRule}
 
-			_, err := initOIDC(args)
+			_, err := initOIDC(args, nil)
 			gotErr := err != nil
 			if gotErr != tt.expectErr {
 				t.Errorf("expect error is %v while actual error is %v", tt.expectErr, gotErr)

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -35,6 +35,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 
 	s.serviceEntryController = serviceentry.NewController(
 		s.configController, s.XDSServer,
+		s.environment.Watcher,
 		serviceentry.WithClusterID(s.clusterID),
 	)
 	serviceControllers.AddRegistry(s.serviceEntryController)

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -161,8 +161,9 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 
 func (cb *ClusterBuilder) buildWaypointConnectOriginate(proxy *model.Proxy, push *model.PushContext) *cluster.Cluster {
 	m := &matcher.StringMatcher{}
+
 	m.MatchPattern = &matcher.StringMatcher_Prefix{
-		Prefix: spiffe.URIPrefix + spiffe.GetTrustDomain() + "/ns/" + proxy.Metadata.Namespace + "/sa/",
+		Prefix: spiffe.URIPrefix + push.Mesh.GetTrustDomain() + "/ns/" + proxy.Metadata.Namespace + "/sa/",
 	}
 	return cb.buildConnectOriginate(proxy, push, m)
 }

--- a/pilot/pkg/networking/core/fake.go
+++ b/pilot/pkg/networking/core/fake.go
@@ -136,6 +136,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	}
 
 	env := model.NewEnvironment()
+	env.Watcher = mesh.NewFixedWatcher(m)
 
 	xdsUpdater := opts.XDSUpdater
 	if xdsUpdater == nil {
@@ -146,6 +147,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	se := serviceentry.NewController(
 		configController,
 		xdsUpdater,
+		env.Watcher,
 		serviceentry.WithClusterID(opts.ClusterID))
 	// TODO allow passing in registry, for k8s, mem reigstry
 	serviceDiscovery.AddRegistry(se)
@@ -165,7 +167,6 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	for _, reg := range opts.ServiceRegistries {
 		serviceDiscovery.AddRegistry(reg)
 	}
-	env.Watcher = mesh.NewFixedWatcher(m)
 	if opts.NetworksWatcher == nil {
 		opts.NetworksWatcher = mesh.NewFixedNetworksWatcher(nil)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
-	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/workloadapi"
 )
 
@@ -132,7 +131,7 @@ func (a *index) workloadEntryWorkloadBuilder(
 			AuthorizationPolicies: policies,
 			Status:                workloadapi.WorkloadStatus_HEALTHY, // TODO: WE can be unhealthy
 			Waypoint:              waypointAddress,
-			TrustDomain:           pickTrustDomain(),
+			TrustDomain:           pickTrustDomain(meshCfg),
 			Locality:              getWorkloadEntryLocality(&wle.Spec),
 		}
 
@@ -229,7 +228,7 @@ func (a *index) podWorkloadBuilder(
 			Services:              constructServices(p, services),
 			AuthorizationPolicies: policies,
 			Status:                status,
-			TrustDomain:           pickTrustDomain(),
+			TrustDomain:           pickTrustDomain(meshCfg),
 			Locality:              getPodLocality(ctx, Nodes, p),
 		}
 
@@ -323,7 +322,7 @@ func (a *index) serviceEntryWorkloadBuilder(
 				AuthorizationPolicies: policies,
 				Status:                workloadapi.WorkloadStatus_HEALTHY,
 				Waypoint:              waypointAddress,
-				TrustDomain:           pickTrustDomain(),
+				TrustDomain:           pickTrustDomain(meshCfg),
 				Locality:              getWorkloadEntryLocality(wle),
 			}
 
@@ -355,8 +354,8 @@ func setTunnelProtocol(labels, annotations map[string]string, w *workloadapi.Wor
 	}
 }
 
-func pickTrustDomain() string {
-	if td := spiffe.GetTrustDomain(); td != "cluster.local" {
+func pickTrustDomain(mesh *MeshConfig) string {
+	if td := mesh.GetTrustDomain(); td != "cluster.local" {
 		return td
 	}
 	return ""

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2883,16 +2883,16 @@ func TestServiceUpdateNeedsPush(t *testing.T) {
 			name:     "target ports changed",
 			prev:     &svc,
 			curr:     &updatedSvc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, ""),
-			currConv: kube.ConvertService(updatedSvc, constants.DefaultClusterLocalDomain, ""),
+			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
+			currConv: kube.ConvertService(updatedSvc, constants.DefaultClusterLocalDomain, "", nil),
 			expect:   true,
 		},
 		testcase{
 			name:     "target ports unchanged",
 			prev:     &svc,
 			curr:     &svc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, ""),
-			currConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, ""),
+			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
+			currConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
 			expect:   false,
 		})
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -48,12 +48,12 @@ type EndpointBuilder struct {
 	nodeName string
 }
 
-func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
+func (c *Controller) NewEndpointBuilder(pod *v1.Pod) *EndpointBuilder {
 	var locality, sa, namespace, hostname, subdomain, ip, node string
 	var podLabels labels.Instance
 	if pod != nil {
 		locality = c.getPodLocality(pod)
-		sa = kube.SecureNamingSAN(pod)
+		sa = kube.SecureNamingSAN(pod, c.meshWatcher.Mesh())
 		podLabels = pod.Labels
 		namespace = pod.Namespace
 		subdomain = pod.Spec.Subdomain
@@ -87,7 +87,7 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 	return out
 }
 
-func NewEndpointBuilderFromMetadata(c controllerInterface, proxy *model.Proxy) *EndpointBuilder {
+func (c *Controller) NewEndpointBuilderFromMetadata(proxy *model.Proxy) *EndpointBuilder {
 	locality := util.LocalityToString(proxy.Locality)
 	out := &EndpointBuilder{
 		controller:     c,

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder_test.go
@@ -19,12 +19,19 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/model"
+	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	cluster2 "istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	pkgmodel "istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -126,8 +133,32 @@ func TestNewEndpointBuilderTopologyLabels(t *testing.T) {
 			pod.Namespace = "testns"
 			pod.Spec.ServiceAccountName = "testsan"
 			pod.Labels = c.podLabels
+			pod.Spec.NodeName = "fake"
+			// All should get this
+			c.expected[labelutil.LabelHostname] = "fake"
 
-			eb := NewEndpointBuilder(c.ctl, &pod)
+			loc := pkgmodel.ConvertLocality(c.ctl.locality)
+			fc := kube.NewFakeClient(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
+					NodeRegionLabelGA:          loc.Region,
+					NodeZoneLabel:              loc.Zone,
+					label.TopologySubzone.Name: loc.SubZone,
+				}},
+				Spec:   v1.NodeSpec{},
+				Status: v1.NodeStatus{},
+			})
+			nodes := kclient.New[*v1.Node](fc)
+			fc.RunAndWait(test.NewStop(t))
+			cc := &Controller{
+				nodes:       nodes,
+				meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig()),
+				networkManager: &networkManager{
+					clusterID: c.ctl.cluster,
+					network:   c.ctl.network,
+				},
+				opts: Options{ClusterID: c.ctl.cluster},
+			}
+			eb := cc.NewEndpointBuilder(&pod)
 
 			assert.Equal(t, eb.labels, c.expected)
 		})
@@ -234,32 +265,36 @@ func TestNewEndpointBuilderFromMetadataTopologyLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			eb := NewEndpointBuilderFromMetadata(c.ctl, c.proxy)
+			loc := pkgmodel.ConvertLocality(c.ctl.locality)
+			fc := kube.NewFakeClient(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "fake", Labels: map[string]string{
+					NodeRegionLabelGA:          loc.Region,
+					NodeZoneLabel:              loc.Zone,
+					label.TopologySubzone.Name: loc.SubZone,
+				}},
+				Spec:   v1.NodeSpec{},
+				Status: v1.NodeStatus{},
+			})
+			nodes := kclient.New[*v1.Node](fc)
+			fc.RunAndWait(test.NewStop(t))
+			cc := &Controller{
+				nodes:       nodes,
+				meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig()),
+				networkManager: &networkManager{
+					clusterID: c.ctl.cluster,
+					network:   c.ctl.network,
+				},
+				opts: Options{ClusterID: c.ctl.cluster},
+			}
+			eb := cc.NewEndpointBuilderFromMetadata(c.proxy)
 
 			assert.Equal(t, eb.labels, c.expected)
 		})
 	}
 }
 
-var _ controllerInterface = testController{}
-
 type testController struct {
 	locality string
 	cluster  cluster2.ID
 	network  network.ID
-}
-
-func (c testController) getPodLocality(*v1.Pod) string {
-	return c.locality
-}
-
-func (c testController) Network(ip string, instance labels.Instance) network.ID {
-	if n := instance[label.TopologyNetwork.Name]; n != "" {
-		return network.ID(n)
-	}
-	return c.network
-}
-
-func (c testController) Cluster() cluster2.ID {
-	return c.cluster
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -264,7 +264,7 @@ func (esc *endpointSliceController) updateEndpointCacheForSlice(hostName host.Na
 			if pod == nil && expectedPod {
 				continue
 			}
-			builder := NewEndpointBuilder(esc.c, pod)
+			builder := esc.c.NewEndpointBuilder(pod)
 			// EDS and ServiceEntry use name for service port - ADS will need to map to numbers.
 			for _, port := range slice.Ports {
 				var portNum int32

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -77,7 +77,7 @@ func NewFakeControllerWithOptions(t test.Failer, opts FakeControllerOptions) (*F
 		opts.Client = kubelib.NewFakeClient()
 	}
 	if opts.MeshWatcher == nil {
-		opts.MeshWatcher = mesh.NewFixedWatcher(&meshconfig.MeshConfig{})
+		opts.MeshWatcher = mesh.NewFixedWatcher(&meshconfig.MeshConfig{TrustDomain: "cluster.local"})
 	}
 	cleanupStop := false
 	stop := opts.Stop

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -174,6 +174,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 			configStore := createWleConfigStore(client, m.revision, options)
 			kubeController.workloadEntryController = serviceentry.NewWorkloadEntryController(
 				configStore, options.XDSUpdater,
+				m.opts.MeshWatcher,
 				serviceentry.WithClusterID(cluster.ID),
 				serviceentry.WithNetworkIDCb(kubeRegistry.Network))
 			// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -193,7 +193,7 @@ func (pc *PodCache) notifyWorkloadHandlers(pod *v1.Pod, ev model.Event) {
 		return
 	}
 	// fire instance handles for workload
-	ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(pod.Status.PodIP, 0, "", model.AlwaysDiscoverable, model.Healthy)
+	ep := pc.c.NewEndpointBuilder(pod).buildIstioEndpoint(pod.Status.PodIP, 0, "", model.AlwaysDiscoverable, model.Healthy)
 	workloadInstance := &model.WorkloadInstance{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -24,6 +24,7 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
@@ -44,7 +45,7 @@ func convertPort(port corev1.ServicePort) *model.Port {
 	}
 }
 
-func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.ID) *model.Service {
+func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.ID, mesh *meshconfig.MeshConfig) *model.Service {
 	addrs := []string{constants.UnspecifiedIP}
 	resolution := model.ClientSideLB
 	externalName := ""
@@ -83,7 +84,7 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 	}
 	if svc.Annotations[annotation.AlphaKubernetesServiceAccounts.Name] != "" {
 		for _, ksa := range strings.Split(svc.Annotations[annotation.AlphaKubernetesServiceAccounts.Name], ",") {
-			serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace))
+			serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace, mesh))
 		}
 	}
 	if svc.Annotations[annotation.NetworkingExportTo.Name] != "" {
@@ -203,13 +204,13 @@ func ServiceHostnameForKR(obj metav1.Object, domainSuffix string) host.Name {
 }
 
 // kubeToIstioServiceAccount converts a K8s service account to an Istio service account
-func kubeToIstioServiceAccount(saname string, ns string) string {
-	return spiffe.MustGenSpiffeURI(ns, saname)
+func kubeToIstioServiceAccount(saname string, ns string, mesh *meshconfig.MeshConfig) string {
+	return spiffe.MustGenSpiffeURI(mesh, ns, saname)
 }
 
 // SecureNamingSAN creates the secure naming used for SAN verification from pod metadata
-func SecureNamingSAN(pod *corev1.Pod) string {
-	return spiffe.MustGenSpiffeURI(pod.Namespace, pod.Spec.ServiceAccountName)
+func SecureNamingSAN(pod *corev1.Pod, mesh *meshconfig.MeshConfig) string {
+	return spiffe.MustGenSpiffeURI(mesh, pod.Namespace, pod.Spec.ServiceAccountName)
 }
 
 // PodTLSMode returns the tls mode associated with the pod if pod has been injected with sidecar

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -271,7 +271,7 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 	tlsMode := getTLSModeFromWorkloadEntry(wle)
 	sa := ""
 	if wle.ServiceAccount != "" {
-		sa = spiffe.MustGenSpiffeURI(service.Attributes.Namespace, wle.ServiceAccount)
+		sa = spiffe.MustGenSpiffeURI(s.meshWatcher.Mesh(), service.Attributes.Namespace, wle.ServiceAccount)
 	}
 	networkID := s.workloadEntryNetwork(wle)
 	locality := wle.Locality
@@ -428,7 +428,7 @@ func (s *Controller) convertWorkloadEntryToWorkloadInstance(cfg config.Config, c
 	tlsMode := getTLSModeFromWorkloadEntry(we)
 	sa := ""
 	if we.ServiceAccount != "" {
-		sa = spiffe.MustGenSpiffeURI(cfg.Namespace, we.ServiceAccount)
+		sa = spiffe.MustGenSpiffeURI(s.meshWatcher.Mesh(), cfg.Namespace, we.ServiceAccount)
 	}
 	networkID := s.workloadEntryNetwork(we)
 	locality := we.Locality

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -81,7 +81,7 @@ func setupTest(t *testing.T) (model.ConfigStoreController, kubernetes.Interface,
 	stop := istiotest.NewStop(t)
 	go configController.Run(stop)
 
-	se := serviceentry.NewController(configController, xdsUpdater)
+	se := serviceentry.NewController(configController, xdsUpdater, meshWatcher)
 	client.RunAndWait(stop)
 
 	kc.AppendWorkloadHandler(se.WorkloadInstanceHandler)

--- a/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
+++ b/pilot/pkg/serviceregistry/util/workloadinstances/index_test.go
@@ -58,7 +58,7 @@ func TestIndex(t *testing.T) {
 		Endpoint: &model.IstioEndpoint{
 			Address:        "2.2.2.2",
 			Labels:         map[string]string{"app": "wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI(selector.Name, "default"),
+			ServiceAccount: spiffe.MustGenSpiffeURIForTrustDomain("cluster.local", selector.Name, "default"),
 			TLSMode:        model.IstioMutualTLSModeLabel,
 		},
 	}
@@ -69,7 +69,7 @@ func TestIndex(t *testing.T) {
 		Endpoint: &model.IstioEndpoint{
 			Address:        "3.3.3.3",
 			Labels:         map[string]string{"app": "wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI(selector.Name, "default"),
+			ServiceAccount: spiffe.MustGenSpiffeURIForTrustDomain("cluster.local", selector.Name, "default"),
 			TLSMode:        model.IstioMutualTLSModeLabel,
 		},
 	}
@@ -80,7 +80,7 @@ func TestIndex(t *testing.T) {
 		Endpoint: &model.IstioEndpoint{
 			Address:        "2.2.2.2",
 			Labels:         map[string]string{"app": "dns-wle"},
-			ServiceAccount: spiffe.MustGenSpiffeURI("dns-selector", "default"),
+			ServiceAccount: spiffe.MustGenSpiffeURIForTrustDomain("cluster.local", "dns-selector", "default"),
 			TLSMode:        model.IstioMutualTLSModeLabel,
 		},
 	}

--- a/pilot/pkg/trustbundle/trustbundle_test.go
+++ b/pilot/pkg/trustbundle/trustbundle_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -159,7 +160,7 @@ func TestVerifyTrustAnchor(t *testing.T) {
 
 func TestUpdateTrustAnchor(t *testing.T) {
 	cbCounter := 0
-	tb := NewTrustBundle(nil)
+	tb := NewTrustBundle(nil, nil)
 	tb.UpdateCb(func() { cbCounter++ })
 
 	var trustedCerts []string
@@ -288,7 +289,7 @@ func TestAddMeshConfigUpdate(t *testing.T) {
 	caCertPool.AddCert(server2.Certificate())
 	defer server2.Close()
 
-	tb := NewTrustBundle(caCertPool)
+	tb := NewTrustBundle(caCertPool, mesh.NewFixedWatcher(&meshconfig.MeshConfig{TrustDomain: "cluster.local"}))
 
 	// Change global remote timeout interval for the duration of the unit test
 	remoteTimeout = 30 * time.Millisecond

--- a/security/pkg/nodeagent/test/mock/caserver.go
+++ b/security/pkg/nodeagent/test/mock/caserver.go
@@ -30,7 +30,6 @@ import (
 	pb "istio.io/api/security/v1alpha1"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
-	"istio.io/istio/pkg/spiffe"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -73,25 +72,6 @@ func NewCAServerWithKeyCert(port int, key, cert []byte, opts ...grpc.ServerOptio
 	pb.RegisterIstioCertificateServiceServer(server.GRPCServer, server)
 	ghc.RegisterHealthServer(server.GRPCServer, server)
 	return server, server.start(port)
-}
-
-// NewCAServer creates a new CA server that listens on port.
-func NewCAServer(port int, opts ...grpc.ServerOption) (*CAServer, error) {
-	// Create root cert and private key.
-	options := util.CertOptions{
-		TTL:          3650 * 24 * time.Hour,
-		Org:          spiffe.GetTrustDomain(),
-		IsCA:         true,
-		IsSelfSigned: true,
-		RSAKeySize:   2048,
-		IsDualUse:    true,
-	}
-	cert, key, err := util.GenCertKeyFromOptions(options)
-	if err != nil {
-		caServerLog.Errorf("cannot create CA cert and private key: %+v", err)
-		return nil, err
-	}
-	return NewCAServerWithKeyCert(port, key, cert, opts...)
 }
 
 func (s *CAServer) start(port int) error {

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -129,7 +129,7 @@ func (a *KubeJWTAuthenticator) authenticate(targetJWT string, clusterID cluster.
 	}
 	return &security.Caller{
 		AuthSource:     security.AuthSourceIDToken,
-		Identities:     []string{spiffe.MustGenSpiffeURI(id.PodNamespace, id.PodServiceAccount)},
+		Identities:     []string{spiffe.MustGenSpiffeURI(a.meshHolder.Mesh(), id.PodNamespace, id.PodServiceAccount)},
 		KubernetesInfo: id,
 	}, nil
 }

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
@@ -62,7 +62,6 @@ func TestAuthenticate(t *testing.T) {
 	remoteCluster := cluster.ID("remote")
 	invlidToken := "invalid-token"
 	meshHolder := mockMeshConfigHolder{"example.com"}
-	spiffe.SetTrustDomain("example.com")
 
 	testCases := map[string]struct {
 		remoteCluster  bool
@@ -98,7 +97,7 @@ func TestAuthenticate(t *testing.T) {
 					"Basic callername",
 				},
 			},
-			expectedID:     spiffe.MustGenSpiffeURI("default", "example-pod-sa"),
+			expectedID:     spiffe.MustGenSpiffeURIForTrustDomain("example.com", "default", "example-pod-sa"),
 			expectedErrMsg: "",
 		},
 		"not found remote cluster results in error": {


### PR DESCRIPTION
Before: from mesh config, set a global var

After: read from mesh config

This is a general code smell to use globals, and also the source of a
bug (and a few many years ago IIRC).

Most of the churn is in tests
