### PR TITLE
pilot: include type when panicking on unsupported status type

### DIFF
--- a/pilot/pkg/status/resource.go
+++ b/pilot/pkg/status/resource.go
@@ -102,7 +102,7 @@ func GetStatusManipulator(in any) (out Manipulator) {
 	if ret, ok := in.(*networking.ServiceEntryStatus); ok && ret != nil {
 		return &ServiceEntryGenerationProvider{ret}
 	}
-	return &NopStatusManipulator{in}
+	return &NoopStatusManipulator{in}
 }
 
 func NewIstioContext(stop <-chan struct{}) context.Context {

--- a/pilot/pkg/status/resourcelock.go
+++ b/pilot/pkg/status/resourcelock.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"reflect"
 	"strconv"
 	"sync"
 
@@ -236,24 +237,24 @@ type Manipulator interface {
 var (
 	_ Manipulator = &IstioGenerationProvider{}
 	_ Manipulator = &ServiceEntryGenerationProvider{}
-	_ Manipulator = &NopStatusManipulator{}
+	_ Manipulator = &NoopStatusManipulator{}
 )
 
-type NopStatusManipulator struct {
+type NoopStatusManipulator struct {
 	inner any
 }
 
-func (n *NopStatusManipulator) SetObservedGeneration(i int64) {
+func (n *NoopStatusManipulator) SetObservedGeneration(i int64) {
 }
 
-func (n *NopStatusManipulator) SetValidationMessages(msgs diag.Messages) {
+func (n *NoopStatusManipulator) SetValidationMessages(msgs diag.Messages) {
 }
 
-func (n *NopStatusManipulator) Unwrap() any {
+func (n *NoopStatusManipulator) Unwrap() any {
 	return n.inner
 }
 
-func (n *NopStatusManipulator) SetInner(c any) {
+func (n *NoopStatusManipulator) SetInner(c any) {
 	n.inner = c
 }
 
@@ -262,7 +263,7 @@ type IstioGenerationProvider struct {
 }
 
 func (i *IstioGenerationProvider) SetInner(c any) {
-	panic("not supported for this type")
+	panic("not supported for this type: " + reflect.TypeOf(c).String())
 }
 
 func (i *IstioGenerationProvider) SetObservedGeneration(in int64) {
@@ -286,7 +287,7 @@ type ServiceEntryGenerationProvider struct {
 }
 
 func (i *ServiceEntryGenerationProvider) SetInner(c any) {
-	panic("not supported for this type")
+	panic("not supported for this type: " + reflect.TypeOf(c).String())
 }
 
 func (i *ServiceEntryGenerationProvider) SetObservedGeneration(in int64) {


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds the type of the status that is not supported when we panic in the status manipulator. This should make it more obvious what the failed type is during debugging if there is ever a time that we hit this panic.

Also fixed typo/nit by renaming `Nop` to `Noop` to be more consistent with the codebase where we have other `No-op` types (e.g. [NoopAmbientIndexes](https://github.com/istio/istio/blob/e249e9c389a6793aefd745de26dbfd8aaa4e71ef/pilot/pkg/model/service.go#L914), [noopMetrics](https://github.com/istio/istio/blob/e249e9c389a6793aefd745de26dbfd8aaa4e71ef/pilot/pkg/leaderelection/k8sleaderelection/metrics.go#L73)).