### PR TITLE
ambient: do not allow service waypoint to have a waypoint

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_workloadentry_test.go
@@ -221,7 +221,6 @@ func TestAmbientIndex_WorkloadEntries(t *testing.T) {
 	// all affected addresses with the waypoint should be updated
 	s.assertEvent(t,
 		s.svcXdsName("svc1"),
-		s.svcXdsName("waypoint-ns"),
 		s.wleXdsName("name1"),
 		s.wleXdsName("name2"),
 		s.wleXdsName("name3"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/waypoints.go
@@ -130,6 +130,10 @@ func fetchWaypointForTarget(
 func fetchWaypointForService(ctx krt.HandlerContext, Waypoints krt.Collection[Waypoint],
 	Namespaces krt.Collection[*v1.Namespace], o metav1.ObjectMeta,
 ) *Waypoint {
+	// This is a waypoint, so it cannot have a waypoint
+	if o.Labels[constants.ManagedGatewayLabel] == constants.ManagedGatewayMeshControllerLabel {
+		return nil
+	}
 	w := fetchWaypointForTarget(ctx, Waypoints, Namespaces, o)
 	if w != nil {
 		if w.TrafficType == constants.ServiceTraffic || w.TrafficType == constants.AllTraffic {


### PR DESCRIPTION
This should have effectively no impact (ztunnel will ignore it), but is consistent with workload
waypoints and overall nicer
