### PR TITLE
ztunnel: pass terminationGracePeriodSeconds down to ztunnel

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -107,6 +107,8 @@ spec:
           value: {{ .Values.multiCluster.clusterName | default "Kubernetes" }}
         - name: INPOD_ENABLED
           value: "true"
+        - name: TERMINATION_GRACE_PERIOD_SECONDS
+          value: "{{ .Values.terminationGracePeriodSeconds }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
See https://github.com/istio/ztunnel/pull/1184 for more info. This does
nothing without that PR (but also could merge before; it just would have
no impact).

In practice, this means ztunnel drain period will now be 25s vs the
previous default of 5s. This, however, is configurable.
