### PR TITLE
ambient tests: add all CRDs for unit tests

### DIFF
--- a/pilot/test/xds/fake.go
+++ b/pilot/test/xds/fake.go
@@ -191,8 +191,10 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			ConfigCluster:   k8sCluster == opts.DefaultClusterName,
 			MeshWatcher:     mesh.NewFixedWatcher(m),
 			CRDs: []schema.GroupVersionResource{
+				// Install all CRDs used (mostly in Ambient)
 				gvr.AuthorizationPolicy,
 				gvr.PeerAuthentication,
+				gvr.KubernetesGateway,
 				gvr.KubernetesGateway,
 				gvr.WorkloadEntry,
 				gvr.ServiceEntry,


### PR DESCRIPTION
This allows testing gatewayclass changes as well. Splitting this out to
make things a bit more clean
