### PR TITLE
docs/collateral: make the sub-commands h3

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -504,7 +504,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 
 	normalizedCmdPath := normalizeID(cmd.CommandPath())
 	if cmd.HasParent() {
-		g.emit("<h2 id=\"", normalizedCmdPath, "\">", cmd.CommandPath(), "</h2>")
+		g.emit("<h3 id=\"", normalizedCmdPath, "\">", cmd.CommandPath(), "</h3>")
 	}
 
 	// Check whether there is a custom text for this command
@@ -596,7 +596,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	}
 
 	if len(cmd.Example) > 0 {
-		g.emit("<h3 id=\"", normalizeID(cmd.CommandPath()), " Examples\">", "Examples", "</h3>")
+		g.emit("<h4 id=\"", normalizeID(cmd.CommandPath()), " Examples\">", "Examples", "</h4>")
 		g.emit("<pre class=\"language-bash\"><code>", html.EscapeString(cmd.Example))
 		g.emit("</code></pre>")
 	}


### PR DESCRIPTION
Change the sub-commands `<h3>` when exporting the HTML so the environment variables and metrics elements appear top-level/parents in the TOC.

Ref: https://github.com/istio/istio.io/pull/15451

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions


- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
