### PR TITLE
Don't hardcode CNI namespace

### DIFF
--- a/tests/integration/ambient/untaint/main_test.go
+++ b/tests/integration/ambient/untaint/main_test.go
@@ -52,9 +52,6 @@ func TestMain(m *testing.M) {
 			ctx.Settings().SkipVMs()
 			cfg.DeployEastWestGW = false
 			cfg.ControlPlaneValues = `
-components:
-  cni:
-    namespace: "kube-system"
 values:
   pilot:
     taint:


### PR DESCRIPTION
**Please provide a description of this PR:**

This led me down the garden path a bit.

Attempts to fix what (I think) is the cause of the recent intermittent failures in postsubmit, such as https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-126_istio_postsubmit/1815419669654278144

I think we started seeing those failures after https://github.com/istio/istio/pull/52127 - and I think this is because introducing this test subtly changed the timings and ordering for other tests in `ambient/cni`

What I can see sometimes is rapid redeployments via the tests of `istio-cni` can _sometimes_ lead to scenarios where 

- All `istio-cni` pods go healthy
- Some other pods (on random nodes, sometimes one pod out of a daemonset for instance) will fail to start because the CNI plugin binary returns some error like `User "system:serviceaccount:kube-system:istio-cni" cannot get resource "pods" in API group "" in the namespace "istio-system"`

The above clearly indicates the `ZZZ-istio-cni-kubeconfig` the CNI plugin binary is reading is wrong or outdated.

I originally thought this was a TOCTOU error with how we write out the kubeconfig for the plugin, and contention over terminating and starting pods in writing it, and ripped that stuff out - but that wasn't it either.

Then even with that, the kubeconfig was somehow "wrong" even though we rewrite it every time - which led me to to the K8S svcacct token not being properly mounted/refreshed.

Then I just got to the point where I was ignoring tests and trying to triage, before I realized that some of our tests are hardcoding the `istio-cni` namespace, which I think is leading to doubling-up of CNI instances (@ilrudie actually noticed this but I didn't realize it might be related to what I was seeing).


I don't know for a _fact_ this will fix https://prow.istio.io/view/gs/istio-prow/logs/integ-k8s-126_istio_postsubmit/1815419669654278144 but I suspect it might, and either way it does fix an inconsistency I can create with the tests.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
