### PR TITLE
Support Virtual Service route match percentage

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -1071,6 +1071,12 @@ func TranslateRouteMatch(vs config.Config, in *networking.HTTPMatchRequest, useE
 		out.QueryParameters = append(out.QueryParameters, matcher)
 	}
 
+	if in.Percentage != nil {
+		out.RuntimeFraction = &core.RuntimeFractionalPercent{
+			DefaultValue: translatePercentToFractionalPercent(in.Percentage),
+		}
+	}
+
 	return out
 }
 

--- a/pkg/config/validation/virtualservice.go
+++ b/pkg/config/validation/virtualservice.go
@@ -165,6 +165,8 @@ func validateHTTPRouteMatchRequest(http *networking.HTTPRoute) (errs error) {
 			for _, qp := range match.GetQueryParams() {
 				errs = appendErrors(errs, validateStringMatch(qp, "queryParams"))
 			}
+
+			errs = appendErrors(errs, validatePercentage(match.Percentage))
 		}
 	}
 

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -479,6 +479,76 @@ func TestValidateRootHTTPRoute(t *testing.T) {
 				},
 			}},
 		}, valid: false},
+		{name: "invalid percentage match upper range", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+				},
+				Percentage: &networking.Percent{
+					Value: 101.0,
+				},
+			}},
+		}, valid: false},
+		{name: "invalid percentage match lower range", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+				},
+				Percentage: &networking.Percent{
+					Value: 0.00001,
+				},
+			}},
+		}, valid: false},
+		{name: "percentage match 0.0", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+				},
+				Percentage: &networking.Percent{
+					Value: 0.0,
+				},
+			}},
+		}, valid: true},
+		{name: "percentage match 100.0", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+				},
+				Percentage: &networking.Percent{
+					Value: 100.0,
+				},
+			}},
+		}, valid: true},
+		{name: "percentage match 10.5", route: &networking.HTTPRoute{
+			Delegate: &networking.Delegate{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Match: []*networking.HTTPMatchRequest{{
+				Uri: &networking.StringMatch{
+					MatchType: &networking.StringMatch_Exact{Exact: "/"},
+				},
+				Percentage: &networking.Percent{
+					Value: 10.5,
+				},
+			}},
+		}, valid: true},
 	}
 
 	for _, tc := range testCases {

--- a/releasenotes/notes/virtual-service-route-match-percentage.yaml
+++ b/releasenotes/notes/virtual-service-route-match-percentage.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/39880
+
+releaseNotes:
+  - |
+    **Added** Percentage match support for VirtualServices Route Match.


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes https://github.com/istio/istio/issues/39880

Requires https://github.com/istio/api/pull/3278

Add `percentage` support in Virtual Service route match, this will configure [runtime_fraction](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routematch-runtime-fraction) match in Routes.

This is useful for a couple of usecases:
- applying different timeout, retries configurations in a subset of requests to test changes
- routing a subset of traffic to a different service when service migrations are happening. (route destinations are not usable because they are used by teams to perform deployments)