### PR TITLE
Optimize ParseGatewayRDSRouteName

### DIFF
--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -248,6 +248,14 @@ func makeConfig(name, namespace, host, portName, portProtocol string, portNumber
 	return c
 }
 
+func BenchmarkParseGatewayRDSRouteName(b *testing.B) {
+	for range b.N {
+		ParseGatewayRDSRouteName("https.443.app1.gw1.ns1")
+		ParseGatewayRDSRouteName("https.scooby.dooby.doo")
+		ParseGatewayRDSRouteName("http.80")
+	}
+}
+
 func TestParseGatewayRDSRouteName(t *testing.T) {
 	type args struct {
 		name string


### PR DESCRIPTION
In real world we have seen this use 10% total Istiod CPU. It is trivial to optimize.

Technically we could get rid of the last allocation too but its more complex.

```
name                         old time/op    new time/op    delta
ParseGatewayRDSRouteName-16     227ns ± 8%      66ns ± 7%  -70.77%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
ParseGatewayRDSRouteName-16      184B ± 0%        8B ± 0%  -95.65%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
ParseGatewayRDSRouteName-16      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)
```
