### PR TITLE
ambient: properly mark pod as not ready when it is shutting down

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -169,8 +169,10 @@ func (a *index) podWorkloadBuilder(
 			}))
 		}
 		services := krt.Fetch(ctx, WorkloadServices, fo...)
+		// Logic from https://github.com/howardjohn/kubernetes/blob/7c873327b679a70337288da62b96dd610858181d/staging/src/k8s.io/endpointslice/utils.go#L37
+		// Kubernetes has Ready, Serving, and Terminating. We only have a boolean, which is sufficient for our cases
 		status := workloadapi.WorkloadStatus_HEALTHY
-		if !IsPodReady(p) {
+		if !IsPodReady(p) || p.DeletionTimestamp != nil {
 			status = workloadapi.WorkloadStatus_UNHEALTHY
 		}
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network


### PR DESCRIPTION
I am aware there are no automated tests on this; I am working to add
these but it is very challenging to automate these types of tests that
there is zero-downtime on rollout. I think its best to get this in
in-parallel to test development.
