### PR TITLE
Fix null value in gateway chart values that leads to user values being overridden

### DIFF
--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -34,8 +34,8 @@ defaults:
   # Define the security context for the pod.
   # If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
   # On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.
-  securityContext: ~
-  containerSecurityContext: ~
+  securityContext: {}
+  containerSecurityContext: {}
 
   service:
     # Type of service. Set to "None" to disable the service entirely


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR resolves https://github.com/istio/istio/issues/51460 by specifying the default values for `containerSecurityContext` and `securityContext` in the gateway helm chart as empty objects instead of null objects. Empty objects can be merged with a populated object in `mergo v0.3.5`, while nil maps cannot be merged.