### PR TITLE
revert change to stop manual allocation of se address

### DIFF
--- a/tests/integration/ambient/main_test.go
+++ b/tests/integration/ambient/main_test.go
@@ -329,7 +329,8 @@ func SetupApps(t resource.Context, i istio.Instance, apps *EchoDeployments) erro
 	apps.Mesh = inMesh.GetMatches(echos)
 	apps.MeshExternal = match.Not(inMesh).GetMatches(echos)
 
-	if err := cdeployment.DeployExternalServiceEntry(t.ConfigIstio(), apps.Namespace, apps.ExternalNamespace, false).
+	// TODO(https://github.com/istio/istio/issues/52678) remove manually allocate
+	if err := cdeployment.DeployExternalServiceEntry(t.ConfigIstio(), apps.Namespace, apps.ExternalNamespace, true).
 		Apply(apply.CleanupConditionally); err != nil {
 		return err
 	}


### PR DESCRIPTION
revert change to stop manual allocation of se address in favor of using ip-autoallocate

**Please provide a description of this PR:**

Ambient DS postsubmit tests are failing. Revert the change which leads to this failure until https://github.com/istio/istio/issues/52678 can be resolved.