### PR TITLE
Use more modern app.kubernetes.io/name for legacy sidecar injectors

### DIFF
--- a/manifests/charts/default/templates/mutatingwebhook.yaml
+++ b/manifests/charts/default/templates/mutatingwebhook.yaml
@@ -38,7 +38,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}
-    app.kubernetes.io/name: "sidecar-injector"
+    app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
 webhooks:
 {{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.namespace.") ) }}

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -50,7 +50,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}
-    app.kubernetes.io/name: "sidecar-injector"
+    app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
 webhooks:
 {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -46,7 +46,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ $.Release.Name }}
-    app.kubernetes.io/name: "sidecar-injector"
+    app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" $ | nindent 4 }}
 webhooks:
 {{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.namespace.") ) }}

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -50,7 +50,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}
-    app.kubernetes.io/name: "sidecar-injector"
+    app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
 webhooks:
 {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}

--- a/releasenotes/notes/new-app-kubernetes-name.yaml
+++ b/releasenotes/notes/new-app-kubernetes-name.yaml
@@ -1,7 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: telemetry
-issue: [52034]
-releaseNotes:
-- |
-  **Added** Ingress and Egress gateways now have the `app.kubernetes.io/name=istiod` label.

--- a/releasenotes/notes/new-app-kubernetes-name.yaml
+++ b/releasenotes/notes/new-app-kubernetes-name.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue: [52034]
+releaseNotes:
+- |
+  **Added** Ingress and Egress gateways now have the `app.kubernetes.io/name=istiod` label.


### PR DESCRIPTION
Use more modern `app.kubernetes.io/name` for legacy sidecar injectors.

#52463 auto merged before I could add this.