### PR TITLE
pilot: collapse to single inbound passthrough

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -228,7 +228,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 			clusters = append(clusters, configgen.buildInboundHBONEClusters())
 		}
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
-		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughClusters()...)
+		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughCluster())
 		clusters = append(clusters, inboundPatcher.insertedClusters()...)
 	case model.Waypoint:
 		_, wps := findWaypointResources(proxy, req.Push)

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -454,6 +454,9 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 
 // buildInboundPassthroughCluster builds passthrough cluster for inbound.
 func (cb *ClusterBuilder) buildInboundPassthroughCluster() *cluster.Cluster {
+	// We need to set a local bind address, which we will match in iptables to avoid looping back to ourselves.
+	// This needs a per-IP-version, since we cannot bind to IPv4 and send to IPv6 (or the inverse).
+	// Fortunately, Envoy can natively handle this by giving it a local v4 and v6 address, and it will pick which to use for us.
 	src := InboundPassthroughBindIpv4
 	if !cb.supportsIPv4 {
 		src = InboundPassthroughBindIpv6

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -310,25 +310,25 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusterName:           "outbound|8080||*.example.org",
 			useDownStreamProtocol: false,
 			proxyType:             model.SidecarProxy,
-			clusters:              8,
+			clusters:              7,
 		},
 		{
 			clusterName:           "inbound|10001||",
 			useDownStreamProtocol: false,
 			proxyType:             model.SidecarProxy,
-			clusters:              8,
+			clusters:              7,
 		},
 		{
 			clusterName:           "outbound|9090||*.example.org",
 			useDownStreamProtocol: true,
 			proxyType:             model.SidecarProxy,
-			clusters:              8,
+			clusters:              7,
 		},
 		{
 			clusterName:           "inbound|10002||",
 			useDownStreamProtocol: true,
 			proxyType:             model.SidecarProxy,
-			clusters:              8,
+			clusters:              7,
 		},
 		{
 			clusterName:           "outbound|8080||*.example.org",
@@ -2386,7 +2386,7 @@ func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
 
 	// Expect to ignore STRICT_DNS cluster without endpoints.
 	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).
-		To(Equal([]string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster"}))
+		To(Equal([]string{"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster"}))
 }
 
 func TestEnvoyFilterPatching(t *testing.T) {
@@ -2411,14 +2411,14 @@ func TestEnvoyFilterPatching(t *testing.T) {
 	}{
 		{
 			"no config",
-			[]string{"outbound|8080||static.test", "BlackHoleCluster", "PassthroughCluster", "InboundPassthroughClusterIpv4"},
+			[]string{"outbound|8080||static.test", "BlackHoleCluster", "PassthroughCluster", "InboundPassthroughCluster"},
 			nil,
 			model.SidecarProxy,
 			service,
 		},
 		{
 			"add cluster",
-			[]string{"outbound|8080||static.test", "BlackHoleCluster", "PassthroughCluster", "InboundPassthroughClusterIpv4", "new-cluster1"},
+			[]string{"outbound|8080||static.test", "BlackHoleCluster", "PassthroughCluster", "InboundPassthroughCluster", "new-cluster1"},
 			[]*networking.EnvoyFilter{{
 				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{{
 					ApplyTo: networking.EnvoyFilter_CLUSTER,
@@ -2436,7 +2436,7 @@ func TestEnvoyFilterPatching(t *testing.T) {
 		},
 		{
 			"remove cluster",
-			[]string{"outbound|8080||static.test", "PassthroughCluster", "InboundPassthroughClusterIpv4"},
+			[]string{"outbound|8080||static.test", "PassthroughCluster", "InboundPassthroughCluster"},
 			[]*networking.EnvoyFilter{{
 				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{{
 					ApplyTo: networking.EnvoyFilter_CLUSTER,
@@ -3272,7 +3272,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			watchedResourceNames: []string{"outbound|8080||test.com"},
 			usedDelta:            true,
 			removedClusters:      nil,
-			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "outbound|8080||testnew.com"},
+			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "outbound|8080||testnew.com"},
 		},
 		{
 			name:                 "service is removed",
@@ -3281,7 +3281,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			watchedResourceNames: []string{"outbound|8080||test.com"},
 			usedDelta:            true,
 			removedClusters:      []string{"outbound|8080||test.com"},
-			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster"},
+			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster"},
 		},
 		{
 			name:          "service port is removed",
@@ -3295,7 +3295,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			watchedResourceNames: []string{"outbound|7070||test.com", "inbound|7070||", "inbound|8080||"},
 			usedDelta:            true,
 			removedClusters:      []string{"inbound|7070||", "outbound|7070||test.com"},
-			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "inbound|8080||", "outbound|8080||test.com"},
+			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "inbound|8080||", "outbound|8080||test.com"},
 		},
 		{
 			name:     "destination rule with no subsets is updated",
@@ -3313,7 +3313,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "outbound|8080||test.com",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "outbound|8080||test.com",
 			},
 		},
 		{
@@ -3332,7 +3332,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      []string{},
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 				"outbound|8080|subset-1|test.com", "outbound|8080|subset-2|test.com", "outbound|8080||test.com",
 			},
 		},
@@ -3352,7 +3352,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      []string{"outbound|8080|subset-1|test.com"},
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 				"outbound|8080|subset-2|test.com", "outbound|8080||test.com",
 			},
 		},
@@ -3371,7 +3371,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			watchedResourceNames: []string{"outbound|8080|subset-2|test.com", "outbound|8080||test.com"},
 			usedDelta:            true,
 			removedClusters:      []string{"outbound|8080|subset-2|test.com"},
-			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "outbound|8080||test.com"},
+			expectedClusters:     []string{"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "outbound|8080||test.com"},
 		},
 		{
 			name:     "destination rule with wildcard matching hosts",
@@ -3389,7 +3389,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 				"outbound|8080|subset-1|test.com", "outbound|8080|subset-2|test.com", "outbound|8080||test.com",
 			},
 		},
@@ -3417,7 +3417,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "outbound|8080||test.com",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "outbound|8080||test.com",
 			},
 		},
 		{
@@ -3444,7 +3444,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", "outbound|8080||test.com", "outbound|8080||testnew.com",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", "outbound|8080||test.com", "outbound|8080||testnew.com",
 			},
 		},
 		{
@@ -3465,7 +3465,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            true,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 				"outbound|8080|subset-1|test.com", "outbound|8080|subset-2|test.com", "outbound|8080||test.com",
 				"outbound|8080||testnew.com",
 			},
@@ -3478,7 +3478,7 @@ func TestBuildDeltaClusters(t *testing.T) {
 			usedDelta:            false,
 			removedClusters:      nil,
 			expectedClusters: []string{
-				"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+				"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 				"outbound|8080||test.com", "outbound|8080||testnew.com",
 			},
 		},
@@ -3536,7 +3536,7 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 	clusters := cg.Clusters(proxy)
 	xdstest.ValidateClusters(t, clusters)
 	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
-		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster", security.SDSExternalClusterName,
+		"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster", security.SDSExternalClusterName,
 	}))
 
 	// Expect no sds_external cluster be added if if credentialSocket does NOT exists
@@ -3544,6 +3544,6 @@ func TestBuildStaticClusterWithCredentialSocket(t *testing.T) {
 	clusters = cg.Clusters(proxy)
 	xdstest.ValidateClusters(t, clusters)
 	g.Expect(xdstest.MapKeys(xdstest.ExtractClusters(clusters))).To(Equal([]string{
-		"BlackHoleCluster", "InboundPassthroughClusterIpv4", "PassthroughCluster",
+		"BlackHoleCluster", "InboundPassthroughCluster", "PassthroughCluster",
 	}))
 }

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -201,12 +201,12 @@ func TestInboundListenerConfig(t *testing.T) {
 	})
 
 	t.Run("merge sidecar ingress ports and service ports", func(t *testing.T) {
-		features.EnableSidecarServiceInboundListenerMerge = true
+		test.SetForTest(t, &features.EnableSidecarServiceInboundListenerMerge, true)
 		testInboundListenerConfigWithSidecarIngressPortMergeServicePort(t, getProxy(),
 			buildServiceWithPort("test1.com", 80, protocol.HTTP, tnow.Add(1*time.Second)))
 	})
 	t.Run("merge sidecar ingress and service ports, same port in both sidecar and service", func(t *testing.T) {
-		features.EnableSidecarServiceInboundListenerMerge = true
+		test.SetForTest(t, &features.EnableSidecarServiceInboundListenerMerge, true)
 		testInboundListenerConfigWithSidecar(t, getProxy(),
 			buildService("test.com", wildcardIPv4, protocol.HTTP, tnow))
 	})

--- a/pilot/pkg/networking/core/listenertest/match.go
+++ b/pilot/pkg/networking/core/listenertest/match.go
@@ -189,7 +189,7 @@ func VerifyFilterChain(t test.Failer, have *listener.FilterChain, want FilterCha
 		assert.Equal(t, want.Name, have.Name, context("name should be equal"))
 	}
 	if want.Type != "" {
-		assert.Equal(t, want.Type, haveType, context("type should be equal"))
+		assert.Equal(t, want.Type, haveType, context(fmt.Sprintf("type should be equal (%+v)", have.FilterChainMatch)))
 	}
 	if want.Port != 0 {
 		assert.Equal(t, want.Port, have.GetFilterChainMatch().GetDestinationPort().GetValue(), context("port should be equal"))

--- a/pilot/pkg/networking/core/peer_authentication_simulation_test.go
+++ b/pilot/pkg/networking/core/peer_authentication_simulation_test.go
@@ -142,12 +142,12 @@ spec:
 				{
 					Name:   "mtls",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "plaintext",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -163,7 +163,7 @@ spec:
 				{
 					Name:   "mtls",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -174,12 +174,12 @@ spec:
 				{
 					Name:   "plaintext",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -190,12 +190,12 @@ spec:
 				{
 					Name:   "plaintext on port 8000",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls on port 8000",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "plaintext port 9000",
@@ -205,7 +205,7 @@ spec:
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -232,7 +232,7 @@ spec:
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -248,17 +248,17 @@ spec:
 				{
 					Name:   "mtls on port 8000",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "plaintext port 9000",
 					Call:   mkCall(9000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -279,12 +279,12 @@ spec:
 				{
 					Name:   "plaintext port 9000",
 					Call:   mkCall(9000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -295,22 +295,22 @@ spec:
 				{
 					Name:   "plaintext on port 8000",
 					Call:   mkCall(8000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls on port 8000",
 					Call:   mkCall(8000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "plaintext port 9000",
 					Call:   mkCall(9000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -332,12 +332,12 @@ spec:
 				{
 					Name:   "plaintext port 9000",
 					Call:   mkCall(9000, simulation.Plaintext),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name:   "mtls port 9000",
 					Call:   mkCall(9000, simulation.MTLS),
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -536,19 +536,19 @@ spec:
 					Name: "tls on tls port",
 					Call: mkCall(8080, simulation.MTLS),
 					// no ports defined, so we will passthrough
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name: "plaintext on plaintext port",
 					Call: mkCall(9090, simulation.Plaintext),
 					// no ports defined, so we will passthrough
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name: "tls on plaintext port",
 					Call: mkCall(9090, simulation.MTLS),
 					// no ports defined, so we will passthrough
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},
@@ -598,13 +598,13 @@ spec:
 					Name: "plaintext on plaintext port",
 					Call: mkCall(9090, simulation.Plaintext),
 					// port 9090 not defined in partialSidecar and will use plain text, plaintext request should pass.
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 				{
 					Name: "tls on plaintext port",
 					Call: mkCall(9090, simulation.MTLS),
 					// no ports defined, so we will passthrough
-					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughCluster"},
 				},
 			},
 		},

--- a/pilot/pkg/networking/core/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/sidecar_simulation_test.go
@@ -928,11 +928,11 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				ClusterMatched:     "InboundPassthroughCluster",
 				FilterChainMatched: "virtualInbound-catchall-http",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				ClusterMatched:     "InboundPassthroughCluster",
 				FilterChainMatched: "virtualInbound-catchall-http",
 			},
 			Strict: simulation.Result{
@@ -949,11 +949,11 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				ClusterMatched:     "InboundPassthroughCluster",
 				FilterChainMatched: "virtualInbound",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				ClusterMatched:     "InboundPassthroughCluster",
 				FilterChainMatched: "virtualInbound",
 			},
 			Strict: simulation.Result{
@@ -971,11 +971,11 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				ClusterMatched:     "InboundPassthroughCluster",
 				FilterChainMatched: "virtualInbound",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 			Strict: simulation.Result{
 				// tls, but not mTLS
@@ -992,10 +992,10 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 			Strict: simulation.Result{
 				// tls, but not mTLS
@@ -1012,13 +1012,13 @@ spec:
 				CallMode: simulation.CallModeInbound,
 			},
 			Disabled: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 			Permissive: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 			Strict: simulation.Result{
-				ClusterMatched: "InboundPassthroughClusterIpv4",
+				ClusterMatched: "InboundPassthroughCluster",
 			},
 		},
 	}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -69,8 +69,7 @@ const (
 	PassthroughFilterChain = "PassthroughFilterChain"
 
 	// Inbound pass through cluster need to the bind the loopback ip address for the security and loop avoidance.
-	InboundPassthroughClusterIpv4 = "InboundPassthroughClusterIpv4"
-	InboundPassthroughClusterIpv6 = "InboundPassthroughClusterIpv6"
+	InboundPassthroughCluster = "InboundPassthroughCluster"
 
 	// IstioMetadataKey is the key under which metadata is added to a route or cluster
 	// regarding the virtual service or destination rule used for each

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -570,7 +570,7 @@ func (sim *Simulation) matchFilterChain(chains []*listener.FilterChain, defaultC
 	// We do not implement the "source" based filters as we do not use them
 	if len(chains) > 1 {
 		for _, c := range chains {
-			log.Warnf("Matched chain %v", c.Name)
+			log.Warnf("Matched chain %v: %+v", c.Name, c.FilterChainMatch)
 		}
 		return nil, ErrMultipleFilterChain
 	}

--- a/pilot/pkg/xds/delta_test.go
+++ b/pilot/pkg/xds/delta_test.go
@@ -71,7 +71,7 @@ func TestDeltaAdsClusterUpdate(t *testing.T) {
 }
 
 func TestDeltaCDS(t *testing.T) {
-	base := sets.New("BlackHoleCluster", "PassthroughCluster", "InboundPassthroughClusterIpv4")
+	base := sets.New("BlackHoleCluster", "PassthroughCluster", "InboundPassthroughCluster")
 	assertResources := func(resp *discovery.DeltaDiscoveryResponse, names ...string) {
 		t.Helper()
 		got := slices.Map(resp.Resources, (*discovery.Resource).GetName)
@@ -110,7 +110,7 @@ func TestDeltaCDS(t *testing.T) {
 }
 
 func TestDeltaCDSReconnect(t *testing.T) {
-	base := sets.New("BlackHoleCluster", "PassthroughCluster", "InboundPassthroughClusterIpv4")
+	base := sets.New("BlackHoleCluster", "PassthroughCluster", "InboundPassthroughCluster")
 	assertResources := func(resp *discovery.DeltaDiscoveryResponse, names ...string) {
 		t.Helper()
 		got := slices.Map(resp.Resources, (*discovery.Resource).GetName)

--- a/pilot/pkg/xds/deltatest.go
+++ b/pilot/pkg/xds/deltatest.go
@@ -29,8 +29,7 @@ import (
 
 var knownOptimizationGaps = sets.New(
 	"BlackHoleCluster",
-	"InboundPassthroughClusterIpv4",
-	"InboundPassthroughClusterIpv6",
+	"InboundPassthroughCluster",
 	"PassthroughCluster",
 )
 


### PR DESCRIPTION
There is no need for 2 clusters/filter chains now, envoy can handle this
directly

However, this is slgiht breaking change -- the cluster name changes,
which can be used for XDS matching in Envoyfilter and stats. Worse,
istio/proxy itself has hardcoded semantics around the cluster name. I
think we can just fix istio/proxy and release note the rest.

Currently a draft to fix tests and istio/proxy, pending feedback on if ^ is acceptable
