### PR TITLE
Better auth logs for cluster mismatch

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -373,7 +373,7 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	// so we build it later.
 	if s.kubeClient != nil {
 		authenticators = append(authenticators,
-			kubeauth.NewKubeJWTAuthenticator(s.environment.Watcher, s.kubeClient.Kube(), s.clusterID, s.multiclusterController.GetRemoteKubeClient))
+			kubeauth.NewKubeJWTAuthenticator(s.environment.Watcher, s.kubeClient.Kube(), s.clusterID, s.multiclusterController))
 	}
 	if len(features.TrustedGatewayCIDR) > 0 {
 		authenticators = append(authenticators, &authenticate.XfccAuthenticator{})

--- a/pkg/kube/multicluster/secretcontroller.go
+++ b/pkg/kube/multicluster/secretcontroller.go
@@ -35,6 +35,8 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/monitoring"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 const (
@@ -382,4 +384,10 @@ func (c *Controller) GetRemoteKubeClient(clusterID cluster.ID) kubernetes.Interf
 		return remoteCluster.Client.Kube()
 	}
 	return nil
+}
+
+func (c *Controller) ListClusters() []cluster.ID {
+	return slices.Map(sets.SortedList(c.cs.clusters), func(e string) cluster.ID {
+		return cluster.ID(e)
+	})
 }


### PR DESCRIPTION
Common error is configure client and istiod with different cluster name.
This shows it clearly.

```
Failed to authenticate client from 10.244.0.20:55098: Authenticator ClientCertAuthenticator: no verified chain is found; Authenticator KubeJWTAuthenticator: could not get cluster Kubernetesx's kube client
Failed to authenticate client from 10.244.0.20:36552: Authenticator ClientCertAuthenticator: no verified chain is found; Authenticator KubeJWTAuthenticator: client claims to be in cluster "Kubernetesx", but we only know about local cluster "Kubernetes" and remote clusters []
```
