### PR TITLE
wip: fix overlapping IP

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -834,6 +834,7 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 				}
 			}
 		}
+		log.Errorf("howardjohn: %+v", listenerOpts.bind)
 		for _, b := range listenerOpts.bind.binds {
 			listenerMapKeys = append(listenerMapKeys, listenerKey{b, listenerOpts.port.Port})
 		}
@@ -866,6 +867,8 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 	// resolution type, since we collapse all HTTP listeners into a
 	// single 0.0.0.0:port listener and use vhosts to distinguish
 	// individual http services in that port
+	// TODO: this isn't right, we don't want to just filter locked here. Locked is a rare thing.
+	// we need to make the currentListenerEntry have multiple
 	listenerMapKeys = slices.FilterInPlace(listenerMapKeys, func(key listenerKey) bool {
 		if cur, exists := listenerMap[key]; exists {
 			currentListenerEntry = cur

--- a/pilot/pkg/networking/core/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/sidecar_simulation_test.go
@@ -1295,6 +1295,80 @@ spec:
 	})
 }
 
+func TestOverlappingServices(t *testing.T) {
+	// Regression test for https://github.com/istio/istio/issues/52847
+	// Ensure we can have a partial overlap between ServiceEntry addresses and Service addresses.
+	runSimulationTest(t, &model.Proxy{Metadata: &model.NodeMetadata{ClusterID: "Kubernetes"}}, xds.FakeOptions{}, simulationTest{
+		config: `apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: echo-se-cip-first
+  namespace: default
+spec:
+  addresses:
+    - 10.96.0.1 # Service IP. This is first in the list for this case
+    - 240.240.0.1
+  hosts:
+    - test-first
+  ports:
+  - name: TCP-443
+    number: 443
+    protocol: TCP
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: echo-se-unique-first
+  namespace: default
+spec:
+  addresses:
+    - 240.240.0.2
+    - 10.96.0.1  # Service IP. This is last in the list for this case
+  hosts:
+    - test-last
+  ports:
+  - name: TCP-443
+    number: 443
+    protocol: TCP`,
+		kubeConfig: `apiVersion: v1
+kind: Service
+metadata:
+  name: echo-svc
+  namespace: default
+spec:
+  clusterIP: 10.96.0.1
+  clusterIPs:
+  - 10.96.0.1
+  ports:
+  - name: https
+    port: 443
+  type: ClusterIP`,
+		calls: []simulation.Expect{
+			{
+				Name: "Service",
+				Call: simulation.Call{Address: "10.96.0.1", Port: 443, Protocol: simulation.TCP},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|443||echo-svc.default.svc.cluster.local",
+				},
+			},
+			{
+				Name: "SE first",
+				Call: simulation.Call{Address: "240.240.0.1", Port: 443, Protocol: simulation.TCP},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|443||test-first",
+				},
+			},
+			{
+				Name: "SE last",
+				Call: simulation.Call{Address: "240.240.0.2", Port: 443, Protocol: simulation.TCP},
+				Result: simulation.Result{
+					ClusterMatched: "outbound|443||test-last",
+				},
+			},
+		},
+	})
+}
+
 func TestPassthroughTraffic(t *testing.T) {
 	calls := map[string]simulation.Call{}
 	for port := 80; port < 87; port++ {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/52847

This is a WIP fix for the above.

The part that isn't yet implemented is how do we handle conflicts.

We currently build a `currentListenerEntry` and then check if we conflict with it. Now should we start building `[]currentListenerEntry` and compare to all of them? Seems fairly complex but maybe the best thing to do?

The second commit on the PR attempts an approach here, but it falls short as well... Basically the idea was we would do the conflict resolution for each address. But even with this, things get wonky. Imagine I have address `[a,b',c]`. We want to make 1 listener with 3 addresses. Another service has `b` already. In my commit, we detect `b'` is a already conflicted with `b`, so we merge it. But we end up inserting entries for `a` **and** `c` and get 2 listeners -- this is broken.

What we probably need to do is that, but a much more complex multistep process...

1. Service `[a,b,c]` comes in: insert a "primary listener key" for `a`, and "secondary" for `b`, `c`.
2. Service `[b]` comes in. We detect its a conflict we can merge, merge with secondary entry `b`. Note this needs a copy-on-write of `opts` or something from step (1) else it will mutate shared state. mark it as 'primary' now
3. When we go to build the listeners, now we want `[a,c]` and `[b]`. We need to know to filter `c` as only a secondary key. We also need to know to remove `b` from the first listener (or, alternatively, know to add `c` to it, depending on how we want to approach it)


