### PR TITLE
optimize: sidecar service selection and merge

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -959,16 +959,16 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 			return
 		}
 
-		if !canMergeServices(existing, s) {
-			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
-				existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
-			return
-		}
-
-		// if both services have the same ports, no need to merge them and save a deepcopy
+		// if both services have the same ports, no need to merge and we save a deepcopy
 		if existing.Ports.Equals(s.Ports) {
 			log.Debugf("Service %s/%s from registry %s ignored as it has the same ports as %s/%s/%s", s.Attributes.Namespace, s.Hostname,
 				s.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
+			return
+		}
+
+		if !canMergeServices(existing, s) {
+			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
+				existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
 			return
 		}
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -929,6 +929,12 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 		sc.servicesByHostname[s.Hostname] = s
 	} else {
 		existing := foundSvc.svc
+		// Skip services which are already added, this can happen when a service is explicitly requested
+		// but is also a virtualservice destination, or if the service is a destination of multiple virtualservices
+		if s == existing {
+			log.Debugf("Service %s/%s from registry %s ignored as it is already added", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry)
+			return
+		}
 		// We do not merge k8s service with any other services from other registries
 		if existing.Attributes.ServiceRegistry == provider.Kubernetes && s.Attributes.ServiceRegistry != provider.Kubernetes {
 			log.Debugf("Service %s/%s from registry %s ignored as there is an existing service in Kubernetes already %s/%s/%s",
@@ -956,6 +962,13 @@ func (sc *SidecarScope) appendSidecarServices(servicesAdded map[host.Name]sideca
 		if !canMergeServices(existing, s) {
 			log.Debugf("Service %s/%s from registry %s ignored by %s/%s/%s", s.Attributes.Namespace, s.Hostname, s.Attributes.ServiceRegistry,
 				existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
+			return
+		}
+
+		// if both services have the same ports, no need to merge them and save a deepcopy
+		if existing.Ports.Equals(s.Ports) {
+			log.Debugf("Service %s/%s from registry %s ignored as it has the same ports as %s/%s/%s", s.Attributes.Namespace, s.Hostname,
+				s.Attributes.ServiceRegistry, existing.Attributes.Namespace, existing.Hostname, existing.Attributes.ServiceRegistry)
 			return
 		}
 


### PR DESCRIPTION
**Please provide a description of this PR:**
If a Service is selected multiple times (might happen if it's a destination of multiple routes or multiple VirtualServices), we currently **always DeepCopy the service** even though it's not actually needed and nothing is actually changing.

Changes proposed:
- fast equals check to see if the service being added is already present (this only actually succeeds if the service has not been copied by some other process, but should be true for most cases unless sidecar egress is matching a subset of ports of a service, even so, it's mostly free to make this check)
- ignore services with the same hostname and the same ports, since we're not gonna merge them anyways

Data:
We're currently seeing `Service.DeepCopy()` spending ~5% of cpu and `model.canMergeServices()` another ~3% of cpu, and we're running with services which all use the same ports and we also don't have services with the same hostnames in other namespaces.