### PR TITLE
Avoid opening two watches when analysis is enabled

### DIFF
--- a/pkg/config/analysis/local/istiod_analyze.go
+++ b/pkg/config/analysis/local/istiod_analyze.go
@@ -351,6 +351,9 @@ func (sa *IstiodAnalyzer) GetFiltersByGVK() map[config.GroupVersionKind]kubetype
 		gvk.Secret: {
 			FieldSelector: secretFieldSelector,
 		},
+		gvk.Pod: {
+			ObjectTransform: kubelib.StripPodUnusedFields,
+		},
 	}
 }
 

--- a/pkg/kube/informerfactory/factory.go
+++ b/pkg/kube/informerfactory/factory.go
@@ -159,7 +159,7 @@ func checkInformerOverlap(inf builtInformer, resource schema.GroupVersionResourc
 	if features.EnableUnsafeAssertions && !allowedOverlap(resource) {
 		l = log.Fatalf
 	}
-	l("for type %v, registered conflicting ObjectTransform. Stack: %v", resource, string(debug.Stack()))
+	l("for type %v, registered conflicting ObjectTransform. %p != %p, Stack: %v", resource, inf.objectTransform, opts.ObjectTransform, string(debug.Stack()))
 }
 
 func (f *informerFactory) makeStartableInformer(informer cache.SharedIndexInformer, key informerKey) StartableInformer {


### PR DESCRIPTION
Else we get `for type /v1, Resource=pods, registered conflicting ObjectTransform. Stack: goroutine 833 [running]:`
