### PR TITLE
ambient: make waypoints handle dual stack services

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1287,6 +1287,20 @@ func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
 	return nil
 }
 
+// UnconditionallyGetAllAddressesForProxy returns a k8s service's extra addresses to the cluster where the node resides.
+// Especially for dual stack k8s service to get other IP family addresses.
+func (s *Service) UnconditionallyGetAllAddressesForProxy(node *Proxy) []string {
+	if node.Metadata != nil && node.Metadata.ClusterID != "" {
+		addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
+		if len(addresses) > 0 {
+			return addresses
+		}
+	}
+	if a := s.GetAddressForProxy(node); a != "" {
+		return []string{a}
+	}
+	return nil
+}
 // getAllAddresses returns a Service's all addresses.
 func (s *Service) getAllAddresses() []string {
 	var addresses []string

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -366,7 +366,7 @@ func getUpdatedConfigs(services []*model.Service) sets.Set[model.ConfigKey] {
 func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Event) {
 	log.Debugf("Handle event %s for service entry %s/%s", event, curr.Namespace, curr.Name)
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
-	cs := convertServices(curr)
+	cs := convertServices(curr, s.clusterID)
 	configsUpdated := sets.New[model.ConfigKey]()
 	key := curr.NamespacedName()
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1493,7 +1493,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 
 func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
-	svcs := convertServices(*cfg)
+	svcs := convertServices(*cfg, "")
 	if len(svcs) != len(expected) {
 		t.Fatalf("got more services than expected: %v vs %v", len(svcs), len(expected))
 	}
@@ -1727,8 +1727,8 @@ func TestServicesDiff(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			as := convertServices(*tt.current)
-			bs := convertServices(*tt.new)
+			as := convertServices(*tt.current, "")
+			bs := convertServices(*tt.new, "")
 			added, deleted, updated, unchanged := servicesDiff(as, bs)
 			for i, item := range []struct {
 				hostnames []host.Name

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -566,7 +566,7 @@ func makeInstanceWithServiceAccount(cfg *config.Config, address string, port int
 func makeTarget(cfg *config.Config, address string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
 ) model.ServiceTarget {
-	services := convertServices(*cfg)
+	services := convertServices(*cfg, "")
 	svc := services[0] // default
 	for _, s := range services {
 		if string(s.Hostname) == address {
@@ -597,7 +597,7 @@ func makeTarget(cfg *config.Config, address string, port int,
 func makeInstance(cfg *config.Config, address string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
 ) *model.ServiceInstance {
-	services := convertServices(*cfg)
+	services := convertServices(*cfg, "")
 	svc := services[0] // default
 	for _, s := range services {
 		if string(s.Hostname) == address {
@@ -757,7 +757,7 @@ func testConvertServiceBody(t *testing.T) {
 	})
 
 	for _, tt := range serviceTests {
-		services := convertServices(*tt.externalSvc)
+		services := convertServices(*tt.externalSvc, "")
 		if err := compare(t, services, tt.services); err != nil {
 			t.Errorf("testcase: %v\n%v ", tt.externalSvc.Name, err)
 		}
@@ -944,7 +944,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
-			services := convertServices(*tt.se)
+			services := convertServices(*tt.se, "")
 			s := &Controller{meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig())}
 			instances := s.convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{}, tt.clusterID)
 			sortServiceInstances(instances)


### PR DESCRIPTION
1. Make waypoint use all service addresses.
2. Make ServiceEntry with multiple addresses one service instead of N services. 

(2) has potential impacts beyond ambient so need to closely evaluate that