### PR TITLE
cni: properly cleanup completed pods

### DIFF
--- a/cni/pkg/iptables/iptables_linux.go
+++ b/cni/pkg/iptables/iptables_linux.go
@@ -70,14 +70,14 @@ func forEachInpodMarkIPRule(cfg *Config, f func(*netlink.Rule) error) error {
 }
 
 func AddLoopbackRoutes(cfg *Config) error {
-	return forEachLoopbackRoute(cfg, netlink.RouteReplace)
+	return forEachLoopbackRoute(cfg, "add", netlink.RouteReplace)
 }
 
 func DelLoopbackRoutes(cfg *Config) error {
-	return forEachLoopbackRoute(cfg, netlink.RouteDel)
+	return forEachLoopbackRoute(cfg, "remove", netlink.RouteDel)
 }
 
-func forEachLoopbackRoute(cfg *Config, f func(*netlink.Route) error) error {
+func forEachLoopbackRoute(cfg *Config, operation string, f func(*netlink.Route) error) error {
 	loopbackLink, err := netlink.LinkByName("lo")
 	if err != nil {
 		return fmt.Errorf("failed to find 'lo' link: %v", err)
@@ -108,10 +108,9 @@ func forEachLoopbackRoute(cfg *Config, f func(*netlink.Route) error) error {
 		}
 
 		for _, route := range netlinkRoutes {
-			log.Debugf("Iterating netlink route : %+v", route)
+			log.Debugf("Iterating netlink route: %+v", route)
 			if err := f(route); err != nil {
-				log.Errorf("Failed to add netlink route : %+v", route)
-				return fmt.Errorf("failed to add route: %v", err)
+				return fmt.Errorf("failed to %v route (%+v): %v", operation, route, err)
 			}
 		}
 	}

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -198,6 +198,7 @@ func getModeLabel(m map[string]string) string {
 func (s *InformerHandlers) reconcilePod(input any) error {
 	event := input.(controllers.Event)
 	pod := event.Latest().(*corev1.Pod)
+	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
 
 	defer EventTotals.With(eventTypeTag.Value(event.Event.String())).Increment()
 
@@ -228,35 +229,35 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 		changeNeeded := (isAnnotated != shouldBeEnabled) && !isTerminated
 
 		// nolint: lll
-		log.Debugf("pod %s events: wasAnnotated(%v), isAnnotated(%v), shouldBeEnabled(%v), changeNeeded(%v), isTerminated(%v), oldPod(%+v), newPod(%+v)",
-			pod.Name, wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
+		log.Debugf("pod update: annotation=%v->%v shouldBeEnabled=%v changeNeeded=%v isTerminated=%v, oldPod=%+v, newPod=%+v",
+			wasAnnotated, isAnnotated, shouldBeEnabled, changeNeeded, isTerminated, oldPod.ObjectMeta, newPod.ObjectMeta)
 
 		// If it was a job pod that (a) we captured and (b) just terminated (successfully or otherwise)
 		// remove it (the pod process is gone, but kube will keep the Pods around in
 		// a terminated || failed state - we should still do cleanup)
 		if isAnnotated && isTerminated {
-			log.Debugf("deleting pod %s from mesh, reason: isAnnotated(%v), isTerminated(%v)", newPod.Name, isAnnotated, isTerminated)
+			log.Debugf("deleting pod from mesh: pod was enabled but is now terminated")
 			// Unlike the other cases, we actually want to use the "old" event for terminated job pods
 			// - kubernetes will (weirdly) issue a new status to the pod with no IP on termination, meaning
 			// our check of `pod.status` will fail for (some) termination events.
 			//
 			// We will get subsequent events that append a new status with the IP put back, but it's simpler
 			// and safer to just check the old pod status for the IP.
-			err := s.dataplane.RemovePodFromMesh(s.ctx, oldPod)
-			log.Debugf("RemovePodFromMesh(%s) returned %v", newPod.Name, err)
+			err := s.dataplane.RemovePodFromMesh(s.ctx, oldPod, true)
+			log.Debugf("RemovePodFromMesh returned: %v", err)
 			return nil
 		}
 
 		if !changeNeeded {
-			log.Debugf("pod %s update event skipped, reason: changeNeeded(%v)", pod.Name, changeNeeded)
+			log.Debugf("pod update event skipped: no change needed")
 			return nil
 		}
 
 		// Pod is not terminated, and has changed in a way we care about - so reconcile
 		if !shouldBeEnabled {
-			log.Debugf("removing pod %s from mesh, reason: shouldBeEnabled(%v)", newPod.Name, shouldBeEnabled)
-			err := s.dataplane.RemovePodFromMesh(s.ctx, pod)
-			log.Debugf("RemovePodFromMesh(%s) returned %v", newPod.Name, err)
+			log.Debugf("removing pod from mesh: no longer should be enabled")
+			err := s.dataplane.RemovePodFromMesh(s.ctx, pod, false)
+			log.Debugf("RemovePodFromMesh returned: %v", err)
 			// we ignore errors here as we don't want this event to be retried by the queue.
 		} else {
 			// If oldpod != ready && newpod != ready, but the ambient annotation was added,
@@ -269,11 +270,10 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			wasReady := kube.CheckPodReadyOrComplete(oldPod)
 			isReady := kube.CheckPodReadyOrComplete(newPod)
 			if wasReady != nil && isReady != nil && isAnnotated {
-				log.Infof("pod %s update event skipped, reason: added/labeled by CNI plugin", pod.Name)
+				log.Infof("pod update event skipped: added/labeled by CNI plugin")
 				return nil
 			}
 
-			log.Debugf("pod %s now matches, adding to mesh", newPod.Name)
 			// netns == ""; at this point netns should have been added via the initial snapshot,
 			// or via the cni plugin. If it happens to get here before the cni plugin somehow,
 			// then we will just fail to add the pod to the mesh, and it will be retried later when cni plugin adds it.
@@ -288,26 +288,27 @@ func (s *InformerHandlers) reconcilePod(input any) error {
 			// it's not routable at this point and something is wrong/we should discard this event.
 			podIPs := util.GetPodIPsIfPresent(pod)
 			if len(podIPs) == 0 {
-				log.Warnf("pod %s does not appear to have any assigned IPs, not capturing", pod.Name)
+				log.Debugf("pod update event skipped: no IP assigned yet")
 				return nil
 			}
 
+			log.Debugf("pod is now enrolled, adding to mesh")
 			err := s.dataplane.AddPodToMesh(s.ctx, pod, podIPs, "")
 			if err != nil {
-				log.Warnf("AddPodToMesh(%s) returned %v", newPod.Name, err)
+				log.Warnf("AddPodToMesh returned: %v", err)
 			}
 		}
 	case controllers.EventDelete:
 		// We are the only thing that should be annotating the pods for mesh inclusion.
 		// If we did, remove it from ztunnel
 		if util.PodRedirectionActive(pod) {
-			log.Debugf("pod %s is deleted and was annotated, removing from ztunnel", pod.Name)
-			err := s.dataplane.DelPodFromMesh(s.ctx, pod)
+			log.Debugf("pod is deleted and was captured, removing from ztunnel")
+			err := s.dataplane.RemovePodFromMesh(s.ctx, pod, true)
 			if err != nil {
-				log.Warnf("DelPodFromMesh(%s) returned %v", pod.Name, err)
+				log.Warnf("DelPodFromMesh returned: %v", err)
 			}
 		} else {
-			log.Debugf("skipped deleting from mesh for pod (%s), pod not in mesh", pod.Name)
+			log.Debugf("skipped deleting from mesh for pod, pod not in mesh")
 		}
 	}
 	return nil

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -275,6 +275,7 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 	fs.On("RemovePodFromMesh",
 		ctx,
 		mock.Anything,
+		false,
 	).Once().Return(nil)
 
 	// unlabel the namespace
@@ -367,6 +368,7 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 	fs.On("RemovePodFromMesh",
 		ctx,
 		mock.Anything,
+		false,
 	).Once().Return(nil)
 
 	// label the pod for exclusion
@@ -469,6 +471,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 	fs.On("RemovePodFromMesh",
 		ctx,
 		mock.Anything,
+		true,
 	).Once().Return(nil)
 
 	// Patch the pod to a succeeded status

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/netip"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,7 +28,6 @@ import (
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/slices"
-	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/istio/pkg/util/sets"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
@@ -233,14 +231,14 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	log.WithLabels("delete", isDelete).Debugf("removing pod from the mesh")
 
 	// Aggregate errors together, so that if part of the cleanup fails we still proceed with other steps.
-	errs := istiomultierror.New()
+	var errs []error
 
 	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.
 	if !isDelete {
 		openNetns := s.currentPodSnapshot.Take(string(pod.UID))
 		if openNetns == nil {
 			log.Warn("failed to find pod netns during removal")
-			errs = multierror.Append(errs, fmt.Errorf("failed to find pod netns during removal"))
+			errs = append(errs, fmt.Errorf("failed to find pod netns during removal"))
 		} else {
 			// pod is removed from the mesh, but is still running. remove iptables rules
 			log.Debugf("calling DeleteInpodRules.")
@@ -252,39 +250,15 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 
 	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
 		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
-		errs = multierror.Append(errs, err)
+		errs = append(errs, err)
 	}
 
 	log.Debug("removing pod from ztunnel")
 	if err := s.ztunnelServer.PodDeleted(ctx, string(pod.UID)); err != nil {
 		log.Errorf("failed to delete pod from ztunnel: %v", err)
-		errs = multierror.Append(errs, err)
+		errs = append(errs, err)
 	}
-	return errs.ErrorOrNil()
-}
-
-// Delete pod from mesh: pod is deleted. iptables rules will die with it, we just need to update ztunnel
-func (s *NetServer) DelPodFromMesh(ctx context.Context, pod *corev1.Pod) error {
-	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debug("Pod is now stopped... cleaning up.")
-
-	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
-		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
-		return err
-	}
-
-	log.Info("in pod mode - deleting pod from ztunnel")
-
-	// pod is deleted, clean-up its open netns
-	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
-	if openNetns == nil {
-		log.Warn("failed to find pod netns")
-	}
-
-	if err := s.ztunnelServer.PodDeleted(ctx, string(pod.UID)); err != nil {
-		return err
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // syncHostIPSets is called after the host node ipset has been created (or found + flushed)

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/netip"
 
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +29,7 @@ import (
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/istiomultierror"
 	"istio.io/istio/pkg/util/sets"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
@@ -133,7 +135,8 @@ func (s *NetServer) getNetns(pod *corev1.Pod) (Netns, error) {
 // which always has the firsthand info of the IPs, even before K8S does - so we pass them separately here because
 // we actually may have them before K8S in the Pod object.
 func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error {
-	log.Infof("in pod mode - adding pod %s/%s to ztunnel ", pod.Namespace, pod.Name)
+	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
+	log.Infof("adding pod to the mesh")
 	// make sure the cache is aware of the pod, even if we don't have the netns yet.
 	s.currentPodSnapshot.Ensure(string(pod.UID))
 	openNetns, err := s.getOrOpenNetns(pod, netNs)
@@ -224,33 +227,40 @@ func realDependencies() *dep.RealDependencies {
 	}
 }
 
-// Remove pod from mesh: pod is not deleted, we just want to remove it from the mesh.
-func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) error {
+// RemovePodFromMesh is called when a pod needs to be removed from the mesh
+func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Debugf("Pod is now opt out... cleaning up.")
+	log.WithLabels("delete", isDelete).Debugf("removing pod from the mesh")
 
-	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
-	if openNetns == nil {
-		log.Warn("failed to find pod netns during removal")
-		return fmt.Errorf("failed to find pod netns during removal")
-	}
-	// pod is removed from the mesh, but is still running. remove iptables rules
-	log.Debugf("calling DeleteInpodRules.")
-	if err := s.netnsRunner(openNetns, func() error { return s.iptablesConfigurator.DeleteInpodRules() }); err != nil {
-		log.Errorf("failed to delete inpod rules %v", err)
-		return fmt.Errorf("failed to delete inpod rules %w", err)
+	// Aggregate errors together, so that if part of the cleanup fails we still proceed with other steps.
+	errs := istiomultierror.New()
+
+	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.
+	if !isDelete {
+		openNetns := s.currentPodSnapshot.Take(string(pod.UID))
+		if openNetns == nil {
+			log.Warn("failed to find pod netns during removal")
+			errs = multierror.Append(errs, fmt.Errorf("failed to find pod netns during removal"))
+		} else {
+			// pod is removed from the mesh, but is still running. remove iptables rules
+			log.Debugf("calling DeleteInpodRules.")
+			if err := s.netnsRunner(openNetns, func() error { return s.iptablesConfigurator.DeleteInpodRules() }); err != nil {
+				return fmt.Errorf("failed to delete inpod rules: %w", err)
+			}
+		}
 	}
 
 	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
 		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
-		return err
+		errs = multierror.Append(errs, err)
 	}
 
-	log.Debug("in pod mode - removing pod from ztunnel")
+	log.Debug("removing pod from ztunnel")
 	if err := s.ztunnelServer.PodDeleted(ctx, string(pod.UID)); err != nil {
 		log.Errorf("failed to delete pod from ztunnel: %v", err)
+		errs = multierror.Append(errs, err)
 	}
-	return nil
+	return errs.ErrorOrNil()
 }
 
 // Delete pod from mesh: pod is deleted. iptables rules will die with it, we just need to update ztunnel

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -189,7 +189,7 @@ func TestServerRemovePod(t *testing.T) {
 		Netns:    fakens,
 	}
 	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
-	err := netServer.RemovePodFromMesh(ctx, pod)
+	err := netServer.RemovePodFromMesh(ctx, pod, false)
 	assert.NoError(t, err)
 	assert.Equal(t, ztunnelServer.deletedPods.Load(), 1)
 	assert.Equal(t, nlDeps.DelInpodMarkIPRuleCnt.Load(), 1)

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -44,8 +44,7 @@ type MeshDataplane interface {
 
 	//	IsPodInMesh(ctx context.Context, pod *metav1.ObjectMeta, netNs string) (bool, error)
 	AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error
-	RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) error
-	DelPodFromMesh(ctx context.Context, pod *corev1.Pod) error
+	RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error
 
 	Stop()
 }
@@ -225,9 +224,9 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 	return retErr
 }
 
-func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) error {
+func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDelete bool) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	err := s.netServer.RemovePodFromMesh(ctx, pod)
+	err := s.netServer.RemovePodFromMesh(ctx, pod, isDelete)
 	if err != nil {
 		log.Errorf("failed to remove pod from mesh: %v", err)
 		return err
@@ -238,15 +237,4 @@ func (s *meshDataplane) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod) 
 		log.Errorf("failed to annotate pod unenrollment: %v", err)
 	}
 	return err
-}
-
-// Delete pod from mesh: pod is deleted. iptables rules will die with it, we just need to update ztunnel
-func (s *meshDataplane) DelPodFromMesh(ctx context.Context, pod *corev1.Pod) error {
-	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	err := s.netServer.DelPodFromMesh(ctx, pod)
-	if err != nil {
-		log.Errorf("failed to delete pod from mesh: %v", err)
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
Followup to https://github.com/istio/istio/pull/51429.

When a pod is moved to terminal stage, we call RemovePodFromMesh. This
has a variety of cleanup steps, and aborts early if any fail.

Because the pod is terminated, we will fail to cleanup the in-pod rules.
This is OK! The pod is terminated anyways. But with the current logic,
this also means we do not send ztunnel the removed message, and it will
leak proxy instances.

Additionally, this does a variety of logging cleanups so that we
consistently format messages and always show which pod we are acting on.
