### PR TITLE
Drop redundant test suite in security sds_ingress

### DIFF
--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/jwt"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
+	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
 var (
@@ -81,5 +82,8 @@ meshConfig:
 				},
 				ExternalNamespace: namespace.Future(&externalNS),
 			})).
+		Setup(func(ctx resource.Context) error {
+			return ingressutil.SetInstances(apps.Ns1.All)
+		}).
 		Run()
 }

--- a/tests/integration/security/sds_ingress/quic/ingress_test.go
+++ b/tests/integration/security/sds_ingress/quic/ingress_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 			Configs: echo.ConfigFuture(&customConfig),
 		})).
 		Setup(func(ctx resource.Context) error {
-			return ingressutil.CreateCustomInstances(&apps)
+			return ingressutil.SetInstances(apps.All)
 		}).
 		Run()
 }

--- a/tests/integration/security/sds_ingress/util/util.go
+++ b/tests/integration/security/sds_ingress/util/util.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/cluster"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
-	"istio.io/istio/pkg/test/framework/components/echo/common/deployment"
 	"istio.io/istio/pkg/test/framework/components/echo/echotest"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
@@ -635,13 +634,13 @@ func RunTestMultiQUICGateways(t framework.TestContext, inst istio.Instance, call
 	}
 }
 
-func CreateCustomInstances(apps *deployment.SingleNamespaceView) error {
-	for index, namespacedName := range apps.EchoNamespace.All.NamespacedNames() {
+func SetInstances(apps echo.Services) error {
+	for index, namespacedName := range apps.NamespacedNames() {
 		switch {
 		case namespacedName.Name == "a":
-			A = apps.EchoNamespace.All[index]
+			A = apps[index]
 		case namespacedName.Name == "vm":
-			VM = apps.EchoNamespace.All[index]
+			VM = apps[index]
 		}
 	}
 	return nil


### PR DESCRIPTION
The test takes 90s to run before, 10s after. We should only create new
suite when it has a new setup requirement.
