### PR TITLE
istioctl: Show all addresses in eds proxy-config

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -29,6 +29,8 @@ import (
 
 	"istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 type EndpointFilter struct {
@@ -43,9 +45,15 @@ func (e *EndpointFilter) Verify(ep *endpoint.LbEndpoint, cluster string) bool {
 	if e.Address == "" && e.Port == 0 && e.Cluster == "" && e.Status == "" {
 		return true
 	}
-	if e.Address != "" && !strings.EqualFold(retrieveEndpointAddress(ep), e.Address) {
-		return false
+	if e.Address != "" {
+		found := slices.FindFunc(retrieveEndpointAddresses(ep), func(s string) bool {
+			return strings.EqualFold(s, e.Address)
+		}) != nil
+		if !found {
+			return false
+		}
 	}
+
 	if e.Port != 0 && retrieveEndpointPort(ep) != e.Port {
 		return false
 	}
@@ -67,21 +75,40 @@ func retrieveEndpointPort(ep *endpoint.LbEndpoint) uint32 {
 	return ep.GetEndpoint().GetAddress().GetSocketAddress().GetPortValue()
 }
 
-func retrieveEndpointAddress(ep *endpoint.LbEndpoint) string {
-	addr := ep.GetEndpoint().GetAddress()
-	if addr := addr.GetSocketAddress(); addr != nil {
-		return addr.Address + ":" + strconv.Itoa(int(addr.GetPortValue()))
+func retrieveEndpointAddresses(ep *endpoint.LbEndpoint) []string {
+	addrs := []*core.Address{ep.GetEndpoint().GetAddress()}
+	for _, a := range ep.GetEndpoint().GetAdditionalAddresses() {
+		addrs = append(addrs, a.GetAddress())
 	}
-	if addr := addr.GetPipe(); addr != nil {
-		return addr.GetPath()
+	result := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr := addr.GetSocketAddress(); addr != nil {
+			result = append(result, addr.Address+":"+strconv.Itoa(int(addr.GetPortValue())))
+			continue
+		}
+		if addr := addr.GetPipe(); addr != nil {
+			result = append(result, addr.GetPath())
+			continue
+		}
+		if internal := addr.GetEnvoyInternalAddress(); internal != nil {
+			switch an := internal.GetAddressNameSpecifier().(type) {
+			case *core.EnvoyInternalAddress_ServerListenerName:
+				result = append(result, fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId))
+				continue
+			}
+		}
+		result = append(result, "unknown")
 	}
-	if internal := addr.GetEnvoyInternalAddress(); internal != nil {
-		switch an := internal.GetAddressNameSpecifier().(type) {
-		case *core.EnvoyInternalAddress_ServerListenerName:
-			return fmt.Sprintf("envoy://%s/%s", an.ServerListenerName, internal.EndpointId)
+
+	// Workaround https://github.com/envoyproxy/envoy/issues/35100. We can remove if it is fixed.
+	filtered := make([]string, 0, len(result))
+	seen := sets.New[string]()
+	for _, r := range result {
+		if !seen.InsertContains(r) {
+			filtered = append(filtered, r)
 		}
 	}
-	return "unknown"
+	return filtered
 }
 
 func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter, outputFormat string) error {
@@ -120,7 +147,7 @@ func (c *ConfigWriter) PrintEndpointsSummary(filter EndpointFilter) error {
 	for _, eds := range dump {
 		for _, llb := range eds.Endpoints {
 			for _, ep := range llb.LbEndpoints {
-				addr := retrieveEndpointAddress(ep)
+				addr := strings.Join(retrieveEndpointAddresses(ep), ",")
 				if includeConfigType {
 					addr = fmt.Sprintf("endpoint/%s", addr)
 				}


### PR DESCRIPTION
Example:
```
NAME                                             STATUS      LOCALITY     CLUSTER
127.0.0.1:15020                                  HEALTHY                  agent
10.244.0.8:80                                    HEALTHY                  outbound|80||echo-v4v6.default.svc.cluster.local
10.244.0.8:9090                                  HEALTHY                  outbound|9090||echo-v4v6.default.svc.cluster.local
10.244.0.8:80                                    HEALTHY                  outbound|80||echo-v6v4.default.svc.cluster.local
10.244.0.8:9090                                  HEALTHY                  outbound|9090||echo-v6v4.default.svc.cluster.local
10.244.0.8:80                                    HEALTHY                  outbound|80||echo.default.svc.cluster.local
10.244.0.8:443                                   HEALTHY                  outbound|443||echo.default.svc.cluster.local
10.244.0.8:7070                                  HEALTHY                  outbound|7070||echo.default.svc.cluster.local
10.244.0.8:9090                                  HEALTHY                  outbound|9090||echo.default.svc.cluster.local
10.244.0.8:9091                                  HEALTHY                  outbound|9091||echo.default.svc.cluster.local
10.244.0.7:8080                                  HEALTHY                  outbound|80||istio-ingressgateway.istio-system.svc.cluster.local
10.244.0.7:8443                                  HEALTHY                  outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
10.244.0.7:15021                                 HEALTHY                  outbound|15021||istio-ingressgateway.istio-system.svc.cluster.local
10.244.0.14:15017,fd00:10:244::e:15017           HEALTHY                  outbound|443||istiod.istio-system.svc.cluster.local
10.244.0.14:15010,fd00:10:244::e:15010           HEALTHY                  outbound|15010||istiod.istio-system.svc.cluster.local
10.244.0.14:15012,fd00:10:244::e:15012           HEALTHY                  outbound|15012||istiod.istio-system.svc.cluster.local
10.244.0.14:15014,fd00:10:244::e:15014           HEALTHY                  outbound|15014||istiod.istio-system.svc.cluster.local
10.244.0.2:53                                    HEALTHY                  outbound|53||kube-dns.kube-system.svc.cluster.local
10.244.0.4:53                                    HEALTHY                  outbound|53||kube-dns.kube-system.svc.cluster.local
10.244.0.2:9153                                  HEALTHY                  outbound|9153||kube-dns.kube-system.svc.cluster.local
10.244.0.4:9153                                  HEALTHY                  outbound|9153||kube-dns.kube-system.svc.cluster.local
172.18.0.3:6443                                  HEALTHY                  outbound|443||kubernetes.default.svc.cluster.local
127.0.0.1:15000                                  HEALTHY                  prometheus_stats
./var/run/secrets/workload-spiffe-uds/socket     HEALTHY                  sds-grpc
10.244.0.10:9087                                 HEALTHY                  outbound|9087||shell.default.svc.cluster.local
./etc/istio/proxy/XDS                            HEALTHY                  xds-grpc
```
