### PR TITLE
cni: expose error messages to client

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher.go
+++ b/cni/pkg/nodeagent/cni-watcher.go
@@ -126,19 +126,19 @@ func (s *CniPluginServer) handleAddEvent(w http.ResponseWriter, req *http.Reques
 	defer req.Body.Close()
 	data, err := io.ReadAll(req.Body)
 	if err != nil {
-		log.Errorf("Failed to read event report from cni plugin: %v", err)
+		log.Errorf("failed to read event report from cni plugin: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	msg, err := processAddEvent(data)
 	if err != nil {
-		log.Errorf("Failed to process CNI event payload: %v", err)
+		log.Errorf("failed to process CNI event payload: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if err := s.ReconcileCNIAddEvent(req.Context(), msg); err != nil {
-		log.Errorf("Failed to handle add event: %v", err)
+		log.WithLabels("ns", msg.PodNamespace, "name", msg.PodName).Errorf("failed to handle add event: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cni/pkg/plugin/cnieventclient.go
+++ b/cni/pkg/plugin/cnieventclient.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -69,15 +70,18 @@ func PushCNIEvent(cniClient CNIEventClient, event *skel.CmdArgs, prevResIps []*c
 	if err != nil {
 		return err
 	}
-	var response *http.Response
-	response, err = cniClient.client.Post(cniClient.url, "application/json", bytes.NewBuffer(eventData))
+	response, err := cniClient.client.Post(cniClient.url, "application/json", bytes.NewBuffer(eventData))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to send event request: %v", err)
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("unable to push CNI event, error was %d", response.StatusCode)
+		body, err := io.ReadAll(io.LimitReader(response.Body, 1024*1024))
+		if err != nil {
+			return fmt.Errorf("unable to push CNI event and failed to read body (status code %d): %v", response.StatusCode, err)
+		}
+		return fmt.Errorf("unable to push CNI event (status code %d): %v", response.StatusCode, string(body))
 	}
 
 	return nil

--- a/cni/pkg/plugin/cnieventclient_test.go
+++ b/cni/pkg/plugin/cnieventclient_test.go
@@ -89,7 +89,7 @@ func TestPushCNIAddEventNotOK(t *testing.T) {
 	err := PushCNIEvent(cniC, fakeCmdArgs, []*cniv1.IPConfig{&fakePrevResultIPConfig}, "testpod", "testns")
 
 	assert.Error(t, err)
-	assert.Equal(t, strings.Contains(err.Error(), fmt.Sprintf("unable to push CNI event, error was %d", http.StatusInternalServerError)), true)
+	assert.Equal(t, strings.Contains(err.Error(), fmt.Sprintf("unable to push CNI event (status code %d)", http.StatusInternalServerError)), true)
 }
 
 func TestPushCNIAddEventGoodPayload(t *testing.T) {


### PR DESCRIPTION
```
  Warning  FailedCreatePodSandBox  2m28s              kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "5971b5502d010075b13fa87ad7fce07e164dbba7fada3c9e498ebf1a55693c8e": plugin type="istio-cni" name="istio-cni" failed (add): unable to push CNI event, error was 500
  Warning  FailedCreatePodSandBox  2m17s              kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "6738e4113866d42813aeb65a90e87a3ae40a18cc2cc5e93ee86d4332db5d783e": plugin type="istio-cni" name="istio-cni" failed (add): unable to push CNI event, error was 500
  Warning  FailedCreatePodSandBox  2m3s               kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "d19b382a3aa067ad7be02526bbfef9fb5425e9120cac28aaae38fc69c5206808": plugin type="istio-cni" name="istio-cni" failed (add): unable to push CNI event (status code 500): failed, sorry
  Warning  FailedCreatePodSandBox  5s (x9 over 112s)  kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "219c60bc7257d0ee3e130df905b8a6670f26f36ebf99dab31957d3d5cf3dcac3": plugin type="istio-cni" name="istio-cni" failed (add): unable to push CNI event (status code 500): failed, sorry
```

First two logs are before my change, second 2 are after.

Note "failed, sorry" is an error I synthetically returned for testing; usually it would be more helpful :slightly_smiling_face: 