### PR TITLE
ambient chart: bikeshed enablement

### DIFF
--- a/manifests/sample-charts/ambient/Chart.yaml
+++ b/manifests/sample-charts/ambient/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
   - name: istiod
     version: 1.0.0
     repository: "file://../../charts/istio-control/istio-discovery"
-    condition: enable.istiod
+    condition: istiod.enabled
   - name: ztunnel
     version: 1.0.0
     repository: "file://../../charts/ztunnel"

--- a/manifests/sample-charts/ambient/values.yaml
+++ b/manifests/sample-charts/ambient/values.yaml
@@ -1,11 +1,9 @@
 global:
   variant: distroless
 
-enable:
-  istiod: true
-
 # Overrides for the `istiod-remote` dep
 istiod:
+  enabled: true
   profile: ambient
 
 # Overrides for the `ztunnel` dep


### PR DESCRIPTION
`chart.enabled` is pretty standard across the ecosystem, Istio itself in
other places, and Helm recommendations
(https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies)
