### PR TITLE
Fix flake in TestCreateSidecarScope

### DIFF
--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1198,7 +1198,7 @@ var (
 		{
 			Hostname: "bar.svc.cluster.local",
 			Attributes: ServiceAttributes{
-				Name:            "baz",
+				Name:            "bar",
 				Namespace:       "ns2",
 				ServiceRegistry: provider.Kubernetes,
 			},
@@ -2196,18 +2196,18 @@ func TestCreateSidecarScope(t *testing.T) {
 			virtualServices6,
 			[]*Service{
 				{
-					Hostname: "baz.svc.cluster.local",
+					Hostname: "bar.svc.cluster.local",
 					Attributes: ServiceAttributes{
-						Name:            "baz",
-						Namespace:       "ns1",
+						Name:            "bar",
+						Namespace:       "ns2",
 						ServiceRegistry: provider.Kubernetes,
 					},
 				},
 				{
-					Hostname: "bar.svc.cluster.local",
+					Hostname: "baz.svc.cluster.local",
 					Attributes: ServiceAttributes{
 						Name:            "baz",
-						Namespace:       "ns2",
+						Namespace:       "ns1",
 						ServiceRegistry: provider.Kubernetes,
 					},
 				},


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/52559

The issue is the sorting logic for the services only took name into
account and we had overlapping names. Could sort it more, but its more
clear to just have a distinct name (which does not impact the test
coverage in any way here).
