### PR TITLE
Do not add pod to ipset if we have a "partial failure" adding to the dataplane.

### DIFF
--- a/cni/pkg/nodeagent/cni-watcher_test.go
+++ b/cni/pkg/nodeagent/cni-watcher_test.go
@@ -107,10 +107,7 @@ func TestCNIPluginServer(t *testing.T) {
 		valid.Netns,
 	).Return(nil)
 
-	dpServer := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	dpServer := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
 
@@ -183,10 +180,7 @@ func TestGetPodWithRetry(t *testing.T) {
 	wg, _ := NewWaitForNCalls(t, 1)
 	fs := &fakeServer{testWG: wg}
 
-	dpServer := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	dpServer := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
 
@@ -261,10 +255,7 @@ func TestCNIPluginServerPrefersCNIProvidedPodIP(t *testing.T) {
 		valid.Netns,
 	).Return(nil)
 
-	dpServer := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	dpServer := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, dpServer, "istio-system")
 

--- a/cni/pkg/nodeagent/informers_test.go
+++ b/cni/pkg/nodeagent/informers_test.go
@@ -65,10 +65,7 @@ func TestExistingPodAddedWhenNsLabeled(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -127,10 +124,7 @@ func TestExistingPodAddedWhenDualStack(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	fs.Start(ctx)
 	handlers := setupHandlers(ctx, client, server, "istio-system")
@@ -179,10 +173,7 @@ func TestExistingPodNotAddedIfNoIPInAnyStatusField(t *testing.T) {
 
 	fs := &fakeServer{}
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -244,10 +235,7 @@ func TestExistingPodRemovedWhenNsUnlabeled(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -337,10 +325,7 @@ func TestExistingPodRemovedWhenPodLabelRemoved(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -440,10 +425,7 @@ func TestJobPodRemovedWhenPodTerminates(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -556,10 +538,8 @@ func TestGetActiveAmbientPodSnapshotOnlyReturnsActivePods(t *testing.T) {
 	client := kube.NewFakeClient(ns, enrolledNotRedirected, redirectedNotEnrolled)
 	fs := &fakeServer{}
 	fs.Start(ctx)
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -618,10 +598,8 @@ func TestGetActiveAmbientPodSnapshotSkipsTerminatedJobPods(t *testing.T) {
 	client := kube.NewFakeClient(ns, enrolledNotRedirected, enrolledButTerminated)
 	fs := &fakeServer{}
 	fs.Start(ctx)
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -661,10 +639,8 @@ func TestAmbientEnabledReturnsPodIfEnabled(t *testing.T) {
 	client := kube.NewFakeClient(ns, pod)
 	fs := &fakeServer{}
 	fs.Start(ctx)
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -704,10 +680,8 @@ func TestAmbientEnabledReturnsNoPodIfNotEnabled(t *testing.T) {
 	client := kube.NewFakeClient(ns, pod)
 	fs := &fakeServer{}
 	fs.Start(ctx)
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -748,10 +722,8 @@ func TestAmbientEnabledReturnsErrorIfBogusNS(t *testing.T) {
 	client := kube.NewFakeClient(ns, pod)
 	fs := &fakeServer{}
 	fs.Start(ctx)
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())
@@ -802,10 +774,7 @@ func TestExistingPodAddedWhenItPreExists(t *testing.T) {
 		"",
 	).Return(nil)
 
-	server := &meshDataplane{
-		kubeClient: client.Kube(),
-		netServer:  fs,
-	}
+	server := getFakeDP(fs, client.Kube())
 
 	handlers := setupHandlers(ctx, client, server, "istio-system")
 	client.RunAndWait(ctx.Done())

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/cni/pkg/iptables"
 	"istio.io/istio/pkg/slices"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
@@ -41,10 +40,7 @@ type NetServer struct {
 
 var _ MeshDataplane = &NetServer{}
 
-func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache,
-	hostIptables *iptables.IptablesConfigurator, podIptables *iptables.IptablesConfigurator, podNs PodNetnsFinder,
-	probeSet ipset.IPSet,
-) *NetServer {
+func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache, podIptables *iptables.IptablesConfigurator, podNs PodNetnsFinder) *NetServer {
 	return &NetServer{
 		ztunnelServer:      ztunnelServer,
 		currentPodSnapshot: podNsMap,

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -36,7 +36,7 @@ type NetServer struct {
 	podIptables        *iptables.IptablesConfigurator
 	podNs              PodNetnsFinder
 	// allow overriding for tests
-	netnsRunner        func(fdable NetnsFd, toRun func() error) error
+	netnsRunner func(fdable NetnsFd, toRun func() error) error
 }
 
 var _ MeshDataplane = &NetServer{}

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -20,15 +20,12 @@ import (
 	"fmt"
 	"net/netip"
 
-	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/cni/pkg/iptables"
-	"istio.io/istio/cni/pkg/util"
 	"istio.io/istio/pkg/slices"
-	"istio.io/istio/pkg/util/sets"
 	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
@@ -36,12 +33,10 @@ import (
 type NetServer struct {
 	ztunnelServer      ZtunnelServer
 	currentPodSnapshot *podNetnsCache
-	hostIptables       *iptables.IptablesConfigurator
 	podIptables        *iptables.IptablesConfigurator
 	podNs              PodNetnsFinder
 	// allow overriding for tests
 	netnsRunner        func(fdable NetnsFd, toRun func() error) error
-	hostsideProbeIPSet ipset.IPSet
 }
 
 var _ MeshDataplane = &NetServer{}
@@ -54,10 +49,8 @@ func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache,
 		ztunnelServer:      ztunnelServer,
 		currentPodSnapshot: podNsMap,
 		podNs:              podNs,
-		hostIptables:       hostIptables,
 		podIptables:        podIptables,
 		netnsRunner:        NetnsDo,
-		hostsideProbeIPSet: probeSet,
 	}
 }
 
@@ -67,14 +60,6 @@ func (s *NetServer) Start(ctx context.Context) {
 }
 
 func (s *NetServer) Stop() {
-	log.Debug("removing host iptables rules")
-	s.hostIptables.DeleteHostRules()
-
-	log.Debug("destroying host ipset")
-	s.hostsideProbeIPSet.Flush()
-	if err := s.hostsideProbeIPSet.DestroySet(); err != nil {
-		log.Warnf("could not destroy host ipset on shutdown")
-	}
 	log.Debug("stopping ztunnel server")
 	s.ztunnelServer.Close()
 }
@@ -176,11 +161,6 @@ func (s *NetServer) sendPodToZtunnelAndWaitForAck(ctx context.Context, pod *core
 func (s *NetServer) ConstructInitialSnapshot(ambientPods []*corev1.Pod) error {
 	var consErr []error
 
-	if err := s.syncHostIPSets(ambientPods); err != nil {
-		log.Warnf("failed to sync host IPset: %v", err)
-		consErr = append(consErr, err)
-	}
-
 	podsByUID := slices.GroupUnique(ambientPods, (*corev1.Pod).GetUID)
 	if err := s.buildZtunnelSnapshot(podsByUID); err != nil {
 		log.Warnf("failed to construct initial ztunnel snapshot: %v", err)
@@ -237,13 +217,6 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 	// Aggregate errors together, so that if part of the cleanup fails we still proceed with other steps.
 	var errs []error
 
-	// Remove the hostside ipset entry first, and unconditionally - if later failures happen, we never
-	// want to leave stale entries
-	if err := removePodFromHostNSIpset(pod, &s.hostsideProbeIPSet); err != nil {
-		log.Errorf("failed to remove pod %s from host ipset, error was: %v", pod.Name, err)
-		errs = append(errs, err)
-	}
-
 	// Whether pod is already deleted or not, we need to let go of our netns ref.
 	openNetns := s.currentPodSnapshot.Take(string(pod.UID))
 	if openNetns == nil {
@@ -269,99 +242,4 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
-}
-
-// syncHostIPSets is called after the host node ipset has been created (or found + flushed)
-// during initial snapshot creation, it will insert every snapshotted pod's IP into the set.
-//
-// The set does not allow dupes (obviously, that would be undefined) - but in the real world due to misconfigured
-// IPAM or other things, we may see two pods with the same IP on the same node - we will skip the dupes,
-// which is all we can do - these pods will fail healthcheck until the IPAM issue is resolved (which seems reasonable)
-func (s *NetServer) syncHostIPSets(ambientPods []*corev1.Pod) error {
-	var addedIPSnapshot []netip.Addr
-
-	for _, pod := range ambientPods {
-		podIPs := util.GetPodIPsIfPresent(pod)
-		if len(podIPs) == 0 {
-			log.Warnf("pod %s does not appear to have any assigned IPs, not syncing with ipset", pod.Name)
-		} else {
-			addedIps, err := s.AddPodToHostNSIpset(pod, podIPs)
-			if err != nil {
-				log.Errorf("pod %s has IP collision, pod will be skipped and will fail healthchecks", pod.Name, podIPs)
-			}
-			addedIPSnapshot = append(addedIPSnapshot, addedIps...)
-		}
-
-	}
-	return pruneHostIPset(sets.New(addedIPSnapshot...), &s.hostsideProbeIPSet)
-}
-
-// addPodToHostNSIpset:
-// 1. get pod manifest
-// 2. Get all pod ips (might be several, v6/v4)
-// 3. update ipsets accordingly
-// 4. return the ones we added successfully, and errors for any we couldn't (dupes)
-//
-// Dupe IPs should be considered an IPAM error and should never happen.
-func (s *NetServer) AddPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr) ([]netip.Addr, error) {
-	// Add the pod UID as an ipset entry comment, so we can (more) easily find and delete
-	// all relevant entries for a pod later.
-	podUID := string(pod.ObjectMeta.UID)
-	ipProto := uint8(unix.IPPROTO_TCP)
-
-	var ipsetAddrErrs []error
-	var addedIps []netip.Addr
-
-	// For each pod IP
-	for _, pip := range podIPs {
-		// Add to host ipset
-		log.Debugf("adding pod %s probe to ipset %s with ip %s", pod.Name, s.hostsideProbeIPSet.Prefix, pip)
-		// Add IP/port combo to set. Note that we set Replace to false here - we _did_ previously
-		// set it to true, but in theory that could mask weird scenarios where K8S triggers events out of order ->
-		// an add(sameIPreused) then delete(originalIP).
-		// Which will result in the new pod starting to fail healthchecks.
-		//
-		// Since we purge on restart of CNI, and remove pod IPs from the set on every pod removal/deletion,
-		// we _shouldn't_ get any overwrite/overlap, unless something is wrong and we are asked to add
-		// a pod by an IP we already have in the set (which will give an error, which we want).
-		if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, false); err != nil {
-			ipsetAddrErrs = append(ipsetAddrErrs, err)
-			log.Errorf("failed adding pod %s to ipset %s with ip %s, error was %s",
-				pod.Name, &s.hostsideProbeIPSet.Prefix, pip, err)
-		} else {
-			addedIps = append(addedIps, pip)
-		}
-	}
-
-	return addedIps, errors.Join(ipsetAddrErrs...)
-}
-
-func removePodFromHostNSIpset(pod *corev1.Pod, hostsideProbeSet *ipset.IPSet) error {
-	podIPs := util.GetPodIPsIfPresent(pod)
-	for _, pip := range podIPs {
-		if err := hostsideProbeSet.ClearEntriesWithIP(pip); err != nil {
-			return err
-		}
-		log.Debugf("removed pod name %s with UID %s from host ipset %s by ip %s", pod.Name, pod.UID, hostsideProbeSet.Prefix, pip)
-	}
-
-	return nil
-}
-
-func pruneHostIPset(expected sets.Set[netip.Addr], hostsideProbeSet *ipset.IPSet) error {
-	actualIPSetContents, err := hostsideProbeSet.ListEntriesByIP()
-	if err != nil {
-		log.Warnf("unable to list IPSet: %v", err)
-		return err
-	}
-	actual := sets.New[netip.Addr](actualIPSetContents...)
-	stales := actual.DifferenceInPlace(expected)
-
-	for staleIP := range stales {
-		if err := hostsideProbeSet.ClearEntriesWithIP(staleIP); err != nil {
-			return err
-		}
-		log.Debugf("removed stale ip %s from host ipset %s", staleIP, hostsideProbeSet.Prefix)
-	}
-	return nil
 }

--- a/cni/pkg/nodeagent/net_test.go
+++ b/cni/pkg/nodeagent/net_test.go
@@ -55,14 +55,18 @@ type netTestFixture struct {
 }
 
 func getTestFixure(ctx context.Context) netTestFixture {
+	fakeIPSetDeps := ipset.FakeNLDeps()
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
+	return getTestFixureWithIPSet(ctx, set, fakeIPSetDeps)
+}
+
+func getTestFixureWithIPSet(ctx context.Context, set ipset.IPSet, fakeIPSetDeps *ipset.MockedIpsetDeps) netTestFixture {
 	podNsMap := newPodNetnsCache(openNsTestOverride)
 	nlDeps := &fakeIptablesDeps{}
 	iptablesConfigurator, _, _ := iptables.NewIptablesConfigurator(nil, &dependencies.DependenciesStub{}, &dependencies.DependenciesStub{}, nlDeps)
 
 	ztunnelServer := &fakeZtunnel{}
 
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 	netServer := newNetServer(ztunnelServer, podNsMap, iptablesConfigurator, iptablesConfigurator, NewPodNetnsProcFinder(fakeFs()), set)
 
 	netServer.netnsRunner = func(fdable NetnsFd, toRun func() error) error {
@@ -181,7 +185,6 @@ func TestServerRemovePod(t *testing.T) {
 		Netns:    fakens,
 	}
 
-	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
 	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
 	err := netServer.RemovePodFromMesh(ctx, pod, false)
 	assert.NoError(t, err)
@@ -225,7 +228,6 @@ func TestServerRemovePodAlwaysRemovesIPSetEntryEvenOnFail(t *testing.T) {
 		Workload: podToWorkload(pod),
 		Netns:    fakens,
 	}
-	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
 	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
 	err := netServer.RemovePodFromMesh(ctx, pod, false)
 	assert.Error(t, err)
@@ -269,7 +271,6 @@ func TestServerDeletePod(t *testing.T) {
 		Netns:    fakens,
 	}
 	fixture.podNsMap.UpsertPodCacheWithNetns(string(pod.UID), workload)
-	expectPodRemovedFromIPSet(fixture.ipsetDeps, pod.Status.PodIPs)
 	err := netServer.RemovePodFromMesh(ctx, pod, true)
 	assert.NoError(t, err)
 	assert.Equal(t, ztunnelServer.deletedPods.Load(), 1)
@@ -280,31 +281,11 @@ func TestServerDeletePod(t *testing.T) {
 	// make sure the uid was taken from cache and netns closed
 	netns := fixture.podNsMap.Take(string(pod.UID))
 	assert.Equal(t, nil, netns)
-	fixture.ipsetDeps.AssertExpectations(t)
 	// run gc to clean up ns:
 
 	//revive:disable-next-line:call-to-gc Just a test that we are cleaning up the netns
 	runtime.GC()
 	assertNSClosed(t, closed)
-}
-
-func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIP netip.Addr, podMeta metav1.ObjectMeta) {
-	ipsetDeps.On("addIP",
-		"foo-v4",
-		podIP,
-		uint8(unix.IPPROTO_TCP),
-		string(podMeta.UID),
-		false,
-	).Return(nil)
-}
-
-func expectPodRemovedFromIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIPs []corev1.PodIP) {
-	for _, ip := range podIPs {
-		ipsetDeps.On("clearEntriesWithIP",
-			"foo-v4",
-			netip.MustParseAddr(ip.IP),
-		).Return(nil)
-	}
 }
 
 func TestServerAddPodWithNoNetns(t *testing.T) {
@@ -406,323 +387,6 @@ func TestConstructInitialSnap(t *testing.T) {
 	if fixture.podNsMap.Get("863b91d4-4b68-4efa-917f-4b560e3e86aa") == nil {
 		t.Fatal("expected pod to be in cache")
 	}
-}
-
-func TestAddPodToHostNSIPSets(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
-	ipProto := uint8(unix.IPPROTO_TCP)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("99.9.9.9"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
-	_, err := addPodToHostNSIpset(pod, podIPs, &set)
-	assert.NoError(t, err)
-
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestAddPodToHostNSIPSetsV6(t *testing.T) {
-	pod := buildConvincingPod(true)
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", V6Name: "foo-v6", Prefix: "foo", Deps: fakeIPSetDeps}
-	ipProto := uint8(unix.IPPROTO_TCP)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v6",
-		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v6",
-		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")}
-	_, err := addPodToHostNSIpset(pod, podIPs, &set)
-	assert.NoError(t, err)
-
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestAddPodToHostNSIPSetsDualstack(t *testing.T) {
-	pod := buildConvincingPod(true)
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", V6Name: "foo-v6", Prefix: "foo", Deps: fakeIPSetDeps}
-	ipProto := uint8(unix.IPPROTO_TCP)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v6",
-		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("99.9.9.9"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("99.9.9.9")}
-	_, err := addPodToHostNSIpset(pod, podIPs, &set)
-	assert.NoError(t, err)
-
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestAddPodIPToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
-	ipProto := uint8(unix.IPPROTO_TCP)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("99.9.9.9"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fakeIPSetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		podUID,
-		false,
-	).Return(errors.New("bwoah"))
-
-	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
-
-	addedPIPs, err := addPodToHostNSIpset(pod, podIPs, &set)
-	assert.Error(t, err)
-	assert.Equal(t, 1, len(addedPIPs), "only expected one IP to be added")
-
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestRemovePodIPFromHostNSIPSets(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	fakeIPSetDeps := ipset.FakeNLDeps()
-	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
-
-	fakeIPSetDeps.On("clearEntriesWithIP",
-		"foo-v4",
-		netip.MustParseAddr("3.3.3.3"),
-	).Return(nil)
-
-	fakeIPSetDeps.On("clearEntriesWithIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-	).Return(nil)
-
-	err := removePodFromHostNSIpset(pod, &set)
-	assert.NoError(t, err)
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	fakeIPSetDeps := ipset.FakeNLDeps()
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	ipProto := uint8(unix.IPPROTO_TCP)
-	ctx, cancel := context.WithCancel(context.Background())
-	fixture := getTestFixure(ctx)
-	defer cancel()
-	setupLogging()
-
-	// expectations
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("3.3.3.3"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{}, nil)
-
-	netServer := fixture.netServer
-	err := netServer.syncHostIPSets([]*corev1.Pod{pod})
-	assert.NoError(t, err)
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestSyncHostIPSetsIgnoresPodIPAddErrorAndContinues(t *testing.T) {
-	pod1 := buildConvincingPod(false)
-	pod2 := buildConvincingPod(false)
-
-	pod2.ObjectMeta.SetUID("4455")
-
-	fakeIPSetDeps := ipset.FakeNLDeps()
-
-	var pod1UID string = string(pod1.ObjectMeta.UID)
-	var pod2UID string = string(pod2.ObjectMeta.UID)
-	ipProto := uint8(unix.IPPROTO_TCP)
-	ctx, cancel := context.WithCancel(context.Background())
-	fixture := getTestFixure(ctx)
-	defer cancel()
-	setupLogging()
-
-	// First IP of first pod should error, but we should add the rest
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("3.3.3.3"),
-		ipProto,
-		pod1UID,
-		false,
-	).Return(errors.New("CANNOT ADD"))
-
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		pod1UID,
-		false,
-	).Return(nil)
-
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("3.3.3.3"),
-		ipProto,
-		pod2UID,
-		false,
-	).Return(errors.New("CANNOT ADD"))
-
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		pod2UID,
-		false,
-	).Return(nil)
-
-	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{}, nil)
-
-	netServer := fixture.netServer
-	err := netServer.syncHostIPSets([]*corev1.Pod{pod1, pod2})
-	assert.NoError(t, err)
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestSyncHostIPSetsAddsNothingIfPodHasNoIPs(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	pod.Status.PodIP = ""
-	pod.Status.PodIPs = []corev1.PodIP{}
-
-	fakeIPSetDeps := ipset.FakeNLDeps()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	fixture := getTestFixure(ctx)
-	defer cancel()
-	setupLogging()
-
-	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{}, nil)
-
-	netServer := fixture.netServer
-	err := netServer.syncHostIPSets([]*corev1.Pod{pod})
-	assert.NoError(t, err)
-	fakeIPSetDeps.AssertExpectations(t)
-}
-
-func TestSyncHostIPSetsPrunesIfExtras(t *testing.T) {
-	pod := buildConvincingPod(false)
-
-	fakeIPSetDeps := ipset.FakeNLDeps()
-
-	var podUID string = string(pod.ObjectMeta.UID)
-	ipProto := uint8(unix.IPPROTO_TCP)
-	ctx, cancel := context.WithCancel(context.Background())
-	fixture := getTestFixure(ctx)
-	defer cancel()
-	setupLogging()
-
-	// expectations
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("3.3.3.3"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	fixture.ipsetDeps.On("addIP",
-		"foo-v4",
-		netip.MustParseAddr("2.2.2.2"),
-		ipProto,
-		podUID,
-		false,
-	).Return(nil)
-
-	// List should return one IP not in our "pod snapshot", which means we prune
-	fixture.ipsetDeps.On("listEntriesByIP",
-		"foo-v4",
-	).Return([]netip.Addr{
-		netip.MustParseAddr("2.2.2.2"),
-		netip.MustParseAddr("6.6.6.6"),
-		netip.MustParseAddr("3.3.3.3"),
-	}, nil)
-
-	fixture.ipsetDeps.On("clearEntriesWithIP",
-		"foo-v4",
-		netip.MustParseAddr("6.6.6.6"),
-	).Return(nil)
-
-	netServer := fixture.netServer
-	err := netServer.syncHostIPSets([]*corev1.Pod{pod})
-	assert.NoError(t, err)
-	fakeIPSetDeps.AssertExpectations(t)
 }
 
 // for tests that call `runtime.GC()` - we have no control over when the GC is actually scheduled,

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -100,7 +100,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 	}
 
 	podNetns := NewPodNetnsProcFinder(os.DirFS(filepath.Join(pconstants.HostMountsPath, "proc")))
-	netServer := newNetServer(ztunnelServer, podNsMap, hostIptables, podIptables, podNetns, set)
+	netServer := newNetServer(ztunnelServer, podNsMap, podIptables, podNetns)
 
 	// Set some defaults
 	s := &Server{
@@ -216,7 +216,6 @@ func (s *meshDataplane) Stop() {
 }
 
 func (s *meshDataplane) ConstructInitialSnapshot(ambientPods []*corev1.Pod) error {
-
 	if err := s.syncHostIPSets(ambientPods); err != nil {
 		log.Errorf("failed to sync host IPset: %v", err)
 		return err

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -108,8 +108,8 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 		kubeClient: client,
 		isReady:    ready,
 		dataplane: &meshDataplane{
-			kubeClient: client.Kube(),
-			netServer:  netServer,
+			kubeClient:         client.Kube(),
+			netServer:          netServer,
 			hostIptables:       hostIptables,
 			hostsideProbeIPSet: set,
 		},
@@ -190,8 +190,8 @@ func (s *Server) Stop() {
 }
 
 type meshDataplane struct {
-	kubeClient kubernetes.Interface
-	netServer  MeshDataplane
+	kubeClient         kubernetes.Interface
+	netServer          MeshDataplane
 	hostIptables       *iptables.IptablesConfigurator
 	hostsideProbeIPSet ipset.IPSet
 }

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -247,7 +247,8 @@ func (s *meshDataplane) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIP
 	// and the operator can investigate.
 	//
 	// This is also important to avoid ipset sync issues if we add the pod ip to the ipset, but
-	// enrolling fails, and the pod is rescheduled with a new IP. In that case we don't get
+	// enrolling fails because ztunnel (or the pod netns, or whatever) isn't ready yet,
+	// and the pod is rescheduled with a new IP. In that case we don't get
 	// a removal event, and so would never clean up the old IP that we eagerly-added.
 	//
 	// TODO one place this *can* fail is

--- a/cni/pkg/nodeagent/server_test.go
+++ b/cni/pkg/nodeagent/server_test.go
@@ -24,15 +24,15 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/sys/unix"
-	"istio.io/istio/cni/pkg/ipset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"istio.io/istio/cni/pkg/ipset"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/util/assert"
-	"k8s.io/client-go/kubernetes"
 )
 
 func TestMeshDataplaneAddsAnnotationOnAdd(t *testing.T) {
@@ -315,7 +315,7 @@ func TestMeshDataplaneAddPodToHostNSIPSets(t *testing.T) {
 }
 
 func TestMeshDataplaneAddPodToHostNSIPSetsV6(t *testing.T) {
-	pod := buildConvincingPod(false)
+	pod := buildConvincingPod(true)
 
 	fakeCtx := context.Background()
 	server := &fakeServer{}
@@ -331,7 +331,7 @@ func TestMeshDataplaneAddPodToHostNSIPSetsV6(t *testing.T) {
 
 	fakeIPSetDeps.On("addIP",
 		"foo-v6",
-		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
+		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"),
 		ipProto,
 		podUID,
 		false,
@@ -339,13 +339,13 @@ func TestMeshDataplaneAddPodToHostNSIPSetsV6(t *testing.T) {
 
 	fakeIPSetDeps.On("addIP",
 		"foo-v6",
-		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"),
+		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3165"),
 		ipProto,
 		podUID,
 		false,
 	).Return(nil)
 
-	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164")}
+	podIPs := []netip.Addr{netip.MustParseAddr(pod.Status.PodIPs[0].IP), netip.MustParseAddr(pod.Status.PodIPs[1].IP)}
 	_, err := m.addPodToHostNSIpset(pod, podIPs)
 	assert.NoError(t, err)
 

--- a/releasenotes/notes/52320.yaml
+++ b/releasenotes/notes/52320.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 52218
+releaseNotes:
+- |
+  **Fixed** Do not add pod to ipset if we have a partial failure adding to the dataplane.


### PR DESCRIPTION
**Please provide a description of this PR:**

Should fix: https://github.com/istio/istio/issues/52218 (@howardjohn repro'd locally)

Basically, when we "add" a pod to the mesh, there are several things that (in order) can fail.

1. We can fail to get the pod netns.
2. We can fail to inject iptables
3. We can fail to talk to ztunnel
4. We can fail to annotate the pod (which officially indicates to the Istio CP that the pod is "in  ambient")
5. We can fail to add the pod to the hostipset, so health checks begin working for that pod

For _anything_ after No. 2, we return a PartialError - Before that point failures don't have side effects really - but once we step into the netns and mutate the pod netrules, we have changed the app pod state and (potentially) must unhook at least something before the pod can be considered "healthy" again - which is why we have "special" kind of error for those cases.

Basically, before, we were adding the pod IPs to the ipset at the start of all that - so that if anything later on failed, and k8s restarted the pod with a new IP without issuing us any delete event, we would lose track of that original IP and never be able to clean it up - which would cause later collisions (maybe/eventually).

This is effectively the invert of https://github.com/istio/istio/pull/51796, which moved ipset ip removal to the start of the `PodRemove` action to avoid a similar problem on the other end - I should have fixed it in both spots at that time but it wasn't clear to me we could have this kind of ordering error on the `PodAdd` side as well.

With this fix we are strictly _not_ adding the pod IP to the ipset until the very end of the `add` operation and following the above order exactly, so that if we fail to add at any point (ztunnel isn't ready or something) we don't stick a stale IP entry in - your pod only ends up health-checkable IF we were able to add it with no errors at all, otherwise it will be (permanently) unhealthy and not be added to the `ipset` for healthchecks.

Note the TODO - today we are the last CNI plugin in the chain, as a matter of explicit configuration, for several reasons. If that ever changes and we are not the last plugin, we could very well hit this problem again if a 3rd-party plugin _after_ ours failed during `CmdAdd` for some reason, and we would not know to clean up the ipset for the failed pod - to fix this fully we'd need to implement `CmdDelete` support and maintain our own internal ip-netns-uid map for context, and maybe use `ipset swap` or similar to update the whole ipset every time with an internally-tracked snapshot.

That isn't current state tho, and we'd have to make other changes if we wanted to account for being the non-final plugin anyway.

---
Mostly, the changes involve moving all `hostside` stuff (ipset, host iptables rules) out of the `net.go` dataplane component where they were before, and into the `server.go` component. This makes the logical separation a little bit more obvious, and actually makes testing this scenario properly easier. Test code needed to be moved around to accommodate, but no tests were dropped - most just moved, and a few extra checks added to existing ones to ensure ADD errors do not result in the ipset being updated.