### PR TITLE
Strict CSR validation in k8s CSR workflow

### DIFF
--- a/releasenotes/notes/51966.yaml
+++ b/releasenotes/notes/51966.yaml
@@ -5,4 +5,4 @@ issue:
   - 51966
 releaseNotes:
   - |
-    **Added** stricter validation of Istio CSR requests when Istio is functioning as the RA and is configured with an external CA for workload certificate signing
+    **Added** stricter validation of CSRs when Istio is functioning as the RA and is configured with an external CA for workload certificate signing.

--- a/releasenotes/notes/51966.yaml
+++ b/releasenotes/notes/51966.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 51966
+releaseNotes:
+  - |
+    **Added** stricter validation of Istio CSR requests when Istio is functioning as the RA and is configured with an external CA for workload certificate signing

--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -94,13 +94,13 @@ func ValidateCSR(csrPEM []byte, subjectIDs []string) bool {
 	// same process as performed on the client and comparing the generated CSR with the
 	// received CSR.
 
-	// Convert csrIDs to Host comma seperated string
+	// Convert csrIDs to Host comma separated string
 	hosts := strings.Join(csrIDs, ",")
-	// genCSRTemplate is the expected CSR template. The template's extensions are marshalled
+	// genCSRTemplate is the expected CSR template. The template's extensions are marshaled
 	// in the ExtraExtensions field. CreateCertificateRequest would normally add the SAN extensions
 	// from ExtraExtensions to the Extensions field. However, we are only generating the
 	// template here and not the actual CSR since we do not know the exact signing mechanisms
-	// of the client. Additionaly, if we compared extensions the the generated CSR and the orginal
+	// of the client. Additionally, if we compared extensions the the generated CSR and the orginal
 	// CSR would match since the hosts where constructed from the extracted SAN extensions.
 	genCSRTemplate, err := util.GenCSRTemplate(util.CertOptions{Host: hosts})
 	if err != nil {
@@ -156,7 +156,7 @@ func compareCSRs(orgCSR, genCSR *x509.CertificateRequest) bool {
 		}
 	}
 	// ExtraExtensions should not be populated in the orgCSR
-	if len(orgCSR.ExtraExtensions) != 0 {
+	if len(orgCSR.ExtraExtensions) > 0 {
 		return false
 	}
 	return true

--- a/security/pkg/pki/ra/common.go
+++ b/security/pkg/pki/ra/common.go
@@ -100,7 +100,7 @@ func ValidateCSR(csrPEM []byte, subjectIDs []string) bool {
 	// in the ExtraExtensions field. CreateCertificateRequest would normally add the SAN extensions
 	// from ExtraExtensions to the Extensions field. However, we are only generating the
 	// template here and not the actual CSR since we do not know the exact signing mechanisms
-	// of the client. Additionally, if we compared extensions the the generated CSR and the orginal
+	// of the client. Additionally, if we compared extensions the the generated CSR and the original
 	// CSR would match since the hosts where constructed from the extracted SAN extensions.
 	genCSRTemplate, err := util.GenCSRTemplate(util.CertOptions{Host: hosts})
 	if err != nil {
@@ -156,10 +156,7 @@ func compareCSRs(orgCSR, genCSR *x509.CertificateRequest) bool {
 		}
 	}
 	// ExtraExtensions should not be populated in the orgCSR
-	if len(orgCSR.ExtraExtensions) > 0 {
-		return false
-	}
-	return true
+	return len(orgCSR.ExtraExtensions) == 0
 }
 
 // NewIstioRA is a factory method that returns an RA that implements the RegistrationAuthority functionality.

--- a/security/pkg/pki/ra/common_test.go
+++ b/security/pkg/pki/ra/common_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestCompareCSRs(t *testing.T) {
 	basicGenCSR, err := util.GenCSRTemplate(util.CertOptions{Host: testCsrHostName})
+	basicGenDualHostCSR, err := util.GenCSRTemplate(util.CertOptions{Host: testCsrHostName, IsDualUse: true})
 	if err != nil {
 		t.Fatalf("Failed to generate CSR template: %v", err)
 	}
@@ -49,13 +50,19 @@ func TestCompareCSRs(t *testing.T) {
 		},
 		{
 			name:           "orgCSR CN is invalid (not empty)",
-			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{CommonName: "invalid"}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}, CommonName: "invalid"}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
+			name:           "orgCSR CN set to host (valid with isDualHost is true)",
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}, CommonName: testCsrHostName}},
+			genCSR:         basicGenDualHostCSR,
+			expectedResult: true,
+		},
+		{
 			name:           "orgCSR CN empty string",
-			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}, CommonName: ""}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
@@ -63,7 +70,7 @@ func TestCompareCSRs(t *testing.T) {
 			name:           "orgCSR Org is unset",
 			orgCSR:         &x509.CertificateRequest{},
 			genCSR:         basicGenCSR,
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			name:           "orgCSR Org is set to empty string",
@@ -79,103 +86,103 @@ func TestCompareCSRs(t *testing.T) {
 		},
 		{
 			name:           "orgCSR URI is empty",
-			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, URIs: []*url.URL{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR URI set to host",
-			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{{Host: testCsrHostName}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, URIs: []*url.URL{{Host: testCsrHostName}}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with multiple URIs",
-			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{{Host: testCsrHostName}, {Host: "another"}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, URIs: []*url.URL{{Host: testCsrHostName}, {Host: "another"}}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with unset emailAddresses",
-			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, EmailAddresses: []string{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with emailAddresses set to empty string",
-			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{""}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, EmailAddresses: []string{""}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with invalid emailAddresses",
-			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{"invalid", "another-invalid"}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, EmailAddresses: []string{"invalid", "another-invalid"}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with invalid IPAddresses",
-			orgCSR:         &x509.CertificateRequest{IPAddresses: []net.IP{{1, 2, 3, 4}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, IPAddresses: []net.IP{{1, 2, 3, 4}}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with empty IPAddresses",
-			orgCSR:         &x509.CertificateRequest{IPAddresses: []net.IP{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, IPAddresses: []net.IP{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with empty DNSNames",
-			orgCSR:         &x509.CertificateRequest{DNSNames: []string{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, DNSNames: []string{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with empty string DNSNames",
-			orgCSR:         &x509.CertificateRequest{DNSNames: []string{""}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, DNSNames: []string{""}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with invalid DNSNames",
-			orgCSR:         &x509.CertificateRequest{DNSNames: []string{"invalid", "antoher-invalid"}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, DNSNames: []string{"invalid", "antoher-invalid"}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with SANs extensions only",
-			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with SANs and non SANs extensions",
-			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}, {Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}, {Id: asn1.ObjectIdentifier{1, 2, 3}}}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with non SANs extensions",
-			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, Extensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
 		{
 			name:           "orgCSR with empty extensions",
-			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, Extensions: []pkix.Extension{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with empty extra extensions",
-			orgCSR:         &x509.CertificateRequest{ExtraExtensions: []pkix.Extension{}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, ExtraExtensions: []pkix.Extension{}},
 			genCSR:         basicGenCSR,
 			expectedResult: true,
 		},
 		{
 			name:           "orgCSR with non empty extra extensions",
-			orgCSR:         &x509.CertificateRequest{ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},

--- a/security/pkg/pki/ra/common_test.go
+++ b/security/pkg/pki/ra/common_test.go
@@ -26,9 +26,12 @@ import (
 
 func TestCompareCSRs(t *testing.T) {
 	basicGenCSR, err := util.GenCSRTemplate(util.CertOptions{Host: testCsrHostName})
+	if err != nil {
+		t.Fatalf("Failed to generate basic CSR template: %v", err)
+	}
 	basicGenDualHostCSR, err := util.GenCSRTemplate(util.CertOptions{Host: testCsrHostName, IsDualUse: true})
 	if err != nil {
-		t.Fatalf("Failed to generate CSR template: %v", err)
+		t.Fatalf("Failed to generate dual host CSR template: %v", err)
 	}
 	cases := []struct {
 		name           string
@@ -157,8 +160,11 @@ func TestCompareCSRs(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "orgCSR with SANs and non SANs extensions",
-			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}, {Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			name: "orgCSR with SANs and non SANs extensions",
+			orgCSR: &x509.CertificateRequest{
+				Subject:    pkix.Name{Organization: []string{""}},
+				Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}, {Id: asn1.ObjectIdentifier{1, 2, 3}}},
+			},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},
@@ -181,8 +187,11 @@ func TestCompareCSRs(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "orgCSR with non empty extra extensions",
-			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}, ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			name: "orgCSR with non empty extra extensions",
+			orgCSR: &x509.CertificateRequest{
+				Subject:         pkix.Name{Organization: []string{""}},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}},
+			},
 			genCSR:         basicGenCSR,
 			expectedResult: false,
 		},

--- a/security/pkg/pki/ra/common_test.go
+++ b/security/pkg/pki/ra/common_test.go
@@ -1,0 +1,192 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ra
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"net"
+	"net/url"
+	"testing"
+
+	"istio.io/istio/security/pkg/pki/util"
+)
+
+func TestCompareCSRs(t *testing.T) {
+	basicGenCSR, err := util.GenCSRTemplate(util.CertOptions{Host: testCsrHostName})
+	if err != nil {
+		t.Fatalf("Failed to generate CSR template: %v", err)
+	}
+	cases := []struct {
+		name           string
+		orgCSR         *x509.CertificateRequest
+		genCSR         *x509.CertificateRequest
+		expectedResult bool
+	}{
+		{
+			name:           "orgCSR is nil",
+			orgCSR:         nil,
+			genCSR:         &x509.CertificateRequest{},
+			expectedResult: false,
+		},
+		{
+			name:           "genCSR is nil",
+			orgCSR:         &x509.CertificateRequest{},
+			genCSR:         nil,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR CN is invalid (not empty)",
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{CommonName: "invalid"}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR CN empty string",
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{CommonName: ""}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR Org is unset",
+			orgCSR:         &x509.CertificateRequest{},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR Org is set to empty string",
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{""}}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR Org is invalid (not empty or empt string)",
+			orgCSR:         &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"invalid"}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR URI is empty",
+			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR URI set to host",
+			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{{Host: testCsrHostName}}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with multiple URIs",
+			orgCSR:         &x509.CertificateRequest{URIs: []*url.URL{{Host: testCsrHostName}, {Host: "another"}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with unset emailAddresses",
+			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with emailAddresses set to empty string",
+			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{""}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with invalid emailAddresses",
+			orgCSR:         &x509.CertificateRequest{EmailAddresses: []string{"invalid", "another-invalid"}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with invalid IPAddresses",
+			orgCSR:         &x509.CertificateRequest{IPAddresses: []net.IP{{1, 2, 3, 4}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with empty IPAddresses",
+			orgCSR:         &x509.CertificateRequest{IPAddresses: []net.IP{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with empty DNSNames",
+			orgCSR:         &x509.CertificateRequest{DNSNames: []string{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with empty string DNSNames",
+			orgCSR:         &x509.CertificateRequest{DNSNames: []string{""}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with invalid DNSNames",
+			orgCSR:         &x509.CertificateRequest{DNSNames: []string{"invalid", "antoher-invalid"}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with SANs extensions only",
+			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with SANs and non SANs extensions",
+			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: util.OidSubjectAlternativeName}, {Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with non SANs extensions",
+			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+		{
+			name:           "orgCSR with empty extensions",
+			orgCSR:         &x509.CertificateRequest{Extensions: []pkix.Extension{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with empty extra extensions",
+			orgCSR:         &x509.CertificateRequest{ExtraExtensions: []pkix.Extension{}},
+			genCSR:         basicGenCSR,
+			expectedResult: true,
+		},
+		{
+			name:           "orgCSR with non empty extra extensions",
+			orgCSR:         &x509.CertificateRequest{ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3}}}},
+			genCSR:         basicGenCSR,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := compareCSRs(tc.orgCSR, tc.genCSR)
+			if result != tc.expectedResult {
+				t.Errorf("Expected %t, but got %t", tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/security/pkg/pki/ra/k8s_ra_test.go
+++ b/security/pkg/pki/ra/k8s_ra_test.go
@@ -15,6 +15,14 @@
 package ra
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"os"
 	"path"
 	"testing"
@@ -53,73 +61,26 @@ SpAJos6OfJqyok7JXDdOYRDD5/hBerj68R9llWzNJd27/1jZ0NF2sIE1W4QFddy/
 e+5z6MTAO6ktvHdQlSuH6ARn47bJrZOlkttAhg==
 -----END CERTIFICATE-----
 `
-
-	// Steps to recreate CSR for testCSRWithCATrue
-	//
-	// cat > client.conf <<EOF
-	// [req]
-	// req_extensions = v3_req
-	// distinguished_name = req_distinguished_name
-	// [req_distinguished_name]
-	// [ v3_req ]
-	// basicConstraints = CA:TRUE
-	// keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-	// extendedKeyUsage = clientAuth, serverAuth
-	// subjectAltName = @alt_names
-	// [alt_names]
-	// URI = spiffe://cluster.local/ns/default/sa/bookinfo-productpage
-	// EOF
-	//
-	// openssl ecparam -out ./key.pem -name prime256v1 -genkey
-	//
-	// openssl req -new -sha256 -key key.pem -out client.csr -subj /CN="" -config client.conf
-	testCSRWithCATrue = `-----BEGIN CERTIFICATE REQUEST-----
-MIIBUDCB9wIBADAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElNlH1xq0iqhW
-LjCEVV6W58UKS66yZgmcm81SDWxB2LH+eZ+61Udq6EElHd51C9XmPBoAln7TjDgO
-rP4Lsxl48qCBlDCBkQYJKoZIhvcNAQkOMYGDMIGAMAwGA1UdEwQFMAMBAf8wCwYD
-VR0PBAQDAgXgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATBEBgNVHREE
-PTA7hjlzcGlmZmU6Ly9jbHVzdGVyLmxvY2FsL25zL2RlZmF1bHQvc2EvYm9va2lu
-Zm8tcHJvZHVjdHBhZ2UwCgYIKoZIzj0EAwIDSAAwRQIgP8PYpt0pUOCGtz5PopBt
-ZkifGDtZspkygoghA/A8hw0CIQDJyJhcijKfHN1fri9VFKarjKYDpQXD9aiGtrMf
-PK0qAQ==
------END CERTIFICATE REQUEST-----
-`
-
-	// Steps to recretae CSR for testCSRWithInvalidCN
-	// cat > client-test3.conf <<EOF
-	// [req]
-	// req_extensions = v3_req
-	// distinguished_name = req_distinguished_name
-	// [req_distinguished_name]
-	// [ v3_req ]
-	// keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-	// extendedKeyUsage = clientAuth, serverAuth
-	// subjectAltName = @alt_names
-	// [alt_names]
-	// URI = spiffe://cluster.local/ns/default/sa/bookinfo-productpage
-	// EOF
-
-	// openssl ecparam -out ./key.pem -name prime256v1 -genkey
-
-	// openssl req -new -sha256 -key key.pem -out client-test3.csr -subj "/CN=test.test.svc.cluster.local" -config client-test3.conf
-	testCSRWithInvalidCN = `-----BEGIN CERTIFICATE REQUEST-----
-MIIBTzCB9gIBADAPMQ0wCwYDVQQDDAR0ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
-AQcDQgAEilbgGZrCywnsO9VCji1E2+9vNg5c4qSxSHeOx6v47V04k72BlemfSWYR
-1dl//qZTbTVBuIRGl2C8zD3kQ+2s1KCBhDCBgQYJKoZIhvcNAQkOMXQwcjALBgNV
-HQ8EBAMCBeAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMEQGA1UdEQQ9
-MDuGOXNwaWZmZTovL2NsdXN0ZXIubG9jYWwvbnMvZGVmYXVsdC9zYS9ib29raW5m
-by1wcm9kdWN0cGFnZTAKBggqhkjOPQQDAgNIADBFAiB0LzGRZ1xg2QxMlNlb18uB
-ldHWJYmbT0gJp6ZncK/OUgIhALG0Wzg1UqGGJ3qfrqNw/QnAcp22eQO6Bc+r8plk
-wQBl
------END CERTIFICATE REQUEST-----
-`
 )
 
 var (
 	testCsrHostName       = spiffe.Identity{TrustDomain: "cluster.local", Namespace: "default", ServiceAccount: "bookinfo-productpage"}.String()
 	TestCACertFile        = "../testdata/example-ca-cert.pem"
 	mismatchCertChainFile = "../testdata/cert-chain.pem"
+
+	// The OID for the BasicConstraints extension (See
+	// https://www.alvestrand.no/objectid/2.5.29.19.html).
+	oidBasicConstraints = asn1.ObjectIdentifier{2, 5, 29, 19}
 )
+
+// basicConstraints is a structure that represents the ASN.1 encoding of the
+// BasicConstraints extension.
+// The structure is borrowed from
+// https://github.com/golang/go/blob/master/src/crypto/x509/x509.go#L975
+type basicConstraints struct {
+	IsCA       bool `asn1:"optional"`
+	MaxPathLen int  `asn1:"optional,default:-1"`
+}
 
 func TestK8sSignWithMeshConfig(t *testing.T) {
 	cases := []struct {
@@ -222,10 +183,12 @@ func TestK8sSignWithMeshConfig(t *testing.T) {
 	}
 }
 
+// createDefaultFakeCsr create a default fake CSR
 func createDefaultFakeCsr(t *testing.T) []byte {
 	return createFakeCsr(t, "")
 }
 
+// createFakeCsr creates a fake CSR with the given org
 func createFakeCsr(t *testing.T, org string) []byte {
 	options := pkiutil.CertOptions{
 		Host:       testCsrHostName,
@@ -240,6 +203,99 @@ func createFakeCsr(t *testing.T, org string) []byte {
 		return nil
 	}
 	return csrPEM
+}
+
+// genTestCSR generates a test CSR with more configurability than supported by the GenCSR() function
+// For basic CSR generation, use createFakeCsr() since this is more consistent with how istio-proxy
+// generated CSRs
+func genTestCSR(t *testing.T, options pkiutil.CertOptions, cn string) []byte {
+	// GenCSRTemplates configures the following fields:
+	// - CN if IsDualUse is set to true
+	// - ExtraExtensions for SANs using host values
+	// - Organization to the value of certOpts.Org
+	csr, err := pkiutil.GenCSRTemplate(options)
+	if err != nil {
+		t.Fatalf("Error creating fake CSR: %v", err)
+		return nil
+	}
+	// Set DNSNames
+	csr.DNSNames = append(csr.DNSNames, options.DNSNames)
+
+	// Set IsCA
+	basicConstraints, err := marshalBasicConstraints(options.IsCA)
+	if err != nil {
+		t.Fatalf("Error marshaling basic constraints: %v", err)
+	}
+	csr.Extensions = append(csr.Extensions, *basicConstraints)
+
+	// Allow setting CN even if isDualUse is false
+	if !options.IsDualUse && cn != "" {
+		csr.Subject.CommonName = cn
+	}
+
+	// Set certOptions not being tested
+	if options.RSAKeySize == 0 {
+		// MinimumRsaKeySize is 2048
+		options.RSAKeySize = 2048
+	}
+	if options.ECSigAlg == "" {
+		options.ECSigAlg = pkiutil.SupportedECSignatureAlgorithms("ECDSA")
+	}
+
+	// Generate private key for the CSR
+	// copied from GenCSR() in security/pkg/pki/util/generate_csr.go
+	var priv any
+	if options.ECSigAlg != "" {
+		switch options.ECSigAlg {
+		case pkiutil.EcdsaSigAlg:
+			var curve elliptic.Curve
+			switch options.ECCCurve {
+			case pkiutil.P384Curve:
+				curve = elliptic.P384()
+			default:
+				curve = elliptic.P256()
+			}
+			priv, err = ecdsa.GenerateKey(curve, rand.Reader)
+			if err != nil {
+				t.Fatalf("EC key generation failed (%v)", err)
+				return nil
+			}
+		default:
+			t.Fatalf("csr cert generation fails due to unsupported EC signature algorithm")
+			return nil
+		}
+	} else {
+		if options.RSAKeySize < pkiutil.MinimumRsaKeySize {
+			t.Fatalf("requested key size does not meet the minimum required size of %d (requested: %d)", pkiutil.MinimumRsaKeySize, options.RSAKeySize)
+			return nil
+		}
+
+		priv, err = rsa.GenerateKey(rand.Reader, options.RSAKeySize)
+		if err != nil {
+			t.Fatalf("RSA key generation failed (%v)", err)
+			return nil
+		}
+	}
+
+	// CreateCertificateRequest creates a new certificate using template and private key
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, csr, crypto.PrivateKey(priv))
+	if err != nil {
+		t.Fatalf("x509 CreateCertificateRequest (%v)", err)
+		return nil
+	}
+
+	return csrBytes
+}
+
+// marshalBasicConstraints marshals the isCA value into a BasicConstraints extension.
+func marshalBasicConstraints(isCA bool) (*pkix.Extension, error) {
+	ext := &pkix.Extension{Id: oidBasicConstraints, Critical: true}
+	// Leaving MaxPathLen as zero indicates that no maximum path
+	// length is desired, unless MaxPathLenZero is set. A value of
+	// -1 causes encoding/asn1 to omit the value as desired.
+	var err error
+	ext.Value, err = asn1.Marshal(basicConstraints{isCA, -1})
+	return ext, err
 }
 
 func initFakeKubeClient(t test.Failer, certificate []byte) kube.CLIClient {
@@ -306,6 +362,10 @@ func TestValidateCSR(t *testing.T) {
 	csrPEM := createDefaultFakeCsr(t)
 	csrPEMWithInvalidOrg := createFakeCsr(t, "Invalid-Org")
 
+	testCSRWithInvalidCN := genTestCSR(t, pkiutil.CertOptions{Host: testCsrHostName}, "test.test.svc.cluster.local")
+	testCSRWithCATrue := genTestCSR(t, pkiutil.CertOptions{Host: testCsrHostName, IsCA: true}, "")
+	testCSRWithDNSHostNames := genTestCSR(t, pkiutil.CertOptions{Host: testCsrHostName, DNSNames: "test.test.svc.cluster.local"}, "")
+
 	client := initFakeKubeClient(t, []byte(TestCertificatePEM))
 	_, err := createFakeK8sRA(client, TestCACertFile)
 	if err != nil {
@@ -333,18 +393,24 @@ func TestValidateCSR(t *testing.T) {
 			" succeeded when expected failure due invalid Org")
 	}
 
-	// Independently creating CSRs for tests for fields that are not configurable
-	// via GenCSR() - CN and CA
+	// Independently creating CSRs with GetTestCSR for tests for
+	// fields that are not configurable via GenCSR()
 	// Test Case 4
-	if ValidateCSR([]byte(testCSRWithInvalidCN), testSubjectIDs) {
+	if ValidateCSR(testCSRWithInvalidCN, testSubjectIDs) {
 		t.Errorf("Test 4: CSR Validation failed. CSR validation" +
 			" succeeded when expected failure due invalid CN")
 	}
 
 	// Test Case 5
-	if ValidateCSR([]byte(testCSRWithCATrue), testSubjectIDs) {
+	if ValidateCSR(testCSRWithCATrue, testSubjectIDs) {
 		t.Errorf("Test 5: CSR Validation failed. CSR validation" +
 			" succeeded when expected failure due to basic constraint" +
 			" CA being set to true")
+	}
+
+	// Test Case 6
+	if ValidateCSR(testCSRWithDNSHostNames, testSubjectIDs) {
+		t.Errorf("Test 5: CSR Validation failed. CSR validation" +
+			" succeeded when expected failure due to DNSHostNames")
 	}
 }

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -146,8 +146,8 @@ func GenCertKeyFromOptions(options CertOptions) (pemCert []byte, pemKey []byte, 
 		return genCert(options, ecPriv, &ecPriv.PublicKey)
 	}
 
-	if options.RSAKeySize < minimumRsaKeySize {
-		return nil, nil, fmt.Errorf("requested key size does not meet the minimum required size of %d (requested: %d)", minimumRsaKeySize, options.RSAKeySize)
+	if options.RSAKeySize < MinimumRsaKeySize {
+		return nil, nil, fmt.Errorf("requested key size does not meet the minimum required size of %d (requested: %d)", MinimumRsaKeySize, options.RSAKeySize)
 	}
 	rsaPriv, err := rsa.GenerateKey(rand.Reader, options.RSAKeySize)
 	if err != nil {

--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -34,9 +34,9 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-// minimumRsaKeySize is the minimum RSA key size to generate certificates
+// MinimumRsaKeySize is the minimum RSA key size to generate certificates
 // to ensure proper security
-const minimumRsaKeySize = 2048
+const MinimumRsaKeySize = 2048
 
 // GenCSR generates a X.509 certificate sign request and private key with the given options.
 func GenCSR(options CertOptions) ([]byte, []byte, error) {
@@ -60,8 +60,8 @@ func GenCSR(options CertOptions) ([]byte, []byte, error) {
 			return nil, nil, errors.New("csr cert generation fails due to unsupported EC signature algorithm")
 		}
 	} else {
-		if options.RSAKeySize < minimumRsaKeySize {
-			return nil, nil, fmt.Errorf("requested key size does not meet the minimum required size of %d (requested: %d)", minimumRsaKeySize, options.RSAKeySize)
+		if options.RSAKeySize < MinimumRsaKeySize {
+			return nil, nil, fmt.Errorf("requested key size does not meet the minimum required size of %d (requested: %d)", MinimumRsaKeySize, options.RSAKeySize)
 		}
 
 		priv, err = rsa.GenerateKey(rand.Reader, options.RSAKeySize)

--- a/security/pkg/pki/util/san.go
+++ b/security/pkg/pki/util/san.go
@@ -60,9 +60,9 @@ var (
 	// type.
 	identityTypeMap = generateReversedMap(oidTagMap)
 
-	// The OID for the SAN extension (See
+	// OidSubjectAlternativeName The OID for the SAN extension (See
 	// http://www.alvestrand.no/objectid/2.5.29.17.html).
-	oidSubjectAlternativeName = asn1.ObjectIdentifier{2, 5, 29, 17}
+	OidSubjectAlternativeName = asn1.ObjectIdentifier{2, 5, 29, 17}
 )
 
 // Identity is an object holding both the encoded identifier bytes as well as
@@ -122,7 +122,7 @@ func BuildSANExtension(identites []Identity) (*pkix.Extension, error) {
 	}
 
 	// SAN is Critical because the subject is empty. This is compliant with X.509 and SPIFFE standards.
-	return &pkix.Extension{Id: oidSubjectAlternativeName, Critical: true, Value: bs}, nil
+	return &pkix.Extension{Id: OidSubjectAlternativeName, Critical: true, Value: bs}, nil
 }
 
 // ExtractIDsFromSAN takes a SAN extension and extracts the identities.
@@ -130,7 +130,7 @@ func BuildSANExtension(identites []Identity) (*pkix.Extension, error) {
 // https://github.com/golang/go/blob/master/src/crypto/x509/x509.go, with the
 // addition of supporting extracting URIs.
 func ExtractIDsFromSAN(sanExt *pkix.Extension) ([]Identity, error) {
-	if !sanExt.Id.Equal(oidSubjectAlternativeName) {
+	if !sanExt.Id.Equal(OidSubjectAlternativeName) {
 		return nil, fmt.Errorf("the input is not a SAN extension")
 	}
 
@@ -165,7 +165,7 @@ func ExtractIDsFromSAN(sanExt *pkix.Extension) ([]Identity, error) {
 // the given PKIX extension set.
 func ExtractSANExtension(exts []pkix.Extension) *pkix.Extension {
 	for _, ext := range exts {
-		if ext.Id.Equal(oidSubjectAlternativeName) {
+		if ext.Id.Equal(OidSubjectAlternativeName) {
 			// We don't need to examine other extensions anymore since a certificate
 			// must not include more than one instance of a particular extension. See
 			// https://tools.ietf.org/html/rfc5280#section-4.2.

--- a/security/pkg/pki/util/san_test.go
+++ b/security/pkg/pki/util/san_test.go
@@ -109,7 +109,7 @@ func TestExtractIDsFromSANWithError(t *testing.T) {
 		},
 		"Wrong encoding": {
 			ext: &pkix.Extension{
-				Id:    oidSubjectAlternativeName,
+				Id:    OidSubjectAlternativeName,
 				Value: []byte("bad value"),
 			},
 		},
@@ -124,7 +124,7 @@ func TestExtractIDsFromSANWithError(t *testing.T) {
 
 func TestExtractIDsFromSANWithBadEncoding(t *testing.T) {
 	ext := &pkix.Extension{
-		Id:    oidSubjectAlternativeName,
+		Id:    OidSubjectAlternativeName,
 		Value: []byte("bad value"),
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Alternative to https://github.com/istio/istio/pull/51920
- [x] Needs additional unit testing for `compareCSRs`

Notes on https://github.com/istio/istio/pull/51959:
- This change is very similar but generated the CSR template using the same code as the client (istio-proxy) making the istio CSR request
- Added some additional testing using CSRs from `genCSR` and individually built CSRs for testing fields that could not be set with `GenCSR`
- Slightly different logical comparisons to add some leniency in negligible config difference of the CSRs (which in turn makes the code more testable. I was unable to use `openss`l to generate a CSR with an `Org` value of "". It is always interpreted as unset.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Security
- [ ] Test and Release
- [x] User Experience