### PR TITLE
manifest: Ensure profile is a string

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -6,7 +6,7 @@ To learn more about the release, try:
 
 Next steps:
 {{- $profile := default "" .Values.profile }}
-{{- if (eq $profile "ambient") }
+{{- if (eq $profile "ambient") }}
   * Get started with ambient: https://istio.io/latest/docs/ops/ambient/getting-started/
   * Review ambient's architecture: https://istio.io/latest/docs/ops/ambient/architecture/
 {{- else }}

--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -5,7 +5,8 @@ To learn more about the release, try:
   $ helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 Next steps:
-{{- if (eq .Values.profile "ambient") }}
+{{- $profile := default "" .Values.profile }}
+{{- if (eq $profile "ambient") }
   * Get started with ambient: https://istio.io/latest/docs/ops/ambient/getting-started/
   * Review ambient's architecture: https://istio.io/latest/docs/ops/ambient/architecture/
 {{- else }}

--- a/releasenotes/notes/52017.yaml
+++ b/releasenotes/notes/52017.yaml
@@ -5,4 +5,4 @@ issue:
   - 52016
 releaseNotes:
 - |
-  **Fixed** Explicitly set .profile to a string to support older version of Helm (namely v3.6 and v3.7).
+  **Fixed** the istiod chart installation for older Helm versions (v3.6 and v3.7) by ensuring that `.Values.profile` is set to a string.

--- a/releasenotes/notes/52017.yaml
+++ b/releasenotes/notes/52017.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 52016
+releaseNotes:
+- |
+  **Fixed** Explicitly set .profile to a string to support older version of Helm (namely v3.6 and v3.7).


### PR DESCRIPTION
**Please provide a description of this PR:**

For older versions of Helm (namely v3.6, as mentioned in the docs as (minimum) prerequisite https://istio.io/latest/docs/setup/install/helm/#prerequisites), type checking is not handled gracefully as the newer version. For those versions, we ensure that `.Values.profile` is explicitly set to a string.

Fix https://github.com/istio/istio/issues/52016.
