### PR TITLE
operator: do not reconcile all IOPs if `REVISION` env is set to blank

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -62,8 +62,10 @@ spec:
               value: {{.Release.Namespace | quote}}
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: {{.Values.waitForResourcesTimeout | quote}}
+{{- if ne .Values.revision "" }}
             - name: REVISION
               value: {{.Values.revision | quote}}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -232,9 +232,8 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	if iop.Spec == nil {
 		iop.Spec = &v1alpha1.IstioOperatorSpec{Profile: name.DefaultProfileName}
 	}
-	operatorRevision, _ := os.LookupEnv("REVISION")
-	if operatorRevision != "" && operatorRevision != iop.Spec.Revision {
-		scope.Infof("Ignoring IstioOperator CR %s with revision %s, since operator revision is %s.", iopName, iop.Spec.Revision, operatorRevision)
+	if operatorRevision, revisionEnvExists := os.LookupEnv("REVISION"); revisionEnvExists && operatorRevision != iop.Spec.Revision {
+		scope.Infof("Ignoring IstioOperator CR %s with revision %s, since operator revision is %q.", iopName, iop.Spec.Revision, operatorRevision)
 		return reconcile.Result{}, nil
 	}
 	if iop.Annotations != nil {

--- a/releasenotes/notes/51250.yaml
+++ b/releasenotes/notes/51250.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** istio operator with `REVISION` env set to blank reconciling revisioned IOPs. The change limits the reconciliation in this case to only IOPs which have `revision` field set to blank.

--- a/releasenotes/notes/51250.yaml
+++ b/releasenotes/notes/51250.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: installation
 releaseNotes:
   - |
-    **Fixed** istio operator with `REVISION` env set to blank reconciling revisioned IOPs. The change limits the reconciliation in this case to only IOPs which have `revision` field set to blank.
+    **Fixed** istio operator with `REVISION` env set to blank reconciling revisioned IOPs. The change limits the reconciliation in this case to only IOPs which have `revision` field set to blank or `default`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently operator which has `REVISION` env set to `""` or unset tries to reconcile IOPs of all revisions. Thus there is no easy way to allow migration from a `default` install of istio to a revisioned install without changing REVISION to be `default` at multiple IOPs to avoid this behavior. However that introduces multiple changes needed in the environment and possibly restarting all gateways deployments since now the IOPs are expected to have the revision as well.

With this PR the intent to only reconcile a non revisioned IOP (blank revision) and not others is honored when REVISION env is present but blank. If env is not set, the behavior remains same.

> `""` (BLANK) means either non revisioned or IOPs with revision `default` will be reconciled.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
