### PR TITLE
[release-1.23] cherry-pick: implement addressing per-hosts for autoallocate (#52319)

### DIFF
--- a/pilot/pkg/controllers/ipallocate/ipallocate.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate.go
@@ -29,11 +29,13 @@ import (
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	autoallocate "istio.io/istio/pilot/pkg/networking/serviceentry"
 	"istio.io/istio/pkg/config"
+	cfghost "istio.io/istio/pkg/config/host"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/sets"
 )
 
 var log = istiolog.RegisterScope("ip-autoallocate", "IP autoallocate controller")
@@ -98,7 +100,7 @@ const (
 func NewIPAllocator(stop <-chan struct{}, c kubelib.Client) *IPAllocator {
 	client := kclient.New[*networkingv1alpha3.ServiceEntry](c)
 	index := kclient.CreateIndex[netip.Addr, *networkingv1alpha3.ServiceEntry](client, func(serviceentry *networkingv1alpha3.ServiceEntry) []netip.Addr {
-		addresses := autoallocate.GetV2AddressesFromServiceEntry(serviceentry)
+		addresses := autoallocate.GetAddressesFromServiceEntry(serviceentry)
 		for _, addr := range serviceentry.Spec.Addresses {
 			a, err := netip.ParseAddr(addr)
 			if err != nil {
@@ -142,7 +144,7 @@ func (c *IPAllocator) populateControllerDatastructures() {
 		count++
 		owner := config.NamespacedName(serviceentry)
 		c.checkInSpecAddresses(serviceentry)
-		c.markUsedOrQueueConflict(autoallocate.GetV2AddressesFromServiceEntry(serviceentry), owner)
+		c.markUsedOrQueueConflict(autoallocate.GetAddressesFromServiceEntry(serviceentry), owner)
 	}
 
 	log.Debugf("discovered %v during warming", count)
@@ -176,22 +178,23 @@ func (c *IPAllocator) reconcileServiceEntry(se types.NamespacedName) error {
 		return nil
 	}
 
-	patch, atomicAddPatch, err := c.statusPatchForAddresses(serviceentry, false)
+	replaceAddresses, addStatusAndAddresses, err := c.statusPatchForAddresses(serviceentry, false)
 	if err != nil {
 		return err
 	}
 
-	if patch == nil {
+	if replaceAddresses == nil {
+		log.Debugf("no change needed")
 		return nil // nothing to patch
 	}
 
 	// this patch may fail if there is no status which exists
-	_, err = c.serviceEntryClient.PatchStatus(se.Name, se.Namespace, types.JSONPatchType, patch)
+	_, err = c.serviceEntryClient.PatchStatus(se.Name, se.Namespace, types.JSONPatchType, replaceAddresses)
 	if err != nil {
 		// try this patch which tests that status doesn't exist, adds status and then add addresses all in 1 operation
-		_, err2 := c.serviceEntryClient.PatchStatus(se.Name, se.Namespace, types.JSONPatchType, atomicAddPatch)
+		_, err2 := c.serviceEntryClient.PatchStatus(se.Name, se.Namespace, types.JSONPatchType, addStatusAndAddresses)
 		if err2 != nil {
-			log.Errorf("second patch also rejected %v, patch: %s", err2.Error(), atomicAddPatch)
+			log.Errorf("second patch also rejected %v, patch: %s", err2.Error(), addStatusAndAddresses)
 			// if this also didn't work there is perhaps a real issue and perhaps a requeue will resolve
 			return err
 		}
@@ -264,7 +267,7 @@ func allAddresses(se *networkingv1alpha3.ServiceEntry) ([]netip.Addr, []netip.Ad
 	if se == nil {
 		return nil, nil
 	}
-	autoAssigned := autoallocate.GetV2AddressesFromServiceEntry(se)
+	autoAssigned := autoallocate.GetAddressesFromServiceEntry(se)
 	userAssigned := []netip.Addr{}
 
 	for _, a := range se.Spec.Addresses {
@@ -319,20 +322,57 @@ type jsonPatch struct {
 	Value     interface{} `json:"value"`
 }
 
+// filter out any wildcarded hosts
+func removeWildCarded(h string) bool {
+	return !cfghost.Name(h).IsWildCarded()
+}
+
 func (c *IPAllocator) statusPatchForAddresses(se *networkingv1alpha3.ServiceEntry, forcedReassign bool) ([]byte, []byte, error) {
 	if se == nil {
 		return nil, nil, nil
 	}
 
-	existingAddresses := autoallocate.GetV2AddressesFromServiceEntry(se)
-	if len(existingAddresses) > 0 && !forcedReassign {
+	existingHostAddresses := autoallocate.GetHostAddressesFromServiceEntry(se)
+	existingAddresses := []netip.Addr{}
+	hostsWithAddresses := sets.New[string]()
+
+	// collect existing addresses and the hosts which already have assigned addresses
+	for host, addresses := range existingHostAddresses {
 		// this is likely a noop, but just to be safe we should check and potentially resolve conflict
-		c.markUsedOrQueueConflict(existingAddresses, config.NamespacedName(se))
-		return nil, nil, nil // nothing to patch
+		existingAddresses = append(existingAddresses, addresses...)
+		hostsWithAddresses.Insert(host)
 	}
+
+	// if we are being forced to reassign we already know there is a conflict
+	if !forcedReassign {
+		// if we're not being forced to reassign then we should ensure any addresses found are marked for use and queue up any conflicts found
+		c.markUsedOrQueueConflict(existingAddresses, config.NamespacedName(se))
+	}
+
+	// construct the assigned addresses datastructure to patch
 	assignedAddresses := []apiv1alpha3.ServiceEntryAddress{}
-	for _, a := range c.nextAddresses(config.NamespacedName(se)) {
-		assignedAddresses = append(assignedAddresses, apiv1alpha3.ServiceEntryAddress{Value: a.String()})
+	hostsInSpec := sets.New[string]()
+	for _, host := range slices.Filter(se.Spec.Hosts, removeWildCarded) {
+		if hostsInSpec.InsertContains(host) {
+			// if we already worked on this host don't process it again
+			continue
+		}
+		assignedIPs := []netip.Addr{}
+		if aa, ok := existingHostAddresses[host]; ok && !forcedReassign {
+			// we already assigned this host, do not re-assign
+			assignedIPs = append(assignedIPs, aa...)
+		} else {
+			assignedIPs = append(assignedIPs, c.nextAddresses(config.NamespacedName(se))...)
+		}
+
+		for _, a := range assignedIPs {
+			assignedAddresses = append(assignedAddresses, apiv1alpha3.ServiceEntryAddress{Value: a.String(), Host: host})
+		}
+	}
+
+	// nothing to patch
+	if hostsInSpec.Equals(hostsWithAddresses) && !forcedReassign {
+		return nil, nil, nil
 	}
 
 	replaceAddresses, err := json.Marshal([]jsonPatch{
@@ -343,7 +383,7 @@ func (c *IPAllocator) statusPatchForAddresses(se *networkingv1alpha3.ServiceEntr
 		},
 	})
 
-	atomicAddAndAddresses, err2 := json.Marshal([]jsonPatch{
+	addStatusAndAddresses, err2 := json.Marshal([]jsonPatch{
 		{
 			Operation: "test",
 			Path:      "/status",
@@ -361,7 +401,7 @@ func (c *IPAllocator) statusPatchForAddresses(se *networkingv1alpha3.ServiceEntr
 		},
 	})
 
-	return replaceAddresses, atomicAddAndAddresses, errors.Join(err, err2)
+	return replaceAddresses, addStatusAndAddresses, errors.Join(err, err2)
 }
 
 func (c *IPAllocator) checkInSpecAddresses(serviceentry *networkingv1alpha3.ServiceEntry) {

--- a/pilot/pkg/controllers/ipallocate/ipallocate_test.go
+++ b/pilot/pkg/controllers/ipallocate/ipallocate_test.go
@@ -16,6 +16,7 @@ package ipallocate_test
 
 import (
 	"net/netip"
+	"strconv"
 	"testing"
 	"time"
 
@@ -35,6 +36,21 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
+const (
+	TestIPV4Prefix = "240.240.0."
+	TestIPV6Prefix = "2001:2::"
+)
+
+func newV4AddressString(i uint64) string {
+	s := strconv.FormatUint(i, 10)
+	return TestIPV4Prefix + s
+}
+
+func newV6AddressString(i uint64) string {
+	s := strconv.FormatUint(i, 16)
+	return TestIPV6Prefix + s
+}
+
 type ipAllocateTestRig struct {
 	client kubelib.Client
 	se     clienttest.TestClient[*networkingv1alpha3.ServiceEntry]
@@ -51,8 +67,6 @@ func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocator, ipAllocateTestR
 	se := clienttest.NewDirectClient[*networkingv1alpha3.ServiceEntry, networkingv1alpha3.ServiceEntry, *networkingv1alpha3.ServiceEntryList](t, c)
 	ipController := ipallocate.NewIPAllocator(s, c)
 	// these would normally be the first addresses consumed, we should check that warming works by asserting that we get their nexts when we reconcile
-	v4 := netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next().String()
-	v6 := netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next().String()
 	se.CreateOrUpdateStatus(
 		&networkingv1alpha3.ServiceEntry{
 			ObjectMeta: metav1.ObjectMeta{
@@ -63,13 +77,16 @@ func setupIPAllocateTest(t *testing.T) (*ipallocate.IPAllocator, ipAllocateTestR
 				Hosts: []string{
 					"test.testing.io",
 				},
+				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
 			Status: v1alpha3.ServiceEntryStatus{Addresses: []*v1alpha3.ServiceEntryAddress{
 				{
-					Value: v4,
+					Host:  "test.testing.io",
+					Value: newV4AddressString(1),
 				},
 				{
-					Value: v6,
+					Host:  "test.testing.io",
+					Value: newV6AddressString(1),
 				},
 			}},
 		},
@@ -164,7 +181,7 @@ func TestIPAllocate(t *testing.T) {
 		},
 	)
 	getter := func() []string {
-		addr := autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
+		addr := autoallocate.GetAddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
 		var res []string
 		for _, a := range addr {
 			res = append(res, a.String())
@@ -173,28 +190,28 @@ func TestIPAllocate(t *testing.T) {
 	}
 	// this effectively asserts that allocation did work for boop/beep and also that with-address and opt-out did not get addresses
 	assert.EventuallyEqual(t, getter, []string{
-		netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next().Next().String(),
-		netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next().Next().String(),
+		newV4AddressString(2),
+		newV6AddressString(2),
 	}, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
 	assert.Equal(t,
 		len(rig.se.Get("with-existing-status", "boop").Status.GetConditions()),
 		1,
 		"assert that test SE still has its condition")
 	assert.Equal(t,
-		len(autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("opt-out", "boop"))),
+		len(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("opt-out", "boop"))),
 		0,
 		"assert that we did not did not assign addresses when use opted out")
 	assert.Equal(t,
-		len(autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("with-v4-address", "boop"))),
+		len(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("with-v4-address", "boop"))),
 		0,
 		"assert that we did not assign addresses when user supplied their own")
 	assert.Equal(t,
-		len(autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("with-v6-address", "boop"))),
+		len(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("with-v6-address", "boop"))),
 		0,
 		"assert that we did not assign addresses when user supplied their own")
 
 	// Testing conflict resolution
-	addr := autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
+	addr := autoallocate.GetAddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
 	assert.Equal(t, len(addr), 2, "ensure we retrieved addresses to create a conflict with")
 	rig.se.Create(
 		&networkingv1alpha3.ServiceEntry{
@@ -216,8 +233,8 @@ func TestIPAllocate(t *testing.T) {
 	)
 	// Assert this conflict was resolved as expected by allocating new auto-assigned addresses
 	assert.EventuallyEqual(t, getter, []string{
-		netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next().Next().Next().String(),
-		netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next().Next().Next().String(),
+		newV4AddressString(3),
+		newV6AddressString(3),
 	}, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
 
 	// Assert that we are not mutating user spec during resolution of conflicts
@@ -235,12 +252,13 @@ func TestIPAllocate(t *testing.T) {
 	)
 
 	// let's generate an even worse conflict now
-	// this is almost certainly caused by some bug in, none the less test we can recover
-	conflictingAddresses := autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
+	// this is almost certainly caused by some bug in our code, none the less test we can recover
+	conflictingAddresses := autoallocate.GetAddressesFromServiceEntry(rig.se.Get("with-existing-status", "boop"))
 	assert.Equal(t, len(conflictingAddresses), 2, "ensure we retrieved addresses to create a conflict with")
 	conflictingStatusAddresses := []*v1alpha3.ServiceEntryAddress{}
+	statusConflictHost := "status-conflict.boop.testing.io"
 	for _, a := range conflictingAddresses {
-		conflictingStatusAddresses = append(conflictingStatusAddresses, &v1alpha3.ServiceEntryAddress{Value: a.String()})
+		conflictingStatusAddresses = append(conflictingStatusAddresses, &v1alpha3.ServiceEntryAddress{Value: a.String(), Host: statusConflictHost})
 	}
 	// create an auto-assigned conflict
 	rig.se.Create(
@@ -252,7 +270,7 @@ func TestIPAllocate(t *testing.T) {
 			},
 			Spec: v1alpha3.ServiceEntry{
 				Hosts: []string{
-					"status-conflict.boop.testing.io",
+					statusConflictHost,
 				},
 				Resolution: v1alpha3.ServiceEntry_DNS,
 			},
@@ -272,15 +290,15 @@ func TestIPAllocate(t *testing.T) {
 
 	// assert that conflicts are resolved on the newer SE
 	assert.EventuallyEqual(t, func() []string {
-		addr := autoallocate.GetV2AddressesFromServiceEntry(rig.se.Get("status-conflict", "boop"))
+		addr := autoallocate.GetAddressesFromServiceEntry(rig.se.Get("status-conflict", "boop"))
 		var res []string
 		for _, a := range addr {
 			res = append(res, a.String())
 		}
 		return res
 	}, []string{
-		netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next().Next().Next().Next().String(),
-		netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next().Next().Next().Next().String(),
+		newV4AddressString(4),
+		newV6AddressString(4),
 	}, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
 
 	// assert that resolving conflicts does not destroy existing status items
@@ -291,7 +309,158 @@ func TestIPAllocate(t *testing.T) {
 
 	// assert that the elder SE doesn't change for 10 consecutive tries
 	assert.EventuallyEqual(t, getter, []string{
-		netip.MustParsePrefix(ipallocate.IPV4Prefix).Addr().Next().Next().Next().String(),
-		netip.MustParsePrefix(ipallocate.IPV6Prefix).Addr().Next().Next().Next().String(),
+		newV4AddressString(3),
+		newV6AddressString(3),
 	}, retry.Converge(10), retry.Delay(time.Millisecond*5))
+
+	// test that adding to the list of hosts produces the correct host to IP mapping
+	se := rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = append(se.Spec.Hosts, "added.testing.io")
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 4, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{
+			"test.testing.io": {
+				newV4AddressString(1),
+				newV6AddressString(1),
+			},
+			"added.testing.io": {
+				newV4AddressString(5),
+				newV6AddressString(5),
+			},
+		},
+	)
+
+	// test that adding a wildcard host to the list of hosts does not allocate an ip for it
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = append(se.Spec.Hosts, "*.bad-wildcard.testing.io")
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 4, retry.Converge(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{
+			"test.testing.io": {
+				newV4AddressString(1),
+				newV6AddressString(1),
+			},
+			"added.testing.io": {
+				newV4AddressString(5),
+				newV6AddressString(5),
+			},
+		},
+	)
+
+	// reset pre-existing to single host
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = []string{"test.testing.io"}
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 2, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
+
+	// check that adding lots of duplicate host entries at once does not allocate new IPs for each
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = append(se.Spec.Hosts, []string{
+		"added.testing.io",
+		"added.testing.io",
+		"added.testing.io",
+		"added.testing.io",
+	}...)
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 4, retry.Converge(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{
+			"test.testing.io": {
+				newV4AddressString(1),
+				newV6AddressString(1),
+			},
+			"added.testing.io": {
+				newV4AddressString(6),
+				newV6AddressString(6),
+			},
+		},
+	)
+
+	// test that removing from the list of hosts produces the correct host to IP mapping
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = []string{"added.testing.io"}
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 2, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{
+			"added.testing.io": {
+				newV4AddressString(6),
+				newV6AddressString(6),
+			},
+		},
+	)
+
+	// a big add + remove to list of hosts produces the correct host to IP mapping
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = []string{
+		"seven.testing.io",
+		"eight.testing.io",
+		"nine.testing.io",
+		"A.testing.io",
+	}
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 8, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{
+			"seven.testing.io": {
+				newV4AddressString(7),
+				newV6AddressString(7),
+			},
+			"eight.testing.io": {
+				newV4AddressString(8),
+				newV6AddressString(8),
+			},
+			"nine.testing.io": {
+				newV4AddressString(9),
+				newV6AddressString(9),
+			},
+			"A.testing.io": {
+				newV4AddressString(10),
+				newV6AddressString(10),
+			},
+		},
+	)
+
+	// for completeness test that having no hosts produces an empty map
+	se = rig.se.Get("pre-existing", "default")
+	se.Spec.Hosts = []string{}
+	rig.se.Update(se)
+	assert.EventuallyEqual(t, func() int {
+		se := rig.se.Get("pre-existing", "default")
+		return len(autoallocate.GetAddressesFromServiceEntry(se))
+	}, 0, retry.MaxAttempts(10), retry.Delay(time.Millisecond*5))
+	assert.Equal(t, toMapStringString(autoallocate.GetHostAddressesFromServiceEntry(rig.se.Get("pre-existing", "default"))),
+		map[string][]string{})
+}
+
+func toMapStringString(in map[string][]netip.Addr) map[string][]string {
+	out := map[string][]string{}
+
+	for k, v := range in {
+		for _, ip := range v {
+			out[k] = append(out[k], ip.String())
+		}
+	}
+
+	return out
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services_test.go
@@ -114,9 +114,11 @@ func TestServiceEntryServices(t *testing.T) {
 				Status: networking.ServiceEntryStatus{
 					Addresses: []*networking.ServiceEntryAddress{
 						{
+							Host:  "assign-me.example.com",
 							Value: "240.240.0.1",
 						},
 						{
+							Host:  "assign-me.example.com",
 							Value: "2001:2::1",
 						},
 					},
@@ -135,6 +137,90 @@ func TestServiceEntryServices(t *testing.T) {
 						{
 							Network: testNW,
 							Address: netip.MustParseAddr("2001:2::1").AsSlice(),
+						},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+			},
+		},
+		{
+			name:   "Uses multiple auto-assigned addresses",
+			inputs: []any{},
+			se: &networkingclient.ServiceEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-host-auto-assigned",
+					Namespace: "ns",
+				},
+				Spec: networking.ServiceEntry{
+					Hosts: []string{
+						"multi-host-assign-me.example.com",
+						"second-host-assign-me.example.com",
+					},
+					Ports: []*networking.ServicePort{{
+						Number: 80,
+						Name:   "http",
+					}},
+					SubjectAltNames: []string{"san1"},
+					Resolution:      networking.ServiceEntry_DNS,
+				},
+				Status: networking.ServiceEntryStatus{
+					Addresses: []*networking.ServiceEntryAddress{
+						{
+							Host:  "multi-host-assign-me.example.com",
+							Value: "240.240.0.1",
+						},
+						{
+							Host:  "multi-host-assign-me.example.com",
+							Value: "2001:2::1",
+						},
+						{
+							Host:  "second-host-assign-me.example.com",
+							Value: "240.240.0.2",
+						},
+						{
+							Host:  "second-host-assign-me.example.com",
+							Value: "2001:2::2",
+						},
+					},
+				},
+			},
+			result: []*workloadapi.Service{
+				{
+					Name:      "multi-host-auto-assigned",
+					Namespace: "ns",
+					Hostname:  "multi-host-assign-me.example.com",
+					Addresses: []*workloadapi.NetworkAddress{
+						{
+							Network: testNW,
+							Address: netip.AddrFrom4([4]byte{240, 240, 0, 1}).AsSlice(),
+						},
+						{
+							Network: testNW,
+							Address: netip.MustParseAddr("2001:2::1").AsSlice(),
+						},
+					},
+					Ports: []*workloadapi.Port{{
+						ServicePort: 80,
+						TargetPort:  80,
+					}},
+					SubjectAltNames: []string{"san1"},
+				},
+				{
+					Name:      "multi-host-auto-assigned",
+					Namespace: "ns",
+					Hostname:  "second-host-assign-me.example.com",
+					Addresses: []*workloadapi.NetworkAddress{
+						{
+							Network: testNW,
+							Address: netip.AddrFrom4([4]byte{240, 240, 0, 2}).AsSlice(),
+						},
+						{
+							Network: testNW,
+							Address: netip.MustParseAddr("2001:2::2").AsSlice(),
 						},
 					},
 					Ports: []*workloadapi.Port{{
@@ -166,9 +252,11 @@ func TestServiceEntryServices(t *testing.T) {
 				Status: networking.ServiceEntryStatus{
 					Addresses: []*networking.ServiceEntryAddress{
 						{
+							Host:  "user-provided.example.com",
 							Value: "240.240.0.1",
 						},
 						{
+							Host:  "user-provided.example.com",
 							Value: "2001:2::1",
 						},
 					},
@@ -213,9 +301,11 @@ func TestServiceEntryServices(t *testing.T) {
 				Status: networking.ServiceEntryStatus{
 					Addresses: []*networking.ServiceEntryAddress{
 						{
+							Host:  "none-resolution.example.com",
 							Value: "240.240.0.1",
 						},
 						{
+							Host:  "none-resolution.example.com",
 							Value: "2001:2::1",
 						},
 					},
@@ -258,9 +348,11 @@ func TestServiceEntryServices(t *testing.T) {
 				Status: networking.ServiceEntryStatus{
 					Addresses: []*networking.ServiceEntryAddress{
 						{
+							Host:  "user-opt-out.example.com",
 							Value: "240.240.0.1",
 						},
 						{
+							Host:  "user-opt-out.example.com",
 							Value: "2001:2::1",
 						},
 					},
@@ -300,9 +392,11 @@ func TestServiceEntryServices(t *testing.T) {
 				Status: networking.ServiceEntryStatus{
 					Addresses: []*networking.ServiceEntryAddress{
 						{
+							Host:  "this-is-ok.example.com",
 							Value: "240.240.0.1",
 						},
 						{
+							Host:  "this-is-ok.example.com",
 							Value: "2001:2::1",
 						},
 					},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -145,10 +145,9 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 	// ShouldV2AutoAllocateIP already checks that there are no addresses in the spec however this is critical enough to likely be worth checking
 	// explicitly as well in case the logic changes. We never want to overwrite addresses in the spec if there are any
 	addresses := serviceEntry.Addresses
+	addressLookup := map[string][]netip.Addr{}
 	if serviceentry.ShouldV2AutoAllocateIPFromConfig(cfg) && len(addresses) == 0 {
-		addresses = slices.Map(serviceentry.GetV2AddressesFromConfig(cfg), func(a netip.Addr) string {
-			return a.String()
-		})
+		addressLookup = serviceentry.GetHostAddressesFromConfig(cfg)
 	}
 
 	creationTime := cfg.CreationTimestamp
@@ -192,10 +191,19 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 
 	hostAddresses := []*HostAddress{}
 	for _, hostname := range serviceEntry.Hosts {
-		if len(addresses) > 0 {
+		localAddresses := addresses
+		if len(localAddresses) == 0 {
+			// we have no user-assed addresses but we can check if we have auto-assigned addresses
+			if autoAddresses, ok := addressLookup[hostname]; ok {
+				for _, aa := range autoAddresses {
+					localAddresses = append(localAddresses, aa.String())
+				}
+			}
+		}
+		if len(localAddresses) > 0 {
 			ha := &HostAddress{hostname, []string{}}
-			for _, address := range addresses {
-				// Check if address is an IP first because that is the most common case.
+			for _, address := range localAddresses {
+				// Check if addresses is an IP first because that is the most common case.
 				if netutil.IsValidIPAddress(address) {
 					ha.addresses = append(ha.addresses, address)
 				} else if cidr, cidrErr := netip.ParsePrefix(address); cidrErr == nil {

--- a/releasenotes/notes/52319.yaml
+++ b/releasenotes/notes/52319.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 52319
+releaseNotes:
+- |
+  **Fixed** persistent IP autoallocation for service entry to allocate per-host rather than per-servicenEntry


### PR DESCRIPTION
Fixes #52481

Manual cherry-pick of #52319, the change in master from working with v1alpha3 types to v1 types prevented the automatic cherry-pick from working

**Please provide a description of this PR:**