### PR TITLE
[DO NOT MERGE] Configure registry-redirector to use kind-registry

### DIFF
--- a/pkg/test/framework/components/registryredirector/kube.go
+++ b/pkg/test/framework/components/registryredirector/kube.go
@@ -83,6 +83,10 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		args["TargetRegistry"] = cfg.TargetRegistry
 	}
 
+	if len(cfg.Scheme) != 0 {
+		args["Scheme"] = cfg.Scheme
+	}
+
 	if len(cfg.Image) != 0 {
 		args["Image"] = cfg.Image
 	}

--- a/pkg/test/framework/components/registryredirector/registryredirector.go
+++ b/pkg/test/framework/components/registryredirector/registryredirector.go
@@ -38,6 +38,8 @@ type Config struct {
 	Cluster cluster.Cluster
 	// Upstream registry. Default is "gcr.io".
 	TargetRegistry string
+	// URL scheme for the registry. Default is "https".
+	Scheme string
 	// Docker image location of the fake registry. Default is "gcr.io/istio-testing/fake-registry:x.x".
 	// Please refer to registry_redirector_server.yaml for the exact default image.
 	Image string

--- a/tests/integration/telemetry/api/customize_metrics_test.go
+++ b/tests/integration/telemetry/api/customize_metrics_test.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 )
@@ -40,7 +39,6 @@ const (
 
 func TestCustomizeMetrics(t *testing.T) {
 	framework.NewTest(t).
-		Label(label.IPv4). // https://github.com/istio/istio/issues/35835
 		Run(func(t framework.TestContext) {
 			setupWasmExtension(t)
 			t.ConfigIstio().YAML(apps.Namespace.Name(), `

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -18,11 +18,8 @@
 package api
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework/components/registryredirector"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -37,18 +34,9 @@ const (
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
-	cm, err := ctx.Clusters().Default().Kube().CoreV1().ConfigMaps("default").Get(context.TODO(), "kind-registry-addr", metav1.GetOptions{})
-	if err != nil {
-		return
-	}
-	ip, found := cm.Data["ip"]
-	if !found {
-		err = fmt.Errorf("kind-registry IP not found in the config map kind-registry-addr/default")
-		return
-	}
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
 		Cluster:        ctx.AllClusters().Default(),
-		TargetRegistry: fmt.Sprintf("%s:5000", ip),
+		TargetRegistry: "kind-registry:5000",
 		Scheme:         "http",
 		Image:          "quay.io/jewertow/fake-registry:latest",
 	})

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -18,8 +18,11 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework/components/registryredirector"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -34,8 +37,20 @@ const (
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
+	cm, err := ctx.Clusters().Default().Kube().CoreV1().ConfigMaps("default").Get(context.TODO(), "kind-registry-addr", metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+	ip, found := cm.Data["ip"]
+	if !found {
+		err = fmt.Errorf("kind-registry IP not found in the config map kind-registry-addr/default")
+		return
+	}
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
-		Cluster: ctx.AllClusters().Default(),
+		Cluster:        ctx.AllClusters().Default(),
+		TargetRegistry: fmt.Sprintf("%s:5000", ip),
+		Scheme:         "http",
+		Image:          "quay.io/jewertow/fake-registry:latest",
 	})
 	if err != nil {
 		return


### PR DESCRIPTION
I just want to check if istiod is able to resolve `kind-registry` in IPv6 cluster as it does not work in my local environment.