### PR TITLE
ambient: set decoration name properly

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/route/retry"
 	"istio.io/istio/pilot/pkg/networking/plugin/authn"
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
+	"istio.io/istio/pilot/pkg/networking/telemetry"
 	"istio.io/istio/pilot/pkg/networking/util"
 	security "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -209,6 +210,11 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 				},
 				bind:  "0.0.0.0",
 				hbone: true,
+				telemetryMetadata: telemetry.FilterChainMetadata{
+					InstanceHostname:           svc.Hostname,
+					KubernetesServiceNamespace: svc.Attributes.Namespace,
+					KubernetesServiceName:      svc.Attributes.Name,
+				},
 			}
 			name := model.BuildSubsetKey(model.TrafficDirectionInboundVIP, "", svc.Hostname, port.Port)
 			tcpName := name + "-tcp"


### PR DESCRIPTION
Now operation shows as 'productpage.amb.svc.cluster.local:9080/*' vs
':9080/*'
