### PR TITLE
Drop SupportedFeatures from gateway-api

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -1865,7 +1865,7 @@ func createGRPCURIMatch(match k8s.GRPCRouteMatch) (*istio.StringMatch, *ConfigEr
 
 // getGatewayClass finds all gateway class that are owned by Istio
 // Response is ClassName -> Controller type
-func getGatewayClasses(r GatewayResources, supportedFeatures []k8s.SupportedFeature) map[string]k8s.GatewayController {
+func getGatewayClasses(r GatewayResources) map[string]k8s.GatewayController {
 	res := map[string]k8s.GatewayController{}
 	// Setup builtin ones - these can be overridden possibly
 	for name, controller := range builtinClasses {
@@ -1883,7 +1883,6 @@ func getGatewayClasses(r GatewayResources, supportedFeatures []k8s.SupportedFeat
 		obj.Status.(*kstatus.WrappedStatus).Mutate(func(s config.Status) config.Status {
 			gcs := s.(*k8s.GatewayClassStatus)
 			*gcs = GetClassStatus(gcs, obj.Generation)
-			gcs.SupportedFeatures = supportedFeatures
 			return gcs
 		})
 	}
@@ -2032,7 +2031,7 @@ func convertGateways(r configContext) ([]config.Config, map[parentKey][]*parentI
 	// namespaceLabelReferences keeps track of all namespace label keys referenced by Gateways. This is
 	// used to ensure we handle namespace updates for those keys.
 	namespaceLabelReferences := sets.New[string]()
-	classes := getGatewayClasses(r.GatewayResources, gatewaySupportedFeatures)
+	classes := getGatewayClasses(r.GatewayResources)
 	for _, obj := range r.Gateway {
 		obj := obj
 		kgw := obj.Spec.(*k8s.GatewaySpec)

--- a/pilot/pkg/config/kube/gateway/supported_features.go
+++ b/pilot/pkg/config/kube/gateway/supported_features.go
@@ -15,20 +15,7 @@
 package gateway
 
 import (
-	k8sv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/features"
-
-	"istio.io/istio/pkg/util/sets"
 )
 
 var SupportedFeatures = features.AllFeatures
-
-var gatewaySupportedFeatures = getSupportedFeatures()
-
-func getSupportedFeatures() []k8sv1.SupportedFeature {
-	ret := sets.New[k8sv1.SupportedFeature]()
-	for _, feature := range SupportedFeatures.UnsortedList() {
-		ret.Insert(k8sv1.SupportedFeature(feature))
-	}
-	return sets.SortedList(ret)
-}

--- a/releasenotes/notes/support-features.yaml
+++ b/releasenotes/notes/support-features.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Removed** writing the experimental field `GatewayClass.status.supportedFeatures`, as it is unstable in the API.


### PR DESCRIPTION
This field provides no value but causes a lot of harm:
* https://github.com/kubernetes-sigs/gateway-api/pull/3200#discussion_r1681853821
* https://github.com/istio/istio/issues/50851

And it looks like there is no conformance requirement to support it.

If we do, we need to make it off-by-default with a flag; I see no reason to provide this.