### PR TITLE
networking: fix DNS auto-allocation

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/pkg/util/sets"
@@ -225,11 +226,13 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 				LabelSelectors:         labelSelectors,
 			},
 			ServiceAccounts: serviceEntry.SubjectAltNames,
-			ClusterVIPs: model.AddressMap{
+		}
+		if !slices.Equal(ha.addresses, []string{constants.UnspecifiedIP}) {
+			svc.ClusterVIPs = model.AddressMap{
 				Addresses: map[cluster.ID][]string{
 					clusterID: ha.addresses,
 				},
-			},
+			}
 		}
 		out = append(out, svc)
 	}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 )
@@ -535,9 +536,11 @@ func makeService(hostname host.Name, configNamespace string, addresses []string,
 			Name:            string(hostname),
 			Namespace:       configNamespace,
 		},
-		ClusterVIPs: model.AddressMap{
+	}
+	if !slices.Equal(addresses, []string{constants.UnspecifiedIP}) {
+		svc.ClusterVIPs = model.AddressMap{
 			Addresses: map[cluster.ID][]string{"": addresses},
-		},
+		}
 	}
 
 	if external && features.CanonicalServiceForMeshExternalServiceEntry {

--- a/tests/integration/pilot/dns_auto_allocation_test.go
+++ b/tests/integration/pilot/dns_auto_allocation_test.go
@@ -41,6 +41,9 @@ kind: ProxyConfig
 metadata:
   name: enable-dns-auto-allocation
 spec:
+  selector:
+    matchLabels:
+      app: a
   environmentVariables:
     ISTIO_META_DNS_CAPTURE: "true"
     ISTIO_META_DNS_AUTO_ALLOCATE: "true"

--- a/tests/integration/pilot/dns_auto_allocation_test.go
+++ b/tests/integration/pilot/dns_auto_allocation_test.go
@@ -1,0 +1,69 @@
+package pilot
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+)
+
+func TestDNSAutoAllocation(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(func(t framework.TestContext) {
+			ns := namespace.NewOrFail(t, t, namespace.Config{
+				Prefix: "dns-auto-allocation",
+				Inject: true,
+			})
+			cfg := `apiVersion: networking.istio.io/v1beta1
+kind: ProxyConfig
+metadata:
+  name: enable-dns-auto-allocation
+spec:
+  environmentVariables:
+    ISTIO_META_DNS_CAPTURE: "true"
+    ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: fake-local
+spec:
+  hosts:
+  - "fake.local"
+  resolution: DNS
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route-to-b
+spec:
+  hosts:
+  - fake.local
+  http:
+  - route:
+    - destination:
+        host: b.{{.echoNamespace}}.svc.cluster.local
+`
+			t.ConfigIstio().Eval(ns.Name(), map[string]string{"echoNamespace": apps.Namespace.Name()}, cfg).ApplyOrFail(t)
+			instances := deployment.New(t, t.AllClusters().Configs()...).WithConfig(echo.Config{Namespace: ns, Service: "a"}).BuildOrFail(t)
+
+			_ = instances[0].CallOrFail(t, echo.CallOptions{
+				Address: "fake.local",
+				Port: echo.Port{
+					Name:        "http",
+					ServicePort: 80,
+					Protocol:    protocol.HTTP,
+				},
+				Check: check.OK(),
+			})
+		})
+}

--- a/tests/integration/pilot/dns_auto_allocation_test.go
+++ b/tests/integration/pilot/dns_auto_allocation_test.go
@@ -1,3 +1,20 @@
+//go:build integ
+// +build integ
+
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pilot
 
 import (


### PR DESCRIPTION
**Please provide a description of this PR:**

I introduced a regression in https://github.com/istio/istio/pull/51939, because in that PR I set addresses in `ClusterVIPs`. Previously when `ClusterVIPs` was empty, function `GetAddressForProxy` was trying to return auto-allocated address, so I fixed it by setting `ClusterVIPs` only if addresses are explicitly specified in a ServiceEntry. I also added an integration test.