### PR TITLE
Add support for resource request/limit annotations on k8s Gateways

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -1,3 +1,29 @@
+{{- define "resources"  }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | nindent 10 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -87,10 +113,8 @@ spec:
       {{- else }}
         image: "{{ .ProxyImage }}"
       {{- end }}
-        {{- if .Values.global.proxy.resources }}
         resources:
-          {{- toYaml .Values.global.proxy.resources | nindent 10 }}
-        {{- end }}
+      {{-  template "resources" . }}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         securityContext:
           capabilities:

--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -1,21 +1,21 @@
 {{- define "resources"  }}
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+  {{- if or (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu`) (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory`) (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu-limit`) (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory-limit`) }}
+    {{- if or (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu`) (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory`) }}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ if (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu`) -}}
+            cpu: "{{ index .InfrastructureAnnotations `gateway.istio.io/proxy-cpu` }}"
             {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ if (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory`) -}}
+            memory: "{{ index .InfrastructureAnnotations `gateway.istio.io/proxy-memory` }}"
             {{ end }}
     {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu-limit`) (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory-limit`) }}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ if (isset .InfrastructureAnnotations `gateway.istio.io/proxy-cpu-limit`) -}}
+            cpu: "{{ index .InfrastructureAnnotations `gateway.istio.io/proxy-cpu-limit` }}"
             {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ if (isset .InfrastructureAnnotations `gateway.istio.io/proxy-memory-limit`) -}}
+            memory: "{{ index .InfrastructureAnnotations `gateway.istio.io/proxy-memory-limit` }}"
             {{ end }}
     {{- end }}
   {{- else }}


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to feature request in https://github.com/istio/istio/issues/52692.

This PR adds support for overriding resource requests and limits on Deployments generated by native k8s Gateways, using the same annotations that are available for overriding resources on regular proxy sidecars.

For example, the following Gateway resource:
```
apiVersion: "gateway.networking.k8s.io/v1beta1"
kind: "Gateway"
metadata:
  name: test-gateway
  namespace: istio-system
  annotations:
    "sidecar.istio.io/proxyCPU": 123m
    "sidecar.istio.io/proxyMemory": 456Mi
spec:
  gatewayClassName: "istio"
  listeners:
    - name: "http"
      port: 80
      protocol: "HTTP"
      allowedRoutes:
        namespaces:
          from: "All"
```
will result in a ingress gateway Deployment with the following:
```
        resources:                                                                                                                                                                    
          requests:                                                                                                                                                                   
            cpu: 123m                                                                                                                                                                  
            memory: 456Mi  
```
as opposed to using the values from the global proxy configuration.

This allows users to vertically scale their Gateway deployments without having to resort to changing the global configuration (and thus inadvertently scaling all sidecars within the mesh).

⚠️ This is just a draft PR to showcase a concept. I have not performed any extensive testing on this beyond playing around with individual resources in a local k8s cluster.