### PR TITLE
Update error message for node authorizer

### DIFF
--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -94,7 +94,7 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 		if s.nodeAuthorizer == nil {
 			s.monitoring.AuthnError.Increment()
 			// Return an opaque error (for security purposes) but log the full reason
-			serverCaLog.Warnf("impersonation not allowed, as node authorizer is not configured")
+			serverCaLog.Warnf("impersonation not allowed, as node authorizer (CA_TRUSTED_NODE_ACCOUNTS) is not configured")
 			return nil, status.Error(codes.Unauthenticated, "request impersonation authentication failure")
 
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

Update error message to point to something useful to fix the error when CA_TRUSTED_NODE_ACCOUNTS is not set. 

https://istio.slack.com/archives/C041EQL1XMY/p1716558663964619

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [x] Docs