### PR TITLE
Make services dualstack by default in dualstack clusters

### DIFF
--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -283,7 +283,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Ports:           ports.All(),
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
-			IPFamilies:      "IPv6, IPv4",
+			IPFamilies:      "IPv4",
 			IPFamilyPolicy:  string(corev1.IPFamilyPolicyRequireDualStack),
 			DualStack:       true,
 		}

--- a/pkg/test/framework/components/echo/common/deployment/echos.go
+++ b/pkg/test/framework/components/echo/common/deployment/echos.go
@@ -284,7 +284,7 @@ func (c *Config) DefaultEchoConfigs(t resource.Context) []echo.Config {
 			Subsets:         []echo.SubsetConfig{{}},
 			IncludeExtAuthz: c.IncludeExtAuthz,
 			IPFamilies:      "IPv4",
-			IPFamilyPolicy:  string(corev1.IPFamilyPolicyRequireDualStack),
+			IPFamilyPolicy:  string(corev1.IPFamilyPolicySingleStack),
 			DualStack:       true,
 		}
 		eSvc := echo.Config{

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -54,9 +54,9 @@ type EchoNamespace struct {
 	B echo.Instances
 	// Standard echo app to be used by tests
 	C echo.Instances
-	// Dual-stack echo app to be used by tests if running in dual-stack mode
+	// v4-only echo app to be used by tests if running in dual-stack mode
 	D echo.Instances
-	// IPv6 only echo app to be used by tests if running in dual-stack mode
+	// v6-only echo app to be used by tests if running in dual-stack mode
 	E echo.Instances
 	// Standard echo app with TPROXY interception mode to be used by tests
 	Tproxy echo.Instances

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -304,7 +304,7 @@ func (b *builder) deployServices() (err error) {
 	services := make(map[string]string)
 	for _, cfg := range b.configs {
 		if b.ctx.Settings().EnableDualStack && cfg.IPFamilyPolicy == "" {
-			cfg.IPFamilies = "IPv6, IPv4"
+			cfg.IPFamilies = "IPv4, IPv6"
 			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
 		}
 		svc, err := kube.GenerateService(cfg)

--- a/pkg/test/framework/components/echo/deployment/builder.go
+++ b/pkg/test/framework/components/echo/deployment/builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/annotation"
@@ -302,6 +303,10 @@ func (b *builder) getOrCreateNamespace(prefix string) (*builder, namespace.Insta
 func (b *builder) deployServices() (err error) {
 	services := make(map[string]string)
 	for _, cfg := range b.configs {
+		if b.ctx.Settings().EnableDualStack && cfg.IPFamilyPolicy == "" {
+			cfg.IPFamilies = "IPv6, IPv4"
+			cfg.IPFamilyPolicy = string(corev1.IPFamilyPolicyRequireDualStack)
+		}
 		svc, err := kube.GenerateService(cfg)
 		if err != nil {
 			return err

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3604,7 +3604,7 @@ spec:
 			if tt.server != "" {
 				address += "&server=" + tt.server
 			}
-			expected := aInCluster[0].Address()
+			expected := aInCluster[0].Addresses()
 			t.RunTraffic(TrafficTestCase{
 				name: fmt.Sprintf("svc/%s/%s/%s", client.Config().Service, client.Config().Cluster.StableName(), tt.name),
 				call: client.CallOrFail,
@@ -3616,9 +3616,9 @@ spec:
 						for _, r := range result.Responses {
 							ips := r.Body()
 							sort.Strings(ips)
-							exp := []string{expected}
-							if !reflect.DeepEqual(ips, exp) {
-								return fmt.Errorf("unexpected dns response: wanted %v, got %v", exp, ips)
+							sort.Strings(expected)
+							if !reflect.DeepEqual(ips, expected) {
+								return fmt.Errorf("unexpected dns response: wanted %v, got %v", expected, ips)
 							}
 						}
 						return nil

--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -204,9 +204,9 @@ spec:
 			from  echo.Instances
 			host  string
 		}{
-			// apps.D hosts a dual-stack service,
+			// apps.D hosts an ipv4 only service,
 			// apps.E hosts an ipv6 only service and
-			// apps.B hosts an ipv4 only service
+			// apps.B hosts an dualstack service
 			{
 				check: check.OK(),
 				from:  apps.D,


### PR DESCRIPTION
In dualstack integration tests, let all the services be dual-stack by default.
In real deployments, this has not been enforced yet. The discussions in the initial design was that it should be a user decision for which ipFamily to be used in dual-stack clusters. 