### PR TITLE
ambient: do not include LoadBalancer IP in Service VIPs

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -210,11 +210,5 @@ func getVIPs(svc *v1.Service) []string {
 	if svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != v1.ClusterIPNone {
 		res = append(res, svc.Spec.ClusterIP)
 	}
-	for _, ing := range svc.Status.LoadBalancer.Ingress {
-		// IPs are strictly optional for loadbalancers - they may just have a hostname.
-		if ing.IP != "" {
-			res = append(res, ing.IP)
-		}
-	}
 	return res
 }


### PR DESCRIPTION
Currently, we treat LB IP as just another ClusterIP. This is not
correct. Load Balancer IP's are opaque, we cannot just elide them and
proxy directly to pods. The LB may implement arbitrary behavior outside
of our scope.

The correct behavior (also matching sidecars, etc) is to treat these as
opaque traffic that we proxy as-is
