### PR TITLE
Bugfix: actually use v6 SNAT IP inpod

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -176,9 +176,9 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 
 // Setup iptables rules for in-pod mode. Ideally this should be an idempotent function.
 // NOTE that this expects to be run from within the pod network namespace!
-func (cfg *IptablesConfigurator) CreateInpodRules(hostProbeSNAT *netip.Addr) error {
+func (cfg *IptablesConfigurator) CreateInpodRules(hostProbeSNAT, hostProbeV6SNAT *netip.Addr) error {
 	// Append our rules here
-	builder := cfg.appendInpodRules(hostProbeSNAT)
+	builder := cfg.appendInpodRules(hostProbeSNAT, hostProbeV6SNAT)
 
 	if err := cfg.addLoopbackRoute(); err != nil {
 		return err
@@ -197,7 +197,7 @@ func (cfg *IptablesConfigurator) CreateInpodRules(hostProbeSNAT *netip.Addr) err
 	return nil
 }
 
-func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT *netip.Addr) *builder.IptablesRuleBuilder {
+func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT, hostProbeV6SNAT *netip.Addr) *builder.IptablesRuleBuilder {
 	redirectDNS := cfg.cfg.RedirectDNS
 
 	inpodMark := fmt.Sprintf("0x%x", InpodMark) + "/" + fmt.Sprintf("0x%x", InpodMask)
@@ -242,13 +242,11 @@ func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT *netip.Addr) *bu
 	//
 	// We do this so we can exempt this traffic from ztunnel capture/proxy - otherwise both kube-proxy (legit)
 	// and kubelet (skippable) traffic would have the same srcip once they got to the pod, and would be indistinguishable.
-	//
-	// Note that SortedList is used here because the istio sets class has no order guarantees,
-	// and our unit tests will flake if rules have a nondeterministic ordering.
+
 	// CLI: -t mangle -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp --dport <PROBEPORT> -j ACCEPT
 	//
 	// DESC: If this is one of our node-probe ports and is from our SNAT-ed/"special" hostside IP, short-circuit out here
-	iptablesBuilder.AppendRule(iptableslog.UndefinedCommand, ChainInpodPrerouting, iptablesconstants.MANGLE,
+	iptablesBuilder.AppendRuleV4(iptableslog.UndefinedCommand, ChainInpodPrerouting, iptablesconstants.MANGLE,
 		"-s", hostProbeSNAT.String(),
 		"-p", "tcp",
 		"-m", "tcp",
@@ -259,13 +257,37 @@ func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT *netip.Addr) *bu
 	//
 	// DESC: Anything coming BACK from the pod healthcheck port with a dest of our SNAT-ed hostside IP
 	// we also short-circuit.
-	iptablesBuilder.AppendRule(
+	iptablesBuilder.AppendRuleV4(
 		iptableslog.UndefinedCommand, ChainInpodOutput, iptablesconstants.NAT,
 		"-d", hostProbeSNAT.String(),
 		"-p", "tcp",
 		"-m", "tcp",
 		"-j", "ACCEPT",
 	)
+
+	if cfg.cfg.EnableIPv6 {
+		// CLI: -t mangle -A ISTIO_PRERT -s fd16:9254:7127:1337:ffff:ffff:ffff:ffff -p tcp -m tcp --dport <PROBEPORT> -j ACCEPT
+		//
+		// DESC: If this is one of our node-probe ports and is from our SNAT-ed/"special" hostside IP, short-circuit out here
+		iptablesBuilder.AppendRuleV6(iptableslog.UndefinedCommand, ChainInpodPrerouting, iptablesconstants.MANGLE,
+			"-s", hostProbeV6SNAT.String(),
+			"-p", "tcp",
+			"-m", "tcp",
+			"-j", "ACCEPT",
+		)
+
+		// CLI: -t NAT -A ISTIO_OUTPUT -d fd16:9254:7127:1337:ffff:ffff:ffff:ffff -p tcp -m tcp -j ACCEPT
+		//
+		// DESC: Anything coming BACK from the pod healthcheck port with a dest of our SNAT-ed hostside IP
+		// we also short-circuit.
+		iptablesBuilder.AppendRuleV6(
+			iptableslog.UndefinedCommand, ChainInpodOutput, iptablesconstants.NAT,
+			"-d", hostProbeV6SNAT.String(),
+			"-p", "tcp",
+			"-m", "tcp",
+			"-j", "ACCEPT",
+		)
+	}
 
 	// prevent intercept traffic from app ==> app by pod ip
 	iptablesBuilder.AppendVersionedRule("127.0.0.1/32", "::1/128",

--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -47,13 +47,7 @@ func TestIptables(t *testing.T) {
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
 				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
-				var probeIP *netip.Addr
-				if ipv6 {
-					probeIP = &probeSNATipv6
-				} else {
-					probeIP = &probeSNATipv4
-				}
-				err := iptConfigurator.CreateInpodRules(probeIP)
+				err := iptConfigurator.CreateInpodRules(&probeSNATipv4, &probeSNATipv6)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -109,12 +103,13 @@ func TestInvokedTwiceIsIdempotent(t *testing.T) {
 	}
 
 	probeSNATipv4 := netip.MustParseAddr("169.254.7.127")
+	probeSNATipv6 := netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")
 
 	cfg := constructTestConfig()
 	tt.config(cfg)
 	ext := &dep.DependenciesStub{}
 	iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
-	err := iptConfigurator.CreateInpodRules(&probeSNATipv4)
+	err := iptConfigurator.CreateInpodRules(&probeSNATipv4, &probeSNATipv6)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +117,7 @@ func TestInvokedTwiceIsIdempotent(t *testing.T) {
 
 	*ext = dep.DependenciesStub{}
 	// run another time to make sure we are idempotent
-	err = iptConfigurator.CreateInpodRules(&probeSNATipv4)
+	err = iptConfigurator.CreateInpodRules(&probeSNATipv4, &probeSNATipv6)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cni/pkg/iptables/testdata/default_ipv6.golden
+++ b/cni/pkg/iptables/testdata/default_ipv6.golden
@@ -5,8 +5,8 @@ iptables -t mangle -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -j ISTIO_OUTPUT
 iptables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
-iptables -t mangle -A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
-iptables -t nat -A ISTIO_OUTPUT -d e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
+iptables -t mangle -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
+iptables -t nat -A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t mangle -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp -i lo -j ACCEPT
 iptables -t mangle -A ISTIO_PRERT -p tcp -m tcp --dport 15008 -m mark ! --mark 0x539/0xfff -j TPROXY --on-port 15008 --tproxy-mark 0x111/0xfff
 iptables -t mangle -A ISTIO_PRERT -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -154,7 +154,7 @@ func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []
 
 	log.Debug("calling CreateInpodRules")
 	if err := s.netnsRunner(openNetns, func() error {
-		return s.iptablesConfigurator.CreateInpodRules(&HostProbeSNATIP)
+		return s.iptablesConfigurator.CreateInpodRules(&HostProbeSNATIP, &HostProbeSNATIPV6)
 	}); err != nil {
 		log.Errorf("failed to update POD inpod: %s/%s %v", pod.Namespace, pod.Name, err)
 		return err

--- a/releasenotes/notes/51221.yaml
+++ b/releasenotes/notes/51221.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** Incorrect iptables rules for ambient in IPv6 mode


### PR DESCRIPTION
This should have been in https://github.com/istio/istio/pull/50747 but somehow I looked at that (and the goldens!) and _didn't_ recognize that using a v4 ip in a v6 rule was wrong.