### PR TITLE
Typo in "proxy-config route" name flag description

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -483,7 +483,7 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 	allConfigCmd.PersistentFlags().StringVar(&listenerType, "type", "", "Filter listeners by type field")
 
 	// route
-	allConfigCmd.PersistentFlags().StringVar(&routeName, "name", "", "Filter listeners by route name field")
+	allConfigCmd.PersistentFlags().StringVar(&routeName, "name", "", "Filter routes by route name field")
 
 	return allConfigCmd
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

The flag is relevant to routes, not listeners.