### PR TITLE
Read proxyImage in the gateway injection template.

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   containers:
   - name: istio-proxy
-  {{- if contains "/" .Values.global.proxy.image }}
+  {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
     image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
   {{- else }}
     image: "{{ .ProxyImage }}"

--- a/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   containers:
   - name: istio-proxy
-  {{- if contains "/" .Values.global.proxy.image }}
+  {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
     image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
   {{- else }}
     image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -579,7 +579,7 @@ templates:
       {{- end }}
       containers:
       - name: istio-proxy
-      {{- if contains "/" .Values.global.proxy.image }}
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
         image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
       {{- else }}
         image: "{{ .ProxyImage }}"

--- a/releasenotes/notes/51900.yaml
+++ b/releasenotes/notes/51900.yaml
@@ -1,0 +1,15 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+ - 51888
+
+releaseNotes:
+- |
+  **Fixed** an issue where sidecar.istio.io/proxyImage annotation was ignored during the gateway injection.
+
+# docs is a list of related docs to the change.
+docs:
+ - '[reference] https://istio.io/latest/docs/reference/config/annotations/#SidecarProxyImage'

--- a/releasenotes/notes/51900.yaml
+++ b/releasenotes/notes/51900.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
-area: traffic-management
+area: installation
 
 # issue is a list of GitHub issues resolved in this note.
 issue:
@@ -8,8 +8,4 @@ issue:
 
 releaseNotes:
 - |
-  **Fixed** an issue where sidecar.istio.io/proxyImage annotation was ignored during the gateway injection.
-
-# docs is a list of related docs to the change.
-docs:
- - '[reference] https://istio.io/latest/docs/reference/config/annotations/#SidecarProxyImage'
+  **Fixed** an issue where `sidecar.istio.io/proxyImage` annotation was ignored during the gateway injection.


### PR DESCRIPTION
Currently `sidecar.istio.io/proxyImage` annotation is ignored in the gateway injection template.

Fixes: https://github.com/istio/istio/issues/51888