### PR TITLE
disable sorting of JSON logging by default due to float serialization in envoy

### DIFF
--- a/pilot/pkg/model/telemetry_logging.go
+++ b/pilot/pkg/model/telemetry_logging.go
@@ -280,7 +280,7 @@ func buildFileAccessJSONLogFormat(
 			Format: &core.SubstitutionFormatString_JsonFormat{
 				JsonFormat: jsonLogStruct,
 			},
-			JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+			JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 		},
 	}, formatters
 }
@@ -425,7 +425,7 @@ func FileAccessLogFromMeshConfig(path string, mesh *meshconfig.MeshConfig) *acce
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: jsonLogStruct,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 			},
 		}
 	default:

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -1339,7 +1339,7 @@ func TestTelemetryAccessLog(t *testing.T) {
 						},
 					},
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 			},
 		},
 	}

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -102,7 +102,7 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: EnvoyJSONLogFormatIstio,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 			},
 		},
 	}
@@ -125,7 +125,7 @@ var (
 						},
 					},
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 			},
 		},
 	}

--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -349,7 +349,7 @@ var (
 				Format: &core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: model.EnvoyJSONLogFormatIstio,
 				},
-				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: true},
+				JsonFormatOptions: &core.JsonFormatOptions{SortProperties: false},
 			},
 		},
 	}

--- a/releasenotes/notes/48882.yaml
+++ b/releasenotes/notes/48882.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+  - |
+    **Removed** JSON access logs no longer emit keys in a stable ordering awaiting fix https://github.com/envoyproxy/envoy/issues/34420.


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/istio/istio/pull/48882 due to an bug in envoy where all numbers are logged as floating numbers. When removing sorting, a different serializer is used in envoy ensuring consistent behaviour.

Envoy issue: https://github.com/envoyproxy/envoy/issues/34420.

Another approach would be to add sorting of json output as a mesh option, but I am unfamiliar with the definition of the meshconfig, and if that woul be a viable approach?

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
