### PR TITLE
cni: fix k/v pairs in UDS logging from plugin

### DIFF
--- a/cni/pkg/log/uds_test.go
+++ b/cni/pkg/log/uds_test.go
@@ -15,14 +15,17 @@
 package log
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"istio.io/istio/cni/pkg/constants"
 	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -40,6 +43,7 @@ func TestUDSLog(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 	loggingOptions := istiolog.DefaultOptions()
+	loggingOptions.JSONEncoding = true
 	loggingOptions.WithTeeToUDS(udsSock, constants.UDSLogPath)
 	assert.NoError(t, istiolog.Configure(loggingOptions))
 	istiolog.FindScope("default").SetOutputLevel(istiolog.DebugLevel)
@@ -47,6 +51,7 @@ func TestUDSLog(t *testing.T) {
 	istiolog.Info("info log")
 	istiolog.Warn("warn log")
 	istiolog.Error("error log")
+	istiolog.WithLabels("key", 2).Infof("with labels")
 	// This will error because stdout cannot sync, but the UDS part should sync
 	// Ideally we would fail if the UDS part fails but the error library makes it kind of tricky
 	_ = istiolog.Sync()
@@ -59,20 +64,88 @@ func TestUDSLog(t *testing.T) {
 	out, err := io.ReadAll(r)
 	assert.NoError(t, err)
 
+	cases := []struct {
+		level string
+		msg   string
+		key   *float64
+	}{
+		{"debug", "debug log", nil},
+		{"info", "info log", nil},
+		{"warn", "warn log", nil},
+		{"error", "error log", nil},
+		{"info", "with labels", ptr.Of(float64(2))},
+	}
 	// For each level, there should be two lines, one from direct log,
 	// the other one from UDS server
-	wantLevels := []string{"debug", "info", "warn", "error", "debug", "info", "warn", "error"}
 	gotLogs := strings.Split(
 		strings.TrimSuffix(string(out), "\n"), "\n")
-	if want, got := len(wantLevels), len(gotLogs); want != got {
+	if want, got := len(cases)*2, len(gotLogs); want != got {
 		t.Fatalf("Number of logs want %v, got %v logs: %v", want, got, gotLogs)
 	}
-
-	for i, l := range gotLogs {
-		// For each line, there should be two level string, e.g.
-		// "2021-07-09T03:26:08.984951Z	debug	debug log"
-		if got, want := strings.Count(l, wantLevels[i]), 2; want != got {
-			t.Errorf("Number of log level string want %v, got %v", want, got)
+	i := 0
+	for _, l := range gotLogs {
+		var parsedLog map[string]any
+		assert.NoError(t, json.Unmarshal([]byte(l), &parsedLog))
+		if parsedLog["scope"] != "cni-plugin" {
+			// Each log is 2x: one direct, and one over UDS. Just test the UDS one
+			continue
 		}
+		// remove scope since it is constant and not needed to test
+		delete(parsedLog, "scope")
+		// check time is there
+		if _, f := parsedLog["time"]; !f {
+			t.Fatalf("log %v did not have time", i)
+		}
+		// but remove time since it changes on each test
+		delete(parsedLog, "time")
+		want := map[string]any{
+			"level": cases[i].level,
+			"msg":   cases[i].msg,
+		}
+		if k := cases[i].key; k != nil {
+			want["key"] = *k
+		}
+		assert.Equal(t, want, parsedLog)
+		i++
+	}
+}
+
+func TestParseCniLog(t *testing.T) {
+	wantT := &time.Time{}
+	assert.NoError(t, wantT.UnmarshalText([]byte("2020-01-01T00:00:00.356374Z")))
+	cases := []struct {
+		name string
+		in   string
+		out  cniLog
+	}{
+		{
+			"without keys",
+			`{"level":"info","time":"2020-01-01T00:00:00.356374Z","msg":"my message"}`,
+			cniLog{
+				Level:     "info",
+				Time:      *wantT,
+				Msg:       "my message",
+				Arbitrary: nil,
+			},
+		},
+		{
+			"with keys",
+			`{"level":"info","time":"2020-01-01T00:00:00.356374Z","msg":"my message","key":"string value","bar":2}`,
+			cniLog{
+				Level: "info",
+				Time:  *wantT,
+				Msg:   "my message",
+				Arbitrary: map[string]any{
+					"key": "string value",
+					"bar": float64(2),
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := parseCniLog(tt.in)
+			assert.Equal(t, got, tt.out)
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/51494

We dropped these on the floor when we unmarshal into a struct with only
static fields
