### PR TITLE
[release-1.22] Work around netlink bug on ipset create error

### DIFF
--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netlink/nl"
 )
 
 func RealNlDeps() NetlinkIpsetDeps {
@@ -32,7 +32,16 @@ type realDeps struct{}
 
 func (m *realDeps) ipsetIPPortCreate(name string) error {
 	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true})
-	if ipsetErr, ok := err.(nl.IPSetError); ok && ipsetErr == nl.IPSET_ERR_EXIST {
+	// Note there appears to be a bug in vishvananda/netlink here:
+	// https://github.com/vishvananda/netlink/issues/992
+	//
+	// The "right" way to do this is:
+	// if err == nl.IPSetError(nl.IPSET_ERR_EXIST) {
+	// 	log.Debugf("ignoring ipset err")
+	// 	return nil
+	// }
+	// but that doesn't actually work, so strings.Contains the error.
+	if err != nil && strings.Contains(err.Error(), "exists") {
 		return nil
 	}
 	return err


### PR DESCRIPTION
Manual cherry for https://github.com/istio/istio/issues/52172

As this is a backport, this omits the

- user-facing changes to remove an unused var
- tests added to a suite that doesn't exist in this release

present in the original.

---------

**Please provide a description of this PR:**