### PR TITLE
hbone: log transport errors

### DIFF
--- a/pilot/pkg/networking/core/accesslog.go
+++ b/pilot/pkg/networking/core/accesslog.go
@@ -68,6 +68,7 @@ type AccessLogBuilder struct {
 	mutex                 sync.RWMutex
 	fileAccesslog         *accesslog.AccessLog
 	listenerFileAccessLog *accesslog.AccessLog
+	hboneFileAccessLog    *accesslog.AccessLog
 }
 
 func newAccessLogBuilder() *AccessLogBuilder {
@@ -95,20 +96,37 @@ func (b *AccessLogBuilder) setTCPAccessLog(push *model.PushContext, proxy *model
 		return
 	}
 
-	if al := buildAccessLogFromTelemetry(cfgs, false); len(al) != 0 {
+	if al := buildAccessLogFromTelemetry(cfgs, nil); len(al) != 0 {
 		tcp.AccessLog = append(tcp.AccessLog, al...)
 	}
 }
 
-func buildAccessLogFromTelemetry(cfgs []model.LoggingConfig, forListener bool) []*accesslog.AccessLog {
+func (b *AccessLogBuilder) setHboneAccessLog(push *model.PushContext, proxy *model.Proxy, tcp *tcp.TcpProxy, class networking.ListenerClass) {
+	mesh := push.Mesh
+	cfgs := push.Telemetry.AccessLogging(push, proxy, class, nil)
+
+	if len(cfgs) == 0 {
+		// No Telemetry API configured, fall back to legacy mesh config setting
+		if mesh.AccessLogFile != "" {
+			tcp.AccessLog = append(tcp.AccessLog, b.buildHboneFileAccessLog(mesh, proxy.IstioVersion))
+		}
+		return
+	}
+
+	if al := buildAccessLogFromTelemetry(cfgs, hboneAccessLogFilter()); len(al) != 0 {
+		tcp.AccessLog = append(tcp.AccessLog, al...)
+	}
+}
+
+func buildAccessLogFromTelemetry(cfgs []model.LoggingConfig, filter *accesslog.AccessLogFilter) []*accesslog.AccessLog {
 	als := make([]*accesslog.AccessLog, 0, len(cfgs))
 	for _, c := range cfgs {
 		if c.Disabled {
 			continue
 		}
 		filters := make([]*accesslog.AccessLogFilter, 0, 2)
-		if forListener {
-			filters = append(filters, addAccessLogFilter())
+		if filter != nil {
+			filters = append(filters, filter)
 		}
 
 		if telFilter := buildAccessLogFilterFromTelemetry(c); telFilter != nil {
@@ -162,7 +180,7 @@ func (b *AccessLogBuilder) setHTTPAccessLog(push *model.PushContext, proxy *mode
 		return
 	}
 
-	if al := buildAccessLogFromTelemetry(cfgs, false); len(al) != 0 {
+	if al := buildAccessLogFromTelemetry(cfgs, nil); len(al) != 0 {
 		connectionManager.AccessLog = append(connectionManager.AccessLog, al...)
 	}
 }
@@ -191,7 +209,7 @@ func (b *AccessLogBuilder) setListenerAccessLog(push *model.PushContext, proxy *
 		return
 	}
 
-	if al := buildAccessLogFromTelemetry(cfgs, true); len(al) != 0 {
+	if al := buildAccessLogFromTelemetry(cfgs, listenerAccessLogFilter()); len(al) != 0 {
 		listener.AccessLog = append(listener.AccessLog, al...)
 	}
 }
@@ -222,10 +240,21 @@ func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig, proxy
 	return al
 }
 
-func addAccessLogFilter() *accesslog.AccessLogFilter {
+func listenerAccessLogFilter() *accesslog.AccessLogFilter {
 	return &accesslog.AccessLogFilter{
 		FilterSpecifier: &accesslog.AccessLogFilter_ResponseFlagFilter{
+			// NR: no filter chain found. This is triggered, typically, when the incoming TLS request doesn't match any filters
 			ResponseFlagFilter: &accesslog.ResponseFlagFilter{Flags: []string{"NR"}},
+		},
+	}
+}
+
+func hboneAccessLogFilter() *accesslog.AccessLogFilter {
+	return &accesslog.AccessLogFilter{
+		FilterSpecifier: &accesslog.AccessLogFilter_ResponseFlagFilter{
+			// UF: upstream failure, we couldn't connect. This is important to log at this layer, since the error details
+			// are lost otherwise.
+			ResponseFlagFilter: &accesslog.ResponseFlagFilter{Flags: []string{"UF"}},
 		},
 	}
 }
@@ -257,11 +286,29 @@ func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfi
 	lal := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh, proxyVersion)
 	// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 	// not get filter Access Logs like in cases like NR to upstream.
-	lal.Filter = addAccessLogFilter()
+	lal.Filter = listenerAccessLogFilter()
 
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	b.listenerFileAccessLog = lal
+
+	return lal
+}
+
+func (b *AccessLogBuilder) buildHboneFileAccessLog(mesh *meshconfig.MeshConfig, proxyVersion *model.IstioVersion) *accesslog.AccessLog {
+	if cal := b.cachedHboneFileAccessLog(); cal != nil {
+		return cal
+	}
+
+	// We need to build access log. This is needed either on first access or when mesh config changes.
+	lal := model.FileAccessLogFromMeshConfig(mesh.AccessLogFile, mesh, proxyVersion)
+	// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
+	// not get filter Access Logs like in cases like NR to upstream.
+	lal.Filter = hboneAccessLogFilter()
+
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	b.hboneFileAccessLog = lal
 
 	return lal
 }
@@ -276,6 +323,12 @@ func (b *AccessLogBuilder) cachedListenerFileAccessLog() *accesslog.AccessLog {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
 	return b.listenerFileAccessLog
+}
+
+func (b *AccessLogBuilder) cachedHboneFileAccessLog() *accesslog.AccessLog {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+	return b.hboneFileAccessLog
 }
 
 func tcpGrpcAccessLog(isListener bool) *accesslog.AccessLog {
@@ -300,7 +353,7 @@ func tcpGrpcAccessLog(isListener bool) *accesslog.AccessLog {
 
 	var filter *accesslog.AccessLogFilter
 	if isListener {
-		filter = addAccessLogFilter()
+		filter = listenerAccessLogFilter()
 	}
 	return &accesslog.AccessLog{
 		Name:       model.TCPEnvoyALSName,

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -111,7 +111,11 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(node *model.Proxy,
 	builder.patchListeners()
 	l := builder.getListeners()
 	if features.EnableHBONESend && !builder.node.IsWaypointProxy() {
-		l = append(l, buildConnectOriginateListener())
+		class := istionetworking.ListenerClassSidecarOutbound
+		if node.Type == model.Router {
+			class = istionetworking.ListenerClassGateway
+		}
+		l = append(l, buildConnectOriginateListener(push, node, class))
 	}
 
 	return l

--- a/releasenotes/notes/ambient-logs.yaml
+++ b/releasenotes/notes/ambient-logs.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+
+releaseNotes:
+  - |
+    **Improved** logs from Envoy when connection failures occur in ambient mode to show more error details.


### PR DESCRIPTION
This takes a similar approach to our current 'listener' logs -- we apply
a access logger somewhere but only log on certain error conditions. In
this case, upstream HBONE connection failure.

Some example failures; in both cases, the top line is new:

```
[2024-08-27T20:00:10.142Z] "- - -" 0 UF,URX - - "delayed_connect_error:_Connection_refused" 0 0 0 - "-" "-" "-" "-" "10.244.0.17:15008" connect_originate - 10.244.0.17:80 envoy://internal_client_address/ - -
[2024-08-27T20:00:10.142Z] "GET / HTTP/1.1" 503 UF upstream_reset_before_response_started{remote_connection_failure|delayed_connect_error:_Invalid_argument} - "delayed_connect_error:_Invalid_argument" 0 165 0 - "10.244.0.1" "curl/8.9.1" "58c0e2c6-fa7e-4a68-a4f1-3bae11113f7c" "172.18.0.101" "envoy://connect_originate/10.244.0.17:80" outbound|80||echo.default.svc.cluster.local - 10.244.0.7:8080 10.244.0.1:10858 - -

[2024-08-27T20:00:02.995Z] "- - -" 0 UF,URX - - "TLS_error:|67108971:RSA_routines:OPENSSL_internal:BLOCK_TYPE_IS_NOT_01|67109000:RSA_routines:OPENSSL_internal:PADDING_CHECK_FAILED|184549382:X.509_certificate_routines:OPENSSL_internal:public_key_routines|268435581:SSL_routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED:TLS_error_end" 0 0 3 - "-" "-" "-" "-" "10.244.0.17:15008" connect_originate - 10.244.0.17:80 envoy://internal_client_address/ - -
[2024-08-27T20:00:02.995Z] "GET / HTTP/1.1" 503 UC upstream_reset_before_response_started{connection_termination} - "-" 0 95 3 - "10.244.0.1" "curl/8.9.1" "84dca388-2c14-46dc-b1c4-3b5169ab94d9" "172.18.0.101" "envoy://connect_originate/10.244.0.17:80" outbound|80||echo.default.svc.cluster.local envoy://internal_client_address/ 10.244.0.7:8080 10.244.0.1:30061 - -
```
