### PR TITLE
WIP: Remove few more obsolete uses of K8S signer.

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -40,10 +40,6 @@ const (
 
 	// the interval polling root cert and resign istiod cert when it changes.
 	rootCertPollingInterval = 60 * time.Second
-
-	// Default CA certificate path
-	// Currently, custom CA path is not supported; no API to get custom CA cert yet.
-	defaultCACertPath = "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
 // initDNSCertsK8SRA will create the certificates using K8S RA.

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -26,7 +26,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/features"
 	tb "istio.io/istio/pilot/pkg/trustbundle"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/sleep"
 	"istio.io/istio/security/pkg/k8s/chiron"
@@ -55,9 +54,8 @@ const (
 func (s *Server) initDNSCertsK8SRA() error {
 	var certChain, keyPEM, caBundle []byte
 	var err error
-	pilotCertProviderName := features.PilotCertProvider
+	signerName := features.PilotCertProvider
 
-	signerName := strings.TrimPrefix(pilotCertProviderName, constants.CertProviderKubernetesSignerPrefix)
 	log.Infof("Generating K8S-signed cert for %v using signer %v", s.dnsNames, signerName)
 	certChain, keyPEM, _, err = chiron.GenKeyCertK8sCA(s.kubeClient.Kube(),
 		strings.Join(s.dnsNames, ","), "", signerName, true, SelfSignedCACertTTL.Get())

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -523,21 +523,14 @@ func (s *Server) createSelfSignedCACertificateOptions(fileBundle *ca.SigningCAFi
 // 3. Extract from the cert-chain signed by other CSR signer.
 func (s *Server) createIstioRA(opts *caOptions) (ra.RegistrationAuthority, error) {
 	caCertFile := path.Join(ra.DefaultExtCACertDir, constants.CACertNamespaceConfigMapDataName)
-	certSignerDomain := opts.CertSignerDomain
 	_, err := os.Stat(caCertFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to get file info: %v", err)
 		}
 
-		// File does not exist.
-		if certSignerDomain == "" {
-			log.Infof("CA cert file %q not found, using %q.", caCertFile, defaultCACertPath)
-			caCertFile = defaultCACertPath
-		} else {
-			log.Infof("CA cert file %q not found - ignoring.", caCertFile)
-			caCertFile = ""
-		}
+		log.Infof("CA cert file %q not found, using MeshConfig for RA", caCertFile)
+		caCertFile = ""
 	}
 
 	if s.kubeClient == nil {

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -139,8 +139,6 @@ const (
 	// This used to use the no longer supported default K8S signer.
 	// Deprecated - used to detect the old setting and generate the error message.
 	CertProviderKubernetes = "kubernetes"
-	// CertProviderKubernetesSignerPrefix uses the Kubernetes CSR API and the specified signer to generate a DNS certificate for the control plane
-	CertProviderKubernetesSignerPrefix = "k8s.io/"
 	// CertProviderCustom uses the custom root certificate mounted in a well known location for the control plane
 	CertProviderCustom = "custom"
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -98,6 +98,7 @@ func NewVerifiedKeyCertBundleFromFile(certFile string, privKeyFile string, certC
 }
 
 // NewKeyCertBundleWithRootCertFromFile returns a new KeyCertBundle with the root cert without verification.
+// Used by K8S RA.
 func NewKeyCertBundleWithRootCertFromFile(rootCertFile string) (*KeyCertBundle, error) {
 	var rootCertBytes []byte
 	var err error
@@ -106,7 +107,11 @@ func NewKeyCertBundleWithRootCertFromFile(rootCertFile string) (*KeyCertBundle, 
 	} else {
 		rootCertBytes, err = os.ReadFile(rootCertFile)
 		if err != nil {
-			return nil, err
+			if os.IsNotExist(err) {
+				rootCertBytes = []byte{}
+			} else {
+				return nil, err
+			}
 		}
 	}
 	return &KeyCertBundle{


### PR DESCRIPTION
**Please provide a description of this PR:**

This removes the k8s signer ( we already removed signing with it, and k8s removed the support as well), and 
clarifies the loading of roots for RA case  - but the explicitly mounted config map and meshconfig will be 
added.  

K8S_SIGNER can currently be example.com/name or k8s.io/example.com/name - the k8s.io prefix is removed and 
pretty confusing (doesn't match the name of the signer)