### PR TITLE
ambient: enhance DNS capture

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -455,8 +455,6 @@ func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT, hostProbeV6SNAT
 		"-o", "lo",
 		"-j", "ACCEPT",
 	)
-
-
 	// CLI: -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports <OUTPORT>
 	//
 	// DESC: If this is outbound, not bound for localhost, and does not have our packet mark, redirect to ztunnel proxy <OUTPORT>

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -377,10 +377,23 @@ func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT, hostProbeV6SNAT
 			iptableslog.UndefinedCommand, ChainInpodOutput, iptablesconstants.NAT,
 			"!", "-o", "lo",
 			"-p", "udp",
+			"-m", "mark", "!",
+			"--mark", inpodMark,
 			"-m", "udp",
 			"--dport", "53",
 			"-j", "REDIRECT",
 			"--to-port", fmt.Sprintf("%d", DNSCapturePort),
+		)
+
+		iptablesBuilder.AppendVersionedRule("127.0.0.1/32", "::1/128",
+			iptableslog.UndefinedCommand, ChainInpodOutput, iptablesconstants.NAT,
+			"!", "-d", iptablesconstants.IPVersionSpecific,
+			"-p", "tcp",
+			"--dport", "53",
+			"-m", "mark", "!",
+			"--mark", inpodMark,
+			"-j", "REDIRECT",
+			"--to-ports", fmt.Sprintf("%d", DNSCapturePort),
 		)
 	}
 
@@ -403,6 +416,7 @@ func (cfg *IptablesConfigurator) appendInpodRules(hostProbeSNAT, hostProbeV6SNAT
 		"-o", "lo",
 		"-j", "ACCEPT",
 	)
+
 
 	// CLI: -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports <OUTPORT>
 	//

--- a/cni/pkg/iptables/testdata/default.golden
+++ b/cni/pkg/iptables/testdata/default.golden
@@ -2,9 +2,13 @@ iptables -t mangle -N ISTIO_PRERT
 iptables -t nat -N ISTIO_PRERT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t mangle -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_PRERT
 iptables -t mangle -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -j ISTIO_OUTPUT
+iptables -t raw -A PREROUTING -j ISTIO_PRERT
+iptables -t raw -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 iptables -t nat -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
@@ -13,6 +17,8 @@ iptables -t nat -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark 
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+iptables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+iptables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/default.golden
+++ b/cni/pkg/iptables/testdata/default.golden
@@ -11,7 +11,8 @@ iptables -t nat -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/default_ipv6.golden
+++ b/cni/pkg/iptables/testdata/default_ipv6.golden
@@ -11,7 +11,8 @@ iptables -t nat -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
@@ -28,7 +29,8 @@ ip6tables -t nat -A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tc
 ip6tables -t nat -A ISTIO_OUTPUT -d e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
 ip6tables -t nat -A ISTIO_PRERT ! -d ::1/128 -p tcp ! --dport 15008 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15006
 ip6tables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 ip6tables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/default_ipv6.golden
+++ b/cni/pkg/iptables/testdata/default_ipv6.golden
@@ -2,9 +2,13 @@ iptables -t mangle -N ISTIO_PRERT
 iptables -t nat -N ISTIO_PRERT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t mangle -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_PRERT
 iptables -t mangle -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -j ISTIO_OUTPUT
+iptables -t raw -A PREROUTING -j ISTIO_PRERT
+iptables -t raw -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 iptables -t nat -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
@@ -13,6 +17,8 @@ iptables -t nat -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp ! --dport 15008 -m mark 
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+iptables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+iptables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
@@ -20,9 +26,13 @@ ip6tables -t mangle -N ISTIO_PRERT
 ip6tables -t nat -N ISTIO_PRERT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t mangle -N ISTIO_OUTPUT
+ip6tables -t raw -N ISTIO_OUTPUT
+ip6tables -t raw -N ISTIO_PRERT
 ip6tables -t mangle -A PREROUTING -j ISTIO_PRERT
 ip6tables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 ip6tables -t nat -A OUTPUT -j ISTIO_OUTPUT
+ip6tables -t raw -A PREROUTING -j ISTIO_PRERT
+ip6tables -t raw -A OUTPUT -j ISTIO_OUTPUT
 ip6tables -t nat -A PREROUTING -j ISTIO_PRERT
 ip6tables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 ip6tables -t nat -A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
@@ -31,6 +41,8 @@ ip6tables -t nat -A ISTIO_PRERT ! -d ::1/128 -p tcp ! --dport 15008 -m mark ! --
 ip6tables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+ip6tables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+ip6tables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 ip6tables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/tproxy.golden
+++ b/cni/pkg/iptables/testdata/tproxy.golden
@@ -12,7 +12,8 @@ iptables -t mangle -A ISTIO_PRERT -p tcp -m tcp --dport 15008 -m mark ! --mark 0
 iptables -t mangle -A ISTIO_PRERT -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -t mangle -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j TPROXY --on-port 15006 --tproxy-mark 0x111/0xfff
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/tproxy.golden
+++ b/cni/pkg/iptables/testdata/tproxy.golden
@@ -1,9 +1,13 @@
 iptables -t mangle -N ISTIO_PRERT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t mangle -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_PRERT
 iptables -t mangle -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -j ISTIO_OUTPUT
+iptables -t raw -A PREROUTING -j ISTIO_PRERT
+iptables -t raw -A OUTPUT -j ISTIO_OUTPUT
 iptables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 iptables -t mangle -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
@@ -14,6 +18,8 @@ iptables -t mangle -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x53
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+iptables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+iptables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/tproxy_ipv6.golden
+++ b/cni/pkg/iptables/testdata/tproxy_ipv6.golden
@@ -12,7 +12,8 @@ iptables -t mangle -A ISTIO_PRERT -p tcp -m tcp --dport 15008 -m mark ! --mark 0
 iptables -t mangle -A ISTIO_PRERT -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -t mangle -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j TPROXY --on-port 15006 --tproxy-mark 0x111/0xfff
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
@@ -30,7 +31,8 @@ ip6tables -t mangle -A ISTIO_PRERT -p tcp -m tcp --dport 15008 -m mark ! --mark 
 ip6tables -t mangle -A ISTIO_PRERT -p tcp -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 ip6tables -t mangle -A ISTIO_PRERT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j TPROXY --on-port 15006 --tproxy-mark 0x111/0xfff
 ip6tables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
-ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m udp --dport 53 -j REDIRECT --to-port 15053
+ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
+ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
 ip6tables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001

--- a/cni/pkg/iptables/testdata/tproxy_ipv6.golden
+++ b/cni/pkg/iptables/testdata/tproxy_ipv6.golden
@@ -1,9 +1,13 @@
 iptables -t mangle -N ISTIO_PRERT
 iptables -t nat -N ISTIO_OUTPUT
 iptables -t mangle -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_OUTPUT
+iptables -t raw -N ISTIO_PRERT
 iptables -t mangle -A PREROUTING -j ISTIO_PRERT
 iptables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 iptables -t nat -A OUTPUT -j ISTIO_OUTPUT
+iptables -t raw -A PREROUTING -j ISTIO_PRERT
+iptables -t raw -A OUTPUT -j ISTIO_OUTPUT
 iptables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 iptables -t mangle -A ISTIO_PRERT -s 169.254.7.127 -p tcp -m tcp -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT -d 169.254.7.127 -p tcp -m tcp -j ACCEPT
@@ -14,15 +18,21 @@ iptables -t mangle -A ISTIO_PRERT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x53
 iptables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 iptables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+iptables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+iptables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 iptables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -j ACCEPT
 iptables -t nat -A ISTIO_OUTPUT ! -d 127.0.0.1/32 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001
 ip6tables -t mangle -N ISTIO_PRERT
 ip6tables -t nat -N ISTIO_OUTPUT
 ip6tables -t mangle -N ISTIO_OUTPUT
+ip6tables -t raw -N ISTIO_OUTPUT
+ip6tables -t raw -N ISTIO_PRERT
 ip6tables -t mangle -A PREROUTING -j ISTIO_PRERT
 ip6tables -t mangle -A OUTPUT -j ISTIO_OUTPUT
 ip6tables -t nat -A OUTPUT -j ISTIO_OUTPUT
+ip6tables -t raw -A PREROUTING -j ISTIO_PRERT
+ip6tables -t raw -A OUTPUT -j ISTIO_OUTPUT
 ip6tables -t mangle -A ISTIO_PRERT -m mark --mark 0x539/0xfff -j CONNMARK --set-xmark 0x111/0xfff
 ip6tables -t mangle -A ISTIO_PRERT -s e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT -d e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164 -p tcp -m tcp -j ACCEPT
@@ -33,6 +43,8 @@ ip6tables -t mangle -A ISTIO_PRERT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0x
 ip6tables -t mangle -A ISTIO_OUTPUT -m connmark --mark 0x111/0xfff -j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff
 ip6tables -t nat -A ISTIO_OUTPUT ! -o lo -p udp -m mark ! --mark 0x539/0xfff -m udp --dport 53 -j REDIRECT --to-port 15053
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp --dport 53 -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15053
+ip6tables -t raw -A ISTIO_OUTPUT -p udp -m mark --mark 0x539/0xfff -m udp --dport 53 -j CT --zone 1
+ip6tables -t raw -A ISTIO_PRERT -p udp -m mark ! --mark 0x539/0xfff -m udp --sport 53 -j CT --zone 1
 ip6tables -t nat -A ISTIO_OUTPUT -p tcp -m mark --mark 0x111/0xfff -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -o lo -j ACCEPT
 ip6tables -t nat -A ISTIO_OUTPUT ! -d ::1/128 -p tcp -m mark ! --mark 0x539/0xfff -j REDIRECT --to-ports 15001


### PR DESCRIPTION
Fixes https://github.com/istio/ztunnel/issues/1177
Pre-req for https://github.com/istio/ztunnel/issues/1281

This adds TCP redirection, and excludes marked traffic.

## Upgrade path

The supported upgrade path is CNI first, then Ztunnel.

CNI w/ this patch, Ztunnel 1.23: TCP will start redirecting, which is
already supported by Ztunnel. UDP change does nothing

CNI + Ztunnel patched (with https://github.com/istio/ztunnel/pull/1282):
DNS requests come from the application pod. UDP packets are marked, so
they do not loop due to the CNI change here.
