### PR TITLE
Fix 52273: add CNI_NET_DIR back. It's used.

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -17,6 +17,7 @@ data:
   {{- if .Values.cni.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cni.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}
+  CNI_NET_DIR: {{ .Values.cni.cniConfDir | default "/etc/cni/net.d" }} # Directory where the CNI config file is going to be created. 
   CHAINED_CNI_PLUGIN: {{ .Values.cni.chained | quote }}
   EXCLUDED_NAMESPACES: "{{ range $idx, $ns := .Values.cni.excludeNamespaces }}{{ if $idx }},{{ end }}{{ $ns }}{{ end }}"
   REPAIR_ENABLED: {{ .Values.cni.chained | quote }}

--- a/releasenotes/notes/52127.yaml
+++ b/releasenotes/notes/52127.yaml
@@ -5,4 +5,3 @@ area: installation
 releaseNotes:
   - |
     **Fixed** netlink error may not be correctly parsed, leading to `istio-cni` not properly ignoring leftover ipset.
-    **Removed** CNI_NET_DIR variable from `istio-cni` configmap - it is unused


### PR DESCRIPTION
Fixes #52273, this PR is to revert some changes made by #52127. 

CNI_NET_DIR is needed in the configmap and populated by the openshift profile to avoid cni issue. Without this variable is not possible to deploy any application with sidecar injection:

```
kubectl get pods -n bookinfo
NAME                             READY   STATUS     RESTARTS   AGE
details-v1-cf74bb974-vnnd9       0/2     Init:0/1   0          3m22s
productpage-v1-87d54dd59-djzmq   0/2     Init:0/1   0          3m21s
ratings-v1-7c4bbf97db-b54dw      0/2     Init:0/1   0          3m22s
reviews-v1-5fd6d4f8f8-x89gp      0/2     Init:0/1   0          3m21s
reviews-v2-6f9b55c5db-svjfj      0/2     Init:0/1   0          3m21s
reviews-v3-7d99fd7978-qrwsg      0/2     Init:0/1   0          3m21s
```

```
CNI request failed with status 400: 'ContainerID:"f741c70eef632c141df64e41a58c86adb428c25be41f660a6014ff198204111e" Netns:"/var/run/netns/e36df6a1-350c-42c0-a5d7-f7d21abec7dc" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=bookinfo;K8S_POD_NAME=reviews-v3-7d99fd7978-qrwsg;K8S_POD_INFRA_CONTAINER_ID=f741c70eef632c141df64e41a58c86adb428c25be41f660a6014ff198204111e;K8S_POD_UID=dfa61557-995a-4263-99db-7dd29884c6ed" Path:"" ERRORED: error configuring pod [bookinfo/reviews-v3-7d99fd7978-qrwsg] networking: [bookinfo/reviews-v3-7d99fd7978-qrwsg/dfa61557-995a-4263-99db-7dd29884c6ed:istio-cni]: error adding container to network "istio-cni": Get "http://localhost:8080/api/v1/namespaces/bookinfo/pods/reviews-v3-7d99fd7978-qrwsg": dial tcp [::1]:8080: connect: connection refused
```





I changed the release note created by the PR #52127 to delete the mention of the deletion of the variable