### PR TITLE
ambient: make HostNetwork pods work

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -285,19 +285,7 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 	// 2. Workload by IP
 	if wls := a.workloads.ByAddress.Lookup(networkAddr); len(wls) > 0 {
-		// If there is just one, return it
-		if len(wls) == 1 {
-			return []model.AddressInfo{modelWorkloadToAddressInfo(wls[0])}
-		}
-		// Otherwise, try to find a pod - pods have precedence
-		pod := slices.FindFunc(wls, func(info model.WorkloadInfo) bool {
-			return info.Source == kind.Pod
-		})
-		if pod != nil {
-			return []model.AddressInfo{modelWorkloadToAddressInfo(*pod)}
-		}
-		// Otherwise just return the first one; all WorkloadEntry have the same weight
-		return []model.AddressInfo{modelWorkloadToAddressInfo(wls[0])}
+		return dedupeWorkloads(wls)
 	}
 
 	// 3. Service
@@ -329,26 +317,39 @@ func (a *index) lookupService(key string) *model.ServiceInfo {
 
 // All return all known workloads. Result is un-ordered
 func (a *index) All() []model.AddressInfo {
+	res := dedupeWorkloads(a.workloads.List())
+	for _, s := range a.services.List() {
+		res = append(res, serviceToAddressInfo(s.Service))
+	}
+	return res
+}
+
+func dedupeWorkloads(workloads []model.WorkloadInfo) []model.AddressInfo {
+	if len(workloads) <= 1 {
+		return slices.Map(workloads, modelWorkloadToAddressInfo)
+	}
 	res := []model.AddressInfo{}
 	seenAddresses := sets.New[netip.Addr]()
-	for _, wl := range a.workloads.List() {
+	for _, wl := range workloads {
 		write := true
-		for _, addr := range wl.Addresses {
-			a := byteIPToAddr(addr)
-			if seenAddresses.InsertContains(a) {
-				// We have already seen this address. We don't want to include it.
-				// We do want to prefer Pods > WorkloadEntry to give precedence to Kubernetes. However, the underlying `a.workloads`
-				// already guarantees this, so no need to handle it here.
-				write = false
-				break
+		// HostNetwork mode is expected to have overlapping IPs, and tells the data plane to avoid relying on the IP as a unique
+		// identifier.
+		// For anything else, exclude duplicates.
+		if wl.NetworkMode != workloadapi.NetworkMode_HOST_NETWORK {
+			for _, addr := range wl.Addresses {
+				a := byteIPToAddr(addr)
+				if seenAddresses.InsertContains(a) {
+					// We have already seen this address. We don't want to include it.
+					// We do want to prefer Pods > WorkloadEntry to give precedence to Kubernetes. However, the underlying `a.workloads`
+					// already guarantees this, so no need to handle it here.
+					write = false
+					break
+				}
 			}
 		}
 		if write {
 			res = append(res, workloadToAddressInfo(wl.Workload))
 		}
-	}
-	for _, s := range a.services.List() {
-		res = append(res, serviceToAddressInfo(s.Service))
 	}
 	return res
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -448,6 +448,192 @@ func TestPodWorkloads(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod as part of selectorless service without targetRef",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "svc",
+						Namespace: "default",
+						Hostname:  "svc.default.svc.domain.suffix",
+						Ports: []*workloadapi.Port{
+							{
+								ServicePort: 80,
+								TargetPort:  80,
+							},
+						},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: {PortName: "80"},
+					},
+					// no selector!
+					LabelSelector: model.LabelSelector{},
+					Source:        kind.Service,
+				},
+				// EndpointSlice manually created with the IP of the pod, but does NOT have a targetRef
+				&discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-123",
+						Namespace: "default",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"1.2.3.4"},
+							Conditions: discovery.EndpointConditions{
+								Ready: ptr.Of(true),
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     ptr.Of("http"),
+							Protocol: ptr.Of(v1.ProtocolTCP),
+							Port:     ptr.Of(int32(80)),
+						},
+					},
+				},
+			},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-123",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					PodIP:      "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/default/pod-123",
+				Name:              "pod-123",
+				Namespace:         "default",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "pod-123",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				// We do NOT associate this with the service.
+				// However, there will be a corresponding Workload created from the raw EndpointSlice. See TestEndpointSliceWorkloads
+				// for corresponding test.
+				Services: nil,
+			},
+		},
+		{
+			name: "host network pod",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "svc",
+						Namespace: "default",
+						Hostname:  "svc.default.svc.domain.suffix",
+						Ports:     []*workloadapi.Port{{ServicePort: 80, TargetPort: 80}},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: {PortName: "80"},
+					},
+					LabelSelector: model.NewSelector(map[string]string{"app": "foo"}),
+					Source:        kind.Service,
+				},
+				// Another endpointslice exists with the same IP... This should have no impact
+				kubernetesAPIServerEndpoint("1.1.1.1"),
+				kubernetesAPIServerService("1.2.3.4"),
+				// Another Service with an endpointslice for the same IP and for *a* pod, but not this pod. Again, no impact
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "some-other-svc",
+						Namespace: "default",
+						Hostname:  "some-other-svc.default.svc.domain.suffix",
+						Ports:     []*workloadapi.Port{{ServicePort: 80, TargetPort: 80}},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: {PortName: "80"},
+					},
+					Source: kind.Service,
+				},
+				&discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-other-svc",
+						Namespace: "default",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "some-other-svc",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"1.1.1.1"},
+							Conditions: discovery.EndpointConditions{
+								Ready: ptr.Of(true),
+							},
+							TargetRef: &v1.ObjectReference{
+								Kind:      "Pod",
+								Name:      "not-the-same-pod",
+								Namespace: "default",
+							},
+						},
+					},
+					Ports: []discovery.EndpointPort{
+						{
+							Name:     ptr.Of("80"),
+							Protocol: ptr.Of(v1.ProtocolTCP),
+							Port:     ptr.Of(int32(80)),
+						},
+					},
+				},
+			},
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-123",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+				Spec: v1.PodSpec{HostNetwork: true},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					// Important: aligns with the kubernetesAPIServerEndpoint above
+					PodIP: "1.1.1.1",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/default/pod-123",
+				Name:              "pod-123",
+				Namespace:         "default",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 1, 1, 1}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "pod-123",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				NetworkMode:       workloadapi.NetworkMode_HOST_NETWORK,
+				ClusterId:         testC,
+				Services: map[string]*workloadapi.PortList{
+					"default/svc.default.svc.domain.suffix": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  80,
+						}},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -867,20 +1053,66 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 		result []*workloadapi.Workload
 	}{
 		{
-			name:   "api server",
-			inputs: []any{},
+			name: "api server",
+			inputs: []any{
+				kubernetesAPIServerService("1.2.3.4"),
+			},
+			slice: kubernetesAPIServerEndpoint("172.18.0.5"),
+			result: []*workloadapi.Workload{{
+				Uid:         "cluster0/discovery.k8s.io/EndpointSlice/default/kubernetes/172.18.0.5",
+				Name:        "kubernetes",
+				Namespace:   "default",
+				Addresses:   [][]byte{netip.MustParseAddr("172.18.0.5").AsSlice()},
+				Network:     testNW,
+				Status:      workloadapi.WorkloadStatus_HEALTHY,
+				NetworkMode: workloadapi.NetworkMode_HOST_NETWORK,
+				ClusterId:   testC,
+				Services: map[string]*workloadapi.PortList{
+					"default/kubernetes.default.svc.domain.suffix": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 443,
+							TargetPort:  6443,
+						}},
+					},
+				},
+			}},
+		},
+		{
+			name: "pod as part of selectorless service without targetRef",
+			inputs: []any{
+				model.ServiceInfo{
+					Service: &workloadapi.Service{
+						Name:      "svc",
+						Namespace: "default",
+						Hostname:  "svc.default.svc.domain.suffix",
+						Ports: []*workloadapi.Port{
+							{
+								ServicePort: 80,
+								TargetPort:  80,
+							},
+						},
+					},
+					PortNames: map[int32]model.ServicePortName{
+						80: {PortName: "http"},
+					},
+					// no selector!
+					LabelSelector: model.LabelSelector{},
+					Source:        kind.Service,
+				},
+			},
+			// EndpointSlice manually created with the IP of the pod, but does NOT have a targetRef
 			slice: &discovery.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kubernetes",
+					Name:      "svc-123",
 					Namespace: "default",
 					Labels: map[string]string{
-						discovery.LabelServiceName: "kubernetes",
+						discovery.LabelServiceName: "svc",
 					},
 				},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
 					{
-						Addresses: []string{"172.18.0.5"},
+						Addresses: []string{"1.2.3.4"},
 						Conditions: discovery.EndpointConditions{
 							Ready: ptr.Of(true),
 						},
@@ -888,13 +1120,30 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{
 					{
-						Name:     ptr.Of("https"),
+						Name:     ptr.Of("http"),
 						Protocol: ptr.Of(v1.ProtocolTCP),
-						Port:     ptr.Of(int32(6443)),
+						Port:     ptr.Of(int32(80)),
 					},
 				},
 			},
-			result: nil,
+			result: []*workloadapi.Workload{{
+				Uid:         "cluster0/discovery.k8s.io/EndpointSlice/default/svc-123/1.2.3.4",
+				Name:        "svc-123",
+				Namespace:   "default",
+				Addresses:   [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:     testNW,
+				Status:      workloadapi.WorkloadStatus_HEALTHY,
+				NetworkMode: workloadapi.NetworkMode_HOST_NETWORK,
+				ClusterId:   testC,
+				Services: map[string]*workloadapi.PortList{
+					"default/svc.default.svc.domain.suffix": {
+						Ports: []*workloadapi.Port{{
+							ServicePort: 80,
+							TargetPort:  80,
+						}},
+					},
+				},
+			}},
 		},
 	}
 	for _, tt := range cases {
@@ -912,6 +1161,58 @@ func TestEndpointSliceWorkloads(t *testing.T) {
 			})
 			assert.Equal(t, wl, tt.result)
 		})
+	}
+}
+
+func kubernetesAPIServerService(ip string) model.ServiceInfo {
+	return model.ServiceInfo{
+		Service: &workloadapi.Service{
+			Name:      "kubernetes",
+			Namespace: "default",
+			Hostname:  "kubernetes.default.svc.domain.suffix",
+			Addresses: []*workloadapi.NetworkAddress{{
+				Network: testNW,
+				Address: netip.MustParseAddr(ip).AsSlice(),
+			}},
+			Ports: []*workloadapi.Port{
+				{
+					ServicePort: 443,
+					TargetPort:  6443,
+				},
+			},
+		},
+		PortNames: map[int32]model.ServicePortName{
+			443: {PortName: "https"},
+		},
+		Source: kind.Service,
+	}
+}
+
+func kubernetesAPIServerEndpoint(ip string) *discovery.EndpointSlice {
+	return &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: "default",
+			Labels: map[string]string{
+				discovery.LabelServiceName: "kubernetes",
+			},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses: []string{ip},
+				Conditions: discovery.EndpointConditions{
+					Ready: ptr.Of(true),
+				},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     ptr.Of("https"),
+				Protocol: ptr.Of(v1.ProtocolTCP),
+				Port:     ptr.Of(int32(6443)),
+			},
+		},
 	}
 }
 

--- a/pkg/workloadapi/workload.pb.go
+++ b/pkg/workloadapi/workload.pb.go
@@ -90,6 +90,56 @@ func (IPFamilies) EnumDescriptor() ([]byte, []int) {
 	return file_workloadapi_workload_proto_rawDescGZIP(), []int{0}
 }
 
+// NetworkMode indicates how the addresses of the workload should be treated.
+type NetworkMode int32
+
+const (
+	// STANDARD means that the workload is uniquely identified by its address (within its network).
+	NetworkMode_STANDARD NetworkMode = 0
+	// HOST_NETWORK means the workload has an IP address that is shared by many workloads. The data plane should avoid
+	// attempting to lookup these workloads by IP address (which could return the wrong result).
+	NetworkMode_HOST_NETWORK NetworkMode = 1
+)
+
+// Enum value maps for NetworkMode.
+var (
+	NetworkMode_name = map[int32]string{
+		0: "STANDARD",
+		1: "HOST_NETWORK",
+	}
+	NetworkMode_value = map[string]int32{
+		"STANDARD":     0,
+		"HOST_NETWORK": 1,
+	}
+)
+
+func (x NetworkMode) Enum() *NetworkMode {
+	p := new(NetworkMode)
+	*p = x
+	return p
+}
+
+func (x NetworkMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (NetworkMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_workloadapi_workload_proto_enumTypes[1].Descriptor()
+}
+
+func (NetworkMode) Type() protoreflect.EnumType {
+	return &file_workloadapi_workload_proto_enumTypes[1]
+}
+
+func (x NetworkMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use NetworkMode.Descriptor instead.
+func (NetworkMode) EnumDescriptor() ([]byte, []int) {
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{1}
+}
+
 type WorkloadStatus int32
 
 const (
@@ -122,11 +172,11 @@ func (x WorkloadStatus) String() string {
 }
 
 func (WorkloadStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[1].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[2].Descriptor()
 }
 
 func (WorkloadStatus) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[1]
+	return &file_workloadapi_workload_proto_enumTypes[2]
 }
 
 func (x WorkloadStatus) Number() protoreflect.EnumNumber {
@@ -135,7 +185,7 @@ func (x WorkloadStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadStatus.Descriptor instead.
 func (WorkloadStatus) EnumDescriptor() ([]byte, []int) {
-	return file_workloadapi_workload_proto_rawDescGZIP(), []int{1}
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{2}
 }
 
 type WorkloadType int32
@@ -174,11 +224,11 @@ func (x WorkloadType) String() string {
 }
 
 func (WorkloadType) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[2].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[3].Descriptor()
 }
 
 func (WorkloadType) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[2]
+	return &file_workloadapi_workload_proto_enumTypes[3]
 }
 
 func (x WorkloadType) Number() protoreflect.EnumNumber {
@@ -187,7 +237,7 @@ func (x WorkloadType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadType.Descriptor instead.
 func (WorkloadType) EnumDescriptor() ([]byte, []int) {
-	return file_workloadapi_workload_proto_rawDescGZIP(), []int{2}
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{3}
 }
 
 // TunnelProtocol indicates the tunneling protocol for requests.
@@ -224,11 +274,11 @@ func (x TunnelProtocol) String() string {
 }
 
 func (TunnelProtocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[3].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[4].Descriptor()
 }
 
 func (TunnelProtocol) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[3]
+	return &file_workloadapi_workload_proto_enumTypes[4]
 }
 
 func (x TunnelProtocol) Number() protoreflect.EnumNumber {
@@ -237,7 +287,7 @@ func (x TunnelProtocol) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use TunnelProtocol.Descriptor instead.
 func (TunnelProtocol) EnumDescriptor() ([]byte, []int) {
-	return file_workloadapi_workload_proto_rawDescGZIP(), []int{3}
+	return file_workloadapi_workload_proto_rawDescGZIP(), []int{4}
 }
 
 type LoadBalancing_Scope int32
@@ -291,11 +341,11 @@ func (x LoadBalancing_Scope) String() string {
 }
 
 func (LoadBalancing_Scope) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[4].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[5].Descriptor()
 }
 
 func (LoadBalancing_Scope) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[4]
+	return &file_workloadapi_workload_proto_enumTypes[5]
 }
 
 func (x LoadBalancing_Scope) Number() protoreflect.EnumNumber {
@@ -351,11 +401,11 @@ func (x LoadBalancing_Mode) String() string {
 }
 
 func (LoadBalancing_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[5].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
 }
 
 func (LoadBalancing_Mode) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[5]
+	return &file_workloadapi_workload_proto_enumTypes[6]
 }
 
 func (x LoadBalancing_Mode) Number() protoreflect.EnumNumber {
@@ -403,11 +453,11 @@ func (x ApplicationTunnel_Protocol) String() string {
 }
 
 func (ApplicationTunnel_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_workloadapi_workload_proto_enumTypes[6].Descriptor()
+	return file_workloadapi_workload_proto_enumTypes[7].Descriptor()
 }
 
 func (ApplicationTunnel_Protocol) Type() protoreflect.EnumType {
-	return &file_workloadapi_workload_proto_enumTypes[6]
+	return &file_workloadapi_workload_proto_enumTypes[7]
 }
 
 func (x ApplicationTunnel_Protocol) Number() protoreflect.EnumNumber {
@@ -804,7 +854,8 @@ type Workload struct {
 	// The cluster ID that the workload instance belongs to
 	ClusterId string `protobuf:"bytes,18,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	// The Locality defines information about where a workload is geographically deployed
-	Locality *Locality `protobuf:"bytes,24,opt,name=locality,proto3" json:"locality,omitempty"`
+	Locality    *Locality   `protobuf:"bytes,24,opt,name=locality,proto3" json:"locality,omitempty"`
+	NetworkMode NetworkMode `protobuf:"varint,25,opt,name=network_mode,json=networkMode,proto3,enum=istio.workload.NetworkMode" json:"network_mode,omitempty"`
 }
 
 func (x *Workload) Reset() {
@@ -998,6 +1049,13 @@ func (x *Workload) GetLocality() *Locality {
 		return x.Locality
 	}
 	return nil
+}
+
+func (x *Workload) GetNetworkMode() NetworkMode {
+	if x != nil {
+		return x.NetworkMode
+	}
+	return NetworkMode_STANDARD
 }
 
 type Locality struct {
@@ -1497,7 +1555,7 @@ var file_workloadapi_workload_proto_rawDesc = []byte{
 	0x22, 0x36, 0x0a, 0x04, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x14, 0x0a, 0x10, 0x55, 0x4e, 0x53, 0x50,
 	0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x5f, 0x4d, 0x4f, 0x44, 0x45, 0x10, 0x00, 0x12, 0x0a,
 	0x0a, 0x06, 0x53, 0x54, 0x52, 0x49, 0x43, 0x54, 0x10, 0x01, 0x12, 0x0c, 0x0a, 0x08, 0x46, 0x41,
-	0x49, 0x4c, 0x4f, 0x56, 0x45, 0x52, 0x10, 0x02, 0x22, 0xea, 0x08, 0x0a, 0x08, 0x57, 0x6f, 0x72,
+	0x49, 0x4c, 0x4f, 0x56, 0x45, 0x52, 0x10, 0x02, 0x22, 0xaa, 0x09, 0x0a, 0x08, 0x57, 0x6f, 0x72,
 	0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x75, 0x69, 0x64, 0x18, 0x14, 0x20, 0x01,
 	0x28, 0x09, 0x52, 0x03, 0x75, 0x69, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
 	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x1c, 0x0a, 0x09, 0x6e,
@@ -1562,7 +1620,11 @@ var file_workloadapi_workload_proto_rawDesc = []byte{
 	0x49, 0x64, 0x12, 0x34, 0x0a, 0x08, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x69, 0x74, 0x79, 0x18, 0x18,
 	0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2e, 0x77, 0x6f, 0x72,
 	0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x2e, 0x4c, 0x6f, 0x63, 0x61, 0x6c, 0x69, 0x74, 0x79, 0x52, 0x08,
-	0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x69, 0x74, 0x79, 0x1a, 0x55, 0x0a, 0x0d, 0x53, 0x65, 0x72, 0x76,
+	0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x69, 0x74, 0x79, 0x12, 0x3e, 0x0a, 0x0c, 0x6e, 0x65, 0x74, 0x77,
+	0x6f, 0x72, 0x6b, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x18, 0x19, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x1b,
+	0x2e, 0x69, 0x73, 0x74, 0x69, 0x6f, 0x2e, 0x77, 0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x2e,
+	0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x4d, 0x6f, 0x64, 0x65, 0x52, 0x0b, 0x6e, 0x65, 0x74,
+	0x77, 0x6f, 0x72, 0x6b, 0x4d, 0x6f, 0x64, 0x65, 0x1a, 0x55, 0x0a, 0x0d, 0x53, 0x65, 0x72, 0x76,
 	0x69, 0x63, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x2e, 0x0a, 0x05, 0x76,
 	0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x69, 0x73, 0x74,
@@ -1618,18 +1680,21 @@ var file_workloadapi_workload_proto_rawDesc = []byte{
 	0x61, 0x6d, 0x69, 0x6c, 0x69, 0x65, 0x73, 0x12, 0x0d, 0x0a, 0x09, 0x41, 0x55, 0x54, 0x4f, 0x4d,
 	0x41, 0x54, 0x49, 0x43, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09, 0x49, 0x50, 0x56, 0x34, 0x5f, 0x4f,
 	0x4e, 0x4c, 0x59, 0x10, 0x01, 0x12, 0x0d, 0x0a, 0x09, 0x49, 0x50, 0x56, 0x36, 0x5f, 0x4f, 0x4e,
-	0x4c, 0x59, 0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x55, 0x41, 0x4c, 0x10, 0x03, 0x2a, 0x2c,
-	0x0a, 0x0e, 0x57, 0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73,
-	0x12, 0x0b, 0x0a, 0x07, 0x48, 0x45, 0x41, 0x4c, 0x54, 0x48, 0x59, 0x10, 0x00, 0x12, 0x0d, 0x0a,
-	0x09, 0x55, 0x4e, 0x48, 0x45, 0x41, 0x4c, 0x54, 0x48, 0x59, 0x10, 0x01, 0x2a, 0x3d, 0x0a, 0x0c,
-	0x57, 0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0e, 0x0a, 0x0a,
-	0x44, 0x45, 0x50, 0x4c, 0x4f, 0x59, 0x4d, 0x45, 0x4e, 0x54, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07,
-	0x43, 0x52, 0x4f, 0x4e, 0x4a, 0x4f, 0x42, 0x10, 0x01, 0x12, 0x07, 0x0a, 0x03, 0x50, 0x4f, 0x44,
-	0x10, 0x02, 0x12, 0x07, 0x0a, 0x03, 0x4a, 0x4f, 0x42, 0x10, 0x03, 0x2a, 0x25, 0x0a, 0x0e, 0x54,
-	0x75, 0x6e, 0x6e, 0x65, 0x6c, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x12, 0x08, 0x0a,
-	0x04, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x48, 0x42, 0x4f, 0x4e, 0x45,
-	0x10, 0x01, 0x42, 0x11, 0x5a, 0x0f, 0x70, 0x6b, 0x67, 0x2f, 0x77, 0x6f, 0x72, 0x6b, 0x6c, 0x6f,
-	0x61, 0x64, 0x61, 0x70, 0x69, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x4c, 0x59, 0x10, 0x02, 0x12, 0x08, 0x0a, 0x04, 0x44, 0x55, 0x41, 0x4c, 0x10, 0x03, 0x2a, 0x2d,
+	0x0a, 0x0b, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x0c, 0x0a,
+	0x08, 0x53, 0x54, 0x41, 0x4e, 0x44, 0x41, 0x52, 0x44, 0x10, 0x00, 0x12, 0x10, 0x0a, 0x0c, 0x48,
+	0x4f, 0x53, 0x54, 0x5f, 0x4e, 0x45, 0x54, 0x57, 0x4f, 0x52, 0x4b, 0x10, 0x01, 0x2a, 0x2c, 0x0a,
+	0x0e, 0x57, 0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12,
+	0x0b, 0x0a, 0x07, 0x48, 0x45, 0x41, 0x4c, 0x54, 0x48, 0x59, 0x10, 0x00, 0x12, 0x0d, 0x0a, 0x09,
+	0x55, 0x4e, 0x48, 0x45, 0x41, 0x4c, 0x54, 0x48, 0x59, 0x10, 0x01, 0x2a, 0x3d, 0x0a, 0x0c, 0x57,
+	0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61, 0x64, 0x54, 0x79, 0x70, 0x65, 0x12, 0x0e, 0x0a, 0x0a, 0x44,
+	0x45, 0x50, 0x4c, 0x4f, 0x59, 0x4d, 0x45, 0x4e, 0x54, 0x10, 0x00, 0x12, 0x0b, 0x0a, 0x07, 0x43,
+	0x52, 0x4f, 0x4e, 0x4a, 0x4f, 0x42, 0x10, 0x01, 0x12, 0x07, 0x0a, 0x03, 0x50, 0x4f, 0x44, 0x10,
+	0x02, 0x12, 0x07, 0x0a, 0x03, 0x4a, 0x4f, 0x42, 0x10, 0x03, 0x2a, 0x25, 0x0a, 0x0e, 0x54, 0x75,
+	0x6e, 0x6e, 0x65, 0x6c, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x12, 0x08, 0x0a, 0x04,
+	0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x48, 0x42, 0x4f, 0x4e, 0x45, 0x10,
+	0x01, 0x42, 0x11, 0x5a, 0x0f, 0x70, 0x6b, 0x67, 0x2f, 0x77, 0x6f, 0x72, 0x6b, 0x6c, 0x6f, 0x61,
+	0x64, 0x61, 0x70, 0x69, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1644,57 +1709,59 @@ func file_workloadapi_workload_proto_rawDescGZIP() []byte {
 	return file_workloadapi_workload_proto_rawDescData
 }
 
-var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_workloadapi_workload_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
 var file_workloadapi_workload_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_workloadapi_workload_proto_goTypes = []any{
 	(IPFamilies)(0),                 // 0: istio.workload.IPFamilies
-	(WorkloadStatus)(0),             // 1: istio.workload.WorkloadStatus
-	(WorkloadType)(0),               // 2: istio.workload.WorkloadType
-	(TunnelProtocol)(0),             // 3: istio.workload.TunnelProtocol
-	(LoadBalancing_Scope)(0),        // 4: istio.workload.LoadBalancing.Scope
-	(LoadBalancing_Mode)(0),         // 5: istio.workload.LoadBalancing.Mode
-	(ApplicationTunnel_Protocol)(0), // 6: istio.workload.ApplicationTunnel.Protocol
-	(*Address)(nil),                 // 7: istio.workload.Address
-	(*Service)(nil),                 // 8: istio.workload.Service
-	(*LoadBalancing)(nil),           // 9: istio.workload.LoadBalancing
-	(*Workload)(nil),                // 10: istio.workload.Workload
-	(*Locality)(nil),                // 11: istio.workload.Locality
-	(*PortList)(nil),                // 12: istio.workload.PortList
-	(*Port)(nil),                    // 13: istio.workload.Port
-	(*ApplicationTunnel)(nil),       // 14: istio.workload.ApplicationTunnel
-	(*GatewayAddress)(nil),          // 15: istio.workload.GatewayAddress
-	(*NetworkAddress)(nil),          // 16: istio.workload.NetworkAddress
-	(*NamespacedHostname)(nil),      // 17: istio.workload.NamespacedHostname
-	nil,                             // 18: istio.workload.Workload.ServicesEntry
+	(NetworkMode)(0),                // 1: istio.workload.NetworkMode
+	(WorkloadStatus)(0),             // 2: istio.workload.WorkloadStatus
+	(WorkloadType)(0),               // 3: istio.workload.WorkloadType
+	(TunnelProtocol)(0),             // 4: istio.workload.TunnelProtocol
+	(LoadBalancing_Scope)(0),        // 5: istio.workload.LoadBalancing.Scope
+	(LoadBalancing_Mode)(0),         // 6: istio.workload.LoadBalancing.Mode
+	(ApplicationTunnel_Protocol)(0), // 7: istio.workload.ApplicationTunnel.Protocol
+	(*Address)(nil),                 // 8: istio.workload.Address
+	(*Service)(nil),                 // 9: istio.workload.Service
+	(*LoadBalancing)(nil),           // 10: istio.workload.LoadBalancing
+	(*Workload)(nil),                // 11: istio.workload.Workload
+	(*Locality)(nil),                // 12: istio.workload.Locality
+	(*PortList)(nil),                // 13: istio.workload.PortList
+	(*Port)(nil),                    // 14: istio.workload.Port
+	(*ApplicationTunnel)(nil),       // 15: istio.workload.ApplicationTunnel
+	(*GatewayAddress)(nil),          // 16: istio.workload.GatewayAddress
+	(*NetworkAddress)(nil),          // 17: istio.workload.NetworkAddress
+	(*NamespacedHostname)(nil),      // 18: istio.workload.NamespacedHostname
+	nil,                             // 19: istio.workload.Workload.ServicesEntry
 }
 var file_workloadapi_workload_proto_depIdxs = []int32{
-	10, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
-	8,  // 1: istio.workload.Address.service:type_name -> istio.workload.Service
-	16, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
-	13, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
-	15, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
-	9,  // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
+	11, // 0: istio.workload.Address.workload:type_name -> istio.workload.Workload
+	9,  // 1: istio.workload.Address.service:type_name -> istio.workload.Service
+	17, // 2: istio.workload.Service.addresses:type_name -> istio.workload.NetworkAddress
+	14, // 3: istio.workload.Service.ports:type_name -> istio.workload.Port
+	16, // 4: istio.workload.Service.waypoint:type_name -> istio.workload.GatewayAddress
+	10, // 5: istio.workload.Service.load_balancing:type_name -> istio.workload.LoadBalancing
 	0,  // 6: istio.workload.Service.ip_families:type_name -> istio.workload.IPFamilies
-	4,  // 7: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
-	5,  // 8: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
-	3,  // 9: istio.workload.Workload.tunnel_protocol:type_name -> istio.workload.TunnelProtocol
-	15, // 10: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
-	15, // 11: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
-	2,  // 12: istio.workload.Workload.workload_type:type_name -> istio.workload.WorkloadType
-	14, // 13: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
-	18, // 14: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
-	1,  // 15: istio.workload.Workload.status:type_name -> istio.workload.WorkloadStatus
-	11, // 16: istio.workload.Workload.locality:type_name -> istio.workload.Locality
-	13, // 17: istio.workload.PortList.ports:type_name -> istio.workload.Port
-	6,  // 18: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
-	17, // 19: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
-	16, // 20: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
-	12, // 21: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
-	22, // [22:22] is the sub-list for method output_type
-	22, // [22:22] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	5,  // 7: istio.workload.LoadBalancing.routing_preference:type_name -> istio.workload.LoadBalancing.Scope
+	6,  // 8: istio.workload.LoadBalancing.mode:type_name -> istio.workload.LoadBalancing.Mode
+	4,  // 9: istio.workload.Workload.tunnel_protocol:type_name -> istio.workload.TunnelProtocol
+	16, // 10: istio.workload.Workload.waypoint:type_name -> istio.workload.GatewayAddress
+	16, // 11: istio.workload.Workload.network_gateway:type_name -> istio.workload.GatewayAddress
+	3,  // 12: istio.workload.Workload.workload_type:type_name -> istio.workload.WorkloadType
+	15, // 13: istio.workload.Workload.application_tunnel:type_name -> istio.workload.ApplicationTunnel
+	19, // 14: istio.workload.Workload.services:type_name -> istio.workload.Workload.ServicesEntry
+	2,  // 15: istio.workload.Workload.status:type_name -> istio.workload.WorkloadStatus
+	12, // 16: istio.workload.Workload.locality:type_name -> istio.workload.Locality
+	1,  // 17: istio.workload.Workload.network_mode:type_name -> istio.workload.NetworkMode
+	14, // 18: istio.workload.PortList.ports:type_name -> istio.workload.Port
+	7,  // 19: istio.workload.ApplicationTunnel.protocol:type_name -> istio.workload.ApplicationTunnel.Protocol
+	18, // 20: istio.workload.GatewayAddress.hostname:type_name -> istio.workload.NamespacedHostname
+	17, // 21: istio.workload.GatewayAddress.address:type_name -> istio.workload.NetworkAddress
+	13, // 22: istio.workload.Workload.ServicesEntry.value:type_name -> istio.workload.PortList
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_workloadapi_workload_proto_init() }
@@ -1849,7 +1916,7 @@ func file_workloadapi_workload_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_workloadapi_workload_proto_rawDesc,
-			NumEnums:      7,
+			NumEnums:      8,
 			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/pkg/workloadapi/workload.proto
+++ b/pkg/workloadapi/workload.proto
@@ -95,6 +95,15 @@ enum IPFamilies {
   DUAL = 3;
 }
 
+// NetworkMode indicates how the addresses of the workload should be treated.
+enum NetworkMode {
+  // STANDARD means that the workload is uniquely identified by its address (within its network).
+  STANDARD = 0;
+  // HOST_NETWORK means the workload has an IP address that is shared by many workloads. The data plane should avoid
+  // attempting to lookup these workloads by IP address (which could return the wrong result).
+  HOST_NETWORK = 1;
+}
+
 message LoadBalancing {
   enum Scope {
     UNSPECIFIED_SCOPE = 0;
@@ -238,6 +247,8 @@ message Workload {
 
   // The Locality defines information about where a workload is geographically deployed
   Locality locality = 24;
+
+  NetworkMode network_mode = 25;
 
   // Reservations for deleted fields.
   reserved 15;

--- a/releasenotes/notes/ambient-hostnetwork.yaml
+++ b/releasenotes/notes/ambient-hostnetwork.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Fixed** an issue causing `hostNetwork` pods to be ignored in ambient mode.


### PR DESCRIPTION
This contains a series of fixes to make pods in the hostNetwork work.

Ztunnel side: https://github.com/istio/ztunnel/pull/1216. Either PR can merge first (though the Ztunnel one will not do anything without this change), and the ztunnel change only really addresses a minor edge case.

On the surface, the fix is trivial: just allow hostNetwork pods. The
issue arises in the fact this now allows duplication of IPs, since
multiple host network pods on the same node will share the same IP.

We address this in a number of ways.

1. Remove the restriction on overlapping IPs that we currently have. If
   the pod is a host network pod, we allow multiple with the same IP.
  1. In order to facilitate this, we indicate this in WDS. This allows
Ztunnel to know it should not treat the address as unique. In
particular, this means that it will never do an incorrect lookup when
calling the pod directly. Without this change, we may see `curl
host-network-pod`, ztunnel look's up the IP, and finds
`some-other-host-network-pod`. With this change, we recognize these IPs
are not valid to lookup like this and skip them. See the Ztunnel PR for
more info.
2. Fix our EndpointSlice lookup logic. Today, its based on IP matching.
   This isn't really safe in general, but especially not with our new
world of duplicate IPs. Switch this logic to specifically lookup by the
targetRef, which is more clear, safer, and more efficient.

Some minor changes are commented inline in the code
