### PR TITLE
substitute default ns for  telemetryNs in yaml for prom install

### DIFF
--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -74,6 +74,7 @@ func installPrometheus(ctx resource.Context, ns string) error {
 	if err != nil {
 		return err
 	}
+	yaml = strings.ReplaceAll(yaml, "namespace: istio-system", fmt.Sprintf("namespace: %s", ns))
 	if err := ctx.ConfigKube().YAML(ns, yaml).Apply(apply.NoCleanup); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

The `telemetryNamespace` works as expected except for substituting the namespace of the subjects for the ClusterRoleBinding. 
 
```
subjects:
  - kind: ServiceAccount
    name: prometheus
    namespace: istio-system
```
 
Replacing all instances of `namespace: istio-system` in the YAML before applying the configuration solves this. I hard coded `istio-system` as the user can change the `systemNamespace` variable and `istio-system` is set in [samples/addons/prometheus.yaml](https://github.com/istio/istio/blob/77fda683f0d37a23879e1e258d9d82e1d0844eec/samples/addons/prometheus.yaml)
