### PR TITLE
Use real cluster name in telemetry test

### DIFF
--- a/tests/integration/telemetry/api/stats_test.go
+++ b/tests/integration/telemetry/api/stats_test.go
@@ -82,10 +82,7 @@ func TestStatsFilter(t *testing.T) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
-						sourceCluster := constants.DefaultClusterName
-						if len(t.AllClusters()) > 1 {
-							sourceCluster = c.Name()
-						}
+						sourceCluster := c.Name()
 						sourceQuery, destinationQuery, appQuery := buildQuery(sourceCluster)
 						// Query client side metrics
 						prom := promInst


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently "Kubernetes" placeholder is used which breaks test run if the cluster name is different as it get unexpected "source_cluster" label.