### PR TITLE
Ambient: Fix bug with initial node agent snapshot create

### DIFF
--- a/cni/pkg/nodeagent/pod_cache.go
+++ b/cni/pkg/nodeagent/pod_cache.go
@@ -91,8 +91,7 @@ func (p *podNetnsCache) UpsertPodCacheWithNetns(uid string, workload WorkloadInf
 	return workload.Netns
 }
 
-// Update the cache with the given uid and nspath. Return the Netns for the given uid.
-// If uid is already present, a cached Netns is returned, and the given nspath is ignored.
+// Get the netns if it's in the cache
 func (p *podNetnsCache) Get(uid string) Netns {
 	// lock current snapshot pod map
 	p.mu.RLock()

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -32,7 +32,10 @@ import (
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/kube"
+	istiolog "istio.io/istio/pkg/log"
 )
+
+var log = istiolog.RegisterScope(pconstants.CNIAgentLogScope, "ambient node agent server").WithLabels("server")
 
 type MeshDataplane interface {
 	// called first, (even before Start()).
@@ -167,7 +170,7 @@ func (s *Server) Start() {
 	log.Info("CNI ambient server starting")
 	s.kubeClient.RunAndWait(s.ctx.Done())
 	log.Info("CNI ambient server kubeclient started")
-	pods := s.handlers.GetAmbientPods()
+	pods := s.handlers.GetActiveAmbientPodSnapshot()
 	err := s.dataplane.ConstructInitialSnapshot(pods)
 	if err != nil {
 		log.Warnf("failed to construct initial snapshot: %v", err)

--- a/cni/pkg/util/podutil.go
+++ b/cni/pkg/util/podutil.go
@@ -59,6 +59,15 @@ func PodRedirectionEnabled(namespace *corev1.Namespace, pod *corev1.Pod) bool {
 	return true
 }
 
+// PodRedirectionActive reports on whether the pod _has_ actually been configured for traffic redirection.
+//
+// That is, have we annotated it after successfully sending it to the node proxy and set up iptables rules.
+//
+// If you just want to know if the pod _should be_ configured for traffic redirection, see PodRedirectionEnabled
+func PodRedirectionActive(pod *corev1.Pod) bool {
+	return pod.GetAnnotations()[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled
+}
+
 func podHasSidecar(pod *corev1.Pod) bool {
 	if _, f := pod.GetAnnotations()[annotation.SidecarStatus.Name]; f {
 		return true


### PR DESCRIPTION
**Please provide a description of this PR:**

When `istio-cni` (re)starts up, we build a snapshot of currently-enrolled ambient pods, which we send to ztunnel. This is to make sure a new ztunnel client connection always gets the current set of enrolled pods.

We cannot rely on the informer for this, because it is (correctly) designed to not-enroll pods that have already been marked as enrolled.

The informer decides whether it should do something with a new pod event by looking at
-  user _intent_ (the `istio.io/dataplane-mode=ambient` label)
- actual state (the `ambient.istio.io/redirection=enabled` annotation)

and reconciling any mismatch between the two. There is of course a time window/delta between someone labelling a pod with _intent_, and then k8s telling us about it, and us actually successfully _enrolling_ the pod - the annotation and label combinatorics nicely describe this delta unambiguously, and it is the job of the informer to deal with this.

tl;dr We _only_ apply the actual state annotation when we have actually added the pod to ztunnel and set up iptables redirection - users do not set that annotation.

ConstructInitialSnapshot was building a list of enrolled pods based on the _user_ intent label, and not the actual enrolled state (the annotation). I at first thought this was recently injected, but it's been there for a bit :D - we have always only checked the label, which is wrong.

This created a bug where ConstructInitialSnapshot would actually grab pods that _weren't_ in an enrolled state, and try to enroll them (and add them to the node ipset). This isn't correct, as it means we could include pods that were never enrolled in the ztunnel snapshot (they had the label, but not the annotation, and were not redirected via iptables), and when the informer did its initial namespace reconciliation, it correctly detected the mismatch and tried to properly add the pod, causing an ipset conflict.

It wasn't obvious this was happening until https://github.com/istio/istio/pull/51081 exposed this by refusing to allow pod IP overwrites in the ipset.