### PR TITLE
Add a polling logic for TestIngress, while the ingress gateway gets ready

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -286,6 +286,18 @@ spec:
 				},
 			}
 
+			// wait until ingress ip is set
+			retry.UntilSuccess(func() error {
+				for _, ingr := range istio.IngressesOrFail(t, t) {
+					if len(ingr.DiscoveryAddresses()) == 0 || !ingr.DiscoveryAddresses()[0].Addr().IsValid() {
+						t.Logf("ingress gateway not ready yet")
+						return fmt.Errorf("ingress gateway not ready yet")
+					}
+					t.Logf("Ingress : %v %v", ingr, ingr.DiscoveryAddresses()[0])
+				}
+				return nil
+			}, retry.Timeout(20*time.Minute), retry.Delay(5*time.Second))
+
 			for _, ingr := range istio.IngressesOrFail(t, t) {
 				ingr := ingr
 				t.NewSubTestf("from %s", ingr.Cluster().StableName()).Run(func(t framework.TestContext) {


### PR DESCRIPTION
…eady

**Please provide a description of this PR:**

Add a polling logic for TestIngress, while the ingress gateway gets ready with being assigned a discovery address.