### PR TITLE
pilot: fix treating spontaneous request as ACK

### DIFF
--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -406,16 +406,23 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 		xds.ExpiredNonce.With(typeTag.Value(v3.GetMetricType(request.TypeUrl))).Increment()
 		return false
 	}
-	// If it comes here, that means nonce match. This an ACK. We should record
-	// the ack details and respond if there is a change in resource names.
 	var previousResources, currentResources []string
 	var alwaysRespond bool
+
+	// Spontaneous DeltaDiscoveryRequests from the client.
+	// This can be done to dynamically add or remove elements from the tracked resource_names set.
+	// In this case response_nonce is empty.
+	spontaneousReq := request.ResponseNonce == ""
+	// If it comes here, that means nonce match. This an ACK. We should record
+	// the ack details and respond if there is a change in resource names.
 	con.proxy.UpdateWatchedResource(request.TypeUrl, func(wr *model.WatchedResource) *model.WatchedResource {
 		previousResources = wr.ResourceNames
 		currentResources, _ = deltaWatchedResources(previousResources, request)
-		// Clear last error, we got an ACK.
-		wr.LastError = ""
-		wr.NonceAcked = request.ResponseNonce
+		if !spontaneousReq {
+			// Clear last error, we got an ACK.
+			wr.LastError = ""
+			wr.NonceAcked = request.ResponseNonce
+		}
 		wr.ResourceNames = currentResources
 		alwaysRespond = wr.AlwaysRespond
 		wr.AlwaysRespond = false
@@ -423,10 +430,6 @@ func (s *DiscoveryServer) shouldRespondDelta(con *Connection, request *discovery
 	})
 
 	subChanged := !slices.EqualUnordered(previousResources, currentResources)
-	// Spontaneous DeltaDiscoveryRequests from the client.
-	// This can be done to dynamically add or remove elements from the tracked resource_names set.
-	// In this case response_nonce is empty.
-	spontaneousReq := request.ResponseNonce == ""
 	// It is invalid in the below two cases:
 	// 1. no subscribed resources change from spontaneous delta request.
 	// 2. subscribed resources changes from ACK.

--- a/releasenotes/notes/delta-xds-stale.yaml
+++ b/releasenotes/notes/delta-xds-stale.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 51612
+
+releaseNotes:
+  - |
+    **Fixed** an issue causing resources to incorrectly be reported by `istioctl proxy-status` as `STALE`.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/51612

What is happening here is we get a request from Envoy without Nonce set. We end up setting `Acked=""`. Then, `istioctl ps` sees `sent=some-nonce, acked=""` and thinks it is STALE; its not.

Instead, we should not reset the `Acked` var when its not a real ACK.

This PR fixes this issue and adds a test case.

I am fairly sure this fixes https://github.com/istio/istio/issues/51165 as well, not but 100%

Easy manual reproducer is to apply a Gateway to an otherwise empty cluster, then remove it. 45s later the listener will drain and RDS will start reporting as stale