### PR TITLE
istioctl: provide custom html for completion commands to fix formatting

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -432,19 +432,65 @@ func (g *generator) genFrontMatter(root *cobra.Command, numEntries int) {
 	g.emit("---")
 }
 
+var CustomTextForCmds = map[string]string{
+	"istioctl-completion-bash": `<p>Generate the autocompletion script for the bash shell.</p>
+<p>This script depends on the 'bash-completion' package.
+If it is not installed already, you can install it via your OS's package manager.</p>
+<p>To load completions in your current shell session:</p>
+<pre class="language-bash"><code>source <(istioctl completion bash)</code></pre>
+<p>To load completions for every new session, execute once:</p>
+<h4>Linux:</h4>
+<pre class="language-bash"><code>istioctl completion bash > /etc/bash_completion.d/istioctl</code></pre>
+<h4>macOS:</h4>
+<pre class="language-bash"><code>istioctl completion bash > /usr/local/etc/bash_completion.d/istioctl</code></pre>
+<p>You will need to start a new shell for this setup to take effect.</p>`,
+
+	"istioctl-completion-fish": `<p>Generate the autocompletion script for the fish shell.</p>
+<p>To load completions in your current shell session:</p>
+<pre class="language-bash"><code>istioctl completion fish | source</code></pre>
+<p>To load completions for every new session, execute once:</p>
+<pre class="language-bash"><code>istioctl completion bash > ~/.config/fish/completions/istioctl.fish</code></pre>
+<p>You will need to start a new shell for this setup to take effect.</p>`,
+
+	"istioctl-completion-powershell": `<p>Generate the autocompletion script for PowerShell.</p>
+<p>To load completions in your current shell session:</p>
+<pre class="language-bash"><code>istioctl completion powershell | Out-String | Invoke-Expression</code></pre>
+<p>To load completions for every new session, add the output of the above command to your powershell profile.</p>`,
+
+	"istioctl-completion-zsh": `<p>Generate the autocompletion script for the zsh shell.</p>
+	<p>If shell completion is not already enabled in your environment you will need to enable it. You can execute the following once:</p>
+	<pre class="language-bash"><code>echo "autoload -U compinit; compinit" >> ~/.zshrc</code></pre>
+	<p>To load completions in your current shell session:</p>
+	<pre class="language-bash"><code>source <(istioctl completion zsh)</code></pre>
+	<p>To load completions for every new session, execute once:</p>
+	<h4>Linux:</h4>
+	<pre class="language-bash"><code>istioctl completion zsh > "${fpath[1]}/_istioctl"</code></pre>
+	<h4>macOS:</h4>
+	<pre class="language-bash"><code>istioctl completion zsh > $(brew --prefix)/share/zsh/site-functions/_istioctl</code></pre>
+	<p>You will need to start a new shell for this setup to take effect.</p>`,
+}
+
 func (g *generator) genCommand(cmd *cobra.Command) {
 	if cmd.Hidden || cmd.Deprecated != "" {
 		return
 	}
 
+	normalizedCmdPath := normalizeID(cmd.CommandPath())
 	if cmd.HasParent() {
-		g.emit("<h2 id=\"", normalizeID(cmd.CommandPath()), "\">", cmd.CommandPath(), "</h2>")
+		g.emit("<h2 id=\"", normalizedCmdPath, "\">", cmd.CommandPath(), "</h2>")
 	}
 
-	if cmd.Long != "" {
-		g.emitText(cmd.Long)
-	} else if cmd.Short != "" {
-		g.emitText(cmd.Short)
+	// Check whether there is a custom text for this command
+	// For now, this only applies to completion commands (bash, zsh, etc.)
+	// as the descriptions for these were coming from non-Istio owned package (cobra).
+	if customText, ok := CustomTextForCmds[normalizedCmdPath]; ok {
+		g.emit(customText)
+	} else {
+		if cmd.Long != "" {
+			g.emitText(cmd.Long)
+		} else if cmd.Short != "" {
+			g.emitText(cmd.Short)
+		}
 	}
 
 	if cmd.Runnable() {


### PR DESCRIPTION
The completion command descriptions come from the `cobra` package and contain Markdown. When rendering this as HTML, it obviously doesn't render. This brings the descriptions into our codebase and formats it as HTML (not sure if there's a better fix for this - we could update the command descriptions in `cobra`, but it still wouldn't render nicely in our docs). 

Ref: https://github.com/istio/istio.io/issues/15417