### PR TITLE
Fix EndpointSlice test name

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -287,7 +287,7 @@ func TestUpdateEndpointCacheForSlice(t *testing.T) {
 	}
 }
 
-func TestMe(t *testing.T) {
+func TestEndpointSliceGeneration(t *testing.T) {
 	const (
 		ns      = "nsa"
 		svcName = "svc1"


### PR DESCRIPTION
The name was meant to be temp, forgot to rename before merge
