### PR TITLE
Speedup isntall of multiple suites by up to 30s

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -193,6 +193,10 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
     echo "${patched_coredns_config}"
     printf '%s' "${patched_coredns_config}" | kubectl apply -f -
   fi
+  # CoreDNS by default caches Kubernetes objects for 30s. This leads to problematic timing issues when we tear down + re-install
+  # in our tests. We will negative-cache the object, adding up to 30s on each test suite.
+  # See https://github.com/coredns/coredns/pull/2348
+  kubectl get -oyaml -n=kube-system configmap/coredns | sed 's/ttl 30/ttl 0/g' | kubectl apply -f -
 fi
 
 # Run the test target if provided.


### PR DESCRIPTION
Without this, you will see ingress pod hang for 30s to resolve Istiod
DNS on each additional suite
