### PR TITLE
istioctl: advise user to monitor gtw deployment when applying waypoint

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -241,6 +241,8 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v labeled with \"%v: %v\"\n", ctx.NamespaceOrDefault(ctx.Namespace()),
 					constants.AmbientUseWaypointLabel, gw.Name)
 			}
+			fmt.Fprintf(cmd.OutOrStdout(), "monitor status of waypoint deployment with "+
+				"`"+"kubectl get gateways -n %s"+"`\n", ns)
 			return nil
 		},
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #51294 

Includes a kubectl command in the output that advises users to monitor their gateway deployment to ensure that it was actually deployed or not:

```bash
azureuser@dev-2024:~/istio$ k create ns test9000
namespace/test9000 created

azureuser@dev-2024:~/istio$ k apply -f samples/httpbin/httpbin.yaml -n test9000
serviceaccount/httpbin created
service/httpbin created
deployment.apps/httpbin created

azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl x waypoint apply -n test9000 --name httpbin --enroll-nam
espace
waypoint test9000/httpbin applied
namespace test9000 labeled with "istio.io/use-waypoint: httpbin"
monitor status of waypoint deployment with `kubectl get gateways -n test9000`

azureuser@dev-2024:~/istio$ k create ns testing
namespace/testing created

azureuser@dev-2024:~/istio$ k apply -f samples/httpbin/httpbin.yaml -n testing
serviceaccount/httpbin created
service/httpbin created
deployment.apps/httpbin created

azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl x waypoint apply -n testing --name httpbin
waypoint testing/httpbin applied
monitor status of waypoint deployment with `kubectl get gateways -n testing`
``` 