### PR TITLE
add useful labels to helm templates for ztunnel

### DIFF
--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -4,7 +4,7 @@
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- end }}
     {{- if .Release.Name}}
-    # app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     {{- end }}
     app.kubernetes.io/part-of: istio
 {{- end }}

--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{- define "istio-labels" }}
+    app.kubernetes.io/name: ztunnel
+    {{- if .Release.Service }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    {{- if .Release.Name}}
+    # app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
+    app.kubernetes.io/part-of: istio
+{{- end }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -4,10 +4,7 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    istio.io/component: ztunnel
-    operator.istio.io/component: Ztunnel
-    k8s-app: ztunnel
-    app: ztunnel
+{{ template "istio-labels" }}
 {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-{{ template "istio-labels" }}
+{{- template "istio-labels" -}}
 {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -4,7 +4,11 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- .Values.labels | toYaml | nindent 4}}
+    istio.io/component: ztunnel
+    operator.istio.io/component: Ztunnel
+    k8s-app: ztunnel
+    app: ztunnel
+{{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-{{ template "istio-labels" }}
+{{- template "istio-labels" -}}
 {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -10,7 +10,11 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- .Values.labels | toYaml | nindent 4}}
+    istio.io/component: ztunnel
+    operator.istio.io/component: Ztunnel
+    k8s-app: ztunnel
+    app: ztunnel
+{{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}
     {{- $annos := set $.Values.annotations "istio.io/rev" .Values.revision }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -10,10 +10,7 @@ metadata:
   name: ztunnel
   namespace: {{ .Release.Namespace }}
   labels:
-    istio.io/component: ztunnel
-    operator.istio.io/component: Ztunnel
-    k8s-app: ztunnel
-    app: ztunnel
+{{ template "istio-labels" }}
 {{ with .Values.labels -}}{{ toYaml . | nindent 4}}{{ end }}
   annotations:
 {{- if .Values.revision }}

--- a/releasenotes/notes/52033.yaml
+++ b/releasenotes/notes/52033.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** an omission in ztunnel helm charts which resulted in some Kubernetes resources being created without labels


### PR DESCRIPTION
**Please provide a description of this PR:**

This adds some useful labels to our ztunnel helm installations which would normally be found only if you use istioctl. I think we should phase out `operator.istio.io/component` in favor of `istio.io/component` or something similar. Also IMO we shouldn't be capitalizing the component name. Ztunnel or Cni just look weird to my eye. Lets go with lowercase for the new label's value but left uppercase since that is what istioctl and other components have for their `operator.istio.io/component `value...