### PR TITLE
ambient: initial status writing

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -49,11 +49,10 @@ rules:
     resources: [ "workloadentries" ]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
-    resources: [ "workloadentries/status" ]
-
-  - apiGroups: ["networking.istio.io"]
-    verbs: [ "get", "watch", "list", "update", "patch" ]
-    resources: [ "serviceentries/status" ]
+    resources: [ "workloadentries/status",  "serviceentries/status" ]
+  - apiGroups: [""]
+    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
+    resources: [ "services/status" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -50,11 +50,10 @@ rules:
     resources: [ "workloadentries" ]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
-    resources: [ "workloadentries/status" ]
-
-  - apiGroups: ["networking.istio.io"]
-    verbs: [ "get", "watch", "list", "update", "patch" ]
-    resources: [ "serviceentries/status" ]
+    resources: [ "workloadentries/status",  "serviceentries/status" ]
+  - apiGroups: [""]
+    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
+    resources: [ "services/status" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -39,6 +39,12 @@ var (
 		true, false,
 		"If enabled, HBONE support can be configured for proxies.")
 
+	EnableAmbientStatus = registerAmbient(
+		"AMBIENT_ENABLE_STATUS",
+		false, false,
+		"If enabled, status messages for ambient mode will be written to resources. "+
+			"Currently, this does not do leader election, so may be unsafe to enable with multiple replicas.")
+
 	// Not required for ambient, so disabled by default
 	PreferHBONESend = registerAmbient(
 		"PILOT_PREFER_SENDING_HBONE",

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -45,7 +45,6 @@ const (
 	// this was formally "istio-gateway-leader"; because they are a different API group we need a different
 	// election to ensure we do not only handle one or the other.
 	GatewayStatusController = "istio-gateway-status-leader"
-	StatusController        = "istio-status-leader"
 	AnalyzeController       = "istio-analyze-leader"
 	// GatewayDeploymentController controls translating Kubernetes Gateway objects into various derived
 	// resources (Service, Deployment, etc).

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1023,6 +1023,8 @@ type Condition struct {
 
 func (i ServiceInfo) GetConditions() ConditionSet {
 	set := map[ConditionType]*Condition{
+		// Write all conditions here, then overide if we want them set.
+		// This ensures we can properly prune the condition if its no longer needed (such as if there is no waypoint attached at all).
 		WaypointBound: nil,
 	}
 	if i.Waypoint.ResourceName != "" {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -79,6 +79,7 @@ func (a *index) serviceServiceBuilder(
 	}
 }
 
+// MakeSource is a helper to turn an Object into a model.TypedObject.
 func MakeSource(o controllers.Object) model.TypedObject {
 	return model.TypedObject{
 		NamespacedName: config.NamespacedName(o),

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -29,6 +29,8 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/config/schema/kubetypes"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
@@ -59,19 +61,28 @@ func (a *index) serviceServiceBuilder(
 				TargetPortName: p.TargetPort.StrVal,
 			}
 		}
-		waypointKey := ""
-		waypoint := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
+		waypointStatus := model.WaypointBindingStatus{}
+		waypoint, wperr := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
 		if waypoint != nil {
-			waypointKey = waypoint.ResourceName()
+			waypointStatus.ResourceName = waypoint.ResourceName()
 		}
+		waypointStatus.Error = wperr
+
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
 		return &model.ServiceInfo{
 			Service:       a.constructService(s, waypoint),
 			PortNames:     portNames,
 			LabelSelector: model.NewSelector(s.Spec.Selector),
-			Source:        kind.Service,
-			Waypoint:      waypointKey,
+			Source:        MakeSource(s),
+			Waypoint:      waypointStatus,
 		}
+	}
+}
+
+func MakeSource(o controllers.Object) model.TypedObject {
+	return model.TypedObject{
+		NamespacedName: config.NamespacedName(o),
+		Kind:           kind.MustFromGVK(kubetypes.GvkFromObject(o)),
 	}
 }
 
@@ -80,13 +91,13 @@ func (a *index) serviceEntryServiceBuilder(
 	namespaces krt.Collection[*v1.Namespace],
 ) krt.TransformationMulti[*networkingclient.ServiceEntry, model.ServiceInfo] {
 	return func(ctx krt.HandlerContext, s *networkingclient.ServiceEntry) []model.ServiceInfo {
-		waypoint := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
+		waypoint, waypointError := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
 		a.networkUpdateTrigger.MarkDependant(ctx) // Mark we depend on out of band a.Network
-		return a.serviceEntriesInfo(s, waypoint)
+		return a.serviceEntriesInfo(s, waypoint, waypointError)
 	}
 }
 
-func (a *index) serviceEntriesInfo(s *networkingclient.ServiceEntry, w *Waypoint) []model.ServiceInfo {
+func (a *index) serviceEntriesInfo(s *networkingclient.ServiceEntry, w *Waypoint, wperr *model.StatusMessage) []model.ServiceInfo {
 	sel := model.NewSelector(s.Spec.GetWorkloadSelector().GetLabels())
 	portNames := map[int32]model.ServicePortName{}
 	for _, p := range s.Spec.Ports {
@@ -94,17 +105,20 @@ func (a *index) serviceEntriesInfo(s *networkingclient.ServiceEntry, w *Waypoint
 			PortName: p.Name,
 		}
 	}
-	waypointKey := ""
+	waypoint := model.WaypointBindingStatus{}
 	if w != nil {
-		waypointKey = w.ResourceName()
+		waypoint.ResourceName = w.ResourceName()
+	}
+	if wperr != nil {
+		waypoint.Error = wperr
 	}
 	return slices.Map(a.constructServiceEntries(s, w), func(e *workloadapi.Service) model.ServiceInfo {
 		return model.ServiceInfo{
 			Service:       e,
 			PortNames:     portNames,
 			LabelSelector: sel,
-			Source:        kind.ServiceEntry,
-			Waypoint:      waypointKey,
+			Source:        MakeSource(s),
+			Waypoint:      waypoint,
 		}
 	})
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/status.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/status.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"fmt"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func ReportWaypointIsNotReady(waypoint string) *model.StatusMessage {
+	return &model.StatusMessage{
+		Reason:  "WaypointIsNotReady",
+		Message: fmt.Sprintf("waypoint %q is not ready", waypoint),
+	}
+}
+
+func ReportWaypointAttachmentDenied(waypoint string) *model.StatusMessage {
+	return &model.StatusMessage{
+		Reason:  "AttachmentDenied",
+		Message: fmt.Sprintf("we are not permitted to attach to waypoint %q (missing allowedRoutes?)", waypoint),
+	}
+}
+
+func ReportWaypointUnsupportedTrafficType(waypoint string, ttype string) *model.StatusMessage {
+	return &model.StatusMessage{
+		Reason:  "UnsupportedTrafficType",
+		Message: fmt.Sprintf("attempting to bind to traffic type %q which the waypoint %q does not support", ttype, waypoint),
+	}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/conversion.go
@@ -1,0 +1,85 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusqueue
+
+import (
+	"encoding/json"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/meta/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/smallset"
+)
+
+type statusConditions struct {
+	metav1.TypeMeta
+	// TODO(https://github.com/kubernetes/kubernetes/issues/126726) drop this
+	metav1.ObjectMeta `json:"metadata"`
+	Status            conditions `json:"status"`
+}
+
+type conditions struct {
+	Conditions []any `json:"conditions"`
+}
+
+// translateToPatch converts a ConditionSet to a patch
+// The ConditionSet is expected to contain all Types owned by this controller; if they should be unset, they should nil.
+// Failure to do so means the status may not properly get pruned.
+func translateToPatch(object model.TypedObject, status model.ConditionSet, currentConditionsList []string) []byte {
+	currentConditions := smallset.New(currentConditionsList...)
+	conds := make([]any, 0, len(status))
+
+	needsDelete := false
+
+	for t, v := range status {
+		if currentConditions.Contains(string(t)) {
+			needsDelete = true
+		}
+		if v != nil {
+			s := string(metav1.ConditionFalse)
+			if v.Status {
+				s = string(metav1.ConditionTrue)
+			}
+			conds = append(conds, &v1alpha1.IstioCondition{
+				Type:               string(t),
+				Status:             s,
+				LastTransitionTime: timestamppb.Now(),
+				Reason:             v.Reason,
+				Message:            v.Message,
+			})
+		}
+	}
+	if len(conds) == 0 && !needsDelete {
+		return nil
+	}
+	// TODO: it would be nice to have a more direct kind -> GVK mapping
+	s := slices.FindFunc(collections.All.All(), func(schema resource.Schema) bool {
+		return schema.Kind() == object.Kind.String()
+	})
+	res, _ := json.Marshal(statusConditions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       object.Kind.String(),
+			APIVersion: (*s).APIVersion(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: object.Name},
+		Status:     conditions{Conditions: conds},
+	})
+	return res
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
@@ -1,0 +1,142 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusqueue
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	istiolog "istio.io/istio/pkg/log"
+)
+
+var log = istiolog.RegisterScope("status", "status reporting")
+
+type StatusQueue struct {
+	queue controllers.Queue
+
+	// reporters is a mapping of unique controller name -> status information.
+	// Note: this is user facing in the fieldManager!
+	reporters map[string]statusReporter
+}
+
+// statusItem represents the objects stored on the queue
+type statusItem struct {
+	Key      string
+	Reporter string
+}
+
+// NewQueue builds a new status queue.
+func NewQueue() *StatusQueue {
+	sq := &StatusQueue{
+		reporters: make(map[string]statusReporter),
+	}
+	sq.queue = controllers.NewQueue("ambient status",
+		controllers.WithGenericReconciler(sq.reconcile),
+		controllers.WithMaxAttempts(5))
+	return sq
+}
+
+// Run starts the queue, which will process items until the channel is closed
+func (q *StatusQueue) Run(stop <-chan struct{}) {
+	for _, r := range q.reporters {
+		r.start()
+	}
+	q.queue.Run(stop)
+}
+
+// reconcile processes a single queue item
+func (q *StatusQueue) reconcile(raw any) error {
+	key := raw.(statusItem)
+	log := log.WithLabels("key", key.Key)
+	log.Debugf("reconciling status")
+
+	reporter, f := q.reporters[key.Reporter]
+	if !f {
+		log.Fatalf("impossible; an item was enqueued with an unknown reporter")
+	}
+	obj, f := reporter.getObject(key.Key)
+	if !f {
+		log.Infof("object is removed, no action needed")
+		return nil
+	}
+	// Fetch the client to apply patches, and the set of current conditions
+	patcher, currentConditions := reporter.patcher(obj)
+	// Turn the conditions into a patch. Using currentConditions, this will determine whether we can skip the patch entirely
+	// or if we need to send an empty patch. With an empty patch, SSA will automatically prune out anything *we* (identified by the fieldManager) wrote.
+	//
+	// This gives us essentially the same behavior as always writing, but saves a lot of writes... with the caveat of one race condition:
+	// the object can change between when we fetch the currentConditions and apply the patch.
+	// * Condition was there, but is now removed: No problem, we will at worst do a patch that wasn't needed.
+	// * Condition was not there, but now it was added: clearly some other controller is writing the same type as us, which is not really allowed.
+	targetObject := obj.GetStatusTarget()
+	status := translateToPatch(targetObject, obj.GetConditions(), currentConditions)
+
+	if status == nil {
+		log.Debugf("no status to write")
+		return nil
+	}
+	log.Debugf("writing patch %v", string(status))
+	// Pass key.Reporter as the fieldManager. This ensures we have a unique value there.
+	// This means we could have multiple unique writers for the same object, as long as they have a unique set of conditions.
+	return patcher.ApplyStatus(targetObject.Name, targetObject.Namespace, types.ApplyPatchType, status, key.Reporter)
+}
+
+// StatusWriter is a type that can write status messages
+type StatusWriter interface {
+	// GetStatusTarget returns the metadata about the object we are writing to
+	GetStatusTarget() model.TypedObject
+	// GetConditions returns a set of conditions for the object
+	GetConditions() model.ConditionSet
+}
+
+// statusReporter is a generics-erased object storing context on how to write status for a given type.
+type statusReporter struct {
+	getObject func(string) (StatusWriter, bool)
+	patcher   func(StatusWriter) (kclient.Patcher, []string)
+	start     func()
+}
+
+// Register registers a collection to have status reconciled.
+// The Collection is expected to produce objects that implement StatusWriter, which tells us what status to write.
+// The name is user facing, and ends up as a fieldManager for server-side-apply. It must be unique.
+func Register[T StatusWriter](q *StatusQueue, name string, col krt.Collection[T], getPatcher func(T) (kclient.Patcher, []string)) {
+	sr := statusReporter{
+		getObject: func(s string) (StatusWriter, bool) {
+			if o := col.GetKey(krt.Key[T](s)); o != nil {
+				return *o, true
+			}
+			return nil, false
+		},
+		// Wrapper to remove generics
+		patcher: func(writer StatusWriter) (kclient.Patcher, []string) {
+			return getPatcher(writer.(T))
+		},
+		start: func() {
+			col.Register(func(o krt.Event[T]) {
+				ol := o.Latest()
+				key := string(krt.GetKey(ol))
+				log.Debugf("registering key for processing: %s", key)
+				q.queue.Add(statusItem{
+					Key:      key,
+					Reporter: name,
+				})
+			})
+		},
+	}
+	q.reporters[name] = sr
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue_test.go
@@ -1,0 +1,128 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusqueue_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+type serviceStatus struct {
+	Target     model.TypedObject
+	Conditions model.ConditionSet
+}
+
+func (s serviceStatus) GetStatusTarget() model.TypedObject {
+	return s.Target
+}
+
+func (s serviceStatus) ResourceName() string {
+	return s.Target.String()
+}
+
+func (s serviceStatus) GetConditions() model.ConditionSet {
+	return s.Conditions
+}
+
+func TestQueue(t *testing.T) {
+	q := statusqueue.NewQueue()
+	c := kube.NewFakeClient()
+	svc := kclient.New[*v1.Service](c)
+	svcs := krt.WrapClient[*v1.Service](svc)
+	col := krt.NewCollection(svcs, func(ctx krt.HandlerContext, i *v1.Service) *serviceStatus {
+		conds := model.ConditionSet{
+			model.ConditionType("t1"): nil,
+			model.ConditionType("t2"): nil,
+			model.ConditionType("t3"): nil,
+		}
+		for _, set := range strings.Split(i.Annotations["conditions"], ",") {
+			k, v, _ := strings.Cut(set, "=")
+			conds[model.ConditionType(k)] = &model.Condition{Status: v == "true", Reason: "some reason"}
+		}
+		return &serviceStatus{
+			Target: model.TypedObject{
+				NamespacedName: config.NamespacedName(i),
+				Kind:           kind.Service,
+			},
+			Conditions: conds,
+		}
+	})
+	statusqueue.Register(q, "services", col, func(status serviceStatus) (kclient.Patcher, []string) {
+		return kclient.ToPatcher(svc), nil
+	})
+	clienttest.Wrap(t, svc).Create(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "none", Namespace: "default"}})
+	clienttest.Wrap(t, svc).Create(&v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:        "conds",
+		Namespace:   "default",
+		Annotations: map[string]string{"conditions": "t1=true"},
+	}})
+	stop := test.NewStop(t)
+	c.RunAndWait(stop)
+	go q.Run(stop)
+
+	expectConditions := func(name string, conds map[string]bool) {
+		t.Helper()
+		retry.UntilSuccessOrFail(t, func() error {
+			s := svc.Get(name, "default")
+			allHave := slices.Map(s.Status.Conditions, func(t metav1.Condition) string {
+				return t.Type
+			})
+			have := slices.GroupUnique(s.Status.Conditions, func(t metav1.Condition) string {
+				return t.Type
+			})
+
+			for wc, wv := range conds {
+				realCond, f := have[wc]
+				if !f {
+					return fmt.Errorf("expected condition %q, had %v", wc, allHave)
+				}
+				delete(have, wc)
+				if (realCond.Status == metav1.ConditionTrue) != wv {
+					return fmt.Errorf("expected condition %q to be %v, got %v", wc, realCond.Status, wv)
+				}
+			}
+			if len(have) > 0 {
+				return fmt.Errorf("unexpected conditions, wanted %v, got %v", maps.Keys(conds), allHave)
+			}
+			return nil
+		})
+	}
+	expectConditions("none", nil)
+	expectConditions("conds", map[string]bool{"t1": true})
+
+	clienttest.Wrap(t, svc).CreateOrUpdate(&v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:        "conds",
+		Namespace:   "default",
+		Annotations: map[string]string{"conditions": "t2=true"},
+	}})
+	expectConditions("conds", map[string]bool{"t2": true})
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -376,7 +376,7 @@ func TestPodWorkloads(t *testing.T) {
 					},
 					// no selector!
 					LabelSelector: model.LabelSelector{},
-					Source:        kind.Service,
+					Source:        model.TypedObject{Kind: kind.Service},
 				},
 				// EndpointSlice manually associates the pod with a service
 				&discovery.EndpointSlice{
@@ -468,7 +468,7 @@ func TestPodWorkloads(t *testing.T) {
 					},
 					// no selector!
 					LabelSelector: model.LabelSelector{},
-					Source:        kind.Service,
+					Source:        model.TypedObject{Kind: kind.Service},
 				},
 				// EndpointSlice manually created with the IP of the pod, but does NOT have a targetRef
 				&discovery.EndpointSlice{
@@ -545,7 +545,7 @@ func TestPodWorkloads(t *testing.T) {
 						80: {PortName: "80"},
 					},
 					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
-					Source:        kind.Service,
+					Source:        model.TypedObject{Kind: kind.Service},
 				},
 				// Another endpointslice exists with the same IP... This should have no impact
 				kubernetesAPIServerEndpoint("1.1.1.1"),
@@ -561,7 +561,7 @@ func TestPodWorkloads(t *testing.T) {
 					PortNames: map[int32]model.ServicePortName{
 						80: {PortName: "80"},
 					},
-					Source: kind.Service,
+					Source: model.TypedObject{Kind: kind.Service},
 				},
 				&discovery.EndpointSlice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -761,7 +761,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 						83: {PortName: "83", TargetPortName: "83-target"},
 					},
 					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
-					Source:        kind.Service,
+					Source:        model.TypedObject{Kind: kind.Service},
 				},
 			},
 			we: &networkingclient.WorkloadEntry{
@@ -841,7 +841,7 @@ func TestWorkloadEntryWorkloads(t *testing.T) {
 						82: {PortName: "82"},
 					},
 					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
-					Source:        kind.ServiceEntry,
+					Source:        model.TypedObject{Kind: kind.ServiceEntry},
 				},
 			},
 			we: &networkingclient.WorkloadEntry{
@@ -1097,7 +1097,7 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 					},
 					// no selector!
 					LabelSelector: model.LabelSelector{},
-					Source:        kind.Service,
+					Source:        model.TypedObject{Kind: kind.Service},
 				},
 			},
 			// EndpointSlice manually created with the IP of the pod, but does NOT have a targetRef
@@ -1184,7 +1184,7 @@ func kubernetesAPIServerService(ip string) model.ServiceInfo {
 		PortNames: map[int32]model.ServicePortName{
 			443: {PortName: "https"},
 		},
-		Source: kind.Service,
+		Source: model.TypedObject{Kind: kind.Service},
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -660,6 +660,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 			})
 
 			c.ambientIndex.NetworksSynced()
+			c.ambientIndex.RunStatus(stop)
 		}()
 	}
 

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -147,6 +147,14 @@ func (n *writeClient[T]) PatchStatus(name, namespace string, pt apitypes.PatchTy
 	return api.Patch(context.Background(), name, pt, data, metav1.PatchOptions{}, "status")
 }
 
+func (n *writeClient[T]) ApplyStatus(name, namespace string, pt apitypes.PatchType, data []byte, fieldManager string) (T, error) {
+	api := kubeclient.GetWriteClient[T](n.client, namespace)
+	return api.Patch(context.Background(), name, pt, data, metav1.PatchOptions{
+		Force:        ptr.Of(true),
+		FieldManager: fieldManager,
+	}, "status")
+}
+
 func (n *writeClient[T]) UpdateStatus(object T) (T, error) {
 	api, ok := kubeclient.GetWriteClient[T](n.client, object.GetNamespace()).(kubetypes.WriteStatusAPI[T])
 	if !ok {


### PR DESCRIPTION
This PR builds out initial support for writing to status. This is a new condition on Service/ServiceEntry to indicate the waypoint binding status.

Decisions to make:
* Do we use Patch or Update (prefer patch)
* Do we use `pkg/status/manager.go` - probably nice but needs to support patch if we do for ^
* API decision around naming of condition types and reasons

The current PR is just a POC, don't worry about the quality which is low.

End result:
```yaml
apiVersion: networking.istio.io/v1
kind: ServiceEntry
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"networking.istio.io/v1beta1","kind":"ServiceEntry","metadata":{"annotations":{},"name":"test-se","namespace":"default"},"spec":{"hosts":["dummy.example.com"],"ports":[{"name":"tcp","number":9090,"protocol":"TCP"}],"resolution":"DNS"}}
  creationTimestamp: "2024-07-08T16:24:18Z"
  generation: 2
  name: test-se
  namespace: default
  resourceVersion: "64229"
  uid: 92cd1a63-b46d-4cac-92c7-0129217a6770
spec:
  hosts:
  - dummy.example.com
  ports:
  - name: tcp
    number: 9090
    protocol: TCP
  resolution: DNS
status:
  conditions:
  - lastTransitionTime: "2024-07-08T16:24:56.946472175Z"
    message: Successfull attached to waypoint default/waypoint
    reason: WaypointAccepted
    status: "True"
    type: istio.io/WaypointBound
  observedGeneration: "2"
  validationMessages:
  - documentationUrl: https://istio.io/v1.23/docs/reference/config/analysis/ist0133/
    level: WARNING
    type:
      code: IST0133
  - documentationUrl: https://istio.io/v1.23/docs/reference/config/analysis/ist0134/
    level: WARNING
    type:
      code: IST0134
```