### PR TITLE
improved istioctl version format more user-friendly

### DIFF
--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -75,14 +76,20 @@ func getRemoteInfo(ctx cli.Context, opts clioptions.ControlPlaneOptions) (*istio
 func getRemoteInfoWrapper(ctx cli.Context, pc **cobra.Command, opts *clioptions.ControlPlaneOptions) func() (*istioVersion.MeshInfo, error) {
 	return func() (*istioVersion.MeshInfo, error) {
 		remInfo, err := getRemoteInfo(ctx, *opts)
-		if err != nil {
-			fmt.Fprintf((*pc).OutOrStderr(), "%v\n", err)
-			// Return nil so that the client version is printed
-			return nil, nil
-		}
+		var errMses []string
+
 		if remInfo == nil {
-			fmt.Fprintf((*pc).OutOrStderr(), "Istio is not present in the cluster with namespace %q\n", ctx.IstioNamespace())
+			errMses = append(errMses, "Istio is not present in the cluster")
 		}
+
+		if err != nil {
+			errMses = append(errMses, fmt.Sprintf("-- %v", err))
+		}
+
+		if len(errMses) > 0 {
+			fmt.Fprintln((*pc).OutOrStderr(), strings.Join(errMses, " "))
+		}
+
 		return remInfo, err
 	}
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -857,7 +857,7 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 		}
 	}
 	if len(readyPods) == 0 {
-		return nil, fmt.Errorf("no ready Istio pods in %q", namespace)
+		return nil, fmt.Errorf("no running Istio pods in namespace %q", namespace)
 	}
 
 	var errs error

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -62,7 +62,6 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 		remote        bool
 		version       Version
 		remoteVersion *MeshInfo
-		serverErr     error
 	)
 
 	cmd := &cobra.Command{
@@ -76,10 +75,7 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 			version.ClientVersion = &Info
 
 			if options.GetRemoteVersion != nil && remote {
-				remoteVersion, serverErr = options.GetRemoteVersion()
-				if serverErr != nil {
-					return serverErr
-				}
+				remoteVersion, _ = options.GetRemoteVersion()
 				version.MeshVersion = remoteVersion
 			}
 			if options.GetProxyVersions != nil && remote {
@@ -89,27 +85,22 @@ func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
 			switch output {
 			case "":
 				if short {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.Version)
 					if remoteVersion != nil {
 						remoteVersion = coalesceVersions(remoteVersion)
-						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.Version)
 						for _, remote := range *remoteVersion {
 							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s version: %s\n", remote.Component, remote.Info.Version)
 						}
-
-					} else {
-						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.Version)
 					}
 					if version.DataPlaneVersion != nil {
 						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "data plane version: %s\n", renderProxyVersions(version.DataPlaneVersion))
 					}
 				} else {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.LongForm())
 					if remoteVersion != nil {
-						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.LongForm())
 						for _, remote := range *remoteVersion {
 							_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s version: %s\n", remote.Component, remote.Info.LongForm())
 						}
-					} else {
-						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.LongForm())
 					}
 					if version.DataPlaneVersion != nil {
 						for _, proxy := range *version.DataPlaneVersion {

--- a/releasenotes/notes/51296.yaml
+++ b/releasenotes/notes/51296.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 51296
+releaseNotes:
+  - |
+    **Improved** Improved the error output for `istioctl version` to be more user-friendly.


### PR DESCRIPTION
resolved #51296

**Please provide a description of this PR:**
 
before:
```bash
$ istioctl version           
no ready Istio pods in "istio-system"
1.21.2
```

after:
```bash
$ istioctl version           
Istio is not present in the cluster -- no running Istio pods in namespace "istio-system"
client version: 1.21.2
```


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
