### PR TITLE
Fix istioctl describe service being unable to display the HBONE protocol

### DIFF
--- a/istioctl/pkg/describe/describe.go
+++ b/istioctl/pkg/describe/describe.go
@@ -64,6 +64,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	configKube "istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/mesh"
+	protocolinstance "istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/labels"
@@ -586,6 +587,10 @@ func findProtocolForPort(port *corev1.ServicePort) string {
 		protocol = "auto-detect"
 	} else {
 		protocol = string(configKube.ConvertProtocol(port.Port, port.Name, port.Protocol, port.AppProtocol))
+		if protocol == protocolinstance.Unsupported.String() && port.AppProtocol != nil && *port.AppProtocol == "hbone" {
+			// HBONE is used for some internal code.
+			protocol = string(protocolinstance.HBONE)
+		}
 	}
 	return protocol
 }

--- a/istioctl/pkg/describe/describe_test.go
+++ b/istioctl/pkg/describe/describe_test.go
@@ -1018,6 +1018,7 @@ func TestGetRevisionFromPodAnnotation(t *testing.T) {
 
 func TestFindProtocolForPort(t *testing.T) {
 	http := "HTTP"
+	hbone := "hbone"
 	cases := []struct {
 		port             corev1.ServicePort
 		expectedProtocol string
@@ -1056,6 +1057,15 @@ func TestFindProtocolForPort(t *testing.T) {
 				Port:     80,
 			},
 			expectedProtocol: "UDP",
+		},
+		{
+			port: corev1.ServicePort{
+				Protocol:    corev1.ProtocolTCP,
+				Port:        15008,
+				Name:        "mesh",
+				AppProtocol: &hbone,
+			},
+			expectedProtocol: "HBONE",
 		},
 	}
 


### PR DESCRIPTION

**Please provide a description of this PR:**
```
➜  ~ istioctl x describe service waypoint
Service: waypoint
   Port: status-port 15021/TCP targets pod port 15021
   Port: mesh 15008/UnsupportedProtocol targets pod port 15008
15021:
15008:
Skipping Gateway information (no ingress gateway pods)
```