### PR TITLE
Remove code paths for VERIFY_CERTIFICATE_AT_CLIENT

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -225,9 +225,6 @@ var (
 	EnableAutoSni = env.Register("ENABLE_AUTO_SNI", true,
 		"If enabled, automatically set SNI when `DestinationRules` do not specify the same").Get()
 
-	VerifyCertAtClient = env.Register("VERIFY_CERTIFICATE_AT_CLIENT", true,
-		"If enabled, certificates received by the proxy will be verified against the OS CA certificate bundle.").Get()
-
 	EnableVtprotobuf = env.Register("ENABLE_VTPROTOBUF", true,
 		"If true, will use optimized vtprotobuf based marshaling. Requires a build with -tags=vtprotobuf.").Get()
 

--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -2560,10 +2560,9 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 		proxyView                 model.ProxyView
 		destRule                  *networking.DestinationRule
 		expectedCaCertificateName string
-		enableVerifyCertAtClient  bool
 	}{
 		{
-			name:        "VerifyCertAtClient set and destination rule with empty string CaCertificates",
+			name:        "destination rule with empty string CaCertificates",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -2585,10 +2584,9 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 				},
 			},
 			expectedCaCertificateName: "system",
-			enableVerifyCertAtClient:  true,
 		},
 		{
-			name:        "VerifyCertAtClient set and destination rule with CaCertificates",
+			name:        "destination rule with CaCertificates",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -2610,10 +2608,9 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 				},
 			},
 			expectedCaCertificateName: "root-cert.pem",
-			enableVerifyCertAtClient:  true,
 		},
 		{
-			name:        "VerifyCertAtClient set and destination rule without CaCertificates",
+			name:        "destination rule without CaCertificates",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -2634,63 +2631,11 @@ func TestApplyDestinationRuleOSCACert(t *testing.T) {
 				},
 			},
 			expectedCaCertificateName: "system",
-			enableVerifyCertAtClient:  true,
-		},
-		{
-			name:        "VerifyCertAtClient false and destination rule without CaCertificates",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
-			clusterMode: DefaultClusterMode,
-			service:     service,
-			port:        servicePort[0],
-			proxyView:   model.ProxyViewAll,
-			destRule: &networking.DestinationRule{
-				Host: "foo.default.svc.cluster.local",
-				TrafficPolicy: &networking.TrafficPolicy{
-					ConnectionPool: &networking.ConnectionPoolSettings{
-						Http: &networking.ConnectionPoolSettings_HTTPSettings{
-							MaxRetries:        10,
-							UseClientProtocol: true,
-						},
-					},
-					Tls: &networking.ClientTLSSettings{
-						Mode: networking.ClientTLSSettings_SIMPLE,
-					},
-				},
-			},
-			expectedCaCertificateName: "",
-			enableVerifyCertAtClient:  false,
-		},
-		{
-			name:        "VerifyCertAtClient false and destination rule with CaCertificates",
-			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
-			clusterMode: DefaultClusterMode,
-			service:     service,
-			port:        servicePort[0],
-			proxyView:   model.ProxyViewAll,
-			destRule: &networking.DestinationRule{
-				Host: "foo.default.svc.cluster.local",
-				TrafficPolicy: &networking.TrafficPolicy{
-					ConnectionPool: &networking.ConnectionPoolSettings{
-						Http: &networking.ConnectionPoolSettings_HTTPSettings{
-							MaxRetries:        10,
-							UseClientProtocol: true,
-						},
-					},
-					Tls: &networking.ClientTLSSettings{
-						CaCertificates: "root-cert.pem",
-						Mode:           networking.ClientTLSSettings_SIMPLE,
-					},
-				},
-			},
-			expectedCaCertificateName: "root-cert.pem",
-			enableVerifyCertAtClient:  false,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			test.SetForTest(t, &features.VerifyCertAtClient, tt.enableVerifyCertAtClient)
-
 			var cfg *config.Config
 			if tt.destRule != nil {
 				cfg = &config.Config{
@@ -3077,8 +3022,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: false,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3134,8 +3078,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: false,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3173,7 +3116,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode simple, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
+			name:        "With tls mode simple, InsecureSkipVerify is set true",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3190,8 +3133,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3205,7 +3147,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode simple, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true and AUTO_SNI is true",
+			name:        "With tls mode simple, InsecureSkipVerify is set true and AUTO_SNI is true",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3221,8 +3163,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            true,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3235,7 +3176,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode simple and CredentialName, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
+			name:        "With tls mode simple and CredentialName, InsecureSkipVerify is set true and env",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3254,8 +3195,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 				},
 				WorkloadSelector: &v1beta1.WorkloadSelector{},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3287,8 +3227,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: false,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3368,8 +3307,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: false,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3429,7 +3367,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode mutual, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
+			name:        "With tls mode mutual, InsecureSkipVerify is set true",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3448,8 +3386,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3485,7 +3422,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode mutual, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true and AUTO_SNI is true",
+			name:        "With tls mode mutual, InsecureSkipVerify is set true and AUTO_SNI is true",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3503,8 +3440,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            true,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3539,7 +3475,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 			},
 		},
 		{
-			name:        "With tls mode mutual and CredentialName, InsecureSkipVerify is set true and env VERIFY_CERTIFICATE_AT_CLIENT is true",
+			name:        "With tls mode mutual and CredentialName, InsecureSkipVerify is set true",
 			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
 			clusterMode: DefaultClusterMode,
 			service:     service,
@@ -3558,8 +3494,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 				},
 				WorkloadSelector: &v1beta1.WorkloadSelector{},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3600,8 +3535,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 					},
 				},
 			},
-			enableAutoSni:            false,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: false,
 			expectTLSContext: &tls.UpstreamTlsContext{
 				CommonTlsContext: &tls.CommonTlsContext{
 					TlsParams: &tls.TlsParameters{
@@ -3668,7 +3602,6 @@ func TestInsecureSkipVerify(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			test.SetForTest(t, &features.EnableAutoSni, tc.enableAutoSni)
-			test.SetForTest(t, &features.VerifyCertAtClient, tc.enableVerifyCertAtClient)
 
 			targets := []model.ServiceTarget{
 				{

--- a/pilot/pkg/networking/core/cluster_test.go
+++ b/pilot/pkg/networking/core/cluster_test.go
@@ -2998,11 +2998,10 @@ func TestVerifyCertAtClient(t *testing.T) {
 	testCases := []struct {
 		name               string
 		policy             *networking.TrafficPolicy
-		verifyCertAtClient bool
 		expectedCARootPath string
 	}{
 		{
-			name: "VERIFY_CERTIFICATE_AT_CLIENT works as expected",
+			name: "Check that certs are verfied against the OS CA certificate bundle",
 			policy: &networking.TrafficPolicy{
 				ConnectionPool: &networking.ConnectionPoolSettings{
 					Http: &networking.ConnectionPoolSettings_HTTPSettings{
@@ -3013,11 +3012,10 @@ func TestVerifyCertAtClient(t *testing.T) {
 					CaCertificates: "",
 				},
 			},
-			verifyCertAtClient: true,
 			expectedCARootPath: "system",
 		},
 		{
-			name: "VERIFY_CERTIFICATE_AT_CLIENT does not override CaCertificates",
+			name: "Check that CaCertificates has priority over OS CA certificate bundle",
 			policy: &networking.TrafficPolicy{
 				ConnectionPool: &networking.ConnectionPoolSettings{
 					Http: &networking.ConnectionPoolSettings_HTTPSettings{
@@ -3028,44 +3026,12 @@ func TestVerifyCertAtClient(t *testing.T) {
 					CaCertificates: "file-root:certPath",
 				},
 			},
-			verifyCertAtClient: true,
 			expectedCARootPath: "file-root:certPath",
-		},
-		{
-			name: "Filled CaCertificates does not get over written by VERIFY_CERTIFICATE_AT_CLIENT is false",
-			policy: &networking.TrafficPolicy{
-				ConnectionPool: &networking.ConnectionPoolSettings{
-					Http: &networking.ConnectionPoolSettings_HTTPSettings{
-						MaxRetries: 10,
-					},
-				},
-				Tls: &networking.ClientTLSSettings{
-					CaCertificates: "file-root:certPath",
-				},
-			},
-			verifyCertAtClient: false,
-			expectedCARootPath: "file-root:certPath",
-		},
-		{
-			name: "Empty CaCertificates does not get over written by VERIFY_CERTIFICATE_AT_CLIENT is false",
-			policy: &networking.TrafficPolicy{
-				ConnectionPool: &networking.ConnectionPoolSettings{
-					Http: &networking.ConnectionPoolSettings_HTTPSettings{
-						MaxRetries: 10,
-					},
-				},
-				Tls: &networking.ClientTLSSettings{
-					CaCertificates: "",
-				},
-			},
-			verifyCertAtClient: false,
-			expectedCARootPath: "",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			test.SetForTest(t, &features.VerifyCertAtClient, testCase.verifyCertAtClient)
 			selectTrafficPolicyComponents(testCase.policy)
 			if testCase.policy.Tls.CaCertificates != testCase.expectedCARootPath {
 				t.Errorf("%v got %v when expecting %v", testCase.name, testCase.policy.Tls.CaCertificates, testCase.expectedCARootPath)

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -288,7 +288,7 @@ func applyTLSDefaults(tlsContext *tlsv3.UpstreamTlsContext, tlsDefaults *v1alpha
 }
 
 // Set auto_sni if EnableAutoSni feature flag is enabled and if sni field is not explicitly set in DR.
-// Set auto_san_validation if VerifyCertAtClient feature flag is enabled and if there is no explicit SubjectAltNames specified  in DR.
+// Set auto_san_validation if there is no explicit SubjectAltNames specified in DR.
 func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTLSSettings) {
 	if mc == nil || !features.EnableAutoSni {
 		return
@@ -299,7 +299,7 @@ func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTL
 	if len(tls.Sni) == 0 {
 		setAutoSni = true
 	}
-	if features.VerifyCertAtClient && setAutoSni && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
+	if setAutoSni && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
 		setAutoSanValidation = true
 	}
 

--- a/pilot/pkg/networking/core/cluster_tls_test.go
+++ b/pilot/pkg/networking/core/cluster_tls_test.go
@@ -434,14 +434,13 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 	credentialName := "some-fake-credential"
 
 	testCases := []struct {
-		name                     string
-		opts                     *buildClusterOpts
-		tls                      *networking.ClientTLSSettings
-		h2                       bool
-		router                   bool
-		result                   expectedResult
-		enableAutoSni            bool
-		enableVerifyCertAtClient bool
+		name          string
+		opts          *buildClusterOpts
+		tls           *networking.ClientTLSSettings
+		h2            bool
+		router        bool
+		result        expectedResult
+		enableAutoSni bool
 	}{
 		{
 			name: "tls mode disabled",
@@ -703,8 +702,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				err: nil,
 			},
-			enableAutoSni:            true,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 		},
 		{
 			name: "tls mode SIMPLE, with VerifyCert and AutoSni enabled without SubjectAltNames set",
@@ -729,8 +727,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				err: nil,
 			},
-			enableAutoSni:            true,
-			enableVerifyCertAtClient: true,
+			enableAutoSni: true,
 		},
 		{
 			name: "tls mode SIMPLE, with certs specified in tls",
@@ -1670,7 +1667,6 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			test.SetForTest(t, &features.EnableAutoSni, tc.enableAutoSni)
-			test.SetForTest(t, &features.VerifyCertAtClient, tc.enableVerifyCertAtClient)
 			var proxy *model.Proxy
 			if tc.router {
 				proxy = newGatewayProxy()
@@ -1691,7 +1687,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				if len(tc.tls.Sni) == 0 {
 					assert.Equal(t, tc.opts.mutable.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSni, true)
 				}
-				if tc.enableVerifyCertAtClient && len(tc.tls.Sni) == 0 && len(tc.tls.SubjectAltNames) == 0 {
+				if len(tc.tls.Sni) == 0 && len(tc.tls.SubjectAltNames) == 0 {
 					assert.Equal(t, tc.opts.mutable.httpProtocolOptions.UpstreamHttpProtocolOptions.AutoSanValidation, true)
 				}
 			}

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -83,7 +83,7 @@ func selectTrafficPolicyComponents(policy *networking.TrafficPolicy) (
 	proxyProtocol := policy.ProxyProtocol
 
 	// Check if CA Certificate should be System CA Certificate
-	if features.VerifyCertAtClient && tls != nil && tls.CaCertificates == "" {
+	if tls != nil && tls.CaCertificates == "" {
 		tls.CaCertificates = "system"
 	}
 


### PR DESCRIPTION
**Please provide a description of this PR:**

VERIFY_CERTIFICATE_AT_CLIENT is officially removed from 1.20 compatibility charts on master.
This commit remove the relevant code paths.