### PR TITLE
Return nil if gRPC stream returns io.EOF instead of returning io.EOF itself.

### DIFF
--- a/pilot/pkg/grpc/grpc_test.go
+++ b/pilot/pkg/grpc/grpc_test.go
@@ -16,12 +16,32 @@ package grpc
 
 import (
 	"errors"
+	"io"
 	"testing"
 )
 
 func TestIsExpectedGRPCError(t *testing.T) {
-	err := errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR")
-	if got := IsExpectedGRPCError(err); !got {
-		t.Fatalf("expected true, got %v", got)
+	tests := []struct {
+		name string
+		err  error
+		want ErrorType
+	}{
+		{
+			name: "RST_STREAM",
+			err:  errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR"),
+			want: ExpectedError,
+		},
+		{
+			name: "EOF",
+			err:  io.EOF,
+			want: GracefulTermination,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GRPCErrorType(tc.err); got != tc.want {
+				t.Fatalf("expected got %v, but want: %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -193,7 +193,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 	for {
 		req, err := con.deltaStream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				deltaLog.Infof("ADS: %q %s terminated", con.Peer(), con.ID())
 				return
 			}

--- a/pkg/xds/server.go
+++ b/pkg/xds/server.go
@@ -309,7 +309,7 @@ func Receive(ctx ConnectionContext) {
 	for {
 		req, err := con.stream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}


### PR DESCRIPTION
Currently, in istio-agent, if there is an EOF from Recv for the upstream, xds_proxy sends EOF error to the downstream.
But, since EOF is meaning the graceful termination of the connection, we need to return `nil` instead of EOF.
Note that this returning EOF is regarded as 'Unknown' error in gRPC and so Envoy is now displaying confusing error message like:

```
... warning envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_stream.h:152 
StreamAggregatedResources gRPC config stream to xds-grpc closed: 2, EOF thread=15
```
(2 is Unknown error code.)

This is the second trial after https://github.com/istio/istio/pull/52608, but followed the last comments.

Change-Id: I88e225acad5a359f663eaf6b215c601b13410ea0