### PR TITLE
install: drop legacy k8s provider

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -430,10 +430,6 @@ spec:
     - mountPath: /var/run/secrets/istio
       name: istiod-ca-cert
     {{- end }}
-    {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-    - mountPath: /var/run/secrets/istio/kubernetes
-      name: kube-ca-cert
-    {{- end }}
     - mountPath: /var/lib/istio/data
       name: istio-data
     {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
+++ b/manifests/charts/istio-control/istio-discovery/templates/NOTES.txt
@@ -76,3 +76,6 @@ WARNING: {{$dep|quote}} is deprecated; use {{$replace|quote}} instead.
 {{fail (print $dep " is removed")}}
 {{- end }}
 {{- end }}
+{{- if eq $.Values.global.pilotCertProvider "kubernetes" }}
+{{- fail "pilotCertProvider=kubernetes is not supported" }}
+{{- end }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -430,10 +430,6 @@ spec:
     - mountPath: /var/run/secrets/istio
       name: istiod-ca-cert
     {{- end }}
-    {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-    - mountPath: /var/run/secrets/istio/kubernetes
-      name: kube-ca-cert
-    {{- end }}
     - mountPath: /var/lib/istio/data
       name: istio-data
     {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/operator/pkg/controller/istiocontrolplane/errdict.go
+++ b/operator/pkg/controller/istiocontrolplane/errdict.go
@@ -86,14 +86,6 @@ var (
 		Action: "Check that the IstioOperator resource has the correct syntax. " +
 			actionIfErrSureCorrectConfigContactSupport,
 	}
-	operatorFailedToConfigure = &structured.Error{
-		MoreInfo: "the IstioOperator Resource could not be applied on the cluster " +
-			"because of incompatible Kubernetes settings",
-		Impact:      operatorImpactNoUpdates,
-		LikelyCause: formatCauses(likelyCauseConfiguration),
-		Action: "Ensure that IstioOperator config is compatible with current Kubernetes version." +
-			actionIfErrSureCorrectConfigContactSupport,
-	}
 )
 
 func fixFormat(s string) string {

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -324,11 +324,6 @@ func (r *ReconcileIstioOperator) Reconcile(_ context.Context, request reconcile.
 	if _, ok := val["global"]; !ok {
 		val["global"] = make(map[string]any)
 	}
-	err = util.ValidateIOPCAConfig(r.kubeClient, iopMerged)
-	if err != nil {
-		operatorFailedToConfigure.Log(scope).Errorf("failed to apply IstioOperator resources. Error %s", err)
-		return reconcile.Result{}, err
-	}
 	helmReconcilerOptions := &helmreconciler.Options{
 		Log:         clog.NewDefaultLogger(),
 		ProgressLog: progress.NewLog(),

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -206,13 +206,6 @@ func GenIOPFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string,
 		return "", nil, err
 	}
 
-	// Validate Final IOP config against K8s cluster
-	if client != nil {
-		err = util.ValidateIOPCAConfig(client, finalIOP)
-		if err != nil {
-			return "", nil, err
-		}
-	}
 	// InstallPackagePath may have been a URL, change to extracted to local file path.
 	finalIOP.Spec.InstallPackagePath = installPackagePath
 	if ns := GetValueForSetFlag(setFlags, "values.global.istioNamespace"); ns != "" {

--- a/operator/pkg/util/k8s.go
+++ b/operator/pkg/util/k8s.go
@@ -27,41 +27,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/api/label"
-	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/kube"
 )
 
 // GKString differs from default representation of GroupKind
 func GKString(gvk schema.GroupKind) string {
 	return fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind)
-}
-
-// ValidateIOPCAConfig validates if the IstioOperator CA configs are applicable to the K8s cluster
-func ValidateIOPCAConfig(client kube.Client, iop *iopv1alpha1.IstioOperator) error {
-	globalI := iop.Spec.Values.AsMap()["global"]
-	global, ok := globalI.(map[string]any)
-	if !ok {
-		// This means no explicit global configuration. Still okay
-		return nil
-	}
-	ca, ok := global["pilotCertProvider"].(string)
-	if !ok {
-		// This means the default pilotCertProvider is being used
-		return nil
-	}
-	if ca == "kubernetes" {
-		ver, err := client.GetKubernetesVersion()
-		if err != nil {
-			return fmt.Errorf("failed to determine support for K8s legacy signer. Use the --force flag to ignore this: %v", err)
-		}
-
-		if kube.IsAtLeastVersion(client, 22) {
-			return fmt.Errorf("configuration PILOT_CERT_PROVIDER=%s not supported in Kubernetes %v."+
-				"Please pick another value for PILOT_CERT_PROVIDER", ca, ver.String())
-		}
-	}
-	return nil
 }
 
 // CreateNamespace creates a namespace using the given k8s interface.

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -441,10 +441,6 @@ templates:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
         {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "kubernetes" }}
-        - mountPath: /var/run/secrets/istio/kubernetes
-          name: kube-ca-cert
-        {{- end }}
         - mountPath: /var/lib/istio/data
           name: istio-data
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}


### PR DESCRIPTION
* Remove validation check that is operator specific and k8s version
  specific; move to helm and always fail if it is set
* Remove deadcode now that it can never be set
