### PR TITLE
Optimize resource sorting performance

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -15,6 +15,7 @@
 package gateway
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -50,11 +51,20 @@ import (
 )
 
 func sortConfigByCreationTime(configs []config.Config) {
+	in := bytes.NewBuffer(make([]byte, 0, 100))
+	jn := bytes.NewBuffer(make([]byte, 0, 100))
 	sort.Slice(configs, func(i, j int) bool {
 		if configs[i].CreationTimestamp.Equal(configs[j].CreationTimestamp) {
-			in := configs[i].Namespace + "/" + configs[i].Name
-			jn := configs[j].Namespace + "/" + configs[j].Name
-			return in < jn
+			in.Reset()
+			in.WriteString(configs[i].Namespace)
+			in.WriteString("/")
+			in.WriteString(configs[i].Name)
+
+			jn.Reset()
+			jn.WriteString(configs[j].Namespace)
+			jn.WriteString("/")
+			jn.WriteString(configs[j].Name)
+			return bytes.Compare(in.Bytes(), jn.Bytes()) == -1
 		}
 		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
 	})

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -15,7 +15,7 @@
 package gateway
 
 import (
-	"bytes"
+	"cmp"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -51,22 +51,14 @@ import (
 )
 
 func sortConfigByCreationTime(configs []config.Config) {
-	in := bytes.NewBuffer(make([]byte, 0, 100))
-	jn := bytes.NewBuffer(make([]byte, 0, 100))
 	sort.Slice(configs, func(i, j int) bool {
-		if configs[i].CreationTimestamp.Equal(configs[j].CreationTimestamp) {
-			in.Reset()
-			in.WriteString(configs[i].Namespace)
-			in.WriteString("/")
-			in.WriteString(configs[i].Name)
-
-			jn.Reset()
-			jn.WriteString(configs[j].Namespace)
-			jn.WriteString("/")
-			jn.WriteString(configs[j].Name)
-			return bytes.Compare(in.Bytes(), jn.Bytes()) == -1
+		if r := configs[i].CreationTimestamp.Compare(configs[j].CreationTimestamp); r != 0 {
+			return r == -1 // -1 means i is less than j, so return true
 		}
-		return configs[i].CreationTimestamp.Before(configs[j].CreationTimestamp)
+		if r := cmp.Compare(configs[i].Namespace, configs[j].Namespace); r != 0 {
+			return r == -1
+		}
+		return cmp.Compare(configs[i].Name, configs[j].Name) == -1
 	})
 }
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"sync"
 
-	"istio.io/istio/pkg/slices"
 	corev1 "k8s.io/api/core/v1"
 	knetworking "k8s.io/api/networking/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -41,6 +40,7 @@ import (
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -1205,8 +1205,8 @@ func TestWasmPlugins(t *testing.T) {
 			expectedExtensions: map[extensions.PluginPhase][]*WasmPluginWrapper{
 				extensions.PluginPhase_AUTHN: {
 					convertToWasmPluginWrapper(wasmPlugins["authn-med-prio-all"]),
-					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all-network"]),
 					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all"]),
+					convertToWasmPluginWrapper(wasmPlugins["authn-low-prio-all-network"]),
 					convertToWasmPluginWrapper(wasmPlugins["global-authn-low-prio-ingress"]),
 				},
 			},


### PR DESCRIPTION
Trades slight complexity for better performance.

Please note that since `BenchmarkInitPushContext` does not set `CreationTimestamp` for the resources, the time of the resources are the same, which causes the `name/namespace` comparison to be performed when sorting, which is the main reason why the benchmark shows a significant improvement in performance. In a production environment, there are generally not too many resources with the same `CreationTimestamp`, so the overall performance improvement of this optimization is limited.

```
#  BenchmarkInitPushContext
goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/xds
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                                              │   old.txt    │               new.txt               │
                                              │    sec/op    │    sec/op     vs base               │
InitPushContext/gateways-12                      12.30m ± 5%   10.97m ±  2%  -10.76% (p=0.002 n=6)
InitPushContext/gateways-shared-12              10.808m ± 5%   9.828m ± 12%        ~ (p=0.093 n=6)
InitPushContext/knative-gateway-12               1.308m ± 1%   1.346m ±  6%        ~ (p=0.394 n=6)
InitPushContext/http-12                          224.1µ ± 6%   156.1µ ±  8%  -30.34% (p=0.002 n=6)
InitPushContext/tcp-12                           226.2µ ± 5%   156.4µ ±  5%  -30.84% (p=0.002 n=6)
InitPushContext/tls-12                           221.6µ ± 4%   154.2µ ±  5%  -30.40% (p=0.002 n=6)
InitPushContext/auto-12                          223.1µ ± 4%   153.9µ ±  8%  -31.03% (p=0.002 n=6)
InitPushContext/strict-12                        11.14µ ± 3%   11.03µ ±  6%        ~ (p=0.589 n=6)
InitPushContext/disabled-12                      11.22µ ± 1%   11.07µ ±  4%        ~ (p=0.240 n=6)
InitPushContext/externalname-12                  133.9µ ± 3%   129.6µ ±  4%   -3.26% (p=0.026 n=6)
InitPushContext/telemetry-api-12                 279.0µ ± 1%   206.1µ ±  3%  -26.11% (p=0.002 n=6)
InitPushContext/virtualservice-12                496.0µ ± 2%   428.6µ ±  2%  -13.60% (p=0.002 n=6)
InitPushContext/authorizationpolicy-12           54.08µ ± 6%   54.63µ ±  3%        ~ (p=0.589 n=6)
InitPushContext/serviceentry-workloadentry-12    433.6µ ± 2%   365.8µ ±  2%  -15.65% (p=0.002 n=6)
geomean                                          285.3µ        241.9µ        -15.21%

                                              │   old.txt    │               new.txt               │
                                              │     B/op     │     B/op      vs base               │
InitPushContext/gateways-12                     7.222Mi ± 0%   6.471Mi ± 0%  -10.40% (p=0.002 n=6)
InitPushContext/gateways-shared-12              6.268Mi ± 0%   5.517Mi ± 0%  -11.98% (p=0.002 n=6)
InitPushContext/knative-gateway-12              999.0Ki ± 0%   998.8Ki ± 0%   -0.03% (p=0.002 n=6)
InitPushContext/http-12                         168.4Ki ± 1%   118.3Ki ± 0%  -29.74% (p=0.002 n=6)
InitPushContext/tcp-12                          168.5Ki ± 1%   118.4Ki ± 0%  -29.73% (p=0.002 n=6)
InitPushContext/tls-12                          168.6Ki ± 1%   118.5Ki ± 0%  -29.72% (p=0.002 n=6)
InitPushContext/auto-12                         168.6Ki ± 1%   118.5Ki ± 0%  -29.72% (p=0.002 n=6)
InitPushContext/strict-12                       5.817Ki ± 0%   5.817Ki ± 0%        ~ (p=0.810 n=6)
InitPushContext/disabled-12                     5.816Ki ± 0%   5.817Ki ± 0%        ~ (p=0.870 n=6)
InitPushContext/externalname-12                 71.27Ki ± 1%   71.31Ki ± 1%        ~ (p=0.818 n=6)
InitPushContext/telemetry-api-12                171.2Ki ± 1%   121.9Ki ± 0%  -28.77% (p=0.002 n=6)
InitPushContext/virtualservice-12               483.5Ki ± 0%   433.0Ki ± 0%  -10.44% (p=0.002 n=6)
InitPushContext/authorizationpolicy-12          73.50Ki ± 0%   73.50Ki ± 0%        ~ (p=0.381 n=6)
InitPushContext/serviceentry-workloadentry-12   266.6Ki ± 1%   216.1Ki ± 0%  -18.92% (p=0.002 n=6)
geomean                                         198.7Ki        168.5Ki       -15.20%

                                              │   old.txt   │               new.txt                │
                                              │  allocs/op  │  allocs/op   vs base                 │
InitPushContext/gateways-12                     80.16k ± 0%   55.46k ± 0%  -30.81% (p=0.002 n=6)
InitPushContext/gateways-shared-12              71.81k ± 0%   47.22k ± 0%  -34.25% (p=0.002 n=6)
InitPushContext/knative-gateway-12              11.24k ± 0%   11.24k ± 0%   -0.04% (p=0.002 n=6)
InitPushContext/http-12                         2.790k ± 2%   1.187k ± 0%  -57.46% (p=0.002 n=6)
InitPushContext/tcp-12                          2.800k ± 1%   1.187k ± 0%  -57.60% (p=0.002 n=6)
InitPushContext/tls-12                          2.800k ± 1%   1.187k ± 0%  -57.61% (p=0.002 n=6)
InitPushContext/auto-12                         2.801k ± 1%   1.187k ± 0%  -57.63% (p=0.002 n=6)
InitPushContext/strict-12                        102.0 ± 0%    102.0 ± 0%        ~ (p=1.000 n=6) ¹
InitPushContext/disabled-12                      102.0 ± 0%    102.0 ± 0%        ~ (p=1.000 n=6) ¹
InitPushContext/externalname-12                  729.0 ± 0%    729.0 ± 0%        ~ (p=1.000 n=6) ¹
InitPushContext/telemetry-api-12                3.090k ± 1%   1.498k ± 0%  -51.51% (p=0.002 n=6)
InitPushContext/virtualservice-12               4.711k ± 1%   3.106k ± 0%  -34.07% (p=0.002 n=6)
InitPushContext/authorizationpolicy-12           107.0 ± 0%    107.0 ± 0%        ~ (p=1.000 n=6) ¹
InitPushContext/serviceentry-workloadentry-12   4.806k ± 1%   3.194k ± 0%  -33.54% (p=0.002 n=6)
geomean                                         2.412k        1.597k       -33.76%
¹ all samples are equal
```