### PR TITLE
tests: upload WASM plugins to kind-registry to avoid DNS issues in IPv6 clusters

### DIFF
--- a/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
+++ b/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
@@ -40,7 +40,7 @@ spec:
         app: registry-redirector
     spec:
       containers:
-      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.3"}}
+      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.4"}}
         name: registry-redirector
         {{- if .TargetRegistry }}
         args: ["--registry", {{ .TargetRegistry }}, "--scheme", {{ or .Scheme "https" }}]

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -176,6 +176,12 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   docker pull gcr.io/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
   docker tag gcr.io/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG localhost:5000/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
   docker push localhost:5000/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
+  docker pull gcr.io/istio-testing/wasm/header-injector:0.0.1
+  docker tag gcr.io/istio-testing/wasm/header-injector:0.0.1 localhost:5000/istio-testing/wasm/header-injector:0.0.1
+  docker push localhost:5000/istio-testing/wasm/header-injector:0.0.1
+  docker pull gcr.io/istio-testing/wasm/header-injector:0.0.2
+  docker tag gcr.io/istio-testing/wasm/header-injector:0.0.2 localhost:5000/istio-testing/wasm/header-injector:0.0.2
+  docker push localhost:5000/istio-testing/wasm/header-injector:0.0.2
   if [[ "$IP_FAMILY" == "ipv6" ]]; then
     kind_registry_ip=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{if eq $k "kind"}}{{.GlobalIPv6Address}}{{end}}{{end}}' kind-registry)
   else

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -172,16 +172,11 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   trace "setup kind registry" setup_kind_registry
   trace "build images" build_images "${PARAMS[*]}"
 
-  WASM_ATTRGEN_TAG="359dcd3a19f109c50e97517fe6b1e2676e870c4d"
-  docker pull gcr.io/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
-  docker tag gcr.io/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG localhost:5000/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
-  docker push localhost:5000/istio-testing/wasm/attributegen:$WASM_ATTRGEN_TAG
-  docker pull gcr.io/istio-testing/wasm/header-injector:0.0.1
-  docker tag gcr.io/istio-testing/wasm/header-injector:0.0.1 localhost:5000/istio-testing/wasm/header-injector:0.0.1
-  docker push localhost:5000/istio-testing/wasm/header-injector:0.0.1
-  docker pull gcr.io/istio-testing/wasm/header-injector:0.0.2
-  docker tag gcr.io/istio-testing/wasm/header-injector:0.0.2 localhost:5000/istio-testing/wasm/header-injector:0.0.2
-  docker push localhost:5000/istio-testing/wasm/header-injector:0.0.2
+  # upload WASM plugins to kind-registry
+  crane copy gcr.io/istio-testing/wasm/attributegen:359dcd3a19f109c50e97517fe6b1e2676e870c4d localhost:5000/istio-testing/wasm/attributegen:0.0.1
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.1 localhost:5000/istio-testing/wasm/header-injector:0.0.1
+  crane copy gcr.io/istio-testing/wasm/header-injector:0.0.2 localhost:5000/istio-testing/wasm/header-injector:0.0.2
+
   # Make "kind-registry" resolvable in IPv6 cluster
   if [[ "$IP_FAMILY" == "ipv6" ]]; then
     kind_registry_ip=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{if eq $k "kind"}}{{.GlobalIPv6Address}}{{end}}{{end}}' kind-registry)

--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -111,8 +111,7 @@ spec:
 }
 
 func setupWasmExtension(t framework.TestContext) {
-	proxySHA := "359dcd3a19f109c50e97517fe6b1e2676e870c4d"
-	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:%v", registry.Address(), proxySHA)
+	attrGenImageURL := fmt.Sprintf("oci://%v/istio-testing/wasm/attributegen:0.0.1", registry.Address())
 	args := map[string]any{
 		"AttributeGenURL": attrGenImageURL,
 	}

--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 )
@@ -40,7 +39,6 @@ const (
 
 func TestCustomizeMetrics(t *testing.T) {
 	framework.NewTest(t).
-		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
 		Run(func(t framework.TestContext) {
 			setupWasmExtension(t)
 			t.ConfigIstio().YAML(apps.Namespace.Name(), `

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -18,12 +18,8 @@
 package api
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
-	"net/netip"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework/components/registryredirector"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -38,29 +34,9 @@ const (
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
-	cm, err := ctx.Clusters().Default().Kube().CoreV1().ConfigMaps("default").Get(context.TODO(), "kind-registry-addr", metav1.GetOptions{})
-	if err != nil {
-		return
-	}
-	ip, found := cm.Data["ip"]
-	if !found {
-		err = fmt.Errorf("kind-registry IP not found in the config map kind-registry-addr/default")
-		return
-	}
-	ipAddr, err := netip.ParseAddr(ip)
-	if err != nil {
-		err = fmt.Errorf("failed to parse IP address '%s': %s", ip, err)
-		return
-	}
-	var formattedAddr string
-	if ipAddr.Is6() {
-		formattedAddr = fmt.Sprintf("'[%s]:5000'", ipAddr.String())
-	} else {
-		formattedAddr = fmt.Sprintf("%s:5000", ipAddr.String())
-	}
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
 		Cluster:        ctx.AllClusters().Default(),
-		TargetRegistry: formattedAddr,
+		TargetRegistry: "kind-registry:5000",
 		Scheme:         "http",
 		Image:          "quay.io/jewertow/fake-registry:latest",
 	})

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -38,7 +38,6 @@ func testRegistrySetup(ctx resource.Context) (err error) {
 		Cluster:        ctx.AllClusters().Default(),
 		TargetRegistry: "kind-registry:5000",
 		Scheme:         "http",
-		Image:          "quay.io/jewertow/fake-registry:latest",
 	})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -18,8 +18,11 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework/components/registryredirector"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -34,8 +37,20 @@ const (
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
+	cm, err := ctx.Clusters().Default().Kube().CoreV1().ConfigMaps("default").Get(context.TODO(), "kind-registry-addr", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+	ip, found := cm.Data["ip"]
+	if !found {
+		err = fmt.Errorf("kind-registry IP not found in the config map kind-registry-addr/default")
+		return
+	}
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
-		Cluster: ctx.AllClusters().Default(),
+		Cluster:        ctx.AllClusters().Default(),
+		TargetRegistry: fmt.Sprintf("%s:5000", ip),
+		Scheme:         "http",
+		Image:          "quay.io/jewertow/fake-registry:latest",
 	})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/api/setup_test.go
+++ b/tests/integration/telemetry/api/setup_test.go
@@ -52,8 +52,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
-		// TODO: Remove this restriction once we validate our prometheus helm chart version is high enough
-		Label(label.IPv4). // https://github.com/istio/istio/issues/35915
 		Setup(istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			i, err := istio.Get(ctx)

--- a/tests/integration/telemetry/api/stats_test.go
+++ b/tests/integration/telemetry/api/stats_test.go
@@ -38,7 +38,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
 	"istio.io/istio/pkg/test/framework/components/echo/match"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
@@ -470,7 +469,6 @@ func ValidateBucket(cluster cluster.Cluster, prom prometheus.Instance, sourceApp
 // Kiali depends on these metrics
 func TestGRPCCountMetrics(t *testing.T) {
 	framework.NewTest(t).
-		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
 		Run(func(t framework.TestContext) {
 			// Metrics to be queried and tested
 			metrics := []string{"istio_request_messages_total", "istio_response_messages_total"}


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #35915.

This [comment](https://github.com/istio/istio/pull/47978#issuecomment-1823155014) explains why do we have to upload WASM plugins to kind-registry before running tests. Additionally, I had to patch CoreDNS config map, because `kind-registry` is not resolvable in IPv6-only cluster.

First https://github.com/istio/istio/pull/51779 must be merged.