### PR TITLE
Fix stale GVK in benchmark test

### DIFF
--- a/pilot/pkg/config/memory/store_test.go
+++ b/pilot/pkg/config/memory/store_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pilot/test/mock"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 func TestStoreInvariant(t *testing.T) {
@@ -37,16 +38,11 @@ func TestIstioConfig(t *testing.T) {
 
 func BenchmarkStoreGet(b *testing.B) {
 	s := initStore(b)
-	gvk := config.GroupVersionKind{
-		Group:   "networking.istio.io",
-		Version: "v1alpha3",
-		Kind:    "ServiceEntry",
-	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		// get one thousand times
 		for i := 0; i < 1000; i++ {
-			if s.Get(gvk, strconv.Itoa(i), "ns") == nil {
+			if s.Get(gvk.ServiceEntry, strconv.Itoa(i), "ns") == nil {
 				b.Fatal("get failed")
 			}
 		}
@@ -55,14 +51,9 @@ func BenchmarkStoreGet(b *testing.B) {
 
 func BenchmarkStoreList(b *testing.B) {
 	s := initStore(b)
-	gvk := config.GroupVersionKind{
-		Group:   "networking.istio.io",
-		Version: "v1alpha3",
-		Kind:    "ServiceEntry",
-	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		s.List(gvk, "")
+		s.List(gvk.ServiceEntry, "")
 	}
 }
 
@@ -75,12 +66,8 @@ func BenchmarkStoreCreate(b *testing.B) {
 func BenchmarkStoreUpdate(b *testing.B) {
 	cfg := config.Config{
 		Meta: config.Meta{
-			GroupVersionKind: config.GroupVersionKind{
-				Group:   "networking.istio.io",
-				Version: "v1alpha3",
-				Kind:    "ServiceEntry",
-			},
-			Namespace: "ns",
+			GroupVersionKind: gvk.ServiceEntry,
+			Namespace:        "ns",
 		},
 		Spec: &v1alpha3.ServiceEntry{
 			Hosts: []string{"www.foo.com"},
@@ -102,18 +89,13 @@ func BenchmarkStoreUpdate(b *testing.B) {
 }
 
 func BenchmarkStoreDelete(b *testing.B) {
-	gvk := config.GroupVersionKind{
-		Group:   "networking.istio.io",
-		Version: "v1alpha3",
-		Kind:    "ServiceEntry",
-	}
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		s := initStore(b)
 		b.StartTimer()
 		// delete one thousand times
 		for i := 0; i < 1000; i++ {
-			if err := s.Delete(gvk, strconv.Itoa(i), "ns", nil); err != nil {
+			if err := s.Delete(gvk.ServiceEntry, strconv.Itoa(i), "ns", nil); err != nil {
 				b.Fatalf("delete failed: %v", err)
 			}
 		}
@@ -125,12 +107,8 @@ func initStore(b *testing.B) model.ConfigStore {
 	s := MakeSkipValidation(collections.Pilot)
 	cfg := config.Config{
 		Meta: config.Meta{
-			GroupVersionKind: config.GroupVersionKind{
-				Group:   "networking.istio.io",
-				Version: "v1alpha3",
-				Kind:    "ServiceEntry",
-			},
-			Namespace: "ns",
+			GroupVersionKind: gvk.ServiceEntry,
+			Namespace:        "ns",
 		},
 		Spec: &v1alpha3.ServiceEntry{
 			Hosts: []string{"www.foo.com"},


### PR DESCRIPTION
Causing postsubmit failure post merge of the v1 change
