### PR TITLE
remove experimental feature flag METRIC_ROTATION_INTERVAL

### DIFF
--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -15,8 +15,6 @@
 package features
 
 import (
-	"time"
-
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/log"
 )
@@ -50,12 +48,6 @@ var (
 	MetadataExchange = env.Register("PILOT_ENABLE_METADATA_EXCHANGE", true,
 		"If true, pilot will add metadata exchange filters, which will be consumed by telemetry filter.",
 	).Get()
-
-	// This is an experimental feature flag, can be removed once it became stable, and should introduced to Telemetry API.
-	MetricRotationInterval = env.Register("METRIC_ROTATION_INTERVAL", 0*time.Second,
-		"Metric scope rotation interval, set to 0 to disable the metric scope rotation").Get()
-	MetricGracefulDeletionInterval = env.Register("METRIC_GRACEFUL_DELETION_INTERVAL", 5*time.Minute,
-		"Metric expiry graceful deletion interval. No-op if METRIC_ROTATION_INTERVAL is disabled.").Get()
 
 	EnableControllerQueueMetrics = env.Register("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
 		"If enabled, publishes metrics for queue depth, latency and processing times.").Get()

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -16,11 +16,6 @@ package model
 
 import (
 	"fmt"
-	"sort"
-	"strings"
-	"sync"
-	"time"
-
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -30,11 +25,13 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
+	"sort"
+	"strings"
+	"sync"
 
 	"istio.io/api/envoy/extensions/stats"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	tpb "istio.io/api/telemetry/v1alpha1"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -130,11 +127,9 @@ func getTelemetries(env *Environment) *Telemetries {
 }
 
 type metricsConfig struct {
-	ClientMetrics            metricConfig
-	ServerMetrics            metricConfig
-	ReportingInterval        *durationpb.Duration
-	RotationInterval         *durationpb.Duration
-	GracefulDeletionInterval *durationpb.Duration
+	ClientMetrics     metricConfig
+	ServerMetrics     metricConfig
+	ReportingInterval *durationpb.Duration
 }
 
 type metricConfig struct {
@@ -517,9 +512,6 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 		allKeys.Insert(k)
 	}
 
-	rotationInterval := getInterval(features.MetricRotationInterval, defaultMetricRotationInterval)
-	gracefulDeletionInterval := getInterval(features.MetricGracefulDeletionInterval, defaultMetricGracefulDeletionInterval)
-
 	m := make([]telemetryFilterConfig, 0, allKeys.Len())
 	for _, k := range sets.SortedList(allKeys) {
 		p := t.fetchProvider(k)
@@ -527,14 +519,11 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 			continue
 		}
 		loggingCfg, logging := tml[k]
-		mertricCfg, metrics := tmm[k]
-
-		mertricCfg.RotationInterval = rotationInterval
-		mertricCfg.GracefulDeletionInterval = gracefulDeletionInterval
+		metricCfg, metrics := tmm[k]
 
 		cfg := telemetryFilterConfig{
 			Provider:      p,
-			metricsConfig: mertricCfg,
+			metricsConfig: metricCfg,
 			AccessLogging: logging && !loggingCfg.Disabled,
 			Metrics:       metrics,
 			LogsFilter:    tml[p.Name].Filter,
@@ -555,22 +544,6 @@ func (t *Telemetries) telemetryFilters(proxy *Proxy, class networking.ListenerCl
 	// Update cache
 	t.computedMetricsFilters[key] = res
 	return res
-}
-
-// default value for metric rotation interval and graceful deletion interval,
-// more details can be found in here: https://github.com/istio/proxy/blob/master/source/extensions/filters/http/istio_stats/config.proto#L116
-var (
-	defaultMetricRotationInterval         = 0 * time.Second
-	defaultMetricGracefulDeletionInterval = 5 * time.Minute
-)
-
-// getInterval return nil to reduce the size of the config, when equal to the default.
-func getInterval(input, defaultValue time.Duration) *durationpb.Duration {
-	if input == defaultValue {
-		return nil
-	}
-
-	return durationpb.New(input)
 }
 
 // mergeLogs returns the set of providers for the given logging configuration.
@@ -1006,8 +979,6 @@ func generateStatsConfig(class networking.ListenerClass, filterConfig telemetryF
 	cfg := stats.PluginConfig{
 		DisableHostHeaderFallback: disableHostHeaderFallback(class),
 		TcpReportingDuration:      filterConfig.ReportingInterval,
-		RotationInterval:          filterConfig.RotationInterval,
-		GracefulDeletionInterval:  filterConfig.GracefulDeletionInterval,
 	}
 
 	for _, override := range listenerCfg.Overrides {

--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -16,6 +16,10 @@ package model
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -25,9 +29,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
-	"sort"
-	"strings"
-	"sync"
 
 	"istio.io/api/envoy/extensions/stats"
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/pilot/pkg/model/telemetry_test.go
+++ b/pilot/pkg/model/telemetry_test.go
@@ -1026,34 +1026,6 @@ func TestTelemetryFilters(t *testing.T) {
 	}
 }
 
-func TestGetInterval(t *testing.T) {
-	cases := []struct {
-		name              string
-		input, defaultVal time.Duration
-		expected          *durationpb.Duration
-	}{
-		{
-			name:       "return nil",
-			input:      0,
-			defaultVal: 0,
-			expected:   nil,
-		},
-		{
-			name:       "return input",
-			input:      1 * time.Second,
-			defaultVal: 0,
-			expected:   durationpb.New(1 * time.Second),
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := getInterval(tc.input, tc.defaultVal)
-			assert.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
 func Test_appendApplicableTelemetries(t *testing.T) {
 	namespacedName := types.NamespacedName{
 		Name:      "my-telemetry",

--- a/releasenotes/notes/51673.yaml
+++ b/releasenotes/notes/51673.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Removed** experimental feature flag `METRIC_ROTATION_INTERVAL` and `METRIC_GRACEFUL_DELETION_INTERVAL`.


### PR DESCRIPTION
**Please provide a description of this PR:**

This will not be promoted as part of Telemetry API, users who want to use can use following envoyfilter:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: metric-rotation
  namespace: istio-system
spec:
  configPatches:
    - applyTo: HTTP_FILTER
      match:
        context: ANY
        listener:
          filterChain:
            filter:
              name: envoy.filters.network.http_connection_manager
              subFilter:
                name: istio.stats
      patch:
        operation: MERGE
        value:
          name: istio.stats
          typedConfig:
            "@type": type.googleapis.com/stats.PluginConfig
            rotationInterval: 10m
            gracefulDeletionInterval: 5m
    - applyTo: NETWORK_FILTER
      match:
        context: ANY
        listener:
          filterChain:
            filter:
              name: istio.stats
      patch:
        operation: MERGE
        value:
          name: istio.stats
          typedConfig:
            "@type": type.googleapis.com/stats.PluginConfig
            rotationInterval: 10m
            gracefulDeletionInterval: 5m
```