### PR TITLE
Cosmetic: should quote after default

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -12,8 +12,8 @@ metadata:
 data:
   CURRENT_AGENT_VERSION: {{ .Values.cni.tag | default .Values.global.tag | quote }}
   AMBIENT_ENABLED: {{ .Values.cni.ambient.enabled | quote }}
-  AMBIENT_DNS_CAPTURE: {{ .Values.cni.ambient.dnsCapture | quote | default "false" }}
-  AMBIENT_IPV6: {{ .Values.cni.ambient.ipv6 | quote | default "false" }}
+  AMBIENT_DNS_CAPTURE: {{ .Values.cni.ambient.dnsCapture | default "false" | quote  }}
+  AMBIENT_IPV6: {{ .Values.cni.ambient.ipv6 | default "false" | quote }}
   {{- if .Values.cni.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cni.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}


### PR DESCRIPTION
Quote was in the wrong spot, causing the Helm default values to be ignored and an empty value used instead.

In practice this doesn't matter, since in-code we choose defaults for empty values that amount to the same thing, but it's still wrong.