### PR TITLE
Make cluster_name stat tag regex not lazy

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
+++ b/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -78,7 +78,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "^cluster\\.((.+(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
       {
         "tag_name": "tcp_prefix",


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #51761.

Envoy allows specifying stat tags by writing a regex to parse the default metrics it generates. Envoy removes the first capture group from the regex and then sets the tag value to the second capture group. The existing regex for cluster_name (that Istio has had for 6 years) had a lazy qualifier in its second capture group, causing the regex parser to stop at the first match. This means non-Kubernetes FQDNs (i.e. ending in svc.cluster.local) like api.facebook.com would have incorrect values for the cluster_name metric label. This PR fixes that. Adding DNM so I can add a test


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
