### PR TITLE
Return nil if the upstream error is io.EOF in istio-agent

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -403,6 +404,9 @@ func (p *XdsProxy) handleUpstream(ctx context.Context, con *ProxyConnection, xds
 		select {
 		case err := <-con.upstreamError:
 			// error from upstream Istiod.
+			if err == io.EOF {
+				return nil
+			}
 			return err
 		case err := <-con.downstreamError:
 			// error from downstream Envoy.


### PR DESCRIPTION
Currently, in istio-agent, if there is an EOF from Recv for the upstream, xds_proxy sends EOF error to the downstream.
But, since EOF is meaning the graceful termination of the connection, we need to return `nil` instead of EOF.
Note that this returning EOF is regarded as 'Unknown' error in gRPC and so Envoy is now displaying confusing error message like:

```
... warning envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_stream.h:152 
StreamAggregatedResources gRPC config stream to xds-grpc closed: 2, EOF thread=15
```
(2 is Unknown error code.)

Change-Id: I0a3065df3a842ab4fa6336f4155f5aec84fc5226
