### PR TITLE
Add (partial) unit tests for istioctl precheck package

### DIFF
--- a/istioctl/pkg/precheck/precheck.go
+++ b/istioctl/pkg/precheck/precheck.go
@@ -148,6 +148,7 @@ func checkFromVersion(ctx cli.Context, revision, version string) (diag.Messages,
 	}
 
 	var messages diag.Messages = make([]diag.Message, 0)
+
 	if minor <= 21 {
 		// ENHANCED_RESOURCE_SCOPING
 		if err := checkPilot(cli, ctx.IstioNamespace(), &messages); err != nil {

--- a/istioctl/pkg/precheck/precheck_test.go
+++ b/istioctl/pkg/precheck/precheck_test.go
@@ -1,0 +1,72 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package precheck
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"istio.io/istio/istioctl/pkg/cli"
+	"istio.io/istio/pkg/config/analysis/diag"
+)
+
+type execTestCase struct {
+	args     []string
+	revision string
+	noIstiod bool
+
+	// Typically use one of the three
+	expectedOutput string // Expected constant output
+	expectedString string // String output is expected to contain
+
+	wantException bool
+}
+
+func Test_checkFromVersion(t *testing.T) {
+	cases := []struct {
+		revision       string
+		version        string
+		expectedOutput diag.Messages
+		expectedError  error
+	}{
+		{
+			revision:       "canary",
+			version:        "1.21",
+			expectedOutput: diag.Messages{
+				// Add expected messages here
+			},
+			expectedError: nil,
+		},
+		// Add more test cases here
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("revision=%s, version=%s", c.revision, c.version), func(t *testing.T) {
+			ctx := cli.NewFakeContext(&cli.NewFakeContextOption{
+				IstioNamespace: "istio-system",
+			})
+			output, err := checkFromVersion(ctx, c.revision, c.version)
+
+			if !reflect.DeepEqual(output, c.expectedOutput) {
+				t.Errorf("Unexpected output for revision=%s, version=%s\n got: %v\nwant: %v", c.revision, c.version, output, c.expectedOutput)
+			}
+
+			if err != c.expectedError {
+				t.Errorf("Unexpected error for revision=%s, version=%s\n got: %v\nwant: %v", c.revision, c.version, err, c.expectedError)
+			}
+		})
+	}
+}

--- a/istioctl/pkg/precheck/precheck_test.go
+++ b/istioctl/pkg/precheck/precheck_test.go
@@ -96,31 +96,10 @@ func Test_checkTracing_ZipkinNotFound(t *testing.T) {
 	cli := kube.NewFakeClient()
 	messages := diag.Messages{}
 
-	// Test case: zipkin service not found
+	cli.Kube().CoreV1().Services("istio-system").Create(context.Background(), nil, metav1.CreateOptions{})
+
 	err := checkTracing(cli, &messages)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(messages))
-
-	// Test case: zipkin service found
-	zipkinSvc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "zipkin",
-			Namespace: "istio-system",
-		},
-	}
-	cli.Kube().CoreV1().Services("istio-system").Create(context.Background(), zipkinSvc, metav1.CreateOptions{})
-
-	err = checkTracing(cli, &messages)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(messages))
-
-	expectedOutput := msg.NewUpdateIncompatibility(ObjectToInstance(zipkinSvc),
-		"meshConfig.defaultConfig.tracer", "1.21",
-		"tracing is no longer by default enabled to send to 'zipkin.istio-system.svc'; "+
-			"follow https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/",
-		"1.21")
-
-	assert.Equal(t, expectedOutput, messages[0])
+	assert.Error(t, err)
 }
 
 func Test_checkTracing_ZipkinFound(t *testing.T) {

--- a/istioctl/pkg/precheck/precheck_test.go
+++ b/istioctl/pkg/precheck/precheck_test.go
@@ -21,16 +21,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"istio.io/istio/istioctl/pkg/cli"
-	"istio.io/istio/pkg/config/analysis/diag"
-	"istio.io/istio/pkg/config/analysis/msg"
-	"istio.io/istio/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"istio.io/istio/istioctl/pkg/cli"
+	"istio.io/istio/pkg/config/analysis/diag"
+	"istio.io/istio/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/kube"
 )
 
 type testCase struct {
@@ -92,6 +93,7 @@ func Test_checkFromVersion(t *testing.T) {
 		})
 	}
 }
+
 func Test_checkTracing_ZipkinNotFound(t *testing.T) {
 	cli := kube.NewFakeClient()
 	messages := diag.Messages{}

--- a/istioctl/pkg/precheck/precheck_test.go
+++ b/istioctl/pkg/precheck/precheck_test.go
@@ -94,17 +94,7 @@ func Test_checkFromVersion(t *testing.T) {
 	}
 }
 
-func Test_checkTracing_ZipkinNotFound(t *testing.T) {
-	cli := kube.NewFakeClient()
-	messages := diag.Messages{}
-
-	cli.Kube().CoreV1().Services("istio-system").Create(context.Background(), nil, metav1.CreateOptions{})
-
-	err := checkTracing(cli, &messages)
-	assert.Error(t, err)
-}
-
-func Test_checkTracing_ZipkinFound(t *testing.T) {
+func Test_checkTracing(t *testing.T) {
 	cli := kube.NewFakeClient()
 	messages := diag.Messages{}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR adds basic unit tests for the `precheck` package in `istioctl`, as per the issue https://github.com/istio/istio/issues/50255.

I added a basic structure for the `precheck_test.go` file and added basic test cases for the `checkFromVersion` and `checkTracing` functions. This is a partial implementation of the tests for the `precheck` package, and I will continue to add more tests in future PRs. I did not include all the tests in this PR to get feedback on the structure and approach before adding more.

> Note: I hope I ticked the right boxes in the list below. Please let me know if it needs any changes.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.