### PR TITLE
istioctl: add overwrite flag for enroll-namespace

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,6 +55,7 @@ var (
 
 	waypointName    = constants.DefaultNamespaceWaypoint
 	enrollNamespace bool
+	overwrite       bool
 )
 
 const waitTimeout = 90 * time.Second
@@ -93,7 +95,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		// this will allow for gateway class to provide a default for that class rather than always forcing service or requiring users to configure correctly
 		if trafficType != "" {
 			if !validTrafficTypes.Contains(trafficType) {
-				return nil, fmt.Errorf("invalid traffic type: %s. Valid options are: %s", trafficType, validTrafficTypes.String())
+				return nil, fmt.Errorf("invalid traffic type: %s. Valid options are: %v", trafficType, validTrafficTypes)
 			}
 
 			if gw.Labels == nil {
@@ -159,8 +161,19 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			// NOTE: This is a warning and not an error because the user may not intend to label their namespace as ambient.
 			//
 			// e.g. Users are handling ambient redirection per workload rather than at the namespace level.
+			hasWaypoint, err := namespaceHasLabel(kubeClient, ns, constants.AmbientUseWaypointLabel)
+			if err != nil {
+				return err
+			}
 			if enrollNamespace {
-				namespaceIsLabeledAmbient, err := namespaceIsLabeledAmbient(kubeClient, ns)
+				if !overwrite && hasWaypoint {
+					// we don't want to error on the user when they don't explicitly overwrite namespaced Waypoints,
+					// we just warn them and provide a suggestion
+					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace (%s) already has an enrolled Waypoint. Consider "+
+						"adding the `"+"--overwrite"+"` flag to your apply command.\n", ns)
+					return nil
+				}
+				namespaceIsLabeledAmbient, err := namespaceHasLabel(kubeClient, ns, constants.DataplaneModeLabel)
 				if err != nil {
 					return fmt.Errorf("failed to check if namespace is labeled ambient: %v", err)
 				}
@@ -239,6 +252,9 @@ func Cmd(ctx cli.Context) *cobra.Command {
 
 	waypointApplyCmd.PersistentFlags().BoolVarP(&enrollNamespace, "enroll-namespace", "", false,
 		"If set, the namespace will be labeled with the waypoint name")
+
+	waypointApplyCmd.PersistentFlags().BoolVarP(&overwrite, "overwrite", "", false,
+		"Overwrite the existing Waypoint used by the namespace")
 
 	waypointDeleteCmd := &cobra.Command{
 		Use:   "delete",
@@ -430,11 +446,9 @@ func deleteWaypoints(cmd *cobra.Command, kubeClient kube.CLIClient, namespace st
 }
 
 func labelNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
-	nsObj, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		return fmt.Errorf("namespace: %s not found", ns)
-	} else if err != nil {
-		return fmt.Errorf("failed to get namespace %s: %v", ns, err)
+	nsObj, err := getNamespace(kubeClient, ns)
+	if err != nil {
+		return err
 	}
 	if nsObj.Labels == nil {
 		nsObj.Labels = map[string]string{}
@@ -446,15 +460,26 @@ func labelNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
 	return nil
 }
 
-func namespaceIsLabeledAmbient(kubeClient kube.CLIClient, ns string) (bool, error) {
-	nsObj, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		return false, fmt.Errorf("namespace: %s not found", ns)
-	} else if err != nil {
-		return false, fmt.Errorf("failed to get namespace %s: %v", ns, err)
+func namespaceHasLabel(kubeClient kube.CLIClient, ns string, label string) (bool, error) {
+	nsObj, err := getNamespace(kubeClient, ns)
+	if err != nil {
+		return false, err
 	}
 	if nsObj.Labels == nil {
 		return false, nil
 	}
-	return nsObj.Labels[constants.DataplaneModeLabel] == constants.DataplaneModeAmbient, nil
+	if label == constants.DataplaneModeLabel {
+		return nsObj.Labels[label] == constants.DataplaneModeAmbient, nil
+	}
+	return nsObj.Labels[label] != "", nil
+}
+
+func getNamespace(kubeClient kube.CLIClient, ns string) (*corev1.Namespace, error) {
+	nsObj, err := kubeClient.Kube().CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil, fmt.Errorf("namespace: %s not found", ns)
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get namespace %s: %v", ns, err)
+	}
+	return nsObj, nil
 }

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -173,7 +173,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 						"adding the `"+"--overwrite"+"` flag to your apply command.\n", ns)
 					return nil
 				}
-				namespaceIsLabeledAmbient, err := namespaceHasLabel(kubeClient, ns, constants.DataplaneModeLabel)
+				namespaceIsLabeledAmbient, err := namespaceHasLabelWithValue(kubeClient, ns, constants.DataplaneModeLabel, constants.DataplaneModeAmbient)
 				if err != nil {
 					return fmt.Errorf("failed to check if namespace is labeled ambient: %v", err)
 				}
@@ -468,10 +468,18 @@ func namespaceHasLabel(kubeClient kube.CLIClient, ns string, label string) (bool
 	if nsObj.Labels == nil {
 		return false, nil
 	}
-	if label == constants.DataplaneModeLabel {
-		return nsObj.Labels[label] == constants.DataplaneModeAmbient, nil
-	}
 	return nsObj.Labels[label] != "", nil
+}
+
+func namespaceHasLabelWithValue(kubeClient kube.CLIClient, ns string, label, labelValue string) (bool, error) {
+	nsObj, err := getNamespace(kubeClient, ns)
+	if err != nil {
+		return false, err
+	}
+	if nsObj.Labels == nil {
+		return false, nil
+	}
+	return nsObj.Labels[label] == labelValue, nil
 }
 
 func getNamespace(kubeClient kube.CLIClient, ns string) (*corev1.Namespace, error) {

--- a/releasenotes/notes/add-overwrite-flag.yaml
+++ b/releasenotes/notes/add-overwrite-flag.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 51312
+
+releaseNotes:
+  - |
+    **Added** overwrite flag to istioctl apply command to allow overwriting existing resources in the cluster (initially, just namespace waypoint enrollment).


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #51312 

This PR adds an --overwrite flag to force users to explicitly declare that they want to override the namespace's labeled use-waypoint value. If a user doesn't provide the flag, then --enroll-namespace won't add the new waypoint and will instead give them a warning:

```bash
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl x waypoint apply --for all --name test2 --enroll-namespace --overwrite
waypoint default/test2 applied
namespace default labeled with "istio.io/use-waypoint: test2"

azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl x waypoint apply --for all --name test3 --enroll-namespace
Warning: namespace (default) already has an enrolled Waypoint. Consider adding the `--overwrite` flag to your apply command.
```