### PR TITLE
Fix a deadlock when using `discoverySelectors`

### DIFF
--- a/pkg/kube/kclient/client_test.go
+++ b/pkg/kube/kclient/client_test.go
@@ -36,6 +36,7 @@ import (
 	istioclient "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	istionetclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
@@ -510,4 +511,41 @@ func TestFilterClusterScoped(t *testing.T) {
 	}
 	tester.Create(obj1)
 	tracker.WaitOrdered("add/1")
+}
+
+func TestFilterDeadlock(t *testing.T) {
+	// This is a regression test for an issue causing a deadlock when using the filter
+	tracker := assert.NewTracker[string](t)
+
+	c := kube.NewFakeClient(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "random", Namespace: "test"},
+	})
+	meshWatcher := mesh.NewTestWatcher(&meshconfig.MeshConfig{DiscoverySelectors: []*meshconfig.LabelSelector{{
+		MatchLabels: map[string]string{"selected": "yes"},
+	}}})
+	stop := test.NewStop(t)
+	testns := clienttest.NewWriter[*corev1.Namespace](t, c)
+	testns.Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"selected": "no"}}})
+	namespaces := kclient.New[*corev1.Namespace](c)
+	discoveryNamespacesFilter := filter.NewDiscoveryNamespacesFilter(
+		namespaces,
+		meshWatcher,
+		stop,
+	)
+
+	// Create some random client
+	deployments := kclient.NewFiltered[*appsv1.Deployment](c, kubetypes.Filter{
+		ObjectFilter: discoveryNamespacesFilter,
+	})
+	// The client calls .List() in the handler -- this was the cause of the deadlock.
+	deployments.AddEventHandler(controllers.ObjectHandler(func(o controllers.Object) {
+		for _, obj := range deployments.List(o.GetNamespace(), klabels.Everything()) {
+			tracker.Record(config.NamespacedName(obj).String())
+		}
+	}))
+	c.RunAndWait(stop)
+	c.WaitForCacheSync("test", stop, deployments.HasSynced)
+
+	testns.Update(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"selected": "yes"}}})
+	tracker.WaitOrdered("test/random")
 }

--- a/releasenotes/notes/namespace-filter-deadlock.yaml
+++ b/releasenotes/notes/namespace-filter-deadlock.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** an issue that can trigger a deadlock when `discoverySelectors` (configured in `MeshConfig`) and a namespace,
+    which has an `Ingress` object or a `gateway.networking.k8s.io` `Gateway` object, moves from being selected to unselected.


### PR DESCRIPTION
This fixes a bug triggered under a very precise set of circumstances, which has been captured in a unit test:
* Using discoverySelectors
* Namespace changes from selected to not selected. This triggers the namespace filter to call handlers *with the lock held*.
* There are handlers that use the filter, and call .List() in their handler. This ultimately calls .Filter(), which requires a lock, which deadlocks since we hold the lock already.

The fix here is to drop the lock before we call the filter.

In Istio, we have 2 cases that have handlers call .List(): Ingress and Gateway. So this can only occor for namespaces that contain those objects.

Running all the filter tests locally (not just the new one): `2830 runs so far, 0 failures (100.00% pass rate). 552.201538ms avg, 757.274586ms max, 462.657834ms min`

**Please provide a description of this PR:**