### PR TITLE
Multi-cluster analyzer support for clusters with same ID in secrets/kubeconfig

### DIFF
--- a/pkg/config/analysis/analyzer_test.go
+++ b/pkg/config/analysis/analyzer_test.go
@@ -47,12 +47,17 @@ func (a *analyzer) Analyze(Context) {
 
 type context struct{}
 
-func (ctx *context) Report(config.GroupVersionKind, diag.Message)                       {}
-func (ctx *context) Find(config.GroupVersionKind, resource.FullName) *resource.Instance { return nil }
-func (ctx *context) Exists(config.GroupVersionKind, resource.FullName) bool             { return false }
-func (ctx *context) ForEach(config.GroupVersionKind, IteratorFn)                        {}
-func (ctx *context) Canceled() bool                                                     { return false }
-func (ctx *context) SetAnalyzer(_ string)                                               {}
+func (ctx *context) Report(config.GroupVersionKind, diag.Message) {}
+func (ctx *context) Find(config.GroupVersionKind, resource.FullName, resource.UID) *resource.Instance {
+	return nil
+}
+
+func (ctx *context) Exists(config.GroupVersionKind, resource.FullName, resource.UID) bool {
+	return false
+}
+func (ctx *context) ForEach(config.GroupVersionKind, IteratorFn) {}
+func (ctx *context) Canceled() bool                              { return false }
+func (ctx *context) SetAnalyzer(_ string)                        {}
 
 func TestCombinedAnalyzer(t *testing.T) {
 	g := NewWithT(t)

--- a/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/analysis/local"
@@ -94,8 +93,12 @@ func benchmarkAnalyzersArtificialBlankData(count int, b *testing.B) {
 
 		return false
 	})
-	stores := map[cluster.ID]model.ConfigStore{
-		"fake": store,
+
+	stores := []*local.ClusterStore{
+		{
+			ClusterID:   cluster.ID("fake"),
+			ConfigStore: store,
+		},
 	}
 	ctx := local.NewContext(stores, make(chan struct{}), func(name config.GroupVersionKind) {})
 

--- a/pkg/config/analysis/analyzers/gateway/certificate.go
+++ b/pkg/config/analysis/analyzers/gateway/certificate.go
@@ -58,7 +58,7 @@ func (gateway *CertificateAnalyzer) analyzeDuplicateCertificate(currentResource 
 			continue
 		}
 
-		gatewayInstance := context.Find(gvk.Gateway, gatewayFullName)
+		gatewayInstance := context.Find(gvk.Gateway, gatewayFullName, currentResource.Metadata.UID)
 		gateway := gatewayInstance.Message.(*v1alpha3.Gateway)
 		for _, currentServer := range currentGateway.Servers {
 			for _, server := range gateway.Servers {

--- a/pkg/config/analysis/analyzers/gateway/secret.go
+++ b/pkg/config/analysis/analyzers/gateway/secret.go
@@ -82,7 +82,7 @@ func (a *SecretAnalyzer) Analyze(ctx analysis.Context) {
 				continue
 			}
 
-			secret := ctx.Find(gvk.Secret, resource.NewShortOrFullName(gwNs, cn))
+			secret := ctx.Find(gvk.Secret, resource.NewShortOrFullName(gwNs, cn), r.Metadata.UID)
 			if secret == nil {
 				m := msg.NewReferencedResourceNotFound(r, "credentialName", cn)
 

--- a/pkg/config/analysis/analyzers/injection/image-auto.go
+++ b/pkg/config/analysis/analyzers/injection/image-auto.go
@@ -81,7 +81,7 @@ func (a *ImageAutoAnalyzer) Analyze(c analysis.Context) {
 		if !hasAutoImage(&d.Template.Spec) {
 			return true
 		}
-		nsLabels := getNamespaceLabels(c, resource.Metadata.FullName.Namespace.String())
+		nsLabels := getNamespaceLabels(c, resource.Metadata.FullName.Namespace.String(), resource.Metadata.UID)
 		if !matchesWebhooks(nsLabels, d.Template.Labels, istioWebhooks) {
 			m := msg.NewImageAutoWithoutInjectionWarning(resource, "Deployment", resource.Metadata.FullName.Name.String())
 			c.Report(gvk.Deployment, m)
@@ -99,11 +99,11 @@ func hasAutoImage(spec *v1.PodSpec) bool {
 	return false
 }
 
-func getNamespaceLabels(c analysis.Context, nsName string) map[string]string {
+func getNamespaceLabels(c analysis.Context, nsName string, nsUID resource.UID) map[string]string {
 	if nsName == "" {
 		nsName = "default"
 	}
-	ns := c.Find(gvk.Namespace, resource.NewFullName("", resource.LocalName(nsName)))
+	ns := c.Find(gvk.Namespace, resource.NewFullName("", resource.LocalName(nsName)), nsUID)
 	if ns == nil {
 		return nil
 	}

--- a/pkg/config/analysis/analyzers/multicluster/service.go
+++ b/pkg/config/analysis/analyzers/multicluster/service.go
@@ -97,9 +97,9 @@ func findInconsistencies(services []*clusterService) (clusters []string, errors 
 
 	// Convert the first service from resource.Instance to corev1.Service
 	var firstService *corev1.ServiceSpec
-	var firstCluster cluster.ID
+	var firstClusterID cluster.ID
 	for _, svc := range services {
-		firstCluster = svc.clusterID
+		firstClusterID = svc.clusterID
 		firstService = svc.instance.Message.(*corev1.ServiceSpec)
 		if firstService != nil {
 			break
@@ -132,7 +132,7 @@ func findInconsistencies(services []*clusterService) (clusters []string, errors 
 		}
 	}
 	if len(inconsistentClusters) > 0 {
-		inconsistentClusters.Insert(firstCluster.String())
+		inconsistentClusters.Insert(firstClusterID.String())
 	}
 	slices.Sort(inconsistentReasons.UnsortedList())
 	errStr := ""

--- a/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -78,7 +78,7 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
 
 		gwFullName := resource.NewShortOrFullName(vsNs, gwName)
 
-		if !c.Exists(gvk.Gateway, gwFullName) {
+		if !c.Exists(gvk.Gateway, gwFullName, r.Metadata.UID) {
 			m := msg.NewReferencedResourceNotFound(r, "gateway", gwName)
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.VSGateway, i)); ok {

--- a/pkg/config/analysis/analyzers/virtualservice/jwtclaimroute.go
+++ b/pkg/config/analysis/analyzers/virtualservice/jwtclaimroute.go
@@ -83,7 +83,7 @@ func (s *JWTClaimRouteAnalyzer) analyze(r *resource.Instance, c analysis.Context
 		}
 
 		gwFullName := resource.NewShortOrFullName(vsNs, gwName)
-		gwRes := c.Find(gvk.Gateway, gwFullName)
+		gwRes := c.Find(gvk.Gateway, gwFullName, r.Metadata.UID)
 		if gwRes == nil {
 			// The gateway does not exist, this should already be covered by the gateway analyzer.
 			continue

--- a/pkg/config/analysis/context.go
+++ b/pkg/config/analysis/context.go
@@ -29,10 +29,10 @@ type Context interface {
 	Report(c config.GroupVersionKind, t diag.Message)
 
 	// Find a resource in the collection. If not found, nil is returned
-	Find(c config.GroupVersionKind, name resource.FullName) *resource.Instance
+	Find(c config.GroupVersionKind, name resource.FullName, uid resource.UID) *resource.Instance
 
 	// Exists returns true if the specified resource exists in the context, false otherwise
-	Exists(c config.GroupVersionKind, name resource.FullName) bool
+	Exists(c config.GroupVersionKind, name resource.FullName, uid resource.UID) bool
 
 	// ForEach iterates over all the entries of a given collection.
 	ForEach(c config.GroupVersionKind, fn IteratorFn)

--- a/pkg/config/analysis/local/analyze_test.go
+++ b/pkg/config/analysis/local/analyze_test.go
@@ -92,7 +92,7 @@ func TestAnalyzersRun(t *testing.T) {
 	m := msg.NewInternalError(r, "msg")
 	a := &testAnalyzer{
 		fn: func(ctx analysis.Context) {
-			ctx.Exists(K8SCollection1.GroupVersionKind(), resource.NewFullName("", ""))
+			ctx.Exists(K8SCollection1.GroupVersionKind(), resource.NewFullName("", ""), resource.UID("uid"))
 			ctx.Report(K8SCollection1.GroupVersionKind(), m)
 		},
 	}

--- a/pkg/config/analysis/local/context.go
+++ b/pkg/config/analysis/local/context.go
@@ -98,7 +98,7 @@ func (i *istiodContext) GetMessages(analyzerNames ...string) diag.Messages {
 	return result
 }
 
-func (i *istiodContext) Find(col config.GroupVersionKind, name resource.FullName) *resource.Instance {
+func (i *istiodContext) Find(col config.GroupVersionKind, name resource.FullName, uid resource.UID) *resource.Instance {
 	i.collectionReporter(col)
 	k := key{
 		collectionName: col,
@@ -135,9 +135,9 @@ func (i *istiodContext) Find(col config.GroupVersionKind, name resource.FullName
 	return nil
 }
 
-func (i *istiodContext) Exists(col config.GroupVersionKind, name resource.FullName) bool {
+func (i *istiodContext) Exists(col config.GroupVersionKind, name resource.FullName, uid resource.UID) bool {
 	i.collectionReporter(col)
-	return i.Find(col, name) != nil
+	return i.Find(col, name, uid) != nil
 }
 
 func (i *istiodContext) ForEach(col config.GroupVersionKind, fn analysis.IteratorFn) {
@@ -236,6 +236,7 @@ func cfgToInstance(cfg config.Config, col config.GroupVersionKind, colschema sre
 		FieldsMap:       out,
 		Cluster:         cluster,
 	}
+	res.Metadata.UID = resource.UID(cfg.UID)
 	// MCP is not aware of generation, add that here.
 	res.Metadata.Generation = cfg.Generation
 	return res, nil

--- a/pkg/config/analysis/local/context.go
+++ b/pkg/config/analysis/local/context.go
@@ -104,6 +104,7 @@ func (i *istiodContext) Find(col config.GroupVersionKind, name resource.FullName
 		collectionName: col,
 		name:           name,
 		cluster:        "default",
+		uid:            uid,
 	}
 	if result, ok := i.found[k]; ok {
 		return result

--- a/pkg/config/analysis/testing/fixtures/context.go
+++ b/pkg/config/analysis/testing/fixtures/context.go
@@ -35,10 +35,14 @@ func (ctx *Context) Report(_ config.GroupVersionKind, t diag.Message) {
 }
 
 // Find implements analysis.Context
-func (ctx *Context) Find(config.GroupVersionKind, resource.FullName) *resource.Instance { return nil }
+func (ctx *Context) Find(config.GroupVersionKind, resource.FullName, resource.UID) *resource.Instance {
+	return nil
+}
 
 // Exists implements analysis.Context
-func (ctx *Context) Exists(config.GroupVersionKind, resource.FullName) bool { return false }
+func (ctx *Context) Exists(config.GroupVersionKind, resource.FullName, resource.UID) bool {
+	return false
+}
 
 // ForEach implements analysis.Context
 func (ctx *Context) ForEach(_ config.GroupVersionKind, fn analysis.IteratorFn) {

--- a/pkg/config/resource/metadata.go
+++ b/pkg/config/resource/metadata.go
@@ -30,6 +30,7 @@ type Metadata struct {
 	Generation  int64
 	Labels      map[string]string
 	Annotations map[string]string
+	UID         UID
 }
 
 // Clone Metadata. Warning, this is expensive!

--- a/pkg/config/resource/name.go
+++ b/pkg/config/resource/name.go
@@ -33,6 +33,13 @@ func (n LocalName) String() string {
 	return string(n)
 }
 
+// UID that uniquely identifies the resource within the cluster.
+type UID string
+
+func (u UID) String() string {
+	return string(u)
+}
+
 // FullName is a name that uniquely identifies a resource within the mesh.
 type FullName struct {
 	Namespace Namespace


### PR DESCRIPTION


**Please provide a description of this PR:**

Related to #24345  

When multiple clusters assume the same name in their kubeconfig, the service instance data gets overwritten since the multi-cluster store uses the cluster ID as the key in a map. Changed the cluster store to a slice since it is only used for iterating over the store (and not for constant access).

Also added a resource UID to the key in istiod context to uniquely identify service instances with same name across clusters with same ID.