### PR TITLE
ambient: match multiple svc VIPs in waypoint

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1275,7 +1275,7 @@ func (s *Service) GetExtraAddressesForProxy(node *Proxy) []string {
 // GetAllAddressesForProxy returns a k8s service's extra addresses to the cluster where the node resides.
 // Especially for dual stack k8s service to get other IP family addresses.
 func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
-	if features.EnableDualStack && node.Metadata != nil && node.Metadata.ClusterID != "" {
+	if (features.EnableDualStack || features.EnableAmbient) && node.Metadata != nil && node.Metadata.ClusterID != "" {
 		addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 		if len(addresses) > 0 {
 			return addresses

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -52,6 +52,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/proto"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/wellknown"
 )
 
@@ -234,14 +235,13 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 			}
 		}
 		if len(portMapper.Map) > 0 {
-			ranges := []*xds.CidrRange{}
-			for _, vip := range svc.GetAllAddressesForProxy(lb.node) {
+			ranges := slices.Map(svc.GetAllAddressesForProxy(lb.node), func(vip string) *xds.CidrRange {
 				cidr := util.ConvertAddressToCidr(vip)
-				ranges = append(ranges, &xds.CidrRange{
+				return &xds.CidrRange{
 					AddressPrefix: cidr.AddressPrefix,
 					PrefixLen:     cidr.PrefixLen,
-				})
-			}
+				}
+			})
 			rangeMatcher := &matcher.IPMatcher_IPRangeMatcher{
 				Ranges:  ranges,
 				OnMatch: match.ToMatcher(portMapper.Matcher),

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -234,12 +234,16 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 			}
 		}
 		if len(portMapper.Map) > 0 {
-			cidr := util.ConvertAddressToCidr(svc.GetAddressForProxy(lb.node))
-			rangeMatcher := &matcher.IPMatcher_IPRangeMatcher{
-				Ranges: []*xds.CidrRange{{
+			ranges := []*xds.CidrRange{}
+			for _, vip := range svc.GetAllAddressesForProxy(lb.node) {
+				cidr := util.ConvertAddressToCidr(vip)
+				ranges = append(ranges, &xds.CidrRange{
 					AddressPrefix: cidr.AddressPrefix,
 					PrefixLen:     cidr.PrefixLen,
-				}},
+				})
+			}
+			rangeMatcher := &matcher.IPMatcher_IPRangeMatcher{
+				Ranges:  ranges,
 				OnMatch: match.ToMatcher(portMapper.Matcher),
 			}
 			ipMatcher.RangeMatchers = append(ipMatcher.RangeMatchers, rangeMatcher)

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -366,7 +366,7 @@ func getUpdatedConfigs(services []*model.Service) sets.Set[model.ConfigKey] {
 func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Event) {
 	log.Debugf("Handle event %s for service entry %s/%s", event, curr.Namespace, curr.Name)
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
-	cs := convertServices(curr)
+	cs := convertServices(curr, s.clusterID)
 	configsUpdated := sets.New[model.ConfigKey]()
 	key := curr.NamespacedName()
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -132,7 +132,8 @@ func initServiceDiscoveryWithOpts(t test.Failer, workloadOnly bool, opts ...Opti
 func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, fx := initServiceDiscovery(t)
 	expectedServices := []*model.Service{
-		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+		makeService(
+			"*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
 		makeService("*.google.com", "httpDNS", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 		makeService("tcpstatic.com", "tcpStatic", []string{"172.217.0.1"}, map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -132,8 +132,8 @@ func initServiceDiscoveryWithOpts(t test.Failer, workloadOnly bool, opts ...Opti
 func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, fx := initServiceDiscovery(t)
 	expectedServices := []*model.Service{
-		makeService("*.istio.io", "httpDNSRR", nil, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
-		makeService("*.google.com", "httpDNS", nil, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+		makeService("*.google.com", "httpDNS", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 		makeService("tcpstatic.com", "tcpStatic", []string{"172.217.0.1"}, map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
 	}
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -132,9 +132,9 @@ func initServiceDiscoveryWithOpts(t test.Failer, workloadOnly bool, opts ...Opti
 func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, fx := initServiceDiscovery(t)
 	expectedServices := []*model.Service{
-		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
-		makeService("*.google.com", "httpDNS", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
-		makeService("tcpstatic.com", "tcpStatic", "172.217.0.1", map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+		makeService("*.istio.io", "httpDNSRR", nil, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+		makeService("*.google.com", "httpDNS", nil, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+		makeService("tcpstatic.com", "tcpStatic", []string{"172.217.0.1"}, map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
 	}
 
 	createConfigs([]*config.Config{httpDNS, httpDNSRR, tcpStatic}, store, t)
@@ -1493,7 +1493,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 
 func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
-	svcs := convertServices(*cfg)
+	svcs := convertServices(*cfg, "")
 	if len(svcs) != len(expected) {
 		t.Fatalf("got more services than expected: %v vs %v", len(svcs), len(expected))
 	}
@@ -1727,8 +1727,8 @@ func TestServicesDiff(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			as := convertServices(*tt.current)
-			bs := convertServices(*tt.new)
+			as := convertServices(*tt.current, "")
+			bs := convertServices(*tt.new, "")
 			added, deleted, updated, unchanged := servicesDiff(as, bs)
 			for i, item := range []struct {
 				hostnames []host.Name

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -233,7 +233,7 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 		// between using DefaultAddress or ClusterVIPs[0] to create a listener.
 		notDefaultAddresses := sets.New[string](addresses...).Delete(ha.address)
 		addresses = []string{ha.address}
-		addresses = append(addresses, notDefaultAddresses.UnsortedList()...)
+		addresses = append(addresses, sets.SortedList(notDefaultAddresses)...)
 		svc.ClusterVIPs = model.AddressMap{
 			Addresses: map[cluster.ID][]string{
 				clusterID: addresses,

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -114,8 +114,8 @@ func TestServiceStore(t *testing.T) {
 	}
 
 	expectedServices := []*model.Service{
-		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
-		makeService("*.istio.io", "httpDNSRR", constants.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 	}
 
 	store.updateServices(httpDNSRR.NamespacedName(), expectedServices)

--- a/pilot/pkg/serviceregistry/serviceentry/store_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/store_test.go
@@ -114,7 +114,8 @@ func TestServiceStore(t *testing.T) {
 	}
 
 	expectedServices := []*model.Service{
-		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
+		makeService(
+			"*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSRoundRobinLB),
 		makeService("*.istio.io", "httpDNSRR", []string{constants.UnspecifiedIP}, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
 	}
 

--- a/pkg/test/framework/components/echo/common/deployment/namespace.go
+++ b/pkg/test/framework/components/echo/common/deployment/namespace.go
@@ -156,7 +156,7 @@ metadata:
   name: external-service
 spec:
 {{- if .ManuallyAllocate }}
-  addresses: [240.240.240.239] # Semi-random address for the range Istio allocates in
+  addresses: [240.240.240.239, 2001:2::f0f0:239] # Semi-random addresses for the range Istio allocates in
 {{- end }}
   exportTo: [.]
   hosts:

--- a/releasenotes/notes/51939.yaml
+++ b/releasenotes/notes/51939.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 51886
+releaseNotes:
+  - |
+    **Added** support for matching multiple service VIPs in waypoint.

--- a/releasenotes/notes/51939.yaml
+++ b/releasenotes/notes/51939.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 issue:
   - 51886
 releaseNotes:

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -31,7 +31,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -392,11 +391,7 @@ func TestWaypointDNS(t *testing.T) {
 					HTTP: echo.HTTP{
 						Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
 					},
-					Port: echo.Port{
-						Name:        "http",
-						ServicePort: 80,
-						Protocol:    protocol.HTTP,
-					},
+					Port:   echo.Port{Name: "http"},
 					Scheme: scheme.HTTP,
 					Count:  1,
 					Check:  check,

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -36,7 +37,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/check"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
@@ -381,20 +381,25 @@ func TestWaypointDNS(t *testing.T) {
 				if src.Config().HasSidecar() {
 					t.Skip("TODO: sidecars don't properly handle use-waypoint")
 				}
+				address := "240.240.240.239"
+				if _, v6 := getSupportedIPFamilies(t); v6 {
+					address = "2001:2::f0f0:239"
+				}
 				src.CallOrFail(t, echo.CallOptions{
-					To:      apps.MockExternal,
-					Address: apps.MockExternal.Config().DefaultHostHeader,
-					Port:    echo.Port{Name: "http"},
-					Scheme:  scheme.HTTP,
-					Count:   1,
-					Check:   check,
+					Address: address,
+					HTTP: echo.HTTP{
+						Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
+					},
+					Port:   echo.Port{Name: "http"},
+					Scheme: scheme.HTTP,
+					Count:  1,
+					Check:  check,
 				})
 			})
 		}
 	}
 	framework.
 		NewTest(t).
-		Label(label.IPv4). // TODO(https://github.com/istio/istio/issues/51886)
 		Run(func(t framework.TestContext) {
 			t.NewSubTest("without waypoint").Run(func(t framework.TestContext) {
 				runTest(t, check.OK())

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -31,6 +31,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -386,11 +387,16 @@ func TestWaypointDNS(t *testing.T) {
 					address = "2001:2::f0f0:239"
 				}
 				src.CallOrFail(t, echo.CallOptions{
+					To:      apps.MockExternal,
 					Address: address,
 					HTTP: echo.HTTP{
 						Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
 					},
-					Port:   echo.Port{Name: "http"},
+					Port: echo.Port{
+						Name:        "http",
+						ServicePort: 80,
+						Protocol:    protocol.HTTP,
+					},
 					Scheme: scheme.HTTP,
 					Count:  1,
 					Check:  check,


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #51886

Istio will store all cluster VIPs for service entries, but these VIPs will be applied only to waypoint listeners for now -  I will fix sidecars in a follow-up PR.