### PR TITLE
monitoring: move to OTEL sync gauge

### DIFF
--- a/pkg/monitoring/counter.go
+++ b/pkg/monitoring/counter.go
@@ -48,11 +48,7 @@ func newCounter(o options) *counter {
 
 func (f *counter) Record(value float64) {
 	f.runRecordHook(value)
-	if f.precomputedAddOption != nil {
-		f.c.Add(context.Background(), value, f.precomputedAddOption...)
-	} else {
-		f.c.Add(context.Background(), value)
-	}
+	f.c.Add(context.Background(), value, f.precomputedAddOption...)
 }
 
 func (f *counter) With(labelValues ...LabelValue) Metric {

--- a/pkg/monitoring/distribution.go
+++ b/pkg/monitoring/distribution.go
@@ -48,11 +48,7 @@ func newDistribution(o options) *distribution {
 
 func (f *distribution) Record(value float64) {
 	f.runRecordHook(value)
-	if f.precomputedRecordOption != nil {
-		f.d.Record(context.Background(), value, f.precomputedRecordOption...)
-	} else {
-		f.d.Record(context.Background(), value)
-	}
+	f.d.Record(context.Background(), value, f.precomputedRecordOption...)
 }
 
 func (f *distribution) With(labelValues ...LabelValue) Metric {

--- a/pkg/monitoring/gauge.go
+++ b/pkg/monitoring/gauge.go
@@ -48,11 +48,7 @@ func newGauge(o options) *gauge {
 
 func (f *gauge) Record(value float64) {
 	f.runRecordHook(value)
-	if f.precomputedRecordOption != nil {
-		f.g.Record(context.Background(), value, f.precomputedRecordOption...)
-	} else {
-		f.g.Record(context.Background(), value)
-	}
+	f.g.Record(context.Background(), value, f.precomputedRecordOption...)
 }
 
 func (f *gauge) With(labelValues ...LabelValue) Metric {

--- a/pkg/monitoring/monitoring_test.go
+++ b/pkg/monitoring/monitoring_test.go
@@ -15,6 +15,7 @@
 package monitoring_test
 
 import (
+	"fmt"
 	"testing"
 
 	"istio.io/istio/pkg/monitoring"
@@ -157,6 +158,18 @@ func TestGaugeLabels(t *testing.T) {
 
 	mt.Assert(testGauge.Name(), map[string]string{"kind": "foo"}, monitortest.Exactly(42))
 	mt.Assert(testGauge.Name(), map[string]string{"kind": "bar"}, monitortest.Exactly(72))
+}
+
+// Regression test to ensure we can safely mutate labels in parallel
+func TestParallelLabels(t *testing.T) {
+	metrics := []monitoring.Metric{testGauge, testDistribution, testSum}
+	for _, m := range metrics {
+		for i := range 100 {
+			go func() {
+				m.With(kind.Value(fmt.Sprint(i))).Record(1)
+			}()
+		}
+	}
 }
 
 var (


### PR DESCRIPTION
Added in https://github.com/open-telemetry/opentelemetry-go/pull/5304.

Prior to this, we hack around the lack of a sync gauge by approximating one with an async gauge. This is complex and has a race condition, captured by the test I added.

If we compare the performance:

```
name                     old time/op    new time/op    delta
Gauge/no_labels-16         13.0ns ± 1%    50.7ns ± 2%  +290.07%  (p=0.004 n=8+4)
Gauge/dynamic_labels-16     322ns ± 7%     385ns ± 7%   +19.54%  (p=0.002 n=10+4)
Gauge/static_labels-16     13.2ns ± 9%   117.2ns ± 3%  +788.01%  (p=0.004 n=8+4)

name                     old alloc/op   new alloc/op   delta
Gauge/no_labels-16          0.00B          0.00B           ~     (all equal)
Gauge/dynamic_labels-16      288B ± 0%      320B ± 0%   +11.11%  (p=0.002 n=10+4)
Gauge/static_labels-16      0.00B          0.00B           ~     (all equal)

name                     old allocs/op  new allocs/op  delta
Gauge/no_labels-16           0.00           0.00           ~     (all equal)
Gauge/dynamic_labels-16      4.00 ± 0%      6.00 ± 0%   +50.00%  (p=0.002 n=10+4)
Gauge/static_labels-16       0.00           0.00           ~     (all equal)
```

We see a regression. However, this brings it in line with Sum:

```
BenchmarkCounter
BenchmarkCounter/no_labels
BenchmarkCounter/no_labels-16           22860031                49.13 ns/op            0 B/op          0 allocs/op
BenchmarkCounter/dynamic_labels
BenchmarkCounter/dynamic_labels-16       3263858               421.3 ns/op           320 B/op          6 allocs/op
BenchmarkCounter/static_labels
BenchmarkCounter/static_labels-16        8653600               128.8 ns/op             0 B/op          0 allocs/op
BenchmarkGauge
BenchmarkGauge/no_labels
BenchmarkGauge/no_labels-16             23151216                47.95 ns/op            0 B/op          0 allocs/op
BenchmarkGauge/dynamic_labels
BenchmarkGauge/dynamic_labels-16         3267243               370.7 ns/op           320 B/op          6 allocs/op
BenchmarkGauge/static_labels
BenchmarkGauge/static_labels-16         10233974               112.9 ns/op             0 B/op          0 allocs/op
```

Which I think is acceptable. In fact, the only reason we had such strong performance was by bypassing safety-critical locks