### PR TITLE
cleanup HostMatcherWithRegex deadcode

### DIFF
--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -15,7 +15,6 @@
 package matcher
 
 import (
-	"regexp"
 	"strings"
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -52,31 +51,6 @@ func HeaderMatcher(k, v string) *routepb.HeaderMatcher {
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
 			StringMatch: StringMatcherExact(v, false),
-		},
-	}
-}
-
-// HostMatcherWithRegex creates a host matcher for a host using regex for proxies before 1.11.
-func HostMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
-	var regex string
-	if v == "*" {
-		return &routepb.HeaderMatcher{
-			Name: k,
-			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
-				PresentMatch: true,
-			},
-		}
-	} else if strings.HasPrefix(v, "*") {
-		regex = `.*` + regexp.QuoteMeta(v[1:])
-	} else if strings.HasSuffix(v, "*") {
-		regex = regexp.QuoteMeta(v[:len(v)-1]) + `.*`
-	} else {
-		regex = regexp.QuoteMeta(v)
-	}
-	return &routepb.HeaderMatcher{
-		Name: k,
-		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-			StringMatch: StringMatcherRegex(`(?i)` + regex),
 		},
 	}
 }

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -15,7 +15,6 @@
 package matcher
 
 import (
-	"regexp"
 	"testing"
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -80,73 +79,6 @@ func TestHeaderMatcher(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			actual := HeaderMatcher(tc.K, tc.V)
-			if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
-				t.Errorf("expecting %v, but got %v", tc.Expect, actual)
-			}
-		})
-	}
-}
-
-func TestHostMatcherWithRegex(t *testing.T) {
-	testCases := []struct {
-		Name   string
-		K      string
-		V      string
-		Expect *routepb.HeaderMatcher
-	}{
-		{
-			Name: "present match",
-			K:    ":authority",
-			V:    "*",
-			Expect: &routepb.HeaderMatcher{
-				Name:                 ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{PresentMatch: true},
-			},
-		},
-		{
-			Name: "prefix match",
-			K:    ":authority",
-			V:    "*.example.com",
-			Expect: &routepb.HeaderMatcher{
-				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: StringMatcherRegex(`(?i).*\.example\.com`),
-				},
-			},
-		},
-		{
-			Name: "suffix match",
-			K:    ":authority",
-			V:    "example.*",
-			Expect: &routepb.HeaderMatcher{
-				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: StringMatcherRegex(`(?i)example\..*`),
-				},
-			},
-		},
-		{
-			Name: "exact match",
-			K:    ":authority",
-			V:    "example.com",
-			Expect: &routepb.HeaderMatcher{
-				Name: ":authority",
-				HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
-					StringMatch: StringMatcherRegex(`(?i)example\.com`),
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			actual := HostMatcherWithRegex(tc.K, tc.V)
-			if re := actual.GetStringMatch().GetSafeRegex().GetRegex(); re != "" {
-				_, err := regexp.Compile(re)
-				if err != nil {
-					t.Errorf("failed to compile regex %s: %v", re, err)
-				}
-			}
 			if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
 				t.Errorf("expecting %v, but got %v", tc.Expect, actual)
 			}

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -60,7 +60,6 @@ compile_go_fuzzer istio.io/istio/tests/fuzz FuzzWE fuzz_workload_entry
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzConfigValidation3 fuzz_config_validation_3
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzCidrRange fuzz_cidr_range
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHeaderMatcher fuzz_header_matcher
-compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHostMatcherWithRegex fuzz_hostMatcher_with_regex
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzHostMatcher fuzz_host_matcher
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzMetadataListMatcher fuzz_metadata_list_matcher
 compile_go_fuzzer istio.io/istio/tests/fuzz FuzzGrpcGenGenerate fuzz_grpc_gen_generate

--- a/tests/fuzz/pilot_security_fuzzer.go
+++ b/tests/fuzz/pilot_security_fuzzer.go
@@ -37,15 +37,6 @@ func FuzzHeaderMatcher(data []byte) int {
 	return 1
 }
 
-func FuzzHostMatcherWithRegex(data []byte) int {
-	k, v, err := getKandV(data)
-	if err != nil {
-		return 0
-	}
-	_ = matcher.HostMatcherWithRegex(k, v)
-	return 1
-}
-
 func FuzzHostMatcher(data []byte) int {
 	k, v, err := getKandV(data)
 	if err != nil {

--- a/tests/fuzz/regression_test.go
+++ b/tests/fuzz/regression_test.go
@@ -144,7 +144,6 @@ func TestFuzzers(t *testing.T) {
 		{"FuzzConfigValidation3", FuzzConfigValidation3},
 		{"FuzzCidrRange", FuzzCidrRange},
 		{"FuzzHeaderMatcher", FuzzHeaderMatcher},
-		{"FuzzHostMatcherWithRegex", FuzzHostMatcherWithRegex},
 		{"FuzzHostMatcher", FuzzHostMatcher},
 		{"FuzzMetadataListMatcher", FuzzMetadataListMatcher},
 		{"FuzzGrpcGenGenerate", FuzzGrpcGenGenerate},


### PR DESCRIPTION
`HostMatcherWithRegex` only has test cases, which I think could be cleaned up.