### PR TITLE
hand written IstioEndpoint deepcopy

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1440,13 +1440,14 @@ func (s *Service) Equals(other *Service) bool {
 
 // DeepCopy creates a clone of IstioEndpoint.
 func (ep *IstioEndpoint) DeepCopy() *IstioEndpoint {
+	if ep == nil {
+		return ep
+	}
+
 	out := *ep
 	out.Labels = maps.Clone(ep.Labels)
 	out.Addresses = slices.Clone(ep.Addresses)
-	out.Locality = Locality{
-		Label:     ep.Locality.Label,
-		ClusterID: ep.Locality.ClusterID,
-	}
+
 	return &out
 }
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1441,7 +1441,7 @@ func (s *Service) Equals(other *Service) bool {
 // DeepCopy creates a clone of IstioEndpoint.
 func (ep *IstioEndpoint) DeepCopy() *IstioEndpoint {
 	if ep == nil {
-		return ep
+		return nil
 	}
 
 	out := *ep

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -730,3 +730,30 @@ func TestGetAllAddresses(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkEndpointDeepCopy(b *testing.B) {
+	ep := &IstioEndpoint{
+		Labels:          labels.Instance{"label-foo": "aaa", "label-bar": "bbb"},
+		Addresses:       []string{"address-foo", "address-bar"},
+		ServicePortName: "service-port-name",
+		ServiceAccount:  "service-account",
+		Network:         "Network",
+		Locality: Locality{
+			ClusterID: "cluster-id",
+			Label:     "region1/zone1/subzone1",
+		},
+		EndpointPort: 22,
+		LbWeight:     100,
+		TLSMode:      "mutual",
+		Namespace:    "namespace",
+		WorkloadName: "workload-name",
+		HostName:     "foo-pod.svc",
+		SubDomain:    "subdomain",
+		HealthStatus: Healthy,
+		NodeName:     "node1",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ep.DeepCopy()
+	}
+}


### PR DESCRIPTION
fix #52446 

benchmark result:
```
goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/model
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
                    │    old.txt     │               new.txt               │
                    │     sec/op     │    sec/op     vs base               │
EndpointDeepCopy-12   14235.5n ± 16%   271.2n ± 10%  -98.10% (p=0.002 n=6)

                    │   old.txt   │              new.txt              │
                    │    B/op     │    B/op     vs base               │
EndpointDeepCopy-12   6688.0 ± 0%   624.0 ± 0%  -90.67% (p=0.002 n=6)

                    │   old.txt    │              new.txt              │
                    │  allocs/op   │ allocs/op   vs base               │
EndpointDeepCopy-12   189.000 ± 0%   4.000 ± 0%  -97.88% (p=0.002 n=6)
```