### PR TITLE
Optimize test suite setup

### DIFF
--- a/pkg/test/util/yml/parts_test.go
+++ b/pkg/test/util/yml/parts_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/yml"
 )
 
@@ -83,8 +84,7 @@ b
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			parts := yml.SplitString(c.doc)
-			g := NewWithT(t)
-			g.Expect(parts).To(Equal(expected))
+			assert.Equal(t, parts, expected)
 		})
 	}
 }

--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -121,10 +121,19 @@ values:
 
 			return nil
 		}).
-		Setup(func(t resource.Context) error {
-			return SetupApps(t, i, apps)
-		}).
-		Setup(testRegistrySetup).
+		SetupParallel(
+			testRegistrySetup,
+			func(t resource.Context) error {
+				return SetupApps(t, i, apps)
+			},
+			func(t resource.Context) (err error) {
+				prom, err = prometheus.New(t, prometheus.Config{})
+				if err != nil {
+					return err
+				}
+				return
+			},
+		).
 		Run()
 }
 
@@ -159,11 +168,6 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 			"istio.io/test-exclude-namespace": "true",
 		},
 	})
-	if err != nil {
-		return err
-	}
-
-	prom, err = prometheus.New(t, prometheus.Config{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Run steps in parallel
* Avoid using regex to split lines (yes, this really is a bottleneck!
  over 2 CPU seconds spent on this)

This cuts the test setup time on an already deployed cluster from
roughly 4s to .8s. Not crazy but nice for iteration.
