### PR TITLE
Ambient CNI informer: K8S job pods must be handled uniquely

### DIFF
--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -225,6 +225,10 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// Check intent (labels) versus status (annotation) - is there a delta we need to fix?
 		changeNeeded := (isAnnotated != shouldBeEnabled) && !isTerminated
 
+		// nolint: lll
+		log.Debugf("pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), wasTerminated(%v), isTerminated(%v), oldPod(%+v), newPod(%+v)",
+			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, wasTerminated, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
+
 		// If it was a job pod that (a) we captured and (b) just terminated (successfully or otherwise)
 		// remove it (the pod process is gone, but kube will keep the Pods around in
 		// a terminated || failed state - we should still do cleanup)
@@ -244,9 +248,6 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			log.Debugf("pod %s update event skipped, reason: changeNeeded(%v)", pod.Name, changeNeeded)
 			return nil
 		}
-
-		log.Debugf("pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), wasTerminated(%v), isTerminated(%v), oldPod(%+v), newPod(%+v)",
-			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, wasTerminated, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
 
 		// Pod is not terminated, and has changed in a way we care about - so reconcile
 		if !shouldBeEnabled {

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -233,7 +233,9 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		// the job/cronjob is configured. Either way, we will come back thru here.
 		if isAnnotated && justTerminated {
 			log.Debugf("deleting pod %s from mesh, reason: isAnnotated(%v), justTerminated(%v)", newPod.Name, isAnnotated, justTerminated)
-			err := s.dataplane.RemovePodFromMesh(s.ctx, pod)
+			// Unlike the other cases, we actually want to use the "old" event for terminated job pods
+			// - kubernetes will (weirdly) clear the ip from the pod status on termination (boo)
+			err := s.dataplane.RemovePodFromMesh(s.ctx, oldPod)
 			log.Debugf("RemovePodFromMesh(%s) returned %v", newPod.Name, err)
 			return nil
 		}

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -216,10 +216,14 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		wasAnnotated := oldPod.Annotations != nil && oldPod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled
 		isAnnotated := newPod.Annotations != nil && newPod.Annotations[constants.AmbientRedirection] == constants.AmbientRedirectionEnabled
 		shouldBeEnabled := util.PodRedirectionEnabled(ns, newPod)
-		isTerminatedJob := !kube.CheckPodTerminal(oldPod) && kube.CheckPodTerminal(newPod)
+		wasTerminated := kube.CheckPodTerminal(oldPod)
+		isTerminated := kube.CheckPodTerminal(newPod)
+		// only checks if the pod state just changed from not-terminated to terminated.
+		// if pod state changed in *any* other way, this should be false.
+		justTerminated := !wasTerminated && isTerminated
 
-		// We should check the latest annotation vs desired status
-		changeNeeded := isAnnotated != shouldBeEnabled
+		// Check intent (labels) versus status (annotation) - is there a delta we need to fix?
+		changeNeeded := (isAnnotated != shouldBeEnabled) && !isTerminated
 
 		// If it was a job pod that (a) we captured and (b) just terminated (successfully or otherwise)
 		// remove it (the pod process is gone, but kube will keep the Pods around in
@@ -227,22 +231,24 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		//
 		// Note that kube may either restart the same pod, or spawn a new one, depending on how
 		// the job/cronjob is configured. Either way, we will come back thru here.
-		if isAnnotated && isTerminatedJob {
-			log.Debugf("deleting pod %s from mesh, reason: isTerminatedJob", newPod.Name, isTerminatedJob)
-			err := s.dataplane.DelPodFromMesh(s.ctx, pod)
+		if isAnnotated && justTerminated {
+			log.Debugf("deleting pod %s from mesh, reason: isAnnotated(%v), justTerminated(%v)", newPod.Name, isAnnotated, justTerminated)
+			err := s.dataplane.RemovePodFromMesh(s.ctx, pod)
 			log.Debugf("RemovePodFromMesh(%s) returned %v", newPod.Name, err)
 			return nil
 		}
 
-		log.Debugf("pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), oldPod(%+v), newPod(%+v)",
-			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, oldPod.ObjectMeta, newPod.ObjectMeta)
-		if !changeNeeded && !isTerminatedJob {
-			log.Debugf("pod %s update event skipped, no change needed", pod.Name)
+		if !changeNeeded {
+			log.Debugf("pod %s update event skipped, reason: changeNeeded(%v)", pod.Name, changeNeeded)
 			return nil
 		}
 
+		log.Debugf("pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), wasTerminated(%v), isTerminated(%v), oldPod(%+v), newPod(%+v)",
+			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, wasTerminated, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
+
+		// Pod is not terminated, and has changed in a way we care about - so reconcile
 		if !shouldBeEnabled {
-			log.Debugf("removing pod %s from mesh, reason: notLabeled", newPod.Name, shouldBeEnabled, isTerminatedJob)
+			log.Debugf("removing pod %s from mesh, reason: shouldBeEnabled(%v)", newPod.Name, shouldBeEnabled)
 			err := s.dataplane.RemovePodFromMesh(s.ctx, pod)
 			log.Debugf("RemovePodFromMesh(%s) returned %v", newPod.Name, err)
 			// we ignore errors here as we don't want this event to be retried by the queue.
@@ -257,7 +263,7 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			wasReady := kube.CheckPodReadyOrComplete(oldPod)
 			isReady := kube.CheckPodReadyOrComplete(newPod)
 			if wasReady != nil && isReady != nil && isAnnotated {
-				log.Infof("pod %s update event skipped, added/labeled by CNI plugin", pod.Name)
+				log.Infof("pod %s update event skipped, reason: added/labeled by CNI plugin", pod.Name)
 				return nil
 			}
 

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -296,7 +296,7 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 	fs.AssertExpectations(t)
 }
 
-func TestExistingPodRemovedWhenPodAnnotated(t *testing.T) {
+func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	setupLogging()
 	mt := monitortest.New(t)
 	NodeName = "testnode"
@@ -398,6 +398,116 @@ func TestExistingPodRemovedWhenPodAnnotated(t *testing.T) {
 	fs.AssertExpectations(t)
 }
 
+func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
+	setupLogging()
+	mt := monitortest.New(t)
+	NodeName = "testnode"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeName,
+		},
+		Status: corev1.PodStatus{
+			PodIP: "11.1.1.12",
+		},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		// TODO: once we if the add pod bug, re-enable this and remove the patch below
+		//		Labels: map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient},
+
+	}
+
+	client := kube.NewFakeClient(ns, pod)
+
+	// We are expecting at most 2 calls to the mock, wait for them
+	wg, waitForMockCalls := NewWaitForNCalls(t, 2)
+	fs := &fakeServer{testWG: wg}
+
+	fs.On("AddPodToMesh",
+		ctx,
+		pod,
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Return(nil)
+
+	server := &meshDataplane{
+		kubeClient: client.Kube(),
+		netServer:  fs,
+	}
+
+	handlers := setupHandlers(ctx, client, server, "istio-system")
+	client.RunAndWait(ctx.Done())
+	go handlers.Start()
+	// wait until pod add was called
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(1))
+
+	log.Debug("labeling namespace")
+	_, err := client.Kube().CoreV1().Namespaces().Patch(ctx, ns.Name,
+		types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
+			constants.DataplaneModeLabel, constants.DataplaneModeAmbient)), metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for an update event
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(2))
+
+	// wait for the pod to be annotated
+	// after Pod annotated, another update event will be triggered.
+	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+
+	// annotate Pod as disabled should cause only one RemovePodFromMesh to happen
+	fs.On("RemovePodFromMesh",
+		ctx,
+		mock.Anything,
+	).Once().Return(nil)
+
+	// Patch the pod to a succeeded status
+	phasePatch := []byte(`{"status":{"phase":"Succeeded"}}`)
+	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
+		types.MergePatchType, phasePatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for an update events
+	// total 3 update at before unlabel point: 1. init ns reconcile 2. ns label reconcile 3. pod status update
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(4))
+
+	waitForMockCalls()
+
+	assertPodNotAnnotated(t, client, pod)
+
+	fs.On("AddPodToMesh",
+		ctx,
+		mock.Anything,
+		util.GetPodIPsIfPresent(pod),
+		"",
+	).Return(nil)
+
+	// Now bring it back
+	// Patch the pod back to a running status
+	phaseRunPatch := []byte(`{"status":{"phase":"Running"}}`)
+	_, err = client.Kube().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name,
+		types.MergePatchType, phaseRunPatch, metav1.PatchOptions{})
+	assert.NoError(t, err)
+
+	// wait for an update events
+	mt.Assert(EventTotals.Name(), map[string]string{"type": "update"}, monitortest.AtLeast(5))
+
+	assertPodAnnotated(t, client, pod)
+
+	// Assert expected calls actually made
+	fs.AssertExpectations(t)
+}
+
 func TestGetActiveAmbientPodSnapshotOnlyReturnsActivePods(t *testing.T) {
 	setupLogging()
 	NodeName = "testnode"
@@ -481,10 +591,10 @@ func TestGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T) {
 	}
 	enrolledButTerminated := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "enrolled-but-terminated",
-			Namespace: "test",
-			UID:       "12345",
-			Labels:    map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient},
+			Name:        "enrolled-but-terminated",
+			Namespace:   "test",
+			UID:         "12345",
+			Labels:      map[string]string{constants.DataplaneModeLabel: constants.DataplaneModeAmbient},
 			Annotations: map[string]string{constants.AmbientRedirection: constants.AmbientRedirectionEnabled},
 		},
 		Spec: corev1.PodSpec{
@@ -514,7 +624,7 @@ func TestGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T) {
 	client.RunAndWait(ctx.Done())
 	pods := handlers.GetActiveAmbientPodSnapshot()
 
-	//Should skip both pods - the one that's labeled but not annotated, and the one that's annotated but terminated.
+	// Should skip both pods - the one that's labeled but not annotated, and the one that's annotated but terminated.
 	assert.Equal(t, len(pods), 0)
 }
 

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -293,8 +293,7 @@ func (s *NetServer) syncHostIPSets(ambientPods []*corev1.Pod) error {
 		} else {
 			err := addPodToHostNSIpset(pod, podIPs, &s.hostsideProbeIPSet)
 			if err != nil {
-				// nolint: lll
-				log.Errorf("pod %s has IPs %v, but previously inserted one of those IPs for a different pod, this indicates an IPAM problem, pod will be skipped and will fail healthchecks", pod.Name, podIPs)
+				log.Errorf("pod %s has IP collision, pod will be skipped and will fail healthchecks", pod.Name, podIPs)
 			}
 			addedIPSnapshot = append(addedIPSnapshot, podIPs...)
 		}

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -293,6 +293,7 @@ func (s *NetServer) syncHostIPSets(ambientPods []*corev1.Pod) error {
 		} else {
 			err := addPodToHostNSIpset(pod, podIPs, &s.hostsideProbeIPSet)
 			if err != nil {
+				// nolint: lll
 				log.Errorf("pod %s has IPs %v, but previously inserted one of those IPs for a different pod, this indicates an IPAM problem, pod will be skipped and will fail healthchecks", pod.Name, podIPs)
 			}
 			addedIPSnapshot = append(addedIPSnapshot, podIPs...)

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -383,7 +383,7 @@ func TestAddPodToHostNSIPSets(t *testing.T) {
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
-	err := addPodToHostNSIpset(pod, podIPs, &set)
+	_, err := addPodToHostNSIpset(pod, podIPs, &set)
 	assert.NoError(t, err)
 
 	fakeIPSetDeps.AssertExpectations(t)
@@ -414,7 +414,7 @@ func TestAddPodToHostNSIPSetsV6(t *testing.T) {
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")}
-	err := addPodToHostNSIpset(pod, podIPs, &set)
+	_, err := addPodToHostNSIpset(pod, podIPs, &set)
 	assert.NoError(t, err)
 
 	fakeIPSetDeps.AssertExpectations(t)
@@ -445,7 +445,7 @@ func TestAddPodToHostNSIPSetsDualstack(t *testing.T) {
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("99.9.9.9")}
-	err := addPodToHostNSIpset(pod, podIPs, &set)
+	_, err := addPodToHostNSIpset(pod, podIPs, &set)
 	assert.NoError(t, err)
 
 	fakeIPSetDeps.AssertExpectations(t)
@@ -477,8 +477,9 @@ func TestAddPodIPToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
 
-	err := addPodToHostNSIpset(pod, podIPs, &set)
+	addedPIPs, err := addPodToHostNSIpset(pod, podIPs, &set)
 	assert.Error(t, err)
+	assert.Equal(t, 1, len(addedPIPs), "only expected one IP to be added")
 
 	fakeIPSetDeps.AssertExpectations(t)
 }

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -204,6 +204,12 @@ func SetRestDefaults(config *rest.Config) *rest.Config {
 	return config
 }
 
+// CheckPodTermina returns true if the pod's phase is terminal (succeeded || failed)
+// usually used to filter cron jobs.
+func CheckPodTerminal(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
+}
+
 // CheckPodReadyOrComplete returns nil if the given pod and all of its containers are ready or terminated
 // successfully.
 func CheckPodReadyOrComplete(pod *corev1.Pod) error {

--- a/releasenotes/notes/51429.yaml
+++ b/releasenotes/notes/51429.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** If we are asked to enroll a pod with a duplicate IP as another pod on the same node, skip that pod and continue attempting the rest, rather than erroring out.

--- a/releasenotes/notes/51429.yaml
+++ b/releasenotes/notes/51429.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
 - |
-  **Fixed** If we are asked to enroll a pod with a duplicate IP as another pod on the same node, skip that pod and continue attempting the rest, rather than erroring out.
+  **Fixed** K8S job pod IPs may not be fully unenrolled from ambient despite being in a terminated state


### PR DESCRIPTION
Original:

Similar to https://github.com/istio/istio/pull/51081 - in the *real* world we may have misconfigured IPAM or other problems, and during initial snapshot of the node, we could get 2 pods with the same IP.

This is an error state for the cluster generally, and there's not much we can do about it, but one thing we _can_ do is skip the problem pod and carry on processing the rest, rather than immediately stopping and returning an error.


Updated:

Retain above, but actual root cause is K8S terminated jobs never triggering Delete events (k8s keeps them around), effectively letting terminated job pods eat up IPs in the ambient ipset. Fix this by special casing terminated pods - we now explicitly unenroll all pods that enter a terminated state, regardless of other labels or annotations.