### PR TITLE
istioctl: Add a Warning when a Waypoint namespace has enabled sidecar mode

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -244,7 +244,7 @@ func Cmd(ctx cli.Context) *cobra.Command {
 				}
 				if hasSidecarInjection {
 					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace is enrolled in sidecar mode. It takes precedence over ambient mode. Consider running\t"+
-						"`"+"kubectl label namespace %s istio-injection-"+"`\n", ns)
+						"`"+"kubectl label namespace %s istio-injection=disabled"+"`\n", ns)
 				}
 			}
 			gw, err := makeGateway(true)


### PR DESCRIPTION
**Please provide a description of this PR:**
This change follows Doc `Pod selection logic for ambient and sidecar modes` [1]
If a namespace has got configured to use automatic sidecar injection, `istioctl` should display a warning message and suggest a user to avoid a configuration conflict when enrolling a Waypoint.

```
The simplest option to avoid a configuration conflict is for a user to ensure that for each namespace, it either has the label for sidecar injection (istio-injection=enabled) or for ambient mode (istio.io/dataplane-mode=ambient), but never both.
```

Ref: [1] https://istio.io/latest/docs/ambient/usage/add-workloads/#pod-selection-logic-for-ambient-and-sidecar-modes


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions