### PR TITLE
[release-1.21] fix inconsistent behavior with the 'istio_agent_cert_expiry_seconds' metric

### DIFF
--- a/pkg/monitoring/monitortest/test.go
+++ b/pkg/monitoring/monitortest/test.go
@@ -112,6 +112,15 @@ func Exactly(v float64) func(any) error {
 	}
 }
 
+func LessThan(v float64) func(any) error {
+	return func(f any) error {
+		if v <= toFloat(f) {
+			return fmt.Errorf("want <= %v (got %v)", v, toFloat(f))
+		}
+		return nil
+	}
+}
+
 func Distribution(count uint64, sum float64) func(any) error {
 	return func(f any) error {
 		d := f.(*dto.Histogram)

--- a/releasenotes/notes/52005.yaml
+++ b/releasenotes/notes/52005.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+  - |
+    **Fixed** inconsistent behavior with the `istio_agent_cert_expiry_seconds` metric.


### PR DESCRIPTION
fixes: #52022 

**Please provide a description of this PR:**