### PR TITLE
tests: properly cleanup config from previous test

### DIFF
--- a/tests/integration/security/egress_sidecar_tls_origination_test.go
+++ b/tests/integration/security/egress_sidecar_tls_origination_test.go
@@ -254,7 +254,7 @@ spec:
           credentialName: {{.CredentialName}}
           sni: {{ .to.Config.ClusterLocalFQDN }}
 `
-	t.ConfigIstio().Eval(clientNamespace.Name(), args, se, dr).ApplyOrFail(t, apply.NoCleanup)
+	t.ConfigIstio().Eval(clientNamespace.Name(), args, se, dr).ApplyOrFail(t)
 }
 
 func newTLSSidecarCallOpts(to echo.Target, host string, exRsp ingressutil.ExpectedResponse) echo.CallOptions {


### PR DESCRIPTION
Otherwise we are leaking the DR config, which impacts future tests
