### PR TITLE
[release-1.20] Don't reset the jwks refresh ticker on URI fetch errors

### DIFF
--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -505,9 +505,9 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 		for {
 			select {
 			case <-time.After(refreshInterval / 2):
-				pk, err = r.GetPublicKey("", mockInvalidCertURL, testRequestTimeout)
+				invalidKey, err := r.GetPublicKey("", mockInvalidCertURL, testRequestTimeout)
 				if err == nil {
-					t.Logf("expected error for %q, but got key %q", mockInvalidCertURL, pk)
+					t.Logf("expected error for %q, but got key %q", mockInvalidCertURL, invalidKey)
 				}
 			case <-goroutineCtx.Done():
 				return

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -505,7 +505,7 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 		for {
 			select {
 			case <-time.After(refreshInterval / 2):
-				invalidKey, err := r.GetPublicKey("", mockInvalidCertURL, testRequestTimeout)
+				invalidKey, err := r.GetPublicKey("", mockInvalidCertURL)
 				if err == nil {
 					t.Logf("expected error for %q, but got key %q", mockInvalidCertURL, invalidKey)
 				}
@@ -518,7 +518,7 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 	// Ensure that the good URL is still refreshed, and updated to JwtPubKey2
 	time.Sleep(2 * refreshInterval)
 
-	pk, err = r.GetPublicKey("", mockCertURL, testRequestTimeout)
+	pk, err = r.GetPublicKey("", mockCertURL)
 	if err != nil {
 		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -154,7 +155,7 @@ func TestGetPublicKeyReorderedKey(t *testing.T) {
 		if c.expectedJwtPubkey != pk {
 			t.Errorf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
 		}
-		r.refresh()
+		r.refresh(false)
 	}
 
 	// Verify refresh job key changed count is zero.
@@ -468,6 +469,62 @@ func TestJwtPubKeyMetric(t *testing.T) {
 			return c.expectedJwtPubkey == pk
 		}, retry.Delay(time.Millisecond))
 		mt.Assert(c.metric, nil, monitortest.AtLeast(1))
+	}
+}
+
+func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
+	refreshInterval := 50 * time.Millisecond
+	r := NewJwksResolver(
+		JwtPubKeyEvictionDuration,
+		refreshInterval,
+		JwtPubKeyRefreshIntervalOnFailure,
+		time.Millisecond, /*RetryInterval*/
+	)
+	defer r.Close()
+
+	ms := startMockServer(t)
+	defer ms.Stop()
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+	mockInvalidCertURL := ms.URL + "/invalid"
+
+	// Get a key added to the cache
+	pk, err := r.GetPublicKey("", mockCertURL, testRequestTimeout)
+	if err != nil {
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey1 for the first call
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+	}
+
+	// Start a goroutine that requests an invalid URL repeatedly
+	goroutineCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-time.After(refreshInterval / 2):
+				pk, err = r.GetPublicKey("", mockInvalidCertURL, testRequestTimeout)
+				if err == nil {
+					t.Fatalf("GetPublicKey(\"\", %+v): expected error, got (%s)", mockInvalidCertURL, pk)
+				}
+			case <-goroutineCtx.Done():
+				return
+			}
+		}
+	}()
+
+	// Ensure that the good URL is still refreshed, and updated to JwtPubKey2
+	time.Sleep(2 * refreshInterval)
+
+	pk, err = r.GetPublicKey("", mockCertURL, testRequestTimeout)
+	if err != nil {
+		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey2 for later calls
+	if test.JwtPubKey2 != pk {
+		t.Fatalf("GetPublicKey(\"\", %+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey2, pk)
 	}
 }
 

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -489,7 +489,7 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 	mockInvalidCertURL := ms.URL + "/invalid"
 
 	// Get a key added to the cache
-	pk, err := r.GetPublicKey("", mockCertURL, testRequestTimeout)
+	pk, err := r.GetPublicKey("", mockCertURL)
 	if err != nil {
 		t.Fatalf("GetPublicKey(\"\", %+v) fails: expected no error, got (%v)", mockCertURL, err)
 	}

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -507,7 +507,7 @@ func TestJwtPubKeyRefreshedWhenErrorsGettingOtherURLs(t *testing.T) {
 			case <-time.After(refreshInterval / 2):
 				pk, err = r.GetPublicKey("", mockInvalidCertURL, testRequestTimeout)
 				if err == nil {
-					t.Fatalf("GetPublicKey(\"\", %+v): expected error, got (%s)", mockInvalidCertURL, pk)
+					t.Logf("expected error for %q, but got key %q", mockInvalidCertURL, pk)
 				}
 			case <-goroutineCtx.Done():
 				return

--- a/releasenotes/notes/51636.yaml
+++ b/releasenotes/notes/51636.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 51636
+releaseNotes:
+- |
+  **Fixed** JWKS fetched from URIs may not be updated promptly when there are errors fetching other URIs


### PR DESCRIPTION
Cherry picks #51637 

There was a function signature change so the automated CP (https://github.com/istio/istio/pull/51680) failed, this includes the fix