### PR TITLE
Fix ambient IPv6 tests

### DIFF
--- a/pkg/test/framework/components/echo/calloptions.go
+++ b/pkg/test/framework/components/echo/calloptions.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"time"
 
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
@@ -199,11 +200,13 @@ func (o CallOptions) GetHost() string {
 		return o.To.Config().DefaultHostHeader
 	}
 
-	// Next, if the Address was manually specified use it as the Host.
+	// Next, if the Address was manually specified use it as the Host. If it is an IP, leave it so Go can handle the logic to decide
+	// how to format it (whether to add brackets, port, etc)
 	if len(o.Address) > 0 {
-		return o.Address
+		if _, err := netip.ParseAddr(o.Address); err != nil {
+			return o.Address
+		}
 	}
-
 	// Finally, use the target's FQDN.
 	if o.To != nil {
 		return o.To.Config().ClusterLocalFQDN()


### PR DESCRIPTION
Skip JWT test, it is legit broken for a known issue (impacting tests
only, not real code, hopefully)

Fix SE test:
* Stop setting Host header invalid in the test (we are not wrapping Ipv6
  in `[]`). Leaving unset allows Go to default it more correctly, so no
need for more complex logic.
* Create SE for v4 and v6. This cannot be one single SE due to a bug
* Call v4 and/or v6 depending on the environment
