### PR TITLE
Improvements to Helm ambient test

### DIFF
--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -402,7 +402,7 @@ func verifyInstallation(t framework.TestContext, ctx resource.Context,
 	}
 
 	compareInClusterAndGeneratedResources(t, cs, K8SObjects, false)
-	sanitycheck.RunTrafficTest(t, ctx)
+	sanitycheck.RunTrafficTest(t, ctx, false)
 	scopes.Framework.Infof("=== succeeded ===")
 	return K8SObjects
 }

--- a/tests/util/sanitycheck/sanity_check.go
+++ b/tests/util/sanitycheck/sanity_check.go
@@ -15,6 +15,8 @@
 package sanitycheck
 
 import (
+	"istio.io/api/label"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -26,24 +28,45 @@ import (
 )
 
 // RunTrafficTest deploys echo server/client and runs an Istio traffic test
-func RunTrafficTest(t framework.TestContext, ctx resource.Context) {
+func RunTrafficTest(t framework.TestContext, ctx resource.Context, ambient bool) {
 	scopes.Framework.Infof("running sanity test")
-	_, client, server := SetupTrafficTest(t, ctx, "")
+	_, client, server := setupTrafficTest(t, ctx, "", ambient)
 	RunTrafficTestClientServer(t, client, server)
 }
 
+func SetupTrafficTestAmbient(t framework.TestContext, ctx resource.Context, revision string) (namespace.Instance, echo.Instance, echo.Instance) {
+	return setupTrafficTest(t, ctx, revision, true)
+}
+
 func SetupTrafficTest(t framework.TestContext, ctx resource.Context, revision string) (namespace.Instance, echo.Instance, echo.Instance) {
+	return setupTrafficTest(t, ctx, revision, false)
+}
+
+func setupTrafficTest(t framework.TestContext, ctx resource.Context, revision string, ambient bool) (namespace.Instance, echo.Instance, echo.Instance) {
 	var client, server echo.Instance
-	testNs := namespace.NewOrFail(t, ctx, namespace.Config{
+	nsConfig := namespace.Config{
 		Prefix:   "default",
 		Revision: revision,
 		Inject:   true,
-	})
+	}
+	var subsetConfig []echo.SubsetConfig
+	if ambient {
+		nsConfig.Inject = false
+		nsConfig.Labels = map[string]string{
+			constants.DataplaneModeLabel: "ambient",
+		}
+		// not really needed from Istio POV, but the test will add the `istio-proxy` container if we don't tell it not to.
+		subsetConfig = []echo.SubsetConfig{{
+			Annotations: map[string]string{label.SidecarInject.Name: "false"},
+		}}
+	}
+	testNs := namespace.NewOrFail(t, ctx, nsConfig)
 	deployment.New(ctx).
 		With(&client, echo.Config{
 			Service:   "client",
 			Namespace: testNs,
 			Ports:     []echo.Port{},
+			Subsets:   subsetConfig,
 		}).
 		With(&server, echo.Config{
 			Service:   "server",
@@ -55,6 +78,7 @@ func SetupTrafficTest(t framework.TestContext, ctx resource.Context, revision st
 					WorkloadPort: 8090,
 				},
 			},
+			Subsets: subsetConfig,
 		}).
 		BuildOrFail(t)
 


### PR DESCRIPTION
This is currently the slowest test in istio, taking 225s to complete.

This speeds it up and improves coverage

* Do not do 3 tests, one for each component -- deploy all of them in
  their own namespace in one test.
* Also deploy istiod in its own namespace
* Actually deploy pods into ambient, which reveals a bug/misconfig (not
  setting ztunnel sa)
* Cleanup namespace in parallel
