### PR TITLE
Fix gateway trigger for ambient

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -297,6 +297,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		})
 		c.reloadMeshNetworks()
 	}
+	if c.ambientIndex != nil {
+		c.networkManager.NetworkGatewaysHandler.AppendNetworkGatewayHandler(func() {
+			// This is to ensure the ambient workloads are updated dynamically, aligning them with the current network settings.
+			// With this, the pod do not need to restart when the network configuration changes.
+			c.ambientIndex.SyncAll()
+		})
+	}
 	return c
 }
 


### PR DESCRIPTION
Apparently there are two ways to subscribe to gateways, and we need to
do both. Adds a unit test to capture this case
