### PR TITLE
log: fix race when updating output level and cloning

### DIFF
--- a/pkg/log/logr_test.go
+++ b/pkg/log/logr_test.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -38,7 +39,12 @@ func runLogrTestWithScope(t *testing.T, s *Scope, f func(l logr.Logger)) []strin
 }
 
 func newScope() *Scope {
-	s := &Scope{name: "test"}
+	s := &Scope{
+		name:            "test",
+		outputLevel:     &atomic.Value{},
+		stackTraceLevel: &atomic.Value{},
+		logCallers:      &atomic.Value{},
+	}
 	s.SetOutputLevel(InfoLevel)
 	s.SetStackTraceLevel(NoneLevel)
 	s.SetLogCallers(false)

--- a/pkg/log/scope.go
+++ b/pkg/log/scope.go
@@ -55,9 +55,9 @@ type Scope struct {
 	callerSkip  int
 
 	// set by the Configure method and adjustable dynamically
-	outputLevel     atomic.Value
-	stackTraceLevel atomic.Value
-	logCallers      atomic.Value
+	outputLevel     *atomic.Value
+	stackTraceLevel *atomic.Value
+	logCallers      *atomic.Value
 
 	// labels data - key slice to preserve ordering
 	labelKeys []string
@@ -89,9 +89,12 @@ func registerScope(name string, description string, callerSkip int) *Scope {
 	s, ok := scopes[name]
 	if !ok {
 		s = &Scope{
-			name:        name,
-			description: description,
-			callerSkip:  callerSkip,
+			name:            name,
+			description:     description,
+			callerSkip:      callerSkip,
+			outputLevel:     &atomic.Value{},
+			stackTraceLevel: &atomic.Value{},
+			logCallers:      &atomic.Value{},
 		}
 		s.SetOutputLevel(InfoLevel)
 		s.SetStackTraceLevel(NoneLevel)

--- a/pkg/log/scope_test.go
+++ b/pkg/log/scope_test.go
@@ -444,6 +444,25 @@ func TestBadWriter(t *testing.T) {
 	defaultScope.Error("TestBadWriter")
 }
 
+// Regression test for a race condition
+func TestUpdateScope(t *testing.T) {
+	o := testOptions()
+	if err := Configure(o); err != nil {
+		t.Errorf("Got err '%v', expecting success", err)
+	}
+
+	go func() {
+		for range 100 {
+			defaultScope.SetOutputLevel(DebugLevel)
+		}
+	}()
+	go func() {
+		for range 100 {
+			defaultScope.WithLabels("foo", "bar")
+		}
+	}()
+}
+
 func BenchmarkLog(b *testing.B) {
 	run := func(name string, f func()) {
 		b.Run(name, func(b *testing.B) {


### PR DESCRIPTION
in withLabels we do a copy. Copy of atomic.Value is bad, and makes it so the updates no longer work -- instead we want to just copy the pointer