### PR TITLE
Minor improvement to sds init logging

### DIFF
--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -97,7 +97,7 @@ func (s *Server) initWorkloadSdsService() {
 				}
 			}
 			if s.grpcWorkloadListener != nil {
-				sdsServiceLog.Infof("Starting SDS server for workload certificates, listening on %q", security.WorkloadIdentitySocketPath)
+				sdsServiceLog.Infof("Starting SDS server for workload certificates, will listen on %q", security.WorkloadIdentitySocketPath)
 				if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
 					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
 					serverOk = false

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -97,13 +97,13 @@ func (s *Server) initWorkloadSdsService() {
 				}
 			}
 			if s.grpcWorkloadListener != nil {
+				sdsServiceLog.Infof("Starting SDS server for workload certificates, listening on %q", security.WorkloadIdentitySocketPath)
 				if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
 					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
 					serverOk = false
 				}
 			}
 			if serverOk && setUpUdsOK {
-				sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", security.WorkloadIdentitySocketPath)
 				started = true
 				break
 			}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #51433
Commit is moving and changing the "SDS has started" message since it will never be printed at the right time due to Server() being blocking.