### PR TITLE
testing: create dependency deny/allow list

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -278,34 +278,10 @@ MARKDOWN_LINT_ALLOWLIST=localhost:8080,storage.googleapis.com/istio-artifacts/pi
 lint-helm-global:
 	find manifests -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint
 
-lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global check-agent-deps ## Runs all linters.
+lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global ## Runs all linters.
 	@bin/check_samples.sh
 	@testlinter
 	@envvarlinter istioctl pilot security
-
-# Allow-list:
-# (k8s) some Machinery, utils, klog
-# (proto) Istio API non-CRDs, MeshConfig and ProxyConfig
-# (proto) Envoy TLS proto for SDS
-# (proto) Envoy Wasm filters for wasm xDS proxy
-# (proto) xDS discovery service for xDS proxy
-# (proto) SDS secret and contrib QAT and cryptomb
-.PHONY: check-agent-deps
-check-agent-deps:
-	@go list -f '{{ join .Deps "\n" }}' -tags=agent \
-			./pilot/cmd/pilot-agent/... \
-			./pkg/istio-agent/... | sort | uniq |\
-		grep -Pv '^k8s.io/(utils|klog)/' |\
-		grep -Pv '^k8s.io/apimachinery/pkg/types' |\
-		grep -Pv '^k8s.io/apimachinery/pkg/util/(rand|version)' |\
-		grep -Pv 'envoy/type/|envoy/annotations|envoy/config/core/' |\
-		grep -Pv 'envoy/extensions/transport_sockets/tls/' |\
-		grep -Pv 'envoy/service/(discovery|secret)/v3' |\
-		grep -Pv 'envoy/extensions/wasm/' |\
-		grep -Pv 'envoy/extensions/filters/(http|network)/wasm/' |\
-		grep -Pv 'contrib/envoy/extensions/private_key_providers/' |\
-		grep -Pv 'istio\.io/api/(annotation|label|mcp|mesh|networking|analysis/v1alpha1|meta/v1alpha1|security/v1alpha1|type)' |\
-		(! grep -P '^k8s.io|^sigs.k8s.io/gateway-api|cel|antlr|jwx/jwk|envoy/|istio.io/api')
 
 go-gen:
 	@mkdir -p /tmp/bin

--- a/tests/binary/dependencies_test.go
+++ b/tests/binary/dependencies_test.go
@@ -1,0 +1,190 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binary
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/util/sets"
+)
+
+// TestDependencies controls which binaries can import which packages.
+// Note we also use linting (depguard), but that only handles direct dependencies, while this covers indirect ones.
+func TestDependencies(t *testing.T) {
+	tests := []struct {
+		entrypoint string
+		tag        string
+		// Regex of dependencies we do not allow
+		denied []string
+		// Exceptions to the above. This allows a denial like `foo/` with an exception for `foo/bar/bz`
+		exceptions []string
+		// Things we wish were not import
+		wantToDeny []string
+	}{
+		{
+			entrypoint: "pilot/cmd/pilot-agent",
+			tag:        "agent,disable_pgv",
+			exceptions: []string{
+				`^k8s\.io/(utils|klog)/`,
+				`^k8s\.io/apimachinery/pkg/types`,
+				`^k8s\.io/apimachinery/pkg/util/(rand|version)`,
+				`envoy/type/|envoy/annotations|envoy/config/core/`,
+				`envoy/extensions/transport_sockets/tls/`,
+				`envoy/service/(discovery|secret)/v3`,
+				`envoy/extensions/wasm/`,
+				`envoy/extensions/filters/(http|network)/wasm/`,
+				`github.com/envoyproxy/protoc-gen-validate/validate`,
+				`github.com/envoyproxy/go-control-plane/pkg/conversion`,
+				`contrib/envoy/extensions/private_key_providers/`,
+				`^istio\.io/api/(annotation|label|mcp|mesh|networking|type)`,
+				`^istio\.io/api/analysis/v1alpha1`,
+				`^istio\.io/api/meta/v1alpha1`,
+				`^istio\.io/api/security/v1alpha1`,
+			},
+			denied: []string{
+				`^k8s\.io`,
+				`^sigs\.k8s\.io/gateway-api`,
+				`^github\.com/google/cel-go`,
+				`^github\.com/antlr/antlr4`,
+				`^github\.com/lestrrat-go/jwx/jwk`,
+				`^github\.com/envoyproxy`,
+				`^istio\.io/api`,
+			},
+			wantToDeny: []string{
+				`^testing$`,
+			},
+		},
+		{
+			entrypoint: "pilot/cmd/pilot-discovery",
+			tag:        "vtprotobuf,disable_pgv",
+			exceptions: []string{},
+			denied: []string{
+				// Deps meant only for other components; if we import them, something may be wrong
+				`^github\.com/containernetworking/`,
+				`^github\.com/fatih/color`,
+				`^github\.com/florianl/go-nflog/v2`,
+				`^github\.com/vishvananda/`,
+				`^helm\.sh/helm/v3`,
+				`^sigs\.k8s\.io/controller-runtime`,
+				// Testing deps
+				`^github\.com/AdaLogics/go-fuzz-headers`,
+				`^github\.com/google/shlex`,
+				`^github\.com/howardjohn/unshare-go`,
+				`^github\.com/pmezard/go-difflib`,
+			},
+			wantToDeny: []string{
+				`^testing$`,
+			},
+		},
+	}
+	allDenials := []*regexp.Regexp{}
+	for _, tt := range tests {
+		t.Run(tt.entrypoint, func(t *testing.T) {
+			deps, err := getDependencies(filepath.Join(env.IstioSrc, tt.entrypoint), tt.tag, false)
+			assert.NoError(t, err)
+			denies, err := slices.MapErr(tt.denied, regexp.Compile)
+			allDenials = append(allDenials, denies...)
+			assert.NoError(t, err)
+			exceptions, err := slices.MapErr(tt.exceptions, regexp.Compile)
+			assert.NoError(t, err)
+			maybeCanMoveToDeny := map[string]*regexp.Regexp{}
+			for _, wd := range tt.wantToDeny {
+				maybeCanMoveToDeny[wd] = regexp.MustCompile(wd)
+			}
+			assert.NoError(t, err)
+			unseenExceptions := sets.New[string](tt.exceptions...)
+			for _, dep := range deps {
+				for _, deny := range denies {
+					if !deny.MatchString(dep) {
+						continue
+					}
+					allowed := false
+					for _, allow := range exceptions {
+						if allow.MatchString(dep) {
+							unseenExceptions.Delete(allow.String())
+							allowed = true
+							break
+						}
+					}
+					if !allowed {
+						t.Errorf("illegal dependency: %v", dep)
+					}
+				}
+				for _, wantDeny := range maybeCanMoveToDeny {
+					if wantDeny.MatchString(dep) {
+						// We want to deny it, but we are depending on it.. cannot deny it
+						delete(maybeCanMoveToDeny, wantDeny.String())
+					}
+				}
+			}
+			for us := range unseenExceptions {
+				t.Errorf("exception %q was never matched, maybe redundant?", us)
+			}
+			for rgx := range maybeCanMoveToDeny {
+				t.Errorf("we wanted to deny %q, and it was not found! move it to the denials list", rgx)
+			}
+			t.Logf("%d total dependencies", len(deps))
+		})
+	}
+	t.Run("exhaustive", func(t *testing.T) {
+		all, err := getDependencies(env.IstioSrc+"/...", "", true)
+		assert.NoError(t, err)
+		for _, d := range allDenials {
+			found := false
+			for _, dep := range all {
+				if d.MatchString(dep) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Had a deny rule %q, but it doesn't match *any* dependency in the repo. This is likely a bug.", d)
+			}
+		}
+		t.Logf("%d total dependencies", len(all))
+	})
+}
+
+func getDependencies(path, tag string, tests bool) ([]string, error) {
+	args := []string{"list", "-mod=readonly", "-f", `{{ join .Deps "\n" }}`, "-tags=" + tag}
+	if tests {
+		args = append(args, "-test")
+	}
+	args = append(args, path)
+	cmd := exec.Command("go", args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("%v: %v", err, stderr.String())
+	}
+	modules := strings.Split(stdout.String(), "\n")
+	modules = slices.Sort(modules)
+	modules = slices.FilterDuplicatesPresorted(modules)
+
+	return modules, nil
+}


### PR DESCRIPTION
This was previously done partially for agent, but in a hard to
understand makefile target. Now it is a bit more explicit, and added
pilot
