### PR TITLE
webhooks: move to v1

### DIFF
--- a/manifests/charts/base/templates/default.yaml
+++ b/manifests/charts/base/templates/default.yaml
@@ -50,5 +50,5 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
 {{- end }}

--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -24,7 +24,7 @@
       apiVersions: ["v1"]
       resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
 {{- end }}
 
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/default/templates/validatingwebhook.yaml
+++ b/manifests/charts/default/templates/validatingwebhook.yaml
@@ -36,7 +36,7 @@ webhooks:
           - "*"
     failurePolicy: Ignore
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
     objectSelector:
       matchExpressions:
         - key: istio.io/rev

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -32,7 +32,7 @@ a unique prefix to each. */}}
     resources: ["pods"]
   failurePolicy: Fail
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
 {{- end }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -28,7 +28,7 @@ a unique prefix to each. */}}
     apiVersions: ["v1"]
     resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
 {{- end }}
 {{- range $tagName := $.Values.revisionTags }}
 apiVersion: admissionregistration.k8s.io/v1

--- a/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -48,7 +48,7 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
     objectSelector:
       matchExpressions:
         - key: istio.io/rev

--- a/manifests/charts/istiod-remote/templates/default.yaml
+++ b/manifests/charts/istiod-remote/templates/default.yaml
@@ -51,6 +51,6 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
 {{- end }}
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -32,7 +32,7 @@ a unique prefix to each. */}}
     resources: ["pods"]
   failurePolicy: Fail
   reinvocationPolicy: "{{ .reinvocationPolicy }}"
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
 {{- end }}
 {{- /* Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds) */}}
 {{- if not .Values.global.operatorManageWebhooks }}

--- a/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/istiod-remote/templates/validatingwebhookconfiguration.yaml
@@ -49,7 +49,7 @@ webhooks:
     failurePolicy: Ignore
     {{- end }}
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
     objectSelector:
       matchExpressions:
         - key: istio.io/rev

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -1052,7 +1052,7 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
   namespaceSelector:
     matchLabels:
       istio-injection: enabled
@@ -1084,7 +1084,7 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
   namespaceSelector:
     matchExpressions:
     - key: istio-injection

--- a/samples/ambient-argo/tag-chart/templates/mutatingwebhooks.yaml
+++ b/samples/ambient-argo/tag-chart/templates/mutatingwebhooks.yaml
@@ -16,7 +16,7 @@
       apiVersions: ["v1"]
       resources: ["pods"]
   failurePolicy: Fail
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions: ["v1"]
 {{- end }}
 
 {{- range $tagName, $tag := $.Values.base.tags }}

--- a/samples/ambient-argo/tag-chart/templates/validatingwebhook.yaml
+++ b/samples/ambient-argo/tag-chart/templates/validatingwebhook.yaml
@@ -38,7 +38,7 @@ webhooks:
           - "*"
     failurePolicy: Ignore
     sideEffects: None
-    admissionReviewVersions: ["v1beta1", "v1"]
+    admissionReviewVersions: ["v1"]
     objectSelector:
       matchExpressions:
         - key: istio.io/rev


### PR DESCRIPTION
This was added to K8s and istio over 3 years ago. Time to start moving
over so we can be on only v1 APIs.

Note we do not remove support for handling v1beta1 in Istiod go code; we
can do that in a few releases
