### PR TITLE
Expose retry_budget configuration in DestinationRule ConnectionPoolSettings

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -378,6 +378,32 @@ func TestApplyDestinationRule(t *testing.T) {
 			expectedSubsetClusters: []*cluster.Cluster{},
 		},
 		{
+			name:        "destination rule with retry budget",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					ConnectionPool: &networking.ConnectionPoolSettings{
+						Http: &networking.ConnectionPoolSettings_HTTPSettings{
+							RetryBudget: &networking.RetryBudget{
+								MinRetryConcurrency: &wrappers.UInt32Value{
+									Value: 10,
+								},
+								BudgetPercent: &networking.Percent{
+									Value: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
 			name:        "subset without labels in both",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS}},
 			clusterMode: DefaultClusterMode,

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -117,6 +117,16 @@ func (cb *ClusterBuilder) applyConnectionPool(mesh *meshconfig.MeshConfig,
 			threshold.MaxRetries = &wrapperspb.UInt32Value{Value: uint32(settings.Http.MaxRetries)}
 		}
 
+        if settings.Http.RetryBudget != nil {
+			threshold.RetryBudget = getDefaultCircuitBreakerThresholdsRetryBudget()
+			if settings.Http.RetryBudget.MinRetryConcurrency != nil {
+				threshold.RetryBudget.MinRetryConcurrency = &wrapperspb.UInt32Value{Value: settings.Http.RetryBudget.MinRetryConcurrency.Value}
+			}
+			if settings.Http.RetryBudget.BudgetPercent != nil {
+				threshold.RetryBudget.BudgetPercent = &xdstype.Percent{Value: settings.Http.RetryBudget.BudgetPercent.Value}
+			}
+		}
+
 		idleTimeout = settings.Http.IdleTimeout
 		maxRequestsPerConnection = uint32(settings.Http.MaxRequestsPerConnection)
 		maxConcurrentStreams = uint32(settings.Http.MaxConcurrentStreams)
@@ -345,6 +355,14 @@ func getDefaultCircuitBreakerThresholds() *cluster.CircuitBreakers_Thresholds {
 		MaxConnections:     &wrapperspb.UInt32Value{Value: math.MaxUint32},
 		MaxPendingRequests: &wrapperspb.UInt32Value{Value: math.MaxUint32},
 		TrackRemaining:     true,
+	}
+}
+
+// getDefaultCircuitBreakerThresholdsRetryBudget returns a copy of the default circuit breaker thresholds retry budget for the given traffic direction.
+func getDefaultCircuitBreakerThresholdsRetryBudget() *cluster.CircuitBreakers_Thresholds_RetryBudget {
+	return &cluster.CircuitBreakers_Thresholds_RetryBudget{
+		BudgetPercent: &xdstype.Percent{Value: math.MaxFloat64},
+		MinRetryConcurrency: &wrapperspb.UInt32Value{Value: math.MaxUint32},
 	}
 }
 

--- a/releasenotes/notes/dr-retry-budget.yaml
+++ b/releasenotes/notes/dr-retry-budget.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/27419
+releaseNotes:
+  - |
+    **Added** DestinationRule ConnectionPoolSettings retry_budget configuration.


### PR DESCRIPTION
**Please provide a description of this PR:**

Attempting to expose the Envoy CircuitBreaker retry_budget threshold within DestinationRule configuration. The only alternate way to maintain retry_budget configurations at the moment is through complex EnvoyFilter’s, which becomes very difficult to maintain across hundreds of separate microservices within the mesh & requires automation to generate the configs.

We are aware that there is concern about forwards compatibility with the work that @mikemorris is leading for the Kubernetes Gateway API in order to expose retry_budget configuration within HTTPRoute. But we don’t currently have plans to adopt Gateway API in the foreseeable future, and exposing retry_budget alongside max_retries within the DestinationRule seems to make the most sense in the context of Istio based off of [Envoy CircuitBreaker configuration](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#config-cluster-v3-circuitbreakers-thresholds).

From our own testing, we have found that a dynamic retry budget performs far better than configuring a static value for max retries. Would be happy to discuss this more, but we feel that this is an important feature based off of the other issues and PR’s that have been submitted for exposing this configuration, as well as what we’ve found through testing. Looking forward to feedback as this is a high priority feature for us. cc @tejokumar

api: https://github.com/istio/api/pull/3249

Credit to @quraynai as I used [their previous work in this area](https://github.com/istio/istio/pull/47094) as a reference.
Issue: https://github.com/istio/istio/issues/27419