### PR TITLE
CNI Plugin: Adds K8S_POD_UID Field to K8sArgs Struct

### DIFF
--- a/cni/pkg/plugin/plugin.go
+++ b/cni/pkg/plugin/plugin.go
@@ -80,6 +80,7 @@ type K8sArgs struct {
 	K8S_POD_NAME               types.UnmarshallableString // nolint: revive, stylecheck
 	K8S_POD_NAMESPACE          types.UnmarshallableString // nolint: revive, stylecheck
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString // nolint: revive, stylecheck
+	K8S_POD_UID                types.UnmarshallableString // nolint: revive, stylecheck
 }
 
 // parseConfig parses the supplied configuration (and prevResult) from stdin.

--- a/cni/pkg/plugin/plugin_cni_conformance.go
+++ b/cni/pkg/plugin/plugin_cni_conformance.go
@@ -25,15 +25,18 @@ import (
 func TestLoadArgs(t *testing.T) {
 	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
 		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +
-		"K8S_POD_INFRA_CONTAINER_ID=3c41e946cf17a32760ff86940a73b06982f1815e9083cf2f4bfccb9b7605f326"
+		"K8S_POD_INFRA_CONTAINER_ID=3c41e946cf17a32760ff86940a73b06982f1815e9083cf2f4bfccb9b7605f326" +
+		"K8S_POD_UID=a09038c7-df3c-4c0e-8667-487b1fe8055f"
 
 	k8sArgs := K8sArgs{}
 	if err := types.LoadArgs(kubeletArgs, &k8sArgs); err != nil {
 		t.Fatalf("LoadArgs failed with error: %v", err)
 	}
 
-	if string(k8sArgs.K8S_POD_NAMESPACE) == "" || string(k8sArgs.K8S_POD_NAME) == "" {
-		t.Fatalf("LoadArgs didn't convert args properly, K8S_POD_NAME=\"%s\";K8S_POD_NAMESPACE=\"%s\"",
-			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE))
+	if string(k8sArgs.K8S_POD_NAMESPACE) == "" ||
+		string(k8sArgs.K8S_POD_NAME) == "" ||
+		string(k8sArgs.K8S_POD_UID) == "" {
+		t.Fatalf("LoadArgs didn't convert args properly, K8S_POD_NAME=\"%s\";K8S_POD_NAMESPACE=\"%s\";K8S_POD_UID=\"%s\"",
+			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_UID))
 	}
 }


### PR DESCRIPTION
The K8sArgs struct should be in sync with the k/v map returned by the containerd `toCNILabels` function. This PR adds the missing `K8S_POD_UID` CNI label.

Fixes #51292