### PR TITLE
TestReachability: prune redundant test cases

### DIFF
--- a/pkg/test/framework/components/echo/match/matchers.go
+++ b/pkg/test/framework/components/echo/match/matchers.go
@@ -142,6 +142,14 @@ var Headless Matcher = func(i echo.Instance) bool {
 // NotHeadless is equivalent to Not(Headless)
 var NotHeadless = Not(Headless)
 
+// StatefulSet matches instances that are a stateful set
+var StatefulSet Matcher = func(i echo.Instance) bool {
+	return i.Config().StatefulSet
+}
+
+// NotStatefulSet is equivalent to Not(StatefulSet)
+var NoStatefulSet = Not(StatefulSet)
+
 // ProxylessGRPC matches instances that are Pods with a SidecarInjectTemplate annotation equal to grpc.
 var ProxylessGRPC Matcher = func(i echo.Instance) bool {
 	return i.Config().IsProxylessGRPC()

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -167,6 +167,43 @@ func TestReachability(t *testing.T) {
 					expectCrossNetwork: notNaked,
 					expectSuccess:      notNaked,
 					minIstioVersion:    integIstioVersion,
+					// For this one test, run all protocols.
+					// For others, we will just run the 3 core (HTTP, HTTPS, TCP).
+					// Because security code does not treat HTTP2, WS, or GRPC differently, we are skip those protocols to speed up tests,
+					// and avoid expensive calls that give no coverage (TestReachability is by far the slowest test in Istio).
+					callOpts: []echo.CallOptions{
+						{
+							Port: echo.Port{
+								Name: ports.HTTP.Name,
+							},
+						},
+						{
+							Port: echo.Port{
+								Name: ports.HTTP.Name,
+							},
+							Scheme: scheme.WebSocket,
+						},
+						{
+							Port: echo.Port{
+								Name: ports.HTTP2.Name,
+							},
+						},
+						{
+							Port: echo.Port{
+								Name: ports.HTTPS.Name,
+							},
+						},
+						{
+							Port: echo.Port{
+								Name: ports.TCP.Name,
+							},
+						},
+						{
+							Port: echo.Port{
+								Name: ports.GRPC.Name,
+							},
+						},
+					},
 				},
 				{
 					name: "global mtls permissive",
@@ -441,28 +478,12 @@ func TestReachability(t *testing.T) {
 							},
 							{
 								Port: echo.Port{
-									Name: ports.HTTP.Name,
-								},
-								Scheme: scheme.WebSocket,
-							},
-							{
-								Port: echo.Port{
-									Name: ports.HTTP2.Name,
-								},
-							},
-							{
-								Port: echo.Port{
 									Name: ports.HTTPS.Name,
 								},
 							},
 							{
 								Port: echo.Port{
 									Name: ports.TCP.Name,
-								},
-							},
-							{
-								Port: echo.Port{
-									Name: ports.GRPC.Name,
 								},
 							},
 						}
@@ -481,7 +502,9 @@ func TestReachability(t *testing.T) {
 						t.NewSubTestf("%s%s", schemeStr, opts.HTTP.Path).Run(func(t framework.TestContext) {
 							// Run the test cases.
 							echotest.New(t, allServices.Instances()).
-								FromMatch(match.And(c.fromMatch, match.NotProxylessGRPC)).
+								// Proxyless gRPC is not tested in this test
+								// Headless and statefulset do not impact behavior as a client, so they are skipped in FromMatch to speed up tests
+								FromMatch(match.And(c.fromMatch, match.NotProxylessGRPC, match.NotHeadless, match.NoStatefulSet)).
 								ToMatch(match.And(c.toMatch, match.NotProxylessGRPC)).
 								WithDefaultFilters(1, 1).
 								ConditionallyTo(echotest.NoSelfCalls).


### PR DESCRIPTION
TestReachability accounts for a whopping 10minutes total. This cuts the
runtime (TBD how much...) while retaining ~identical coverage.
