### PR TITLE
minor optimization in route patch matching

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -276,17 +276,8 @@ func routeConfigurationMatch(patchContext networking.EnvoyFilter_PatchContext, r
 		}
 		// FIXME: Ports on a route can be 0. the API only takes uint32 for ports
 		// We should either make that field in API as a wrapper type or switch to int
-		if rMatch.PortNumber != 0 {
-			listenerPort := 0
-			if strings.HasPrefix(rc.Name, string(model.TrafficDirectionInbound)) {
-				_, _, _, listenerPort = model.ParseSubsetKey(rc.Name)
-			} else {
-				listenerPort, _ = strconv.Atoi(rc.Name)
-			}
-
-			if int(rMatch.PortNumber) != listenerPort {
-				return false
-			}
+		if rMatch.PortNumber != 0 && int(rMatch.PortNumber) != getListenerPortFromName(rc.Name) {
+			return false
 		}
 		return true
 	}
@@ -308,6 +299,16 @@ func routeConfigurationMatch(patchContext networking.EnvoyFilter_PatchContext, r
 	}
 
 	return true
+}
+
+func getListenerPortFromName(name string) int {
+	listenerPort := 0
+	if strings.HasPrefix(name, string(model.TrafficDirectionInbound)) {
+		_, _, _, listenerPort = model.ParseSubsetKey(name)
+	} else {
+		listenerPort, _ = strconv.Atoi(name)
+	}
+	return listenerPort
 }
 
 func anyPortMatches(m model.GatewayPortMap, number int, matchNumber int) bool {

--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -271,23 +271,23 @@ func routeConfigurationMatch(patchContext networking.EnvoyFilter_PatchContext, r
 	// we match on the port number and virtual host for sidecars
 	// we match on port number, server port name, gateway name, plus virtual host for gateways
 	if patchContext != networking.EnvoyFilter_GATEWAY {
-		listenerPort := 0
-		if strings.HasPrefix(rc.Name, string(model.TrafficDirectionInbound)) {
-			_, _, _, listenerPort = model.ParseSubsetKey(rc.Name)
-		} else {
-			listenerPort, _ = strconv.Atoi(rc.Name)
-		}
-
-		// FIXME: Ports on a route can be 0. the API only takes uint32 for ports
-		// We should either make that field in API as a wrapper type or switch to int
-		if rMatch.PortNumber != 0 && int(rMatch.PortNumber) != listenerPort {
-			return false
-		}
-
 		if rMatch.Name != "" && rMatch.Name != rc.Name {
 			return false
 		}
+		// FIXME: Ports on a route can be 0. the API only takes uint32 for ports
+		// We should either make that field in API as a wrapper type or switch to int
+		if rMatch.PortNumber != 0 {
+			listenerPort := 0
+			if strings.HasPrefix(rc.Name, string(model.TrafficDirectionInbound)) {
+				_, _, _, listenerPort = model.ParseSubsetKey(rc.Name)
+			} else {
+				listenerPort, _ = strconv.Atoi(rc.Name)
+			}
 
+			if int(rMatch.PortNumber) != listenerPort {
+				return false
+			}
+		}
 		return true
 	}
 


### PR DESCRIPTION
Only compute listenerPort related logic when routeConfiguration has match on port

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions