### PR TITLE
go 1.21 introduced min/max function names; update dockerfiles

### DIFF
--- a/cni/deployments/kubernetes/Dockerfile.install-cni
+++ b/cni/deployments/kubernetes/Dockerfile.install-cni
@@ -6,10 +6,10 @@ ARG BASE_VERSION=latest
 ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} AS distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,8 +1,8 @@
 # prepare a distroless source context to copy files from
-FROM cgr.dev/chainguard/static@sha256:873e9709e2a83acc995ff24e71c100480f9c0368e0d86eaee9c3c7cb8fb5f0e0 as distroless_source
+FROM cgr.dev/chainguard/static@sha256:873e9709e2a83acc995ff24e71c100480f9c0368e0d86eaee9c3c7cb8fb5f0e0 AS distroless_source
 
 # prepare a base dev to modify file contents
-FROM ubuntu:noble as ubuntu_source
+FROM ubuntu:noble AS ubuntu_source
 
 # Modify contents of container
 COPY --from=distroless_source /etc/ /home/etc

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -100,7 +100,7 @@ func describeRouteDomains(domains []string) string {
 	}
 
 	// Return the shortest non-numeric domain.  Count of domains seems uninteresting.
-	max := 2
+	maximum := 2
 	withoutPort := make([]string, 0, len(domains))
 	for _, d := range domains {
 		if !strings.Contains(d, ":") {
@@ -114,9 +114,9 @@ func describeRouteDomains(domains []string) string {
 		}
 	}
 	withoutPort = unexpandDomains(withoutPort)
-	if len(withoutPort) > max {
-		ret := strings.Join(withoutPort[:max], ", ")
-		return fmt.Sprintf("%s + %d more...", ret, len(withoutPort)-max)
+	if len(withoutPort) > maximum {
+		ret := strings.Join(withoutPort[:maximum], ", ")
+		return fmt.Sprintf("%s + %d more...", ret, len(withoutPort)-maximum)
 	}
 	return strings.Join(withoutPort, ", ")
 }

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -6,10 +6,10 @@ ARG BASE_VERSION=latest
 ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} as distroless
+FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} AS distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -159,24 +159,24 @@ func validateIPRangesOrStar(path util.Path, val any) (errs util.Errors) {
 }
 
 // validateIntRange checks whether val is an integer in [min, max].
-func validateIntRange(path util.Path, val any, min, max int64) util.Errors {
+func validateIntRange(path util.Path, val any, minimum, maximum int64) util.Errors {
 	k := reflect.TypeOf(val).Kind()
 	var err error
 	switch {
 	case util.IsIntKind(k):
 		v := reflect.ValueOf(val).Int()
-		if v < min || v > max {
-			err = fmt.Errorf("value %s:%v falls outside range [%v, %v]", path, v, min, max)
+		if v < minimum || v > maximum {
+			err = fmt.Errorf("value %s:%v falls outside range [%v, %v]", path, v, minimum, maximum)
 		}
 	case util.IsUintKind(k):
 		v := reflect.ValueOf(val).Uint()
-		if int64(v) < min || int64(v) > max {
-			err = fmt.Errorf("value %s:%v falls out side range [%v, %v]", path, v, min, max)
+		if int64(v) < minimum || int64(v) > maximum {
+			err = fmt.Errorf("value %s:%v falls out side range [%v, %v]", path, v, minimum, maximum)
 		}
 	default:
 		err = fmt.Errorf("validateIntRange %s unexpected type %T, want int type", path, val)
 	}
-	logWithError(err, "validateIntRange %s:%v in [%d, %d]?: ", path, val, min, max)
+	logWithError(err, "validateIntRange %s:%v in [%d, %d]?: ", path, val, minimum, maximum)
 	return util.NewErrs(err)
 }
 

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -6,10 +6,10 @@ ARG BASE_VERSION=latest
 ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} as distroless
+FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} AS distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -6,10 +6,10 @@ ARG BASE_VERSION=latest
 ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} AS distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.ztunnel
+++ b/pilot/docker/Dockerfile.ztunnel
@@ -6,10 +6,10 @@ ARG BASE_VERSION=latest
 ARG ISTIO_BASE_REGISTRY=gcr.io/istio-release
 
 # The following section is used as base image if BASE_DISTRIBUTION=debug
-FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} as debug
+FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} as distroless
+FROM ${ISTIO_BASE_REGISTRY}/iptables:${BASE_VERSION} AS distroless
 
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006

--- a/pkg/config/validation/agent/validation.go
+++ b/pkg/config/validation/agent/validation.go
@@ -144,9 +144,9 @@ func ValidateDuration(pd *durationpb.Duration) error {
 }
 
 // ValidateDurationRange verifies range is in specified duration
-func ValidateDurationRange(dur, min, max time.Duration) error {
-	if dur > max || dur < min {
-		return fmt.Errorf("time %v must be >%v and <%v", dur.String(), min.String(), max.String())
+func ValidateDurationRange(dur, minimum, maximum time.Duration) error {
+	if dur > maximum || dur < minimum {
+		return fmt.Errorf("time %v must be >%v and <%v", dur.String(), minimum.String(), maximum.String())
 	}
 
 	return nil

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -619,7 +619,7 @@ func fastWaitForCacheSync(stop <-chan struct{}, informerFactory informerfactory.
 // expensive checks this function may not be suitable.
 func WaitForCacheSync(name string, stop <-chan struct{}, cacheSyncs ...cache.InformerSynced) (r bool) {
 	t0 := time.Now()
-	max := time.Millisecond * 100
+	maximum := time.Millisecond * 100
 	delay := time.Millisecond
 	f := func() bool {
 		for _, syncFunc := range cacheSyncs {
@@ -649,8 +649,8 @@ func WaitForCacheSync(name string, stop <-chan struct{}, cacheSyncs ...cache.Inf
 			return true
 		}
 		delay *= 2
-		if delay > max {
-			delay = max
+		if delay > maximum {
+			delay = maximum
 		}
 		log.WithLabels("name", name, "attempt", attempt, "time", time.Since(t0)).Debugf("waiting for sync...")
 		if attempt%50 == 0 {

--- a/pkg/kube/inject/openshift.go
+++ b/pkg/kube/inject/openshift.go
@@ -44,10 +44,10 @@ func getPreallocatedUIDRange(ns *corev1.Namespace) (*int64, *int64, error) {
 		return nil, nil, err
 	}
 
-	min := int64(uidBlock.Start)
-	max := int64(uidBlock.End)
-	log.Debugf("got preallocated values for min: %d, max: %d for uid range in namespace %s", min, max, ns.Name)
-	return &min, &max, nil
+	minimum := int64(uidBlock.Start)
+	maximum := int64(uidBlock.End)
+	log.Debugf("got preallocated values for minimum: %d, maximum: %d for uid range in namespace %s", minimum, maximum, ns.Name)
+	return &minimum, &maximum, nil
 }
 
 // getPreallocatedSupplementalGroups gets the annotated value from the namespace.

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -102,10 +102,10 @@ func (t *T) applyCombinationFilters(from echo.Instance, to echo.Instances) echo.
 //   - This filter would result in a, d, e, headless, naked and vm.
 //
 // TODO this name is not good
-func SimplePodServiceAndAllSpecial(min int, exclude ...echo.Instance) Filter {
+func SimplePodServiceAndAllSpecial(minimum int, exclude ...echo.Instance) Filter {
 	return func(instances echo.Instances) echo.Instances {
 		nonRegular := notRegularPods()(instances)
-		needed := min - len(nonRegular)
+		needed := minimum - len(nonRegular)
 		if needed <= 0 {
 			needed = 1
 		}

--- a/pkg/test/framework/resource/version.go
+++ b/pkg/test/framework/resource/version.go
@@ -107,15 +107,15 @@ func (rv *RevVerMap) Default() string {
 	if rv == nil || len(*rv) == 0 {
 		return ""
 	}
-	max := rv.Maximum()
+	maximum := rv.Maximum()
 	var candidates []string
 	for rev, ver := range *rv {
-		if ver.Compare(max) == 0 {
+		if ver.Compare(maximum) == 0 {
 			candidates = append(candidates, rev)
 		}
 	}
 	if len(candidates) == 0 {
-		panic("could not find revision with max IstioVersion")
+		panic("could not find revision with maximum IstioVersion")
 	}
 	sort.Strings(candidates)
 	if candidates[0] == "default" {
@@ -200,14 +200,14 @@ func (v IstioVersions) Minimum() IstioVersion {
 	if len(v) == 0 {
 		return ""
 	}
-	min := v[0]
+	minimum := v[0]
 	for i := 1; i < len(v); i++ {
 		ver := v[i]
-		if ver.Compare(min) < 0 {
-			min = ver
+		if ver.Compare(minimum) < 0 {
+			minimum = ver
 		}
 	}
-	return min
+	return minimum
 }
 
 // Maximum returns the maximum from a set of IstioVersions
@@ -216,12 +216,12 @@ func (v IstioVersions) Maximum() IstioVersion {
 	if len(v) == 0 {
 		return ""
 	}
-	max := v[0]
+	maximum := v[0]
 	for i := 1; i < len(v); i++ {
 		ver := v[i]
-		if ver.Compare(max) > 0 {
-			max = ver
+		if ver.Compare(maximum) > 0 {
+			maximum = ver
 		}
 	}
-	return max
+	return maximum
 }

--- a/pkg/test/framework/resource/version_test.go
+++ b/pkg/test/framework/resource/version_test.go
@@ -103,9 +103,9 @@ func TestMinimumIstioVersion(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			min := tc.versions.Minimum()
-			if min != tc.result {
-				t.Errorf("expected %v, got %v", tc.result, min)
+			minimum := tc.versions.Minimum()
+			if minimum != tc.result {
+				t.Errorf("expected %v, got %v", tc.result, minimum)
 			}
 		})
 	}
@@ -146,9 +146,9 @@ func TestAtLeast(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			min := tc.versions.AtLeast(tc.version)
-			if min != tc.result {
-				t.Errorf("expected %v, got %v", tc.result, min)
+			minimum := tc.versions.AtLeast(tc.version)
+			if minimum != tc.result {
+				t.Errorf("expected %v, got %v", tc.result, minimum)
 			}
 		})
 	}

--- a/samples/bookinfo/src/reviews/Dockerfile
+++ b/samples/bookinfo/src/reviews/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM gradle:8.6.0-jdk8 as builder
+FROM gradle:8.6.0-jdk8 AS builder
 
 # Not sure why but we need root to build. Ignore lint error, this is for a multistage builder so it doesn't matter.
 # hadolint ignore=DL3002

--- a/samples/jwt-server/src/Dockerfile
+++ b/samples/jwt-server/src/Dockerfile
@@ -13,12 +13,12 @@
 #   limitations under the License.
 
 # build a jwt-server binary using the golang container
-FROM golang:1.19 as builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/istio.io/jwt-server/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o jwt-server main.go
 
-FROM gcr.io/distroless/static-debian11@sha256:21d3f84a4f37c36199fd07ad5544dcafecc17776e3f3628baf9a57c8c0181b3f as distroless
+FROM gcr.io/distroless/static-debian11@sha256:21d3f84a4f37c36199fd07ad5544dcafecc17776e3f3628baf9a57c8c0181b3f AS distroless
 
 WORKDIR /bin/
 # copy the jwt-server binary to a separate container based on BASE_DISTRIBUTION

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 # build a tcp-echo binary using the golang container
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags -static -s -w' -o tcp-echo main.go


### PR DESCRIPTION
**Please provide a description of this PR:**

go 1.21 introduced builtins for min/max. This causes newer versions of golangci-lint to mark it as a problem.

Docker buildx bake has a warning for mismatched names (e.g., FROM foo as f => FROM foo AS f)