### PR TITLE
Make waypoint treat SE like services

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -709,7 +709,7 @@ func (lb *ListenerBuilder) GetDestinationCluster(destination *networking.Destina
 	if service != nil {
 		_, wps := findWaypointResources(lb.node, lb.push)
 		_, f := wps.services[service.Hostname]
-		if !f || service.MeshExternal {
+		if !f {
 			// this waypoint proxy isn't responsible for this service so we use outbound; TODO quicker lookup
 			dir, subset = model.TrafficDirectionOutbound, destination.Subset
 		}


### PR DESCRIPTION
Currently, with a SE bound to a waypoint, we end up hitting the
inbound-vip path if there is no route, but if we make a route -- even
pointing to the same SE -- we start treating it as 'outbound'.

A route pointing from X to X should never change the behavior. Remove
this special case, which I added in the very first Waypoint Routing PR
long before we had SE support.
