### PR TITLE
Fix upgrade issue when using a configmap to set the trusted CAs

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -222,7 +222,7 @@ spec:
           - name: istio-csr-dns-cert
             mountPath: /var/run/secrets/istiod/tls
             readOnly: true
-          - name: istio-csr-ca-configmap
+          - name: istio-trust-bundle
             mountPath: /var/run/secrets/istiod/ca
             readOnly: true
           {{- with .Values.pilot.volumeMounts }}
@@ -255,9 +255,9 @@ spec:
         secret:
           secretName: istiod-tls
           optional: true
-      - name: istio-csr-ca-configmap
+      - name: istio-trust-bundle
         configMap:
-          name: istio-ca-root-cert
+          name: istio-trust-bundle
           defaultMode: 420
           optional: true
   {{- if .Values.pilot.jwksResolverExtraRootCA }}


### PR DESCRIPTION
While testing CA rotation and custom CAs I noticed that the configmap istio-ca-root-cert is used to configure
Istiod - but it is also the map generated by Istiod.

On a clean install with the controller disabled it doesn't have any problem and works, but if this is 
done for an upgrade or with other revisions of Istiod it breaks, since the configmap will be replaced
or changed with the wrong values. 

Using a different name is safer. 

Note that K8S has a new TrustBundle cluster CRD that can be mounted as a projected volume - and once it
moves past alpha it will probably be the 'right' way to configure the root CAs and remove the need for the
controller. Same TrustBundle can be mounted in both Istiod and sidecars/ambient - greatly simplifying the
code. 