### PR TITLE
fix: istio-cni uses hostPort only when ambient enabled

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -78,7 +78,6 @@ spec:
 {{- end }}
           ports:
           - containerPort: 15014
-            hostPort: 15014
             name: metrics
             protocol: TCP
           readinessProbe:


### PR DESCRIPTION
  # Context:
   In PR #52461 ports section is added to `istio-cni` daemonset, the
   `hostPort` is set and is not needed for either `ambient` or `sidecar`
   mode. It can even cause issue for `sidecar` mode if something else is
   running in that port iside the nodes.

  # What does this PR?
  - Delete `hostPort` for istio-cni metrics port.