### PR TITLE
cni: extend timeout for command and improve logs

### DIFF
--- a/cni/pkg/nodeagent/ztunnelserver.go
+++ b/cni/pkg/nodeagent/ztunnelserver.go
@@ -422,14 +422,14 @@ func (z *ZtunnelConnection) send(ctx context.Context, data []byte, fd *int) (*zd
 	select {
 	case z.Updates <- req:
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("context expired before request sent: %v", ctx.Err())
 	}
 
 	select {
 	case r := <-ret:
 		return r.resp, r.err
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("context expired before response received: %v", ctx.Err())
 	}
 }
 

--- a/cni/pkg/plugin/cnieventclient.go
+++ b/cni/pkg/plugin/cnieventclient.go
@@ -45,7 +45,7 @@ func buildClient(address, path string) CNIEventClient {
 				return net.Dial("unix", address)
 			},
 		},
-		Timeout: 1000 * time.Millisecond,
+		Timeout: 5 * time.Second,
 	}
 	eventC := CNIEventClient{
 		client: c,


### PR DESCRIPTION
This was being consistently hit when concurrently spawning pods due to a
bug in iptables causing it to wait too long for the lock (if it cannot
obtain the lock, it would always wait on 1s intervals). This is fixed in
https://github.com/istio/istio/pull/51738.

This extends the timeout to not be so aggressive; a hard 1s deadline to
manipulate iptables rules and make write calls to the API server is
pretty tight deadline. Additionally, if we do hit the deadline, improve
the error logs.
