### PR TITLE
authz support string contains match

### DIFF
--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -33,14 +33,27 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 				PresentMatch: true,
 			},
 		}
-	} else if strings.HasPrefix(v, "*") {
+	}
+
+	if strings.HasPrefix(v, "*") && strings.HasSuffix(v, "*") {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+				StringMatch: StringMatcherContains(v[1:len(v)-1], false),
+			},
+		}
+	}
+
+	if strings.HasPrefix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
 			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
 				StringMatch: StringMatcherSuffix(v[1:], false),
 			},
 		}
-	} else if strings.HasSuffix(v, "*") {
+	}
+
+	if strings.HasSuffix(v, "*") {
 		return &routepb.HeaderMatcher{
 			Name: k,
 			HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
@@ -48,6 +61,7 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 			},
 		}
 	}
+
 	return &routepb.HeaderMatcher{
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -75,6 +75,17 @@ func TestHeaderMatcher(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "contains match",
+			K:    "cookie",
+			V:    "*foo*",
+			Expect: &routepb.HeaderMatcher{
+				Name: "cookie",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
+					StringMatch: StringMatcherContains("foo", false),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -45,11 +45,11 @@ func TestHeaderMatcher(t *testing.T) {
 		{
 			Name: "suffix match",
 			K:    ":path",
-			V:    "*/productpage*",
+			V:    "*/productpage",
 			Expect: &routepb.HeaderMatcher{
 				Name: ":path",
 				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: StringMatcherSuffix("/productpage*", false),
+					StringMatch: StringMatcherSuffix("/productpage", false),
 				},
 			},
 		},

--- a/pilot/pkg/security/authz/matcher/string.go
+++ b/pilot/pkg/security/authz/matcher/string.go
@@ -93,6 +93,16 @@ func StringMatcherExact(exact string, ignoreCase bool) *matcher.StringMatcher {
 	}
 }
 
+// StringMatcherContains create a string matcher for contains matching.
+func StringMatcherContains(str string, ignoreCase bool) *matcher.StringMatcher {
+	return &matcher.StringMatcher{
+		IgnoreCase: ignoreCase,
+		MatchPattern: &matcher.StringMatcher_Contains{
+			Contains: str,
+		},
+	}
+}
+
 // StringMatcherWithPrefix creates a string matcher for v with the extra prefix inserted to the
 // created string matcher, note the prefix is ignored if v is wildcard ("*").
 // The wildcard "*" will be generated as ".+" instead of ".*".

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -417,6 +417,17 @@ func TestGenerator(t *testing.T) {
             exact: foo`),
 		},
 		{
+			name:  "requestHeaderGenerator contains",
+			g:     requestHeaderGenerator{},
+			key:   "request.headers[x-foo]",
+			value: "*foo*",
+			want: yamlPrincipal(t, `
+        header:
+          name: x-foo
+          stringMatch:
+            contains: foo`),
+		},
+		{
 			name:  "requestClaimGenerator",
 			g:     requestClaimGenerator{},
 			key:   "request.auth.claims[bar]",

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1419,6 +1419,30 @@ func TestAuthz_Conditions(t *testing.T) {
 							headers: headers.New().With("x-foo", "bar").Build(),
 							allow:   false,
 						},
+						{
+							path:    "/request-headers-valueContains",
+							headers: headers.New().With("Cookie", "foo=bar").Build(),
+							allow:   true,
+						},
+						{
+							path:    "/request-headers-valueContains",
+							headers: headers.New().With("Cookie", "abc=bar").Build(),
+							allow:   false,
+						},
+						{
+							path:    "/request-headers-valueContains",
+							headers: headers.New().With("Cookie", "foo=bar; abc=bar").Build(),
+							allow:   true,
+						},
+						{
+							path:    "/request-headers-valueContains",
+							headers: headers.New().With("Cookie", "abc=bar; foo=bar").Build(),
+							allow:   true,
+						},
+						{
+							path:  "/request-headers-valueContains",
+							allow: false,
+						},
 
 						// Test source IP
 						{

--- a/tests/integration/security/testdata/authz/conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/conditions.yaml.tmpl
@@ -19,6 +19,12 @@ spec:
     when:
       - key: request.headers[x-foo]
         notValues: [ "bar" ]
+  - to:
+      - operation:
+          paths: [ "/request-headers-valueContains" ]
+    when:
+      - key: request.headers[Cookie]
+        values: [ "*foo=*" ]
 ---
 
 apiVersion: security.istio.io/v1


### PR DESCRIPTION
support string contains match or authz `request.headers`, fix https://github.com/istio/istio/issues/52557

This is probably a behavior change: 
the old unit tests treat it as a `suffix` match, this PR treat it as a `contains` match, see:
https://github.com/istio/istio/blob/42e7e83686df24d519c5dd6ac626e3394e44c61b/pilot/pkg/security/authz/matcher/header_test.go#L48

Another option is to treat `.*foo.*` (rather than `*foo*`) as a `contains` semantic. (Or use other methods to support `contains` or `regex` semantics.)