### PR TITLE
update supported groups for TLS

### DIFF
--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -242,14 +242,14 @@ var ValidCipherSuites = sets.New(
 
 // ValidECDHCurves contains a list of all ecdh curves supported in MeshConfig.TlsDefaults.ecdhCurves
 // Source:
-// https://github.com/google/boringssl/blob/3743aafdacff2f7b083615a043a37101f740fa53/ssl/ssl_key_share.cc#L302-L309
+// https://github.com/google/boringssl/blob/45cf810dbdbd767f09f8cb0b0fcccd342c39041f/src/ssl/ssl_key_share.cc#L285-L293
 var ValidECDHCurves = sets.New(
 	"P-224",
 	"P-256",
 	"P-521",
 	"P-384",
 	"X25519",
-	"CECPQ2",
+	"X25519Kyber768Draft00",
 )
 
 func IsValidCipherSuite(cs string) bool {


### PR DESCRIPTION
**Please provide a description of this PR:**
The underlying boringssl version used in envoy no longer supports CECPQ2 for TLS groups, and is upgraded to use X25519Kyber768Draft00. Reflect this usage accurately in Istio by removing CECPQ2, and enabling X25519Kyber768Draft00

The dependency of istio -> proxy -> envoy -> boringssl is the following: 
Istio -> proxy : [proxy SHA]( https://github.com/istio/istio/blob/master/istio.deps#L7)
Proxy -> envoy: [envoy SHA](https://github.com/istio/proxy/blob/1678bacbcdbc833935ac33a4efbfd59fb6600ef3/WORKSPACE#L26) 
Envoy -> boringssl: [boringssl version](https://github.com/envoyproxy/envoy/blob/a1c5de9500a96553186935a288efaeef47ddbaf0/bazel/repository_locations.bzl#L114-L132)
BoringSSL - [supported groups](https://github.com/google/boringssl/blob/45cf810dbdbd767f09f8cb0b0fcccd342c39041f/src/ssl/ssl_key_share.cc#L285-L293)