### PR TITLE
Enable remote readiness checks over https

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -115,6 +115,7 @@ type Server struct {
 	httpServer  *http.Server // debug, monitoring and readiness Server.
 	httpAddr    string
 	httpsServer *http.Server // webhooks HTTPS Server.
+	httpsAddr   string
 
 	grpcServer        *grpc.Server
 	grpcAddress       string
@@ -485,6 +486,7 @@ func (s *Server) Start(stop <-chan struct{}) error {
 				log.Errorf("error serving https server: %v", err)
 			}
 		}()
+		s.httpsAddr = httpsListener.Addr().String()
 	}
 
 	s.waitForShutdown(stop)

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -582,6 +582,7 @@ func TestIstiodReadinessHandler(t *testing.T) {
 
 	c := http.Client{}
 	c.Transport = &http.Transport{
+		// nolint: gosec
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -68,4 +68,7 @@ func (s *Server) initSecureWebhookServer(args *PilotArgs) {
 		Handler:   s.httpsMux,
 		TLSConfig: tlsConfig,
 	}
+
+	// register istiodReadyHandler on the httpsMux so that readiness can also be checked remotely
+	s.httpsMux.HandleFunc("/ready", s.istiodReadyHandler)
 }

--- a/releasenotes/notes/51506.yaml
+++ b/releasenotes/notes/51506.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 51506
+releaseNotes:
+- |
+  **Added** Istiod's readiness check is now also available over https for use in clusters utilizing a remote control plane for sidecar injection.


### PR DESCRIPTION
**Please provide a description of this PR:**

Previously, remote clusters utilizing a control plane running on a different cluster weren't able to check whether the control plane is ready, because the readiness handler was only exposed over http, which is only accessible within the pod. Now, the control plane's readiness status is also exposed via https, allowing tooling in a remote cluster to check the control plane's readiness.