### PR TITLE
pilot: handle IstioStatus to ServiceEntryStatus conversion for analyzer instead of panicking

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -234,9 +234,8 @@ func (cl *Client) UpdateStatus(cfg config.Config) (string, error) {
 	// TODO: Handle ServiceEntryStatus -> IstioStatus analyzer conversion more elegantly before
 	// we get to this point.
 	if cfg.Meta.GroupVersionKind.Kind == gvk.ServiceEntry.Kind {
-		switch cfg.Status.(type) {
+		switch s := cfg.Status.(type) {
 		case *v1alpha1.IstioStatus:
-			s := cfg.Status.(*v1alpha1.IstioStatus)
 			cfg.Status = &v1alpha3.ServiceEntryStatus{
 				Conditions:         s.Conditions,
 				ValidationMessages: s.ValidationMessages,

--- a/pkg/config/analysis/incluster/controller.go
+++ b/pkg/config/analysis/incluster/controller.go
@@ -79,6 +79,7 @@ func NewController(stop <-chan struct{}, rwConfigStore model.ConfigStoreControll
 		//
 		// TODO: Handle ServiceEntryStatus -> IstioStatus analyzer conversion more elegantly.
 		if status == nil {
+			log.Debugf("ensure that status is initialized before zero-ing out analysis messages")
 			status = &v1alpha1.IstioStatus{}
 		}
 		// zero out analysis messages, as this is the sole controller for those

--- a/pkg/config/analysis/incluster/controller.go
+++ b/pkg/config/analysis/incluster/controller.go
@@ -73,6 +73,14 @@ func NewController(stop <-chan struct{}, rwConfigStore model.ConfigStoreControll
 	}
 	ctl := statusManager.CreateIstioStatusController(func(status *v1alpha1.IstioStatus, context any) *v1alpha1.IstioStatus {
 		msgs := context.(diag.Messages)
+		// There's an edge case with analyzing ServiceEntryStatus that causes status to be nil due to a type conversion issue.
+		// Initialize status here so that it can be converted back to ServiceEntryStatus later on when UpdateStatus is called
+		// instead of panicking and crashing here.
+		//
+		// TODO: Handle ServiceEntryStatus -> IstioStatus analyzer conversion more elegantly.
+		if status == nil {
+			status = &v1alpha1.IstioStatus{}
+		}
 		// zero out analysis messages, as this is the sole controller for those
 		status.ValidationMessages = []*v1alpha12.AnalysisMessageBase{}
 		for _, msg := range msgs {

--- a/releasenotes/notes/52000-fix-istiostatus-sestatus-conversion-bug.yaml
+++ b/releasenotes/notes/52000-fix-istiostatus-sestatus-conversion-bug.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/52000
+
+docs:
+ - '[reference] https://istio.io/latest/docs/reference/config/analysis/ist0134/'
+
+releaseNotes:
+- |
+  **Fixed** an issue that caused the Analyzer to panic when a ServiceEntry with a TCP protocol is added with a nil spec.address. 
+  This ensures that the type conversion between IstioStatus and ServiceEntryStatus succeeds and produces the appropriate validation message.
+  


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to issue #52000 . This PR makes it so we do not panic when attempting to apply a ServiceEntry with no address. Now, with this change, you get the proper `istioctl analyze` result and also Istio does not crash:

> azureuser@dev2024-2:~/Dev/istio$ istioctl analyze
Warning [IST0133] (ServiceEntry default/testing3) Schema validation warning: addresses are required for ports serving TCP (or unset) protocol
Warning [IST0134] (ServiceEntry default/testing3) ServiceEntry addresses are required for this protocol.