### PR TITLE
Bug/stale cert expiration logs

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -343,7 +343,9 @@ func handleEvent(s *Server) {
 		log.Errorf("Failed to update new Plug-in CA certs: %v", err)
 		return
 	}
-
+	if len(s.CA.GetCAKeyCertBundle().GetRootCertPem()) != 0 {
+		caserver.RecordCertsExpiry(s.CA.GetCAKeyCertBundle())
+	}
 	err = s.updateRootCertAndGenKeyCert()
 	if err != nil {
 		log.Errorf("Failed generating plugged-in istiod key cert: %v", err)

--- a/pkg/monitoring/monitortest/test.go
+++ b/pkg/monitoring/monitortest/test.go
@@ -107,12 +107,12 @@ func DoesNotExist(any) error {
 // Check if two floats are equal with some room for errors (for example, rounding errors)
 // For rounding errors, setting `eps` to 1e-7 is a good default
 func AlmostEquals(v float64, eps float64) func(any) error {
-    return func(f any) error  {
-        if math.Abs(v - toFloat(f)) > eps {
+	return func(f any) error {
+		if math.Abs(v-toFloat(f)) > eps {
 			return fmt.Errorf("%v and %v and not within %v", v, toFloat(f), eps)
-        }
-        return nil
-    }
+		}
+		return nil
+	}
 }
 
 func Exactly(v float64) func(any) error {

--- a/pkg/monitoring/monitortest/test.go
+++ b/pkg/monitoring/monitortest/test.go
@@ -16,6 +16,7 @@ package monitortest
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -101,6 +102,17 @@ type Compare func(any) error
 func DoesNotExist(any) error {
 	// special case logic in the Assert
 	return nil
+}
+
+// Check if two floats are equal with some room for errors (for example, rounding errors)
+// For rounding errors, setting `eps` to 1e-7 is a good default
+func AlmostEquals(v float64, eps float64) func(any) error {
+    return func(f any) error  {
+        if math.Abs(v - toFloat(f)) > eps {
+			return fmt.Errorf("%v and %v and not within %v", v, toFloat(f), eps)
+        }
+        return nil
+    }
 }
 
 func Exactly(v float64) func(any) error {

--- a/releasenotes/notes/stale-cert-expiration-metrics.yaml
+++ b/releasenotes/notes/stale-cert-expiration-metrics.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+releaseNotes:
+- |
+  **Fixed** The `citadel_server_root_cert_expiry_timestamp`, `citadel_server_root_cert_expiry_seconds`, `citadel_server_cert_chain_expiry_timestamp`, and `citadel_server_cert_chain_expiry_seconds` update when new certificates are loaded.

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -148,7 +148,8 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	return response, nil
 }
 
-func recordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
+// RecordCertsExpiry updates the certificate-expiration related metrics given a new keycertbundle
+func RecordCertsExpiry(keyCertBundle *util.KeyCertBundle) {
 	// Expiry of the first root cert in trust bundle
 	rootCertExpiry, err := keyCertBundle.ExtractRootCertExpiryTimestamp()
 	if err != nil {
@@ -185,7 +186,7 @@ func New(
 ) (*Server, error) {
 	certBundle := ca.GetCAKeyCertBundle()
 	if len(certBundle.GetRootCertPem()) != 0 {
-		recordCertsExpiry(certBundle)
+		RecordCertsExpiry(certBundle)
 	}
 
 	server := &Server{

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -504,15 +504,15 @@ func TestRecordCertsExipryMetrics(t *testing.T) {
 	t.Run("test certificate metric recording", func(t *testing.T) {
 		mt := monitortest.New(t)
 		now := time.Now()
-		rootTtl := time.Hour
-		certTtl := time.Hour / 2
+		rootTTL := time.Hour
+		certTTL := time.Hour / 2
 		rootCertBytes, rootKeyBytes, err := util.GenCertKeyFromOptions(util.CertOptions{
 			Host:         "citadel.testing.istio.io",
 			Org:          "MyOrg",
 			NotBefore:    now,
 			IsCA:         true,
 			IsSelfSigned: true,
-			TTL:          rootTtl,
+			TTL:          rootTTL,
 			RSAKeySize:   2048,
 		})
 		if err != nil {
@@ -533,7 +533,7 @@ func TestRecordCertsExipryMetrics(t *testing.T) {
 			Host:         "citadel.testing.istio.io",
 			Org:          "MyOrg",
 			NotBefore:    now,
-			TTL:          certTtl,
+			TTL:          certTTL,
 			IsServer:     true,
 			IsCA:         true,
 			IsSelfSigned: false,
@@ -551,22 +551,22 @@ func TestRecordCertsExipryMetrics(t *testing.T) {
 
 		RecordCertsExpiry(kb)
 
-		mt.Assert(rootCertExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(rootTtl).Unix()), 1e-7))
-		mt.Assert(certChainExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(certTtl).Unix()), 1e-7))
+		mt.Assert(rootCertExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(rootTTL).Unix()), 1e-7))
+		mt.Assert(certChainExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(certTTL).Unix()), 1e-7))
 		eps := float64(time.Minute) // so the tests aren't flaky
-		mt.Assert(rootCertExpirySeconds.Name(), nil, monitortest.AlmostEquals(rootTtl.Seconds(), eps))
-		mt.Assert(certChainExpirySeconds.Name(), nil, monitortest.AlmostEquals(certTtl.Seconds(), eps))
+		mt.Assert(rootCertExpirySeconds.Name(), nil, monitortest.AlmostEquals(rootTTL.Seconds(), eps))
+		mt.Assert(certChainExpirySeconds.Name(), nil, monitortest.AlmostEquals(certTTL.Seconds(), eps))
 
 		now = time.Now()
-		rootTtl = time.Hour * 60
-		certTtl = time.Hour * 20
+		rootTTL = time.Hour * 60
+		certTTL = time.Hour * 20
 		rootCertBytes, rootKeyBytes, err = util.GenCertKeyFromOptions(util.CertOptions{
 			Host:         "other-citadel.testing.istio.io",
 			Org:          "other-MyOrg",
 			NotBefore:    now,
 			IsCA:         true,
 			IsSelfSigned: true,
-			TTL:          rootTtl,
+			TTL:          rootTTL,
 			RSAKeySize:   2048,
 		})
 		if err != nil {
@@ -587,7 +587,7 @@ func TestRecordCertsExipryMetrics(t *testing.T) {
 			Host:         "other-citadel.testing.istio.io",
 			Org:          "other-MyOrg",
 			NotBefore:    now,
-			TTL:          certTtl,
+			TTL:          certTTL,
 			IsServer:     true,
 			IsCA:         true,
 			IsSelfSigned: false,
@@ -605,9 +605,9 @@ func TestRecordCertsExipryMetrics(t *testing.T) {
 
 		RecordCertsExpiry(kb)
 
-		mt.Assert(rootCertExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(rootTtl).Unix()), 1e-7))
-		mt.Assert(certChainExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(certTtl).Unix()), 1e-7))
-		mt.Assert(rootCertExpirySeconds.Name(), nil, monitortest.AlmostEquals(rootTtl.Seconds(), eps))
-		mt.Assert(certChainExpirySeconds.Name(), nil, monitortest.AlmostEquals(certTtl.Seconds(), eps))
+		mt.Assert(rootCertExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(rootTTL).Unix()), 1e-7))
+		mt.Assert(certChainExpiryTimestamp.Name(), nil, monitortest.AlmostEquals(float64(now.Add(certTTL).Unix()), 1e-7))
+		mt.Assert(rootCertExpirySeconds.Name(), nil, monitortest.AlmostEquals(rootTTL.Seconds(), eps))
+		mt.Assert(certChainExpirySeconds.Name(), nil, monitortest.AlmostEquals(certTTL.Seconds(), eps))
 	})
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

There is a bug where we update the metrics for cert expiration when **only** when creating the metrics server.
So if a cert changes, these changes would not be reflected in istiod's metrics.
There could be a situation where istiod reports expired certs when they are not expired.

I tested this by loosely following the [Plug in Certs guide](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/). I created a root cert and two intermediate certificates one with a 10 year expiry and one with a 1 day expiry.
I uploaded the first intermediate cert to the `cacert` secret and observed the metrics.
Then, I deleted the `cacert` secret and recreated it, but with the second intermediate cert, and observed the metric.