### PR TITLE
ensure there is always jitter in cert renwals

### DIFF
--- a/releasenotes/notes/grace-ratio-jitter.yaml
+++ b/releasenotes/notes/grace-ratio-jitter.yaml
@@ -10,4 +10,4 @@ docs:
 
 releaseNotes:
 - |
-  **Added** `SECRET_GRACE_PERIOD_RATIO_JITTER` with a default value of `0.01` to introduce a randomized offset in `SECRET_GRACE_PERIOD_RATIO`. Without this configuration proxies deployed at the same time will all request renewed certificates simultaneously. At high enough volumes this can cause signifcant load events that need not occur. The new default behavior of renewing certificates every 12 hours is augmented by this value to be 12 hours +/- approximately 15 minutes.
+  **Added** `SECRET_GRACE_PERIOD_RATIO_JITTER` with a default value of `0.01` to introduce a randomized offset in `SECRET_GRACE_PERIOD_RATIO`. Without this configuration proxies deployed at the same time will all request renewed certificates simultaneously. At high enough volumes this can cause signifcant load events that need not occur. The new default behavior of renewing certificates every 12 hours is augmented by this value to be +/- approximately 15 minutes.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -651,7 +651,7 @@ func (sc *SecretManagerClient) generateNewSecret(resourceName string) (*security
 
 var rotateTime = func(secret security.SecretItem, graceRatio float64, graceRatioJitter float64) time.Duration {
 	// stagger rotation times to prevent large fleets of clients from renewing at the same moment.
-	jitter := (rand.Float64() * graceRatioJitter) * float64(rand.IntN(3)-1) // #nosec G404 -- crypto/rand not worth the cost
+	jitter := (rand.Float64() * graceRatioJitter) * float64(rand.IntN(2)*2-1) // #nosec G404 -- crypto/rand not worth the cost
 	jitterGraceRatio := graceRatio + jitter
 	if jitterGraceRatio > 1 {
 		jitterGraceRatio = 1


### PR DESCRIPTION
**Please provide a description of this PR:**
Just a slight modification to https://github.com/istio/istio/pull/52102/files to ensure there is always "jitter" in cert renewal timeframes. The original implementation leaves ~1/3rd certs un-modified (multiplier was -1, 0, 1 and is now just -1 or 1).