### PR TITLE
ambient: add tests for components restarting

### DIFF
--- a/pilot/pkg/networking/grpcgen/grpcecho_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcecho_test.go
@@ -101,6 +101,8 @@ func newConfigGenTest(t *testing.T, discoveryOpts xds.FakeOptions, servers ...ec
 			},
 			ListenerIP: ip,
 			Version:    s.version,
+			ReportRequest: func() {
+			},
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -23,8 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/atomic"
-	// To install the xds resolvers and balancers.
-	_ "google.golang.org/grpc/xds"
+	_ "google.golang.org/grpc/xds" // To install the xds resolvers and balancers.
 
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/protocol"

--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -241,6 +241,7 @@ type EchoGrpcHandler struct {
 }
 
 func (h *EchoGrpcHandler) Echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResponse, error) {
+	h.ReportRequest()
 	defer common.Metrics.GrpcRequests.With(common.PortLabel.Value(strconv.Itoa(h.Port.Port))).Increment()
 	body := bytes.Buffer{}
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -219,6 +219,7 @@ type codeAndSlices struct {
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.ReportRequest()
 	id := uuid.New()
 	remoteAddr, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/pkg/test/echo/server/endpoint/instance.go
+++ b/pkg/test/echo/server/endpoint/instance.go
@@ -42,6 +42,7 @@ type Config struct {
 	IstioVersion  string
 	Namespace     string
 	DisableALPN   bool
+	ReportRequest func()
 }
 
 // Instance of an endpoint that serves the Echo application on a single port/protocol.

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -124,6 +124,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 
 // Handles incoming connection.
 func (s *tcpInstance) echo(id uuid.UUID, conn net.Conn) {
+	s.ReportRequest()
 	common.Metrics.TCPRequests.With(common.PortLabel.Value(strconv.Itoa(s.Port.Port))).Increment()
 
 	var err error

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -51,6 +51,7 @@ type Config struct {
 	IstioVersion          string
 	Namespace             string
 	DisableALPN           bool
+	ReportRequest         func()
 }
 
 func (c Config) String() string {
@@ -233,6 +234,7 @@ func (s *Instance) newEndpoint(port *common.Port, listenerIP string, udsServer s
 		Port:          port,
 		UDSServer:     udsServer,
 		IsServerReady: s.isReady,
+		ReportRequest: s.ReportRequest,
 		Version:       s.Version,
 		Cluster:       s.Cluster,
 		TLSCert:       s.TLSCert,

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -123,16 +123,18 @@ func newDeployment(ctx resource.Context, cfg echo.Config) (*deployment, error) {
 // This is analogous to `kubectl rollout restart` on the echo deployment and waits for
 // `kubectl rollout status` to complete before returning, but uses direct API calls.
 func (d *deployment) Restart() error {
-	var errs error
 	var deploymentNames []string
 	for _, s := range d.cfg.Subsets {
 		// TODO(Monkeyanator) move to common place so doesn't fall out of sync with templates
 		deploymentNames = append(deploymentNames, fmt.Sprintf("%s-%s", d.cfg.Service, s.Version))
 	}
 	curTimestamp := time.Now().Format(time.RFC3339)
+
+	g := multierror.Group{}
 	for _, deploymentName := range deploymentNames {
-		patchOpts := metav1.PatchOptions{}
-		patchData := fmt.Sprintf(`{
+		g.Go(func() error {
+			patchOpts := metav1.PatchOptions{}
+			patchData := fmt.Sprintf(`{
 			"spec": {
 				"template": {
 					"metadata": {
@@ -143,46 +145,47 @@ func (d *deployment) Restart() error {
 				}
 			}
 		}`, curTimestamp) // e.g., “2006-01-02T15:04:05Z07:00”
-		var err error
-		appsv1Client := d.cfg.Cluster.Kube().AppsV1()
+			var err error
+			appsv1Client := d.cfg.Cluster.Kube().AppsV1()
 
-		if d.cfg.IsStatefulSet() {
-			_, err = appsv1Client.StatefulSets(d.cfg.Namespace.Name()).Patch(context.TODO(), deploymentName,
-				types.StrategicMergePatchType, []byte(patchData), patchOpts)
-		} else {
-			_, err = appsv1Client.Deployments(d.cfg.Namespace.Name()).Patch(context.TODO(), deploymentName,
-				types.StrategicMergePatchType, []byte(patchData), patchOpts)
-		}
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("failed to rollout restart %v/%v: %v (timestamp:%q)", d.cfg.Namespace.Name(), deploymentName, err, curTimestamp))
-			continue
-		}
-
-		if err := retry.UntilSuccess(func() error {
 			if d.cfg.IsStatefulSet() {
-				sts, err := appsv1Client.StatefulSets(d.cfg.Namespace.Name()).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if sts.Spec.Replicas == nil || !statefulsetComplete(sts) {
-					return fmt.Errorf("rollout is not yet done (updated replicas:%v)", sts.Status.UpdatedReplicas)
-				}
+				_, err = appsv1Client.StatefulSets(d.cfg.Namespace.Name()).Patch(context.TODO(), deploymentName,
+					types.StrategicMergePatchType, []byte(patchData), patchOpts)
 			} else {
-				dep, err := appsv1Client.Deployments(d.cfg.Namespace.Name()).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-				if err != nil {
-					return err
+				_, err = appsv1Client.Deployments(d.cfg.Namespace.Name()).Patch(context.TODO(), deploymentName,
+					types.StrategicMergePatchType, []byte(patchData), patchOpts)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to rollout restart %v/%v: %v (timestamp:%q)", d.cfg.Namespace.Name(), deploymentName, err, curTimestamp)
+			}
+
+			if err := retry.UntilSuccess(func() error {
+				if d.cfg.IsStatefulSet() {
+					sts, err := appsv1Client.StatefulSets(d.cfg.Namespace.Name()).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if sts.Spec.Replicas == nil || !statefulsetComplete(sts) {
+						return fmt.Errorf("rollout is not yet done (updated replicas:%v)", sts.Status.UpdatedReplicas)
+					}
+				} else {
+					dep, err := appsv1Client.Deployments(d.cfg.Namespace.Name()).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if dep.Spec.Replicas == nil || !deploymentComplete(dep) {
+						return fmt.Errorf("rollout is not yet done (updated replicas: %v)", dep.Status.UpdatedReplicas)
+					}
 				}
-				if dep.Spec.Replicas == nil || !deploymentComplete(dep) {
-					return fmt.Errorf("rollout is not yet done (updated replicas: %v)", dep.Status.UpdatedReplicas)
-				}
+				return nil
+			}, retry.Timeout(60*time.Second), retry.Delay(2*time.Second)); err != nil {
+				return fmt.Errorf("failed to wait rollout status for %v/%v: %v",
+					d.cfg.Namespace.Name(), deploymentName, err)
 			}
 			return nil
-		}, retry.Timeout(60*time.Second), retry.Delay(2*time.Second)); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("failed to wait rollout status for %v/%v: %v",
-				d.cfg.Namespace.Name(), deploymentName, err))
-		}
+		})
 	}
-	return errs
+	return g.Wait().ErrorOrNil()
 }
 
 func (d *deployment) WorkloadReady(w *workload) {

--- a/pkg/test/framework/components/echo/util/traffic/result.go
+++ b/pkg/test/framework/components/echo/util/traffic/result.go
@@ -62,12 +62,13 @@ func (r Result) PercentSuccess() float64 {
 
 // CheckSuccessRate asserts that a minimum success threshold was met.
 func (r Result) CheckSuccessRate(t test.Failer, minimumPercent float64) {
+	t.Helper()
 	if r.PercentSuccess() < minimumPercent {
 		t.Fatalf("Minimum success threshold, %f, was not met. %d/%d (%f) requests failed: %v",
 			minimumPercent, r.SuccessfulRequests, r.TotalRequests, r.PercentSuccess(), r.Error)
 	}
 	if r.SuccessfulRequests == r.TotalRequests {
-		t.Log("traffic checker succeeded with all successful requests")
+		t.Logf("traffic checker succeeded with all successful requests (%d/%d)", r.SuccessfulRequests, r.TotalRequests)
 	} else {
 		t.Logf("traffic checker met minimum threshold, with %d/%d successes, but encountered some failures: %v", r.SuccessfulRequests, r.TotalRequests, r.Error)
 	}

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2795,7 +2795,8 @@ func TestServiceRestart(t *testing.T) {
 
 func TestZtunnelRestart(t *testing.T) {
 	const callInterval = 50 * time.Millisecond
-	const successThreshold = 1
+	// TODO(https://github.com/istio/istio/issues/51952) make this 1.0
+	const successThreshold = .9
 	const sidecarSuccessThreshold = .9
 
 	framework.NewTest(t).Run(func(t framework.TestContext) {

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -28,8 +28,10 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/constants"
@@ -50,6 +52,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/config/param"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
+	"istio.io/istio/pkg/test/framework/components/echo/util/traffic"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
@@ -2750,4 +2753,122 @@ func TestDirect(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestServiceRestart(t *testing.T) {
+	const callInterval = 100 * time.Millisecond
+	const successThreshold = 1
+
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		dst := apps.Captured
+		generators := []traffic.Generator{}
+		mkGen := func(src echo.Caller) {
+			g := traffic.NewGenerator(t, traffic.Config{
+				Source: src,
+				Options: echo.CallOptions{
+					To:    dst,
+					Count: 1,
+					Check: check.OK(),
+					HTTP:  echo.HTTP{Path: "/?delay=10ms"},
+					Port: echo.Port{
+						Name: "http",
+					},
+					Retry: echo.Retry{NoRetry: true},
+				},
+				Interval: callInterval,
+			}).Start()
+			generators = append(generators, g)
+		}
+		mkGen(apps.Uncaptured[0])
+		mkGen(apps.Sidecar[0])
+		// This is effectively "captured" since its the client; we cannot use captured since captured is the dest, though
+		mkGen(apps.WorkloadAddressedWaypoint[0])
+		if err := dst.Restart(); err != nil {
+			t.Fatal(err)
+		}
+		for _, gen := range generators {
+			// Stop the traffic generator and get the result.
+			gen.Stop().CheckSuccessRate(t, successThreshold)
+		}
+	})
+}
+
+func TestZtunnelRestart(t *testing.T) {
+	const callInterval = 50 * time.Millisecond
+	const successThreshold = 1
+	const sidecarSuccessThreshold = .9
+
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		dst := apps.Captured
+		mkGen := func(src echo.Caller) traffic.Generator {
+			g := traffic.NewGenerator(t, traffic.Config{
+				Source: src,
+				Options: echo.CallOptions{
+					To:    dst,
+					Count: 1,
+					Check: check.OK(),
+					HTTP:  echo.HTTP{Path: "/?delay=10ms"},
+					Port: echo.Port{
+						Name: "http",
+					},
+					Retry: echo.Retry{NoRetry: true},
+				},
+				Interval: callInterval,
+			}).Start()
+			return g
+		}
+		uncap := mkGen(apps.Uncaptured[0])
+		sidecar := mkGen(apps.Sidecar[0])
+		// This is effectively "captured" since its the client; we cannot use captured since captured is the dest, though
+		captured := mkGen(apps.WorkloadAddressedWaypoint[0])
+		restartZtunnel(t)
+		// Stop the traffic generator and get the result.
+		uncap.Stop().CheckSuccessRate(t, successThreshold)
+		captured.Stop().CheckSuccessRate(t, successThreshold)
+		// We have a lighter check for sidecars. Sidecars will pool HTTP, so these are long lived connections.
+		// These we have no way to signal to Envoy (https://github.com/envoyproxy/envoy/issues/34897).
+		sidecar.Stop().CheckSuccessRate(t, sidecarSuccessThreshold)
+	})
+}
+
+func restartZtunnel(t framework.TestContext) {
+	patchOpts := metav1.PatchOptions{}
+	patchData := fmt.Sprintf(`{
+			"spec": {
+				"template": {
+					"metadata": {
+						"annotations": {
+							"kubectl.kubernetes.io/restartedAt": %q
+						}
+					}
+				}
+			}
+		}`, time.Now().Format(time.RFC3339)) // e.g., “2006-01-02T15:04:05Z07:00”
+	ds := t.Clusters().Default().Kube().AppsV1().DaemonSets(i.Settings().SystemNamespace)
+	_, err := ds.Patch(context.Background(), "ztunnel", types.StrategicMergePatchType, []byte(patchData), patchOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := retry.UntilSuccess(func() error {
+		d, err := ds.Get(context.Background(), "ztunnel", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !daemonsetsetComplete(d) {
+			return fmt.Errorf("rollout is not yet done")
+		}
+		return nil
+	}, retry.Timeout(60*time.Second), retry.Delay(2*time.Second)); err != nil {
+		t.Fatalf("failed to wait for ztunnel rollout status for: %v", err)
+	}
+	if _, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(t.AllClusters()[0], i.Settings().SystemNamespace, "app=ztunnel")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func daemonsetsetComplete(ds *appsv1.DaemonSet) bool {
+	return ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
+		ds.Status.ObservedGeneration >= ds.Generation
 }


### PR DESCRIPTION
This adds tests for restarting ztunnel and workloads. Depends on https://github.com/istio/ztunnel/pull/1176 to pass with 100% success rate.

I have been stress testing this on my local machine. We have currently zero tolerance for any errors. This _might_ be too sensitive, in which case we can re-evaluate. But it works fine on my end.

This change includes some logic into the echo server to gracefully shutdown. This is required _outside of Istio_ to properly gracefully shutdown an application running in Kubernetes.