### PR TITLE
add support for publishNotReadyAddresses in headless

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -119,6 +119,8 @@ type Service struct {
 
 	// ResourceVersion represents the internal version of this object.
 	ResourceVersion string
+
+	PublishNotReadyAddresses bool `json:"publishNotReadyAddresses,omitempty"`
 }
 
 func (s *Service) NamespacedName() types.NamespacedName {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -233,6 +233,11 @@ func endpointHealthStatus(svc *model.Service, e v1.Endpoint) model.HealthStatus 
 	if e.Conditions.Ready == nil || *e.Conditions.Ready {
 		return model.Healthy
 	}
+	// For headless services if PublishNotReadyAddresses is set, we consider the endpoint healthy
+	// so that it is available in DNS queries in name table.
+	if svc != nil && svc.Resolution == model.Passthrough && svc.PublishNotReadyAddresses {
+		return model.Healthy
+	}
 
 	if features.PersistentSessionLabel != "" &&
 		svc != nil &&


### PR DESCRIPTION
Add unready endpoints to IstioEndpoints for headless service if publishNotReadyAddresses is set. this will help dns proxy to resolve them without going to core DNS.