### PR TITLE
Enhancements to proxy-status

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -625,16 +625,6 @@ func (s *DiscoveryServer) removeCon(conID string) {
 	}
 }
 
-// nolint
-func (conn *Connection) NonceAcked(typeUrl string) string {
-	return conn.proxy.NonceAcked(typeUrl)
-}
-
-// nolint
-func (conn *Connection) NonceSent(typeUrl string) string {
-	return conn.proxy.NonceSent(typeUrl)
-}
-
 func (conn *Connection) Clusters() []string {
 	return conn.proxy.Clusters()
 }

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -131,7 +131,7 @@ type SyncStatus struct {
 	EndpointAcked        string                    `json:"endpoint_acked,omitempty"`
 	ExtensionConfigSent  string                    `json:"extensionconfig_sent,omitempty"`
 	ExtensionConfigAcked string                    `json:"extensionconfig_acked,omitempty"`
-	Resources            map[string]ResourceStatus `json:"resources,omitempty""`
+	Resources            map[string]ResourceStatus `json:"resources,omitempty"`
 }
 
 type ResourceStatus struct {

--- a/releasenotes/notes/istioctl-ps-improvements.yaml
+++ b/releasenotes/notes/istioctl-ps-improvements.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Improved** the `istioctl proxy-status` command.
+      * Each status now includes the time since the last change.
+      * If a proxy is not subscribed to a resource, it will now be shown as `IGNORED` instead of `NOT SENT`.
+        `NOT SENT` continues to be used for resources that are requested, but never sent.
+      * Include a new `ERROR` status when configuration is rejected.


### PR DESCRIPTION
This PR makes a few improvements to proxy-status:

* Report the timestamp of the last message. This is critical, and we used to have it in `ps` but it was removed. Without this, we do not know if something is stale for 10ms or 10minutes -- a HUGE difference.
* We incorrectly report unsubscribed types as "Not sent". These are **not going to be sent** so they should be marked as IGNORED. 
* Report all types. We do not yet show them in `istioctl ps` but as a followup I would like to add an `-ojson` to `istioctl ps`. `x internal-debug syncz` does have them though.

## Before

```
NAME                                                   CLUSTER        CDS         LDS         EDS         RDS          ECDS         ISTIOD                      VERSION
istio-ingressgateway-64b44c89cd-hnzgz.istio-system     Kubernetes     SYNCED      SYNCED      SYNCED      NOT SENT     NOT SENT     istiod-5df86c949f-lsw54     1.23-dev
waypoint-54bdb68ccd-npw9d.default                      Kubernetes     SYNCED      SYNCED      SYNCED      NOT SENT     NOT SENT     istiod-5df86c949f-lsw54     1.23-dev
ztunnel-jbjg2.istio-system                             Kubernetes     IGNORED     IGNORED     IGNORED     IGNORED      IGNORED      istiod-5df86c949f-lsw54     master-2024-06-02T19-03-25
```

```json
[
  {
    "cluster_id": "Kubernetes",
    "proxy": "istio-ingressgateway-64b44c89cd-hnzgz.istio-system",
    "proxy_type": "router",
    "istio_version": "1.23-dev",
    "cluster_sent": "b4b760ed-75bf-4565-9b37-eaaf68299416",
    "cluster_acked": "b4b760ed-75bf-4565-9b37-eaaf68299416",
    "listener_sent": "3f1627d1-42af-4f10-bac1-1dfc08453910",
    "listener_acked": "3f1627d1-42af-4f10-bac1-1dfc08453910",
    "endpoint_sent": "17ce8692-7c87-45ef-ad61-f4a15300c373",
    "endpoint_acked": "17ce8692-7c87-45ef-ad61-f4a15300c373"
  },
  {
    "cluster_id": "Kubernetes",
    "proxy": "waypoint-54bdb68ccd-npw9d.default",
    "proxy_type": "waypoint",
    "istio_version": "1.23-dev",
    "cluster_sent": "efd51016-bf2a-446e-af9a-b404d30b0e56",
    "cluster_acked": "efd51016-bf2a-446e-af9a-b404d30b0e56",
    "listener_sent": "c1f50e0d-8950-4ea2-80dd-bee22da47e06",
    "listener_acked": "c1f50e0d-8950-4ea2-80dd-bee22da47e06",
    "endpoint_sent": "6e2e201e-faf5-422b-8270-58899e12d0ac",
    "endpoint_acked": "6e2e201e-faf5-422b-8270-58899e12d0ac"
  },
  {
    "cluster_id": "Kubernetes",
    "proxy": "ztunnel-jbjg2.istio-system",
    "proxy_type": "ztunnel",
    "istio_version": "master-2024-06-02T19-03-25"
  }
]
```

## After

```
NAME                                                   CLUSTER        CDS             LDS             EDS             RDS         ECDS        ISTIOD                     VERSION
istio-ingressgateway-78f56bc9f8-z7fc8.istio-system     Kubernetes     ERROR (5s)      SYNCED (5s)     SYNCED (5s)     IGNORED     IGNORED     istiod-6ccf6d888-7vrzd     1.21-alpha.8ae483e8223a498ef8017793c56727df912b2e52
waypoint-54bdb68ccd-59m68.default                      Kubernetes     SYNCED (2s)     SYNCED (2s)     SYNCED (2s)     IGNORED     IGNORED     istiod-6ccf6d888-7vrzd     1.23-dev
ztunnel-jbjg2.istio-system                             Kubernetes     IGNORED         IGNORED         IGNORED         IGNORED     IGNORED     istiod-6ccf6d888-7vrzd     master-2024-06-02T19-03-25
```

```json
[
  {
    "cluster_id": "Kubernetes",
    "proxy": "waypoint-54bdb68ccd-npw9d.default",
    "proxy_type": "waypoint",
    "istio_version": "1.23-dev",
    "cluster_sent": "009dc8f5-f55e-42b2-97b8-51aa73be184e",
    "cluster_acked": "009dc8f5-f55e-42b2-97b8-51aa73be184e",
    "listener_sent": "c6d45eec-faa7-4077-be6e-ac1e60e967dc",
    "listener_acked": "c6d45eec-faa7-4077-be6e-ac1e60e967dc",
    "endpoint_sent": "cc696c5b-33a6-46ba-829a-227dc781dbfd",
    "endpoint_acked": "cc696c5b-33a6-46ba-829a-227dc781dbfd",
    "resources": {
      "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
        "sent": "009dc8f5-f55e-42b2-97b8-51aa73be184e",
        "acked": "009dc8f5-f55e-42b2-97b8-51aa73be184e",
        "sentTime": "2024-06-20T00:49:35.623102331Z"
      },
      "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
        "sent": "cc696c5b-33a6-46ba-829a-227dc781dbfd",
        "acked": "cc696c5b-33a6-46ba-829a-227dc781dbfd",
        "sentTime": "2024-06-20T00:49:35.623189134Z"
      },
      "type.googleapis.com/envoy.config.listener.v3.Listener": {
        "sent": "c6d45eec-faa7-4077-be6e-ac1e60e967dc",
        "acked": "c6d45eec-faa7-4077-be6e-ac1e60e967dc",
        "sentTime": "2024-06-20T00:49:35.623649699Z"
      },
      "type.googleapis.com/istio.workload.Workload": {
        "sent": "754cd10b-ca5b-443a-a343-550201080362",
        "acked": "754cd10b-ca5b-443a-a343-550201080362",
        "sentTime": "2024-06-20T00:49:35.623744998Z"
      }
    }
  },
  {
    "cluster_id": "Kubernetes",
    "proxy": "istio-ingressgateway-64b44c89cd-hnzgz.istio-system",
    "proxy_type": "router",
    "istio_version": "1.23-dev",
    "cluster_sent": "de9120d2-d07b-40d1-bd2c-302056cc9a53",
    "cluster_acked": "de9120d2-d07b-40d1-bd2c-302056cc9a53",
    "listener_sent": "59dfc47a-e329-44d9-af4a-9124a34f94e8",
    "listener_acked": "59dfc47a-e329-44d9-af4a-9124a34f94e8",
    "endpoint_sent": "b85ea980-d8c3-4d47-b71d-4d0b920c6b86",
    "endpoint_acked": "b85ea980-d8c3-4d47-b71d-4d0b920c6b86",
    "resources": {
      "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
        "sent": "de9120d2-d07b-40d1-bd2c-302056cc9a53",
        "acked": "de9120d2-d07b-40d1-bd2c-302056cc9a53",
        "sentTime": "2024-06-20T00:49:35.623432711Z"
      },
      "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
        "sent": "b85ea980-d8c3-4d47-b71d-4d0b920c6b86",
        "acked": "b85ea980-d8c3-4d47-b71d-4d0b920c6b86",
        "sentTime": "2024-06-20T00:49:35.623619933Z"
      },
      "type.googleapis.com/envoy.config.listener.v3.Listener": {
        "sent": "59dfc47a-e329-44d9-af4a-9124a34f94e8",
        "acked": "59dfc47a-e329-44d9-af4a-9124a34f94e8",
        "sentTime": "2024-06-20T00:49:35.623642605Z"
      }
    }
  },
  {
    "cluster_id": "Kubernetes",
    "proxy": "ztunnel-jbjg2.istio-system",
    "proxy_type": "ztunnel",
    "istio_version": "master-2024-06-02T19-03-25",
    "resources": {
      "type.googleapis.com/istio.security.Authorization": {
        "sent": "75ba2c00-5625-4b5a-9a10-4ada7da8472f",
        "acked": "75ba2c00-5625-4b5a-9a10-4ada7da8472f",
        "sentTime": "2024-06-20T00:49:35.623226524Z"
      },
      "type.googleapis.com/istio.workload.Address": {
        "sent": "a85ff263-3350-4286-b6ed-e6ecb60e85f2",
        "acked": "a85ff263-3350-4286-b6ed-e6ecb60e85f2",
        "sentTime": "2024-06-20T00:49:35.623162033Z"
      }
    }
  }
]
```