### PR TITLE
fix ISTIO_DELTA_XDS in compatibility version 1.21 profile

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-operator/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -13,9 +13,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -9,9 +9,9 @@ pilot:
     
 meshConfig:
   # 1.22 behavioral changes
-  proxyMetadata:
-    ISTIO_DELTA_XDS: "false"
   defaultConfig:
+    proxyMetadata:
+      ISTIO_DELTA_XDS: "false"
     tracing:
       zipkin:
         address: zipkin.istio-system:9411


### PR DESCRIPTION
**Please provide a description of this PR:**

Compatibility profile for v1.21 wouldn't disable delta XDS correctly. 

`proxyMetadata` should be under `meshConfig.defaultConfig` in the meshConfig.

Current behavior:
```
      - name: PROXY_CONFIG
        value: |
          {"tracing":{"zipkin":{"address":"zipkin.istio-system:9411"}},"proxyMetadata":{"ISTIO_META_DNS_CAPTURE":"true"},"gatewayTopology":{"numTrustedProxies":2},"meshId":"my-mesh","holdApplicationUntilProxyStarts":true}
```

After patching:
```
      - name: PROXY_CONFIG
        value: |
          {"tracing":{"zipkin":{"address":"zipkin.istio-system:9411"}},"proxyMetadata":{"ISTIO_DELTA_XDS":"false","ISTIO_META_DNS_CAPTURE":"true"},"gatewayTopology":{"numTrustedProxies":2},"meshId":"my-mesh","holdApplicationUntilProxyStarts":true}
```