### PR TITLE
skip xds push if only Gateway API resource status is changed

### DIFF
--- a/pilot/pkg/bootstrap/config_compare.go
+++ b/pilot/pkg/bootstrap/config_compare.go
@@ -28,7 +28,7 @@ import (
 // needsPush checks whether the passed in config has same spec and hence push needs
 // to be triggered. This is to avoid unnecessary pushes only when labels have changed
 // for example.
-func needsPush(prev config.Config, curr config.Config) (toPush bool, skipGenXDS bool) {
+func needsPush(prev config.Config, curr config.Config) (toPush bool, skipXDSPush bool) {
 	if prev.GroupVersionKind != curr.GroupVersionKind {
 		// This should never happen.
 		return true, false
@@ -36,13 +36,13 @@ func needsPush(prev config.Config, curr config.Config) (toPush bool, skipGenXDS 
 
 	if prev.GroupVersionKind.Group == gateway.GroupName {
 		// We always push for Gateway API resources so that the status can be repaired.
-		return true, needsPushXDSForGatewayAPI(&prev, &curr)
+		return true, canSkipXDSPushForGatewayAPI(&prev, &curr)
 	}
 
 	return needsPushForOther(&prev, &curr), false
 }
 
-func needsPushXDSForGatewayAPI(prev *config.Config, curr *config.Config) bool {
+func canSkipXDSPushForGatewayAPI(prev *config.Config, curr *config.Config) bool {
 	// We skip the xDS push for Gateway API when the Spec is the same.
 	return reflect.DeepEqual(prev.Spec, curr.Spec)
 }

--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -196,6 +196,9 @@ var (
 	EnableDualStack = env.RegisterBoolVar("ISTIO_DUAL_STACK", false,
 		"If true, Istio will enable the Dual Stack feature.").Get()
 
+	EnableConditionalXDSPush = env.Register("ISTO_ENABLE_CONDITIONAL_XDS_PUSH", true,
+		"If enabled, Istio will not push xDS to Envoy if the xDS push can be skipped").Get()
+
 	// This is used in injection templates, it is not unused.
 	EnableNativeSidecars = env.Register("ENABLE_NATIVE_SIDECARS", false,
 		"If set, used Kubernetes native Sidecar container support. Requires SidecarContainer feature flag.")

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -359,6 +359,9 @@ type PushRequest struct {
 	// The kind of resources are defined in pkg/config/schemas.
 	ConfigsUpdated sets.Set[ConfigKey]
 
+	// SkipXDSPush indicates that we don't need to generate and push the xDS to Envoy.
+	SkipXDSPush bool
+
 	// Push stores the push context to use for the update. This may initially be nil, as we will
 	// debounce changes before a PushContext is eventually created.
 	Push *PushContext
@@ -489,6 +492,9 @@ func (pr *PushRequest) Merge(other *PushRequest) *PushRequest {
 
 	// If either is full we need a full push
 	pr.Full = pr.Full || other.Full
+
+	// If both skip xDS generation, then skip
+	pr.SkipXDSPush = pr.SkipXDSPush && other.SkipXDSPush
 
 	// The other push context is presumed to be later and more up to date
 	if other.Push != nil {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -86,27 +86,30 @@ func TestMergeUpdateRequest(t *testing.T) {
 		{
 			"simple merge",
 			&PushRequest{
-				Full:  true,
-				Push:  push0,
-				Start: t0,
+				Full:        true,
+				SkipXDSPush: true,
+				Push:        push0,
+				Start:       t0,
 				ConfigsUpdated: sets.Set[ConfigKey]{
 					{Kind: kind.Kind(1), Namespace: "ns1"}: {},
 				},
 				Reason: NewReasonStats(ServiceUpdate, ServiceUpdate),
 			},
 			&PushRequest{
-				Full:  false,
-				Push:  push1,
-				Start: t1,
+				Full:        false,
+				SkipXDSPush: false,
+				Push:        push1,
+				Start:       t1,
 				ConfigsUpdated: sets.Set[ConfigKey]{
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},
 				},
 				Reason: NewReasonStats(EndpointUpdate),
 			},
 			PushRequest{
-				Full:  true,
-				Push:  push1,
-				Start: t0,
+				Full:        true,
+				SkipXDSPush: false,
+				Push:        push1,
+				Start:       t0,
 				ConfigsUpdated: sets.Set[ConfigKey]{
 					{Kind: kind.Kind(1), Namespace: "ns1"}: {},
 					{Kind: kind.Kind(2), Namespace: "ns2"}: {},

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -478,8 +478,13 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		s.computeProxyState(con.proxy, pushRequest)
 	}
 
-	if !s.ProxyNeedsPush(con.proxy, pushRequest) || (features.EnableConditionalXDSPush && pushRequest.SkipXDSPush) {
+	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
 		log.Debugf("Skipping push to %v, no updates required", con.ID())
+		return nil
+	}
+
+	if features.EnableConditionalXDSPush && pushRequest.SkipXDSPush {
+		log.Debugf("Skipping push to %v, no updates required because the push event is caused by gateway api status changing only", con.ID())
 		return nil
 	}
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -478,7 +478,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		s.computeProxyState(con.proxy, pushRequest)
 	}
 
-	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
+	if !s.ProxyNeedsPush(con.proxy, pushRequest) || (features.EnableConditionalXDSPush && pushRequest.SkipXDSPush) {
 		log.Debugf("Skipping push to %v, no updates required", con.ID())
 		return nil
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -160,7 +160,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 		s.computeProxyState(con.proxy, pushRequest)
 	}
 
-	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
+	if !s.ProxyNeedsPush(con.proxy, pushRequest) || (features.EnableConditionalXDSPush && pushRequest.SkipXDSPush) {
 		deltaLog.Debugf("Skipping push to %v, no updates required", con.ID())
 		return nil
 	}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -160,8 +160,13 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 		s.computeProxyState(con.proxy, pushRequest)
 	}
 
-	if !s.ProxyNeedsPush(con.proxy, pushRequest) || (features.EnableConditionalXDSPush && pushRequest.SkipXDSPush) {
+	if !s.ProxyNeedsPush(con.proxy, pushRequest) {
 		deltaLog.Debugf("Skipping push to %v, no updates required", con.ID())
+		return nil
+	}
+
+	if features.EnableConditionalXDSPush && pushRequest.SkipXDSPush {
+		deltaLog.Debugf("Skipping push to %v, no updates required because the push event is caused by gateway api status changing only", con.ID())
 		return nil
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix https://github.com/istio/istio/issues/50998.

This feature can save the xDS push when only the Gateway API resources' statuses are changed. As the Gateway API uses status widely, sometimes this change can save up to 50% xDS push.