### PR TITLE
fix inconsistent behavior with the 'istio_agent_cert_expiry_seconds' metric

### DIFF
--- a/pkg/monitoring/monitortest/test.go
+++ b/pkg/monitoring/monitortest/test.go
@@ -112,6 +112,15 @@ func Exactly(v float64) func(any) error {
 	}
 }
 
+func LessThan(v float64) func(any) error {
+	return func(f any) error {
+		if v <= toFloat(f) {
+			return fmt.Errorf("want <= %v (got %v)", v, toFloat(f))
+		}
+		return nil
+	}
+}
+
 func Distribution(count uint64, sum float64) func(any) error {
 	return func(f any) error {
 		d := f.(*dto.Histogram)

--- a/releasenotes/notes/52005.yaml
+++ b/releasenotes/notes/52005.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+  - |
+    **Fixed** inconsistent behavior with the `istio_agent_cert_expiry_seconds` metric.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -584,7 +584,7 @@ func (sc *SecretManagerClient) generateNewSecret(resourceName string) (*security
 		ServiceAccount: sc.configOptions.ServiceAccount,
 	}
 
-	cacheLog.Debugf("constructed host name for CSR: %s", csrHostName.String())
+	cacheLog.Debugf("%s constructed host name for CSR: %s", logPrefix, csrHostName.String())
 	options := pkiutil.CertOptions{
 		Host:       csrHostName.String(),
 		RSAKeySize: sc.configOptions.WorkloadRSAKeySize,
@@ -626,7 +626,10 @@ func (sc *SecretManagerClient) generateNewSecret(resourceName string) (*security
 		return nil, fmt.Errorf("failed to extract expire time from server certificate in CSR response: %v", err)
 	}
 
-	cacheLog.WithLabels("latency", time.Since(t0), "ttl", time.Until(expireTime)).Info("generated new workload certificate")
+	cacheLog.WithLabels("resourceName", resourceName,
+		"latency", time.Since(t0),
+		"ttl", time.Until(expireTime)).
+		Info("generated new workload certificate")
 
 	if len(trustBundlePEM) > 0 {
 		rootCertPEM = concatCerts(trustBundlePEM)
@@ -657,7 +660,6 @@ var rotateTime = func(secret security.SecretItem, graceRatio float64) time.Durat
 
 func (sc *SecretManagerClient) registerSecret(item security.SecretItem) {
 	delay := rotateTime(item, sc.configOptions.SecretRotationGracePeriodRatio)
-	certExpirySeconds.ValueFrom(func() float64 { return time.Until(item.ExpireTime).Seconds() }, ResourceName.Value(item.ResourceName))
 	item.ResourceName = security.WorkloadKeyCertResourceName
 	// In case there are two calls to GenerateSecret at once, we don't want both to be concurrently registered
 	if sc.cache.GetWorkload() != nil {
@@ -666,6 +668,7 @@ func (sc *SecretManagerClient) registerSecret(item security.SecretItem) {
 	}
 	sc.cache.SetWorkload(&item)
 	resourceLog(item.ResourceName).Debugf("scheduled certificate for rotation in %v", delay)
+	certExpirySeconds.ValueFrom(func() float64 { return time.Until(item.ExpireTime).Seconds() }, ResourceName.Value(item.ResourceName))
 	sc.queue.PushDelayed(func() error {
 		// In case `UpdateConfigTrustBundle` called, it will resign workload cert.
 		// Check if this is a stale scheduled rotating task.

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -17,7 +17,6 @@ package cache
 import (
 	"bytes"
 	"fmt"
-	"istio.io/istio/pkg/monitoring/monitortest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -29,6 +28,7 @@ import (
 
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/monitoring/monitortest"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes: https://github.com/istio/istio/issues/50356

```
	// Cert expire time by default is createTime + sc.configOptions.SecretTTL.
	// Istiod respects SecretTTL that passed to it and use it decide TTL of cert it issued.
	// Some customer CA may override TTL param that's passed to it.
```

For ROOTCA, the expire time is meanlingless, we should just record this for `WorkloadKeyCertResourceName` cert



**Please check any characteristics that apply to this pull request.**

- [] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.