### PR TITLE
Fix sending to external service entry from a VS

### DIFF
--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -388,10 +388,6 @@ func BuildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext
 
 	servicesByName := make(map[host.Name]*model.Service)
 	for _, svc := range services {
-		if svc.Resolution == model.Alias {
-			// Will be handled by the service it is an alias for
-			continue
-		}
 		if listenerPort == 0 {
 			// Take all ports when listen port is 0 (http_proxy or uds)
 			// Expect virtualServices to resolve to right port

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -124,6 +124,13 @@ func BuildSidecarVirtualHostWrapper(routeCache *Cache, node *model.Proxy, push *
 	}
 
 	for _, svc := range serviceRegistry {
+		// Filter any aliases out. While we want to be able to use them as the backend to a route, we don't want
+		// to have them build standalone route matches; this is already handled.
+		// Each alias will get a mapping of 'Alias -> Concrete' service when the concrete service is built
+		// if we let this through, we would get 'Alias -> Alias'.
+		if svc.Resolution == model.Alias {
+			continue
+		}
 		for _, port := range svc.Ports {
 			if port.Protocol.IsHTTPOrSniffed() {
 				hash, destinationRule := hashForService(push, node, svc, port)

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2839,6 +2839,40 @@ spec:
 		children: calls("b-ext-se"),
 	})
 
+	t.RunTraffic(TrafficTestCase{
+		name:         "routed",
+		globalConfig: true,
+		config: fmt.Sprintf(`apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: ext-route
+spec:
+  gateways:
+  - mesh
+  hosts:
+  - c
+  http:
+  - route:
+    - destination:
+        host: b-ext-route.%s.svc.cluster.local
+        port:
+          number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: b-ext-route
+spec:
+  type: ExternalName
+  externalName: b.%s.svc.cluster.local
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80`, t.Apps.Namespace.Name(), t.Apps.Namespace.Name()),
+		children: calls("c", check.MTLSForHTTP()),
+	})
+
 	gatewayListenPort := 80
 	gatewayListenPortName := "http"
 	t.RunTraffic(TrafficTestCase{

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2840,7 +2840,11 @@ spec:
 	})
 
 	t.RunTraffic(TrafficTestCase{
-		name:         "routed",
+		name: "routed",
+		skip: skip{
+			skip:   t.Clusters().IsMulticluster(),
+			reason: "we need to apply service to all but Istio config to only Istio clusters, which we don't support",
+		},
 		globalConfig: true,
 		config: fmt.Sprintf(`apiVersion: networking.istio.io/v1
 kind: VirtualService


### PR DESCRIPTION
Currently, you can send traffic to an ExternalName service to a VS only from Gateways. This was due to an over-ambitiuous filtering. To align with Gateway behavior, move this check later. See the added e2e test case for more info on this.

Reported https://istio.slack.com/archives/C38CF1PEC/p1723100116648679