### PR TITLE
Be explicit to work around K8S capability validation bug

### DIFF
--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -71,7 +71,10 @@ spec:
         imagePullPolicy: {{ . }}
 {{- end }}
         securityContext:
-          allowPrivilegeEscalation: false
+          // K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+          // both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          // But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+          allowPrivilegeEscalation: true
           privileged: false
           capabilities:
             drop:

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -71,9 +71,9 @@ spec:
         imagePullPolicy: {{ . }}
 {{- end }}
         securityContext:
-          // K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
-          // both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-          // But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+          # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+          # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
           allowPrivilegeEscalation: true
           privileged: false
           capabilities:

--- a/releasenotes/notes/52540.yaml
+++ b/releasenotes/notes/52540.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+- |
+  **Fixed** Set `allowPrivilegeEscalation` to `true` in ztunnel - it has always been forced to `true` in reality but K8S does not properly validate this: https://github.com/kubernetes/kubernetes/issues/119568


### PR DESCRIPTION
**Please provide a description of this PR:**

We currently set `allowPrivilegeEscalation: false` in the ztunnel daemonset.

[K8S docs state](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/):

> 
> allowPrivilegeEscalation: Controls whether a process can gain more privileges than its parent process. This bool directly controls whether the [no_new_privs](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) flag gets set on the container process. allowPrivilegeEscalation is always true when the container:
> 
>     is run as privileged, or
>     has CAP_SYS_ADMIN
> 

Ztunnel sets `privileged: false` but does grant itself `CAP_SYS_ADMIN` - which means our manifest is lying, or the kube docs are.

This appears to be because there [is an open K8S validation bug](https://github.com/kubernetes/kubernetes/issues/119568) - their validator checks for `CAP_SYS_ADMIN` but not `SYS_ADMIN` -> they are exactly the same capability, so this is just a bug.

When that bug is fixed our manifest will start to (correctly) fail k8s securityContext validation -> this just fixes it now so the manifest represents reality and is explicit about the actual real-world perms we actually run `ztunnel` under, to avoid misleading security teams.