### PR TITLE
ambient: use "CNIMode" (now renamed) for inpod rules

### DIFF
--- a/cni/pkg/iptables/iptables_test.go
+++ b/cni/pkg/iptables/iptables_test.go
@@ -47,7 +47,7 @@ func TestIptables(t *testing.T) {
 				cfg.EnableIPv6 = ipv6
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
-				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
+				iptConfigurator, _, _ := NewIptablesConfigurator(cfg, ext, ext, EmptyNlDeps())
 				err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, &probeSNATipv4, &probeSNATipv6)
 				if err != nil {
 					t.Fatal(err)
@@ -80,7 +80,7 @@ func TestIptablesHostRules(t *testing.T) {
 				cfg.EnableIPv6 = ipv6
 				tt.config(cfg)
 				ext := &dep.DependenciesStub{}
-				iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
+				iptConfigurator, _, _ := NewIptablesConfigurator(cfg, ext, ext, EmptyNlDeps())
 				err := iptConfigurator.CreateHostRulesForHealthChecks(&probeSNATipv4, &probeSNATipv6)
 				if err != nil {
 					t.Fatal(err)
@@ -109,7 +109,7 @@ func TestInvokedTwiceIsIdempotent(t *testing.T) {
 	cfg := constructTestConfig()
 	tt.config(cfg)
 	ext := &dep.DependenciesStub{}
-	iptConfigurator, _ := NewIptablesConfigurator(cfg, ext, EmptyNlDeps())
+	iptConfigurator, _, _ := NewIptablesConfigurator(cfg, ext, ext, EmptyNlDeps())
 	err := iptConfigurator.CreateInpodRules(scopes.CNIAgent, &probeSNATipv4, &probeSNATipv6)
 	if err != nil {
 		t.Fatal(err)

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -57,13 +57,13 @@ type netTestFixture struct {
 func getTestFixure(ctx context.Context) netTestFixture {
 	podNsMap := newPodNetnsCache(openNsTestOverride)
 	nlDeps := &fakeIptablesDeps{}
-	iptablesConfigurator, _ := iptables.NewIptablesConfigurator(nil, &dependencies.DependenciesStub{}, nlDeps)
+	iptablesConfigurator, _, _ := iptables.NewIptablesConfigurator(nil, &dependencies.DependenciesStub{}, &dependencies.DependenciesStub{}, nlDeps)
 
 	ztunnelServer := &fakeZtunnel{}
 
 	fakeIPSetDeps := ipset.FakeNLDeps()
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
-	netServer := newNetServer(ztunnelServer, podNsMap, iptablesConfigurator, NewPodNetnsProcFinder(fakeFs()), set)
+	netServer := newNetServer(ztunnelServer, podNsMap, iptablesConfigurator, iptablesConfigurator, NewPodNetnsProcFinder(fakeFs()), set)
 
 	netServer.netnsRunner = func(fdable NetnsFd, toRun func() error) error {
 		return toRun()

--- a/cni/pkg/plugin/sidecar_iptables_linux.go
+++ b/cni/pkg/plugin/sidecar_iptables_linux.go
@@ -34,7 +34,7 @@ var getNs = ns.GetNS
 // provided in Redirect.
 func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	cfg := config.DefaultConfig()
-	cfg.CNIMode = true
+	cfg.HostFilesystemPodNetwork = true
 	cfg.NetworkNamespace = netns
 	cfg.ProxyPort = rdrct.targetPort
 	cfg.ProxyUID = rdrct.noRedirectUID

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -135,7 +135,7 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 	flag.BindEnv(fs, constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.",
 		&cfg.NetworkNamespace)
 
-	flag.BindEnv(fs, constants.CNIMode, "", "Whether to run as CNI plugin.", &cfg.CNIMode)
+	flag.BindEnv(fs, constants.CNIMode, "", "Whether to run as CNI plugin.", &cfg.HostFilesystemPodNetwork)
 }
 
 func GetCommand(logOpts *log.Options) *cobra.Command {
@@ -193,8 +193,8 @@ func ProgramIptables(cfg *config.Config) error {
 		ext = &dep.DependenciesStub{}
 	} else {
 		ext = &dep.RealDependencies{
-			CNIMode:          cfg.CNIMode,
-			NetworkNamespace: cfg.NetworkNamespace,
+			HostFilesystemPodNetwork: cfg.HostFilesystemPodNetwork,
+			NetworkNamespace:         cfg.NetworkNamespace,
 		}
 	}
 

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -82,11 +82,14 @@ type Config struct {
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
-	CNIMode                 bool          `json:"CNI_MODE"`
-	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
-	DualStack               bool          `json:"DUAL_STACK"`
-	HostIP                  netip.Addr    `json:"HOST_IP"`
-	HostIPv4LoopbackCidr    string        `json:"HOST_IPV4_LOOPBACK_CIDR"`
+	// When running in host filesystem, we have different semantics around the environment.
+	// For instance, we would have a node-shared IPTables lock, despite not needing it.
+	// HostFilesystemPodNetwork indicates we are in this mode, typically from the CNI.
+	HostFilesystemPodNetwork bool       `json:"CNI_MODE"`
+	TraceLogging             bool       `json:"IPTABLES_TRACE_LOGGING"`
+	DualStack                bool       `json:"DUAL_STACK"`
+	HostIP                   netip.Addr `json:"HOST_IP"`
+	HostIPv4LoopbackCidr     string     `json:"HOST_IPV4_LOOPBACK_CIDR"`
 }
 
 func (c *Config) String() string {
@@ -128,7 +131,7 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
-	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.CNIMode)))
+	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.HostFilesystemPodNetwork)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))
 	log.Infof("Istio iptables variables:\n%s", b.String())
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -53,8 +53,8 @@ var exittypeToString = map[XTablesExittype]string{
 
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
-	NetworkNamespace string
-	CNIMode          bool
+	NetworkNamespace         string
+	HostFilesystemPodNetwork bool
 }
 
 const iptablesVersionPattern = `v([0-9]+(\.[0-9]+)+)`

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -214,7 +214,7 @@ func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *Ipt
 	run := func(c *exec.Cmd) error {
 		return c.Run()
 	}
-	if r.CNIMode {
+	if r.HostFilesystemPodNetwork {
 		c = exec.Command(cmdBin, args...)
 		// In CNI, we are running the pod network namespace, but the host filesystem, so we need to do some tricks
 		// Call our binary again, but with <original binary> "unshare (subcommand to trigger mounts)" --lock-file=<network namespace> <original command...>


### PR DESCRIPTION
"CNIMode" was a mode added to control how IPTables rules are executed
when running like CNI. In particular, that means we are in the host
filesystem, but the pod network namespace. In this case, we would be
fetching the node level lock which doesn't make sense. There is also
some crazy NSS interactions on some platforms; notably, in GKE, this can
lead to ~1min pod startup times.

Another issue with the locking is a bug in some versions of iptables,
including the one in 1.22. In these versions, `--wait` only acts on 1s
intervals. So if I start many pods at the same time, they will take
`NPods seconds` to start. This is observed in real world clusters almost
100% consistently when many cronjobs trigger pods at the same time. By
avoiding the lock, we sidestep this problem.

Because ambient runs in two modes -- in pod, and host -- "CNI Mode" is
kind of misleading. In this PR, I have renamed it to
HostFilesystemPodNetwork to be a bit more clear. Additionally, to handle
these two modes, the ambient server now has two iptables configs: one
for usage in host, and one for usage in pods.

Given the impact on 1.22 with locking, I would like to backport this to
1.22 if feasible.
