### PR TITLE
add the id to the svg element in productpage

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: docker.io/istio/examples-bookinfo-mongodb:1.20.0
+        image: docker.io/istio/examples-bookinfo-mongodb:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-dualstack.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v2:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-dualstack.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -180,7 +180,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -220,7 +220,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -260,7 +260,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -330,7 +330,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: docker.io/istio/examples-bookinfo-mysqldb:1.20.0
+        image: docker.io/istio/examples-bookinfo-mysqldb:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-psa.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-psa.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -178,7 +178,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -270,7 +270,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -344,7 +344,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-dualstack.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-details-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -123,7 +123,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -174,7 +174,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -214,7 +214,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -254,7 +254,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.0
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.20.1
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -322,7 +322,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.0
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.20.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/src/productpage/templates/productpage.html
+++ b/samples/bookinfo/src/productpage/templates/productpage.html
@@ -169,7 +169,7 @@
             {% if review.rating.stars: %}
             <div class="flex gap-x-1 text-{{ review.rating.color }}-500">
               {% for n in range(review.rating.stars) %}
-              <svg class="h-5 w-5 flex-none" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <svg id="glyphicon glyphicon-star" class="h-5 w-5 flex-none" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z" clip-rule="evenodd" />
               </svg>
               {% endfor %}


### PR DESCRIPTION
Some tests rely on checking for the specific output from the productpage (e.g. `glyphicon glyphicon-star` to check whether stars are rendered). 

With the re-design, we're not using glyphicons anymore, so this change adds an`id: glyphicon glyphicon-star` to the SVG element, so we don't have to change all tests. 