### PR TITLE
revised logic for when a proxy consumes autoallocated IPs

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1279,9 +1279,7 @@ func (s *Service) GetAddressForProxy(node *Proxy) string {
 			}
 		}
 
-		if bool(node.Metadata.DNSCapture) &&
-			(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) &&
-			s.DefaultAddress == constants.UnspecifiedIP {
+		if nodeUsesAutoallocatedIPs(node) && s.DefaultAddress == constants.UnspecifiedIP {
 			if node.SupportsIPv4() && s.AutoAllocatedIPv4Address != "" {
 				return s.AutoAllocatedIPv4Address
 			}
@@ -1312,13 +1310,26 @@ func (s *Service) GetAllAddressesForProxy(node *Proxy) []string {
 	return s.getAllAddressesForProxy(node)
 }
 
+// nodeUsesAutoallocatedIPs checks to see if this node is eligible to consume automatically allocated IPs
+func nodeUsesAutoallocatedIPs(node *Proxy) bool {
+	if node == nil {
+		return false
+	}
+	// check whether either version of auto-allocation is enabled
+	autoallocationEnabled := bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate
+
+	// check if this proxy is a type that always consumes or has consumption explicitly enabled
+	nodeConsumesAutoIP := bool(node.Metadata.DNSCapture) || node.Type == Waypoint
+
+	return autoallocationEnabled && nodeConsumesAutoIP
+}
+
 func (s *Service) getAllAddressesForProxy(node *Proxy) []string {
 	addresses := []string{}
 	if node.Metadata != nil && node.Metadata.ClusterID != "" {
 		addresses = s.ClusterVIPs.GetAddressesFor(node.Metadata.ClusterID)
 	}
-	if len(addresses) == 0 && node.Metadata != nil && bool(node.Metadata.DNSCapture) &&
-		(bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate) {
+	if len(addresses) == 0 && nodeUsesAutoallocatedIPs(node) {
 		// The criteria to use AutoAllocated addresses is met so we should go ahead and use them if they are populated
 		if s.AutoAllocatedIPv4Address != "" {
 			addresses = append(addresses, s.AutoAllocatedIPv4Address)

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1315,11 +1315,16 @@ func nodeUsesAutoallocatedIPs(node *Proxy) bool {
 	if node == nil {
 		return false
 	}
+	var DNSAutoAllocate, DNSCapture bool
+	if node.Metadata != nil {
+		DNSAutoAllocate = bool(node.Metadata.DNSAutoAllocate)
+		DNSCapture = bool(node.Metadata.DNSCapture)
+	}
 	// check whether either version of auto-allocation is enabled
-	autoallocationEnabled := bool(node.Metadata.DNSAutoAllocate) || features.EnableIPAutoallocate
+	autoallocationEnabled := DNSAutoAllocate || features.EnableIPAutoallocate
 
 	// check if this proxy is a type that always consumes or has consumption explicitly enabled
-	nodeConsumesAutoIP := bool(node.Metadata.DNSCapture) || node.Type == Waypoint
+	nodeConsumesAutoIP := DNSCapture || node.Type == Waypoint
 
 	return autoallocationEnabled && nodeConsumesAutoIP
 }

--- a/releasenotes/notes/52753.yaml
+++ b/releasenotes/notes/52753.yaml
@@ -1,0 +1,35 @@
+apiVersion: release-notes/v2
+
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# kind describes the type of change that this represents.
+# Valid Values are:
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a vulnerability fix.
+# - feature -- Used to specify a new feature that has been added.
+# - test -- Used to describe additional testing added. This file is optional for
+#   tests, but included for completeness.
+kind: bug-fix
+
+# area describes the area that this change affects.
+# Valid values are:
+# - traffic-management
+# - security
+# - telemetry
+# - installation
+# - istioctl
+# - documentation
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - 52746
+
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+releaseNotes:
+  - |
+    **Fixed** an issue where Waypoints required DNSProxy to be enabled in order to consume auto-allocated IPs
+


### PR DESCRIPTION
**Please provide a description of this PR:**

don't require DNS capture for waypoints to use auto-ups.

fixes #52746 