### PR TITLE
istioctl: add subcommand for retrieving waypoint status

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -558,6 +558,11 @@ func printWaypointStatus(ctx cli.Context, w *tabwriter.Writer, kubeClient kube.C
 	startTime := time.Now()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
+	if ctx.Namespace() == "" {
+		fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tTYPE\tREASON\tMESSAGE")
+	} else {
+		fmt.Fprintln(w, "NAME\tSTATUS\tTYPE\tREASON\tMESSAGE")
+	}
 	fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tTYPE\tREASON\tMESSAGE")
 	for _, gw := range gw {
 		for range ticker.C {
@@ -572,7 +577,12 @@ func printWaypointStatus(ctx cli.Context, w *tabwriter.Writer, kubeClient kube.C
 					}
 				}
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", gwc.Namespace, gwc.Name, cond.Status, cond.Type, cond.Reason, cond.Message)
+			if ctx.Namespace() == "" {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", gwc.Namespace, gwc.Name, cond.Status, cond.Type, cond.Reason, cond.Message)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", gwc.Name, cond.Status, cond.Type, cond.Reason, cond.Message)
+			}
+
 			if programmed {
 				break
 			}

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -96,7 +96,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		// this will allow for gateway class to provide a default for that class rather than always forcing service or requiring users to configure correctly
 		if trafficType != "" {
 			if !validTrafficTypes.Contains(trafficType) {
-				return nil, fmt.Errorf("invalid traffic type: %s. Valid options are: %v", trafficType, validTrafficTypes)
+				return nil, fmt.Errorf("invalid traffic type: %s. Valid options are: %v", trafficType, sets.SortedList(validTrafficTypes))
 			}
 
 			if gw.Labels == nil {

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -135,7 +135,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return nil
 		},
 	}
-	waypointGenerateCmd.PersistentFlags().StringVar(&trafficType,
+	waypointGenerateCmd.Flags().StringVar(&trafficType,
 		"for",
 		"",
 		fmt.Sprintf("Specify the traffic type %s for the waypoint", sets.SortedList(validTrafficTypes)),
@@ -256,10 +256,10 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		},
 	}
 
-	waypointApplyCmd.PersistentFlags().BoolVarP(&waypointStatus, "status", "s", false,
+	waypointApplyCmd.Flags().BoolVarP(&waypointStatus, "status", "s", false,
 		"Show the status of the waypoint after applying")
 
-	waypointApplyCmd.PersistentFlags().StringVar(&trafficType,
+	waypointApplyCmd.Flags().StringVar(&trafficType,
 		"for",
 		"",
 		fmt.Sprintf("Specify the traffic type %s for the waypoint", sets.SortedList(validTrafficTypes)),
@@ -382,7 +382,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return w.Flush()
 		},
 	}
-	waypointListCmd.PersistentFlags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "List all waypoints in all namespaces")
+	waypointListCmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "List all waypoints in all namespaces")
 
 	waypointCmd := &cobra.Command{
 		Use:   "waypoint",
@@ -408,9 +408,9 @@ func Cmd(ctx cli.Context) *cobra.Command {
 		},
 	}
 
-	waypointApplyCmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
-	waypointApplyCmd.PersistentFlags().BoolVarP(&waitReady, "wait", "w", false, "Wait for the waypoint to be ready")
-	waypointGenerateCmd.PersistentFlags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
+	waypointApplyCmd.Flags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
+	waypointApplyCmd.Flags().BoolVarP(&waitReady, "wait", "w", false, "Wait for the waypoint to be ready")
+	waypointGenerateCmd.Flags().StringVarP(&revision, "revision", "r", "", "The revision to label the waypoint with")
 	waypointCmd.AddCommand(waypointGenerateCmd)
 	waypointCmd.AddCommand(waypointDeleteCmd)
 	waypointCmd.AddCommand(waypointListCmd)

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -563,7 +563,6 @@ func printWaypointStatus(ctx cli.Context, w *tabwriter.Writer, kubeClient kube.C
 	} else {
 		fmt.Fprintln(w, "NAME\tSTATUS\tTYPE\tREASON\tMESSAGE")
 	}
-	fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tTYPE\tREASON\tMESSAGE")
 	for _, gw := range gw {
 		for range ticker.C {
 			programmed := false

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -56,8 +56,6 @@ var (
 	waypointName    = constants.DefaultNamespaceWaypoint
 	enrollNamespace bool
 	overwrite       bool
-
-	waypointStatus bool
 )
 
 const waitTimeout = 90 * time.Second
@@ -165,8 +163,6 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return w.Flush()
 		},
 	}
-
-	waypointStatusCmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "List all waypoints in all namespaces")
 
 	waypointGenerateCmd := &cobra.Command{
 		Use:   "generate",
@@ -301,9 +297,6 @@ func Cmd(ctx cli.Context) *cobra.Command {
 			return w.Flush()
 		},
 	}
-
-	waypointApplyCmd.Flags().BoolVarP(&waypointStatus, "status", "s", false,
-		"Show the status of the waypoint after applying")
 
 	waypointApplyCmd.Flags().StringVar(&trafficType,
 		"for",

--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -255,8 +255,6 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				}
 				return err
 			}
-			writer := cmd.OutOrStdout()
-			w := new(tabwriter.Writer).Init(writer, 0, 8, 5, ' ', 0)
 
 			if waitReady {
 				startTime := time.Now()
@@ -294,7 +292,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v labeled with \"%v: %v\"\n", ctx.NamespaceOrDefault(ctx.Namespace()),
 					constants.AmbientUseWaypointLabel, gw.Name)
 			}
-			return w.Flush()
+			return nil
 		},
 	}
 

--- a/releasenotes/notes/51559.yaml
+++ b/releasenotes/notes/51559.yaml
@@ -5,4 +5,4 @@ issue:
   - 51294
 releaseNotes:
   - |
-    **Added** a status subcommand that prints out the status of an applied gateway for a given namespace.
+    **Added** a status subcommand that prints out the status of gateway(s) for a given namespace.

--- a/releasenotes/notes/51559.yaml
+++ b/releasenotes/notes/51559.yaml
@@ -5,4 +5,4 @@ issue:
   - 51294
 releaseNotes:
   - |
-    **Added** a status flag for `istioctl waypoint apply` that prints out the status of their applied gateway.
+    **Added** a status subcommand that prints out the status of an applied gateway for a given namespace.

--- a/releasenotes/notes/51559.yaml
+++ b/releasenotes/notes/51559.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 51294
+releaseNotes:
+  - |
+    **Added** a status flag for `istioctl waypoint apply` that prints out the status of their applied gateway.


### PR DESCRIPTION
**Please provide a description of this PR:**
- Adds a flag for retrieving waypoint status (resolves: #51294)
- Updates unnecessary uses of `PersistentFlags` to `Flags` instead. [PersistentFlags](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#persistent-flags) should only be used if a flag is intended to be a global flag. The following flags are not global, but instead are [local flags](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#local-flags) and were updated to reflect this:
    - `waypointApplyCmd.Flags().StringVarP(&revision, ...)`
    - `waypointApplyCmd.Flags().BoolVarP(&waitReady, ...)`
    - `waypointGenerateCmd.Flags().StringVarP(&revision, ...)`
    - `waypointListCmd.Flags().BoolVarP(&allNamespaces, ...)`
    - `waypointApplyCmd.Flags().BoolVarP(&overwrite, ...)`
    - `waypointApplyCmd.Flags().BoolVarP(&enrollNamespace, ...)`
    - `waypointApplyCmd.Flags().StringVar(&trafficType, ...)`
    - `waypointGenerateCmd.Flags().StringVar(&trafficType, ...)`
- `validTrafficTypes` should be sorted like it is in the rest of this file. Error message references to `validTrafficTypes` values should be the same as what gets referenced in the other messages that include it.

```bash
azureuser@dev-2024:~/istio$ go run ./istioctl/cmd/istioctl waypoint --for workload --name test-1 apply --status
waypoint default/test-1 applied
NAMESPACE     NAME       STATUS     TYPE           REASON                 MESSAGE
default       test-1     False      Programmed     AddressNotAssigned     Failed to assign to any requested addresses: no instances found for hostname "test-1.default.svc.cluster.local"
default       test-1     True       Programmed     Programmed             Resource programmed, assigned to service(s) test-1.default.svc.cluster.local:15008
```