### PR TITLE
docs/collateral: fix docs generator to indent at correct levels

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -438,7 +438,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	}
 
 	if cmd.HasParent() {
-		g.emit("<h3 id=\"", normalizedCmdPath, "\">", cmd.CommandPath(), "</h3>")
+		g.emit("<h3 id=\"", normalizeID(cmd.CommandPath()), "\">", cmd.CommandPath(), "</h>")
 	}
 
 	if cmd.Long != "" {

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -438,7 +438,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	}
 
 	if cmd.HasParent() {
-		g.emit("<h3 id=\"", normalizeID(cmd.CommandPath()), "\">", cmd.CommandPath(), "</h>")
+		g.emit("<h3 id=\"", normalizeID(cmd.CommandPath()), "\">", cmd.CommandPath(), "</h3>")
 	}
 
 	if cmd.Long != "" {

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -438,7 +438,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	}
 
 	if cmd.HasParent() {
-		g.emit("<h2 id=\"", normalizeID(cmd.CommandPath()), "\">", cmd.CommandPath(), "</h2>")
+		g.emit("<h3 id=\"", normalizedCmdPath, "\">", cmd.CommandPath(), "</h3>")
 	}
 
 	if cmd.Long != "" {
@@ -523,7 +523,7 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	}
 
 	if len(cmd.Example) > 0 {
-		g.emit("<h3 id=\"", normalizeID(cmd.CommandPath()), " Examples\">", "Examples", "</h3>")
+		g.emit("<h4 id=\"", normalizeID(cmd.CommandPath()), " Examples\">", "Examples", "</h4>")
 		g.emit("<pre class=\"language-bash\"><code>", html.EscapeString(cmd.Example))
 		g.emit("</code></pre>")
 	}


### PR DESCRIPTION
Manual cherry-pick of #52274.

This changes a generator for command line documentation, needed for a docs change, and shouldn't have any impact elsewhere.

/release-notes-none