### PR TITLE
Fix missed EDS push when overlapping IPs are found between WEs

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -295,65 +295,8 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 
 	ep.Lock()
 	defer ep.Unlock()
-	newIstioEndpoints := istioEndpoints
 	oldIstioEndpoints := ep.Shards[shard]
-	needPush := false
-	if oldIstioEndpoints == nil {
-		// If there are no old endpoints, we should push with incoming endpoints as there is nothing to compare.
-		needPush = true
-	} else {
-		newIstioEndpoints = make([]*IstioEndpoint, 0, len(istioEndpoints))
-		// Check if new Endpoints are ready to be pushed. This check
-		// will ensure that if a new pod comes with a non ready endpoint,
-		// we do not unnecessarily push that config to Envoy.
-		// Please note that address is not a unique key. So this may not accurately
-		// identify based on health status and push too many times - which is ok since its an optimization.
-		omap := make(map[string]*IstioEndpoint, len(oldIstioEndpoints))
-		nmap := make(map[string]*IstioEndpoint, len(newIstioEndpoints))
-		// Add new endpoints only if they are ever ready once to shards
-		// so that full push does not send them from shards.
-		for _, oie := range oldIstioEndpoints {
-			if oie.FirstAddressOrNil() == "" {
-				continue
-			}
-			omap[oie.FirstAddressOrNil()] = oie
-		}
-		for _, nie := range istioEndpoints {
-			if nie.FirstAddressOrNil() == "" {
-				continue
-			}
-			nmap[nie.FirstAddressOrNil()] = nie
-		}
-		for _, nie := range istioEndpoints {
-			if oie, exists := omap[nie.FirstAddressOrNil()]; exists {
-				// If endpoint exists already, we should push if it's changed.
-				// Skip this check if we already decide we need to push to avoid expensive checks
-				if !needPush && !oie.Equals(nie) {
-					needPush = true
-				}
-				newIstioEndpoints = append(newIstioEndpoints, nie)
-			} else {
-				// If the endpoint does not exist in shards that means it is a
-				// new endpoint. Always send new healthy endpoints.
-				// Also send new unhealthy endpoints when SendUnhealthyEndpoints is enabled.
-				// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
-				if nie.HealthStatus != UnHealthy || features.SendUnhealthyEndpoints.Load() {
-					needPush = true
-				}
-				newIstioEndpoints = append(newIstioEndpoints, nie)
-			}
-		}
-		// Next, check for endpoints that were in old but no longer exist. If there are any, there is a
-		// removal so we need to push an update.
-		if !needPush {
-			for _, oie := range oldIstioEndpoints {
-				if _, f := nmap[oie.FirstAddressOrNil()]; !f {
-					needPush = true
-					break
-				}
-			}
-		}
-	}
+	newIstioEndpoints, needPush := endpointUpdateRequiresPush(oldIstioEndpoints, istioEndpoints)
 
 	if pushType != FullPush && !needPush {
 		log.Debugf("No push, either old endpoint health status did not change or new endpoint came with unhealthy status, %v", hostname)
@@ -382,6 +325,60 @@ func (e *EndpointIndex) UpdateServiceEndpoints(
 	e.clearCacheForService(hostname, namespace)
 
 	return pushType
+}
+
+// endpointUpdateRequiresPush determines if an endpoint update is required.
+func endpointUpdateRequiresPush(oldIstioEndpoints []*IstioEndpoint, incomingEndpoints []*IstioEndpoint) ([]*IstioEndpoint, bool) {
+	if oldIstioEndpoints == nil {
+		// If there are no old endpoints, we should push with incoming endpoints as there is nothing to compare.
+		return incomingEndpoints, true
+	}
+	needPush := false
+	newIstioEndpoints := make([]*IstioEndpoint, 0, len(incomingEndpoints))
+	// Check if new Endpoints are ready to be pushed. This check
+	// will ensure that if a new pod comes with a non ready endpoint,
+	// we do not unnecessarily push that config to Envoy.
+	omap := make(map[string]*IstioEndpoint, len(oldIstioEndpoints))
+	nmap := make(map[string]*IstioEndpoint, len(newIstioEndpoints))
+	// Add new endpoints only if they are ever ready once to shards
+	// so that full push does not send them from shards.
+	for _, oie := range oldIstioEndpoints {
+		omap[oie.Key()] = oie
+	}
+	for _, nie := range incomingEndpoints {
+		nmap[nie.Key()] = nie
+	}
+	for _, nie := range incomingEndpoints {
+		if oie, exists := omap[nie.Key()]; exists {
+			// If endpoint exists already, we should push if it's changed.
+			// Skip this check if we already decide we need to push to avoid expensive checks
+			if !needPush && !oie.Equals(nie) {
+				needPush = true
+			}
+			newIstioEndpoints = append(newIstioEndpoints, nie)
+		} else {
+			// If the endpoint does not exist in shards that means it is a
+			// new endpoint. Always send new healthy endpoints.
+			// Also send new unhealthy endpoints when SendUnhealthyEndpoints is enabled.
+			// This is OK since we disable panic threshold when SendUnhealthyEndpoints is enabled.
+			if nie.HealthStatus != UnHealthy || features.SendUnhealthyEndpoints.Load() {
+				needPush = true
+			}
+			newIstioEndpoints = append(newIstioEndpoints, nie)
+		}
+	}
+	// Next, check for endpoints that were in old but no longer exist. If there are any, there is a
+	// removal so we need to push an update.
+	if !needPush {
+		for _, oie := range oldIstioEndpoints {
+			if _, f := nmap[oie.Key()]; !f {
+				needPush = true
+				break
+			}
+		}
+	}
+
+	return newIstioEndpoints, needPush
 }
 
 // updateShardServiceAccount updates the service endpoints' sa when service/endpoint event happens.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -623,6 +623,11 @@ func (ep *IstioEndpoint) FirstAddressOrNil() string {
 	return ep.Addresses[0]
 }
 
+// Key returns a function suitable for usage to distinguish this IstioEndpoint from another
+func (ep *IstioEndpoint) Key() string {
+	return ep.FirstAddressOrNil() + "/" + ep.WorkloadName
+}
+
 // EndpointMetadata represents metadata set on Envoy LbEndpoint used for telemetry purposes.
 type EndpointMetadata struct {
 	// Network holds the network where this endpoint is present

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -519,6 +519,95 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceEndpoints(t, fx, expectedSvc, 80, instances)
 	})
 
+	t.Run("External only: workloadEntry with overlapping IPs", func(t *testing.T) {
+		store, _, fx := setupTest(t)
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "service-entry",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.ServiceEntry,
+			},
+			Spec: &networking.ServiceEntry{
+				Hosts: []string{"example.com"},
+				Ports: []*networking.ServicePort{
+					{Number: 445, Name: "http-445", Protocol: "http"},
+				},
+				WorkloadSelector: &networking.WorkloadSelector{
+					Labels: labels,
+				},
+			},
+		})
+		expectedSvc := &model.Service{
+			Hostname: "example.com",
+			Ports: []*model.Port{{
+				Name:     "http-445",
+				Port:     445,
+				Protocol: "http",
+			}},
+			Attributes: model.ServiceAttributes{
+				Namespace:      namespace,
+				Name:           "service",
+				LabelSelectors: labels,
+			},
+		}
+		we1 := config.Config{
+			Meta: config.Meta{
+				Name:             "we1",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels:  labels,
+				Ports: map[string]uint32{
+					"http-445": 1234,
+				},
+			},
+		}
+		we2 := config.Config{
+			Meta: config.Meta{
+				Name:             "we2",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels:  labels,
+				Ports: map[string]uint32{
+					"http-445": 5678,
+				},
+			},
+		}
+		makeIstioObject(t, store, we1)
+		makeIstioObject(t, store, we2)
+		fx.WaitOrFail(t, "xds full")
+
+		instances := []EndpointResponse{{
+			Address: workloadEntry.Spec.(*networking.WorkloadEntry).Address,
+			Port:    1234,
+		}, {
+			Address: workloadEntry.Spec.(*networking.WorkloadEntry).Address,
+			Port:    5678,
+		}}
+		expectServiceEndpoints(t, fx, expectedSvc, 445, instances)
+
+		fx.Clear()
+
+		// Delete one of the WE
+		_ = store.Delete(gvk.WorkloadEntry, we2.Name, we2.Namespace, nil)
+
+		fx.WaitOrFail(t, "xds")
+		instances = []EndpointResponse{
+			{
+				Address: workloadEntry.Spec.(*networking.WorkloadEntry).Address,
+				Port:    1234,
+			},
+		}
+		expectServiceEndpoints(t, fx, expectedSvc, 445, instances)
+	})
+
 	t.Run("Service selects WorkloadEntry", func(t *testing.T) {
 		store, kube, fx := setupTest(t)
 		makeService(t, kube, service)
@@ -1258,7 +1347,7 @@ func expectServiceEndpointsFromIndex(t *testing.T, ei *model.EndpointIndex, svc 
 			}
 		})
 		slices.SortBy(got, func(a EndpointResponse) string {
-			return a.Address
+			return fmt.Sprintf("%v:%d", a.Address, a.Port)
 		})
 		return assert.Compare(got, expected)
 	}, retry.Converge(2), retry.Timeout(time.Second*2), retry.Delay(time.Millisecond*10))

--- a/releasenotes/notes/pilot-dupe-ip.yaml
+++ b/releasenotes/notes/pilot-dupe-ip.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue causing stale endpoints when the same IP address was present in multiple `WorkloadEntries`.


### PR DESCRIPTION
See test case for details. The problem is we key on IP address; this is
not a unique key. This means a random WE will 'win' the slot, giving us
a 50/50 chance we only compare to ourselves, realize there was no
change, and skip the push.

Interestingly, the comment notes the key is not unique! I believe that
over time the code was refactored to make the uniqueness critcal to
correctness, whereas before it was not.
