### PR TITLE
ztunnel: remove hardcoded DNS address

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -107,8 +107,6 @@ spec:
           value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}
         - name: INPOD_ENABLED
           value: "true"
-        - name: ISTIO_META_DNS_PROXY_ADDR
-          value: "127.0.0.1:15053"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
In older versions Ztunnel defaulted to 0.0.0.0, which does not work with
the current redirection setup. So we hardcoded 127.0.0.1 here.

This is not ideal, since it never binds to IPv6.

In the new ztunnel, it will default to `localhost`, which will bind to
IPv4 and/or IPv6 where appropriate. Unsetting this config gives us that
behavior rather than hardcoding to IPv4 only.
