### PR TITLE
Install: Fixes Logging Docs for CNI

### DIFF
--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -8,7 +8,7 @@ defaults:
 
     # Configuration log level of istio-cni binary
     # by default istio-cni send all logs to UDS server
-    # if want to see them you need change global.logging.level with cni:debug
+    # if want to see them you need change global.logging.level with cni-agent:debug
     logLevel: debug
 
     # Configuration file to insert istio-cni plugin configuration


### PR DESCRIPTION
**Please provide a description of this PR:**
Previously, the inline docs state:

"... change global.logging.level with cni:debug" which does not enable debug logging for the CNI agent. This PR updates the doc to use "cni-agent:debug".