### PR TITLE
Be a bit more consistent with annotations in zt chart

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     {{- .Values.labels | toYaml | nindent 4}}
   annotations:
+{{- if .Values.revision }}
+    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
+    {{- toYaml $annos | nindent 4}}
+{{- else }}
     {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -24,6 +29,9 @@ spec:
 {{ with .Values.podLabels -}}{{ toYaml . | indent 8 }}{{ end }}
       annotations:
         sidecar.istio.io/inject: "false"
+{{- if .Values.revision }}
+        istio.io/rev: {{ .Values.revision }}
+{{- end }}
 {{ with .Values.podAnnotations -}}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       nodeSelector:

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -12,7 +12,12 @@ metadata:
   labels:
     {{- .Values.labels | toYaml | nindent 4}}
   annotations:
+{{- if .Values.revision }}
+    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
+    {{- toYaml $annos | nindent 4}}
+{{- else }}
     {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}
 ---
 {{- if (eq .Values.platform "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,8 +27,14 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+  annotations:
+{{- if .Values.revision }}
+    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
+    {{- toYaml $annos | nindent 4}}
+{{- else }}
+    {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -37,8 +48,14 @@ metadata:
   labels:
     app: ztunnel
     release: {{ .Release.Name }}
-    istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+  annotations:
+{{- if .Values.revision }}
+    {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}
+    {{- toYaml $annos | nindent 4}}
+{{- else }}
+    {{- .Values.annotations | toYaml | nindent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**Please provide a description of this PR:**

1. `revision` label doesn't signal intent for ztunnel, since ztunnel doesn't have revisions. Move it to an annotation, where it's a purely informational indicator as to which Istio controlplane rev this ztunnel happens to have been pointed at during install. Otherwise, you have to eyeball the `env` section and check the Istiod URL, and guess.

2. Propagate Helm-override annotations to _all_ the zt resources, rather than just the Daemonset.


- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions