### PR TITLE
Remove workaround for duplicated addresses in configdump

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/endpoint.go
+++ b/istioctl/pkg/writer/envoy/configdump/endpoint.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/istio/istioctl/pkg/util/proto"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/slices"
-	"istio.io/istio/pkg/util/sets"
 )
 
 type EndpointFilter struct {
@@ -100,15 +99,7 @@ func retrieveEndpointAddresses(ep *endpoint.LbEndpoint) []string {
 		result = append(result, "unknown")
 	}
 
-	// Workaround https://github.com/envoyproxy/envoy/issues/35100. We can remove if it is fixed.
-	filtered := make([]string, 0, len(result))
-	seen := sets.New[string]()
-	for _, r := range result {
-		if !seen.InsertContains(r) {
-			filtered = append(filtered, r)
-		}
-	}
-	return filtered
+	return result
 }
 
 func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter, outputFormat string) error {


### PR DESCRIPTION
**Please provide a description of this PR:**

Remove workaround in configdump handling for istioctl as I merged the fix for https://github.com/envoyproxy/envoy/issues/35100 (fix: https://github.com/envoyproxy/envoy/pull/35120) in Envoy