### PR TITLE
Add special delimeter for cluster stat names

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -40,6 +40,7 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/security"
@@ -289,7 +290,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 ) *clusterWrapper {
 	c := &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + ";",
+		AltStatName:          name + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
@@ -490,7 +491,7 @@ func (cb *ClusterBuilder) buildInboundPassthroughCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 	c := &cluster.Cluster{
 		Name:                 util.BlackHoleCluster,
-		AltStatName:          util.BlackHoleCluster + ";",
+		AltStatName:          util.BlackHoleCluster + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
@@ -503,7 +504,7 @@ func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 	cluster := &cluster.Cluster{
 		Name:                 util.PassthroughCluster,
-		AltStatName:          util.PassthroughCluster + ";",
+		AltStatName:          util.PassthroughCluster + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
@@ -710,7 +711,7 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 	}
 	c := &cluster.Cluster{
 		Name:                 security.SDSExternalClusterName,
-		AltStatName:          security.SDSExternalClusterName + ";",
+		AltStatName:          security.SDSExternalClusterName + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LoadAssignment: &endpoint.ClusterLoadAssignment{

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -291,7 +292,9 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		Name:                 name,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
-		AltStatName:          name + ";", // Add our own delimeter so we can know where the cluster name ends
+	}
+	if strings.Contains(name, ".") {
+		c.AltStatName = name + ";" // Add our own delimeter so we can know where the cluster name ends
 	}
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -490,6 +490,7 @@ func (cb *ClusterBuilder) buildInboundPassthroughCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 	c := &cluster.Cluster{
 		Name:                 util.BlackHoleCluster,
+		AltStatName:          util.BlackHoleCluster + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
@@ -502,6 +503,7 @@ func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 	cluster := &cluster.Cluster{
 		Name:                 util.PassthroughCluster,
+		AltStatName:          util.PassthroughCluster + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
@@ -708,6 +710,7 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 	}
 	c := &cluster.Cluster{
 		Name:                 security.SDSExternalClusterName,
+		AltStatName:          security.SDSExternalClusterName + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LoadAssignment: &endpoint.ClusterLoadAssignment{

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -291,6 +291,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		Name:                 name,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
+		AltStatName:          name + ";", // Add our own delimeter so we can know where the cluster name ends
 	}
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -290,11 +289,9 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 ) *clusterWrapper {
 	c := &cluster.Cluster{
 		Name:                 name,
+		AltStatName:          name + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
-	}
-	if strings.Contains(name, ".") {
-		c.AltStatName = name + ";" // Add our own delimeter so we can know where the cluster name ends
 	}
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -290,7 +290,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 ) *clusterWrapper {
 	c := &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + constants.AltStatNameDelimeter,
+		AltStatName:          name + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
 		CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 	}
@@ -345,8 +345,13 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	if direction == model.TrafficDirectionOutbound {
 		// If stat name is configured, build the alternate stats name.
 		if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
-			ec.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName,
+			statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName,
 				string(service.Hostname), subset, port, 0, &service.Attributes)
+
+			if statPrefix[len(statPrefix)-1:] != constants.ClusterAltStatNameDelimeter {
+				statPrefix += constants.ClusterAltStatNameDelimeter
+			}
+			ec.cluster.AltStatName = statPrefix
 		}
 	}
 
@@ -373,8 +378,14 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 		model.TrafficDirectionInbound, instance.Port.ServicePort, instance.Service, inboundServices, "")
 	// If stat name is configured, build the alt statname.
 	if len(cb.req.Push.Mesh.InboundClusterStatName) != 0 {
-		localCluster.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,
-			string(instance.Service.Hostname), "", instance.Port.ServicePort, clusterPort, &instance.Service.Attributes)
+		statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,
+			string(instance.Service.Hostname), "", instance.Port.ServicePort, clusterPort,
+			&instance.Service.Attributes)
+		// Add the cluster name delimeter if it's not the last character.
+		if statPrefix[len(statPrefix)-1:] != constants.ClusterAltStatNameDelimeter {
+			statPrefix += constants.ClusterAltStatNameDelimeter
+		}
+		localCluster.cluster.AltStatName = statPrefix
 	}
 
 	opts := buildClusterOpts{
@@ -491,7 +502,7 @@ func (cb *ClusterBuilder) buildInboundPassthroughCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 	c := &cluster.Cluster{
 		Name:                 util.BlackHoleCluster,
-		AltStatName:          util.BlackHoleCluster + constants.AltStatNameDelimeter,
+		AltStatName:          util.BlackHoleCluster + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
@@ -504,7 +515,7 @@ func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 	cluster := &cluster.Cluster{
 		Name:                 util.PassthroughCluster,
-		AltStatName:          util.PassthroughCluster + constants.AltStatNameDelimeter,
+		AltStatName:          util.PassthroughCluster + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_CLUSTER_PROVIDED,
@@ -711,7 +722,7 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 	}
 	c := &cluster.Cluster{
 		Name:                 security.SDSExternalClusterName,
-		AltStatName:          security.SDSExternalClusterName + constants.AltStatNameDelimeter,
+		AltStatName:          security.SDSExternalClusterName + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LoadAssignment: &endpoint.ClusterLoadAssignment{

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -996,6 +996,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 			external:    false,
 			expectedCluster: &cluster.Cluster{
 				Name:                 "foo",
+				AltStatName:          "foo;",
 				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 				CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 				ConnectTimeout:       &durationpb.Duration{Seconds: 10, Nanos: 1},
@@ -1083,6 +1084,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 			external:  false,
 			expectedCluster: &cluster.Cluster{
 				Name:                 "foo",
+				AltStatName:          "foo;",
 				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 				CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
 				ConnectTimeout:       &durationpb.Duration{Seconds: 10, Nanos: 1},

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -1045,6 +1045,63 @@ func TestBuildDefaultCluster(t *testing.T) {
 			},
 		},
 		{
+			name:        "static external cluster with . in the name",
+			clusterName: "foo.bar.com",
+			discovery:   cluster.Cluster_EDS,
+			endpoints:   nil,
+			direction:   model.TrafficDirectionOutbound,
+			external:    false,
+			expectedCluster: &cluster.Cluster{
+				Name:                 "foo.bar.com",
+				AltStatName:          "foo.bar.com;",
+				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+				CommonLbConfig:       &cluster.Cluster_CommonLbConfig{},
+				ConnectTimeout:       &durationpb.Duration{Seconds: 10, Nanos: 1},
+				CircuitBreakers: &cluster.CircuitBreakers{
+					Thresholds: []*cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThresholds()},
+				},
+				Filters:  []*cluster.Filter{xdsfilters.TCPClusterMx},
+				LbPolicy: defaultLBAlgorithm(),
+				Metadata: &core.Metadata{
+					FilterMetadata: map[string]*structpb.Struct{
+						util.IstioMetadataKey: {
+							Fields: map[string]*structpb.Value{
+								"services": {Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{
+									{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
+										"host": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "host",
+											},
+										},
+										"name": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "svc",
+											},
+										},
+										"namespace": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "default",
+											},
+										},
+									}}}},
+								}}}},
+							},
+						},
+					},
+				},
+				EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
+					ServiceName: "foo.bar.com",
+					EdsConfig: &core.ConfigSource{
+						ConfigSourceSpecifier: &core.ConfigSource_Ads{
+							Ads: &core.AggregatedConfigSource{},
+						},
+						InitialFetchTimeout: durationpb.New(0),
+						ResourceApiVersion:  core.ApiVersion_V3,
+					},
+				},
+			},
+		},
+		{
 			name:            "static cluster with no endpoints",
 			clusterName:     "foo",
 			discovery:       cluster.Cluster_STATIC,

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -1273,7 +1273,7 @@ func TestStatNamePattern(t *testing.T) {
 		EnableAutoMtls: &wrappers.BoolValue{
 			Value: false,
 		},
-		InboundClusterStatName:  "LocalService_%SERVICE%",
+		InboundClusterStatName:  "LocalService_%SERVICE%;",
 		OutboundClusterStatName: "%SERVICE%_%SERVICE_PORT_NAME%_%SERVICE_PORT%",
 	}
 
@@ -1284,8 +1284,8 @@ func TestStatNamePattern(t *testing.T) {
 			Host: "*.example.org",
 		},
 	})
-	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080;"))
+	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org;"))
 }
 
 func TestDuplicateClusters(t *testing.T) {

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -40,6 +40,7 @@ import (
 	"istio.io/istio/pilot/pkg/xds/endpoints"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
@@ -51,7 +52,7 @@ import (
 func buildInternalUpstreamCluster(name string, internalListener string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + ";",
+		AltStatName:          name + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		LoadAssignment: &endpoint.ClusterLoadAssignment{
 			ClusterName: name,
@@ -290,7 +291,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 	sec_model.EnforceCompliance(ctx)
 	return &cluster.Cluster{
 		Name:                          ConnectOriginate,
-		AltStatName:                   ConnectOriginate + ";",
+		AltStatName:                   ConnectOriginate + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType:          &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		LbPolicy:                      cluster.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -51,6 +51,7 @@ import (
 func buildInternalUpstreamCluster(name string, internalListener string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
+		AltStatName:          name + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		LoadAssignment: &endpoint.ClusterLoadAssignment{
 			ClusterName: name,
@@ -289,6 +290,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 	sec_model.EnforceCompliance(ctx)
 	return &cluster.Cluster{
 		Name:                          ConnectOriginate,
+		AltStatName:                   ConnectOriginate + ";",
 		ClusterDiscoveryType:          &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		LbPolicy:                      cluster.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -52,7 +52,7 @@ import (
 func buildInternalUpstreamCluster(name string, internalListener string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + constants.AltStatNameDelimeter,
+		AltStatName:          name + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
 		LoadAssignment: &endpoint.ClusterLoadAssignment{
 			ClusterName: name,
@@ -291,7 +291,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 	sec_model.EnforceCompliance(ctx)
 	return &cluster.Cluster{
 		Name:                          ConnectOriginate,
-		AltStatName:                   ConnectOriginate + constants.AltStatNameDelimeter,
+		AltStatName:                   ConnectOriginate + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType:          &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		LbPolicy:                      cluster.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -153,6 +153,7 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 func edsCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
+		AltStatName:          name + ";",
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
 			ServiceName: name,

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -28,6 +28,7 @@ import (
 	corexds "istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/protoconv"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/util/sets"
 )
@@ -153,7 +154,7 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 func edsCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + ";",
+		AltStatName:          name + constants.AltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
 			ServiceName: name,

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -154,7 +154,7 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 func edsCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          name + constants.AltStatNameDelimeter,
+		AltStatName:          name + constants.ClusterAltStatNameDelimeter,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
 			ServiceName: name,

--- a/pilot/pkg/networking/telemetry/telemetry.go
+++ b/pilot/pkg/networking/telemetry/telemetry.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -43,7 +42,7 @@ func BuildStatPrefix(statPattern string, host string, subset string, port *model
 	prefix = strings.ReplaceAll(prefix, serviceTargetPortStatPattern, strconv.Itoa(targetPort))
 	prefix = strings.ReplaceAll(prefix, servicePortStatPattern, strconv.Itoa(port.Port))
 	prefix = strings.ReplaceAll(prefix, servicePortNameStatPattern, port.Name)
-	return prefix + constants.AltStatNameDelimeter
+	return prefix
 }
 
 // BuildInboundStatPrefix builds a stat prefix based on the stat pattern and filter chain telemetry data.
@@ -53,7 +52,7 @@ func BuildInboundStatPrefix(statPattern string, tm FilterChainMetadata, subset s
 	prefix = strings.ReplaceAll(prefix, subsetNameStatPattern, subset)
 	prefix = strings.ReplaceAll(prefix, servicePortStatPattern, strconv.Itoa(int(port)))
 	prefix = strings.ReplaceAll(prefix, servicePortNameStatPattern, portName)
-	return prefix + constants.AltStatNameDelimeter
+	return prefix
 }
 
 // shortHostName constructs the name from kubernetes hosts based on attributes (name and namespace).

--- a/pilot/pkg/networking/telemetry/telemetry.go
+++ b/pilot/pkg/networking/telemetry/telemetry.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -42,7 +43,7 @@ func BuildStatPrefix(statPattern string, host string, subset string, port *model
 	prefix = strings.ReplaceAll(prefix, serviceTargetPortStatPattern, strconv.Itoa(targetPort))
 	prefix = strings.ReplaceAll(prefix, servicePortStatPattern, strconv.Itoa(port.Port))
 	prefix = strings.ReplaceAll(prefix, servicePortNameStatPattern, port.Name)
-	return prefix
+	return prefix + constants.AltStatNameDelimeter
 }
 
 // BuildInboundStatPrefix builds a stat prefix based on the stat pattern and filter chain telemetry data.
@@ -52,7 +53,7 @@ func BuildInboundStatPrefix(statPattern string, tm FilterChainMetadata, subset s
 	prefix = strings.ReplaceAll(prefix, subsetNameStatPattern, subset)
 	prefix = strings.ReplaceAll(prefix, servicePortStatPattern, strconv.Itoa(int(port)))
 	prefix = strings.ReplaceAll(prefix, servicePortNameStatPattern, portName)
-	return prefix
+	return prefix + constants.AltStatNameDelimeter
 }
 
 // shortHostName constructs the name from kubernetes hosts based on attributes (name and namespace).

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -450,20 +450,20 @@ func checkClusterNameTag(t *testing.T, regex string) {
 		{
 			name:               "cluster_name stats tag - external service",
 			clusterName:        "cluster.outbound|443||api.facebook.com;.upstream_rq_retry",
-			firstCaptureGroup:  "outbound|443||api.facebook.com;",
+			firstCaptureGroup:  ".outbound|443||api.facebook.com;",
 			secondCaptureGroup: "outbound|443||api.facebook.com",
 		},
 		{
 			name:               "cluster_name stats tag - internal kubernetes service",
 			clusterName:        "cluster.outbound|443||kubernetes.default.svc.cluster.local;.upstream_rq_retry",
-			firstCaptureGroup:  "outbound|443||kubernetes.default.svc.cluster.local;",
+			firstCaptureGroup:  ".outbound|443||kubernetes.default.svc.cluster.local;",
 			secondCaptureGroup: "outbound|443||kubernetes.default.svc.cluster.local",
 		},
 		{
 			name:               "cluster_name stats tag - no dots in cluster name",
-			clusterName:        "cluster.foo_cluster;.upstream_rq_retry",
-			firstCaptureGroup:  "foo_cluster;",
-			secondCaptureGroup: "foo_cluster",
+			clusterName:        "cluster.xds-grpc;.upstream_rq_retry",
+			firstCaptureGroup:  ".xds-grpc;",
+			secondCaptureGroup: "xds-grpc",
 		},
 	}
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -459,6 +459,12 @@ func checkClusterNameTag(t *testing.T, regex string) {
 			firstCaptureGroup:  "outbound|443||kubernetes.default.svc.cluster.local;",
 			secondCaptureGroup: "outbound|443||kubernetes.default.svc.cluster.local",
 		},
+		{
+			name:               "cluster_name stats tag - no dots in cluster name",
+			clusterName:        "cluster.foo_cluster;.upstream_rq_retry",
+			firstCaptureGroup:  "foo_cluster;",
+			secondCaptureGroup: "foo_cluster",
+		},
 	}
 
 	for _, tt := range tc {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
+++ b/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
+++ b/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
+++ b/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
+++ b/pkg/bootstrap/testdata/deferred_cluster_creation_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/lrs_golden.json
+++ b/pkg/bootstrap/testdata/lrs_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -49,7 +49,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -196,6 +196,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -218,6 +219,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -240,6 +242,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -268,6 +271,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -320,6 +324,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -49,7 +49,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -49,7 +49,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -196,6 +196,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -218,6 +219,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -240,6 +242,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -268,6 +271,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -320,6 +324,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -49,7 +49,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -45,7 +45,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_brotli_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_gzip_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_unknown_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
+++ b/pkg/bootstrap/testdata/stats_compression_zstd_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -338,6 +343,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"alpn_protocols":["h2"],"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/istio/ms/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}},"tls_certificate_sds_secret_configs":[{"name":"file-cert:/etc/istio/ms/client.pem~/etc/istio/ms/key.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}]}}},
         "respect_dns_ttl": true,
@@ -370,6 +376,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -285,6 +285,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -307,6 +308,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -329,6 +331,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -357,6 +360,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "datadog_agent",
+        "alt_stat_name": "datadog_agent;",
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "lightstep",
+        "alt_stat_name": "lightstep;",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/zipkin/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}}},"sni":"zipkin-custom-sni"}},
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "transport_socket": {"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"combined_validation_context":{"default_validation_context":{},"validation_context_sds_secret_config":{"name":"file-root:/etc/zipkin/ca.pem","sds_config":{"api_config_source":{"api_type":"GRPC","grpc_services":[{"envoy_grpc":{"cluster_name":"sds-grpc"}}],"set_node_on_first_message_only":true,"transport_api_version":"V3"},"resource_api_version":"V3"}}}}}},
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -315,6 +319,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -191,6 +191,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -213,6 +214,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -235,6 +237,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -263,6 +266,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -40,7 +40,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -44,7 +44,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -20,6 +20,9 @@ const (
 	// UnspecifiedIPv6 constant for empty IPv6 address
 	UnspecifiedIPv6 = "::"
 
+	// AltStatNameDelimeter constant for the stat delimer
+	AltStatNameDelimeter = ";"
+
 	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
 	PilotWellKnownDNSCertPath   = "./var/run/secrets/istiod/tls/"
 	PilotWellKnownDNSCaCertPath = "./var/run/secrets/istiod/ca/"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -20,8 +20,8 @@ const (
 	// UnspecifiedIPv6 constant for empty IPv6 address
 	UnspecifiedIPv6 = "::"
 
-	// AltStatNameDelimeter constant for the stat delimer
-	AltStatNameDelimeter = ";"
+	// ClusterAltStatNameDelimeter constant for the stat delimer
+	ClusterAltStatNameDelimeter = ";"
 
 	// PilotWellKnownDNSCertPath is the path location for Pilot dns serving cert, often used with custom CA integrations
 	PilotWellKnownDNSCertPath   = "./var/run/secrets/istiod/tls/"

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -27,3 +27,5 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
       endpoint = ["http://kind-registry:5000"]
+networking:
+  ipFamily: ipv4

--- a/prow/config/default.yaml
+++ b/prow/config/default.yaml
@@ -27,5 +27,3 @@ containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
       endpoint = ["http://kind-registry:5000"]
-networking:
-  ipFamily: ipv4

--- a/releasenotes/notes/51761.yaml
+++ b/releasenotes/notes/51761.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+- |
+  **Fixed** an issue where the `cluster_name` label was incorrectly truncated for services without a `.svc.cluster.local` suffix
+upgradeNote:
+- title: Custom stat names
+  content: |
+    Previously, the Envoy cluster metrics for services that did not have a `.svc.cluster.local` suffix
+    were incorrectly truncated and parsed. This was due to the fact that Envoy cluster metrics use dots "." as
+    a delimeter between metric namespaces, and it is impossible to properly distinguish between those
+    delimeters and the dots in hostnames/cluster names. To address this, the regex for parsing the cluster_name
+    has been updated to look for a semicolon to indicate the end of the cluster name. If you're using
+    the `inbound_cluster_stat_name` or `outbound_cluster_stat_name` fields in meshconfig, the semicolon
+    will be added automatically for you.

--- a/tests/integration/telemetry/api/dashboard_test.go
+++ b/tests/integration/telemetry/api/dashboard_test.go
@@ -181,7 +181,7 @@ func TestDashboard(t *testing.T) {
 						}
 
 						for _, query := range queries {
-							retry.UntilSuccessOrFail(t, func() error {
+								retry.UntilSuccessOrFail(t, func() error {
 								return checkMetric(cl, p, query, d.excluded)
 							}, retry.Timeout(time.Minute))
 						}

--- a/tests/integration/telemetry/api/dashboard_test.go
+++ b/tests/integration/telemetry/api/dashboard_test.go
@@ -181,7 +181,7 @@ func TestDashboard(t *testing.T) {
 						}
 
 						for _, query := range queries {
-								retry.UntilSuccessOrFail(t, func() error {
+							retry.UntilSuccessOrFail(t, func() error {
 								return checkMetric(cl, p, query, d.excluded)
 							}, retry.Timeout(time.Minute))
 						}

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -82,7 +82,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp(\\.(.+);)"
+        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -78,7 +78,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "cluster\\.((.+);)"
+        "regex": "cluster(\\.(.+);)"
       },
       {
         "tag_name": "tcp_prefix",
@@ -228,6 +228,7 @@
     "clusters": [
       {
         "name": "prometheus_stats",
+        "alt_stat_name": "prometheus_stats;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -250,6 +251,7 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent;",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
@@ -272,6 +274,7 @@
       },
       {
         "name": "sds-grpc",
+        "alt_stat_name": "sds-grpc;",
         "type": "STATIC",
         "typed_extension_protocol_options": {
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
@@ -300,6 +303,7 @@
       },
       {
         "name": "xds-grpc",
+        "alt_stat_name": "xds-grpc;",
         "type" : "STATIC",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -352,6 +356,7 @@
       ,
       {
         "name": "zipkin",
+        "alt_stat_name": "zipkin;",
         {{- if .tracing_tls }}
         "transport_socket": {{ .tracing_tls }},
         {{- end }}
@@ -378,6 +383,7 @@
       ,
       {
         "name": "lightstep",
+        "alt_stat_name": "lightstep;",
         {{- if .tracing_tls }}
         "transport_socket": {{ .tracing_tls }},
         {{- end }}
@@ -411,6 +417,7 @@
       ,
       {
         "name": "datadog_agent",
+        "alt_stat_name": "datadog_agent;",
         {{- if .tracing_tls }}
         "transport_socket": {{ .tracing_tls }},
         {{- end }}
@@ -437,6 +444,7 @@
       ,
       {
         "name": "envoy_metrics_service",
+        "alt_stat_name": "envoy_metrics_service;",
         "type": "STRICT_DNS",
       {{- if .envoy_metrics_service_tls }}
         "transport_socket": {{ .envoy_metrics_service_tls }},
@@ -474,6 +482,7 @@
       ,
       {
         "name": "envoy_accesslog_service",
+        "alt_stat_name": "envoy_accesslog_service;",
         "type": "STRICT_DNS",
       {{- if .envoy_accesslog_service_tls }}
         "transport_socket": {{ .envoy_accesslog_service_tls }},

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -82,7 +82,7 @@
       },
       {
         "tag_name": "tcp_prefix",
-        "regex": "^tcp\\.((.*?)\\.)\\w+?$"
+        "regex": "^tcp(\\.(.+);)"
       },
       {
         "regex": "_rq(_(\\d{3}))$",

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -78,7 +78,7 @@
     "stats_tags": [
       {
         "tag_name": "cluster_name",
-        "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
+        "regex": "cluster\\.((.+);)"
       },
       {
         "tag_name": "tcp_prefix",


### PR DESCRIPTION
**Please provide a description of this PR:**
Alternative to #5185

Because Envoy uses dots (".") for layering metric namespaces, it is impossible to extract the cluster_name stat tag when cluster names are host names. Therefore, we set an alt_stat_name for all of our Envoy clusters that appends a semicolon (";") to the end of each cluster name so that it is easily parsed by regex

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
