### PR TITLE
Fix(chart): Add control plane monitoring port to deployment yaml

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
+          - containerPort: 15014
+            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
The current helm chart configures a Service that points to the `istiod` pods `15014` port. But in the deployment the port is not listed. 

This technically works but has some drawbacks. For example if you want to scrape `istiod` by creating a `ServiceMonitor` or `PodMonitor` it won't get scraped since the k8s operator only scrapes pod if the port is actually listed. (I think this was not always the case.) 

This is the config the prometheus operator generates

```yaml
...
  - source_labels: [__meta_kubernetes_pod_container_port_number]
    separator: ;
    regex: "15014"
    replacement: $1
    action: keep
...
```

Ports that are open on a pod should be listed as ports in the pod spec, especially when they are already defined at the `Service` and when they are already mentioned as open ports in the annotations.