### PR TITLE
Remove comments about virtual service host matching flag

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -233,8 +233,7 @@ type IstioEgressListenerWrapper struct {
 	virtualServices []config.Config
 
 	// An index of hostname to the namespaced name of the VirtualService containing the most
-	// relevant host match. Depending on the `PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING`
-	// feature flag, it could be the most specific host match or the oldest host match.
+	// specific host match.
 	mostSpecificWildcardVsIndex map[host.Name]types.NamespacedName
 }
 

--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -200,7 +200,7 @@ func separateVSHostsAndServices(virtualService config.Config,
 			}
 			// The mostSpecificWildcardVsIndex ensures that each VirtualService host is only associated with
 			// a single service in the registry. This is generally results in the most specific wildcard match for
-			// a given wildcard host (unless PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING is true).
+			// a given wildcard host.
 			vs, ok := mostSpecificWildcardVsIndex[svcHost]
 			if !ok {
 				// This service doesn't have a virtualService that matches it.


### PR DESCRIPTION
**Please provide a description of this PR:**

PERSIST_OLDEST_FIRST_HEURISTIC_FOR_VIRTUAL_SERVICE_HOST_MATCHING is removed on master.
I'm cleaning up some leftover comments