### PR TITLE
manifests: fix gateways.securityContext not work

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -15,6 +15,8 @@ data:
 {{ $vals := pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
 {{ $pilotVals := pick .Values.pilot "cni" -}}
 {{ $vals = set $vals "pilot" $pilotVals -}}
+{{ $gatewayVals := pick .Values.gateways "securityContext" -}}
+{{ $vals = set $vals "gateways" $gatewayVals -}}
 {{ $vals | toPrettyJson | indent 4 }}
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -15,6 +15,8 @@ data:
 {{ $vals := pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
 {{ $pilotVals := pick .Values.pilot "cni" -}}
 {{ $vals = set $vals "pilot" $pilotVals -}}
+{{ $gatewayVals := pick .Values.gateways "securityContext" -}}
+{{ $vals = set $vals "gateways" $gatewayVals -}}
 {{ $vals | toPrettyJson | indent 4 }}
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching

--- a/operator/pkg/util/merge_iop.go
+++ b/operator/pkg/util/merge_iop.go
@@ -85,8 +85,9 @@ type values struct {
 }
 
 type gatewaysConfig struct {
-	IstioEgressgateway  *egressGatewayConfig  `json:"istio-egressgateway" patchStrategy:"merge"`
-	IstioIngressgateway *ingressGatewayConfig `json:"istio-ingressgateway" patchStrategy:"merge"`
+	SecurityContext     *v1alpha1.PodSecurityContext `json:"securityContext" patchStrategy:"merge"`
+	IstioEgressgateway  *egressGatewayConfig         `json:"istio-egressgateway" patchStrategy:"merge"`
+	IstioIngressgateway *ingressGatewayConfig        `json:"istio-ingressgateway" patchStrategy:"merge"`
 }
 
 // Configuration for an ingress gateway.

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -1,4 +1,7 @@
 {
+  "gateways": {
+    "securityContext": {}
+  },
   "global": {
     "autoscalingv2API": true,
     "caAddress": "",


### PR DESCRIPTION
PR #51234 allows us to configure securityContext for gateways but it does not work for injected gateways and `IstioOperator` resources (failed during merging).

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
