### PR TITLE
make httpbin sample bind on both ipv4 and ipv6

### DIFF
--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - gunicorn
         - -b
-        - 0.0.0.0:8080
+        - "[::]:8080"
         - httpbin:app
         - -k
         - gevent


### PR DESCRIPTION
Currently we are only binding on ipv4.
update gunicorn cmd to bind on both ipv4 and ipv6