### PR TITLE
Support customizing the SDS socket filename used by the agent

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -66,9 +66,9 @@ func NewAgentOptions(proxy *ProxyArgs, cfg *meshconfig.ProxyConfig, sds istioage
 		ProxyNamespace:              PodNamespaceVar.Get(),
 		ProxyDomain:                 proxy.DNSDomain,
 		IstiodSAN:                   istiodSAN.Get(),
-		UseExternalWorkloadSDS:      useExternalWorkloadSDSEnv,
 		MetadataDiscovery:           enableWDSEnv,
 		SDSFactory:                  sds,
+		WorkloadIdentitySocketFile:  workloadIdentitySocketFile,
 	}
 	extractXDSHeadersFromEnv(o)
 	return o

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -53,6 +54,9 @@ var (
 	// set to "SYSTEM" for ACME/public signed XDS servers.
 	xdsRootCA = env.Register("XDS_ROOT_CA", "",
 		"Explicitly set the root CA to expect for the XDS connection.").Get()
+
+	workloadIdentitySocketFile = env.Register("WORKLOAD_IDENTITY_SOCKET_FILE", security.DefaultWorkloadIdentitySocketFile,
+		fmt.Sprintf("SPIRE workload identity SDS socket filename. If set, an SDS socket with this name must exist at %s", security.WorkloadIdentityPath)).Get()
 
 	// set to "SYSTEM" for ACME/public signed CA servers.
 	caRootCA = env.Register("CA_ROOT_CA", "",
@@ -152,7 +156,4 @@ var (
 	exitOnZeroActiveConnectionsEnv = env.Register("EXIT_ON_ZERO_ACTIVE_CONNECTIONS",
 		false,
 		"When set to true, terminates proxy when number of active connections become zero during draining").Get()
-
-	useExternalWorkloadSDSEnv = env.Register("USE_EXTERNAL_WORKLOAD_SDS", false,
-		"When set to true, the istio-agent will require an external SDS and will throw an error if the workload SDS socket is not found").Get()
 )

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -228,12 +228,16 @@ type AgentOptions struct {
 
 	WASMOptions wasm.Options
 
-	UseExternalWorkloadSDS bool
-
 	// Enable metadata discovery bootstrap extension
 	MetadataDiscovery bool
 
 	SDSFactory func(options *security.Options, workloadSecretCache security.SecretManager, pkpConf *mesh.PrivateKeyProvider) SDSService
+
+	// Name of the socket file which will be used for workload SDS.
+	// If this is set to something other than the default socket file used
+	// by Istio's default SDS server, the socket file must be present.
+	// Note that the path is not configurable by design - only the socket file name.
+	WorkloadIdentitySocketFile string
 }
 
 // NewAgent hosts the functionality for local SDS and XDS. This consists of the local SDS server and
@@ -351,20 +355,47 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		return nil, fmt.Errorf("failed to start local DNS server: %v", err)
 	}
 
-	socketExists, err := checkSocket(ctx, security.WorkloadIdentitySocketPath)
+	// There are a couple of things we have to do here
+	//
+	// 1. Use a custom SDS workload socket if one is found+healthy at the configured path
+	// 3. Error out if a custom SDS socket path is configured but no socket is found there.
+	// 4. Do NOT error out, but just start and use the default Istio SDS server, if no socket
+	// is found AND no custom SDS socket path is configured.
+	//
+	//
+	// We do that like so
+	// 1. compare the (hardcoded) Istio default SDS server path with the (configurable) client path.
+	// 2. if they are different, do not start the Istio default SDS server.
+	// 3. if they are different, and no socket exists at that location, error out.
+	// 4. if they are not different, start the Istio default SDS server and use it.
+
+	// Correctness check - we do not want people sneaking paths into this
+	if a.cfg.WorkloadIdentitySocketFile != filepath.Base(a.cfg.WorkloadIdentitySocketFile) {
+		return nil, fmt.Errorf("workload identity socket file override must be a filename, not a path: %s", a.cfg.WorkloadIdentitySocketFile)
+	}
+
+	configuredAgentSocketPath := security.GetWorkloadSDSSocketListenPath(a.cfg.WorkloadIdentitySocketFile)
+
+	// Are we listening to the Istio default SDS server socket, or something else?
+	isIstioSDS := configuredAgentSocketPath == security.GetIstioSDSServerSocketPath()
+
+	socketExists, err := checkSocket(ctx, configuredAgentSocketPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check SDS socket: %v", err)
 	}
 	if socketExists {
-		log.Info("Workload SDS socket found. Istio SDS Server won't be started")
+		log.Infof("Existing workload SDS socket found at %s. Default Istio SDS Server won't be started", configuredAgentSocketPath)
 	} else {
-		if a.cfg.UseExternalWorkloadSDS {
-			return nil, errors.New("workload SDS socket is required but not found")
+		// If we are configured to use something other than the default Istio SDS server and we can't find a socket at that path, error out.
+		if !isIstioSDS {
+			return nil, fmt.Errorf("agent configured for non-default SDS socket path: %s but no socket found", configuredAgentSocketPath)
 		}
-		log.Info("Workload SDS socket not found. Starting Istio SDS Server")
+
+		// otherwise we are not configured to listen to something else, so just start the Istio SDS server and use it.
+		log.Info("Starting default Istio SDS Server")
 		err = a.initSdsServer()
 		if err != nil {
-			return nil, fmt.Errorf("failed to start SDS server: %v", err)
+			return nil, fmt.Errorf("failed to start default Istio SDS server: %v", err)
 		}
 	}
 	a.xdsProxy, err = initXdsProxy(a)
@@ -687,6 +718,7 @@ func socketFileExists(path string) bool {
 // If it cannot be deleted, returns (false, error).
 // Otherwise, returns (true, nil)
 func checkSocket(ctx context.Context, socketPath string) (bool, error) {
+	log := log.WithLabels("path", socketPath)
 	socketExists := socketFileExists(socketPath)
 	if !socketExists {
 		return false, nil

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -619,9 +619,6 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 		ProxyConfig:      mesh.DefaultProxyConfig(),
 	}
 
-	// Set this, as we aren't loading defaults from env
-	resp.agent.cfg.WorkloadIdentitySocketFile = security.DefaultWorkloadIdentitySocketFile
-
 	// Run through opts one time just to get the authenticators.
 	for _, opt := range opts {
 		resp = opt(resp)
@@ -657,6 +654,8 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 		SDSFactory: func(options *security.Options, workloadSecretCache security.SecretManager, pkpConf *meshconfig.PrivateKeyProvider) SDSService {
 			return sds.NewServer(options, workloadSecretCache, pkpConf)
 		},
+		// Set this, as we aren't loading defaults from env
+		WorkloadIdentitySocketFile: security.DefaultWorkloadIdentitySocketFile,
 	}
 
 	// Set-up envoy defaults

--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -618,6 +618,10 @@ func Setup(t *testing.T, opts ...func(a AgentTest) AgentTest) *AgentTest {
 		CaAuthenticator:  security.NewFakeAuthenticator("ca").Set("fake", ""),
 		ProxyConfig:      mesh.DefaultProxyConfig(),
 	}
+
+	// Set this, as we aren't loading defaults from env
+	resp.agent.cfg.WorkloadIdentitySocketFile = security.DefaultWorkloadIdentitySocketFile
+
 	// Run through opts one time just to get the authenticators.
 	for _, opt := range opts {
 		resp = opt(resp)

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -45,8 +46,12 @@ const (
 	// DefaultRootCertFilePath is the well-known path for an existing root certificate file
 	DefaultRootCertFilePath = "./etc/certs/root-cert.pem"
 
-	// WorkloadIdentitySocketPath is the well-known path to the Unix Domain Socket for SDS.
-	WorkloadIdentitySocketPath = "./var/run/secrets/workload-spiffe-uds/socket"
+	// WorkloadIdentityPath is the well-known path to the Unix Domain Socket for SDS.
+	WorkloadIdentityPath = "./var/run/secrets/workload-spiffe-uds"
+
+	// WorkloadIdentitySocketFile is the name of the UDS socket file
+	// Istio's internal SDS server uses.
+	DefaultWorkloadIdentitySocketFile = "socket"
 
 	// CredentialNameSocketPath is the well-known path to the Unix Domain Socket for Credential Name.
 	CredentialNameSocketPath = "./var/run/secrets/credential-uds/socket"
@@ -479,6 +484,16 @@ func CheckWorkloadCertificate(certChainFilePath, keyFilePath, rootCertFilePath s
 		return false
 	}
 	return true
+}
+
+// If we are using Istio's SDS server, the SDS socket listen path == the serve path
+// If we are not using Istio's SDS server, the SDS socket listen path may != the Istio SDS serve path
+func GetWorkloadSDSSocketListenPath(sockfile string) string {
+	return filepath.Join(WorkloadIdentityPath, sockfile)
+}
+
+func GetIstioSDSServerSocketPath() string {
+	return filepath.Join(WorkloadIdentityPath, DefaultWorkloadIdentitySocketFile)
 }
 
 type SdsCertificateConfig struct {

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -486,12 +486,17 @@ func CheckWorkloadCertificate(certChainFilePath, keyFilePath, rootCertFilePath s
 	return true
 }
 
+// This is the fixed-path, configurable filename location where the Istio agent will
+// look for a SDS workload identity server socket.
+//
 // If we are using Istio's SDS server, the SDS socket listen path == the serve path
 // If we are not using Istio's SDS server, the SDS socket listen path may != the Istio SDS serve path
 func GetWorkloadSDSSocketListenPath(sockfile string) string {
 	return filepath.Join(WorkloadIdentityPath, sockfile)
 }
 
+// This is the fixed-path, fixed-filename location where Istio's default SDS workload identity server
+// will put its socket.
 func GetIstioSDSServerSocketPath() string {
 	return filepath.Join(WorkloadIdentityPath, DefaultWorkloadIdentitySocketFile)
 }

--- a/releasenotes/notes/51979.yaml
+++ b/releasenotes/notes/51979.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 48845
+releaseNotes:
+- |
+  **Fixed** Removes the currently-document requirement currently in our SPIRE docs to force the SPIRE SDS server use our Istio-default SDS socket name, versus whatever the (user-configurable) SPIRE SDS server socket filename happens to be. This introduces WORKLOAD_IDENTITY_SOCKET_FILE as an agent env var. If set to a non-default value, the agent will expect to find a non-Istio SDS server socket at the hardcoded path: `WorkloadIdentityPath/WORKLOAD_IDENTITY_SOCKET_FILE` and will throw an error if no healthy socket found. Otherwise it will listen to it. If this is unset, the agent will start and Istio default SDS server instance with a hardcoded path and hardcoded socket file of: `WorkloadIdentityPath/DefaultWorkloadIdentitySocketFile` and listen to it. This removes/replaces the agent env var USE_EXTERNAL_WORKLOAD_SDS (added in #45941)

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -157,7 +157,7 @@ func setupSDS(t *testing.T) *TestServer {
 		t:       t,
 		server:  server,
 		store:   st,
-		udsPath: ca2.WorkloadIdentitySocketPath,
+		udsPath: ca2.GetIstioSDSServerSocketPath(),
 	}
 }
 

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -79,7 +79,7 @@ func (s *Server) initWorkloadSdsService() {
 	s.grpcWorkloadServer = grpc.NewServer(s.grpcServerOptions()...)
 	s.workloadSds.register(s.grpcWorkloadServer)
 	var err error
-	s.grpcWorkloadListener, err = uds.NewListener(security.WorkloadIdentitySocketPath)
+	s.grpcWorkloadListener, err = uds.NewListener(security.GetIstioSDSServerSocketPath())
 	go func() {
 		sdsServiceLog.Info("Starting SDS grpc server")
 		waitTime := time.Second
@@ -91,13 +91,13 @@ func (s *Server) initWorkloadSdsService() {
 			serverOk := true
 			setUpUdsOK := true
 			if s.grpcWorkloadListener == nil {
-				if s.grpcWorkloadListener, err = uds.NewListener(security.WorkloadIdentitySocketPath); err != nil {
+				if s.grpcWorkloadListener, err = uds.NewListener(security.GetIstioSDSServerSocketPath()); err != nil {
 					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to set up UDS: %v", err)
 					setUpUdsOK = false
 				}
 			}
 			if s.grpcWorkloadListener != nil {
-				sdsServiceLog.Infof("Starting SDS server for workload certificates, will listen on %q", security.WorkloadIdentitySocketPath)
+				sdsServiceLog.Infof("Starting SDS server for workload certificates, will listen on %q", security.GetIstioSDSServerSocketPath())
 				if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
 					sdsServiceLog.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
 					serverOk = false


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/48845 and removes the currently-documented requirement to force the SPIRE SDS server use our Istio-default SDS socket name, versus whatever the (user-configurable) SPIRE SDS server socket filename happens to be.

Note that this is still an issue even if you use the SPIRE CSI driver like we strongly suggest you do - the CSI driver will handle translating the path for you, but not the socket filename.

This introduces `WORKLOAD_IDENTITY_SOCKET_FILE` as an agent env var.

- If this is **set** to a non-default value, the agent will expect to find a non-Istio SDS server socket at the _hardcoded_ path:

`WorkloadIdentityPath/WORKLOAD_IDENTITY_SOCKET_FILE`

and will throw an error if no healthy socket found. Otherwise it will listen to it.

- If this is **unset**, the agent will do what it did before, which is start an Istio default SDS server instance with a hardcoded path and hardcoded socket file of:

`WorkloadIdentityPath/DefaultWorkloadIdentitySocketFile`

and listen to it.

As a side effect, this **removes/replaces** the agent env var `USE_EXTERNAL_WORKLOAD_SDS` (which was added in https://github.com/istio/istio/pull/45941) - the same behavior can be obtained by explicitly setting `WORKLOAD_IDENTITY_SOCKET_FILE` to a non-default value.

---

Q: "Why not make the whole path configurable via env var?"

A: One, that would make hijacking workload identity by overriding env vars to any path much easier. This way you can't hijack the path, just the filename - which is relatively trivial to defend against. Two, we want people to use the CSI driver, or K8S volume mounts, to map their host sockets to the (fixed istio location), as a matter of simplicity.