### PR TITLE
respect cluster statname pattern if provided

### DIFF
--- a/pilot/pkg/features/telemetry.go
+++ b/pilot/pkg/features/telemetry.go
@@ -59,6 +59,7 @@ var (
 
 	EnableControllerQueueMetrics = env.Register("ISTIO_ENABLE_CONTROLLER_QUEUE_METRICS", false,
 		"If enabled, publishes metrics for queue depth, latency and processing times.").Get()
+
 	EnableDelimitedStatsTagRegex = env.Register("ENABLE_DELIMITED_STATS_TAG_REGEX", true,
 		"If true, pilot will use the new delimited stat tag regex to generate Envoy stats tags.").Get()
 )

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -351,7 +351,8 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	if direction == model.TrafficDirectionOutbound {
 		// If stat name is configured, build the alternate stats name.
 		if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
-			ec.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName, string(service.Hostname), subset, port, 0, &service.Attributes)
+			statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName, string(service.Hostname), subset, port, 0, &service.Attributes)
+			ec.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix, cb.proxyVersion)
 		}
 	}
 
@@ -362,7 +363,7 @@ func (cb *ClusterBuilder) defaultAltStatName(clusterName string) string {
 	if util.IsIstioVersionGE123(cb.proxyVersion) {
 		return clusterName + constants.StatPrefixDelimiter
 	}
-	return ""
+	return clusterName
 }
 
 // buildInboundCluster constructs a single inbound cluster. The cluster will be bound to
@@ -385,9 +386,10 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 		model.TrafficDirectionInbound, instance.Port.ServicePort, instance.Service, inboundServices, "")
 	// If stat name is configured, build the alt statname.
 	if len(cb.req.Push.Mesh.InboundClusterStatName) != 0 {
-		localCluster.cluster.AltStatName = telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,
+		statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,
 			string(instance.Service.Hostname), "", instance.Port.ServicePort, clusterPort,
 			&instance.Service.Attributes)
+		localCluster.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix, cb.proxyVersion)
 	}
 	if clusterType == cluster.Cluster_ORIGINAL_DST {
 		// Disable cleanup for inbound clusters - set to Max possible duration.

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -40,7 +40,6 @@ import (
 	"istio.io/istio/pilot/pkg/xds/endpoints"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/log"
@@ -63,9 +62,7 @@ func buildInternalUpstreamCluster(proxyVersion *model.IstioVersion, name string,
 		},
 	}
 
-	if util.IsIstioVersionGE123(proxyVersion) {
-		c.AltStatName = name + constants.StatPrefixDelimiter
-	}
+	c.AltStatName = util.DelimitedStatsPrefix(name, proxyVersion)
 
 	return c
 }
@@ -330,9 +327,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 		},
 	}
 
-	if util.IsIstioVersionGE123(proxy.IstioVersion) {
-		c.AltStatName = ConnectOriginate + constants.StatPrefixDelimiter
-	}
+	c.AltStatName = util.DelimitedStatsPrefix(ConnectOriginate, proxy.IstioVersion)
 
 	return c
 }

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -44,7 +44,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -97,10 +96,8 @@ func (ml *MutableGatewayListener) build(builder *ListenerBuilder, opts gatewayLi
 
 			// If statPrefix has been set before calling this method, respect that.
 			if len(opt.httpOpts.statPrefix) == 0 {
-				opt.httpOpts.statPrefix = strings.ToLower(ml.Listener.TrafficDirection.String()) + "_" + ml.Listener.Name
-				if util.IsIstioVersionGE123(builder.node.IstioVersion) {
-					opt.httpOpts.statPrefix += constants.StatPrefixDelimiter
-				}
+				statPrefix := strings.ToLower(ml.Listener.TrafficDirection.String()) + "_" + ml.Listener.Name
+				opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statPrefix, builder.node.IstioVersion)
 			}
 			opt.httpOpts.port = opts.port
 			httpConnectionManagers[i] = builder.buildHTTPConnectionManager(opt.httpOpts)

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -612,10 +612,8 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 			// we are building a network filter chain (no http connection manager) for this filter chain
 			chain.Filters = opt.networkFilters
 		} else {
-			opt.httpOpts.statPrefix = strings.ToLower(l.TrafficDirection.String()) + "_" + l.Name
-			if util.IsIstioVersionGE123(builder.node.IstioVersion) {
-				opt.httpOpts.statPrefix += constants.StatPrefixDelimiter
-			}
+			statsPrefix := strings.ToLower(l.TrafficDirection.String()) + "_" + l.Name
+			opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statsPrefix, builder.node.IstioVersion)
 			opt.httpOpts.port = le.servicePort.Port
 			hcm := builder.buildHTTPConnectionManager(opt.httpOpts)
 			filter := &listener.Filter{

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -39,7 +39,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/security"
@@ -101,10 +100,7 @@ func (cc inboundChainConfig) StatPrefix(istioVersion *model.IstioVersion) string
 		statPrefix = "inbound_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	}
 
-	if util.IsIstioVersionGE123(istioVersion) {
-		statPrefix += constants.StatPrefixDelimiter
-	}
-
+	statPrefix = util.DelimitedStatsPrefix(statPrefix, istioVersion)
 	return statPrefix
 }
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -45,6 +45,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	kubelabels "istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/log"
 	pm "istio.io/istio/pkg/model"
@@ -888,4 +889,11 @@ func ShallowCopyTrafficPolicy(original *networking.TrafficPolicy) *networking.Tr
 
 func VersionGreaterOrEqual124(proxy *model.Proxy) bool {
 	return proxy.VersionGreaterAndEqual(&model.IstioVersion{Major: 1, Minor: 24, Patch: -1})
+}
+
+func DelimitedStatsPrefix(statPrefix string, proxyVersion *model.IstioVersion) string {
+	if features.EnableDelimitedStatsTagRegex && IsIstioVersionGE123(proxyVersion) {
+		statPrefix += constants.StatPrefixDelimiter
+	}
+	return statPrefix
 }


### PR DESCRIPTION
We changed all statnames to end with a delimiter(;) but if user provides a statname format - it should be respected. If he needs regex support, he should add that in that format.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions