### PR TITLE
Fix Handling of Deletions in EDS Cache and Update Functions

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -748,14 +748,14 @@ func (s *Controller) queueEdsEvent(keys sets.Set[instancesKey], edsFn func(keys 
 func (s *Controller) doEdsCacheUpdate(keys sets.Set[instancesKey]) {
 	endpoints := s.buildEndpoints(keys)
 	shard := model.ShardKeyFromRegistry(s)
-	// This is delete.
-	if len(endpoints) == 0 {
-		for k := range keys {
-			s.XdsUpdater.EDSCacheUpdate(shard, string(k.hostname), k.namespace, nil)
-		}
-	} else {
-		for k, eps := range endpoints {
+
+	for k := range keys {
+		if eps, ok := endpoints[k]; ok {
+			// Update the cache with the generated endpoints.
 			s.XdsUpdater.EDSCacheUpdate(shard, string(k.hostname), k.namespace, eps)
+		} else {
+			// Handle deletions by sending a nil endpoints update.
+			s.XdsUpdater.EDSCacheUpdate(shard, string(k.hostname), k.namespace, nil)
 		}
 	}
 }
@@ -764,14 +764,14 @@ func (s *Controller) doEdsCacheUpdate(keys sets.Set[instancesKey]) {
 func (s *Controller) doEdsUpdate(keys sets.Set[instancesKey]) {
 	endpoints := s.buildEndpoints(keys)
 	shard := model.ShardKeyFromRegistry(s)
-	// This is delete.
-	if len(endpoints) == 0 {
-		for k := range keys {
-			s.XdsUpdater.EDSUpdate(shard, string(k.hostname), k.namespace, nil)
-		}
-	} else {
-		for k, eps := range endpoints {
+
+	for k := range keys {
+		if eps, ok := endpoints[k]; ok {
+			// Update with the generated endpoints.
 			s.XdsUpdater.EDSUpdate(shard, string(k.hostname), k.namespace, eps)
+		} else {
+			// Handle deletions by sending a nil endpoints update.
+			s.XdsUpdater.EDSUpdate(shard, string(k.hostname), k.namespace, nil)
 		}
 	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -558,6 +558,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			Event{Type: "service", ID: "selector1.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "service", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "eds cache", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
+			Event{Type: "eds cache", ID: "selector1.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "xds full", ID: "*.google.com,selector1.com"}) // service added
 
 		selector1Updated := func() *config.Config {
@@ -573,6 +574,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			Event{Type: "service", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "service", ID: "selector1.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "eds cache", ID: "*.google.com", Namespace: httpStaticOverlay.Namespace},
+			Event{Type: "eds cache", ID: "selector1.com", Namespace: httpStaticOverlay.Namespace},
 			Event{Type: "xds full", ID: "*.google.com,selector1.com"}) // service updated
 	})
 }

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -1012,6 +1012,119 @@ func TestWorkloadInstances(t *testing.T) {
 		expectServiceEndpoints(t, fx, expectedSvc, 80, instances)
 	})
 
+	t.Run("ServiceEntry selects WorkloadEntry", func(t *testing.T) {
+		store, _, fx := setupTest(t)
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "service-entry-1",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.ServiceEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.ServiceEntry{
+				Hosts: []string{"service-1.namespace.svc.cluster.local"},
+				Ports: []*networking.ServicePort{port},
+				WorkloadSelector: &networking.WorkloadSelector{
+					Labels: map[string]string{
+						"app.foo": "true",
+					},
+				},
+				Resolution: networking.ServiceEntry_STATIC,
+			},
+		})
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "service-entry-2",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.ServiceEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.ServiceEntry{
+				Hosts: []string{"service-2.namespace.svc.cluster.local"},
+				Ports: []*networking.ServicePort{port},
+				WorkloadSelector: &networking.WorkloadSelector{
+					Labels: map[string]string{
+						"app.bar": "true",
+					},
+				},
+				Resolution: networking.ServiceEntry_STATIC,
+			},
+		})
+		// Both service entries share a common workload entry
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "workloadentry",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels: map[string]string{
+					"app.foo": "true",
+					"app.bar": "true",
+				},
+			},
+		})
+
+		fx.WaitOrFail(t, "xds full")
+		instances := []EndpointResponse{{
+			Address: "2.3.4.5",
+			Port:    80,
+		}}
+		expectedSvc1 := &model.Service{
+			Hostname: "service-1.namespace.svc.cluster.local",
+			Ports: []*model.Port{{
+				Name:     "http",
+				Port:     80,
+				Protocol: "http",
+			}},
+			Attributes: model.ServiceAttributes{
+				Namespace: namespace,
+				Name:      "service-entry-1",
+				LabelSelectors: map[string]string{
+					"app.foo": "true",
+				},
+			},
+		}
+		expectedSvc2 := &model.Service{
+			Hostname: "service-2.namespace.svc.cluster.local",
+			Ports: []*model.Port{{
+				Name:     "http",
+				Port:     80,
+				Protocol: "http",
+			}},
+			Attributes: model.ServiceAttributes{
+				Namespace: namespace,
+				Name:      "service-entry-2",
+				LabelSelectors: map[string]string{
+					"app.bar": "true",
+				},
+			},
+		}
+		expectServiceEndpoints(t, fx, expectedSvc1, 80, instances)
+		expectServiceEndpoints(t, fx, expectedSvc2, 80, instances)
+		fx.Clear()
+		// Delete the `app.foo` label to unselect service entry
+		makeIstioObject(t, store, config.Config{
+			Meta: config.Meta{
+				Name:             "workloadentry",
+				Namespace:        namespace,
+				GroupVersionKind: gvk.WorkloadEntry,
+				Domain:           "cluster.local",
+			},
+			Spec: &networking.WorkloadEntry{
+				Address: "2.3.4.5",
+				Labels: map[string]string{
+					"app.bar": "true",
+				},
+			},
+		})
+		fx.WaitOrFail(t, "xds")
+		expectServiceEndpoints(t, fx, expectedSvc1, 80, []EndpointResponse{})
+		expectServiceEndpoints(t, fx, expectedSvc2, 80, instances)
+	})
+
 	t.Run("All directions", func(t *testing.T) {
 		store, kube, fx := setupTest(t)
 		makeService(t, kube, service)


### PR DESCRIPTION
**Please provide a description of this PR:**

Added logic to ensure that any keys without corresponding endpoints are explicitly treated as deletions by sending a `nil` endpoints update. Previously, such keys were not properly handled, leading to potential inconsistencies in the EDS Updates.
