### PR TITLE
Fix istiod helm chart for remote

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,7 +168,7 @@ spec:
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
-{{- if and .Values.global.externalIstiod (not and (.Values.pilot.env .Values.pilot.env.EXTERNAL_ISTIOD)) }}
+{{- if and .Values.global.externalIstiod (not (and .Values.pilot.env .Values.pilot.env.EXTERNAL_ISTIOD)) }}
           - name: EXTERNAL_ISTIOD
             value: "{{ .Values.global.externalIstiod }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,7 +168,7 @@ spec:
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
-{{- if and .Values.global.externalIstiod (not .Values.pilot.env.EXTERNAL_ISTIOD) }}
+{{- if and .Values.global.externalIstiod (not and (.Values.pilot.env .Values.pilot.env.EXTERNAL_ISTIOD)) }}
           - name: EXTERNAL_ISTIOD
             value: "{{ .Values.global.externalIstiod }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,7 +168,7 @@ spec:
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
-{{- if and .Values.global.externalIstiod (eq .Values.env.EXTERNAL_ISTIOD "")}}
+{{- if and .Values.global.externalIstiod (not .Values.pilot.env.EXTERNAL_ISTIOD) }}
           - name: EXTERNAL_ISTIOD
             value: "{{ .Values.global.externalIstiod }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -168,6 +168,7 @@ spec:
 {{- end }}
 # If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
 # don't set it here to avoid duplication.
+# TODO (nshankar13): Move from Helm chart to code: https://github.com/istio/istio/issues/52449
 {{- if and .Values.global.externalIstiod (not (and .Values.pilot.env .Values.pilot.env.EXTERNAL_ISTIOD)) }}
           - name: EXTERNAL_ISTIOD
             value: "{{ .Values.global.externalIstiod }}"


### PR DESCRIPTION
Fix a bug with the Istiod chart and remote installations so that only values.global.externalIstiod needs to be set. 

Original PR and issue: https://github.com/istio/istio/pull/51596