### PR TITLE
minor refactor and optimize serviceregistry

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -375,15 +375,11 @@ func (instance *WorkloadInstance) CmpOpts() []cmp.Option {
 
 // DeepCopy creates a copy of WorkloadInstance.
 func (instance *WorkloadInstance) DeepCopy() *WorkloadInstance {
-	pmap := map[string]uint32{}
-	for k, v := range instance.PortMap {
-		pmap[k] = v
-	}
 	return &WorkloadInstance{
 		Name:      instance.Name,
 		Namespace: instance.Namespace,
 		Kind:      instance.Kind,
-		PortMap:   pmap,
+		PortMap:   maps.Clone(instance.PortMap),
 		Endpoint:  instance.Endpoint.DeepCopy(),
 	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -154,9 +154,6 @@ func NewWorkloadEntryController(configController model.ConfigStoreController, xd
 	s := newController(configController, xdsUpdater, options...)
 	// Disable service entry processing for workload entry controller.
 	s.workloadEntryController = true
-	for _, o := range options {
-		o(s)
-	}
 
 	if configController != nil {
 		configController.RegisterEventHandler(gvk.WorkloadEntry, s.workloadEntryHandler)
@@ -184,19 +181,6 @@ func newController(store model.ConfigStore, xdsUpdater model.XDSUpdater, options
 		o(s)
 	}
 	return s
-}
-
-// ConvertServiceEntry convert se from Config.Spec.
-func ConvertServiceEntry(cfg config.Config) *networking.ServiceEntry {
-	se := cfg.Spec.(*networking.ServiceEntry)
-	if se == nil {
-		return nil
-	}
-
-	// shallow copy
-	copied := &networking.ServiceEntry{}
-	protomarshal.ShallowCopy(copied, se)
-	return copied
 }
 
 // ConvertWorkloadEntry convert wle from Config.Spec and populate the metadata labels into it.
@@ -251,7 +235,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 	addConfigs := func(se *networking.ServiceEntry, services []*model.Service) {
 		// If serviceentry's resolution is DNS, make a full push
 		// TODO: maybe cds?
-		if se.Resolution == networking.ServiceEntry_DNS || se.Resolution == networking.ServiceEntry_DNS_ROUND_ROBIN {
+		if isDNSTypeServiceEntry(se) {
 			fullPush = true
 			for key, value := range getUpdatedConfigs(services) {
 				configsUpdated[key] = value
@@ -277,8 +261,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 	for namespacedName, cfg := range currSes {
 		services := s.services.getServices(namespacedName)
 		se := cfg.Spec.(*networking.ServiceEntry)
-		if wi.DNSServiceEntryOnly && se.Resolution != networking.ServiceEntry_DNS &&
-			se.Resolution != networking.ServiceEntry_DNS_ROUND_ROBIN {
+		if wi.DNSServiceEntryOnly && !isDNSTypeServiceEntry(se) {
 			log.Debugf("skip selecting workload instance %v/%v for DNS service entry %v", wi.Namespace, wi.Name, se.Hosts)
 			continue
 		}
@@ -296,8 +279,7 @@ func (s *Controller) workloadEntryHandler(old, curr config.Config, event model.E
 		services := s.services.getServices(namespacedName)
 		cfg := oldSes[namespacedName]
 		se := cfg.Spec.(*networking.ServiceEntry)
-		if wi.DNSServiceEntryOnly && se.Resolution != networking.ServiceEntry_DNS &&
-			se.Resolution != networking.ServiceEntry_DNS_ROUND_ROBIN {
+		if wi.DNSServiceEntryOnly && !isDNSTypeServiceEntry(se) {
 			log.Debugf("skip selecting workload instance %v/%v for DNS service entry %v", wi.Namespace, wi.Name, se.Hosts)
 			continue
 		}
@@ -347,7 +329,7 @@ func (s *Controller) NotifyWorkloadInstanceHandlers(wi *model.WorkloadInstance, 
 
 // getUpdatedConfigs returns related service entries when full push
 func getUpdatedConfigs(services []*model.Service) sets.Set[model.ConfigKey] {
-	configsUpdated := sets.New[model.ConfigKey]()
+	configsUpdated := sets.NewWithLength[model.ConfigKey](len(services))
 	for _, svc := range services {
 		configsUpdated.Insert(model.ConfigKey{
 			Kind:      kind.ServiceEntry,
@@ -439,7 +421,7 @@ func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Ev
 	// If the service entry had endpoints with FQDNs (i.e. resolution DNS), then we need to do
 	// full push (as fqdn endpoints go via strict_dns clusters in cds).
 	if len(unchangedSvcs) > 0 {
-		if currentServiceEntry.Resolution == networking.ServiceEntry_DNS || currentServiceEntry.Resolution == networking.ServiceEntry_DNS_ROUND_ROBIN {
+		if isDNSTypeServiceEntry(currentServiceEntry) {
 			for _, svc := range unchangedSvcs {
 				configsUpdated.Insert(makeConfigKey(svc))
 			}
@@ -570,7 +552,7 @@ func (s *Controller) WorkloadInstanceHandler(wi *model.WorkloadInstance, event m
 			}
 			// If serviceentry's resolution is DNS, make a full push
 			// TODO: maybe cds?
-			if (se.Resolution == networking.ServiceEntry_DNS || se.Resolution == networking.ServiceEntry_DNS_ROUND_ROBIN) &&
+			if isDNSTypeServiceEntry(se) &&
 				se.WorkloadSelector != nil {
 
 				fullPush = true
@@ -1024,8 +1006,7 @@ func (s *Controller) buildServiceInstances(
 		selector := workloadinstances.ByServiceSelector(curr.Namespace, currentServiceEntry.WorkloadSelector.Labels)
 		workloadInstances := workloadinstances.FindAllInIndex(s.workloadInstances, selector)
 		for _, wi := range workloadInstances {
-			if wi.DNSServiceEntryOnly && currentServiceEntry.Resolution != networking.ServiceEntry_DNS &&
-				currentServiceEntry.Resolution != networking.ServiceEntry_DNS_ROUND_ROBIN {
+			if wi.DNSServiceEntryOnly && !isDNSTypeServiceEntry(currentServiceEntry) {
 				log.Debugf("skip selecting workload instance %v/%v for DNS service entry %v", wi.Namespace, wi.Name,
 					currentServiceEntry.Hosts)
 				continue

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -179,6 +179,7 @@ func convertServices(cfg config.Config) []*model.Service {
 	if serviceEntry.WorkloadSelector != nil {
 		labelSelectors = serviceEntry.WorkloadSelector.Labels
 	}
+
 	hostAddresses := []*HostAddress{}
 	for _, hostname := range serviceEntry.Hosts {
 		if len(serviceEntry.Addresses) > 0 {
@@ -310,7 +311,7 @@ func (s *Controller) convertEndpoint(service *model.Service, servicePort *networ
 func (s *Controller) convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, services []*model.Service,
 	se *networking.ServiceEntry, configKey *configKey, clusterID cluster.ID,
 ) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
+	out := make([]*model.ServiceInstance, 0, len(services)*len(se.Ports))
 	for _, service := range services {
 		for _, port := range se.Ports {
 			out = append(out, s.convertEndpoint(service, port, wle, configKey, clusterID))
@@ -320,7 +321,6 @@ func (s *Controller) convertWorkloadEntryToServiceInstances(wle *networking.Work
 }
 
 func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services []*model.Service) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	if serviceEntry == nil {
 		return nil
@@ -328,15 +328,22 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 	if services == nil {
 		services = convertServices(cfg)
 	}
+
+	endpointsNum := len(serviceEntry.Endpoints)
+	hostnameToServiceInstance := false
+	if len(serviceEntry.Endpoints) == 0 && serviceEntry.WorkloadSelector == nil && isDNSTypeServiceEntry(serviceEntry) {
+		hostnameToServiceInstance = true
+		endpointsNum = 1
+	}
+
+	out := make([]*model.ServiceInstance, 0, len(services)*len(serviceEntry.Ports)*endpointsNum)
 	for _, service := range services {
 		for _, serviceEntryPort := range serviceEntry.Ports {
-			if len(serviceEntry.Endpoints) == 0 && serviceEntry.WorkloadSelector == nil &&
-				(serviceEntry.Resolution == networking.ServiceEntry_DNS || serviceEntry.Resolution == networking.ServiceEntry_DNS_ROUND_ROBIN) {
+			if hostnameToServiceInstance {
 				// Note: only convert the hostname to service instance if WorkloadSelector is not set
-				// when service entry has discovery type DNS and no endpoints
-				// we create endpoints from service's host
-				// Do not use serviceentry.hosts as a service entry is converted into
-				// multiple services (one for each host)
+				// when service entry has discovery type DNS and no endpoints.
+				// We create endpoints from service's host, do not use serviceentry.hosts
+				// as a service entry is converted into multiple services (one for each host)
 				endpointPort := serviceEntryPort.Number
 				if serviceEntryPort.TargetPort > 0 {
 					endpointPort = serviceEntryPort.TargetPort
@@ -381,7 +388,7 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 func convertWorkloadInstanceToServiceInstance(workloadInstance *model.WorkloadInstance, serviceEntryServices []*model.Service,
 	serviceEntry *networking.ServiceEntry,
 ) []*model.ServiceInstance {
-	out := make([]*model.ServiceInstance, 0)
+	out := make([]*model.ServiceInstance, 0, len(serviceEntryServices)*len(serviceEntry.Ports))
 	for _, service := range serviceEntryServices {
 		for _, serviceEntryPort := range serviceEntry.Ports {
 			// note: this is same as workloadentry handler

--- a/pilot/pkg/serviceregistry/serviceentry/store.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store.go
@@ -43,7 +43,7 @@ func (s *serviceInstancesStore) getByIP(ip string) []*model.ServiceInstance {
 }
 
 func (s *serviceInstancesStore) getAll() []*model.ServiceInstance {
-	all := []*model.ServiceInstance{}
+	all := make([]*model.ServiceInstance, 0, countSliceValue(s.ip2instance))
 	for _, instances := range s.ip2instance {
 		all = append(all, instances...)
 	}
@@ -51,7 +51,7 @@ func (s *serviceInstancesStore) getAll() []*model.ServiceInstance {
 }
 
 func (s *serviceInstancesStore) getByKey(key instancesKey) []*model.ServiceInstance {
-	all := []*model.ServiceInstance{}
+	all := make([]*model.ServiceInstance, 0, countSliceValue(s.instances[key]))
 	for _, instances := range s.instances[key] {
 		all = append(all, instances...)
 	}
@@ -148,7 +148,7 @@ type serviceStore struct {
 
 // getAllServices return all the services.
 func (s *serviceStore) getAllServices() []*model.Service {
-	var out []*model.Service
+	out := make([]*model.Service, 0, countSliceValue(s.servicesBySE))
 	for _, svcs := range s.servicesBySE {
 		out = append(out, svcs...)
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -132,7 +132,7 @@ func TestServiceStore(t *testing.T) {
 	store.allocateNeeded = false
 	store.deleteServices(httpDNSRR.NamespacedName())
 	got = store.getAllServices()
-	if got != nil {
+	if len(got) != 0 {
 		t.Errorf("got unexpected services %v", got)
 	}
 	if store.allocateNeeded {

--- a/pilot/pkg/serviceregistry/serviceentry/util.go
+++ b/pilot/pkg/serviceregistry/serviceentry/util.go
@@ -49,3 +49,19 @@ func difference(old, curr map[types.NamespacedName]*config.Config) []types.Names
 
 	return out
 }
+
+func isDNSTypeServiceEntry(se *networking.ServiceEntry) bool {
+	if se == nil {
+		return false
+	}
+	return se.Resolution == networking.ServiceEntry_DNS || se.Resolution == networking.ServiceEntry_DNS_ROUND_ROBIN
+}
+
+// count the number of elements in the map value. The value is []any type.
+func countSliceValue[M ~map[K][]V, K comparable, V any](m M) int {
+	n := 0
+	for _, v := range m {
+		n += len(v)
+	}
+	return n
+}

--- a/pkg/config/kube/conversion.go
+++ b/pkg/config/kube/conversion.go
@@ -17,10 +17,10 @@ package kube
 import (
 	"strings"
 
-	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/util/sets"
 )
 
 const (

--- a/pkg/config/kube/conversion.go
+++ b/pkg/config/kube/conversion.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"strings"
 
+	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -31,12 +32,12 @@ const (
 
 // Ports be skipped for protocol sniffing. Applications bound to these ports will be broken if
 // protocol sniffing is enabled.
-var wellKnownPorts = map[int32]struct{}{
-	SMTP:    {},
-	DNS:     {},
-	MySQL:   {},
-	MongoDB: {},
-}
+var wellKnownPorts = sets.New[int32](
+	SMTP,
+	DNS,
+	MySQL,
+	MongoDB,
+)
 
 var (
 	grpcWeb    = string(protocol.GRPCWeb)
@@ -78,7 +79,7 @@ func ConvertProtocol(port int32, portName string, proto corev1.Protocol, appProt
 	p := protocol.Parse(name)
 	if p == protocol.Unsupported {
 		// Make TCP as default protocol for well know ports if protocol is not specified.
-		if _, has := wellKnownPorts[port]; has {
+		if wellKnownPorts.Contains(port) {
 			return protocol.TCP
 		}
 	}


### PR DESCRIPTION
Some miscellaneous refactorings and optimizations:
1. ~fix typo: `initialSyncTimedout` -> `initialSyncTimeout`~
2. remove redundant set options, remove `ConvertServiceEntry` function
3. extract a `isDNSTypeServiceEntry` function
4. set capacity when initializing slices in some places
5. for other information, see code comments