### PR TITLE
Work around netlink bug on ipset create error

### DIFF
--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -42,7 +42,6 @@ func (m *realDeps) ipsetIPHashCreate(name string, v6 bool) error {
 		family = unix.AF_INET
 	}
 	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Family: family})
-	log.Debugf("IPSET ERROR IS: %s", err)
 	// Note there appears to be a bug in vishvananda/netlink here:
 	// https://github.com/vishvananda/netlink/issues/992
 	//

--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
-
-	"istio.io/istio/pkg/log"
 )
 
 func RealNlDeps() NetlinkIpsetDeps {

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -17,7 +17,6 @@ data:
   {{- if .Values.cni.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cni.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}
-  CNI_NET_DIR: {{ .Values.cni.cniConfDir | default "/etc/cni/net.d" }}
   CHAINED_CNI_PLUGIN: {{ .Values.cni.chained | quote }}
   EXCLUDED_NAMESPACES: "{{ range $idx, $ns := .Values.cni.excludeNamespaces }}{{ if $idx }},{{ end }}{{ $ns }}{{ end }}"
   REPAIR_ENABLED: {{ .Values.cni.chained | quote }}

--- a/releasenotes/notes/52127.yaml
+++ b/releasenotes/notes/52127.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+releaseNotes:
+  - |
+    **Fixed** netlink error may not be correctly parsed, leading to `istio-cni` not properly ignoring leftover ipset.
+    **Removed** CNI_NET_DIR variable from `istio-cni` configmap - it is unused

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -214,11 +214,6 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 	framework.NewTest(t).
 		TopLevel().
 		Run(func(t framework.TestContext) {
-			apps := common_deploy.NewOrFail(t, t, common_deploy.Config{
-				NoExternalNamespace: true,
-				IncludeExtAuthz:     false,
-			})
-
 			c := t.Clusters().Default()
 			t.Log("Updating CNI Daemonset config")
 			origCNIDaemonSet := getCNIDaemonSet(t, c)
@@ -229,7 +224,7 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 			// Rollout restart instances in the echo namespace, and wait for a broken instance.
 			// The CNI pods should never go healthy because of the bad CNI_NET_DIR above
 			t.Log("Rollout restart CNI daemonset to get a broken instance")
-			rolloutCmd := fmt.Sprintf("kubectl rollout restart daemonset/%s -n %s", "istio-cni-node", i.Settings.SystemNamespace.Name())
+			rolloutCmd := fmt.Sprintf("kubectl rollout restart daemonset/%s -n %s", "istio-cni-node", i.Settings().SystemNamespace)
 			if _, err := shell.Execute(true, rolloutCmd); err != nil {
 				t.Fatalf("failed to rollout restart deployments %v", err)
 			}

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -246,7 +246,7 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 			deployCNIDaemonset(t, c, origCNIDaemonSet)
 
 			// Rollout restart instances in the echo namespace.
-			t.Log("Rollout restart echo instance to get a fixed instance")
+			t.Log("Rollout restart CNI daemonset to get a fixed instance")
 			if _, err := shell.Execute(true, rolloutCmd); err != nil {
 				t.Fatalf("failed to rollout restart deployments %v", err)
 			}

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -21,13 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/config/constants"
 	istioKube "istio.io/istio/pkg/kube"

--- a/tests/integration/ambient/cni/main_test.go
+++ b/tests/integration/ambient/cni/main_test.go
@@ -245,6 +245,8 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 
 			retry.UntilSuccessOrFail(t, func() error {
 				t.Log("Rollout restart CNI daemonset to get a fixed instance")
+				// depending on timing it can actually take little bit for the patch to be applied and
+				// to get all pods to enter a broken state break - so rely on the retry delay to sort that for us
 				if _, err := shell.Execute(true, rolloutCmd); err != nil {
 					t.Fatalf("failed to rollout restart deployments %v", err)
 				}
@@ -277,6 +279,7 @@ func TestCNIMisconfigHealsOnRestart(t *testing.T) {
 			time.Sleep(1 * time.Second)
 
 			// Rollout restart CNI pods so they get the fixed config.
+			// to _fix_ the pods we should only have to do this *once*
 			t.Log("Rollout restart CNI daemonset to get a fixed instance")
 			if _, err := shell.Execute(true, rolloutCmd); err != nil {
 				t.Fatalf("failed to rollout restart deployments %v", err)


### PR DESCRIPTION
**Please provide a description of this PR:**

1. Normally, we unconditionally remove the `ipset` we create in istio cni on shutdown
2. if istio cni happens to crash or otherwise terminate uncleanly, there is a chance we can not remove the ipset
3. this is fine, as on startup we explicitly ignore `IPSET_ERR_EXIST` errors from `netlink` so we can recover.

Except it is not fine, as the error `netlink` ACTUALLY returns is not that at all, which _appears_ to be due to an early return: https://github.com/vishvananda/netlink/blob/d13535d71ed3e430e26c7538cd6266d026b26f54/ipset_linux.go#L410

and we consequently do not ignore.

So, do something a little more foolproof

`netlink` bug is: https://github.com/vishvananda/netlink/issues/992

We have  been doing this check since 1.21 at least, and `netlink` does the same kind of check in their test code - it just doesn't actually work correctly in all cases.

Will see if I can add an integ test for this as well.


You can repro this by 

- manually jumping onto a node before installing istio
- manually creating a `hash:ip` ipset named `istio-inpod-probes-v4`
- installing istio