### PR TITLE
Only apply metadata exchange filter to mesh internal services' cluster

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -107,6 +107,10 @@ var (
 		"If true, pilot will add Istio ALPN filters, required for proper protocol sniffing.",
 	).Get()
 
+	MxFilter = env.Register("PILOT_DISABLE_MX_FILTER_ON_MESH_EXTERNAl_SERVICE", true,
+		"If true, pilot will not add metadata exchange cluster filter for mesh external service.",
+	).Get()
+
 	WorkloadEntryAutoRegistration = env.Register("PILOT_ENABLE_WORKLOAD_ENTRY_AUTOREGISTRATION", true,
 		"Enables auto-registering WorkloadEntries based on associated WorkloadGroups upon XDS connection by the workload.").Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -107,7 +107,7 @@ var (
 		"If true, pilot will add Istio ALPN filters, required for proper protocol sniffing.",
 	).Get()
 
-	MxFilter = env.Register("PILOT_DISABLE_MX_FILTER_ON_MESH_EXTERNAl_SERVICE", true,
+	DisableMxFilter = env.Register("PILOT_DISABLE_MX_FILTER_ON_MESH_EXTERNAl_SERVICE", true,
 		"If true, pilot will not add metadata exchange cluster filter for mesh external service.",
 	).Get()
 

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -205,7 +205,9 @@ func (cb *ClusterBuilder) buildSubsetCluster(
 
 	maybeApplyEdsConfig(subsetCluster.cluster)
 
-	cb.applyMetadataExchange(opts.mutable.cluster)
+	if !service.MeshExternal {
+		cb.applyMetadataExchange(opts.mutable.cluster)
+	}
 
 	// Add the DestinationRule+subsets metadata. Metadata here is generated on a per-cluster
 	// basis in buildCluster, so we can just insert without a copy.
@@ -252,7 +254,9 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	// discovery type.
 	maybeApplyEdsConfig(mc.cluster)
 
-	cb.applyMetadataExchange(opts.mutable.cluster)
+	if !service.MeshExternal {
+		cb.applyMetadataExchange(opts.mutable.cluster)
+	}
 
 	if service.MeshExternal {
 		im := getOrCreateIstioMetadata(mc.cluster)
@@ -529,7 +533,6 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 	}
 	cluster.AltStatName = util.DelimitedStatsPrefix(util.PassthroughCluster, cb.proxyVersion)
 	cb.applyConnectionPool(cb.req.Push.Mesh, newClusterWrapper(cluster), &networking.ConnectionPoolSettings{})
-	cb.applyMetadataExchange(cluster)
 	return cluster
 }
 

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -205,7 +205,7 @@ func (cb *ClusterBuilder) buildSubsetCluster(
 
 	maybeApplyEdsConfig(subsetCluster.cluster)
 
-	if !service.MeshExternal {
+	if !features.DisableMxFilter || !service.MeshExternal {
 		cb.applyMetadataExchange(opts.mutable.cluster)
 	}
 
@@ -254,7 +254,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *clusterWrapper, clusterMode C
 	// discovery type.
 	maybeApplyEdsConfig(mc.cluster)
 
-	if !service.MeshExternal {
+	if !features.DisableMxFilter || !service.MeshExternal {
 		cb.applyMetadataExchange(opts.mutable.cluster)
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix #52432


Stop adding mx filter to clusters which are for external services, they are meaningless. 

It is to make mx not functioning at all. 