### PR TITLE
Use UPSTREAM_CLUSTER_RAW for access log format

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -270,7 +270,7 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 			Disabled: v.Disabled,
 		}
 
-		al := telemetryAccessLog(push, fp)
+		al := telemetryAccessLog(push, fp, proxy.IstioVersion)
 		if al == nil {
 			// stackdriver will be handled in HTTPFilters/TCPFilters
 			continue

--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -84,7 +84,7 @@ func (b *AccessLogBuilder) setTCPAccessLog(push *model.PushContext, proxy *model
 	if len(cfgs) == 0 {
 		// No Telemetry API configured, fall back to legacy mesh config setting
 		if mesh.AccessLogFile != "" {
-			tcp.AccessLog = append(tcp.AccessLog, b.buildFileAccessLog(mesh))
+			tcp.AccessLog = append(tcp.AccessLog, b.buildFileAccessLog(mesh, proxy.IstioVersion))
 		}
 
 		if mesh.EnableEnvoyAccessLogService {
@@ -152,7 +152,7 @@ func (b *AccessLogBuilder) setHTTPAccessLog(push *model.PushContext, proxy *mode
 	if len(cfgs) == 0 {
 		// No Telemetry API configured, fall back to legacy mesh config setting
 		if mesh.AccessLogFile != "" {
-			connectionManager.AccessLog = append(connectionManager.AccessLog, b.buildFileAccessLog(mesh))
+			connectionManager.AccessLog = append(connectionManager.AccessLog, b.buildFileAccessLog(mesh, proxy.IstioVersion))
 		}
 
 		if mesh.EnableEnvoyAccessLogService {
@@ -179,7 +179,7 @@ func (b *AccessLogBuilder) setListenerAccessLog(push *model.PushContext, proxy *
 	if len(cfgs) == 0 {
 		// No Telemetry API configured, fall back to legacy mesh config setting
 		if mesh.AccessLogFile != "" {
-			listener.AccessLog = append(listener.AccessLog, b.buildListenerFileAccessLog(mesh))
+			listener.AccessLog = append(listener.AccessLog, b.buildListenerFileAccessLog(mesh, proxy.IstioVersion))
 		}
 
 		if mesh.EnableEnvoyAccessLogService {
@@ -195,13 +195,13 @@ func (b *AccessLogBuilder) setListenerAccessLog(push *model.PushContext, proxy *
 	}
 }
 
-func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig, proxyVersion *model.IstioVersion) *accesslog.AccessLog {
 	if cal := b.cachedFileAccessLog(); cal != nil {
 		return cal
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	al := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
+	al := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh, proxyVersion)
 
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
@@ -236,13 +236,13 @@ func buildAccessLogFilter(f ...*accesslog.AccessLogFilter) *accesslog.AccessLogF
 	}
 }
 
-func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfig, proxyVersion *model.IstioVersion) *accesslog.AccessLog {
 	if cal := b.cachedListenerFileAccessLog(); cal != nil {
 		return cal
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	lal := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh)
+	lal := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh, proxyVersion)
 	// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 	// not get filter Access Logs like in cases like NR to upstream.
 	lal.Filter = addAccessLogFilter()

--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -95,7 +95,7 @@ func TestListenerAccessLog(t *testing.T) {
 		{
 			name:       "default text format",
 			encoding:   meshconfig.MeshConfig_TEXT,
-			wantFormat: model.EnvoyTextLogFormat,
+			wantFormat: model.LegacyEnvoyTextLogFormat,
 		},
 	} {
 		tc := tc
@@ -361,7 +361,7 @@ var (
 				Format: &core.SubstitutionFormatString_TextFormatSource{
 					TextFormatSource: &core.DataSource{
 						Specifier: &core.DataSource_InlineString{
-							InlineString: model.EnvoyTextLogFormat,
+							InlineString: model.LegacyEnvoyTextLogFormat,
 						},
 					},
 				},

--- a/pilot/pkg/networking/core/accesslog_test.go
+++ b/pilot/pkg/networking/core/accesslog_test.go
@@ -95,7 +95,7 @@ func TestListenerAccessLog(t *testing.T) {
 		{
 			name:       "default text format",
 			encoding:   meshconfig.MeshConfig_TEXT,
-			wantFormat: model.LegacyEnvoyTextLogFormat,
+			wantFormat: model.EnvoyTextLogFormat,
 		},
 	} {
 		tc := tc
@@ -361,7 +361,7 @@ var (
 				Format: &core.SubstitutionFormatString_TextFormatSource{
 					TextFormatSource: &core.DataSource{
 						Specifier: &core.DataSource_InlineString{
-							InlineString: model.LegacyEnvoyTextLogFormat,
+							InlineString: model.EnvoyTextLogFormat,
 						},
 					},
 				},


### PR DESCRIPTION
**Please provide a description of this PR:**
This should be the last in the series of PRs around stats and delimiters. This PR utilizes the new UPSTREAM_CLUSTER_RAW formatter that I added in Envoy to ignore the alt stat name for access logs (but not metrics). This keeps access logs consistent for users, and they don't have to see a random semicolon show up.