### PR TITLE
Fix pilot-agent stats: pass `usedonly` query string to envoy

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -540,7 +540,11 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 
 	// Gather all the metrics we will merge
 	if !s.config.NoEnvoy {
-		if envoy, envoyCancel, _, err = s.scrape(fmt.Sprintf("http://localhost:%d/stats/prometheus", s.envoyStatsPort), r.Header); err != nil {
+		scrapeURL := fmt.Sprintf("http://localhost:%d/stats/prometheus", s.envoyStatsPort)
+		if r.URL != nil && r.URL.Query().Has("usedonly") {
+			scrapeURL += "?usedonly"
+		}
+		if envoy, envoyCancel, _, err = s.scrape(scrapeURL, r.Header); err != nil {
 			log.Errorf("failed scraping envoy metrics: %v", err)
 			metrics.EnvoyScrapeErrors.Increment()
 		}


### PR DESCRIPTION
**Please provide a description of this PR:**

When using `:15020/stats/prometheus?usedonly`, the pilot-agent does not pass the `usedonly` query string to Envoy. This may result in collecting too many metrics and leads to inconsistent behavior compared to Envoy's `/stats/prometheus?usedonly` endpoint.

https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats?usedonly

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
