### PR TITLE
Fix old base image in 1.22

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -49,7 +49,7 @@ endif
 export VERSION
 
 # Base version of Istio image to use
-BASE_VERSION ?= master-2024-04-19T19-01-19
+BASE_VERSION ?= 1.22-2024-06-02T19-02-59
 ISTIO_BASE_REGISTRY ?= gcr.io/istio-release
 
 export GO111MODULE ?= on


### PR DESCRIPTION
I am not sure why this is broken
(https://github.com/istio/istio/issues/51737); I will look into that.
For now, manually update to the latest version
