### PR TITLE
fix compatibility version for stat regex

### DIFF
--- a/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/base/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/default/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/istiod-remote/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/istiod-remote/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.21.yaml
@@ -8,6 +8,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.22.yaml
@@ -4,6 +4,9 @@
 
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -14,4 +17,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"

--- a/manifests/helm-profiles/compatibility-version-1.21.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.21.yaml
@@ -4,6 +4,9 @@ pilot:
     ENABLE_ENHANCED_RESOURCE_SCOPING: "false"
     ENABLE_RESOLUTION_NONE_TARGET_PORT: "false"
 
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"

--- a/manifests/helm-profiles/compatibility-version-1.22.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.22.yaml
@@ -1,5 +1,8 @@
 pilot:
   env:
+    # 1.23 behavioral changes
+    ENABLE_DELIMITED_STATS_TAG_REGEX: "false"
+    
     # 1.24 behavioral changes
     ENABLE_INBOUND_RETRY_POLICY: "false"
     EXCLUDE_UNSAFE_503_FROM_DEFAULT_RETRY: "false"
@@ -10,4 +13,4 @@ meshConfig:
       # 1.22 behavioral changes
       ENABLE_DEFERRED_CLUSTER_CREATION: "false"
       # 1.23 behavioral changes
-      ENABLE_DELIMITED_STATS_TAG_REGEX": "false"
+      ENABLE_DELIMITED_STATS_TAG_REGEX: "false"


### PR DESCRIPTION
There are two problems
- Compatibility version did not reflect in pilot env
- In one of the files extra(") came.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions