### PR TITLE
Adding Gemfile.lock to bookinfo

### DIFF
--- a/samples/bookinfo/src/details/Gemfile.lock
+++ b/samples/bookinfo/src/details/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  aarch64-linux
   ruby
   x86_64-linux
 

--- a/samples/bookinfo/src/details/Gemfile.lock
+++ b/samples/bookinfo/src/details/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    webrick (1.8.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  webrick (~> 1.7)
+
+BUNDLED WITH
+   2.5.10


### PR DESCRIPTION
It is best practice to include Gemfile.lock. Adding that to bookinfo.

More platforms are supported, but they can be added as-tested; the "ruby" entry should make it work platform-independently most of the time any way.

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
