### PR TITLE
operator: internal refactoring of `components`

### DIFF
--- a/operator/pkg/controlplane/control_plane.go
+++ b/operator/pkg/controlplane/control_plane.go
@@ -32,7 +32,7 @@ import (
 // IstioControlPlane is an installation of an Istio control plane.
 type IstioControlPlane struct {
 	// components is a slice of components that are part of the feature.
-	components []component.IstioComponent
+	components []*component.IstioComponent
 	started    bool
 }
 
@@ -112,7 +112,7 @@ func (i *IstioControlPlane) RenderManifest() (manifests name.ManifestMap, errsOu
 	for _, c := range i.components {
 		ms, err := c.RenderManifest()
 		errsOut = util.AppendErr(errsOut, err)
-		manifests[c.ComponentName()] = append(manifests[c.ComponentName()], ms)
+		manifests[c.ComponentName] = append(manifests[c.ComponentName], ms)
 	}
 	if len(errsOut) > 0 {
 		return nil, errsOut
@@ -121,7 +121,7 @@ func (i *IstioControlPlane) RenderManifest() (manifests name.ManifestMap, errsOu
 }
 
 // componentsEqual reports whether the given components are equal to those in i.
-func (i *IstioControlPlane) componentsEqual(components []component.IstioComponent) bool {
+func (i *IstioControlPlane) componentsEqual(components []*component.IstioComponent) bool {
 	if i.components == nil && components == nil {
 		return true
 	}
@@ -129,16 +129,16 @@ func (i *IstioControlPlane) componentsEqual(components []component.IstioComponen
 		return false
 	}
 	for c := 0; c < len(i.components); c++ {
-		if i.components[c].ComponentName() != components[c].ComponentName() {
+		if i.components[c].ComponentName != components[c].ComponentName {
 			return false
 		}
-		if i.components[c].Namespace() != components[c].Namespace() {
+		if i.components[c].Namespace != components[c].Namespace {
 			return false
 		}
 		if i.components[c].Enabled() != components[c].Enabled() {
 			return false
 		}
-		if i.components[c].ResourceName() != components[c].ResourceName() {
+		if i.components[c].ResourceName != components[c].ResourceName {
 			return false
 		}
 	}

--- a/operator/pkg/controlplane/control_plane_test.go
+++ b/operator/pkg/controlplane/control_plane_test.go
@@ -83,47 +83,27 @@ func TestNewIstioOperator(t *testing.T) {
 			},
 			wantErr: nil,
 			wantIstioOperator: &IstioControlPlane{
-				components: []component.IstioComponent{
-					&component.BaseComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options:       coreComponentOptions,
-								ComponentName: name.IstioBaseComponentName,
-							},
-						},
+				components: []*component.IstioComponent{
+					{
+						Options:       coreComponentOptions,
+						ComponentName: name.IstioBaseComponentName,
 					},
-					&component.PilotComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options:       coreComponentOptions,
-								ResourceName:  "test-resource",
-								ComponentName: name.PilotComponentName,
-							},
-						},
+					{
+						Options:       coreComponentOptions,
+						ResourceName:  "test-resource",
+						ComponentName: name.PilotComponentName,
 					},
-					&component.CNIComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								ComponentName: name.CNIComponentName,
-								Options:       coreComponentOptions,
-							},
-						},
+					{
+						ComponentName: name.CNIComponentName,
+						Options:       coreComponentOptions,
 					},
-					&component.IstiodRemoteComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								ComponentName: name.IstiodRemoteComponentName,
-								Options:       coreComponentOptions,
-							},
-						},
+					{
+						ComponentName: name.IstiodRemoteComponentName,
+						Options:       coreComponentOptions,
 					},
-					&component.ZtunnelComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								ComponentName: name.ZtunnelComponentName,
-								Options:       coreComponentOptions,
-							},
-						},
+					{
+						ComponentName: name.ZtunnelComponentName,
+						Options:       coreComponentOptions,
 					},
 				},
 			},
@@ -154,34 +134,19 @@ func TestIstioOperator_RenderManifest(t *testing.T) {
 		{
 			desc: "components-not-started-operator-started",
 			testOperator: &IstioControlPlane{
-				components: []component.IstioComponent{
-					&component.BaseComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options:       coreComponentOptions,
-								ComponentName: name.IstioBaseComponentName,
-							},
-						},
+				components: []*component.IstioComponent{
+					{
+						Options:       coreComponentOptions,
+						ComponentName: name.IstioBaseComponentName,
 					},
-					&component.PilotComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options: &component.Options{
-									InstallSpec: &v1alpha1.IstioOperatorSpec{},
-									Translator:  &translate.Translator{},
-								},
-								ResourceName:  "test-resource",
-								ComponentName: name.PilotComponentName,
-							},
-						},
+					{
+						Options:       coreComponentOptions,
+						ResourceName:  "test-resource",
+						ComponentName: name.PilotComponentName,
 					},
-					&component.CNIComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								ComponentName: name.CNIComponentName,
-								Options:       coreComponentOptions,
-							},
-						},
+					{
+						ComponentName: name.CNIComponentName,
+						Options:       coreComponentOptions,
 					},
 				},
 				started: true,
@@ -196,34 +161,19 @@ func TestIstioOperator_RenderManifest(t *testing.T) {
 		{
 			desc: "operator-not-started",
 			testOperator: &IstioControlPlane{
-				components: []component.IstioComponent{
-					&component.BaseComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options:       coreComponentOptions,
-								ComponentName: name.IstioBaseComponentName,
-							},
-						},
+				components: []*component.IstioComponent{
+					{
+						Options:       coreComponentOptions,
+						ComponentName: name.IstioBaseComponentName,
 					},
-					&component.PilotComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								Options: &component.Options{
-									InstallSpec: &v1alpha1.IstioOperatorSpec{},
-									Translator:  &translate.Translator{},
-								},
-								ResourceName:  "test-resource",
-								ComponentName: name.PilotComponentName,
-							},
-						},
+					{
+						Options:       coreComponentOptions,
+						ResourceName:  "test-resource",
+						ComponentName: name.PilotComponentName,
 					},
-					&component.CNIComponent{
-						IstioComponentBase: &component.IstioComponentBase{
-							CommonComponentFields: &component.CommonComponentFields{
-								ComponentName: name.CNIComponentName,
-								Options:       coreComponentOptions,
-							},
-						},
+					{
+						ComponentName: name.CNIComponentName,
+						Options:       coreComponentOptions,
 					},
 				},
 				started: false,


### PR DESCRIPTION
This is a NOP change, just cleaning up. we do not need to nest each
component through 3 structs and an interface; can just expose the struct
directly
