### PR TITLE
added a unit test for envoysocketfunction

### DIFF
--- a/pilot/pkg/networking/networking_test.go
+++ b/pilot/pkg/networking/networking_test.go
@@ -113,3 +113,35 @@ func TestString(t *testing.T) {
 		})
 	}
 }
+
+func TestToEnvoySocketProtocol(t *testing.T) {
+	tests := []struct {
+		name  string
+		value uint
+		want  core.SocketAddress_Protocol
+	}{
+		{
+			"test ToEnvoySocketProtocol method for tcp transport protocol",
+			TransportProtocolTCP,
+			core.SocketAddress_TCP,
+		},
+		{
+			"test ToEnvoySocketProtocol method for udp transport protocol",
+			TransportProtocolQUIC,
+			core.SocketAddress_UDP,
+		},
+		{
+			"test ToEnvoySocketProtocol method for invalid transport protocol",
+			2,
+			core.SocketAddress_TCP,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TransportProtocol(tt.value).ToEnvoySocketProtocol(); got != tt.want {
+				t.Errorf("Failed to get TransportProtocol.String :: got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While going through `networking.go` in pilot pkg,found out that no testcase was written for `envoysocketprotocol` function so added a testcase for it in `networking_test.go`.