### PR TITLE
specify ns to find prometheus pods

### DIFF
--- a/tests/integration/telemetry/api/istioctl_metrics_test.go
+++ b/tests/integration/telemetry/api/istioctl_metrics_test.go
@@ -38,15 +38,15 @@ func TestIstioctlMetrics(t *testing.T) {
 				if err := SendTraffic(GetClientInstances()[0]); err != nil {
 					return err
 				}
-				return validateDefaultOutput(t, GetTarget().Config().Service)
+				return validateDefaultOutput(t, GetTarget().Config().Service, ist.Settings().SystemNamespace)
 			}, retry.Delay(framework.TelemetryRetryDelay), retry.Timeout(framework.TelemetryRetryTimeout))
 		})
 }
 
-func validateDefaultOutput(t framework.TestContext, workload string) error { // nolint:interfacer
+func validateDefaultOutput(t framework.TestContext, workload string, systemNamespace string) error { // nolint:interfacer
 	t.Helper()
 	istioCtl := istioctl.NewOrFail(t, istioctl.Config{})
-	args := []string{"experimental", "metrics", workload}
+	args := []string{"experimental", "metrics", workload, "-i", systemNamespace}
 	output, stderr, fErr := istioCtl.Invoke(args)
 	if fErr != nil {
 		t.Logf("Unwanted exception for 'istioctl %s': %v. Stderr: %v", strings.Join(args, " "), fErr, stderr)


### PR DESCRIPTION
**Please provide a description of this PR:**

The default system namespace for the `istioctl experimental metrics` command is set to `istio-system` where the command looks for prometheus pods. If any other system ns is used during testing, this test fails. 