### PR TITLE
Improve multi-addrs handling in test functions

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1800,14 +1800,6 @@ func TestController_ExternalNameService(t *testing.T) {
 	}
 }
 
-func createEndpointsWait(t *testing.T, controller *FakeController, name, namespace string,
-	portNames, ips []string, refs []*corev1.ObjectReference, labels map[string]string,
-) {
-	t.Helper()
-	createEndpoints(t, controller, name, namespace, portNames, ips, refs, labels)
-	controller.opts.XDSUpdater.(*xdsfake.Updater).WaitOrFail(t, "eds")
-}
-
 func createEndpoints(t *testing.T, controller *FakeController, name, namespace string,
 	portNames, ips []string, refs []*corev1.ObjectReference, labels map[string]string,
 ) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -53,6 +53,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
@@ -172,9 +173,9 @@ func makeService(n, ns string, cl *FakeController, t *testing.T) {
 }
 
 func TestController_GetPodLocality(t *testing.T) {
-	pod1 := generatePod("128.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-	pod2 := generatePod("128.0.1.2", "pod2", "nsB", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
-	podOverride := generatePod("128.0.1.2", "pod2", "nsB", "",
+	pod1 := generatePod([]string{"128.0.1.1"}, "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod2 := generatePod([]string{"128.0.1.2"}, "pod2", "nsB", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
+	podOverride := generatePod([]string{"128.0.1.2"}, "pod2", "nsB", "",
 		"node1", map[string]string{"app": "prod-app", model.LocalityLabel: "regionOverride.zoneOverride.subzoneOverride"}, map[string]string{})
 	testCases := []struct {
 		name   string
@@ -304,7 +305,7 @@ func TestProxyK8sHostnameLabel(t *testing.T) {
 		ClusterID: clusterID,
 	})
 
-	pod := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
+	pod := generatePod([]string{"128.0.0.1"}, "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	addPods(t, controller, fx, pod)
 
 	proxy := &model.Proxy{
@@ -329,13 +330,13 @@ func TestGetProxyServiceTargets(t *testing.T) {
 	// add a network ID to test endpoints include topology.istio.io/network label
 	controller.network = networkID
 
-	p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
+	p := generatePod([]string{"128.0.0.1"}, "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	addPods(t, controller, fx, p)
 
 	k8sSaOnVM := "acct4"
 	canonicalSaOnVM := "acctvm2@gserviceaccount2.com"
 
-	createServiceWait(controller, "svc1", "nsa", nil,
+	createServiceWait(controller, "svc1", "nsa", []string{"10.0.0.1", "10.0.0.2"}, nil,
 		map[string]string{
 			annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
 			annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM,
@@ -353,7 +354,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 	fakeSvcCounts := 100
 	for i := 0; i < fakeSvcCounts; i++ {
 		svcName := fmt.Sprintf("svc-fake-%d", i)
-		createServiceWait(controller, svcName, "nsfake", nil,
+		createServiceWait(controller, svcName, "nsfake", []string{"10.0.0.1", "10.0.0.2"}, nil,
 			map[string]string{
 				annotation.AlphaKubernetesServiceAccounts.Name: k8sSaOnVM,
 				annotation.AlphaCanonicalServiceAccounts.Name:  canonicalSaOnVM,
@@ -446,7 +447,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 	addNodes(t, controller, node)
 
 	// 1. pod without `istio-locality` label, get locality from node label.
-	p = generatePod("129.0.0.1", "pod2", "nsa", "svcaccount", "node1",
+	p = generatePod([]string{"129.0.0.1"}, "pod2", "nsa", "svcaccount", "node1",
 		map[string]string{"app": "prod-app"}, nil)
 	addPods(t, controller, fx, p)
 
@@ -500,7 +501,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 	}
 
 	// 2. pod with `istio-locality` label, ignore node label.
-	p = generatePod("129.0.0.2", "pod3", "nsa", "svcaccount", "node1",
+	p = generatePod([]string{"129.0.0.2"}, "pod3", "nsa", "svcaccount", "node1",
 		map[string]string{"app": "prod-app", "istio-locality": "region.zone"}, nil)
 	addPods(t, controller, fx, p)
 
@@ -553,7 +554,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 	}
 
 	// pod with no services should return no service targets
-	p = generatePod("130.0.0.1", "pod4", "nsa", "foo", "node1", map[string]string{"app": "no-service-app"}, map[string]string{})
+	p = generatePod([]string{"130.0.0.1"}, "pod4", "nsa", "foo", "node1", map[string]string{"app": "no-service-app"}, map[string]string{})
 	addPods(t, controller, fx, p)
 
 	podServices = controller.GetProxyServiceTargets(&model.Proxy{
@@ -578,7 +579,7 @@ func TestGetProxyServiceTargets(t *testing.T) {
 }
 
 func TestGetProxyServiceTargetsWithMultiIPsAndTargetPorts(t *testing.T) {
-	pod1 := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
+	pod1 := generatePod([]string{"128.0.0.1"}, "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
 	testCases := []struct {
 		name      string
 		pods      []*corev1.Pod
@@ -822,7 +823,7 @@ func TestGetProxyServiceTargetsWithMultiIPsAndTargetPorts(t *testing.T) {
 func TestGetProxyServiceTargets_WorkloadInstance(t *testing.T) {
 	ctl, _ := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 
-	createServiceWait(ctl, "ratings", "bookinfo-ratings",
+	createServiceWait(ctl, "ratings", "bookinfo-ratings", []string{"10.0.0.1"},
 		map[string]string{},
 		map[string]string{
 			annotation.AlphaKubernetesServiceAccounts.Name: "ratings",
@@ -830,7 +831,7 @@ func TestGetProxyServiceTargets_WorkloadInstance(t *testing.T) {
 		},
 		[]int32{8080}, map[string]string{"app": "ratings"}, t)
 
-	createServiceWait(ctl, "details", "bookinfo-details",
+	createServiceWait(ctl, "details", "bookinfo-details", []string{"10.0.0.2"},
 		map[string]string{},
 		map[string]string{
 			annotation.AlphaKubernetesServiceAccounts.Name: "details",
@@ -838,7 +839,7 @@ func TestGetProxyServiceTargets_WorkloadInstance(t *testing.T) {
 		},
 		[]int32{9090}, map[string]string{"app": "details"}, t)
 
-	createServiceWait(ctl, "reviews", "bookinfo-reviews",
+	createServiceWait(ctl, "reviews", "bookinfo-reviews", []string{"10.0.0.3"},
 		map[string]string{},
 		map[string]string{
 			annotation.AlphaKubernetesServiceAccounts.Name: "reviews",
@@ -1033,16 +1034,16 @@ func TestController_Service(t *testing.T) {
 
 	// Use a timeout to keep the test from hanging.
 
-	createServiceWait(controller, "svc1", "nsA",
+	createServiceWait(controller, "svc1", "nsA", []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
-	createServiceWait(controller, "svc2", "nsA",
+	createServiceWait(controller, "svc2", "nsA", []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
-	createServiceWait(controller, "svc3", "nsA",
+	createServiceWait(controller, "svc3", "nsA", []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
-	createServiceWait(controller, "svc4", "nsA",
+	createServiceWait(controller, "svc4", "nsA", []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
 
@@ -1174,17 +1175,17 @@ func TestController_ServiceWithFixedDiscoveryNamespaces(t *testing.T) {
 	createNamespace(t, controller.client.Kube(), nsB, map[string]string{})
 
 	// service event handlers should trigger for svc1 and svc2
-	createServiceWait(controller, "svc1", nsA,
+	createServiceWait(controller, "svc1", nsA, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
-	createServiceWait(controller, "svc2", nsA,
+	createServiceWait(controller, "svc2", nsA, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
 	// service event handlers should not trigger for svc3 and svc4
-	createService(controller, "svc3", nsB,
+	createService(controller, "svc3", nsB, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
-	createService(controller, "svc4", nsB,
+	createService(controller, "svc4", nsB, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
 
@@ -1304,16 +1305,16 @@ func TestController_ServiceWithChangingDiscoveryNamespaces(t *testing.T) {
 	})
 
 	// service event handlers should trigger for all svcs
-	createServiceWait(controller, "svc1", nsA,
+	createServiceWait(controller, "svc1", nsA, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
-	createServiceWait(controller, "svc2", nsA,
+	createServiceWait(controller, "svc2", nsA, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
-	createServiceWait(controller, "svc3", nsB,
+	createServiceWait(controller, "svc3", nsB, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
-	createServiceWait(controller, "svc4", nsC,
+	createServiceWait(controller, "svc4", nsC, []string{"10.0.0.1"},
 		map[string]string{}, map[string]string{},
 		[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
 
@@ -1408,7 +1409,7 @@ func TestControllerResourceScoping(t *testing.T) {
 	}
 	svc2 := &model.Service{
 		Hostname:       kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix),
-		DefaultAddress: "10.0.0.1",
+		DefaultAddress: "10.0.0.2",
 		Ports: model.PortList{
 			&model.Port{
 				Name:     "tcp-port",
@@ -1419,7 +1420,7 @@ func TestControllerResourceScoping(t *testing.T) {
 	}
 	svc3 := &model.Service{
 		Hostname:       kube.ServiceHostname("svc3", "nsB", defaultFakeDomainSuffix),
-		DefaultAddress: "10.0.0.1",
+		DefaultAddress: "10.0.0.3",
 		Ports: model.PortList{
 			&model.Port{
 				Name:     "tcp-port",
@@ -1430,7 +1431,7 @@ func TestControllerResourceScoping(t *testing.T) {
 	}
 	svc4 := &model.Service{
 		Hostname:       kube.ServiceHostname("svc4", "nsC", defaultFakeDomainSuffix),
-		DefaultAddress: "10.0.0.1",
+		DefaultAddress: "10.0.0.4",
 		Ports: model.PortList{
 			&model.Port{
 				Name:     "tcp-port",
@@ -1483,22 +1484,22 @@ func TestControllerResourceScoping(t *testing.T) {
 	})
 
 	// service event handlers should trigger for all svcs
-	createServiceWait(controller, "svc1", nsA,
+	createServiceWait(controller, "svc1", nsA, []string{"10.0.0.1"},
 		map[string]string{},
 		map[string]string{},
 		[]int32{8080}, map[string]string{"test-app": "test-app-1"}, t)
 
-	createServiceWait(controller, "svc2", nsA,
+	createServiceWait(controller, "svc2", nsA, []string{"10.0.0.2"},
 		map[string]string{},
 		map[string]string{},
 		[]int32{8081}, map[string]string{"test-app": "test-app-2"}, t)
 
-	createServiceWait(controller, "svc3", nsB,
+	createServiceWait(controller, "svc3", nsB, []string{"10.0.0.3"},
 		map[string]string{},
 		map[string]string{},
 		[]int32{8082}, map[string]string{"test-app": "test-app-3"}, t)
 
-	createServiceWait(controller, "svc4", nsC,
+	createServiceWait(controller, "svc4", nsC, []string{"10.0.0.4"},
 		map[string]string{},
 		map[string]string{},
 		[]int32{8083}, map[string]string{"test-app": "test-app-4"}, t)
@@ -1799,6 +1800,14 @@ func TestController_ExternalNameService(t *testing.T) {
 	}
 }
 
+func createEndpointsWait(t *testing.T, controller *FakeController, name, namespace string,
+	portNames, ips []string, refs []*corev1.ObjectReference, labels map[string]string,
+) {
+	t.Helper()
+	createEndpoints(t, controller, name, namespace, portNames, ips, refs, labels)
+	controller.opts.XDSUpdater.(*xdsfake.Updater).WaitOrFail(t, "eds")
+}
+
 func createEndpoints(t *testing.T, controller *FakeController, name, namespace string,
 	portNames, ips []string, refs []*corev1.ObjectReference, labels map[string]string,
 ) {
@@ -1934,18 +1943,18 @@ func createServiceWithTargetPorts(controller *FakeController, name, namespace st
 	controller.opts.XDSUpdater.(*xdsfake.Updater).WaitOrFail(t, "service")
 }
 
-func createServiceWait(controller *FakeController, name, namespace string, labels, annotations map[string]string,
+func createServiceWait(controller *FakeController, name, namespace string, ips []string, labels, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T,
 ) {
 	t.Helper()
-	createService(controller, name, namespace, labels, annotations, ports, selector, t)
+	createService(controller, name, namespace, ips, labels, annotations, ports, selector, t)
 	controller.opts.XDSUpdater.(*xdsfake.Updater).WaitOrFail(t, "service")
 }
 
-func createService(controller *FakeController, name, namespace string, labels, annotations map[string]string,
+func createService(controller *FakeController, name, namespace string, ips []string, labels, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T,
 ) {
-	service := generateService(name, namespace, labels, annotations, ports, selector, []string{"10.0.0.1", "10.0.0.2"})
+	service := generateService(name, namespace, labels, annotations, ports, selector, ips)
 	clienttest.Wrap(t, controller.services).CreateOrUpdate(service)
 }
 
@@ -2119,8 +2128,11 @@ func setPodReady(pod *corev1.Pod) {
 	}
 }
 
-func generatePod(ip, name, namespace, saName, node string, labels map[string]string, annotations map[string]string) *corev1.Pod {
+func generatePod(ips []string, name, namespace, saName, node string, labels map[string]string, annotations map[string]string) *corev1.Pod {
 	automount := false
+	coreIPs := slices.Map(ips, func(ip string) corev1.PodIP {
+		return corev1.PodIP{IP: ip}
+	})
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -2149,14 +2161,10 @@ func generatePod(ip, name, namespace, saName, node string, labels map[string]str
 					LastTransitionTime: metav1.Now(),
 				},
 			},
-			PodIP:  ip,
-			HostIP: ip,
-			PodIPs: []corev1.PodIP{
-				{
-					IP: ip,
-				},
-			},
-			Phase: corev1.PodRunning,
+			PodIP:  ips[0],
+			HostIP: ips[0],
+			PodIPs: coreIPs,
+			Phase:  corev1.PodRunning,
 		},
 	}
 }
@@ -2184,12 +2192,12 @@ func addNodes(t *testing.T, controller *FakeController, nodes ...*corev1.Node) {
 func TestEndpointUpdate(t *testing.T) {
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 
-	pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod1 := generatePod([]string{"128.0.0.1"}, "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 	pods := []*corev1.Pod{pod1}
 	addPods(t, controller, fx, pods...)
 
 	// 1. incremental eds for normal service endpoint update
-	createServiceWait(controller, "svc1", "nsa", nil, nil,
+	createServiceWait(controller, "svc1", "nsa", []string{"10.0.0.1"}, nil, nil,
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 
 	// Endpoints are generated by Kubernetes from pod labels and service selectors.
@@ -2225,7 +2233,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}))
 	// Setup help functions to make the test more explicit
 	addPod := func(name, ip string) {
-		pod := generatePod(ip, name, "nsA", name, "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+		pod := generatePod([]string{ip}, name, "nsA", name, "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 		addPods(t, controller, fx, pod)
 	}
 	deletePod := func(name, ip string) {
@@ -2243,7 +2251,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	}
 	addService := func(name string) {
 		// create service
-		createServiceWait(controller, name, "nsA", nil, nil,
+		createServiceWait(controller, name, "nsA", []string{"10.0.0.1"}, nil, nil,
 			[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	}
 	addEndpoint := func(svcName string, ips []string, pods []string) {
@@ -2365,15 +2373,15 @@ func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 
 	// Create an initial pod with a service, and endpoint.
-	pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-	pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod1 := generatePod([]string{"172.0.1.1"}, "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod2 := generatePod([]string{"172.0.1.2"}, "pod2", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 	pods := []*corev1.Pod{pod1, pod2}
 	nodes := []*corev1.Node{
 		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}),
 	}
 	addNodes(t, controller, nodes...)
 	addPods(t, controller, fx, pods...)
-	createServiceWait(controller, "svc1", "nsA", nil, nil,
+	createServiceWait(controller, "svc1", "nsA", []string{"10.0.0.1"}, nil, nil,
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	pod1Ips := []string{"172.0.1.1"}
 	portNames := []string{"tcp-port"}
@@ -2529,15 +2537,15 @@ func TestUpdateEdsCacheOnServiceUpdate(t *testing.T) {
 	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
 
 	// Create an initial pod with a service, and endpoint.
-	pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-	pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod1 := generatePod([]string{"172.0.1.1"}, "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+	pod2 := generatePod([]string{"172.0.1.2"}, "pod2", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 	pods := []*corev1.Pod{pod1, pod2}
 	nodes := []*corev1.Node{
 		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}),
 	}
 	addNodes(t, controller, nodes...)
 	addPods(t, controller, fx, pods...)
-	createServiceWait(controller, "svc1", "nsA", nil, nil,
+	createServiceWait(controller, "svc1", "nsA", []string{"10.0.0.1"}, nil, nil,
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 
 	pod1Ips := []string{"172.0.1.1"}

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice_test.go
@@ -15,7 +15,6 @@
 package controller
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -80,75 +79,6 @@ func TestEndpointSliceFromMCSShouldBeIgnored(t *testing.T) {
 	// Ensure that no endpoint is create
 	endpoints := GetEndpoints(svc, controller.Endpoints)
 	assert.Equal(t, len(endpoints), 0)
-}
-
-func TestEndpointFromSlice(t *testing.T) {
-	const (
-		ns      = "nsa"
-		svcName = "svc1"
-		appName = "prod-app"
-	)
-
-	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
-
-	addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}))
-
-	pods := []*corev1.Pod{generatePod([]string{"128.0.0.1"}, "pod1", ns, "svcaccount", "node1",
-		map[string]string{"app": appName}, map[string]string{})}
-	addPods(t, controller, fx, pods...)
-
-	createServiceWait(controller, svcName, ns, []string{"10.0.0.1"}, nil, nil,
-		[]int32{8080}, map[string]string{"app": appName}, t)
-
-	// Ensure that the service is available.
-	hostname := kube.ServiceHostname(svcName, ns, controller.opts.DomainSuffix)
-	svc := controller.GetService(hostname)
-	if svc == nil {
-		t.Fatal("failed to get service")
-	}
-
-	svc1Ips := []string{"128.0.0.1"}
-	portNames := []string{"tcp-port"}
-	createEndpointsWait(t, controller, svcName, ns, portNames, svc1Ips, nil, nil)
-
-	// Ensure that no endpoint is create
-	endpoints := GetEndpoints(svc, controller.Endpoints)
-	assert.Equal(t, len(endpoints), 1)
-}
-
-func TestEndpointFromSliceWithMultipleAddrs(t *testing.T) {
-	const (
-		ns      = "nsa"
-		svcName = "svc1"
-		appName = "prod-app"
-	)
-
-	controller, fx := NewFakeControllerWithOptions(t, FakeControllerOptions{})
-
-	addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", label.TopologySubzone.Name: "subzone1"}))
-
-	pods := []*corev1.Pod{generatePod([]string{"128.0.0.1", "2001:1:2:3:4:5:6:7"}, "pod1", ns, "svcaccount", "node1",
-		map[string]string{"app": appName}, map[string]string{})}
-	addPods(t, controller, fx, pods...)
-
-	createServiceWait(controller, svcName, ns, []string{"10.0.0.1", "2001:1:2:3:4:5:6:7"}, nil, nil,
-		[]int32{8080}, map[string]string{"app": appName}, t)
-
-	// Ensure that the service is available.
-	hostname := kube.ServiceHostname(svcName, ns, controller.opts.DomainSuffix)
-	svc := controller.GetService(hostname)
-	if svc == nil {
-		t.Fatal("failed to get service")
-	}
-
-	svc1Ips := []string{"128.0.0.1", "2001:1:2:3:4:5:6:7"}
-	portNames := []string{"tcp-port"}
-	createEndpointsWait(t, controller, svcName, ns, portNames, svc1Ips, nil, nil)
-
-	// Ensure that no endpoint is create
-	endpoints := GetEndpoints(svc, controller.Endpoints)
-	fmt.Printf("%+v", endpoints[0])
-	assert.Equal(t, len(endpoints), 2)
 }
 
 func TestEndpointSliceCache(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/network_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network_test.go
@@ -280,11 +280,11 @@ func TestAmbientSystemNamespaceNetworkChange(t *testing.T) {
 
 	pc := clienttest.NewWriter[*corev1.Pod](t, s.client)
 	sc := clienttest.NewWriter[*corev1.Service](t, s.client)
-	pod1 := generatePod("127.0.0.1", "pod1", testNS, "sa1", "node1", map[string]string{"app": "a"}, nil)
+	pod1 := generatePod([]string{"127.0.0.1"}, "pod1", testNS, "sa1", "node1", map[string]string{"app": "a"}, nil)
 	pc.CreateOrUpdateStatus(pod1)
 	fx.WaitOrFail(t, "xds")
 
-	pod2 := generatePod("127.0.0.2", "pod2", testNS, "sa2", "node1", map[string]string{"app": "a"}, nil)
+	pod2 := generatePod([]string{"127.0.0.2"}, "pod2", testNS, "sa2", "node1", map[string]string{"app": "a"}, nil)
 	pc.CreateOrUpdateStatus(pod2)
 	fx.WaitOrFail(t, "xds")
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -113,9 +113,9 @@ func TestPodLabelUpdate(t *testing.T) {
 
 	initTestEnv(t, c.client.Kube(), fx)
 	// Setup a service with 1 pod and endpointslices
-	createServiceWait(c, "ratings", "nsa",
+	createServiceWait(c, "ratings", "nsa", []string{"10.0.0.1"},
 		nil, nil, []int32{8080}, map[string]string{"app": "test"}, t)
-	pod := generatePod("128.0.0.1", "cpod1", "nsa", "", "", map[string]string{"app": "test", "foo": "bar"}, map[string]string{})
+	pod := generatePod([]string{"128.0.0.1"}, "cpod1", "nsa", "", "", map[string]string{"app": "test", "foo": "bar"}, map[string]string{})
 	addPods(t, c, fx, pod)
 	createEndpoints(t, c, "rating", "nsa", []string{"tcp-port"}, []string{"128.0.0.1"}, []*v1.ObjectReference{
 		{
@@ -157,7 +157,7 @@ func TestHostNetworkPod(t *testing.T) {
 	})
 	initTestEnv(t, c.client.Kube(), fx)
 	createPod := func(ip, name string) {
-		addPods(t, c, fx, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
+		addPods(t, c, fx, generatePod([]string{ip}, name, "ns", "1", "", map[string]string{}, map[string]string{}))
 	}
 
 	createPod("128.0.0.1", "pod1")
@@ -186,7 +186,7 @@ func TestIPReuse(t *testing.T) {
 	initTestEnv(t, c.client.Kube(), fx)
 
 	createPod := func(ip, name string) {
-		addPods(t, c, fx, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
+		addPods(t, c, fx, generatePod([]string{ip}, name, "ns", "1", "", map[string]string{}, map[string]string{}))
 	}
 
 	createPod("128.0.0.1", "pod")
@@ -336,9 +336,9 @@ func TestPodUpdates(t *testing.T) {
 
 	// Namespace must be lowercase (nsA doesn't work)
 	pods := []*v1.Pod{
-		generatePod("128.0.0.1", "cpod1", "nsa", "", "", map[string]string{"app": "test-app"}, map[string]string{}),
-		generatePod("128.0.0.2", "cpod2", "nsa", "", "", map[string]string{"app": "prod-app-1"}, map[string]string{}),
-		generatePod("128.0.0.3", "cpod3", "nsb", "", "", map[string]string{"app": "prod-app-2"}, map[string]string{}),
+		generatePod([]string{"128.0.0.1"}, "cpod1", "nsa", "", "", map[string]string{"app": "test-app"}, map[string]string{}),
+		generatePod([]string{"128.0.0.2"}, "cpod2", "nsa", "", "", map[string]string{"app": "prod-app-1"}, map[string]string{}),
+		generatePod([]string{"128.0.0.3"}, "cpod3", "nsb", "", "", map[string]string{"app": "prod-app-2"}, map[string]string{}),
 	}
 
 	addPods(t, c, fx, pods...)

--- a/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceexportcache_test.go
@@ -128,7 +128,7 @@ func newTestServiceExportCache(t *testing.T, clusterLocalMode ClusterLocalMode) 
 	})
 
 	// Create the test service and endpoints.
-	createService(c, serviceExportName, serviceExportNamespace, map[string]string{}, map[string]string{},
+	createService(c, serviceExportName, serviceExportNamespace, []string{"10.0.0.1"}, map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	createEndpoints(t, c, serviceExportName, serviceExportNamespace, []string{"tcp-port"}, []string{serviceExportPodIP}, nil, nil)
 

--- a/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/serviceimportcache_test.go
@@ -124,7 +124,7 @@ func TestDeleteImportedService(t *testing.T) {
 	ic.checkServiceInstances(t)
 
 	// create the same service in cluster2
-	createService(c2, serviceImportName, serviceImportNamespace, map[string]string{}, map[string]string{},
+	createService(c2, serviceImportName, serviceImportNamespace, []string{"10.0.0.1"}, map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 
 	// Delete the k8s service and verify that all internal services are removed.
@@ -180,7 +180,7 @@ func (ic *serviceImportCacheImpl) createKubeService(t *testing.T, c *FakeControl
 	t.Helper()
 
 	// Create the test service and endpoints.
-	createService(c, serviceImportName, serviceImportNamespace, map[string]string{}, map[string]string{},
+	createService(c, serviceImportName, serviceImportNamespace, []string{"10.0.0.1"}, map[string]string{}, map[string]string{},
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	createEndpoints(t, c, serviceImportName, serviceImportNamespace, []string{"tcp-port"}, []string{serviceImportPodIP}, nil, nil)
 


### PR DESCRIPTION
**Please provide a description of this PR:**
No major changes

- generatePod will now take ips instead of only one ip
- remove code in TestUpdateEndpointCacheForSliceWithMultiAddrs that inserted the additional pod IPs after creation of the pod object
- createServiceWait, createService, generateService will take an IPs list as arg instead of always creating a service with IPs 10.0.0.1, 10.0.0.2