### PR TITLE
ambient: cleanup sidecar tests

### DIFF
--- a/tests/integration/ambient/cnirepair/main_test.go
+++ b/tests/integration/ambient/cnirepair/main_test.go
@@ -52,10 +52,8 @@ type EchoDeployments struct {
 	Captured echo.Instances
 	// Uncaptured echo Service
 	Uncaptured echo.Instances
-	// SidecarCaptured echo services with sidecar and ambient capture
-	SidecarCaptured echo.Instances
-	// SidecarUncaptured echo services with sidecar and no ambient capture
-	SidecarUncaptured echo.Instances
+	// Sidecar echo services with sidecar
+	Sidecar echo.Instances
 
 	// All echo services
 	All echo.Instances
@@ -97,10 +95,9 @@ values:
 }
 
 const (
-	Captured          = "captured"
-	Uncaptured        = "uncaptured"
-	SidecarCaptured   = "sidecar-captured"
-	SidecarUncaptured = "sidecar-uncaptured"
+	Captured   = "captured"
+	Uncaptured = "uncaptured"
+	Sidecar    = "sidecar"
 )
 
 func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) error {
@@ -153,7 +150,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			},
 		}).
 		WithConfig(echo.Config{
-			Service:        SidecarUncaptured,
+			Service:        Sidecar,
 			Namespace:      apps.Namespace,
 			Ports:          ports.All(),
 			ServiceAccount: true,
@@ -189,8 +186,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.All = echos
 	apps.Uncaptured = match.ServiceName(echo.NamespacedName{Name: Uncaptured, Namespace: apps.Namespace}).GetMatches(echos)
 	apps.Captured = match.ServiceName(echo.NamespacedName{Name: Captured, Namespace: apps.Namespace}).GetMatches(echos)
-	apps.SidecarUncaptured = match.ServiceName(echo.NamespacedName{Name: SidecarUncaptured, Namespace: apps.Namespace}).GetMatches(echos)
-	apps.SidecarCaptured = match.ServiceName(echo.NamespacedName{Name: SidecarCaptured, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.Sidecar = match.ServiceName(echo.NamespacedName{Name: Sidecar, Namespace: apps.Namespace}).GetMatches(echos)
 
 	return nil
 }

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -70,12 +70,8 @@ type EchoDeployments struct {
 	Captured echo.Instances
 	// Uncaptured echo Service
 	Uncaptured echo.Instances
-	// SidecarWaypoint is a sidecar with a waypoint
-	SidecarWaypoint echo.Instances
-	// SidecarCaptured echo services with sidecar and ambient capture
-	SidecarCaptured echo.Instances
-	// SidecarUncaptured echo services with sidecar and no ambient capture
-	SidecarUncaptured echo.Instances
+	// Sidecar echo services with sidecar
+	Sidecar echo.Instances
 
 	// All echo services
 	All echo.Instances
@@ -140,9 +136,7 @@ const (
 	ServiceAddressedWaypoint  = "service-addressed-waypoint"
 	Captured                  = "captured"
 	Uncaptured                = "uncaptured"
-	SidecarWaypoint           = "sidecar-waypoint"
-	SidecarCaptured           = "sidecar-captured"
-	SidecarUncaptured         = "sidecar-uncaptured"
+	Sidecar                   = "sidecar"
 )
 
 var inMesh = match.Matcher(func(instance echo.Instance) bool {
@@ -284,55 +278,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	}
 	// Only setup sidecar tests if webhook is installed
 	if whErr == nil {
-		// TODO(https://github.com/istio/istio/issues/43244) support sidecars that are captured
-		//builder = builder.WithConfig(echo.Config{
-		//	Service:   SidecarWaypoint,
-		//	Namespace: apps.Namespace,
-		//	Ports:     ports.All(),
-		//	Subsets: []echo.SubsetConfig{
-		//		{
-		//			Replicas: 1,
-		//			Version:  "v1",
-		//			Labels: map[string]string{
-		//				"ambient-type":            "workload",
-		//				"sidecar.istio.io/inject": "true",
-		//			},
-		//		},
-		//		{
-		//			Replicas: 1,
-		//			Version:  "v2",
-		//			Labels: map[string]string{
-		//				"ambient-type":            "workload",
-		//				"sidecar.istio.io/inject": "true",
-		//			},
-		//		},
-		//	},
-		//})
-		//	builder = builder.WithConfig(echo.Config{
-		//		Service:   SidecarCaptured,
-		//		Namespace: apps.Namespace,
-		//		Ports:     ports.All(),
-		//		Subsets: []echo.SubsetConfig{
-		//			{
-		//				Replicas: 1,
-		//				Version:  "v1",
-		//				Labels: map[string]string{
-		//					"ambient-type":            "workload",
-		//					"sidecar.istio.io/inject": "true",
-		//				},
-		//			},
-		//			{
-		//				Replicas: 1,
-		//				Version:  "v2",
-		//				Labels: map[string]string{
-		//					"ambient-type":            "workload",
-		//					"sidecar.istio.io/inject": "true",
-		//				},
-		//			},
-		//		},
-		//	})
 		builder = builder.WithConfig(echo.Config{
-			Service:        SidecarUncaptured,
+			Service:        Sidecar,
 			Namespace:      apps.Namespace,
 			Ports:          ports.All(),
 			ServiceAccount: true,
@@ -380,9 +327,7 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.AllWaypoint = apps.AllWaypoint.Append(apps.ServiceAddressedWaypoint)
 	apps.Uncaptured = match.ServiceName(echo.NamespacedName{Name: Uncaptured, Namespace: apps.Namespace}).GetMatches(echos)
 	apps.Captured = match.ServiceName(echo.NamespacedName{Name: Captured, Namespace: apps.Namespace}).GetMatches(echos)
-	apps.SidecarWaypoint = match.ServiceName(echo.NamespacedName{Name: SidecarWaypoint, Namespace: apps.Namespace}).GetMatches(echos)
-	apps.SidecarUncaptured = match.ServiceName(echo.NamespacedName{Name: SidecarUncaptured, Namespace: apps.Namespace}).GetMatches(echos)
-	apps.SidecarCaptured = match.ServiceName(echo.NamespacedName{Name: SidecarCaptured, Namespace: apps.Namespace}).GetMatches(echos)
+	apps.Sidecar = match.ServiceName(echo.NamespacedName{Name: Sidecar, Namespace: apps.Namespace}).GetMatches(echos)
 	apps.Mesh = inMesh.GetMatches(echos)
 	apps.MeshExternal = match.Not(inMesh).GetMatches(echos)
 


### PR DESCRIPTION
We have 3 sidecar configs, but 2 are unused and never applied. This
doesn't change tests at all, just removes dead code
