### PR TITLE
Refactor keycertbundle

### DIFF
--- a/releasenotes/notes/52193.yaml
+++ b/releasenotes/notes/52193.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue: []
+releaseNotes:
+  - |
+    **Fixed** Corrected documentation for `rootCertExpiryTimestamp` and `citadel_server_cert_chain_expiry_timestamp`.

--- a/releasenotes/notes/52193.yaml
+++ b/releasenotes/notes/52193.yaml
@@ -7,7 +7,7 @@ releaseNotes:
     **Fixed** Corrected documentation for `rootCertExpiryTimestamp` and `citadel_server_cert_chain_expiry_timestamp`.
 upgradeNotes:
   - title: |
-      `rootCertExpiryTimestamp` and `certChainExpiryTimestamp` no longer record a negative number for expired certificate/certificate change.
+      `rootCertExpiryTimestamp` and `certChainExpiryTimestamp` no longer record a negative number for expired certificate/certificate chains.
       This was never the actual behavior, but the docs are now updated to reflect the actual behavior.
-      To quickly check for expired certs, check the sign of `rootCertExpirySeconds` and `certChainExpirySeconds`.
+      Users who relied on this behavior should check the check the signs of `rootCertExpirySeconds` and `certChainExpirySeconds` instead.
 

--- a/releasenotes/notes/52193.yaml
+++ b/releasenotes/notes/52193.yaml
@@ -5,3 +5,9 @@ issue: []
 releaseNotes:
   - |
     **Fixed** Corrected documentation for `rootCertExpiryTimestamp` and `citadel_server_cert_chain_expiry_timestamp`.
+upgradeNotes:
+  - title: |
+      `rootCertExpiryTimestamp` and `certChainExpiryTimestamp` no longer record a negative number for expired certificate/certificate change.
+      This was never the actual behavior, but the docs are now updated to reflect the actual behavior.
+      To quickly check for expired certs, check the sign of `rootCertExpirySeconds` and `certChainExpirySeconds`.
+

--- a/releasenotes/notes/52193.yaml
+++ b/releasenotes/notes/52193.yaml
@@ -6,7 +6,8 @@ releaseNotes:
   - |
     **Fixed** Corrected documentation for `rootCertExpiryTimestamp` and `citadel_server_cert_chain_expiry_timestamp`.
 upgradeNotes:
-  - title: |
+  - title: Change in cert expiry metrics
+    content: |
       `rootCertExpiryTimestamp` and `certChainExpiryTimestamp` no longer record a negative number for expired certificate/certificate chains.
       This was never the actual behavior, but the docs are now updated to reflect the actual behavior.
       Users who relied on this behavior should check the check the signs of `rootCertExpirySeconds` and `certChainExpirySeconds` instead.

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -439,11 +439,11 @@ func (ca *IstioCA) minTTL(defaultCertTTL time.Duration) (time.Duration, error) {
 		return 0, fmt.Errorf("failed to get cert chain TTL %s", err.Error())
 	}
 
-	if certChainExpiration.Seconds() <= 0 {
+	if certChainExpiration <= 0 {
 		return 0, fmt.Errorf("cert chain has expired")
 	}
 
-	if defaultCertTTL.Seconds() > certChainExpiration.Seconds() {
+	if defaultCertTTL > certChainExpiration {
 		return certChainExpiration, nil
 	}
 

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -253,12 +253,12 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(certFile string, pri
 	return nil
 }
 
-// ExtractRootCertExpiryTimestamp returns when the root cert expires
+// ExtractRootCertExpiryTimestamp returns a time.Time of when the root cert expires
 func (b *KeyCertBundle) ExtractRootCertExpiryTimestamp() (*time.Time, error) {
 	return extractCertExpiryTimestamp("root cert", b.GetRootCertPem())
 }
 
-// ExtractCACertExpiryTimestamp returns when the cert chains expires
+// ExtractCACertExpiryTimestamp returns a time.Time of when the cert chain expires
 func (b *KeyCertBundle) ExtractCACertExpiryTimestamp() (*time.Time, error) {
 	return extractCertExpiryTimestamp("CA cert", b.GetCertChainPem())
 }

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -265,6 +265,7 @@ func (b *KeyCertBundle) ExtractCACertExpiryTimestamp() (*time.Time, error) {
 
 // TimeBeforeCertExpires returns the time duration before the cert gets expired.
 // It returns an error if it failed to extract the cert expiration timestamp.
+// The returned time duration could be a negative value indicating the cert has already expired.
 func TimeBeforeCertExpires(certBytes []byte, now time.Time) (time.Duration, error) {
 	if len(certBytes) == 0 {
 		return 0, fmt.Errorf("no certificate found")

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -253,26 +253,24 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(certFile string, pri
 	return nil
 }
 
-// ExtractRootCertExpiryTimestamp returns the unix timestamp when the root becomes expires.
+// ExtractRootCertExpiryTimestamp returns when the root cert expires
 func (b *KeyCertBundle) ExtractRootCertExpiryTimestamp() (*time.Time, error) {
 	return extractCertExpiryTimestamp("root cert", b.GetRootCertPem())
 }
 
-// ExtractCACertExpiryTimestamp returns the unix timestamp when the cert chain becomes expires.
+// ExtractCACertExpiryTimestamp returns when the cert chains expires
 func (b *KeyCertBundle) ExtractCACertExpiryTimestamp() (*time.Time, error) {
 	return extractCertExpiryTimestamp("CA cert", b.GetCertChainPem())
 }
 
 // TimeBeforeCertExpires returns the time duration before the cert gets expired.
 // It returns an error if it failed to extract the cert expiration timestamp.
-// The returned time duration could be a negative value indicating the cert has already been expired.
 func TimeBeforeCertExpires(certBytes []byte, now time.Time) (time.Duration, error) {
 	if len(certBytes) == 0 {
 		return 0, fmt.Errorf("no certificate found")
 	}
 
 	certExpiryTimestamp, err := extractCertExpiryTimestamp("cert", certBytes)
-
 	if err != nil {
 		return 0, fmt.Errorf("failed to extract cert expiration timestamp: %v", err)
 	}

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -253,13 +253,13 @@ func (b *KeyCertBundle) UpdateVerifiedKeyCertBundleFromFile(certFile string, pri
 	return nil
 }
 
-// ExtractRootCertExpiryTimestamp returns a time.Time of when the root cert expires
-func (b *KeyCertBundle) ExtractRootCertExpiryTimestamp() (*time.Time, error) {
+// ExtractRootCertExpiryTimestamp returns the expiration of the first root cert
+func (b *KeyCertBundle) ExtractRootCertExpiryTimestamp() (time.Time, error) {
 	return extractCertExpiryTimestamp("root cert", b.GetRootCertPem())
 }
 
-// ExtractCACertExpiryTimestamp returns a time.Time of when the cert chain expires
-func (b *KeyCertBundle) ExtractCACertExpiryTimestamp() (*time.Time, error) {
+// ExtractCACertExpiryTimestamp returns the expiration of the leaf certificate
+func (b *KeyCertBundle) ExtractCACertExpiryTimestamp() (time.Time, error) {
 	return extractCertExpiryTimestamp("CA cert", b.GetCertChainPem())
 }
 
@@ -318,12 +318,12 @@ func Verify(certBytes, privKeyBytes, certChainBytes, rootCertBytes []byte) error
 	return nil
 }
 
-func extractCertExpiryTimestamp(certType string, certPem []byte) (*time.Time, error) {
+func extractCertExpiryTimestamp(certType string, certPem []byte) (time.Time, error) {
 	cert, err := ParsePemEncodedCertificate(certPem)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse the %s: %v", certType, err)
+		return time.Unix(0, 0), fmt.Errorf("failed to parse the %s: %v", certType, err)
 	}
-	return &cert.NotAfter, nil
+	return cert.NotAfter, nil
 }
 
 func copyBytes(src []byte) []byte {

--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -399,7 +399,6 @@ func TestExtractRootCertExpiryTimestamp(t *testing.T) {
 			if expiryTimestamp.Sub(expectedExpiryTimestamp).Abs() > tol {
 				t.Errorf("Expected %d and %d to be almost equal", expiryTimestamp.Unix(), expectedExpiryTimestamp.Unix())
 			}
-
 		})
 	}
 
@@ -509,17 +508,13 @@ func TestExtractCACertExpiryTimestamp(t *testing.T) {
 		garbage := []byte{0, 0, 0, 0}
 		kb := NewKeyCertBundleFromPem(garbage, garbage, nil, garbage)
 		// will return error if expired
-		expiryTimestamp, err := kb.ExtractCACertExpiryTimestamp()
-		if expiryTimestamp != nil {
-			t.Errorf("Expected nil value")
-		}
+		_, err := kb.ExtractCACertExpiryTimestamp()
 		if err == nil {
 			t.Errorf("Expected error parsing malformed cert")
 		} else if err.Error() != errorMessage {
 			t.Errorf("Expected error %s, but got %s", errorMessage, err.Error())
 		}
 	})
-
 }
 
 func TestTimeBeforeCertExpires(t *testing.T) {

--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -408,10 +408,7 @@ func TestExtractRootCertExpiryTimestamp(t *testing.T) {
 		garbage := []byte{0, 0, 0, 0}
 		kb := NewKeyCertBundleFromPem(garbage, garbage, nil, garbage)
 		// will return error if expired
-		expiryTimestamp, err := kb.ExtractRootCertExpiryTimestamp()
-		if expiryTimestamp != nil {
-			t.Errorf("Expected nil value")
-		}
+		_, err := kb.ExtractRootCertExpiryTimestamp()
 		if err == nil {
 			t.Errorf("Expected error parsing malformed cert")
 		} else if err.Error() != errorMessage {

--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -344,32 +344,32 @@ func TestNewVerifiedKeyCertBundleFromFile(t *testing.T) {
 // Test the root cert expiry timestamp can be extracted correctly.
 func TestExtractRootCertExpiryTimestamp(t *testing.T) {
 	testCases := []struct {
-		NotBefore time.Time
-		TTL       time.Duration
+		notBefore time.Time
+		ttl       time.Duration
 	}{
 		{
-			NotBefore: time.Unix(0, 0),
-			TTL:       time.Minute,
+			notBefore: time.Unix(0, 0),
+			ttl:       time.Minute,
 		},
 		{
-			NotBefore: time.Unix(1721769413, 1000),
-			TTL:       time.Minute * 70,
+			notBefore: time.Unix(1721769413, 1000),
+			ttl:       time.Minute * 70,
 		},
 		{
-			NotBefore: time.Unix(2721769413, 1000),
-			TTL:       time.Minute * 10,
+			notBefore: time.Unix(2721769413, 1000),
+			ttl:       time.Minute * 10,
 		},
 		{
-			NotBefore: time.Unix((1<<31)-2, 1000),
-			TTL:       time.Minute * 10,
+			notBefore: time.Unix((1<<31)-2, 1000),
+			ttl:       time.Minute * 10,
 		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Test case %d", i), func(t *testing.T) {
 			cert, key, err := GenCertKeyFromOptions(CertOptions{
 				Host:         "citadel.testing.istio.io",
-				NotBefore:    tc.NotBefore,
-				TTL:          tc.TTL,
+				NotBefore:    tc.notBefore,
+				TTL:          tc.ttl,
 				Org:          "MyOrg",
 				IsCA:         true,
 				IsSelfSigned: true,
@@ -383,9 +383,9 @@ func TestExtractRootCertExpiryTimestamp(t *testing.T) {
 			kb := NewKeyCertBundleFromPem(cert, key, nil, cert)
 			// will return error if expired
 			expiryTimestamp, _ := kb.ExtractRootCertExpiryTimestamp()
-			expectedExpiryTimestamp := tc.NotBefore.Add(tc.TTL)
-            // One second toleration because x509 cert times have one second of precision
-            tol := time.Second
+			expectedExpiryTimestamp := tc.notBefore.Add(tc.ttl)
+			// One second toleration because x509 cert times have one second of precision
+			tol := time.Second
 			if expiryTimestamp.Sub(expectedExpiryTimestamp).Abs() > tol {
 				t.Errorf("Expected %d and %d to be almost equal", expiryTimestamp.Unix(), expectedExpiryTimestamp.Unix())
 			}
@@ -396,24 +396,24 @@ func TestExtractRootCertExpiryTimestamp(t *testing.T) {
 // Test the CA cert expiry timestamp can be extracted correctly.
 func TestExtractCACertExpiryTimestamp(t *testing.T) {
 	testCases := []struct {
-		NotBefore time.Time
-		TTL       time.Duration
+		notBefore time.Time
+		ttl       time.Duration
 	}{
 		{
-			NotBefore: time.Unix(0, 0),
-			TTL:       time.Minute,
+			notBefore: time.Unix(0, 0),
+			ttl:       time.Minute,
 		},
 		{
-			NotBefore: time.Unix(1721769413, 1000),
-			TTL:       time.Minute * 70,
+			notBefore: time.Unix(1721769413, 1000),
+			ttl:       time.Minute * 70,
 		},
 		{
-			NotBefore: time.Unix(2721769413, 1000),
-			TTL:       time.Minute * 10,
+			notBefore: time.Unix(2721769413, 1000),
+			ttl:       time.Minute * 10,
 		},
 		{
-			NotBefore: time.Unix((1<<31)-2, 1000),
-			TTL:       time.Minute * 10,
+			notBefore: time.Unix((1<<31)-2, 1000),
+			ttl:       time.Minute * 10,
 		},
 	}
 	for i, tc := range testCases {
@@ -421,10 +421,10 @@ func TestExtractCACertExpiryTimestamp(t *testing.T) {
 			rootCertBytes, rootKeyBytes, err := GenCertKeyFromOptions(CertOptions{
 				Host:         "citadel.testing.istio.io",
 				Org:          "MyOrg",
-				NotBefore:    tc.NotBefore,
+				NotBefore:    tc.notBefore,
 				IsCA:         true,
 				IsSelfSigned: true,
-				TTL:          tc.TTL,
+				TTL:          tc.ttl,
 				RSAKeySize:   2048,
 			})
 			if err != nil {
@@ -444,8 +444,8 @@ func TestExtractCACertExpiryTimestamp(t *testing.T) {
 			caCertBytes, caCertKeyBytes, err := GenCertKeyFromOptions(CertOptions{
 				Host:         "citadel.testing.istio.io",
 				Org:          "MyOrg",
-				NotBefore:    tc.NotBefore,
-				TTL:          tc.TTL,
+				NotBefore:    tc.notBefore,
+				TTL:          tc.ttl,
 				IsServer:     true,
 				IsCA:         true,
 				IsSelfSigned: false,
@@ -463,9 +463,9 @@ func TestExtractCACertExpiryTimestamp(t *testing.T) {
 
 			expiryTimestamp, _ := kb.ExtractCACertExpiryTimestamp()
 			// Ignore error; it just indicates cert is expired
-			expectedExpiryTimestamp := tc.NotBefore.Add(tc.TTL)
-            // One second toleration because x509 cert times have one second of precision
-            tol := time.Second
+			expectedExpiryTimestamp := tc.notBefore.Add(tc.ttl)
+			// One second toleration because x509 cert times have one second of precision
+			tol := time.Second
 			if expiryTimestamp.Sub(expectedExpiryTimestamp).Abs() > tol {
 				t.Errorf("Expected %d and %d to be almost equal", expiryTimestamp.Unix(), expectedExpiryTimestamp.Unix())
 			}
@@ -540,9 +540,9 @@ func TestTimeBeforeCertExpires(t *testing.T) {
 				return
 			}
 
-            // One second toleration because x509 cert times have one second of precision
-            tol := time.Second
-			if (expiryDuration - tc.expectedTime).Abs() > tol  {
+			// One second toleration because x509 cert times have one second of precision
+			tol := time.Second
+			if (expiryDuration - tc.expectedTime).Abs() > tol {
 				t.Fatalf("expected time %v to be close to %v", tc.expectedTime, expiryDuration)
 			}
 		})

--- a/security/pkg/server/ca/monitoring.go
+++ b/security/pkg/server/ca/monitoring.go
@@ -57,20 +57,20 @@ var (
 
 	rootCertExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_root_cert_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel root cert will expire.",
+		"The unix timestamp, in seconds, when the root cert will expire.",
 	)
 	rootCertExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_root_cert_expiry_seconds",
-		"The time remaining, in seconds, before the root certificate will expire. "+
+		"The time remaining, in seconds, before the root cert will expire. "+
 			"A negative value indicates the cert is expired.",
 	)
 	certChainExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_cert_chain_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel cert chain will expire.",
+		"The unix timestamp, in seconds, when Istio generated cert chain will expire.",
 	)
 	certChainExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_cert_chain_expiry_seconds",
-		"The time remaining, in seconds, before the certificate chain will expire. "+
+		"The time remaining, in seconds, before the Istio Generated cert chain will expire. "+
 			"A negative value indicates the cert is expired.",
 	)
 )

--- a/security/pkg/server/ca/monitoring.go
+++ b/security/pkg/server/ca/monitoring.go
@@ -57,7 +57,7 @@ var (
 
 	rootCertExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_root_cert_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel root cert will expire. ",
+		"The unix timestamp, in seconds, when Citadel root cert will expire.",
 	)
 	rootCertExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_root_cert_expiry_seconds",
@@ -66,7 +66,7 @@ var (
 	)
 	certChainExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_cert_chain_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel cert chain will expire. ",
+		"The unix timestamp, in seconds, when Citadel cert chain will expire.",
 	)
 	certChainExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_cert_chain_expiry_seconds",

--- a/security/pkg/server/ca/monitoring.go
+++ b/security/pkg/server/ca/monitoring.go
@@ -57,8 +57,7 @@ var (
 
 	rootCertExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_root_cert_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel root cert will expire. "+
-			"A negative time indicates the cert is expired.",
+		"The unix timestamp, in seconds, when Citadel root cert will expire. ",
 	)
 	rootCertExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_root_cert_expiry_seconds",
@@ -67,8 +66,7 @@ var (
 	)
 	certChainExpiryTimestamp = monitoring.NewGauge(
 		"citadel_server_cert_chain_expiry_timestamp",
-		"The unix timestamp, in seconds, when Citadel cert chain will expire. "+
-			"A negative time indicates the cert is expired.",
+		"The unix timestamp, in seconds, when Citadel cert chain will expire. ",
 	)
 	certChainExpirySeconds = monitoring.NewDerivedGauge(
 		"citadel_server_cert_chain_expiry_seconds",

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -154,7 +154,7 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 		serverCaLog.Errorf("failed to extract root cert expiry timestamp (error %v)", err)
 	}
 	rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
-	rootCertExpirySeconds.ValueFrom(rootCertExpiry.Sub(time.Now()).Seconds)
+	rootCertExpirySeconds.ValueFrom(time.Until(*rootCertExpiry).Seconds)
 
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
 		return
@@ -166,7 +166,7 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	}
 
 	certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
-	certChainExpirySeconds.ValueFrom(certChainExpiry.Sub(time.Now()).Seconds)
+	certChainExpirySeconds.ValueFrom(time.Until(*certChainExpiry).Seconds)
 }
 
 // Register registers a GRPC server on the specified port.

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -149,12 +149,13 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 }
 
 func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
+    // Expiry of the first cert in trust bundle
 	rootCertExpiry, err := keyCertBundle.ExtractRootCertExpiryTimestamp()
 	if err != nil {
 		serverCaLog.Errorf("failed to extract root cert expiry timestamp (error %v)", err)
 	} else {
 		rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
-		rootCertExpirySeconds.ValueFrom(time.Until(*rootCertExpiry).Seconds)
+		rootCertExpirySeconds.ValueFrom(time.Until(rootCertExpiry).Seconds)
 	}
 
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
@@ -166,7 +167,7 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 		serverCaLog.Errorf("failed to extract CA cert expiry timestamp (error %v)", err)
 	} else {
 		certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
-		certChainExpirySeconds.ValueFrom(time.Until(*certChainExpiry).Seconds)
+		certChainExpirySeconds.ValueFrom(time.Until(certChainExpiry).Seconds)
 	}
 }
 

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -152,9 +152,10 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	rootCertExpiry, err := keyCertBundle.ExtractRootCertExpiryTimestamp()
 	if err != nil {
 		serverCaLog.Errorf("failed to extract root cert expiry timestamp (error %v)", err)
+	} else {
+		rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
+		rootCertExpirySeconds.ValueFrom(time.Until(*rootCertExpiry).Seconds)
 	}
-	rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
-	rootCertExpirySeconds.ValueFrom(time.Until(*rootCertExpiry).Seconds)
 
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
 		return
@@ -163,10 +164,10 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	certChainExpiry, err := keyCertBundle.ExtractCACertExpiryTimestamp()
 	if err != nil {
 		serverCaLog.Errorf("failed to extract CA cert expiry timestamp (error %v)", err)
+	} else {
+		certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
+		certChainExpirySeconds.ValueFrom(time.Until(*certChainExpiry).Seconds)
 	}
-
-	certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
-	certChainExpirySeconds.ValueFrom(time.Until(*certChainExpiry).Seconds)
 }
 
 // Register registers a GRPC server on the specified port.

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -149,13 +149,13 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 }
 
 func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
-    // Expiry of the first cert in trust bundle
+	// Expiry of the first root cert in trust bundle
 	rootCertExpiry, err := keyCertBundle.ExtractRootCertExpiryTimestamp()
 	if err != nil {
 		serverCaLog.Errorf("failed to extract root cert expiry timestamp (error %v)", err)
 	} else {
 		rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
-		rootCertExpirySeconds.ValueFrom(time.Until(rootCertExpiry).Seconds)
+		rootCertExpirySeconds.ValueFrom(func() float64 { return time.Until(rootCertExpiry).Seconds() })
 	}
 
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
@@ -167,7 +167,7 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 		serverCaLog.Errorf("failed to extract CA cert expiry timestamp (error %v)", err)
 	} else {
 		certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
-		certChainExpirySeconds.ValueFrom(time.Until(certChainExpiry).Seconds)
+		certChainExpirySeconds.ValueFrom(func() float64 { return time.Until(rootCertExpiry).Seconds() })
 	}
 }
 

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -159,8 +159,8 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
 		return
 	}
-	certChainExpiry, err := keyCertBundle.ExtractCACertExpiryTimestamp()
 
+	certChainExpiry, err := keyCertBundle.ExtractCACertExpiryTimestamp()
 	if err != nil {
 		serverCaLog.Errorf("failed to extract CA cert expiry timestamp (error %v)", err)
 	}

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -153,29 +153,20 @@ func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	if err != nil {
 		serverCaLog.Errorf("failed to extract root cert expiry timestamp (error %v)", err)
 	}
-	rootCertExpiryTimestamp.Record(rootCertExpiry)
-
-	rootCertPem, err := util.ParsePemEncodedCertificate(keyCertBundle.GetRootCertPem())
-	if err != nil {
-		serverCaLog.Errorf("failed to parse the root cert: %v", err)
-	}
-	rootCertExpirySeconds.ValueFrom(func() float64 { return time.Until(rootCertPem.NotAfter).Seconds() })
+	rootCertExpiryTimestamp.Record(float64(rootCertExpiry.Unix()))
+	rootCertExpirySeconds.ValueFrom(rootCertExpiry.Sub(time.Now()).Seconds)
 
 	if len(keyCertBundle.GetCertChainPem()) == 0 {
 		return
 	}
-
 	certChainExpiry, err := keyCertBundle.ExtractCACertExpiryTimestamp()
+
 	if err != nil {
 		serverCaLog.Errorf("failed to extract CA cert expiry timestamp (error %v)", err)
 	}
-	certChainExpiryTimestamp.Record(certChainExpiry)
 
-	certChainPem, err := util.ParsePemEncodedCertificate(keyCertBundle.GetCertChainPem())
-	if err != nil {
-		serverCaLog.Errorf("failed to parse the cert chain: %v", err)
-	}
-	certChainExpirySeconds.ValueFrom(func() float64 { return time.Until(certChainPem.NotAfter).Seconds() })
+	certChainExpiryTimestamp.Record(float64(certChainExpiry.Unix()))
+	certChainExpirySeconds.ValueFrom(certChainExpiry.Sub(time.Now()).Seconds)
 }
 
 // Register registers a GRPC server on the specified port.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixed some incorrect documentation and refactored keycertbundle logging code to be a bit more efficient.

Main thing is that the documentation for `rootCertExpiryTimestamp`/`certChainExpiryTimestamp` was incorrect and the question is whether we want to keep the docs and update the behavior or update the docs and keep the behavior.