### PR TITLE
istioctl: remove --verbose flag since it should be the default column output anyway

### DIFF
--- a/istioctl/pkg/writer/ztunnel/configdump/configdump.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump.go
@@ -91,7 +91,7 @@ func (c *ConfigWriter) PrintBootstrapDump(outputFormat string) error {
 
 func (c *ConfigWriter) PrintFullSummary() error {
 	_, _ = c.Stdout.Write([]byte("\n"))
-	if err := c.PrintWorkloadSummary(WorkloadFilter{Verbose: true}); err != nil {
+	if err := c.PrintWorkloadSummary(WorkloadFilter{}); err != nil {
 		return err
 	}
 	_, _ = c.Stdout.Write([]byte("\n"))

--- a/istioctl/pkg/writer/ztunnel/configdump/configdump_test.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/configdump_test.go
@@ -112,7 +112,7 @@ func TestConfigWriter_PrintSecretSummary(t *testing.T) {
 				util.CompareContent(t, gotOut.Bytes(), tt.wantOutputSecret)
 			}
 			if tt.wantOutputWorkload != "" {
-				wf := WorkloadFilter{Verbose: true}
+				wf := WorkloadFilter{}
 				if tt.configNamespace != "" {
 					wf.Namespace = tt.configNamespace
 				}

--- a/istioctl/pkg/writer/ztunnel/configdump/workload.go
+++ b/istioctl/pkg/writer/ztunnel/configdump/workload.go
@@ -27,7 +27,6 @@ import (
 type WorkloadFilter struct {
 	Address   string
 	Node      string
-	Verbose   bool
 	Namespace string
 }
 
@@ -85,24 +84,17 @@ func (c *ConfigWriter) PrintWorkloadSummary(filter WorkloadFilter) error {
 		return iNode < jNode
 	})
 
-	if filter.Verbose {
-		fmt.Fprintln(w, "NAMESPACE\tPOD NAME\tIP\tNODE\tWAYPOINT\tPROTOCOL")
-	} else {
-		fmt.Fprintln(w, "NAMESPACE\tPOD NAME\tIP\tNODE")
-	}
+	fmt.Fprintln(w, "NAMESPACE\tPOD NAME\tIP\tNODE\tWAYPOINT\tPROTOCOL")
 
 	for _, wl := range verifiedWorkloads {
 		var ip string
 		if len(wl.WorkloadIPs) > 0 {
 			ip = wl.WorkloadIPs[0]
 		}
-		if filter.Verbose {
-			waypoint := waypointName(wl, zDump.Services)
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n",
-				wl.Namespace, wl.Name, ip, wl.Node, waypoint, wl.Protocol)
-		} else {
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", wl.Namespace, wl.Name, ip, wl.Node)
-		}
+		waypoint := waypointName(wl, zDump.Services)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n",
+			wl.Namespace, wl.Name, ip, wl.Node, waypoint, wl.Protocol)
+
 	}
 	return w.Flush()
 }

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -218,7 +218,6 @@ func allCmd(ctx cli.Context) *cobra.Command {
 func workloadConfigCmd(ctx cli.Context) *cobra.Command {
 	var workloadsNamespace string
 	var workloadNode string
-	var verboseProxyConfig bool
 
 	var address string
 
@@ -250,9 +249,7 @@ func workloadConfigCmd(ctx cli.Context) *cobra.Command {
 				Namespace: workloadsNamespace,
 				Address:   address,
 				Node:      workloadNode,
-				Verbose:   verboseProxyConfig,
 			}
-
 			switch common.outputFormat {
 			case summaryOutput:
 				return cw.PrintWorkloadSummary(filter)
@@ -267,7 +264,6 @@ func workloadConfigCmd(ctx cli.Context) *cobra.Command {
 
 	common.attach(cmd)
 	cmd.PersistentFlags().StringVar(&address, "address", "", "Filter workloads by address field")
-	cmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
 	cmd.PersistentFlags().StringVar(&workloadsNamespace, "workload-namespace", "",
 		"Filter workloads by namespace field")
 	cmd.PersistentFlags().StringVar(&workloadNode, "workload-node", "",


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to: #50655

I went to add more verbosity to the ztunnel-config command and realized we have a command that already does this. It just always defaulted to true and didn't actually do anything. This PR updates it to actually make the `--verbose` flag toggle verbosity when it's used:

**without** update:
```bash
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl zc w
NAMESPACE          POD NAME                              IP          NODE                        WAYPOINT PROTOCOL
default            test1-6484bd9cd9-l7rmh                10.244.0.9  istio-testing-control-plane None     TCP
default            test2-b8dc7b5c9-55pt8                 10.244.0.10 istio-testing-control-plane None     TCP
istio-system       istiod-dbf59dd7b-rqnwn                10.244.0.7  istio-testing-control-plane None     TCP
istio-system       ztunnel-lbqx8                         10.244.0.8  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-q5zwp              10.244.0.2  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-xwqmb              10.244.0.3  istio-testing-control-plane None     TCP
kube-system        metrics-server-57478dfcbd-z66qg       10.244.0.5  istio-testing-control-plane None     TCP
local-path-storage local-path-provisioner-988d74bc-wrgjn 10.244.0.4  istio-testing-control-plane None     TCP
metallb-system     controller-689ddcdb4-qm4ph            10.244.0.6  istio-testing-control-plane None     TCP
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl zc w --verbose
NAMESPACE          POD NAME                              IP          NODE                        WAYPOINT PROTOCOL
default            test1-6484bd9cd9-l7rmh                10.244.0.9  istio-testing-control-plane None     TCP
default            test2-b8dc7b5c9-55pt8                 10.244.0.10 istio-testing-control-plane None     TCP
istio-system       istiod-dbf59dd7b-rqnwn                10.244.0.7  istio-testing-control-plane None     TCP
istio-system       ztunnel-lbqx8                         10.244.0.8  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-q5zwp              10.244.0.2  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-xwqmb              10.244.0.3  istio-testing-control-plane None     TCP
kube-system        metrics-server-57478dfcbd-z66qg       10.244.0.5  istio-testing-control-plane None     TCP
local-path-storage local-path-provisioner-988d74bc-wrgjn 10.244.0.4  istio-testing-control-plane None     TCP
metallb-system     controller-689ddcdb4-qm4ph            10.244.0.6  istio-testing-control-plane None     TCP
```


**with** update:
```bash
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl zc w
Verbose: false
NAMESPACE          POD NAME                              IP          NODE
default            test1-6484bd9cd9-l7rmh                10.244.0.9  istio-testing-control-plane
default            test2-b8dc7b5c9-55pt8                 10.244.0.10 istio-testing-control-plane
istio-system       istiod-dbf59dd7b-rqnwn                10.244.0.7  istio-testing-control-plane
istio-system       ztunnel-lbqx8                         10.244.0.8  istio-testing-control-plane
kube-system        coredns-7db6d8ff4d-q5zwp              10.244.0.2  istio-testing-control-plane
kube-system        coredns-7db6d8ff4d-xwqmb              10.244.0.3  istio-testing-control-plane
kube-system        metrics-server-57478dfcbd-z66qg       10.244.0.5  istio-testing-control-plane
local-path-storage local-path-provisioner-988d74bc-wrgjn 10.244.0.4  istio-testing-control-plane
metallb-system     controller-689ddcdb4-qm4ph            10.244.0.6  istio-testing-control-plane
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl zc w --verbose
Verbose: true
NAMESPACE          POD NAME                              IP          NODE                        WAYPOINT PROTOCOL
default            test1-6484bd9cd9-l7rmh                10.244.0.9  istio-testing-control-plane None     TCP
default            test2-b8dc7b5c9-55pt8                 10.244.0.10 istio-testing-control-plane None     TCP
istio-system       istiod-dbf59dd7b-rqnwn                10.244.0.7  istio-testing-control-plane None     TCP
istio-system       ztunnel-lbqx8                         10.244.0.8  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-q5zwp              10.244.0.2  istio-testing-control-plane None     TCP
kube-system        coredns-7db6d8ff4d-xwqmb              10.244.0.3  istio-testing-control-plane None     TCP
kube-system        metrics-server-57478dfcbd-z66qg       10.244.0.5  istio-testing-control-plane None     TCP
local-path-storage local-path-provisioner-988d74bc-wrgjn 10.244.0.4  istio-testing-control-plane None     TCP
metallb-system     controller-689ddcdb4-qm4ph            10.244.0.6  istio-testing-control-plane None     TCP
```