### PR TITLE
Use Helm global.externalIstiod for pilot env variable

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -166,6 +166,12 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.pilot.traceSampling }}"
 {{- end }}
+# If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
+# don't set it here to avoid duplication.
+{{- if and .Values.global.externalIstiod (not eq .Values.pilot.env.EXTERNAL_ISTIOD "true")}}
+          - name: EXTERNAL_ISTIOD
+            value: "true"
+{{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -170,7 +170,7 @@ spec:
 # don't set it here to avoid duplication.
 {{- if and .Values.global.externalIstiod (eq .Values.pilot.env.EXTERNAL_ISTIOD "")}}
           - name: EXTERNAL_ISTIOD
-            value: {{ .Values.global.externalIstiod }}
+            value: "{{ .Values.global.externalIstiod }}"
 {{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,9 +168,9 @@ spec:
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
-{{- if and .Values.global.externalIstiod (not eq .Values.pilot.env.EXTERNAL_ISTIOD "true")}}
+{{- if and .Values.global.externalIstiod (eq .Values.pilot.env.EXTERNAL_ISTIOD "")}}
           - name: EXTERNAL_ISTIOD
-            value: "true"
+            value: {{ .Values.global.externalIstiod }}
 {{- end }}
           - name: PILOT_ENABLE_ANALYSIS
             value: "{{ .Values.global.istiod.enableAnalysis }}"

--- a/releasenotes/notes/51595.yaml
+++ b/releasenotes/notes/51595.yaml
@@ -8,4 +8,4 @@ issue:
 
 releaseNotes:
 - |
-  Update Helm installation for Istiod multi-cluster for primary-remote to only require setting global.externalIstiod instead of also requiring pilot.env.EXTERNAL_ISTIOD to be set
+  **Improved** the Helm installation for Istiod multi-cluster for primary-remote. Now, Helm installation only requires setting global.externalIstiod, instead of also requiring pilot.env.EXTERNAL_ISTIOD to be set.

--- a/releasenotes/notes/51595.yaml
+++ b/releasenotes/notes/51595.yaml
@@ -1,5 +1,5 @@
 apiVersion: release-notes/v2
-kind: api-change
+kind: feature
 area: installation
 
 # issue is a list of GitHub issues resolved in this note.

--- a/releasenotes/notes/51595.yaml
+++ b/releasenotes/notes/51595.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: api-change
+area: installation
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/51595
+
+releaseNotes:
+- |
+  Update Helm installation for Istiod multi-cluster for primary-remote to only require setting global.externalIstiod instead of also requiring pilot.env.EXTERNAL_ISTIOD to be set


### PR DESCRIPTION
**Please provide a description of this PR:**

For multi-cluster [primary-remote](https://istio.io/latest/docs/setup/install/multicluster/primary-remote/) installation with Helm, externalIstiod needs to be set both for `.Values.global` and `.Values.pilot.env`. This PR consolidates the installation setup to just use `.Values.global` to set the pilot env variable. However, to prevent duplication (setting the same env variable twice), if `EXTERNAL_ISTIOD` is set via the pilot env variable, then the installation will respect that instead. 

Resolves: https://github.com/istio/istio/issues/51595