### PR TITLE
tests: add `--scheme` argument to registry-redirector to allow HTTP requests

### DIFF
--- a/pkg/test/fakes/imageregistry/Makefile
+++ b/pkg/test/fakes/imageregistry/Makefile
@@ -22,7 +22,7 @@ BIN_NAME := main
 
 # NOTE: TAG should be updated whenever changes are made in this directory
 # This should also be updated in dependent components
-TAG := 1.3
+TAG := 1.4
 
 all: build_and_push clean
 

--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -96,8 +96,7 @@ func (h *Handler) getFirstLayerURL(imageName string, tag string) (string, error)
 		return "", fmt.Errorf("could not parse url in image reference: %v", err)
 	}
 
-	var t *http.Transport
-	t = remote.DefaultTransport.(*http.Transport).Clone()
+	t := remote.DefaultTransport.(*http.Transport).Clone()
 	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
 	desc, err := remote.Get(ref, remote.WithTransport(t))
 	if err != nil {

--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -92,9 +92,12 @@ func (h *Handler) getFirstLayerURL(imageName string, tag string) (string, error)
 		return "", fmt.Errorf("could not parse url in image reference: %v", err)
 	}
 
-	t := remote.DefaultTransport.(*http.Transport).Clone()
+	var t *http.Transport
 	if *scheme == "https" {
+		t = remote.DefaultTransport.(*http.Transport).Clone()
 		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
+	} else {
+		t = &http.Transport{}
 	}
 	desc, err := remote.Get(ref, remote.WithTransport(t))
 	if err != nil {

--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -93,7 +93,9 @@ func (h *Handler) getFirstLayerURL(imageName string, tag string) (string, error)
 	}
 
 	t := remote.DefaultTransport.(*http.Transport).Clone()
-	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
+	if *scheme == "https" {
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
+	}
 	desc, err := remote.Get(ref, remote.WithTransport(t))
 	if err != nil {
 		return "", fmt.Errorf("could not get the description: %v", err)

--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -87,7 +87,11 @@ func (h *Handler) getFirstLayerURL(imageName string, tag string) (string, error)
 	}
 
 	u := fmt.Sprintf("%v/%v:%v", *registry, imageName, convertedTag)
-	ref, err := name.ParseReference(u)
+	var opts []name.Option
+	if *scheme == "http" {
+		opts = append(opts, name.Insecure)
+	}
+	ref, err := name.ParseReference(u, opts...)
 	if err != nil {
 		return "", fmt.Errorf("could not parse url in image reference: %v", err)
 	}

--- a/pkg/test/fakes/imageregistry/main.go
+++ b/pkg/test/fakes/imageregistry/main.go
@@ -97,12 +97,8 @@ func (h *Handler) getFirstLayerURL(imageName string, tag string) (string, error)
 	}
 
 	var t *http.Transport
-	if *scheme == "https" {
-		t = remote.DefaultTransport.(*http.Transport).Clone()
-		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
-	} else {
-		t = &http.Transport{}
-	}
+	t = remote.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint: gosec // test only code
 	desc, err := remote.Get(ref, remote.WithTransport(t))
 	if err != nil {
 		return "", fmt.Errorf("could not get the description: %v", err)

--- a/pkg/test/framework/components/registryredirector/kube.go
+++ b/pkg/test/framework/components/registryredirector/kube.go
@@ -83,6 +83,10 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		args["TargetRegistry"] = cfg.TargetRegistry
 	}
 
+	if len(cfg.Scheme) != 0 {
+		args["Scheme"] = cfg.Scheme
+	}
+
 	if len(cfg.Image) != 0 {
 		args["Image"] = cfg.Image
 	}

--- a/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
+++ b/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
@@ -43,7 +43,7 @@ spec:
       - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.3"}}
         name: registry-redirector
         {{- if .TargetRegistry }}
-        args: ["--registry", {{ .TargetRegistry }}]
+        args: ["--registry", {{ .TargetRegistry }}, "--scheme", {{ or .Scheme "https" }}]
         {{- end }}
         ports:
         - containerPort: 1338

--- a/pkg/test/framework/components/registryredirector/registryredirector.go
+++ b/pkg/test/framework/components/registryredirector/registryredirector.go
@@ -38,6 +38,8 @@ type Config struct {
 	Cluster cluster.Cluster
 	// Upstream registry. Default is "gcr.io".
 	TargetRegistry string
+	// URL scheme for the registry. Default is "https".
+	Scheme string
 	// Docker image location of the fake registry. Default is "gcr.io/istio-testing/fake-registry:x.x".
 	// Please refer to registry_redirector_server.yaml for the exact default image.
 	Image string


### PR DESCRIPTION
**Please provide a description of this PR:**

This change is needed to allow HTTP requests to kind-registry. Read #51778 and #35915 for more context.