### PR TITLE
chore: Wrap errors with context in Cleanup function

### DIFF
--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -124,7 +124,7 @@ func (in *Installer) Cleanup() error {
 			// Read JSON from CNI config file
 			cniConfigMap, err := util.ReadCNIConfigMap(in.cniConfigFilepath)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read CNI config map from file %s: %w", in.cniConfigFilepath, err)
 			}
 			// Find Istio CNI and remove from plugin list
 			plugins, err := util.GetPlugins(cniConfigMap)
@@ -144,15 +144,15 @@ func (in *Installer) Cleanup() error {
 
 			cniConfig, err := util.MarshalCNIConfig(cniConfigMap)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to marshal CNI config map in file %s: %w", in.cniConfigFilepath, err)
 			}
 			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0o644)); err != nil {
-				return err
+				return fmt.Errorf("failed to write updated CNI config to file %s: %w", in.cniConfigFilepath, err)
 			}
 		} else {
 			installLog.Infof("removing Istio CNI config file: %s", in.cniConfigFilepath)
 			if err := os.Remove(in.cniConfigFilepath); err != nil {
-				return err
+				return fmt.Errorf("failed to remove CNI config file %s: %w", in.cniConfigFilepath, err)
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func (in *Installer) Cleanup() error {
 	if len(in.kubeconfigFilepath) > 0 && file.Exists(in.kubeconfigFilepath) {
 		installLog.Infof("removing Istio CNI kubeconfig file: %s", in.kubeconfigFilepath)
 		if err := os.Remove(in.kubeconfigFilepath); err != nil {
-			return err
+			return fmt.Errorf("failed to remove kubeconfig file %s: %w", in.kubeconfigFilepath, err)
 		}
 	}
 
@@ -168,7 +168,7 @@ func (in *Installer) Cleanup() error {
 		if istioCNIBin := filepath.Join(targetDir, "istio-cni"); file.Exists(istioCNIBin) {
 			installLog.Infof("removing binary: %s", istioCNIBin)
 			if err := os.Remove(istioCNIBin); err != nil {
-				return err
+				return fmt.Errorf("failed to remove binary %s: %w", istioCNIBin, err)
 			}
 		}
 	}

--- a/releasenotes/notes/52252.yaml
+++ b/releasenotes/notes/52252.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue: []
+releaseNotes:
+  - | 
+    **Fixed** Wrap errors with context in Cleanup function


### PR DESCRIPTION
Description

This PR adds error wrapping to the Cleanup function to provide more detailed context for each possible error. By specifying the file and operation that caused the error, this change enhances the ability to debug and trace issues effectively.

Changes

	•	Wrapped errors with fmt.Errorf in the Cleanup function.
	•	Provided detailed context for each error, including file paths and operation descriptions.