### PR TITLE
ambient: ensure we sync network before we mark ourselves synced

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -48,6 +48,7 @@ type Index interface {
 	WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo
 	ServicesForWaypoint(key model.WaypointKey) []model.ServiceInfo
 	SyncAll()
+	NetworksSynced()
 	HasSynced() bool
 	model.AmbientIndexes
 }
@@ -105,7 +106,7 @@ type Options struct {
 
 func New(options Options) Index {
 	a := &index{
-		networkUpdateTrigger: krt.NewRecomputeTrigger(),
+		networkUpdateTrigger: krt.NewRecomputeTrigger(false),
 
 		SystemNamespace:       options.SystemNamespace,
 		DomainSuffix:          options.DomainSuffix,
@@ -444,6 +445,10 @@ func (a *index) AdditionalPodSubscriptions(
 
 func (a *index) SyncAll() {
 	a.networkUpdateTrigger.TriggerRecomputation()
+}
+
+func (a *index) NetworksSynced() {
+	a.networkUpdateTrigger.MarkSynced()
 }
 
 func (a *index) HasSynced() bool {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -1492,6 +1492,7 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 			return nil
 		},
 	})
+	idx.NetworksSynced()
 	cl.RunAndWait(test.NewStop(t))
 
 	t.Cleanup(func() {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -173,9 +173,9 @@ func (a *index) workloadEntryWorkloadBuilder(
 
 		if addr, err := netip.ParseAddr(wle.Spec.Address); err == nil {
 			w.Addresses = [][]byte{addr.AsSlice()}
-		} else {
+		} else if wle.Spec.Address != "" {
 			log.Warnf("skipping workload entry %s/%s; DNS Address resolution is not yet implemented", wle.Namespace, wle.Name)
-		}
+		} // Else it is an empty address with network set, this is ok
 
 		w.WorkloadName, w.WorkloadType = wle.Name, workloadapi.WorkloadType_POD // XXX(shashankram): HACK to impersonate pod
 		w.CanonicalName, w.CanonicalRevision = kubelabels.CanonicalService(wle.Labels, w.WorkloadName)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -917,7 +917,7 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 
 func newAmbientUnitTest() *index {
 	return &index{
-		networkUpdateTrigger: krt.NewRecomputeTrigger(),
+		networkUpdateTrigger: krt.NewRecomputeTrigger(true),
 		ClusterID:            testC,
 		DomainSuffix:         "domain.suffix",
 		Network: func(endpointIP string, labels labels.Instance) network.ID {
@@ -953,7 +953,7 @@ var podReady = []v1.PodCondition{
 func GetMeshConfig(mc *krttest.MockCollection) krt.StaticSingleton[MeshConfig] {
 	attempt := krttest.GetMockSingleton[MeshConfig](mc)
 	if attempt.Get() == nil {
-		return krt.NewStatic(&MeshConfig{mesh.DefaultMeshConfig()})
+		return krt.NewStatic(&MeshConfig{mesh.DefaultMeshConfig()}, true)
 	}
 	return attempt
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -606,13 +606,16 @@ func registerHandlers[T controllers.ComparableObject](c *Controller,
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
-	return c.queue.HasSynced() || c.initialSyncTimedout.Load()
-}
-
-func (c *Controller) informersSynced() bool {
+	if c.initialSyncTimedout.Load() {
+		return true
+	}
 	if c.ambientIndex != nil && !c.ambientIndex.HasSynced() {
 		return false
 	}
+	return c.queue.HasSynced()
+}
+
+func (c *Controller) informersSynced() bool {
 	return c.namespaces.HasSynced() &&
 		c.services.HasSynced() &&
 		c.endpoints.slices.HasSynced() &&
@@ -649,6 +652,18 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	go c.exports.Run(stop)
 	kubelib.WaitForCacheSync("kube controller", stop, c.informersSynced)
 	log.Infof("kube controller for %s synced after %v", c.opts.ClusterID, time.Since(st))
+	if c.ambientIndex != nil {
+		go func() {
+			// Wait until we have everything ready, then we can notify ambient everything is ready
+			// This ensures it gets the initial network state.
+			kubelib.WaitForCacheSync("kube controller queue", stop, func() bool {
+				return c.queue.HasSynced() || c.initialSyncTimedout.Load()
+			})
+
+			c.ambientIndex.NetworksSynced()
+		}()
+	}
+
 	// after the in-order sync we can start processing the queue
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")

--- a/pkg/kube/krt/join_test.go
+++ b/pkg/kube/krt/join_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 func TestJoinCollection(t *testing.T) {
-	c1 := krt.NewStatic[Named](nil)
-	c2 := krt.NewStatic[Named](nil)
-	c3 := krt.NewStatic[Named](nil)
+	c1 := krt.NewStatic[Named](nil, true)
+	c2 := krt.NewStatic[Named](nil, true)
+	c3 := krt.NewStatic[Named](nil, true)
 	j := krt.JoinCollection([]krt.Collection[Named]{c1.AsCollection(), c2.AsCollection(), c3.AsCollection()})
 	last := atomic.NewString("")
 	j.Register(func(o krt.Event[Named]) {
@@ -82,7 +82,7 @@ func TestCollectionJoin(t *testing.T) {
 		Named:   Named{"namespace", "name-static"},
 		Labeled: Labeled{map[string]string{"app": "foo"}},
 		IP:      "9.9.9.9",
-	})
+	}, true)
 	SimpleServices := SimpleServiceCollection(services)
 	SimpleServiceEntries := SimpleServiceCollectionFromEntries(serviceEntries)
 	AllServices := krt.JoinCollection([]krt.Collection[SimpleService]{SimpleServices, SimpleServiceEntries})
@@ -181,7 +181,7 @@ func TestCollectionJoinSync(t *testing.T) {
 		Named:   Named{"namespace", "name-static"},
 		Labeled: Labeled{map[string]string{"app": "foo"}},
 		IP:      "9.9.9.9",
-	})
+	}, true)
 	AllPods := krt.JoinCollection([]krt.Collection[SimplePod]{SimplePods, ExtraSimplePods.AsCollection()})
 	assert.Equal(t, AllPods.Synced().WaitUntilSynced(stop), true)
 	// Assert Equal -- not EventuallyEqual -- to ensure our WaitForCacheSync is proper

--- a/pkg/kube/krt/krttest/helpers.go
+++ b/pkg/kube/krt/krttest/helpers.go
@@ -56,7 +56,7 @@ func GetMockSingleton[T any](mc *MockCollection) krt.StaticSingleton[T] {
 		mc.t.Helper()
 		mc.t.Fatalf("multiple types returned")
 	}
-	return krt.NewStatic(slices.First(t))
+	return krt.NewStatic(slices.First(t), true)
 }
 
 func extractType[T any](items *[]any) []T {

--- a/pkg/kube/krt/recomputetrigger.go
+++ b/pkg/kube/krt/recomputetrigger.go
@@ -53,7 +53,6 @@ func (r *RecomputeTrigger) MarkDependant(ctx HandlerContext) {
 
 // MarkSynced marks this trigger as ready. Before this is called, dependant collections will be blocked.
 // This ensures initial state is populated.
-func (r *RecomputeTrigger) MarkSynced() *RecomputeTrigger {
+func (r *RecomputeTrigger) MarkSynced() {
 	r.inner.MarkSynced()
-	return r
 }

--- a/pkg/kube/krt/recomputetrigger.go
+++ b/pkg/kube/krt/recomputetrigger.go
@@ -34,8 +34,8 @@ type RecomputeTrigger struct {
 	i *atomic.Int32
 }
 
-func NewRecomputeTrigger() *RecomputeTrigger {
-	inner := NewStatic[int32](ptr.Of(int32(0)))
+func NewRecomputeTrigger(startSynced bool) *RecomputeTrigger {
+	inner := NewStatic[int32](ptr.Of(int32(0)), startSynced)
 	return &RecomputeTrigger{inner: inner, i: atomic.NewInt32(0)}
 }
 
@@ -49,4 +49,11 @@ func (r *RecomputeTrigger) TriggerRecomputation() {
 // is called.
 func (r *RecomputeTrigger) MarkDependant(ctx HandlerContext) {
 	_ = Fetch(ctx, r.inner.AsCollection())
+}
+
+// MarkSynced marks this trigger as ready. Before this is called, dependant collections will be blocked.
+// This ensures initial state is populated.
+func (r *RecomputeTrigger) MarkSynced() *RecomputeTrigger {
+	r.inner.MarkSynced()
+	return r
 }

--- a/pkg/kube/krt/recomputetrigger_test.go
+++ b/pkg/kube/krt/recomputetrigger_test.go
@@ -19,17 +19,23 @@ import (
 
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestRecomputeTrigger(t *testing.T) {
-	rt := krt.NewRecomputeTrigger()
-	col1 := krt.NewStatic(ptr.Of("foo")).AsCollection()
+	rt := krt.NewRecomputeTrigger(false)
+	col1 := krt.NewStatic(ptr.Of("foo"), true).AsCollection()
 	response := "foo"
 	col2 := krt.NewCollection(col1, func(ctx krt.HandlerContext, i string) *string {
 		rt.MarkDependant(ctx)
 		return ptr.Of(response)
 	})
+
+	assert.Equal(t, col2.Synced().HasSynced(), false)
+	rt.MarkSynced()
+	assert.Equal(t, col2.Synced().WaitUntilSynced(test.NewStop(t)), true)
+
 	tt := assert.NewTracker[string](t)
 	col2.Register(TrackerHandler[string](tt))
 	tt.WaitOrdered("add/foo")

--- a/pkg/kube/krt/singleton_test.go
+++ b/pkg/kube/krt/singleton_test.go
@@ -64,7 +64,7 @@ func TestSingleton(t *testing.T) {
 
 func TestNewStatic(t *testing.T) {
 	tt := assert.NewTracker[string](t)
-	s := krt.NewStatic[string](nil)
+	s := krt.NewStatic[string](nil, true)
 	s.Register(TrackerHandler[string](tt))
 
 	assert.Equal(t, s.Get(), nil)


### PR DESCRIPTION
otherwise, we can startup without network gateway sync and give
incorrect response
