### PR TITLE
istioctl: update ZtunnelDump struct to unmarshall data correctly

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/api.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/api.go
@@ -93,11 +93,11 @@ type ZtunnelPolicy struct {
 }
 
 type ZtunnelDump struct {
-	Workloads     map[string]*ZtunnelWorkload `json:"workloads"`
-	Services      map[string]*ZtunnelService  `json:"services"`
-	Policies      map[string]*ZtunnelPolicy   `json:"policies"`
-	Certificates  []*CertsDump                `json:"certificates"`
-	WorkloadState map[string]WorkloadState    `json:"workloadState"`
+	Workloads     []*ZtunnelWorkload       `json:"workloads"`
+	Services      []*ZtunnelService        `json:"services"`
+	Policies      []*ZtunnelPolicy         `json:"policies"`
+	Certificates  []*CertsDump             `json:"certificates"`
+	WorkloadState map[string]WorkloadState `json:"workloadState"`
 }
 
 type CertsDump struct {

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -54,7 +54,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			for _, w := range v.(map[string]interface{}) {
 				wj, err := json.Marshal(w)
 				if err != nil {
-					return fmt.Errorf("error marshalling workload: %v", err)
+					return fmt.Errorf("error marshaling workload: %v", err)
 				}
 				curr := &ZtunnelWorkload{}
 				err = json.Unmarshal(wj, curr)
@@ -68,7 +68,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			for _, c := range v.([]interface{}) {
 				cj, err := json.Marshal(c)
 				if err != nil {
-					return fmt.Errorf("error marshalling certificate: %v", err)
+					return fmt.Errorf("error marshaling certificate: %v", err)
 				}
 				curr := &CertsDump{}
 				err = json.Unmarshal(cj, curr)
@@ -82,7 +82,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			for _, p := range v.([]interface{}) {
 				pj, err := json.Marshal(p)
 				if err != nil {
-					return fmt.Errorf("error marshalling policy: %v", err)
+					return fmt.Errorf("error marshaling policy: %v", err)
 				}
 				curr := &ZtunnelPolicy{}
 				err = json.Unmarshal(pj, curr)
@@ -96,7 +96,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			for _, s := range v.(map[string]interface{}) {
 				sj, err := json.Marshal(s)
 				if err != nil {
-					return fmt.Errorf("error marshalling service: %v", err)
+					return fmt.Errorf("error marshaling service: %v", err)
 				}
 				curr := &ZtunnelService{}
 				err = json.Unmarshal(sj, curr)

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -32,7 +32,7 @@ type ConfigWriter struct {
 
 // Prime loads the config dump into the writer ready for printing
 func (c *ConfigWriter) Prime(b []byte) error {
-	cd := map[string]interface{}{}
+	cd := map[string]json.RawMessage{}
 	zDump := &ZtunnelDump{}
 	var (
 		zw []*ZtunnelWorkload
@@ -51,7 +51,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 	for k, v := range cd {
 		switch k {
 		case "workloads":
-			for _, w := range v.(map[string]interface{}) {
+			for _, w := range v {
 				wj, err := json.Marshal(w)
 				if err != nil {
 					return fmt.Errorf("error marshaling workload: %v", err)
@@ -65,7 +65,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			}
 			zDump.Workloads = zw
 		case "certificates":
-			for _, c := range v.([]interface{}) {
+			for _, c := range v {
 				cj, err := json.Marshal(c)
 				if err != nil {
 					return fmt.Errorf("error marshaling certificate: %v", err)
@@ -79,7 +79,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			}
 			zDump.Certificates = zc
 		case "policies":
-			for _, p := range v.([]interface{}) {
+			for _, p := range v {
 				pj, err := json.Marshal(p)
 				if err != nil {
 					return fmt.Errorf("error marshaling policy: %v", err)
@@ -93,7 +93,7 @@ func (c *ConfigWriter) Prime(b []byte) error {
 			}
 			zDump.Policies = zp
 		case "services":
-			for _, s := range v.(map[string]interface{}) {
+			for _, s := range v {
 				sj, err := json.Marshal(s)
 				if err != nil {
 					return fmt.Errorf("error marshaling service: %v", err)

--- a/istioctl/pkg/writer/ztunnel/configdump/connections.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/connections.go
@@ -66,13 +66,12 @@ func (c *ConfigWriter) PrintConnectionsSummary(filter ConnectionsFilter) error {
 	d := c.ztunnelDump
 	serviceNames := map[string]string{}
 	workloadNames := map[string]string{}
-	for netIP, s := range d.Services {
-		_, ip, _ := strings.Cut(netIP, "/")
+	for _, s := range d.Services {
+		_, ip, _ := strings.Cut(s.Addresses[0], "/")
 		serviceNames[ip] = s.Hostname
 	}
-	for netIP, s := range d.Workloads {
-		_, ip, _ := strings.Cut(netIP, "/")
-		workloadNames[ip] = s.Name + "." + s.Namespace
+	for _, s := range d.Workloads {
+		workloadNames[s.WorkloadIPs[0]] = s.Name + "." + s.Namespace
 	}
 	lookupIP := func(addr string) string {
 		if filter.Raw {

--- a/istioctl/pkg/writer/ztunnel/configdump/connections.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/connections.go
@@ -67,7 +67,10 @@ func (c *ConfigWriter) PrintConnectionsSummary(filter ConnectionsFilter) error {
 	serviceNames := map[string]string{}
 	workloadNames := map[string]string{}
 	for _, s := range d.Services {
-		_, ip, _ := strings.Cut(s.Addresses[0], "/")
+		var ip string
+		if len(s.Addresses) != 0 {
+			_, ip, _ = strings.Cut(s.Addresses[0], "/")
+		}
 		if ip == "" {
 			// fallback to None when a service does not have a VIP
 			ip = "None"

--- a/istioctl/pkg/writer/ztunnel/configdump/connections.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/connections.go
@@ -68,6 +68,10 @@ func (c *ConfigWriter) PrintConnectionsSummary(filter ConnectionsFilter) error {
 	workloadNames := map[string]string{}
 	for _, s := range d.Services {
 		_, ip, _ := strings.Cut(s.Addresses[0], "/")
+		if ip == "" {
+			// fallback to None when a service does not have a VIP
+			ip = "None"
+		}
 		serviceNames[ip] = s.Hostname
 	}
 	for _, s := range d.Workloads {

--- a/istioctl/pkg/writer/ztunnel/configdump/connections.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/connections.go
@@ -78,7 +78,15 @@ func (c *ConfigWriter) PrintConnectionsSummary(filter ConnectionsFilter) error {
 		serviceNames[ip] = s.Hostname
 	}
 	for _, s := range d.Workloads {
-		workloadNames[s.WorkloadIPs[0]] = s.Name + "." + s.Namespace
+		var ip string
+		if len(s.WorkloadIPs) != 0 {
+			ip = s.WorkloadIPs[0]
+		}
+		if ip == "" {
+			// fallback to None when a workload does not have an IP
+			ip = "None"
+		}
+		workloadNames[ip] = s.Name + "." + s.Namespace
 	}
 	lookupIP := func(addr string) string {
 		if filter.Raw {

--- a/istioctl/pkg/writer/ztunnel/configdump/policies.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/policies.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -47,7 +46,7 @@ func (c *ConfigWriter) PrintPolicySummary(filter PolicyFilter) error {
 	w := c.tabwriter()
 	zDump := c.ztunnelDump
 
-	pols := slices.Filter(maps.Values(zDump.Policies), filter.Verify)
+	pols := slices.Filter(zDump.Policies, filter.Verify)
 	slices.SortFunc(pols, func(a, b *ZtunnelPolicy) int {
 		if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
 			return r
@@ -66,7 +65,7 @@ func (c *ConfigWriter) PrintPolicySummary(filter PolicyFilter) error {
 // PrintPolicyDump prints the relevant services in the config dump to the ConfigWriter stdout
 func (c *ConfigWriter) PrintPolicyDump(filter PolicyFilter, outputFormat string) error {
 	zDump := c.ztunnelDump
-	policies := slices.Filter(maps.Values(zDump.Policies), filter.Verify)
+	policies := slices.Filter(zDump.Policies, filter.Verify)
 	slices.SortFunc(policies, func(a, b *ZtunnelPolicy) int {
 		if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
 			return r

--- a/istioctl/pkg/writer/ztunnel/configdump/services.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/services.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -47,7 +46,7 @@ func (c *ConfigWriter) PrintServiceSummary(filter ServiceFilter) error {
 	w := c.tabwriter()
 	zDump := c.ztunnelDump
 
-	svcs := slices.Filter(maps.Values(zDump.Services), filter.Verify)
+	svcs := slices.Filter(zDump.Services, filter.Verify)
 	slices.SortFunc(svcs, func(a, b *ZtunnelService) int {
 		if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
 			return r
@@ -74,7 +73,7 @@ func (c *ConfigWriter) PrintServiceSummary(filter ServiceFilter) error {
 // PrintServiceDump prints the relevant services in the config dump to the ConfigWriter stdout
 func (c *ConfigWriter) PrintServiceDump(filter ServiceFilter, outputFormat string) error {
 	zDump := c.ztunnelDump
-	svcs := slices.Filter(maps.Values(zDump.Services), filter.Verify)
+	svcs := slices.Filter(zDump.Services, filter.Verify)
 	slices.SortFunc(svcs, func(a, b *ZtunnelService) int {
 		if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
 			return r

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -134,10 +134,17 @@ func waypointName(wl *ZtunnelWorkload, services []*ZtunnelService) string {
 		return "None"
 	}
 
-	for i := 0; i < len(services); i++ {
-		if services[i].Hostname == wl.Waypoint.Destination {
-			return services[i].Name
+	// populate a map of address to service name
+	addressMap := make(map[string]string)
+	for _, svc := range services {
+		for _, addr := range svc.Addresses {
+			addressMap[addr] = svc.Name
 		}
+	}
+
+	// check if workload waypoint destination is in the map
+	if name, found := addressMap[wl.Waypoint.Destination]; found {
+		return name
 	}
 
 	return "NA" // Shouldn't normally reach here
@@ -148,10 +155,17 @@ func serviceWaypointName(svc *ZtunnelService, services []*ZtunnelService) string
 		return "None"
 	}
 
-	for i := 0; i < len(services); i++ {
-		if services[i].Hostname == svc.Waypoint.Destination {
-			return services[i].Name
+	// populate a map of address to service name
+	addressMap := make(map[string]string)
+	for _, service := range services {
+		for _, addr := range service.Addresses {
+			addressMap[addr] = service.Name
 		}
+	}
+
+	// check if service waypoint destination is in the map
+	if name, found := addressMap[svc.Waypoint.Destination]; found {
+		return name
 	}
 
 	return "NA" // Shouldn't normally reach here

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -134,17 +134,12 @@ func waypointName(wl *ZtunnelWorkload, services []*ZtunnelService) string {
 		return "None"
 	}
 
-	// populate a map of address to service name
-	addressMap := make(map[string]string)
 	for _, svc := range services {
 		for _, addr := range svc.Addresses {
-			addressMap[addr] = svc.Name
+			if addr == wl.Waypoint.Destination {
+				return svc.Name
+			}
 		}
-	}
-
-	// check if workload waypoint destination is in the map
-	if name, found := addressMap[wl.Waypoint.Destination]; found {
-		return name
 	}
 
 	return "NA" // Shouldn't normally reach here
@@ -155,17 +150,12 @@ func serviceWaypointName(svc *ZtunnelService, services []*ZtunnelService) string
 		return "None"
 	}
 
-	// populate a map of address to service name
-	addressMap := make(map[string]string)
 	for _, service := range services {
 		for _, addr := range service.Addresses {
-			addressMap[addr] = service.Name
+			if addr == svc.Waypoint.Destination {
+				return service.Name
+			}
 		}
-	}
-
-	// check if service waypoint destination is in the map
-	if name, found := addressMap[svc.Waypoint.Destination]; found {
-		return name
 	}
 
 	return "NA" // Shouldn't normally reach here

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -129,25 +129,29 @@ func (c *ConfigWriter) PrintWorkloadDump(filter WorkloadFilter, outputFormat str
 	return nil
 }
 
-func waypointName(wl *ZtunnelWorkload, services map[string]*ZtunnelService) string {
+func waypointName(wl *ZtunnelWorkload, services []*ZtunnelService) string {
 	if wl.Waypoint == nil {
 		return "None"
 	}
 
-	if svc, ok := services[wl.Waypoint.Destination]; ok {
-		return svc.Name
+	for i := 0; i < len(services); i++ {
+		if services[i].Hostname == wl.Waypoint.Destination {
+			return services[i].Name
+		}
 	}
 
 	return "NA" // Shouldn't normally reach here
 }
 
-func serviceWaypointName(svc *ZtunnelService, services map[string]*ZtunnelService) string {
+func serviceWaypointName(svc *ZtunnelService, services []*ZtunnelService) string {
 	if svc.Waypoint == nil {
 		return "None"
 	}
 
-	if svc, ok := services[svc.Waypoint.Destination]; ok {
-		return svc.Name
+	for i := 0; i < len(services); i++ {
+		if services[i].Hostname == svc.Waypoint.Destination {
+			return services[i].Name
+		}
 	}
 
 	return "NA" // Shouldn't normally reach here

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -301,7 +301,6 @@ func connectionsCmd(ctx cli.Context) *cobra.Command {
 				Direction: direction,
 				Raw:       raw,
 			}
-
 			switch common.outputFormat {
 			case summaryOutput:
 				return cw.PrintConnectionsSummary(filter)


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to #51217 

This PR gets the zc command not breaking and functional again for things like `istioctl zc all`, `istioctl zc workload` etc. by updating ZtunnelDump struct types to slice instead of map.

**Notes for Reviewer(s):** can manually confirm this by checking out this branch and running zc commands (e.g. `go run ./istioctl/cmd/istioctl zc all`)