### PR TITLE
handle draining endpoints for stateful header sessions

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -139,6 +139,11 @@ func (s *Service) CmpOpts() []cmp.Option {
 	return serviceCmpOpts
 }
 
+func (s *Service) SupportsDrainingEndpoints() bool {
+	return (features.PersistentSessionLabel != "" && s.Attributes.Labels[features.PersistentSessionLabel] != "") ||
+		(features.PersistentSessionHeaderLabel != "" && s.Attributes.Labels[features.PersistentSessionHeaderLabel] != "")
+}
+
 // Resolution indicates how the service instances need to be resolved before routing traffic.
 type Resolution int
 

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -329,7 +329,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(cb *ClusterBuilder, 
 			// if the service uses persistent sessions, override status allows
 			// DRAINING endpoints to be kept as 'UNHEALTHY' coarse status in envoy.
 			// Will not be used for normal traffic, only when explicit override.
-			if service.Attributes.Labels[features.PersistentSessionLabel] != "" {
+			if service.SupportsDrainingEndpoints() {
 				// Default is UNKNOWN, HEALTHY, DEGRADED. Without this change, Envoy will drop endpoints with any other
 				// status received in EDS. With this setting, the DRAINING and UNHEALTHY endpoints are kept - both marked
 				// as UNHEALTHY ('coarse state'), which is what will show in config dumps.

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -23,7 +23,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	corexds "istio.io/istio/pilot/pkg/networking/core"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -131,7 +130,7 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 	var defaultCluster *cluster.Cluster
 	if b.filter.Contains(b.defaultClusterName) {
 		defaultCluster = edsCluster(b.defaultClusterName)
-		if b.svc.Attributes.Labels[features.PersistentSessionLabel] != "" {
+		if b.svc.SupportsDrainingEndpoints() {
 			// see core/v1alpha3/cluster.go
 			defaultCluster.CommonLbConfig.OverrideHostStatus = &core.HealthStatusSet{
 				Statuses: []core.HealthStatus{

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -234,9 +234,7 @@ func endpointHealthStatus(svc *model.Service, e v1.Endpoint) model.HealthStatus 
 		return model.Healthy
 	}
 
-	if features.PersistentSessionLabel != "" &&
-		svc != nil &&
-		svc.Attributes.Labels[features.PersistentSessionLabel] != "" &&
+	if svc != nil && svc.SupportsDrainingEndpoints() &&
 		(e.Conditions.Serving == nil || *e.Conditions.Serving) &&
 		(e.Conditions.Terminating == nil || *e.Conditions.Terminating) {
 		return model.Draining


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/52256. The same draining logic used for stateful session cookies is extended for header based as well.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions