### PR TITLE
Make sure we always Take() the netns, always remove the IP, and fence with more tests

### DIFF
--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -33,6 +33,7 @@ type fakeZtunnel struct {
 	deletedPods atomic.Int32
 	addedPods   atomic.Int32
 	addError    error
+	delError	error
 }
 
 func (f *fakeZtunnel) Run(ctx context.Context) {
@@ -40,7 +41,7 @@ func (f *fakeZtunnel) Run(ctx context.Context) {
 
 func (f *fakeZtunnel) PodDeleted(ctx context.Context, uid string) error {
 	f.deletedPods.Add(1)
-	return nil
+	return f.delError
 }
 
 func (f *fakeZtunnel) PodAdded(ctx context.Context, pod *corev1.Pod, netns Netns) error {

--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -33,7 +33,7 @@ type fakeZtunnel struct {
 	deletedPods atomic.Int32
 	addedPods   atomic.Int32
 	addError    error
-	delError	error
+	delError    error
 }
 
 func (f *fakeZtunnel) Run(ctx context.Context) {

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -243,7 +243,7 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	// Whether pod is already deleted or not, we need to let go of our netns ref.
 	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
 	if openNetns == nil {
-		log.Warn("failed to find pod netns during removal")
+		log.Debug("failed to find pod netns during removal")
 	}
 
 	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -233,24 +233,30 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	// Aggregate errors together, so that if part of the cleanup fails we still proceed with other steps.
 	var errs []error
 
-	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.
-	if !isDelete {
-		openNetns := s.currentPodSnapshot.Take(string(pod.UID))
-		if openNetns == nil {
-			log.Warn("failed to find pod netns during removal")
-			errs = append(errs, fmt.Errorf("failed to find pod netns during removal"))
-		} else {
-			// pod is removed from the mesh, but is still running. remove iptables rules
-			log.Debugf("calling DeleteInpodRules.")
-			if err := s.netnsRunner(openNetns, func() error { return s.iptablesConfigurator.DeleteInpodRules() }); err != nil {
-				return fmt.Errorf("failed to delete inpod rules: %w", err)
-			}
-		}
-	}
-
+	// Remove the hostside ipset entry first, and unconditionally - if later failures happen, we never
+	// want to leave stale entries
 	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
 		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
 		errs = append(errs, err)
+	}
+
+	// Whether pod is already deleted or not, we need to let go of our netns ref.
+	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
+	if openNetns == nil {
+		log.Warn("failed to find pod netns during removal")
+	}
+
+	// If the pod is already deleted or terminated, we do not need to clean up the pod network -- only the host side.
+	if !isDelete {
+		if openNetns != nil {
+			// pod is removed from the mesh, but is still running. remove iptables rules
+			log.Debugf("calling DeleteInpodRules")
+			if err := s.netnsRunner(openNetns, func() error { return s.iptablesConfigurator.DeleteInpodRules() }); err != nil {
+				return fmt.Errorf("failed to delete inpod rules: %w", err)
+			}
+		} else {
+			log.Warn("pod netns already gone, not deleting inpod rules")
+		}
 	}
 
 	log.Debug("removing pod from ztunnel")

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -172,6 +172,86 @@ func TestServerRemovePod(t *testing.T) {
 	netServer := fixture.netServer
 	ztunnelServer := fixture.ztunnelServer
 	nlDeps := fixture.nlDeps
+	pod := buildConvincingPod(false)
+	// this is usually called after add. so manually add the pod uid for now
+	fakens := newFakeNs(123)
+	closed := fakens.closed
+	workload := WorkloadInfo{
+		Workload: podToWorkload(pod),
+		Netns:    fakens,
+	}
+
+	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
+	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
+	err := netServer.RemovePodFromMesh(ctx, pod, false)
+	assert.NoError(t, err)
+	assert.Equal(t, ztunnelServer.deletedPods.Load(), 1)
+	assert.Equal(t, nlDeps.DelInpodMarkIPRuleCnt.Load(), 1)
+	assert.Equal(t, nlDeps.DelLoopbackRoutesCnt.Load(), 1)
+	// make sure the uid was taken from cache and netns closed
+	netns := fixture.podNsMap.Take(string(pod.UID))
+	assert.Equal(t, nil, netns)
+	fixture.ipsetDeps.AssertExpectations(t)
+
+	// run gc to clean up ns:
+
+	//revive:disable-next-line:call-to-gc Just a test that we are cleaning up the netns
+	runtime.GC()
+	assertNSClosed(t, closed)
+}
+
+func TestServerRemovePodAlwaysRemovesIPSetEntryEvenOnFail (t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupLogging()
+	fixture := getTestFixure(ctx)
+	netServer := fixture.netServer
+	ztunnelServer := fixture.ztunnelServer
+	nlDeps := fixture.nlDeps
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			UID:       "123",
+		},
+		Spec: corev1.PodSpec{ServiceAccountName: "sa"},
+	}
+
+	ztunnelServer.delError = errors.New("fake error")
+	// this is usually called after add. so manually add the pod uid for now
+	fakens := newFakeNs(123)
+	closed := fakens.closed
+	workload := WorkloadInfo{
+		Workload: podToWorkload(pod),
+		Netns:    fakens,
+	}
+	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
+	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
+	err := netServer.RemovePodFromMesh(ctx, pod, false)
+	assert.Error(t, err)
+	assert.Equal(t, ztunnelServer.deletedPods.Load(), 1)
+	assert.Equal(t, nlDeps.DelInpodMarkIPRuleCnt.Load(), 1)
+	assert.Equal(t, nlDeps.DelLoopbackRoutesCnt.Load(), 1)
+	// make sure the uid was taken from cache and netns closed
+	netns := fixture.podNsMap.Take(string(pod.UID))
+	assert.Equal(t, nil, netns)
+	fixture.ipsetDeps.AssertExpectations(t)
+
+	// run gc to clean up ns:
+
+	//revive:disable-next-line:call-to-gc Just a test that we are cleaning up the netns
+	runtime.GC()
+	assertNSClosed(t, closed)
+}
+
+func TestServerDeletePod(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setupLogging()
+	fixture := getTestFixure(ctx)
+	netServer := fixture.netServer
+	ztunnelServer := fixture.ztunnelServer
+	nlDeps := fixture.nlDeps
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -189,15 +269,18 @@ func TestServerRemovePod(t *testing.T) {
 		Netns:    fakens,
 	}
 	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
-	err := netServer.RemovePodFromMesh(ctx, pod, false)
+	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
+	err := netServer.RemovePodFromMesh(ctx, pod, true)
 	assert.NoError(t, err)
 	assert.Equal(t, ztunnelServer.deletedPods.Load(), 1)
-	assert.Equal(t, nlDeps.DelInpodMarkIPRuleCnt.Load(), 1)
-	assert.Equal(t, nlDeps.DelLoopbackRoutesCnt.Load(), 1)
+	// with delete iptables is not called, as there is no need to delete the iptables rules
+	// from a pod that's gone from the cluster.
+	assert.Equal(t, nlDeps.DelInpodMarkIPRuleCnt.Load(), 0)
+	assert.Equal(t, nlDeps.DelLoopbackRoutesCnt.Load(), 0)
 	// make sure the uid was taken from cache and netns closed
 	netns := fixture.podNsMap.Take(string(pod.UID))
 	assert.Equal(t, nil, netns)
-
+	fixture.ipsetDeps.AssertExpectations(t)
 	// run gc to clean up ns:
 
 	//revive:disable-next-line:call-to-gc Just a test that we are cleaning up the netns
@@ -205,14 +288,23 @@ func TestServerRemovePod(t *testing.T) {
 	assertNSClosed(t, closed)
 }
 
-func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podMeta metav1.ObjectMeta) {
+func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIP netip.Addr, podMeta metav1.ObjectMeta) {
 	ipsetDeps.On("addIP",
 		"foo-v4",
-		netip.MustParseAddr("99.9.9.9"),
+		podIP,
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
 		false,
 	).Return(nil)
+}
+
+func expectPodRemovedFromIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIPs []corev1.PodIP) {
+	for _, ip := range podIPs {
+		ipsetDeps.On("clearEntriesWithIP",
+			"foo-v4",
+			netip.MustParseAddr(ip.IP),
+		).Return(nil)
+	}
 }
 
 func TestServerAddPodWithNoNetns(t *testing.T) {
@@ -230,7 +322,7 @@ func TestServerAddPodWithNoNetns(t *testing.T) {
 	}
 	podIP := netip.MustParseAddr("99.9.9.9")
 	podIPs := []netip.Addr{podIP}
-	expectPodAddedToIPSet(fixture.ipsetDeps, podMeta)
+	expectPodAddedToIPSet(fixture.ipsetDeps, podIP, podMeta)
 
 	err := netServer.AddPodToMesh(ctx, &corev1.Pod{ObjectMeta: podMeta}, podIPs, "")
 	assert.NoError(t, err)
@@ -254,7 +346,7 @@ func TestReturnsPartialErrorOnZtunnelFail(t *testing.T) {
 	podIP := netip.MustParseAddr("99.9.9.9")
 	podIPs := []netip.Addr{podIP}
 
-	expectPodAddedToIPSet(fixture.ipsetDeps, podMeta)
+	expectPodAddedToIPSet(fixture.ipsetDeps, podIP, podMeta)
 	err := netServer.AddPodToMesh(ctx, &corev1.Pod{ObjectMeta: podMeta}, podIPs, "faksens")
 	assert.Equal(t, ztunnelServer.addedPods.Load(), 1)
 	if !errors.Is(err, ErrPartialAdd) {
@@ -262,7 +354,7 @@ func TestReturnsPartialErrorOnZtunnelFail(t *testing.T) {
 	}
 }
 
-func TestDoesntReturnsPartialErrorOnIptablesFail(t *testing.T) {
+func TestDoesntReturnPartialErrorOnIptablesFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	setupLogging()
@@ -280,7 +372,7 @@ func TestDoesntReturnsPartialErrorOnIptablesFail(t *testing.T) {
 	podIP := netip.MustParseAddr("99.9.9.9")
 	podIPs := []netip.Addr{podIP}
 
-	expectPodAddedToIPSet(fixture.ipsetDeps, podMeta)
+	expectPodAddedToIPSet(fixture.ipsetDeps, podIP, podMeta)
 	err := netServer.AddPodToMesh(ctx, &corev1.Pod{ObjectMeta: podMeta}, podIPs, "faksens")
 	// no calls to ztunnel if iptables failed
 	assert.Equal(t, ztunnelServer.addedPods.Load(), 0)

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -200,7 +200,7 @@ func TestServerRemovePod(t *testing.T) {
 	assertNSClosed(t, closed)
 }
 
-func TestServerRemovePodAlwaysRemovesIPSetEntryEvenOnFail (t *testing.T) {
+func TestServerRemovePodAlwaysRemovesIPSetEntryEvenOnFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	setupLogging()


### PR DESCRIPTION
**Please provide a description of this PR:**

Few minor tweaks.

1. Make sure we unconditionally drop our netns reference on pod removal if we have one, regardless of whether it's a delete or not (it's _probably_ fine if we do not, but there's no reason not to be eager + consistent with it to avoid the opportunity for leaking netns refs)
2. Make sure we unconditionally remove the ip from the set on pod removal, even if there are later errors.
3. Add some tests to fence the above behaviors.