### PR TITLE
pilot: fix double SE deletion

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -81,6 +81,14 @@ const (
 	podConfigType
 )
 
+// configKeyWithParent is a superset of configKey that also encodes the parent resource. For instance, if something comes
+// from a ServiceEntry selector, the parent is the ServiceEntry
+// This is used to distinguish between 1 config (Pod/SE) selected by 2 different parents (ServiceEntry).
+type configKeyWithParent struct {
+	configKey
+	parent types.NamespacedName
+}
+
 // configKey unique identifies a config object managed by this registry (ServiceEntry and WorkloadEntry)
 type configKey struct {
 	kind      configType
@@ -176,7 +184,7 @@ func newController(store model.ConfigStore, xdsUpdater model.XDSUpdater, meshCon
 		meshWatcher: meshConfig,
 		serviceInstances: serviceInstancesStore{
 			ip2instance:            map[string][]*model.ServiceInstance{},
-			instances:              map[instancesKey]map[configKey][]*model.ServiceInstance{},
+			instances:              map[instancesKey]map[configKeyWithParent][]*model.ServiceInstance{},
 			instancesBySE:          map[types.NamespacedName]map[configKey][]*model.ServiceInstance{},
 			instancesByHostAndPort: sets.New[hostPort](),
 		},
@@ -190,19 +198,6 @@ func newController(store model.ConfigStore, xdsUpdater model.XDSUpdater, meshCon
 		o(s)
 	}
 	return s
-}
-
-// ConvertServiceEntry convert se from Config.Spec.
-func ConvertServiceEntry(cfg config.Config) *networking.ServiceEntry {
-	se := cfg.Spec.(*networking.ServiceEntry)
-	if se == nil {
-		return nil
-	}
-
-	// shallow copy
-	copied := &networking.ServiceEntry{}
-	protomarshal.ShallowCopy(copied, se)
-	return copied
 }
 
 // ConvertWorkloadEntry convert wle from Config.Spec and populate the metadata labels into it.
@@ -290,9 +285,15 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		}
 		instance := s.convertWorkloadEntryToServiceInstances(wle, services, se, &key, s.Cluster())
 		instancesUpdated = append(instancesUpdated, instance...)
+		parentKey := configKeyWithParent{
+			configKey: key,
+			parent:    namespacedName,
+		}
 		if event == model.EventDelete {
 			s.serviceInstances.deleteServiceEntryInstances(namespacedName, key)
+			s.serviceInstances.deleteInstanceKeys(parentKey, instancesUpdated)
 		} else {
+			s.serviceInstances.updateInstances(parentKey, instancesUpdated)
 			s.serviceInstances.updateServiceEntryInstancesPerConfig(namespacedName, key, instance)
 		}
 		addConfigs(se, services)
@@ -308,18 +309,20 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 			continue
 		}
 		instance := s.convertWorkloadEntryToServiceInstances(wle, services, se, &key, s.Cluster())
+		parentKey := configKeyWithParent{
+			configKey: key,
+			parent:    namespacedName,
+		}
 		instancesDeleted = append(instancesDeleted, instance...)
 		s.serviceInstances.deleteServiceEntryInstances(namespacedName, key)
+		s.serviceInstances.deleteInstanceKeys(parentKey, instance)
 		addConfigs(se, services)
 	}
 
-	s.serviceInstances.deleteInstanceKeys(key, instancesDeleted)
 	if event == model.EventDelete {
 		s.workloadInstances.Delete(wi)
-		s.serviceInstances.deleteInstanceKeys(key, instancesUpdated)
 	} else {
 		s.workloadInstances.Insert(wi)
-		s.serviceInstances.updateInstances(key, instancesUpdated)
 	}
 	s.mutex.Unlock()
 
@@ -403,14 +406,14 @@ func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Ev
 	serviceInstancesByConfig, serviceInstances := s.buildServiceInstances(curr, cs)
 	oldInstances := s.serviceInstances.getServiceEntryInstances(key)
 	for configKey, old := range oldInstances {
-		s.serviceInstances.deleteInstanceKeys(configKey, old)
+		s.serviceInstances.deleteInstanceKeys(configKeyWithParent{configKey: configKey, parent: key}, old)
 	}
 	if event == model.EventDelete {
 		s.serviceInstances.deleteAllServiceEntryInstances(key)
 	} else {
 		// Update the indexes with new instances.
 		for ckey, value := range serviceInstancesByConfig {
-			s.serviceInstances.addInstances(ckey, value)
+			s.serviceInstances.addInstances(configKeyWithParent{configKey: ckey, parent: key}, value)
 		}
 		s.serviceInstances.updateServiceEntryInstances(key, serviceInstancesByConfig)
 	}
@@ -548,6 +551,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			// If the labels didn't change. And the new SE doesn't match then the old didn't match either and we can skip processing it.
 			continue
 		}
+		cpKey := configKeyWithParent{configKey: key, parent: config.NamespacedName(cfg)}
 
 		// If we are here, then there are 3 possible cases :
 		// Case 1 : The new wi is a subset of se
@@ -563,16 +567,23 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			// If the workload instance still matches. We take care of the possible events.
 			instances = append(instances, currInstance...)
 			if addressToDelete != "" {
+				cfgInstancesDeleted := []*model.ServiceInstance{}
 				for _, i := range currInstance {
 					di := i.DeepCopy()
 					di.Endpoint.Address = addressToDelete
-					instancesDeleted = append(instancesDeleted, di)
+					cfgInstancesDeleted = append(cfgInstancesDeleted, di)
 				}
+				s.serviceInstances.deleteInstanceKeys(cpKey, cfgInstancesDeleted)
 				s.serviceInstances.deleteServiceEntryInstances(seNamespacedName, key)
 			} else if event == model.EventDelete {
 				s.serviceInstances.deleteServiceEntryInstances(seNamespacedName, key)
 			} else {
 				s.serviceInstances.updateServiceEntryInstancesPerConfig(seNamespacedName, key, currInstance)
+			}
+			if event == model.EventDelete {
+				s.serviceInstances.deleteInstanceKeys(cpKey, currInstance)
+			} else {
+				s.serviceInstances.updateInstances(cpKey, currInstance)
 			}
 			// If serviceentry's resolution is DNS, make a full push
 			// TODO: maybe cds?
@@ -594,19 +605,11 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			// Since the instance doesn't match the SE anymore. We remove it from the list.
 			oldInstance := convertWorkloadInstanceToServiceInstance(oldWi, services, se)
 			instancesDeleted = append(instancesDeleted, oldInstance...)
+			s.serviceInstances.deleteInstanceKeys(cpKey, oldInstance)
 			s.serviceInstances.deleteServiceEntryInstances(seNamespacedName, key)
 		}
 	}
 
-	if len(instancesDeleted) > 0 {
-		s.serviceInstances.deleteInstanceKeys(key, instancesDeleted)
-	}
-
-	if event == model.EventDelete {
-		s.serviceInstances.deleteInstanceKeys(key, instances)
-	} else {
-		s.serviceInstances.updateInstances(key, instances)
-	}
 	s.mutex.Unlock()
 
 	s.edsUpdate(append(instances, instancesDeleted...))

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -22,6 +22,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test/util/assert"
@@ -31,7 +32,7 @@ import (
 func TestServiceInstancesStore(t *testing.T) {
 	store := serviceInstancesStore{
 		ip2instance:            map[string][]*model.ServiceInstance{},
-		instances:              map[instancesKey]map[configKey][]*model.ServiceInstance{},
+		instances:              map[instancesKey]map[configKeyWithParent][]*model.ServiceInstance{},
 		instancesBySE:          map[types.NamespacedName]map[configKey][]*model.ServiceInstance{},
 		instancesByHostAndPort: sets.Set[hostPort]{},
 	}
@@ -44,7 +45,8 @@ func TestServiceInstancesStore(t *testing.T) {
 		namespace: "default",
 		name:      "test-wle",
 	}
-	store.addInstances(cKey, instances)
+	cpKey := configKeyWithParent{configKey: cKey, parent: config.NamespacedName(selector)}
+	store.addInstances(cpKey, instances)
 
 	// 1. test getByIP
 	gotInstances := store.getByIP("1.1.1.1")
@@ -99,7 +101,7 @@ func TestServiceInstancesStore(t *testing.T) {
 	}
 
 	// 7. test deleteInstanceKeys
-	store.deleteInstanceKeys(cKey, instances)
+	store.deleteInstanceKeys(cpKey, instances)
 	gotInstances = store.getAll()
 	if len(gotInstances) != 0 {
 		t.Errorf("got unexpected instances %v", gotSeInstances)
@@ -148,7 +150,7 @@ func TestServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	otherNs.Namespace = "other"
 	store := serviceInstancesStore{
 		ip2instance:            map[string][]*model.ServiceInstance{},
-		instances:              map[instancesKey]map[configKey][]*model.ServiceInstance{},
+		instances:              map[instancesKey]map[configKeyWithParent][]*model.ServiceInstance{},
 		instancesBySE:          map[types.NamespacedName]map[configKey][]*model.ServiceInstance{},
 		instancesByHostAndPort: sets.Set[hostPort]{},
 	}
@@ -160,11 +162,14 @@ func TestServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 		namespace: "dns",
 		name:      "dns-round-robin-1",
 	}
+	cpKey := configKeyWithParent{configKey: cKey, parent: config.NamespacedName(selector)}
 	// Add instance related to first Service Entry and validate they are added correctly.
-	store.addInstances(cKey, instances)
+	store.addInstances(cpKey, instances)
 
 	store.addInstances(
-		configKey{namespace: otherNs.Namespace, name: otherNs.Name},
+		configKeyWithParent{
+			configKey: configKey{namespace: otherNs.Namespace, name: otherNs.Name},
+		},
 		[]*model.ServiceInstance{
 			makeInstance(otherNs, "1.1.1.1", 444, otherNs.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 			makeInstance(otherNs, "1.1.1.1", 445, otherNs.Spec.(*networking.ServiceEntry).Ports[1], nil, PlainText),
@@ -193,11 +198,13 @@ func TestServiceInstancesForDnsRoundRobinLB(t *testing.T) {
 	instances = []*model.ServiceInstance{
 		makeInstance(dnsRoundRobinLBSE2, "2.2.2.2", 444, dnsRoundRobinLBSE2.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 	}
-	cKey = configKey{
-		namespace: "dns",
-		name:      "dns-round-robin-2",
+	cpKey = configKeyWithParent{
+		configKey: configKey{
+			namespace: "dns",
+			name:      "dns-round-robin-2",
+		},
 	}
-	store.addInstances(cKey, instances)
+	store.addInstances(cpKey, instances)
 
 	assert.Equal(t, store.getByKey(instancesKey{
 		hostname:  "example.com",

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -445,7 +445,7 @@ type Namer interface {
 	GetNamespace() string
 }
 
-func NamespacedName(o metav1.Object) kubetypes.NamespacedName {
+func NamespacedName[T Namer](o T) kubetypes.NamespacedName {
 	return kubetypes.NamespacedName{
 		Namespace: o.GetNamespace(),
 		Name:      o.GetName(),


### PR DESCRIPTION
Fixes #51212

In draft since I will probably go and add more comments, etc

Root cause is we key on `hostname+namespace` and delete instances. But we actually need to take into account which SE its from, otherwise if 2 SE share the same hostname, removal of one removes all instances