### PR TITLE
Enable mesh traffic to be secured using qsafe curves

### DIFF
--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -191,6 +191,8 @@ func (cb *ClusterBuilder) buildUpstreamClusterTLSContext(opts *buildClusterOpts,
 				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
 			}
 		}
+                applyTLSConfig(tlsContext, opts.mesh.GetMeshMTLS())
+
 	case networking.ClientTLSSettings_SIMPLE:
 		tlsContext, err = constructUpstreamTLS(opts, tls, c, false)
 
@@ -265,7 +267,7 @@ func constructUpstreamTLS(opts *buildClusterOpts, tls *networking.ClientTLSSetti
 		}
 	}
 
-	applyTLSDefaults(tlsContext, opts.mesh.GetTlsDefaults())
+	applyTLSConfig(tlsContext, opts.mesh.GetTlsDefaults())
 
 	if isHttp2Cluster(c) {
 		// This is HTTP/2 cluster, advertise it with ALPN.
@@ -275,15 +277,15 @@ func constructUpstreamTLS(opts *buildClusterOpts, tls *networking.ClientTLSSetti
 }
 
 // applyTLSDefaults applies tls default settings from mesh config to UpstreamTlsContext.
-func applyTLSDefaults(tlsContext *tlsv3.UpstreamTlsContext, tlsDefaults *v1alpha1.MeshConfig_TLSConfig) {
-	if tlsDefaults == nil {
+func applyTLSConfig(tlsContext *tlsv3.UpstreamTlsContext, tlsConfig *v1alpha1.MeshConfig_TLSConfig) {
+	if tlsConfig == nil {
 		return
 	}
-	if len(tlsDefaults.EcdhCurves) > 0 {
-		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsDefaults.EcdhCurves
+	if len(tlsConfig.EcdhCurves) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.EcdhCurves = tlsConfig.EcdhCurves
 	}
-	if len(tlsDefaults.CipherSuites) > 0 {
-		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsDefaults.CipherSuites
+	if len(tlsConfig.CipherSuites) > 0 {
+		tlsContext.CommonTlsContext.TlsParams.CipherSuites = tlsConfig.CipherSuites
 	}
 }
 

--- a/pilot/pkg/networking/core/cluster_tls_test.go
+++ b/pilot/pkg/networking/core/cluster_tls_test.go
@@ -1416,7 +1416,8 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 							// if not specified, envoy use TLSv1_2 as default for client.
 							TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
 							TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
-						},
+                                                        EcdhCurves:   []string{"P-256", "P-384"},
+                                                },
 						TlsCertificateSdsSecretConfigs: []*tls.SdsSecretConfig{
 							{
 								Name: "default",

--- a/pilot/pkg/networking/core/gateway_test.go
+++ b/pilot/pkg/networking/core/gateway_test.go
@@ -1100,6 +1100,10 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
+                                        TlsParams: &auth.TlsParameters{
+                                                EcdhCurves:   []string{"P-256"},
+                                                CipherSuites: []string{"ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES256-GCM-SHA384"},
+                                        },
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "default",

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -175,28 +175,31 @@ func BuildListenerTLSContext(serverTLSSettings *networking.ServerTLSSettings,
 
 	if isSimpleOrMutual(serverTLSSettings.Mode) {
 		// If Mesh TLSDefaults are set, use them.
-		applyDownstreamTLSDefaults(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
+		applyDownstreamTLSConfig(mesh.GetTlsDefaults(), ctx.CommonTlsContext)
 		applyServerTLSSettings(serverTLSSettings, ctx.CommonTlsContext)
 	}
+        if serverTLSSettings.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
+                        applyDownstreamTLSConfig(mesh.GetMeshMTLS(), ctx.CommonTlsContext)
+        }
 
 	// Compliance for Envoy TLS downstreams.
 	authnmodel.EnforceCompliance(ctx.CommonTlsContext)
 	return ctx
 }
 
-func applyDownstreamTLSDefaults(tlsDefaults *meshconfig.MeshConfig_TLSConfig, ctx *auth.CommonTlsContext) {
-	if tlsDefaults == nil {
+func applyDownstreamTLSConfig(tlsConfig *meshconfig.MeshConfig_TLSConfig, ctx *auth.CommonTlsContext) {
+	if tlsConfig == nil {
 		return
 	}
 
-	if len(tlsDefaults.EcdhCurves) > 0 {
-		tlsParamsOrNew(ctx).EcdhCurves = tlsDefaults.EcdhCurves
+	if len(tlsConfig.EcdhCurves) > 0 {
+		tlsParamsOrNew(ctx).EcdhCurves = tlsConfig.EcdhCurves
 	}
-	if len(tlsDefaults.CipherSuites) > 0 {
-		tlsParamsOrNew(ctx).CipherSuites = tlsDefaults.CipherSuites
+	if len(tlsConfig.CipherSuites) > 0 {
+		tlsParamsOrNew(ctx).CipherSuites = tlsConfig.CipherSuites
 	}
-	if tlsDefaults.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
-		tlsParamsOrNew(ctx).TlsMinimumProtocolVersion = auth.TlsParameters_TlsProtocol(tlsDefaults.MinProtocolVersion)
+	if tlsConfig.MinProtocolVersion != meshconfig.MeshConfig_TLSConfig_TLS_AUTO {
+		tlsParamsOrNew(ctx).TlsMinimumProtocolVersion = auth.TlsParameters_TlsProtocol(tlsConfig.MinProtocolVersion)
 	}
 }
 

--- a/pkg/config/validation/agent/validation_test.go
+++ b/pkg/config/validation/agent/validation_test.go
@@ -1082,7 +1082,6 @@ func TestValidateMeshConfig(t *testing.T) {
 			"trustDomainAliases[0]",
 			"trustDomainAliases[1]",
 			"trustDomainAliases[2]",
-			"mesh TLS does not support ECDH curves configuration",
 		}
 		switch err := err.(type) {
 		case *multierror.Error:


### PR DESCRIPTION
Enable Istio's mesh mTLS communication to be secured using quantum-safe curves supported by boringssl (X25519Kyber768Draft00) today. Extend the current capability to be able to configure the ECDH curves for the mesh mTLS traffic in ISTIO_MUTUAL mode. Based on the current implementation, we can set ecdh curves for mesh traffic where the tls mode is SIMPLE or MUTUAL (using the tlsDefaults setting in MeshConfig) but not for ISTIO_MUTUAL mode (meshMTLS does not respect ecdh curves).

Fixes: #52290

**Please provide a description of this PR:**