### PR TITLE
WIP: Try making ambient integ kind prow clusters dualstack by default

### DIFF
--- a/prow/config/ambient-sc.yaml
+++ b/prow/config/ambient-sc.yaml
@@ -23,3 +23,5 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
     endpoint = ["http://kind-registry:5000"]
+networking:
+  ipFamily: dual


### PR DESCRIPTION
**Please provide a description of this PR:**

I use this config for local testruns (as do the ambient tests)- now that we are shooting for default-v6 support in ambient, see if anything breaks if we enable this.