### PR TITLE
Allow users to explicitly disable trust configmap creation

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1203,6 +1203,10 @@ func (s *Server) maybeCreateCA(caOpts *caOptions) error {
 // Returns true to indicate the K8S multicluster controller should enable replication of
 // root certificates to config maps in namespaces.
 func (s *Server) shouldStartNsController() bool {
+	// Explicitly disable NS controller - user is using other means ( like CertManager trust distribution or TrustBundle)
+	if features.TrustDistribution == "off" {
+		return false
+	}
 	if s.isK8SSigning() {
 		// Need to distribute the roots from MeshConfig
 		return true

--- a/pilot/pkg/features/security.go
+++ b/pilot/pkg/features/security.go
@@ -88,6 +88,8 @@ var (
 		return res
 	}()
 
+	TrustDistribution = env.Register("TRUST_DISTRIBUTION", "", "Control the creation of istio-ca-root-cert configmap. 'off' disables the controller.").Get()
+
 	CertSignerDomain = env.Register("CERT_SIGNER_DOMAIN", "", "The cert signer domain info").Get()
 
 	UseCacertsForSelfSignedCA = env.Register("USE_CACERTS_FOR_SELF_SIGNED_CA", false,

--- a/releasenotes/notes/root-cert-configmap-controller.yaml
+++ b/releasenotes/notes/root-cert-configmap-controller.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Improved** Istio feature TRUST_DISTRIBUTION="off" can be used to explicitly disable the creation of 'istio-ca-root-cert', if other means of trust distribution are used. If not set Istiod will continue to infer based on other settings.


### PR DESCRIPTION
Change-Id: Ic3c9c0ec55b2aa026ae369600861d396e4a594af

**Please provide a description of this PR:**

Current logic is based on various criteria - but user has no way to explicitly disable the creation of the istio-ca-root-cert 
config map. 

There are cases where the roots are distributed via other means - for example CertManager has its own 
trust manager , K8S is defining a cluster CRD (TrustBundle) - or CSI or other means are used when integrating
with other certificate solutions. 