### PR TITLE
tests: use single ServiceEntry with multiple addresses in ambient tests

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2052,7 +2052,6 @@ spec:
 									from.CallOrFail(t, echo.CallOptions{
 										Address: "240.240.240.255",
 										Port:    to.PortForName("http"),
-										// If request is sent before service is processed it will hit 10s timeout, so fail faster
 										Timeout: time.Millisecond * 500,
 									})
 								}
@@ -2060,7 +2059,6 @@ spec:
 									from.CallOrFail(t, echo.CallOptions{
 										Address: "2001:2::f0f0:255",
 										Port:    to.PortForName("http"),
-										// If request is sent before service is processed it will hit 10s timeout, so fail faster
 										Timeout: time.Millisecond * 500,
 									})
 								}

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -2027,7 +2027,7 @@ spec:
 `).
 				WithParams(param.Params{}.SetWellKnown(param.Namespace, apps.Namespace))
 
-			_, v6 := getSupportedIPFamilies(t)
+			v4, v6 := getSupportedIPFamilies(t)
 			ips, ports := istio.DefaultIngressOrFail(t, t).HTTPAddresses()
 			for _, tc := range testCases {
 				tc := tc
@@ -2048,16 +2048,22 @@ spec:
 							})).
 							Run(func(t framework.TestContext, from echo.Instance, to echo.Target) {
 								// TODO validate L7 processing/some headers indicating we reach the svc we wanted
-								address := "240.240.240.255"
-								if v6 {
-									address = "2001:2::f0f0:255"
+								if v4 {
+									from.CallOrFail(t, echo.CallOptions{
+										Address: "240.240.240.255",
+										Port:    to.PortForName("http"),
+										// If request is sent before service is processed it will hit 10s timeout, so fail faster
+										Timeout: time.Millisecond * 500,
+									})
 								}
-								from.CallOrFail(t, echo.CallOptions{
-									Address: address,
-									Port:    to.PortForName("http"),
-									// If request is sent before service is processed it will hit 10s timeout, so fail faster
-									Timeout: time.Millisecond * 500,
-								})
+								if v6 {
+									from.CallOrFail(t, echo.CallOptions{
+										Address: "2001:2::f0f0:255",
+										Port:    to.PortForName("http"),
+										// If request is sent before service is processed it will hit 10s timeout, so fail faster
+										Timeout: time.Millisecond * 500,
+									})
+								}
 							})
 					})
 				}

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1856,7 +1856,7 @@ spec:
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
-  name: test-se-v4
+  name: test-se
 spec:
   hosts:
   - dummy.example.com
@@ -1994,7 +1994,7 @@ spec:
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
 metadata:
-  name: test-se-v4
+  name: test-se
 spec:
   hosts:
   - dummy.example.com

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -382,7 +382,7 @@ func TestWaypointDNS(t *testing.T) {
 					t.Skip("TODO: sidecars don't properly handle use-waypoint")
 				}
 				address := "240.240.240.239"
-				if _, v6 := getAddressForSupportedIPFamily(t); v6 {
+				if _, v6 := getSupportedIPFamilies(t); v6 {
 					address = "2001:2::f0f0:239"
 				}
 				src.CallOrFail(t, echo.CallOptions{

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -382,7 +382,7 @@ func TestWaypointDNS(t *testing.T) {
 					t.Skip("TODO: sidecars don't properly handle use-waypoint")
 				}
 				address := "240.240.240.239"
-				if _, v6 := getSupportedIPFamilies(t); v6 {
+				if _, v6 := getAddressForSupportedIPFamily(t); v6 {
 					address = "2001:2::f0f0:239"
 				}
 				src.CallOrFail(t, echo.CallOptions{

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -381,21 +381,33 @@ func TestWaypointDNS(t *testing.T) {
 				if src.Config().HasSidecar() {
 					t.Skip("TODO: sidecars don't properly handle use-waypoint")
 				}
-				address := "240.240.240.239"
-				if _, v6 := getSupportedIPFamilies(t); v6 {
-					address = "2001:2::f0f0:239"
+				v4, v6 := getSupportedIPFamilies(t)
+				if v4 {
+					src.CallOrFail(t, echo.CallOptions{
+						To:      apps.MockExternal,
+						Address: "240.240.240.239",
+						HTTP: echo.HTTP{
+							Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
+						},
+						Port:   echo.Port{Name: "http"},
+						Scheme: scheme.HTTP,
+						Count:  1,
+						Check:  check,
+					})
 				}
-				src.CallOrFail(t, echo.CallOptions{
-					To:      apps.MockExternal,
-					Address: address,
-					HTTP: echo.HTTP{
-						Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
-					},
-					Port:   echo.Port{Name: "http"},
-					Scheme: scheme.HTTP,
-					Count:  1,
-					Check:  check,
-				})
+				if v6 {
+					src.CallOrFail(t, echo.CallOptions{
+						To:      apps.MockExternal,
+						Address: "2001:2::f0f0:239",
+						HTTP: echo.HTTP{
+							Headers: http.Header{"Host": []string{apps.MockExternal.Config().DefaultHostHeader}},
+						},
+						Port:   echo.Port{Name: "http"},
+						Scheme: scheme.HTTP,
+						Count:  1,
+						Check:  check,
+					})
+				}
 			})
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

It's a follow-up to https://github.com/istio/istio/pull/51939 and addresses this comment: https://github.com/istio/istio/pull/51939#discussion_r1668976103.