### PR TITLE
Tune RBAC privileges to explicitly scope to only status permission

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -27,14 +27,22 @@ rules:
     resources: ["*"]
 {{- if .Values.global.istiod.enableAnalysis }}
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
-    verbs: ["update"]
-    # TODO: should be on just */status but wildcard is not supported
-    resources: ["*"]
-
-  # Needed because status reporter sets the config map owner reference to the istiod pod
-  - apiGroups: [""]
-    verbs: ["update"]
-    resources: ["pods/finalizers"]
+    verbs: ["update", "patch"]
+    resources:
+    - authorizationpolicies/status
+    - destinationrules/status
+    - envoyfilters/status
+    - gateways/status
+    - peerauthentications/status
+    - proxyconfigs/status
+    - requestauthentications/status
+    - serviceentries/status
+    - sidecars/status
+    - telemetries/status
+    - virtualservices/status
+    - wasmplugins/status
+    - workloadentries/status
+    - workloadgroups/status
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
@@ -117,11 +125,20 @@ rules:
     verbs: ["create"]
 
   # Use for Kubernetes Service APIs
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["*"] # TODO: should be on just */status but wildcard is not supported
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+    - backendtlspolicies/status
+    - gatewayclasses/status
+    - gateways/status
+    - grpcroutes/status
+    - httproutes/status
+    - referencegrants/status
+    - tcproutes/status
+    - tlsroutes/status
+    - udproutes/status
     verbs: ["update", "patch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses"]

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -28,14 +28,22 @@ rules:
     resources: ["*"]
 {{- if .Values.global.istiod.enableAnalysis }}
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io", "rbac.istio.io", "telemetry.istio.io", "extensions.istio.io"]
-    verbs: ["update"]
-    # TODO: should be on just */status but wildcard is not supported
-    resources: ["*"]
-
-  # Needed because status reporter sets the config map owner reference to the istiod pod
-  - apiGroups: [""]
-    verbs: ["update"]
-    resources: ["pods/finalizers"]
+    verbs: ["update", "patch"]
+    resources:
+    - authorizationpolicies/status
+    - destinationrules/status
+    - envoyfilters/status
+    - gateways/status
+    - peerauthentications/status
+    - proxyconfigs/status
+    - requestauthentications/status
+    - serviceentries/status
+    - sidecars/status
+    - telemetries/status
+    - virtualservices/status
+    - wasmplugins/status
+    - workloadentries/status
+    - workloadgroups/status
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
@@ -118,11 +126,20 @@ rules:
     verbs: ["create"]
 
   # Use for Kubernetes Service APIs
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["*"] # TODO: should be on just */status but wildcard is not supported
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+    - backendtlspolicies/status
+    - gatewayclasses/status
+    - gateways/status
+    - grpcroutes/status
+    - httproutes/status
+    - referencegrants/status
+    - tcproutes/status
+    - tlsroutes/status
+    - udproutes/status
     verbs: ["update", "patch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses"]

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -547,7 +547,9 @@ func (d *DeploymentController) setGatewayControllerVersion(gws gateway.Gateway) 
 		ControllerVersionAnnotation, ControllerVersion)
 
 	log.Debugf("applying %v", patch)
-	return d.patcher(gvr.KubernetesGateway, gws.GetName(), gws.GetNamespace(), []byte(patch))
+	// Use status RBAC so we do not require full Gateway write.
+	// `status` write can modify annotations, and we already need to write status anyway so we have the permission.
+	return d.patcher(gvr.KubernetesGateway, gws.GetName(), gws.GetNamespace(), []byte(patch), "status")
 }
 
 // apply server-side applies a template to the cluster.


### PR DESCRIPTION
This lows the privileges required to run Istiod.

Note the finalizer bit is removed since it is obsolete and part of a
removed feature.
