### PR TITLE
compute autpassthroughsni hosts once for merged gateways

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -538,7 +538,7 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 	node.MergedGateway = ps.mergeGateways(node)
 	node.PrevMergedGateway = &PrevMergedGateway{
 		ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
-		AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
+		AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthroughGatewaySNIHosts(),
 	}
 }
 

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -389,7 +389,10 @@ func MergeGateways(gateways []gatewayWithInstances, proxy *Proxy, ps *PushContex
 }
 
 func (g *MergedGateway) GetAutoPassthroughGatewaySNIHosts() sets.Set[string] {
-	return g.AutoPassthroughSNIHosts
+	if g != nil {
+		return g.AutoPassthroughSNIHosts
+	}
+	return sets.Set[string]{}
 }
 
 func udpSupportedPort(number uint32, instances []ServiceTarget) bool {

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -217,7 +217,7 @@ func TestGetAutoPassthroughSNIHosts(t *testing.T) {
 	}
 	instances := []gatewayWithInstances{{gateway: gateway, instances: gatewayServiceTargets}}
 	mgw := MergeGateways(instances, &Proxy{}, nil)
-	hosts := mgw.GetAutoPassthrughGatewaySNIHosts()
+	hosts := mgw.GetAutoPassthroughGatewaySNIHosts()
 	expectedHosts := sets.Set[string]{}
 	expectedHosts.InsertAll("a.apps.svc.cluster.local", "b.apps.svc.cluster.local")
 	if !hosts.Equals(expectedHosts) {

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -112,7 +112,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 	}
 	if checkGateway {
 		autoPassthroughModeChanged := proxy.MergedGateway.HasAutoPassthroughGateways() != proxy.PrevMergedGateway.HasAutoPassthroughGateway()
-		autoPassthroughHostsChanged := !proxy.MergedGateway.GetAutoPassthrughGatewaySNIHosts().Equals(proxy.PrevMergedGateway.GetAutoPassthroughSNIHosts())
+		autoPassthroughHostsChanged := !proxy.MergedGateway.GetAutoPassthroughGatewaySNIHosts().Equals(proxy.PrevMergedGateway.GetAutoPassthroughSNIHosts())
 		if autoPassthroughModeChanged || autoPassthroughHostsChanged {
 			return true
 		}


### PR DESCRIPTION
- Fix typo
- Add AutoPassThroughSNIHosts to MergedGateways similar to PrevMergedGateways and compute once instead of in Get

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure