### PR TITLE
Do not retry creating configmap in deleted namespace

### DIFF
--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -43,8 +43,8 @@ func InsertDataToConfigMap(client kclient.Client[*v1.ConfigMap], meta metav1.Obj
 		}
 		if _, err := client.Create(configmap); err != nil {
 			// Namespace may be deleted between now... and our previous check. Just skip this, we cannot create into deleted ns
-			// And don't retry a create if the namespace is terminating
-			if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+			// And don't retry a create if the namespace is terminating or already deleted (not found)
+			if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) || errors.IsNotFound(err) {
 				return nil
 			}
 			if errors.IsForbidden(err) {


### PR DESCRIPTION
Example of us trying to do it: https://storage.googleapis.com/istio-prow/logs/integ-ambient_istio_postsubmit/1813767255159214080/artifacts/ambient-946fbc91d18c49609caffad/TestTraffic/_test_context/istio-state3324201519/primary-0/istiod-5497c4576-pwjt2_discovery.log
