### PR TITLE
networking: match multiple VIPs in sidecar outbound listener

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1283,10 +1283,24 @@ func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
 		var ipv4Addresses []string
 		var ipv6Addresses []string
 		for _, addr := range addresses {
-			if ipAddr, _ := netip.ParseAddr(addr); ipAddr.Is4() {
-				ipv4Addresses = append(ipv4Addresses, ipAddr.String())
-			} else if ipAddr.Is6() {
-				ipv6Addresses = append(ipv6Addresses, ipAddr.String())
+			if strings.Contains(addr, "/") {
+				if prefix, err := netip.ParsePrefix(addr); err != nil {
+					log.Warnf("failed to parse prefix address '%s': %s", addr, err)
+					continue
+				} else if prefix.Addr().Is4() {
+					ipv4Addresses = append(ipv4Addresses, addr)
+				} else if prefix.Addr().Is6() {
+					ipv6Addresses = append(ipv6Addresses, addr)
+				}
+			} else {
+				if ipAddr, err := netip.ParseAddr(addr); err != nil {
+					log.Warnf("failed to parse address '%s': %s", addr, err)
+					continue
+				} else if ipAddr.Is4() {
+					ipv4Addresses = append(ipv4Addresses, ipAddr.String())
+				} else if ipAddr.Is6() {
+					ipv6Addresses = append(ipv6Addresses, ipAddr.String())
+				}
 			}
 		}
 		if node.SupportsIPv4() && len(ipv4Addresses) > 0 {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1261,13 +1261,9 @@ func (s *Service) GetAddressForProxy(node *Proxy) string {
 // GetExtraAddressesForProxy returns a k8s service's extra addresses to the cluster where the node resides.
 // Especially for dual stack k8s service to get other IP family addresses.
 func (s *Service) GetExtraAddressesForProxy(node *Proxy) []string {
-	if features.EnableDualStack && node.Metadata != nil {
-		if node.Metadata.ClusterID != "" {
-			addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
-			if len(addresses) > 1 {
-				return addresses[1:]
-			}
-		}
+	addresses := s.getAllAddressesForProxy(node)
+	if len(addresses) > 1 {
+		return addresses[1:]
 	}
 	return nil
 }
@@ -1275,6 +1271,10 @@ func (s *Service) GetExtraAddressesForProxy(node *Proxy) []string {
 // GetAllAddressesForProxy returns a k8s service's extra addresses to the cluster where the node resides.
 // Especially for dual stack k8s service to get other IP family addresses.
 func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
+	return s.getAllAddressesForProxy(node)
+}
+
+func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 	if node.Metadata != nil && node.Metadata.ClusterID != "" {
 		addresses := s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 		if (features.EnableDualStack || features.EnableAmbient) && len(addresses) > 0 {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1289,6 +1289,8 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 					continue
 				} else if prefix.Addr().Is4() {
 					ipv4Addresses = append(ipv4Addresses, addr)
+				} else if prefix.Addr().Is6() {
+					ipv6Addresses = append(ipv6Addresses, addr)
 				}
 			} else {
 				if ipAddr, err := netip.ParseAddr(addr); err != nil {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1289,17 +1289,15 @@ func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
 					continue
 				} else if prefix.Addr().Is4() {
 					ipv4Addresses = append(ipv4Addresses, addr)
-				} else if prefix.Addr().Is6() {
-					ipv6Addresses = append(ipv6Addresses, addr)
 				}
 			} else {
 				if ipAddr, err := netip.ParseAddr(addr); err != nil {
 					log.Warnf("failed to parse address '%s': %s", addr, err)
 					continue
 				} else if ipAddr.Is4() {
-					ipv4Addresses = append(ipv4Addresses, ipAddr.String())
+					ipv4Addresses = append(ipv4Addresses, addr)
 				} else if ipAddr.Is6() {
-					ipv6Addresses = append(ipv6Addresses, ipAddr.String())
+					ipv6Addresses = append(ipv6Addresses, addr)
 				}
 			}
 		}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1287,26 +1287,26 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 				if prefix, err := netip.ParsePrefix(addr); err != nil {
 					log.Warnf("failed to parse prefix address '%s': %s", addr, err)
 					continue
-				} else if prefix.Addr().Is4() {
+				} else if node.SupportsIPv4() && prefix.Addr().Is4() {
 					ipv4Addresses = append(ipv4Addresses, addr)
-				} else if prefix.Addr().Is6() {
+				} else if node.SupportsIPv6() && prefix.Addr().Is6() {
 					ipv6Addresses = append(ipv6Addresses, addr)
 				}
 			} else {
 				if ipAddr, err := netip.ParseAddr(addr); err != nil {
 					log.Warnf("failed to parse address '%s': %s", addr, err)
 					continue
-				} else if ipAddr.Is4() {
+				} else if node.SupportsIPv4() && ipAddr.Is4() {
 					ipv4Addresses = append(ipv4Addresses, addr)
-				} else if ipAddr.Is6() {
+				} else if node.SupportsIPv6() && ipAddr.Is6() {
 					ipv6Addresses = append(ipv6Addresses, addr)
 				}
 			}
 		}
-		if node.SupportsIPv4() && len(ipv4Addresses) > 0 {
+		if len(ipv4Addresses) > 0 {
 			return ipv4Addresses
 		}
-		if node.SupportsIPv6() && len(ipv6Addresses) > 0 {
+		if len(ipv6Addresses) > 0 {
 			return ipv6Addresses
 		}
 	}

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -600,12 +600,12 @@ func TestGetAllAddresses(t *testing.T) {
 		expectedExtraAddresses []string
 	}{
 		{
-			name: "IPv4 mode, only IPv4 addresses, expected to return all of the Service addresses",
+			name: "IPv4 mode, IPv4 and IPv6 CIDR addresses, expected to return only IPv4 addresses",
 			service: &Service{
 				DefaultAddress: "10.0.0.0/28",
 				ClusterVIPs: AddressMap{
 					Addresses: map[cluster.ID][]string{
-						"id": {"10.0.0.0/28", "10.0.0.16/28"},
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32/96", "::ffff:10.0.0.48/96"},
 					},
 				},
 			},
@@ -614,61 +614,47 @@ func TestGetAllAddresses(t *testing.T) {
 			expectedExtraAddresses: []string{"10.0.0.16/28"},
 		},
 		{
-			name: "IPv4 mode, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
+			name: "IPv6 mode, IPv4 and IPv6 CIDR addresses, expected to return only IPv6 addresses",
 			service: &Service{
 				DefaultAddress: "10.0.0.0/28",
 				ClusterVIPs: AddressMap{
 					Addresses: map[cluster.ID][]string{
-						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
-					},
-				},
-			},
-			ipMode:                 IPv4,
-			expectedAddresses:      []string{"10.0.0.0/28", "10.0.0.16/28"},
-			expectedExtraAddresses: []string{"10.0.0.16/28"},
-		},
-		{
-			name: "IPv6 mode, IPv4 and IPv6 addresses, expected to return only IPv6 addresses",
-			service: &Service{
-				DefaultAddress: "10.0.0.0/28",
-				ClusterVIPs: AddressMap{
-					Addresses: map[cluster.ID][]string{
-						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32/96", "::ffff:10.0.0.48/96"},
 					},
 				},
 			},
 			ipMode:                 IPv6,
-			expectedAddresses:      []string{"::ffff:10.0.0.32", "::ffff:10.0.0.48"},
-			expectedExtraAddresses: []string{"::ffff:10.0.0.48"},
+			expectedAddresses:      []string{"::ffff:10.0.0.32/96", "::ffff:10.0.0.48/96"},
+			expectedExtraAddresses: []string{"::ffff:10.0.0.48/96"},
 		},
 		{
 			name: "dual mode, ISTIO_DUAL_STACK disabled, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
 			service: &Service{
-				DefaultAddress: "10.0.0.0/28",
+				DefaultAddress: "10.0.0.0",
 				ClusterVIPs: AddressMap{
 					Addresses: map[cluster.ID][]string{
-						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+						"id": {"10.0.0.0", "10.0.0.16", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
 					},
 				},
 			},
 			ipMode:                 Dual,
-			expectedAddresses:      []string{"10.0.0.0/28", "10.0.0.16/28"},
-			expectedExtraAddresses: []string{"10.0.0.16/28"},
+			expectedAddresses:      []string{"10.0.0.0", "10.0.0.16"},
+			expectedExtraAddresses: []string{"10.0.0.16"},
 		},
 		{
 			name: "dual mode, ISTIO_DUAL_STACK enabled, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
 			service: &Service{
-				DefaultAddress: "10.0.0.0/28",
+				DefaultAddress: "10.0.0.0",
 				ClusterVIPs: AddressMap{
 					Addresses: map[cluster.ID][]string{
-						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+						"id": {"10.0.0.0", "10.0.0.16", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
 					},
 				},
 			},
 			ipMode:                 Dual,
 			dualStackEnabled:       true,
-			expectedAddresses:      []string{"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
-			expectedExtraAddresses: []string{"10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+			expectedAddresses:      []string{"10.0.0.0", "10.0.0.16", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+			expectedExtraAddresses: []string{"10.0.0.16", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
 		},
 		{
 			name: "IPv4 mode, ISTIO_DUAL_STACK disabled, ambient enabled, IPv4 and IPv6 addresses, expected to return all addresses",

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	fuzz "github.com/google/gofuzz"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/visibility"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -583,6 +585,127 @@ func TestParseSubsetKeyHostname(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
 			assert.Equal(t, ParseSubsetKeyHostname(tt.in), tt.out)
+		})
+	}
+}
+
+func TestGetAllAddresses(t *testing.T) {
+	tests := []struct {
+		name              string
+		service           *Service
+		ipMode            IPMode
+		dualStackEnabled  bool
+		ambientEnabled    bool
+		expectedAddresses []string
+	}{
+		{
+			name: "IPv4 mode, only IPv4 addresses, expected to return all of the Service addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28"},
+					},
+				},
+			},
+			ipMode:            IPv4,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28"},
+		},
+		{
+			name: "IPv4 mode, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            IPv4,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28"},
+		},
+		{
+			name: "IPv6 mode, IPv4 and IPv6 addresses, expected to return only IPv6 addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            IPv6,
+			expectedAddresses: []string{"::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+		},
+		{
+			name: "dual mode, ISTIO_DUAL_STACK disabled, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            Dual,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28"},
+		},
+		{
+			name: "dual mode, ISTIO_DUAL_STACK enabled, IPv4 and IPv6 addresses, expected to return only IPv4 addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            Dual,
+			dualStackEnabled:  true,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+		},
+		{
+			name: "IPv4 mode, ISTIO_DUAL_STACK disabled, ambient enabled, IPv4 and IPv6 addresses, expected to return all addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            IPv4,
+			ambientEnabled:    true,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+		},
+		{
+			name: "IPv6 mode, ISTIO_DUAL_STACK disabled, ambient enabled, IPv4 and IPv6 addresses, expected to return all addresses",
+			service: &Service{
+				DefaultAddress: "10.0.0.0/28",
+				ClusterVIPs: AddressMap{
+					Addresses: map[cluster.ID][]string{
+						"id": {"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+					},
+				},
+			},
+			ipMode:            IPv6,
+			ambientEnabled:    true,
+			expectedAddresses: []string{"10.0.0.0/28", "10.0.0.16/28", "::ffff:10.0.0.32", "::ffff:10.0.0.48"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.dualStackEnabled {
+				test.SetForTest(t, &features.EnableDualStack, true)
+			}
+			if tc.ambientEnabled {
+				test.SetForTest(t, &features.EnableAmbient, true)
+			}
+			addresses := tc.service.GetAllAddressesForProxy(&Proxy{
+				Metadata: &NodeMetadata{ClusterID: "id"},
+				ipMode:   tc.ipMode,
+			})
+			assert.Equal(t, addresses, tc.expectedAddresses)
 		})
 	}
 }

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -803,12 +803,18 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 				svcListenAddress = constants.UnspecifiedIPv6
 			}
 
+			// For dualstack proxies we need to add the unspecifed ipv6 address to the list of extra listen addresses
+			svcExtraListenAddresses := svcListenAddresses
+			if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsDualStack() &&
+				svcListenAddress == constants.UnspecifiedIP {
+				svcExtraListenAddresses = append(svcExtraListenAddresses, constants.UnspecifiedIPv6)
+			}
 			// We should never get an empty address.
 			// This is a safety guard, in case some platform adapter isn't doing things
 			// properly
 			if len(svcListenAddress) > 0 {
 				if !strings.Contains(svcListenAddress, "/") {
-					listenerOpts.bind.binds = svcListenAddresses
+					listenerOpts.bind.binds = svcExtraListenAddresses
 				} else {
 					// Address is a CIDR. Fall back to 0.0.0.0 and
 					// filter chain match

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -264,10 +264,10 @@ func (l listenerBinding) Primary() string {
 
 // Extra returns any additional bindings. This is always empty if dual stack is disabled
 func (l listenerBinding) Extra() []string {
-	if !features.EnableDualStack || len(l.binds) == 1 {
-		return nil
+	if len(l.binds) > 1 {
+		return l.binds[1:]
 	}
-	return l.binds[1:]
+	return nil
 }
 
 type outboundListenerEntry struct {

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -814,7 +814,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 			// properly
 			if len(svcListenAddress) > 0 {
 				if !strings.Contains(svcListenAddress, "/") {
-					listenerOpts.bind.binds = svcExtraListenAddresses
+					listenerOpts.bind.binds = append([]string{svcListenAddress}, svcExtraListenAddresses[1:]...)
 				} else {
 					// Address is a CIDR. Fall back to 0.0.0.0 and
 					// filter chain match

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -793,28 +793,24 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 		// into listener address so that there is a dedicated listener for this
 		// ip:port. This will reduce the impact of a listener reload
 		if listenerOpts.bind.Primary() == "" { // TODO: make this better
-			svcListenAddress := listenerOpts.service.GetAddressForProxy(listenerOpts.proxy)
 			svcListenAddresses := listenerOpts.service.GetAllAddressesForProxy(listenerOpts.proxy)
 			// Override the svcListenAddress, using the proxy ipFamily, for cases where the ipFamily cannot be detected easily.
 			// For example: due to the possibility of using hostnames instead of ips in ServiceEntry,
 			// it is hard to detect ipFamily for such services.
-			if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsIPv6() &&
-				svcListenAddress == constants.UnspecifiedIP {
-				svcListenAddress = constants.UnspecifiedIPv6
+			if listenerOpts.service.Attributes.ServiceRegistry == provider.External && svcListenAddresses[0] == constants.UnspecifiedIP {
+				if listenerOpts.proxy.IsIPv6() {
+					svcListenAddresses[0] = constants.UnspecifiedIPv6
+				} else if listenerOpts.proxy.IsDualStack() {
+					svcListenAddresses = append(svcListenAddresses, constants.UnspecifiedIPv6)
+				}
 			}
 
-			// For dualstack proxies we need to add the unspecifed ipv6 address to the list of extra listen addresses
-			svcExtraListenAddresses := svcListenAddresses
-			if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsDualStack() &&
-				svcListenAddress == constants.UnspecifiedIP {
-				svcExtraListenAddresses = append(svcExtraListenAddresses, constants.UnspecifiedIPv6)
-			}
 			// We should never get an empty address.
 			// This is a safety guard, in case some platform adapter isn't doing things
 			// properly
-			if len(svcListenAddress) > 0 {
-				if !strings.Contains(svcListenAddress, "/") {
-					listenerOpts.bind.binds = append([]string{svcListenAddress}, svcExtraListenAddresses[1:]...)
+			if len(svcListenAddresses[0]) > 0 {
+				if !strings.Contains(svcListenAddresses[0], "/") {
+					listenerOpts.bind.binds = svcListenAddresses
 				} else {
 					// Address is a CIDR. Fall back to 0.0.0.0 and
 					// filter chain match

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -794,6 +794,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 		// ip:port. This will reduce the impact of a listener reload
 		if listenerOpts.bind.Primary() == "" { // TODO: make this better
 			svcListenAddress := listenerOpts.service.GetAddressForProxy(listenerOpts.proxy)
+			svcAddresses := listenerOpts.service.GetAllAddressesForProxy(listenerOpts.proxy)
 			svcExtraListenAddresses := listenerOpts.service.GetExtraAddressesForProxy(listenerOpts.proxy)
 			// Override the svcListenAddress, using the proxy ipFamily, for cases where the ipFamily cannot be detected easily.
 			// For example: due to the possibility of using hostnames instead of ips in ServiceEntry,
@@ -819,7 +820,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 					// filter chain match
 					// TODO: this probably needs to handle dual stack better
 					listenerOpts.bind.binds = actualWildcards
-					listenerOpts.cidr = svcListenAddress
+					listenerOpts.cidr = svcAddresses
 				}
 			}
 		}
@@ -1058,7 +1059,7 @@ type outboundListenerOpts struct {
 	proxy *model.Proxy
 
 	bind listenerBinding
-	cidr string
+	cidr []string
 
 	port    *model.Port
 	service *model.Service

--- a/pilot/pkg/networking/core/tls.go
+++ b/pilot/pkg/networking/core/tls.go
@@ -142,7 +142,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 					// Use the service's CIDRs.
 					// But if a virtual service overrides it with its own destination subnet match
 					// give preference to the user provided one
-					// destinationCIDR will be empty for services with VIPs
+					// destinationCIDRs will be empty for services with VIPs
 					// Only set CIDR match if the listener is bound to an IP.
 					// If its bound to a unix domain socket, then ignore the CIDR matches
 					// Unix domain socket bound ports have Port value set to 0

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -737,11 +737,7 @@ func testConvertServiceBody(t *testing.T) {
 			services: []*model.Service{
 				makeService("tcp1.com", "multiAddrInternal", []string{"1.1.1.0/16", "2.2.2.0/16"},
 					map[string]int{"tcp-444": 444}, false, model.Passthrough),
-				makeService("tcp1.com", "multiAddrInternal", []string{"2.2.2.0/16", "1.1.1.0/16"},
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
 				makeService("tcp2.com", "multiAddrInternal", []string{"1.1.1.0/16", "2.2.2.0/16"},
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
-				makeService("tcp2.com", "multiAddrInternal", []string{"2.2.2.0/16", "1.1.1.0/16"},
 					map[string]int{"tcp-444": 444}, false, model.Passthrough),
 			},
 		},

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -42,6 +42,7 @@ import (
 	xdsfake "istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -1230,7 +1231,8 @@ func updateServiceResolution(s *xdsfake.FakeDiscoveryServer, resolution model.Re
 
 func addOverlappingEndpoints(s *xdsfake.FakeDiscoveryServer) {
 	svc := &model.Service{
-		Hostname: "overlapping.cluster.local",
+		DefaultAddress: constants.UnspecifiedIP,
+		Hostname:       "overlapping.cluster.local",
 		Ports: model.PortList{
 			{
 				Name:     "dns",

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -1265,7 +1265,8 @@ func addOverlappingEndpoints(s *xdsfake.FakeDiscoveryServer) {
 
 func addUnhealthyCluster(s *xdsfake.FakeDiscoveryServer) {
 	svc := &model.Service{
-		Hostname: "unhealthy.svc.cluster.local",
+		DefaultAddress: constants.UnspecifiedIP,
+		Hostname:       "unhealthy.svc.cluster.local",
 		Ports: model.PortList{
 			{
 				Name:     "tcp-dns",

--- a/releasenotes/notes/51967.yaml
+++ b/releasenotes/notes/51967.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 51747
+releaseNotes:
+  - |
+    **Fixed** matching multiple service VIPs in ServiceEntry.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -5093,7 +5093,8 @@ func createService(t TrafficContext, name, ns, appLabelValue string, instances i
 				},
 			},
 		}
-		if _, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		if _, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{});
+			err != nil && !kerrors.IsAlreadyExists(err) {
 			t.Errorf("failed to create service %s: %s", svc, err)
 		}
 		// Wait until a ClusterIP has been assigned.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3826,7 +3826,7 @@ spec:
 	}
 }
 
-func TestServiceEntryWithMultipleVIPs(t TrafficContext) {
+func testServiceEntryWithMultipleVIPs(t TrafficContext) {
 	serviceEntry := fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -5093,12 +5093,13 @@ func createService(t TrafficContext, name, ns, appLabelValue string, instances i
 				},
 			},
 		}
-		if _, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{});
-			err != nil && !kerrors.IsAlreadyExists(err) {
+		_, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{});
+		if err != nil && !kerrors.IsAlreadyExists(err) {
 			t.Errorf("failed to create service %s: %s", svc, err)
 		}
+
 		// Wait until a ClusterIP has been assigned.
-		err := retry.UntilSuccess(func() error {
+		err = retry.UntilSuccess(func() error {
 			svc, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Get(context.TODO(), svcName, metav1.GetOptions{})
 			if err != nil {
 				return err

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3865,7 +3865,7 @@ spec:
 	}
 
 	t.RunTraffic(TrafficTestCase{
-		name:   fmt.Sprintf("send a request to one of the VIPs"),
+		name:   "send a request to one of the service entry VIPs",
 		config: serviceEntry,
 		opts: echo.CallOptions{
 			Address: address,

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -5093,7 +5093,7 @@ func createService(t TrafficContext, name, ns, appLabelValue string, instances i
 				},
 			},
 		}
-		_, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{});
+		_, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{})
 		if err != nil && !kerrors.IsAlreadyExists(err) {
 			t.Errorf("failed to create service %s: %s", svc, err)
 		}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -18,6 +18,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/netip"
@@ -29,7 +30,12 @@ import (
 
 	"google.golang.org/grpc/codes"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"istio.io/api/annotation"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -47,6 +53,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio/ingress"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/tests/common/jwt"
@@ -3826,52 +3833,57 @@ spec:
 	}
 }
 
-func testServiceEntryWithMultipleVIPs(t TrafficContext) {
-	serviceEntry := fmt.Sprintf(`
+func testServiceEntryWithMultipleVIPsAndResolutionNone(t TrafficContext) {
+	if len(t.Apps.External.All) == 0 {
+		t.Skip("no external service instances")
+	}
+
+	clusterIPs := createService(t, "external", t.Apps.External.All.NamespaceName(), "external", 2)
+	if len(clusterIPs) < 2 {
+		t.Errorf("failed to get 2 cluster IPs, got %v", clusterIPs)
+	}
+
+	// Create CIDRs from IPs. We want to check if CIDR matching in a wildcard listener works.
+	var cidrs []string
+	for _, clusterIP := range clusterIPs {
+		if ip, err := netip.ParseAddr(clusterIP); err != nil {
+			t.Errorf("failed to parse cluster IP address '%s': %s", err)
+		} else if ip.Is4() {
+			cidrs = append(cidrs, fmt.Sprintf("%s/24", clusterIP))
+		} else if ip.Is6() {
+			cidrs = append(cidrs, clusterIP)
+		}
+	}
+
+	serviceEntry := tmpl.MustEvaluate(`
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: server-default-svc
-  namespace: %s
+  namespace: {{.Namespace}}
 spec:
   exportTo:
   - "."
   hosts:
-  - "server.default.svc"
+  - server.default.svc
   addresses:
-  - 10.0.0.0/28
-  - 10.0.0.16/28
-  - 2002::1
-  - 2002::2
-  endpoints:
-  - address: %s
-  location: MESH_INTERNAL
+{{ range $ip := .IPs }}
+  - "{{$ip}}"
+{{ end }}
+  location: MESH_EXTERNAL
   ports:
   - number: 443
     name: tcp
     protocol: TCP
-  resolution: STATIC
-`, t.Apps.A.NamespaceName(), t.Apps.External.All.WorkloadsOrFail(t)[0].Address())
-
-	if len(t.Apps.External.All) == 0 {
-		t.Skip("no external service instances")
-	}
-	// Use first host address from the second CIDR to make sure that Istio matches all CIDRs, not only the first one.
-	address := "10.0.0.17"
-	if ip, err := netip.ParseAddr(t.Apps.External.All[0].Address()); err != nil {
-		t.Errorf("failed to parse IP address ['%s'] of external app: %s", err)
-	} else if ip.Is6() {
-		address = "2002::2"
-	}
+  resolution: NONE
+`, map[string]any{"Namespace": t.Apps.A.NamespaceName(), "IPs": cidrs})
 
 	t.RunTraffic(TrafficTestCase{
 		name:   "send a request to one of the service entry VIPs",
 		config: serviceEntry,
 		opts: echo.CallOptions{
-			Address: address,
-			HTTP: echo.HTTP{
-				Headers: HostHeader(t.Apps.External.All[0].Config().DefaultHostHeader),
-			},
+			// Use second IP address to make sure that Istio matches all CIDRs, not only the first one.
+			Address: clusterIPs[1],
 			Port: echo.Port{
 				Protocol:    protocol.HTTPS,
 				ServicePort: 443,
@@ -5050,4 +5062,55 @@ func LocationHeader(expected string) echo.Checker {
 				exp,
 				"Location")
 		})
+}
+
+// createService creates additional Services for a given app to obtain routable VIPs inside the cluster.
+func createService(t TrafficContext, name, ns, appLabelValue string, instances int) []string {
+	var clusterIPs []string
+	for i := 0; i < instances; i++ {
+		svcName := fmt.Sprintf("%s-vip-%d", name, i)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: ns,
+				Annotations: map[string]string{
+					// Export the service nowhere, so that no proxy will receive it or its VIP.
+					annotation.NetworkingExportTo.Name: "~",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": appLabelValue,
+				},
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       ports.HTTPS.Name,
+						Protocol:   corev1.ProtocolTCP,
+						Port:       int32(ports.HTTPS.ServicePort),
+						TargetPort: intstr.IntOrString{IntVal: int32(ports.HTTPS.WorkloadPort)},
+					},
+				},
+			},
+		}
+		if _, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+			t.Errorf("failed to create service %s: %s", svc, err)
+		}
+		// Wait until a ClusterIP has been assigned.
+		err := retry.UntilSuccess(func() error {
+			svc, err := t.Clusters().Default().Kube().CoreV1().Services(ns).Get(context.TODO(), svcName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(svc.Spec.ClusterIPs) == 0 {
+				return fmt.Errorf("service VIP not set for service")
+			}
+			clusterIPs = append(clusterIPs, svc.Spec.ClusterIPs...)
+			return nil
+		}, retry.Timeout(10*time.Second))
+		if err != nil {
+			t.Errorf("failed to assign ClusterIP for %s service: %s", svcName, err)
+		}
+	}
+	return clusterIPs
 }

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -298,7 +298,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	RunSkipAmbient("dns", DNSTestCases, "https://github.com/istio/istio/issues/48614")
 	RunCase("externalservice", TestExternalService)
 	RunCase("upstreamproxy", TestUpstreamProxyProtocol)
-	RunSkipAmbient("service-entry-multiple-vips", testServiceEntryWithMultipleVIPs, "")
+	RunSkipAmbient("service-entry-vips-resolution-none", testServiceEntryWithMultipleVIPsAndResolutionNone, "")
 }
 
 func ExpectString(got, expected, help string) error {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -297,8 +297,8 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	RunCase("vm", VMTestCases(apps.VM))
 	RunSkipAmbient("dns", DNSTestCases, "https://github.com/istio/istio/issues/48614")
 	RunCase("externalservice", TestExternalService)
-	RunCase("service-entry-multiple-vips", TestServiceEntryWithMultipleVIPs)
 	RunCase("upstreamproxy", TestUpstreamProxyProtocol)
+	RunSkipAmbient("service-entry-multiple-vips", testServiceEntryWithMultipleVIPs, "")
 }
 
 func ExpectString(got, expected, help string) error {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -297,6 +297,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	RunCase("vm", VMTestCases(apps.VM))
 	RunSkipAmbient("dns", DNSTestCases, "https://github.com/istio/istio/issues/48614")
 	RunCase("externalservice", TestExternalService)
+	RunCase("service-entry-multiple-vips", TestServiceEntryWithMultipleVIPs)
 	RunCase("upstreamproxy", TestUpstreamProxyProtocol)
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #51747

What did I change:
1. `GetAllAddressesForProxy` and `GetExtraAddressesForProxy` always return all addresses for the proxy's IP family. Previously these functions were returning all addresses only when `ISTIO_DUAL_STACK` was enabled.
2. `buildSidecarOutboundListener` used these functions to configure CIDR matching. These functions always returned the default address, so outbound listeners couldn't match all the addresses. Now, all CIDRs are configured for the supported IP family.
3. `convertServices` created internal service instance for each [host, address] pair. Now, it creates an instance for each [host,  address list] pair.

**Example:**
When the following SE is applied:
```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: dns
spec:
  hosts:
  - "fake.service.local"
  addresses:
  - 10.123.16.192/28
  - 10.123.16.208/28
  - 10.123.16.224/28
  location: MESH_EXTERNAL
  resolution: NONE
  ports:
  - number: 9092
    name: tcp
    protocol: TCP
```
and I check listeners for port 9092:
```
istioctl pc l deploy/sleep --port 9092
```
I get the following results:
1. Istio 1.21:
```
ADDRESSES PORT MATCH                  DESTINATION
0.0.0.0   9092 ALL                    PassthroughCluster
0.0.0.0   9092 Addr: 10.123.16.192/28 Cluster: outbound|9092||fake.service.local
0.0.0.0   9092 Addr: 10.123.16.208/28 Cluster: outbound|9092||fake.service.local
0.0.0.0   9092 Addr: 10.123.16.224/28 Cluster: outbound|9092||fake.service.local
```
2. Istio 1.22:
```
ADDRESSES PORT MATCH                  DESTINATION
0.0.0.0   9092 ALL                    PassthroughCluster
0.0.0.0   9092 Addr: 10.123.16.192/28 Cluster: outbound|9092||fake.service.local
```
3. This branch:
```
ADDRESSES PORT MATCH                                                    DESTINATION
0.0.0.0   9092 ALL                                                      PassthroughCluster
0.0.0.0   9092 Addr: 10.123.16.192/28,10.123.16.208/28,10.123.16.224/28 Cluster: outbound|9092||fake.service.local
```