### PR TITLE
kclient: use internal indexes instead of external

### DIFF
--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -100,7 +100,7 @@ type internalIndex struct {
 func (i internalIndex) Lookup(key string) []interface{} {
 	res, err := i.indexer.ByIndex(i.key, key)
 	if err != nil {
-		// This should only happen if the key does not exist which should be impossible
+		// This should only happen if the index key (i.key, not key) does not exist which should be impossible.
 		log.Fatalf("index lookup failed: %v", err)
 	}
 	return res

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -90,6 +90,43 @@ func (n *informerClient[T]) Start(stopCh <-chan struct{}) {
 	n.startInformer(stopCh)
 }
 
+// internalIndex is the type we use to store a Kubernetes set of index, as well as the key to the index we care about.
+// Users should not interact with this directly, and should instead use CreateIndex.
+type internalIndex struct {
+	key     string
+	indexer cache.Indexer
+}
+
+func (i internalIndex) Lookup(key string) []interface{} {
+	res, err := i.indexer.ByIndex(i.key, key)
+	if err != nil {
+		// This should only happen if the key does not exist which should be impossible
+		log.Fatalf("index lookup failed: %v", err)
+	}
+	return res
+}
+
+var _ RawIndexer = internalIndex{}
+
+func (n *informerClient[T]) Index(extract func(o T) []string) RawIndexer {
+	// We just need some unique key, any will do
+	key := fmt.Sprintf("%p", extract)
+	if err := n.informer.AddIndexers(map[string]cache.IndexFunc{
+		key: func(obj interface{}) ([]string, error) {
+			t := controllers.Extract[T](obj)
+			return extract(t), nil
+		},
+	}); err != nil {
+		// Should only happen on key conflict or on stop
+		log.Warnf("failed to add indexer: %v", err)
+	}
+	ret := internalIndex{
+		key:     key,
+		indexer: n.informer.GetIndexer(),
+	}
+	return ret
+}
+
 func (n *writeClient[T]) Create(object T) (T, error) {
 	api := kubeclient.GetWriteClient[T](n.client, object.GetNamespace())
 	return api.Create(context.Background(), object, metav1.CreateOptions{})

--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -76,7 +76,7 @@ func TestSwappingClientIndex(t *testing.T) {
 
 	// Make the CRD
 	clienttest.MakeCRD(t, c, gvr.WasmPlugin)
-	// Still no response since we haven't started yet
+	// CRD is added, make sure index now works
 	assertIndex("secret1", wasm1)
 }
 

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -55,6 +55,15 @@ type Informer[T controllers.Object] interface {
 	// This function should only be called once. It does not wait for the informer to become ready nor does it block,
 	// so it should generally not be called in a goroutine.
 	Start(stop <-chan struct{})
+	// Index creates an index. The extract function takes an object, and returns all keys to that object.
+	// Later, all objects with a given key can be looked up.
+	// It is strongly recommended to use the typed variants of this with NewIndex; this is needed to workaround Go type limitations.
+	Index(extract func(o T) []string) RawIndexer
+}
+
+// RawIndexer is an internal-ish interface for indexes. Strongly recommended to use NewIndex.
+type RawIndexer interface {
+	Lookup(key string) []interface{}
 }
 
 type Writer[T controllers.Object] interface {

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -74,7 +74,7 @@ func NewNamespaceIndex[I Namespacer](c Collection[I]) *Index[I, string] {
 }
 
 // NewIndex creates a simple index, keyed by key K, over an informer for O. This is similar to
-// NewInformer.AddIndex, but is easier to use and can be added after an informer has already started.
+// Informer.AddIndex, but is easier to use and can be added after an informer has already started.
 func NewIndex[I any, K comparable](
 	c Collection[I],
 	extract func(o I) []K,

--- a/security/pkg/server/ca/node_auth.go
+++ b/security/pkg/server/ca/node_auth.go
@@ -68,7 +68,7 @@ func (m *MulticlusterNodeAuthorizor) authenticateImpersonation(ctx context.Conte
 type ClusterNodeAuthorizer struct {
 	trustedNodeAccounts sets.Set[types.NamespacedName]
 	pods                kclient.Client[*v1.Pod]
-	nodeIndex           *kclient.Index[SaNode, *v1.Pod]
+	nodeIndex           kclient.Index[SaNode, *v1.Pod]
 }
 
 func NewClusterNodeAuthorizer(client kube.Client, trustedNodeAccounts sets.Set[types.NamespacedName]) *ClusterNodeAuthorizer {


### PR DESCRIPTION
Before: we register an informer handler which builds our own index on
top of the underlying store.

After: we register an index directly into the informer, which handles
things entirely.

This was not done originally because Kubernetes only added the ability
to add indexes dynamically recently (I added this).

The benefits here are:
* Deterministic ordering. The index is ALWAYS updated before any other
  handlers are called. This allows us to guarantee the index is up to
date in our handlers. Without this, we had the crazy Delegate hack.
* Minor performance benefit from not needing to cut through as many
  abstractions or locking.

K8s indexes are actually a pain to use, so kclient provides a higher
level API over it; the same as what we had before. One quirk is they
only allow string keys. To get around this, we allow any key, but it
must compile down to a unique string.
