### PR TITLE
Allow ServiceEntry as targetRef

### DIFF
--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -24,6 +24,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
@@ -408,9 +409,10 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "waypoint service attached",
 			selectionOpts: WorkloadPolicyMatcher{
-				IsWaypoint: true,
-				Service:    "foo-svc",
-				Namespace:  "foo",
+				IsWaypoint:      true,
+				Service:         "foo-svc",
+				ServiceRegistry: provider.Kubernetes,
+				Namespace:       "foo",
 				WorkloadLabels: labels.Instance{
 					constants.GatewayNameLabel: "foo-waypoint",
 					// labels match in selector policy but ignore them for waypoint

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1190,6 +1190,7 @@ func validatePolicyTargetReferences(targetRefs []*type_beta.PolicyTargetReferenc
 // don't validate version, just group and kind
 var allowedTargetRefs = []config.GroupVersionKind{
 	gvk.Service,
+	gvk.ServiceEntry,
 	gvk.KubernetesGateway,
 }
 


### PR DESCRIPTION
API change: https://github.com/istio/api/pull/3271

This adds the ability to use SE as a targetRef in policies. We already have Service, so its natural to work with SE.