### PR TITLE
agent sds: fix log of connection line

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -169,7 +169,7 @@ func (s *sdsservice) push(secretName string) {
 	}
 }
 
-func (c Context) XdsConnection() *xds.Connection {
+func (c *Context) XdsConnection() *xds.Connection {
 	return &c.BaseConnection
 }
 


### PR DESCRIPTION
Without this, when we call Initialize we are not always referring to the
same BaseConnection
