### PR TITLE
Add container ports to istio-cni daemonset

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -76,6 +76,11 @@ spec:
 {{- if or .Values.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
+          ports:
+          - containerPort: 15014
+            hostPort: 15014
+            name: metrics
+            protocol: TCP
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
  # Context:
  In `istio-cni` chart the daemonset does not have the port where the
  metrics are exposed specified in the containers spec. This does not
  allow `prometheus-operator` to scrape the metrics using `PodMonitor`
  because it can not find the port specified in the manifest.

  # What does this PR?
  - Adds the metrics port in the daemonset containers spec of the `istio-cni` chart.