### PR TITLE
Use constants for the ipFamilyPolicy

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
@@ -283,7 +284,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
 			IPFamilies:      "IPv6, IPv4",
-			IPFamilyPolicy:  "RequireDualStack",
+			IPFamilyPolicy:  string(corev1.IPFamilyPolicyRequireDualStack),
 			DualStack:       true,
 		}
 		eSvc := echo.Config{
@@ -293,7 +294,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
 			IPFamilies:      "IPv6",
-			IPFamilyPolicy:  "SingleStack",
+			IPFamilyPolicy:  string(corev1.IPFamilyPolicySingleStack),
 			DualStack:       true,
 		}
 		defaultConfigs = append(defaultConfigs, dSvc, eSvc)

--- a/pkg/test/framework/components/echo/common/deployment/external.go
+++ b/pkg/test/framework/components/echo/common/deployment/external.go
@@ -17,6 +17,8 @@ package deployment
 import (
 	"path"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"istio.io/api/annotation"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/env"
@@ -67,7 +69,7 @@ func (e External) Build(t resource.Context, b deployment.Builder) deployment.Bui
 	}
 	if t.Settings().EnableDualStack {
 		config.IPFamilies = "IPv6, IPv4"
-		config.IPFamilyPolicy = "RequireDualStack"
+		config.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
 	}
 	return b.WithConfig(config)
 }

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -175,6 +175,7 @@ type Config struct {
 	// IPFamilyPolicy. This is optional field. Mainly is used for dual stack testing.
 	IPFamilyPolicy string
 
+	// This is an optional field used as part of dual stack testing.
 	DualStack bool
 
 	// ServiceWaypointProxy specifies if this workload should have an associated Waypoint for service-addressed traffic

--- a/pkg/test/framework/components/echo/echotest/filters.go
+++ b/pkg/test/framework/components/echo/echotest/filters.go
@@ -73,10 +73,9 @@ func (t *T) ConditionallyTo(filters ...CombinationFilter) *T {
 
 // WithDefaultFilters applies common filters that work for most tests.
 // Example:
-//   - The full set of apps is a, b, c, d, e, headless, naked, and vm (one simple pod).
-//   - Only a, d, e, headless, naked and vm are used as sources. (d and e applicable are only for dual-stack mode)
+//   - The full set of apps is a, b, c, d (dualStack), e (IPv6), headless, naked, and vm (one simple pod).
+//   - Services d and e are used only when dualStack mode is enabled as part of the tests.
 //   - Subtests are generated only for reachable destinations.
-//   - Pod a will not be in destinations, but b will (one simpe pod not in sources)
 func (t *T) WithDefaultFilters(minimumFrom, minimumTo int) *T {
 	return t.
 		From(FilterMatch(match.NotExternal)).

--- a/pkg/test/framework/components/istio/kube.go
+++ b/pkg/test/framework/components/istio/kube.go
@@ -623,8 +623,8 @@ func commonInstallArgs(ctx resource.Context, cfg Config, c cluster.Cluster, defa
 	if ctx.Settings().EnableDualStack {
 		args.AppendSet("values.pilot.env.ISTIO_DUAL_STACK", "true")
 		args.AppendSet("meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK", "true")
-		args.AppendSet("values.gateways.istio-ingressgateway.ipFamilyPolicy", "RequireDualStack")
-		args.AppendSet("values.gateways.istio-egressgateway.ipFamilyPolicy", "RequireDualStack")
+		args.AppendSet("values.gateways.istio-ingressgateway.ipFamilyPolicy", string(corev1.IPFamilyPolicyRequireDualStack))
+		args.AppendSet("values.gateways.istio-egressgateway.ipFamilyPolicy", string(corev1.IPFamilyPolicyRequireDualStack))
 	}
 
 	// Include all user-specified values.

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -20,6 +20,8 @@ package security
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -104,7 +106,7 @@ func TestReachability(t *testing.T) {
 						},
 					},
 					IPFamilies:     "IPv4, IPv6",
-					IPFamilyPolicy: "RequireDualStack",
+					IPFamilyPolicy: string(corev1.IPFamilyPolicyRequireDualStack),
 				}).BuildOrFail(t)
 			}
 


### PR DESCRIPTION
At couple of places in the integration tests, we use `RequireDualStack` or `SingleStack`. 
This PR modifies the code to use constants and also updates the API comments to match the latest tests.