### PR TITLE
tests: make suite skip immediately exit

### DIFF
--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -384,13 +384,6 @@ func (s *suiteImpl) isSkipped(ctx SuiteContext) bool {
 func (s *suiteImpl) doSkip(ctx *suiteContext) int {
 	scopes.Framework.Infof("Skipping suite %q: %s", ctx.Settings().TestID, s.skipMessage)
 
-	// Mark this suite as skipped in the context.
-	ctx.skipped = true
-
-	// Run the tests so that the golang test framework exits normally. The tests will not run because
-	// they see that this suite has been skipped.
-	_ = s.mRun(ctx)
-
 	// Return success.
 	return 0
 }

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -48,8 +48,6 @@ type suiteContext struct {
 	settings    *resource.Settings
 	environment resource.Environment
 
-	skipped bool
-
 	workDir string
 	yml.FileWriter
 

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -209,11 +209,6 @@ func (t *testImpl) runInternal(fn func(ctx TestContext), parallel bool) {
 		panic(fmt.Sprintf("Attempting to run test `%s` more than once", testName))
 	}
 
-	if t.s.skipped {
-		t.goTest.Skip("Skipped because parent Suite was skipped.")
-		return
-	}
-
 	if t.parent != nil {
 		// Create a new subtest under the parent's test.
 		parentGoTest := t.parent.goTest


### PR DESCRIPTION
See
https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-123_istio_postsubmit/1812908054123909120;
this fails since setup is never run but the test is executed
