### PR TITLE
Do not expose `testing` package beyond where its needed

### DIFF
--- a/pkg/test/failer.go
+++ b/pkg/test/failer.go
@@ -20,16 +20,11 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"testing"
 
 	"istio.io/istio/pkg/log"
 )
 
-var (
-	_ Failer = &testing.T{}
-	_ Failer = &testing.B{}
-	_ Failer = &errorWrapper{}
-)
+var _ Failer = &errorWrapper{}
 
 // Failer is an interface to be provided to test functions of the form XXXOrFail. This is a
 // substitute for testing.TB, which cannot be implemented outside of the testing

--- a/pkg/test/failer_test.go
+++ b/pkg/test/failer_test.go
@@ -16,6 +16,12 @@ package test
 
 import "testing"
 
+// Compile time assertions. In the test package to avoid exposing the `testing` dependency to users.
+var (
+	_ Failer = &testing.T{}
+	_ Failer = &testing.B{}
+)
+
 func TestWrapper(t *testing.T) {
 	t.Run("fail", func(t *testing.T) {
 		if err := Wrap(func(t Failer) {


### PR DESCRIPTION
This is just a trivial dependency trimming