### PR TITLE
V2 IP AutoAllocation Controller + Basic Ambient Support

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -41,6 +41,10 @@ rules:
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "workloadentries/status" ]
 
+  - apiGroups: ["networking.istio.io"]
+    verbs: [ "get", "watch", "list", "update", "patch" ]
+    resources: [ "serviceentries/status" ]
+
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -42,6 +42,10 @@ rules:
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "workloadentries/status" ]
 
+  - apiGroups: ["networking.istio.io"]
+    verbs: [ "get", "watch", "list", "update", "patch" ]
+    resources: [ "serviceentries/status" ]
+
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1138,7 +1138,7 @@ func (s *Server) initControllers(args *PilotArgs) error {
 		s.initNodeUntaintController(args)
 	}
 
-	if features.EnableV2IPAutoallocate {
+	if features.EnableIPAutoallocate {
 		s.initIPAutoallocateController(args)
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1138,7 +1138,9 @@ func (s *Server) initControllers(args *PilotArgs) error {
 		s.initNodeUntaintController(args)
 	}
 
-	s.initIpAutoallocateController(args)
+	if features.EnableV2IPAutoallocate {
+		s.initIPAutoallocateController(args)
+	}
 
 	if err := s.initConfigController(args); err != nil {
 		return fmt.Errorf("error initializing config controller: %v", err)
@@ -1161,10 +1163,10 @@ func (s *Server) initNodeUntaintController(args *PilotArgs) {
 	})
 }
 
-func (s *Server) initIpAutoallocateController(args *PilotArgs) {
-	s.addStartFunc("ipAutoallocat controller", func(stop <-chan struct{}) error {
+func (s *Server) initIPAutoallocateController(args *PilotArgs) {
+	s.addStartFunc("ipAutoallocate controller", func(stop <-chan struct{}) error {
 		go leaderelection.
-			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IpAutoallocateController, args.Revision, s.kubeClient).
+			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IPAutoallocateController, args.Revision, s.kubeClient).
 			AddRunFunction(func(leaderStop <-chan struct{}) {
 				ipallocate := ipallocate.NewIPAllocate(leaderStop, s.kubeClient)
 				ipallocate.Run(leaderStop)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1164,7 +1164,7 @@ func (s *Server) initNodeUntaintController(args *PilotArgs) {
 }
 
 func (s *Server) initIPAutoallocateController(args *PilotArgs) {
-	s.addStartFunc("ipAutoallocate controller", func(stop <-chan struct{}) error {
+	s.addStartFunc("ip autoallocate controller", func(stop <-chan struct{}) error {
 		go leaderelection.
 			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IPAutoallocateController, args.Revision, s.kubeClient).
 			AddRunFunction(func(leaderStop <-chan struct{}) {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1168,7 +1168,7 @@ func (s *Server) initIPAutoallocateController(args *PilotArgs) {
 		go leaderelection.
 			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IPAutoallocateController, args.Revision, s.kubeClient).
 			AddRunFunction(func(leaderStop <-chan struct{}) {
-				ipallocate := ipallocate.NewIPAllocate(leaderStop, s.kubeClient)
+				ipallocate := ipallocate.NewIPAllocator(leaderStop, s.kubeClient)
 				ipallocate.Run(leaderStop)
 			}).Run(stop)
 		return nil

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -19,7 +19,11 @@ import (
 	"fmt"
 	"net/netip"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/api/meta/v1alpha1"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	autoallocate "istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
@@ -28,9 +32,6 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	klabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var log = istiolog.RegisterScope("ip-autoallocate", "IP autoallocate controller")
@@ -74,8 +75,8 @@ func (c *IPAllocate) Run(stop <-chan struct{}) {
 	// failing to warm cache first could result in allocating IP which are already in use
 	c.warmCache()
 	// logically the v1 behavior is a state of the world function which cannot be replicated in reconcile
-	// if we wish to replicate v1 assignment behavior for existing serviceentry it should go here and must include a change to respect the used IPs from the warmed cache
-	// begin reconcile
+	// if we wish to replicate v1 assignment behavior for existing serviceentry it should go here and must
+	// include a change to respect the used IPs from the warmed cache begin reconcile
 	c.queue.Run(stop)
 	c.serviceEntryClient.ShutdownHandlers()
 }
@@ -122,7 +123,8 @@ func (c *IPAllocate) reconcile(se types.NamespacedName) error {
 		return nil
 	}
 
-	// TODO: also what do we do if we already allocated IPs in a previous reconcile but are not longer meant to or IP would not be usabled due to an update? write a condition "IP unsabled due to wildcard host or something similar"
+	// TODO: also what do we do if we already allocated IPs in a previous reconcile but are not longer meant to
+	// or IP would not be usabled due to an update? write a condition "IP unsabled due to wildcard host or something similar"
 	if !autoallocate.ShouldV2AutoAllocateIP(serviceentry) {
 		return nil // nothing to do
 	}

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -232,7 +232,7 @@ func (c *IPAllocator) resolveConflict(conflict conflictDetectedEvent) error {
 		if resolveMe == nil {
 			continue
 		}
-		log.Debugf("reassigned %s/%s due to IP Address conflict", resolveMe.Namespace, resolveMe.Name)
+		log.Warnf("reassigned %s/%s due to IP Address conflict", resolveMe.Namespace, resolveMe.Name)
 		patch, err := c.statusPatchForAddresses(resolveMe, true)
 		if err != nil {
 			errs = errors.Join(errs, err)

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -1,0 +1,278 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipallocate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"istio.io/api/meta/v1alpha1"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	kubelib "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
+	istiolog "istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var log = istiolog.RegisterScope("ipallocate", "IP autoallocate controller")
+
+type IPAllocate struct {
+	serviceEntryClient kclient.Client[*networkingclient.ServiceEntry]
+	stopChan           <-chan struct{}
+	queue              controllers.Queue
+
+	// use this mutext when access these fields
+	// TODO: is locking just a function of the ipAllocator type instead? probably should be
+	mu          sync.Mutex
+	v4allocator *ipAllocator
+	v6allocator *ipAllocator
+}
+
+const (
+	IpAutoallocateStatusType = "ip-autoallocate"
+	IpV4Prefix               = "240.240.0.0/16"
+	IpV6Prefix               = "2001:2::/48"
+)
+
+func NewIPAllocate(stop <-chan struct{}, c kubelib.Client) *IPAllocate {
+	log.Debugf("starting serviceentry ip autoallocate controller")
+	client := kclient.New[*networkingclient.ServiceEntry](c)
+	allocator := &IPAllocate{
+		serviceEntryClient: client,
+		mu:                 sync.Mutex{},
+		stopChan:           stop,
+		v4allocator:        newIpAllocator(netip.MustParsePrefix(IpV4Prefix)),
+		v6allocator:        newIpAllocator(netip.MustParsePrefix(IpV6Prefix)),
+	}
+
+	allocator.queue = controllers.NewQueue("ip autoallocate", controllers.WithReconciler(allocator.reconcile), controllers.WithMaxAttempts(5))
+	client.AddEventHandler(controllers.ObjectHandler(allocator.queue.AddObject))
+	return allocator
+}
+
+func (c *IPAllocate) Run(stop <-chan struct{}) {
+	kubelib.WaitForCacheSync("node untainer", stop, c.serviceEntryClient.HasSynced)
+	c.queue.Run(stop)
+	c.serviceEntryClient.ShutdownHandlers()
+}
+
+func (c *IPAllocate) nextAddresses() []netip.Addr {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v4address, err := c.v4allocator.AllocateNext()
+	if err != nil {
+		panic("failed to allocate v4 address")
+	}
+	v6address, err := c.v6allocator.AllocateNext()
+	if err != nil {
+		panic("failed to allocate v6 address")
+	}
+	return []netip.Addr{
+		v4address,
+		v6address,
+	}
+}
+
+func (c *IPAllocate) reconcile(se types.NamespacedName) error {
+	log.Debugf("reconciling service entry %s/%s", se.Namespace, se.Name)
+	serviceentry := c.serviceEntryClient.Get(se.Name, se.Namespace)
+	if serviceentry == nil {
+		// probably a delete so we should remove ips from our addresses most likely
+		log.Infof("deleted %s", se.String())
+		return nil
+	}
+	// check if we are supposed to assign
+	if !c.queue.HasSynced() {
+		// warming: we need to record any IPs from the status
+		log.Info("beep boop, we're not synced yet")
+		log.Info("we can still look for IPs though")
+		if len(serviceentry.Spec.Addresses) > 0 {
+			// user assiged there own
+			// TODO: we should record this just to be safe, at least if it is without our range
+			log.Infof("%s supplied its own addresses", se.String())
+
+			return nil
+		}
+
+		if serviceentry.Status.String() == "" {
+			log.Info("found no status")
+		} else {
+			log.Infof("status: %s", serviceentry.Status.String())
+			addresses := kludgeFromStatus(serviceentry.Status.GetConditions())
+			if len(addresses) > 0 {
+				c.mu.Lock()
+				defer c.mu.Unlock()
+				for _, a := range addresses {
+					if a.Is6() {
+						if c.v6allocator.MarkUsed(a) {
+							panic("collision v6")
+						}
+					} else {
+						if c.v4allocator.MarkUsed(a) {
+							panic("collision v4")
+						}
+					}
+				}
+				return nil // we found some addresses, lets go
+			}
+		}
+		return fmt.Errorf("unable to assign IPs for %s becuase controller has not synced completely", se.String())
+	}
+	log.Info("now we are synced so we could do something")
+	if len(serviceentry.Spec.Addresses) > 0 {
+		// user assiged there own
+		// TODO: we should record this just to be safe, at least if it is without our range
+		log.Infof("%s supplied its own addresses", se.String())
+
+		return nil
+	}
+	if serviceentry.Status.String() == "" {
+		log.Info("found no status")
+		serviceentry.Status = v1alpha1.IstioStatus{}
+	} else {
+		log.Infof("found a status for %s", se.String())
+		addresses := kludgeFromStatus(serviceentry.Status.GetConditions())
+		if len(addresses) > 0 {
+
+			log.Infof("found addresses %v", addresses)
+			return nil // nothing to do
+		}
+	}
+	addresses := c.nextAddresses()
+	kludge := conditionFromKludge(addresses)
+
+	serviceentry.Status.Conditions = append(serviceentry.Status.Conditions, &kludge)
+
+	_, e := c.serviceEntryClient.UpdateStatus(serviceentry)
+	if e != nil {
+		log.Errorf("darn... %s", e.Error())
+	}
+	log.Info("looks like this all worked")
+
+	return nil
+}
+
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// probably doesn't belong here
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+// ==========================================================================================================================================================
+
+type ipAllocator struct {
+	prefix netip.Prefix
+	used   sets.Set[netip.Addr]
+	next   netip.Addr
+}
+
+func newIpAllocator(p netip.Prefix) *ipAllocator {
+	n := p.Addr().Next()
+	return &ipAllocator{
+		prefix: p,
+		used:   sets.Set[netip.Addr]{},
+		next:   n,
+	}
+}
+
+func (i *ipAllocator) AllocateNext() (netip.Addr, error) {
+	n := i.next
+	var looped bool
+	if !n.IsValid() || !i.prefix.Contains(n) {
+		// unlucky inital looping, start over
+		looped = true
+		n = i.prefix.Addr().Next() // take the net address of the prefix and select next, this should be the first usable
+	}
+
+	for i.IsUsed(n) {
+		n = n.Next()
+		if !n.IsValid() || !i.prefix.Contains(n) {
+			if looped {
+				// prefix is exhausted
+				return netip.Addr{}, fmt.Errorf("%s is exhausted", i.prefix.String())
+			}
+			looped = true
+			n = i.prefix.Addr().Next() // take the net address of the prefix and select next, this should be the first usable
+		}
+	}
+	i.MarkUsed(n)
+
+	i.next = n.Next()
+
+	return n, nil
+}
+
+func (i ipAllocator) IsUsed(n netip.Addr) bool {
+	return i.used.Contains(n)
+}
+
+// MarkUsed will store the provided addr as used in this ipAllocator
+// MarkUsed return true if the addr was already used and false if it was a new insert
+func (i ipAllocator) MarkUsed(n netip.Addr) bool {
+	inUse := i.IsUsed(n)
+	if inUse {
+		return true
+	}
+	i.used.Insert(n)
+	return false
+}
+
+type ServiceEntryStatusKludge struct {
+	Addresses []string // json:"addresses"
+}
+
+func kludgeFromStatus(conditions []*v1alpha1.IstioCondition) []netip.Addr {
+	result := []netip.Addr{}
+	for _, c := range conditions {
+		if c == nil {
+			continue
+		}
+		if c.Type != IpAutoallocateStatusType {
+			continue
+		}
+		jsonAddresses := c.Message
+		kludge := ServiceEntryStatusKludge{}
+		json.Unmarshal([]byte(jsonAddresses), &kludge)
+		for _, address := range kludge.Addresses {
+			result = append(result, netip.MustParseAddr(address))
+		}
+	}
+	return result
+}
+
+func conditionFromKludge(input []netip.Addr) v1alpha1.IstioCondition {
+	addresses := []string{}
+	for _, addr := range input {
+		addresses = append(addresses, addr.String())
+	}
+	kludge := ServiceEntryStatusKludge{
+		Addresses: addresses,
+	}
+	result, _ := json.Marshal(kludge)
+	return v1alpha1.IstioCondition{
+		Type:    IpAutoallocateStatusType,
+		Status:  "true",
+		Reason:  "AutoAllocatedAddress",
+		Message: string(result),
+	}
+}

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -94,7 +94,7 @@ func (c *IPAllocate) Run(stop <-chan struct{}) {
 	kubelib.WaitForCacheSync(controllerName, stop, c.serviceEntryClient.HasSynced)
 	// it is important that we always warm cache before we try to run the queue
 	// failing to warm cache first could result in allocating IP which are already in use
-	c.warmCache()
+	c.populateControllerDatastructures()
 	// logically the v1 behavior is a state of the world function which cannot be replicated in reconcile
 	// if we wish to replicate v1 assignment behavior for existing serviceentry it should go here and must
 	// include a change to respect the used IPs from the warmed cache begin reconcile
@@ -102,8 +102,8 @@ func (c *IPAllocate) Run(stop <-chan struct{}) {
 	c.serviceEntryClient.ShutdownHandlers()
 }
 
-// warmCache reads all serviceentries and records any auto-assigned addresses as in use
-func (c *IPAllocate) warmCache() {
+// populateControllerDatastructures reads all serviceentries and records any addresses in our ranges as in use
+func (c *IPAllocate) populateControllerDatastructures() {
 	serviceentries := c.serviceEntryClient.List(metav1.NamespaceAll, klabels.Everything())
 	count := 0
 	for _, serviceentry := range serviceentries {

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -49,8 +49,8 @@ type IPAllocate struct {
 const (
 	controllerName = "IP Autoallocate"
 	// these are the ranges of the v1 logic, do we need to choose new ranges?
-	IpV4Prefix = "240.240.0.0/16"
-	IpV6Prefix = "2001:2::/48"
+	IPV4Prefix = "240.240.0.0/16"
+	IPV6Prefix = "2001:2::/48"
 )
 
 func NewIPAllocate(stop <-chan struct{}, c kubelib.Client) *IPAllocate {
@@ -59,8 +59,8 @@ func NewIPAllocate(stop <-chan struct{}, c kubelib.Client) *IPAllocate {
 		serviceEntryClient: client,
 		stopChan:           stop,
 		// MustParsePrefix is OK because these are const. If we allow user configuration we must not use this function.
-		v4allocator: newIpAllocator(netip.MustParsePrefix(IpV4Prefix)),
-		v6allocator: newIpAllocator(netip.MustParsePrefix(IpV6Prefix)),
+		v4allocator: newIPAllocator(netip.MustParsePrefix(IPV4Prefix)),
+		v6allocator: newIPAllocator(netip.MustParsePrefix(IPV6Prefix)),
 	}
 	allocator.queue = controllers.NewQueue(controllerName, controllers.WithReconciler(allocator.reconcile), controllers.WithMaxAttempts(5))
 	client.AddEventHandler(controllers.ObjectHandler(allocator.queue.AddObject))
@@ -214,7 +214,7 @@ type ipAllocator struct {
 	next   netip.Addr
 }
 
-func newIpAllocator(p netip.Prefix) *ipAllocator {
+func newIPAllocator(p netip.Prefix) *ipAllocator {
 	n := p.Addr().Next()
 	return &ipAllocator{
 		prefix: p,
@@ -227,7 +227,7 @@ func (i *ipAllocator) AllocateNext() (netip.Addr, error) {
 	n := i.next
 	var looped bool
 	if !n.IsValid() || !i.prefix.Contains(n) {
-		// unlucky inital looping, start over
+		// unlucky initial looping, start over
 		looped = true
 		n = i.prefix.Addr().Next() // take the net address of the prefix and select next, this should be the first usable
 	}

--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -20,7 +20,6 @@ import (
 	"net/netip"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	// "gomodules.xyz/jsonpatch/v2"
 	"istio.io/api/meta/v1alpha1"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	kubelib "istio.io/istio/pkg/kube"
@@ -160,23 +159,14 @@ func (c *IPAllocate) reconcile(se types.NamespacedName) error {
 	if err != nil {
 		panic("failed to marshal modified service entry")
 	}
-	// TODO: patch don't update so we don't accidentally remove status written by another controller during our reconcile
-	// _, e := c.serviceEntryClient.UpdateStatus(serviceentry)
 	patch, err := jsonpatch.CreateMergePatch(orig, modified)
-	// patch, err := jsonpatch.CreatePatch(orig, modified)
 	if err != nil {
 		panic("failed to create merge patch")
 	}
-	// patchjson, err := patch[0].MarshalJSON()
-	// if err != nil {
-	// 	panic("failed to marshal patch")
-	// }
-	log.Infof("patch: %v", string(patch))
-	result, e := c.serviceEntryClient.Patch(se.Name, se.Namespace, types.MergePatchType, patch)
+	_, e := c.serviceEntryClient.PatchStatus(se.Name, se.Namespace, types.MergePatchType, patch)
 	if e != nil {
 		log.Errorf("darn... %s", e.Error())
 	}
-	log.Infof("patching result: %v", result.Status)
 
 	return nil
 }

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -1,0 +1,238 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipallocate
+
+// import (
+// 	"testing"
+// 	"time"
+
+// 	corev1 "k8s.io/api/core/v1"
+// 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// 	"istio.io/istio/pilot/pkg/features"
+// 	kubelib "istio.io/istio/pkg/kube"
+// 	"istio.io/istio/pkg/kube/kclient/clienttest"
+// 	istiolog "istio.io/istio/pkg/log"
+// 	"istio.io/istio/pkg/test"
+// 	"istio.io/istio/pkg/test/util/assert"
+// 	"istio.io/istio/pkg/test/util/retry"
+// )
+
+// const systemNS = "istio-system"
+
+// var cniPodLabels = map[string]string{
+// 	"k8s-app":    "istio-cni-node",
+// 	"some-other": "label",
+// }
+
+// type nodeTainterTestServer struct {
+// 	client kubelib.Client
+// 	pc     clienttest.TestClient[*corev1.Pod]
+// 	nc     clienttest.TestClient[*corev1.Node]
+// 	t      *testing.T
+// }
+
+// func setupLogging() {
+// 	opts := istiolog.DefaultOptions()
+// 	opts.SetDefaultOutputLevel(istiolog.OverrideScopeName, istiolog.DebugLevel)
+// 	istiolog.Configure(opts)
+// 	for _, scope := range istiolog.Scopes() {
+// 		scope.SetOutputLevel(istiolog.DebugLevel)
+// 	}
+// }
+
+// func newNodeUntainterTestServer(t *testing.T) *nodeTainterTestServer {
+// 	stop := make(chan struct{})
+// 	t.Cleanup(func() { close(stop) })
+// 	client := kubelib.NewFakeClient()
+
+// 	nodeUntainter := NewNodeUntainter(stop, client, systemNS, systemNS)
+// 	go nodeUntainter.Run(stop)
+// 	client.RunAndWait(stop)
+// 	kubelib.WaitForCacheSync("test", stop, nodeUntainter.HasSynced)
+
+// 	pc := clienttest.Wrap(t, nodeUntainter.podsClient)
+// 	nc := clienttest.Wrap(t, nodeUntainter.nodesClient)
+
+// 	return &nodeTainterTestServer{
+// 		client: client,
+// 		t:      t,
+// 		pc:     pc,
+// 		nc:     nc,
+// 	}
+// }
+
+// func TestNodeUntainter(t *testing.T) {
+// 	setupLogging()
+// 	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+// 	s := newNodeUntainterTestServer(t)
+// 	s.addTaintedNodes(t, "node1", "node2", "node3")
+// 	s.addPod(t, "node3", true, map[string]string{"k8s-app": "other-app"}, "")
+// 	s.addCniPod(t, "node2", false)
+// 	s.addCniPod(t, "node1", true)
+// 	s.assertNodeUntainted(t, "node1")
+// 	s.assertNodeTainted(t, "node2")
+// 	s.assertNodeTainted(t, "node3")
+// }
+
+// func TestNodeUntainterOnlyUntaintsWhenIstiocniInourNs(t *testing.T) {
+// 	test.SetForTest(t, &features.EnableNodeUntaintControllers, true)
+// 	s := newNodeUntainterTestServer(t)
+// 	s.addTaintedNodes(t, "node1", "node2")
+// 	s.addPod(t, "node2", true, cniPodLabels, "default")
+// 	s.addCniPod(t, "node1", true)
+
+// 	// wait for the untainter to run
+// 	s.assertNodeUntainted(t, "node1")
+// 	s.assertNodeTainted(t, "node2")
+// }
+
+// func (s *nodeTainterTestServer) assertNodeTainted(t *testing.T, node string) {
+// 	t.Helper()
+// 	assert.Equal(t, s.isNodeUntainted(node), false)
+// }
+
+// func (s *nodeTainterTestServer) assertNodeUntainted(t *testing.T, node string) {
+// 	t.Helper()
+// 	assert.EventuallyEqual(t, func() bool {
+// 		return s.isNodeUntainted(node)
+// 	}, true, retry.Timeout(time.Second*3))
+// }
+
+// func (s *nodeTainterTestServer) isNodeUntainted(node string) bool {
+// 	n := s.nc.Get(node, "")
+// 	if n == nil {
+// 		return false
+// 	}
+// 	for _, t := range n.Spec.Taints {
+// 		if t.Key == TaintName {
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
+
+// func (s *nodeTainterTestServer) addTaintedNodes(t *testing.T, nodes ...string) {
+// 	t.Helper()
+// 	for _, node := range nodes {
+// 		node := generateNode(node, nil)
+// 		// add our special taint
+// 		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+// 			Key:    TaintName,
+// 			Value:  "true",
+// 			Effect: corev1.TaintEffectNoSchedule,
+// 		})
+// 		s.nc.Create(node)
+// 	}
+// }
+
+// func (s *nodeTainterTestServer) addCniPod(t *testing.T, node string, markReady bool) {
+// 	s.addPod(t, node, markReady, cniPodLabels, systemNS)
+// }
+
+// func (s *nodeTainterTestServer) addPod(t *testing.T, node string, markReady bool, labels map[string]string, ns string) {
+// 	t.Helper()
+// 	ip := "1.2.3.4"
+// 	name := "istio-cni-" + node
+// 	if ns == "" {
+// 		ns = systemNS
+// 	}
+// 	pod := generatePod(ip, name, ns, "sa", node, labels, nil)
+
+// 	p := s.pc.Get(name, pod.Namespace)
+// 	if p == nil {
+// 		// Apiserver doesn't allow Create to modify the pod status; in real world it's a 2 part process
+// 		pod.Status = corev1.PodStatus{}
+// 		newPod := s.pc.Create(pod)
+// 		if markReady {
+// 			setPodReady(newPod)
+// 		}
+// 		newPod.Status.PodIP = ip
+// 		newPod.Status.Phase = corev1.PodRunning
+// 		newPod.Status.PodIPs = []corev1.PodIP{
+// 			{
+// 				IP: ip,
+// 			},
+// 		}
+// 		s.pc.UpdateStatus(newPod)
+// 	} else {
+// 		s.pc.Update(pod)
+// 	}
+// }
+
+// func generateNode(name string, labels map[string]string) *corev1.Node {
+// 	return &corev1.Node{
+// 		TypeMeta: metav1.TypeMeta{
+// 			Kind:       "Node",
+// 			APIVersion: "v1",
+// 		},
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:   name,
+// 			Labels: labels,
+// 		},
+// 	}
+// }
+
+// func generatePod(ip, name, namespace, saName, node string, labels map[string]string, annotations map[string]string) *corev1.Pod {
+// 	automount := false
+// 	return &corev1.Pod{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:        name,
+// 			Labels:      labels,
+// 			Annotations: annotations,
+// 			Namespace:   namespace,
+// 		},
+// 		Spec: corev1.PodSpec{
+// 			ServiceAccountName:           saName,
+// 			NodeName:                     node,
+// 			AutomountServiceAccountToken: &automount,
+// 			// Validation requires this
+// 			Containers: []corev1.Container{
+// 				{
+// 					Name:  "test",
+// 					Image: "ununtu",
+// 				},
+// 			},
+// 		},
+// 		// The cache controller uses this as key, required by our impl.
+// 		Status: corev1.PodStatus{
+// 			Conditions: []corev1.PodCondition{
+// 				{
+// 					Type:               corev1.PodReady,
+// 					Status:             corev1.ConditionTrue,
+// 					LastTransitionTime: metav1.Now(),
+// 				},
+// 			},
+// 			PodIP:  ip,
+// 			HostIP: ip,
+// 			PodIPs: []corev1.PodIP{
+// 				{
+// 					IP: ip,
+// 				},
+// 			},
+// 			Phase: corev1.PodRunning,
+// 		},
+// 	}
+// }
+
+// func setPodReady(pod *corev1.Pod) {
+// 	pod.Status.Conditions = []corev1.PodCondition{
+// 		{
+// 			Type:               corev1.PodReady,
+// 			Status:             corev1.ConditionTrue,
+// 			LastTransitionTime: metav1.Now(),
+// 		},
+// 	}
+// }

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -96,6 +96,7 @@ func TestIPAllocate(t *testing.T) {
 				Addresses: []string{
 					"1.2.3.4",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 		},
 	)
@@ -112,6 +113,7 @@ func TestIPAllocate(t *testing.T) {
 				Addresses: []string{
 					"1:2::3::4",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 		},
 	)
@@ -128,6 +130,7 @@ func TestIPAllocate(t *testing.T) {
 				Hosts: []string{
 					"nope.boop.testing.io",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 		},
 	)
@@ -142,6 +145,7 @@ func TestIPAllocate(t *testing.T) {
 				Hosts: []string{
 					"beep.boop.testing.io",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 			Status: v1alpha1.IstioStatus{
 				Conditions: []*v1alpha1.IstioCondition{
@@ -201,6 +205,7 @@ func TestIPAllocate(t *testing.T) {
 				Addresses: []string{
 					addr[0].String(),
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 		},
 	)
@@ -225,6 +230,7 @@ func TestIPAllocate(t *testing.T) {
 				Hosts: []string{
 					"status-conflict.boop.testing.io",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 			Status: v1alpha1.IstioStatus{
 				Conditions: []*v1alpha1.IstioCondition{

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -30,15 +32,7 @@ import (
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// const systemNS = "istio-system"
-
-// var cniPodLabels = map[string]string{
-// 	"k8s-app":    "istio-cni-node",
-// 	"some-other": "label",
-// }
 
 type ipAllocateTestRig struct {
 	client kubelib.Client
@@ -49,7 +43,6 @@ type ipAllocateTestRig struct {
 
 func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocate, ipAllocateTestRig) {
 	t.Helper()
-	// t.Setenv("PILOT_ENABLE_V2_IP_AUTOALLOCATE", "true")
 	features.EnableV2IPAutoallocate = true
 	s := make(chan struct{})
 	t.Cleanup(func() { close(s) })

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -88,6 +88,9 @@ func TestIPAllocate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "with-v4-address",
 				Namespace: "boop",
+				Labels: map[string]string{
+					constants.EnableV2AutoAllocationLabel: "true",
+				},
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{
@@ -105,6 +108,9 @@ func TestIPAllocate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "with-v6-address",
 				Namespace: "boop",
+				Labels: map[string]string{
+					constants.EnableV2AutoAllocationLabel: "true",
+				},
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{
@@ -122,9 +128,6 @@ func TestIPAllocate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "opt-out",
 				Namespace: "boop",
-				Labels: map[string]string{
-					constants.DisableV2AutoAllocationLabel: "true",
-				},
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{
@@ -140,6 +143,9 @@ func TestIPAllocate(t *testing.T) {
 				Name:              "beep",
 				Namespace:         "boop",
 				CreationTimestamp: metav1.Now(),
+				Labels: map[string]string{
+					constants.EnableV2AutoAllocationLabel: "true",
+				},
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{
@@ -196,6 +202,9 @@ func TestIPAllocate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "user-assigned conflict",
 				Namespace: "boop",
+				Labels: map[string]string{
+					constants.EnableV2AutoAllocationLabel: "true",
+				},
 			},
 
 			Spec: v1alpha3.ServiceEntry{
@@ -225,6 +234,9 @@ func TestIPAllocate(t *testing.T) {
 				Name:              "status-conflict",
 				Namespace:         "boop",
 				CreationTimestamp: metav1.Now(),
+				Labels: map[string]string{
+					constants.EnableV2AutoAllocationLabel: "true",
+				},
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -41,7 +41,7 @@ type ipAllocateTestRig struct {
 	t      *testing.T
 }
 
-func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocate, ipAllocateTestRig) {
+func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocator, ipAllocateTestRig) {
 	t.Helper()
 	features.EnableV2IPAutoallocate = true
 	s := make(chan struct{})
@@ -49,7 +49,7 @@ func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocate, ipAllocateTestRi
 	c := kubelib.NewFakeClient()
 
 	se := clienttest.NewDirectClient[*networkingv1alpha3.ServiceEntry, networkingv1alpha3.ServiceEntry, *networkingv1alpha3.ServiceEntryList](t, c)
-	ipController := ipallocate.NewIPAllocate(s, c)
+	ipController := ipallocate.NewIPAllocator(s, c)
 	// these would normally be the first addresses consumed, we should check that warming works by asserting that we get their nexts when we reconcile
 	v4 := netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next()
 	v6 := netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next()

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -212,7 +212,8 @@ func TestIPAllocate(t *testing.T) {
 
 	// let's generate an even worse conflict now
 	// this is almost certainly caused by some bug in, none the less test we can recover
-	status := rig.se.Get("beep", "boop").Status
+	conflictingAddresses := autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("beep", "boop"))
+	conflictingCondition := autoallocate.ConditionKludge(conflictingAddresses)
 	rig.se.Create(
 		&networkingv1alpha3.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
@@ -225,7 +226,11 @@ func TestIPAllocate(t *testing.T) {
 					"status-conflict.boop.testing.io",
 				},
 			},
-			Status: status,
+			Status: v1alpha1.IstioStatus{
+				Conditions: []*v1alpha1.IstioCondition{
+					&conflictingCondition,
+				},
+			},
 		},
 	)
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -135,8 +135,8 @@ var (
 		false,
 		"If enabled, controller that untaints nodes with cni pods ready will run. This should be enabled if you disabled ambient init containers.").Get()
 
-	EnableV2IPAutoallocate = env.Register(
-		"PILOT_ENABLE_V2_IP_AUTOALLOCATE",
+	EnableIPAutoallocate = env.Register(
+		"PILOT_ENABLE_IP_AUTOALLOCATE",
 		false,
 		"If enabled, pilot will start a controller that assigns IP addresses to ServiceEntry which do not have a user-supplied IP. "+
 			"This, when combined with DNS capture allows for tcp routing of traffic sent to the ServiceEntry.").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -135,6 +135,12 @@ var (
 		false,
 		"If enabled, controller that untaints nodes with cni pods ready will run. This should be enabled if you disabled ambient init containers.").Get()
 
+	EnableV2IPAutoallocate = env.Register(
+		"PILOT_ENABLE_V2_IP_AUTOALLOCATE",
+		false,
+		"If enabled, pilot will start a controller that assigns IP addresses to ServiceEntry which do not have a user-supplied IP. "+
+			"This, when combined with DNS capture allows for tcp routing of traffic sent to the ServiceEntry.").Get()
+
 	// EnableUnsafeAssertions enables runtime checks to test assertions in our code. This should never be enabled in
 	// production; when assertions fail Istio will panic.
 	EnableUnsafeAssertions = env.Register(

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -55,7 +55,7 @@ const (
 	// * Other types use "prioritized leader election", which isn't implemented for Lease
 	GatewayDeploymentController = "istio-gateway-deployment"
 	NodeUntaintController       = "istio-node-untaint"
-	IpAutoallocateController    = "istio-ip-autoallocate"
+	IPAutoallocateController    = "istio-ip-autoallocate"
 )
 
 // Leader election key prefix for remote istiod managed clusters

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -55,6 +55,7 @@ const (
 	// * Other types use "prioritized leader election", which isn't implemented for Lease
 	GatewayDeploymentController = "istio-gateway-deployment"
 	NodeUntaintController       = "istio-node-untaint"
+	IpAutoallocateController    = "istio-ip-autoallocate"
 )
 
 // Leader election key prefix for remote istiod managed clusters

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -21,6 +21,7 @@ import (
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -109,6 +110,11 @@ func (a *index) constructServiceEntries(svc *networkingclient.ServiceEntry, w *W
 	if err != nil {
 		// TODO: perhaps we should support CIDR in the future?
 		return nil
+	}
+	if serviceentry.ShouldV2AutoAllocateIP(svc) {
+		for _, ipaddr := range serviceentry.GetV2AddressesFromServiceEntry(svc) {
+			addresses = append(addresses, a.toNetworkAddressFromIP(ipaddr))
+		}
 	}
 	ports := make([]*workloadapi.Port, 0, len(svc.Spec.Ports))
 	for _, p := range svc.Spec.Ports {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -18,6 +18,7 @@ package ambient
 import (
 	v1 "k8s.io/api/core/v1"
 
+	"istio.io/api/networking/v1alpha3"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
@@ -140,9 +141,10 @@ func (a *index) constructServiceEntries(svc *networkingclient.ServiceEntry, w *W
 	// TODO this is only checking one controller - we may be missing service vips for instances in another cluster
 	res := make([]*workloadapi.Service, 0, len(svc.Spec.Hosts))
 	for _, h := range svc.Spec.Hosts {
-		// if we have no user-provided addresses and h is not wildcarded we can try to use autoassigned addresses
+		// if we have no user-provided addresses and h is not wildcarded and we have a supported resolution
+		// we can try to use autoassigned addresses
 		a := addresses
-		if len(a) == 0 && !host.Name(h).IsWildCarded() {
+		if len(a) == 0 && !host.Name(h).IsWildCarded() && svc.Spec.Resolution != v1alpha3.ServiceEntry_NONE {
 			a = autoassignedAddresses
 		}
 		res = append(res, &workloadapi.Service{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -352,7 +352,6 @@ func TestServiceEntryServices(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Setenv("PILOT_ENABLE_IP_AUTOALLOCATE", "true")
 			features.EnableIPAutoallocate = true
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest()

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -24,7 +24,9 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	"istio.io/istio/pkg/ptr"
@@ -90,9 +92,268 @@ func TestServiceEntryServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "Uses auto-assigned addresses",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auto-assigned",
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnableV2AutoAllocationLabel: "true",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{"assign-me.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_DNS,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Value: "240.240.0.1",
+						},
+						{
+							Value: "2001:2::1",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "auto-assigned",
+					Namespace: "ns",
+					Hostname:  "assign-me.example.com",
+					Addresses: []*workloadapi.NetworkAddress{
+						{
+							Network: testNW,
+							Address: netip.AddrFrom4([4]byte{240, 240, 0, 1}).AsSlice(),
+						},
+						{
+							Network: testNW,
+							Address: netip.MustParseAddr("2001:2::1").AsSlice(),
+						},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
+		{
+			name:   "Does not use auto-assigned addresses user provided address",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-provided",
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnableV2AutoAllocationLabel: "true",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Addresses: []string{"1.2.3.4"},
+					Hosts:     []string{"user-provided.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_DNS,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Value: "240.240.0.1",
+						},
+						{
+							Value: "2001:2::1",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "user-provided",
+					Namespace: "ns",
+					Hostname:  "user-provided.example.com",
+					Addresses: []*workloadapi.NetworkAddress{
+						{
+							Network: testNW,
+							Address: netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice(),
+						},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
+		{
+			name:   "Does not use auto-assigned addresses none resolution",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "none-resolution",
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnableV2AutoAllocationLabel: "true",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{"none-resolution.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_NONE,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Value: "240.240.0.1",
+						},
+						{
+							Value: "2001:2::1",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "none-resolution",
+					Namespace: "ns",
+					Hostname:  "none-resolution.example.com",
+					Addresses: []*workloadapi.NetworkAddress{},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
+		{
+			name:   "Does not use auto-assigned addresses user opted out",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-opt-out",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{"user-opt-out.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_DNS,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Value: "240.240.0.1",
+						},
+						{
+							Value: "2001:2::1",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "user-opt-out",
+					Namespace: "ns",
+					Hostname:  "user-opt-out.example.com",
+					Addresses: []*workloadapi.NetworkAddress{},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
+		{
+			name:   "Does not use auto-assigned addresses for wildcard host",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "partial-wildcard",
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnableV2AutoAllocationLabel: "true",
+					},
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{"*.wildcard.example.com", "this-is-ok.example.com"},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_DNS,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Value: "240.240.0.1",
+						},
+						{
+							Value: "2001:2::1",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "partial-wildcard",
+					Namespace: "ns",
+					Hostname:  "*.wildcard.example.com",
+					Addresses: []*workloadapi.NetworkAddress{},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+				{
+					Name:      "partial-wildcard",
+					Namespace: "ns",
+					Hostname:  "this-is-ok.example.com",
+					Addresses: []*workloadapi.NetworkAddress{
+						{
+							Network: testNW,
+							Address: netip.AddrFrom4([4]byte{240, 240, 0, 1}).AsSlice(),
+						},
+						{
+							Network: testNW,
+							Address: netip.MustParseAddr("2001:2::1").AsSlice(),
+						},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv("PILOT_ENABLE_IP_AUTOALLOCATE", "true")
+			features.EnableIPAutoallocate = true
 			mock := krttest.NewMock(t, tt.inputs)
 			a := newAmbientUnitTest()
 			builder := a.serviceEntryServiceBuilder(

--- a/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
@@ -51,10 +51,9 @@ func ShouldV2AutoAllocateIP(se *networkingv1alpha3.ServiceEntry) bool {
 		return false
 	}
 
-	// check for opt-out by user
-	// TODO: namespace opt-out?
-	disabledValue, disabledFound := se.Labels[constants.DisableV2AutoAllocationLabel]
-	if disabledFound && disabledValue == "true" {
+	// check for opt-in by user
+	enabledValue, enabledFound := se.Labels[constants.EnableV2AutoAllocationLabel]
+	if !enabledFound || enabledValue == "false" {
 		return false
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
@@ -1,0 +1,88 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceentry
+
+import (
+	"encoding/json"
+	"net/netip"
+
+	"istio.io/api/meta/v1alpha1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+)
+
+const (
+	IpAutoallocateStatusType = "ip-autoallocate"
+)
+
+func GetV2AddressesFromServiceEntry(se *networkingv1alpha3.ServiceEntry) []netip.Addr {
+	if se == nil {
+		return []netip.Addr{}
+	}
+	return kludgeFromStatus(se.Status.GetConditions())
+}
+
+// TODO: impl this
+func ShouldV2AutoAllocateIP(se *networkingv1alpha3.ServiceEntry) bool {
+	if se == nil {
+		return false
+	}
+	if len(se.Spec.Addresses) > 0 {
+		// user assiged
+		// TODO: we should record this just to be safe, at least if it is without our range
+		log.Infof("%s/%s supplied its own addresses", se.Namespace, se.Name)
+		return false
+	}
+	return true
+}
+
+type ServiceEntryStatusKludge struct {
+	Addresses []string // json:"addresses"
+}
+
+func kludgeFromStatus(conditions []*v1alpha1.IstioCondition) []netip.Addr {
+	result := []netip.Addr{}
+	for _, c := range conditions {
+		if c == nil {
+			continue
+		}
+		if c.Type != IpAutoallocateStatusType {
+			continue
+		}
+		jsonAddresses := c.Message
+		kludge := ServiceEntryStatusKludge{}
+		json.Unmarshal([]byte(jsonAddresses), &kludge)
+		for _, address := range kludge.Addresses {
+			result = append(result, netip.MustParseAddr(address))
+		}
+	}
+	return result
+}
+
+func ConditionKludge(input []netip.Addr) v1alpha1.IstioCondition {
+	addresses := []string{}
+	for _, addr := range input {
+		addresses = append(addresses, addr.String())
+	}
+	kludge := ServiceEntryStatusKludge{
+		Addresses: addresses,
+	}
+	result, _ := json.Marshal(kludge)
+	return v1alpha1.IstioCondition{
+		Type:    IpAutoallocateStatusType,
+		Status:  "true",
+		Reason:  "AutoAllocatedAddress",
+		Message: string(result),
+	}
+}

--- a/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
@@ -75,7 +75,10 @@ func kludgeFromStatus(conditions []*v1alpha1.IstioCondition) []netip.Addr {
 		}
 		jsonAddresses := c.Message
 		kludge := ServiceEntryStatusKludge{}
-		json.Unmarshal([]byte(jsonAddresses), &kludge)
+		err := json.Unmarshal([]byte(jsonAddresses), &kludge)
+		if err != nil {
+			continue
+		}
 		for _, address := range kludge.Addresses {
 			result = append(result, netip.MustParseAddr(address))
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
@@ -45,7 +45,7 @@ func GetV2AddressesFromServiceEntry(se *networkingv1alpha3.ServiceEntry) []netip
 
 func ShouldV2AutoAllocateIP(se *networkingv1alpha3.ServiceEntry) bool {
 	// if the feature is off we should not assign/use addresses
-	if !features.EnableV2IPAutoallocate {
+	if !features.EnableIPAutoallocate {
 		return false
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
+++ b/pilot/pkg/serviceregistry/serviceentry/ip_autoallocation.go
@@ -19,6 +19,7 @@ import (
 	"net/netip"
 
 	"istio.io/api/meta/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/constants"
@@ -40,7 +41,13 @@ func ShouldV2AutoAllocateIP(se *networkingv1alpha3.ServiceEntry) bool {
 	if !features.EnableV2IPAutoallocate {
 		return false
 	}
+
 	if se == nil {
+		return false
+	}
+
+	// if resolution is none we cannot honor the assigned IP in the dataplane and should not assign
+	if se.Spec.Resolution == v1alpha3.ServiceEntry_NONE {
 		return false
 	}
 
@@ -48,7 +55,6 @@ func ShouldV2AutoAllocateIP(se *networkingv1alpha3.ServiceEntry) bool {
 	// TODO: namespace opt-out?
 	disabledValue, disabledFound := se.Labels[constants.DisableV2AutoAllocationLabel]
 	if disabledFound && disabledValue == "true" {
-		// user did not opt in
 		return false
 	}
 

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -207,5 +207,5 @@ const (
 	// NoTraffic indicates that no traffic should go through the intended waypoint.
 	NoTraffic = "none"
 
-	DisableV2AutoAllocationLabel = "networking.istio.io/disable-autoallocate-ip"
+	EnableV2AutoAllocationLabel = "networking.istio.io/enable-autoallocate-ip"
 )

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -206,4 +206,6 @@ const (
 	AllTraffic = "all"
 	// NoTraffic indicates that no traffic should go through the intended waypoint.
 	NoTraffic = "none"
+
+	DisableV2AutoAllocationLabel = "networking.istio.io/disable-autoallocate-ip"
 )

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -142,6 +142,11 @@ func (n *writeClient[T]) Patch(name, namespace string, pt apitypes.PatchType, da
 	return api.Patch(context.Background(), name, pt, data, metav1.PatchOptions{})
 }
 
+func (n *writeClient[T]) PatchStatus(name, namespace string, pt apitypes.PatchType, data []byte) (T, error) {
+	api := kubeclient.GetWriteClient[T](n.client, namespace)
+	return api.Patch(context.Background(), name, pt, data, metav1.PatchOptions{}, "status")
+}
+
 func (n *writeClient[T]) UpdateStatus(object T) (T, error) {
 	api, ok := kubeclient.GetWriteClient[T](n.client, object.GetNamespace()).(kubetypes.WriteStatusAPI[T])
 	if !ok {

--- a/pkg/kube/kclient/interfaces.go
+++ b/pkg/kube/kclient/interfaces.go
@@ -75,6 +75,7 @@ type Writer[T controllers.Object] interface {
 	UpdateStatus(object T) (T, error)
 	// Patch patches the resource, returning the newly applied resource.
 	Patch(name, namespace string, pt apitypes.PatchType, data []byte) (T, error)
+	PatchStatus(name, namespace string, pt apitypes.PatchType, data []byte) (T, error)
 	// Delete removes a resource.
 	Delete(name, namespace string) error
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
- Adds a new controller which automatically allocates IP Addresses to ServiceEntry and persists these addresses in Status to provide stability of assignment, allow for ambient controllers to consume the assignments and improve debugging for users by exposing this assignment. Controller is feature-gated at present.
- Adds logic in the ambient controllers to consume auto assigned IP addresses when processing ServiceEntry with similar logic to the v1 method

WIP:
- includes a kludge to write addresses as a condition while https://github.com/istio/api/pull/3244 is being resolved
- includes some panic for unhappy paths that must be handled gracefully
- testing is sparse

**Reviewer Note**
I did my best to isolate the kludge of using conditions as much as possible. I would recommend you more or less ignore this kludge while reviewing.