### PR TITLE
update check-agent-deps to support ServiceEntryStatus

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -305,7 +305,7 @@ check-agent-deps:
 		grep -Pv 'envoy/extensions/wasm/' |\
 		grep -Pv 'envoy/extensions/filters/(http|network)/wasm/' |\
 		grep -Pv 'contrib/envoy/extensions/private_key_providers/' |\
-		grep -Pv 'istio\.io/api/(annotation|label|mcp|mesh|networking|security/v1alpha1|type)' |\
+		grep -Pv 'istio\.io/api/(annotation|label|mcp|mesh|networking|analysis/v1alpha1|meta/v1alpha1|security/v1alpha1|type)' |\
 		(! grep -P '^k8s.io|^sigs.k8s.io/gateway-api|cel|antlr|jwx/jwk|envoy/|istio.io/api')
 
 go-gen:


### PR DESCRIPTION
**Please provide a description of this PR:**

updates `check-agent-deps` to support ServiceEntryStatus

https://github.com/istio/api/pull/3244 and https://github.com/istio/istio/pull/51834 add a new status field which has a few different deps. These deps are part and parcel with having ServiceEntryStatus live under networking and should be acceptable.