### PR TITLE
Continue improving helm charts values

### DIFF
--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/base/files/profile-openshift.yaml
+++ b/manifests/charts/base/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/default/files/profile-openshift.yaml
+++ b/manifests/charts/default/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/gateway/files/profile-openshift.yaml
+++ b/manifests/charts/gateway/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
             runAsUser: 1337
             runAsGroup: 1337
             {{- end }}

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/install-OpenShift.md
+++ b/manifests/charts/install-OpenShift.md
@@ -18,7 +18,7 @@ The installation process using the Helm charts is as follows:
 helm install istio-base -n istio-system manifests/charts/base --set profile=openshift
 ```
 
-2) `istio-cni` chart installs the CNI plugin. This should be installed after the `base` chart and prior to `istiod` chart. Need to add `--set pilot.cni.enabled=true` to the `istiod` install to enable its usage.
+2) `istio-cni` chart installs the CNI plugin. This should be installed after the `base` chart and prior to `istiod` chart. Need to add `--set pilot.cniEnabled=true` to the `istiod` install to enable its usage.
 
 ```console
 helm install istio-cni -n kube-system manifests/charts/istio-cni --set profile=openshift

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/istio-cni/files/profile-openshift.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/istio-cni/templates/clusterrole.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods","nodes","namespaces"]
   verbs: ["get", "list", "watch"]
-{{- if (eq .Values.platform "openshift") }}
+{{- if (eq .Values.global.platform "openshift") }}
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
   resourceNames: ["privileged"]

--- a/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
+++ b/manifests/charts/istio-cni/templates/network-attachment-definition.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.provider "multus" }}
+{{- if eq .Values.global.platform "openshift" }}
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -45,8 +45,8 @@ metadata:
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
     {{- end }}
     {{- end }}
-{{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-    {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+{{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+    {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
     k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
     {{- end }}
     sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -70,7 +70,7 @@ spec:
       (not $nativeSidecar) }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-  {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+  {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
   - name: istio-validation
   {{ else -}}
   - name: istio-init
@@ -122,7 +122,7 @@ spec:
     {{ if .Values.global.logAsJson -}}
     - "--log_as_json"
     {{ end -}}
-    {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+    {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
     {{ end -}}
@@ -140,14 +140,14 @@ spec:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
-    {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+    {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
         add:
         - NET_ADMIN
         - NET_RAW
     {{- end }}
         drop:
         - ALL
-    {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+    {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -12,9 +12,7 @@ metadata:
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-
-{{ $vals := pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
-{{ $pilotVals := pick .Values "cni" -}}
-{{ $vals = set $vals "pilot" $pilotVals -}}
+{{ $vals := pick .Values "global" "pilot" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
 {{ $gatewayVals := pick .Values.gateways "securityContext" "seccompProfile" -}}
 {{ $vals = set $vals "gateways" $gatewayVals -}}
 {{ $vals | toPrettyJson | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -27,9 +27,8 @@ defaults:
   seccompProfile: {}
 
   # Whether to use an existing CNI installation
-  cni:
-    enabled: false
-    provider: default
+  pilot:
+    cniEnabled: false
 
   # Additional container arguments
   extraContainerArgs: []

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -45,8 +45,8 @@ metadata:
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
     {{- end }}
     {{- end }}
-{{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-    {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+{{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+    {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
     k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
     {{- end }}
     sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -70,7 +70,7 @@ spec:
       (not $nativeSidecar) }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-  {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+  {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
   - name: istio-validation
   {{ else -}}
   - name: istio-init
@@ -122,7 +122,7 @@ spec:
     {{ if .Values.global.logAsJson -}}
     - "--log_as_json"
     {{ end -}}
-    {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+    {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
     {{ end -}}
@@ -140,14 +140,14 @@ spec:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
-    {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+    {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
         add:
         - NET_ADMIN
         - NET_RAW
     {{- end }}
         drop:
         - ALL
-    {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+    {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/istiod-remote/files/profile-openshift.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -12,9 +12,7 @@ metadata:
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-
-{{ $vals := pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
-{{ $pilotVals := pick .Values "cni" -}}
-{{ $vals = set $vals "pilot" $pilotVals -}}
+{{ $vals := pick .Values "global" "pilot" "istio_cni" "sidecarInjectorWebhook" "revision" -}}
 {{ $gatewayVals := pick .Values.gateways "securityContext" "seccompProfile" -}}
 {{ $vals = set $vals "gateways" $gatewayVals -}}
 {{ $vals | toPrettyJson | indent 4 }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -22,9 +22,8 @@ defaults:
   # Set to `type: RuntimeDefault` to use the default profile if available.
   seccompProfile: {}
   # Whether to use an existing CNI installation
-  cni:
-    enabled: false
-    provider: default
+  pilot:
+    cniEnabled: false
   # Additional container arguments
   extraContainerArgs: []
   env: {}

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -19,10 +19,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/charts/ztunnel/files/profile-openshift.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift.yaml
@@ -10,11 +10,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 ---
-{{- if (eq .Values.platform "openshift") }}
+{{- if (eq .Values.global.platform "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -15,10 +15,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
+  cniEnabled: true
   env:
     PILOT_ENABLE_AMBIENT: "true"

--- a/manifests/helm-profiles/openshift.yaml
+++ b/manifests/helm-profiles/openshift.yaml
@@ -6,11 +6,7 @@ cni:
   chained: false
   cniConfFileName: "istio-cni.conf"
   logLevel: info
-  provider: "multus"
 global:
   platform: openshift
 pilot:
-  cni:
-    enabled: true
-    provider: "multus"
-platform: openshift
+  cniEnabled: true

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.pilot.cniEnabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+      {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.pilot.cniEnabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+      {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.pilot.cniEnabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+      {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.pilot.cniEnabled) (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+      {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "multus"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "multus"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -114,11 +114,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -113,11 +113,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -113,11 +113,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -114,11 +114,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -116,11 +116,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "multus"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -113,11 +113,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
@@ -113,11 +113,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if or .Values.pilot.cni.enabled .Values.istio_cni.enabled }}
-        {{- if or (eq .Values.pilot.cni.provider "multus") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
+    {{- if or .Values.pilot.cniEnabled .Values.istio_cni.enabled }}
+        {{- if or (eq .Values.global.platform "openshift") (eq .Values.istio_cni.provider "multus") (not .Values.istio_cni.chained)}}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+      {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if or .Values.pilot.cni.enabled .Values.istio_cni.enabled -}}
+        {{ if or .Values.pilot.cniEnabled .Values.istio_cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ end -}}
@@ -151,14 +151,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not (or .Values.pilot.cni.enabled .Values.istio_cni.enabled) }}
+        {{- if not (or .Values.pilot.cniEnabled .Values.istio_cni.enabled) }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -112,11 +112,9 @@
     "provider": "default"
   },
   "pilot": {
-    "cni": {
-      "enabled": false,
-      "namespace": "istio-system",
-      "provider": "default"
-    }
+    "cniEnabled": false,
+    "enabled": true,
+    "namespace": "istio-system"
   },
   "revision": "",
   "sidecarInjectorWebhook": {


### PR DESCRIPTION
Continue work from #52459:

* `.Values.platform` is used in multiple charts and we already have `.Values.global.platform` in others places, so, seems logical to me to merge them all in `.Values.global.platform`
* `.Values.provider "multus"` is only used for openshift. Change the use of `.Values.provider "multus"` by directly `.Values.global.platform "openshift"`
* Replace `.Values.pilot.cni.enabled` by `.Values.pilot.cniEnabled` to avoid failures when values are unwrapped
* Mark as deprecated `cni.enabled` and `cni.provider` to be removed in nexts releases
* Delete unsued values from openshift profiles

This PR is part of #52528
