### PR TITLE
fix: ipautoallocate fails if status doesn't exists

### DIFF
--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -240,6 +240,8 @@ func (c *IPAllocator) resolveConflict(conflict conflictDetectedEvent) error {
 			continue
 		}
 		log.Warnf("reassigned %s/%s due to IP Address conflict", resolveMe.Namespace, resolveMe.Name)
+		// we are patching from the slice of ServiceEntry where the conflicting address was found in status.addresses
+		// this means we should already have a status and never need to use the patch that initializes the status
 		patch, _, err := c.statusPatchForAddresses(resolveMe, true)
 		if err != nil {
 			errs = errors.Join(errs, err)


### PR DESCRIPTION
**Please provide a description of this PR:**

adds logic to handle json patching if status doesn't already exist.
this removes use of the jsonpatch library nodeuntaint controller was using from the ip autoallocate controller because it was not able to express the nil test for status.