### PR TITLE
waypoint: Respect port level DR settings

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1265,8 +1265,9 @@ func (s *Service) GetAddressForProxy(node *Proxy) string {
 			}
 		}
 
-		if bool(node.Metadata.DNSCapture) &&
-			(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) &&
+		useAutoAlloc := (bool(node.Metadata.DNSCapture) &&
+			(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate)) || node.IsWaypointProxy()
+		if useAutoAlloc &&
 			s.DefaultAddress == constants.UnspecifiedIP {
 			if node.SupportsIPv4() && s.AutoAllocatedIPv4Address != "" {
 				return s.AutoAllocatedIPv4Address
@@ -1303,8 +1304,8 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 	if node.Metadata != nil && node.Metadata.ClusterID != "" {
 		addresses = s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 	}
-	if len(addresses) == 0 && node.Metadata != nil && bool(node.Metadata.DNSCapture) &&
-		(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) {
+	if len(addresses) == 0 && node.Metadata != nil && (bool(node.Metadata.DNSCapture) &&
+		(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) || node.IsWaypointProxy()) {
 		// The criteria to use AutoAllocated addresses is met so we should go ahead and use them if they are populated
 		if s.AutoAllocatedIPv4Address != "" {
 			addresses = append(addresses, s.AutoAllocatedIPv4Address)

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1265,9 +1265,8 @@ func (s *Service) GetAddressForProxy(node *Proxy) string {
 			}
 		}
 
-		useAutoAlloc := (bool(node.Metadata.DNSCapture) &&
-			(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate)) || node.IsWaypointProxy()
-		if useAutoAlloc &&
+		if bool(node.Metadata.DNSCapture) &&
+			(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) &&
 			s.DefaultAddress == constants.UnspecifiedIP {
 			if node.SupportsIPv4() && s.AutoAllocatedIPv4Address != "" {
 				return s.AutoAllocatedIPv4Address
@@ -1304,8 +1303,8 @@ func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 	if node.Metadata != nil && node.Metadata.ClusterID != "" {
 		addresses = s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 	}
-	if len(addresses) == 0 && node.Metadata != nil && (bool(node.Metadata.DNSCapture) &&
-		(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) || node.IsWaypointProxy()) {
+	if len(addresses) == 0 && node.Metadata != nil && bool(node.Metadata.DNSCapture) &&
+		(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) {
 		// The criteria to use AutoAllocated addresses is met so we should go ahead and use them if they are populated
 		if s.AutoAllocatedIPv4Address != "" {
 			addresses = append(addresses, s.AutoAllocatedIPv4Address)

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -246,7 +246,7 @@ func (cb *ClusterBuilder) buildWaypointInboundVIP(proxy *model.Proxy, svcs map[h
 			}
 			cfg := cb.sidecarScope.DestinationRule(model.TrafficDirectionInbound, proxy, svc.Hostname).GetRule()
 			dr := CastDestinationRule(cfg)
-			policy := dr.GetTrafficPolicy()
+			policy, _ := util.GetPortLevelTrafficPolicy(dr.GetTrafficPolicy(), port)
 			if port.Protocol.IsUnsupported() || port.Protocol.IsTCP() {
 				clusters = append(clusters, cb.buildWaypointInboundVIPCluster(proxy, svc, *port, "tcp", mesh, policy, cfg))
 			}

--- a/releasenotes/notes/ambient-waypoint-portlevel.yaml
+++ b/releasenotes/notes/ambient-waypoint-portlevel.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [52532]
+releaseNotes:
+  - |
+    **Fixed** an issue causing any `portLevelSettings` to be ignored in DestinationRules for waypoints.

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -1490,6 +1490,29 @@ spec:
 				Check:  check.And(check.OK(), check.Protocol("HTTP/2.0")),
 			},
 		},
+		{
+			name: "port level TLS",
+			config: `
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: "{{.Host}}"
+spec:
+  host: "{{.Host}}"
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 443
+      tls:
+        mode: SIMPLE
+        insecureSkipVerify: true
+`,
+			call: echo.CallOptions{
+				// Send to HTTPS port but over HTTP
+				Port:   dst.PortForName("https"),
+				Scheme: scheme.HTTP,
+			},
+		},
 	}
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		for _, tt := range cases {


### PR DESCRIPTION
Respect port level DR settings. Pretty straightforward change; 1 liner fix + adding test. Feature was new in 1.23