### PR TITLE
remove pilot flag PILOT_TRACE_SAMPLING

### DIFF
--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -18,27 +18,10 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/env"
-	"istio.io/istio/pkg/log"
 )
 
 // Define telemetry related features here.
 var (
-	traceSamplingVar = env.Register(
-		"PILOT_TRACE_SAMPLING",
-		1.0,
-		"Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. "+
-			"Default is 1.0.",
-	)
-
-	TraceSampling = func() float64 {
-		f := traceSamplingVar.Get()
-		if f < 0.0 || f > 100.0 {
-			log.Warnf("PILOT_TRACE_SAMPLING out of range: %v", f)
-			return 1.0
-		}
-		return f
-	}()
-
 	EnableTelemetryLabel = env.Register("PILOT_ENABLE_TELEMETRY_LABEL", true,
 		"If true, pilot will add telemetry related metadata to cluster and endpoint resources, which will be consumed by telemetry filter.",
 	).Get()

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -2315,16 +2315,14 @@ func TestHttpProxyListenerPerWorkload(t *testing.T) {
 
 func TestHttpProxyListener_Tracing(t *testing.T) {
 	customTagsTest := []struct {
-		name             string
-		in               *meshconfig.Tracing
-		out              *hcm.HttpConnectionManager_Tracing
-		tproxy           *model.Proxy
-		envPilotSampling float64
+		name   string
+		in     *meshconfig.Tracing
+		out    *hcm.HttpConnectionManager_Tracing
+		tproxy *model.Proxy
 	}{
 		{
-			name:             "random-sampling-env",
-			tproxy:           getProxy(),
-			envPilotSampling: 80.0,
+			name:   "random-sampling-env",
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -2337,7 +2335,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 					Value: 100.0,
 				},
 				RandomSampling: &xdstype.Percent{
-					Value: 80.0,
+					Value: 1.0,
 				},
 				OverallSampling: &xdstype.Percent{
 					Value: 100.0,
@@ -2346,9 +2344,8 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 			},
 		},
 		{
-			name:             "random-sampling-env-and-meshconfig",
-			tproxy:           getProxy(),
-			envPilotSampling: 80.0,
+			name:   "random-sampling-env-and-meshconfig",
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -2370,9 +2367,8 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 			},
 		},
 		{
-			name:             "random-sampling-too-low-env",
-			tproxy:           getProxy(),
-			envPilotSampling: -1,
+			name:   "random-sampling-too-low-env",
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -2394,9 +2390,8 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 			},
 		},
 		{
-			name:             "random-sampling-too-high-meshconfig",
-			tproxy:           getProxy(),
-			envPilotSampling: 80.0,
+			name:   "random-sampling-too-high-meshconfig",
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -2418,9 +2413,8 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 			},
 		},
 		{
-			name:             "random-sampling-too-high-env",
-			tproxy:           getProxy(),
-			envPilotSampling: 2000.0,
+			name:   "random-sampling-too-high-env",
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -2608,10 +2602,6 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 	}
 	for _, tc := range customTagsTest {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.envPilotSampling != 0.0 {
-				test.SetForTest(t, &features.TraceSampling, tc.envPilotSampling)
-			}
-
 			m := mesh.DefaultMeshConfig()
 			m.ProxyHttpPort = 15007
 			m.EnableTracing = true

--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -31,7 +31,6 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	telemetrypb "istio.io/api/telemetry/v1alpha1"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
@@ -577,8 +576,7 @@ func configureSampling(hcmTracing *hcm.HttpConnectionManager_Tracing, providerPe
 }
 
 func proxyConfigSamplingValue(config *meshconfig.ProxyConfig) float64 {
-	// PILOT_TRACE_SAMPLING
-	sampling := features.TraceSampling
+	sampling := 1.0
 
 	// Tracing from default_config
 	if config.Tracing != nil && config.Tracing.Sampling != 0.0 {

--- a/releasenotes/notes/remove-pilot-tracing.yaml
+++ b/releasenotes/notes/remove-pilot-tracing.yaml
@@ -4,3 +4,10 @@ area: telemetry
 releaseNotes:
   - |
     **Removed** pilot flag `PILOT_TRACE_SAMPLING`.
+
+upgradeNotes:
+  - title: pilot flag `PILOT_TRACE_SAMPLING` supported in Istio.
+    content: |
+      If you are using the pilot environment flag `PILOT_TRACE_SAMPLING`, you should
+      replace it with `defaultConfig.tracing.sampling` in the [MeshConfig](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig)
+      or `randomSamplingPercentage`in [Telemetry API](https://istio.io/latest/docs/reference/config/telemetry/).

--- a/releasenotes/notes/remove-pilot-tracing.yaml
+++ b/releasenotes/notes/remove-pilot-tracing.yaml
@@ -6,7 +6,7 @@ releaseNotes:
     **Removed** pilot flag `PILOT_TRACE_SAMPLING`.
 
 upgradeNotes:
-  - title: pilot flag `PILOT_TRACE_SAMPLING` supported in Istio.
+  - title: Removed pilot flag `PILOT_TRACE_SAMPLING` supported in Istio.
     content: |
       If you are using the pilot environment flag `PILOT_TRACE_SAMPLING`, you should
       replace it with `defaultConfig.tracing.sampling` in the [MeshConfig](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig)

--- a/releasenotes/notes/remove-pilot-tracing.yaml
+++ b/releasenotes/notes/remove-pilot-tracing.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Removed** pilot flag `PILOT_TRACE_SAMPLING`.


### PR DESCRIPTION
**Please provide a description of this PR:**

there's three ways to config trace sampling rate today, it's time to remove pilot flag.