### PR TITLE
pilot: drop obsolete 1.22 proxy compat

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -269,7 +269,7 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 			Disabled: v.Disabled,
 		}
 
-		al := telemetryAccessLog(push, fp, proxy.IstioVersion)
+		al := telemetryAccessLog(push, fp)
 		if al == nil {
 			// stackdriver will be handled in HTTPFilters/TCPFilters
 			continue

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -47,16 +47,10 @@ func TestFileAccessLogFormat(t *testing.T) {
 		name         string
 		formatString string
 		expected     string
-		proxyVersion *IstioVersion
 	}{
 		{
 			name:     "empty",
 			expected: EnvoyTextLogFormat,
-		},
-		{
-			name:         "empty - version < 1.23",
-			expected:     LegacyEnvoyTextLogFormat,
-			proxyVersion: &IstioVersion{Major: 1, Minor: 22, Patch: 0},
 		},
 		{
 			name:         "contains newline",
@@ -72,7 +66,7 @@ func TestFileAccessLogFormat(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := fileAccessLogFormat(tc.formatString, tc.proxyVersion)
+			got := fileAccessLogFormat(tc.formatString)
 			assert.Equal(t, tc.expected, got)
 		})
 	}
@@ -1304,21 +1298,6 @@ func TestTelemetryAccessLog(t *testing.T) {
 		},
 	}
 
-	legacyStdout := &fileaccesslog.FileAccessLog{
-		Path: DevStdout,
-		AccessLogFormat: &fileaccesslog.FileAccessLog_LogFormat{
-			LogFormat: &core.SubstitutionFormatString{
-				Format: &core.SubstitutionFormatString_TextFormatSource{
-					TextFormatSource: &core.DataSource{
-						Specifier: &core.DataSource_InlineString{
-							InlineString: LegacyEnvoyTextLogFormat,
-						},
-					},
-				},
-			},
-		},
-	}
-
 	customTextOut := &fileaccesslog.FileAccessLog{
 		Path: DevStdout,
 		AccessLogFormat: &fileaccesslog.FileAccessLog_LogFormat{
@@ -1451,12 +1430,11 @@ func TestTelemetryAccessLog(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name         string
-		ctx          *PushContext
-		meshConfig   *meshconfig.MeshConfig
-		fp           *meshconfig.MeshConfig_ExtensionProvider
-		expected     *accesslog.AccessLog
-		proxyVersion *IstioVersion
+		name       string
+		ctx        *PushContext
+		meshConfig *meshconfig.MeshConfig
+		fp         *meshconfig.MeshConfig_ExtensionProvider
+		expected   *accesslog.AccessLog
 	}{
 		{
 			name: "stdout",
@@ -1470,18 +1448,6 @@ func TestTelemetryAccessLog(t *testing.T) {
 			},
 		},
 		{
-			name: "legacy stdout",
-			meshConfig: &meshconfig.MeshConfig{
-				AccessLogEncoding: meshconfig.MeshConfig_TEXT,
-			},
-			fp: stdoutFormat,
-			expected: &accesslog.AccessLog{
-				Name:       wellknown.FileAccessLog,
-				ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: protoconv.MessageToAny(legacyStdout)},
-			},
-			proxyVersion: &IstioVersion{Major: 1, Minor: 22, Patch: 0},
-		},
-		{
 			name: "stderr",
 			meshConfig: &meshconfig.MeshConfig{
 				AccessLogEncoding: meshconfig.MeshConfig_TEXT,
@@ -1491,7 +1457,6 @@ func TestTelemetryAccessLog(t *testing.T) {
 				Name:       wellknown.FileAccessLog,
 				ConfigType: &accesslog.AccessLog_TypedConfig{TypedConfig: protoconv.MessageToAny(stderrout)},
 			},
-			proxyVersion: &IstioVersion{Major: 1, Minor: 23, Patch: 0},
 		},
 		{
 			name: "custom-text",
@@ -1631,7 +1596,7 @@ func TestTelemetryAccessLog(t *testing.T) {
 			}
 			push.Mesh = tc.meshConfig
 
-			got := telemetryAccessLog(push, tc.fp, tc.proxyVersion)
+			got := telemetryAccessLog(push, tc.fp)
 			if got == nil {
 				t.Fatal("get nil accesslog")
 			}

--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -225,7 +225,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}
 		clusters = append(clusters, configgen.buildInboundClusters(cb, proxy, instances, inboundPatcher)...)
 		if proxy.EnableHBONEListen() {
-			clusters = append(clusters, configgen.buildInboundHBONEClusters(proxy.IstioVersion))
+			clusters = append(clusters, configgen.buildInboundHBONEClusters())
 		}
 		// Pass through clusters for inbound traffic. These cluster bind loopback-ish src address to access node local service.
 		clusters = inboundPatcher.conditionallyAppend(clusters, nil, cb.buildInboundPassthroughCluster())

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -297,7 +297,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 	}
 
 	// Build default alt stat name - This may be overwritten by the MeshConfig options.
-	c.AltStatName = util.DelimitedStatsPrefix(name, cb.proxyVersion)
+	c.AltStatName = util.DelimitedStatsPrefix(name)
 
 	switch discoveryType {
 	case cluster.Cluster_STRICT_DNS, cluster.Cluster_LOGICAL_DNS:
@@ -357,7 +357,7 @@ func (cb *ClusterBuilder) buildCluster(name string, discoveryType cluster.Cluste
 		// If stat name is configured, build the alternate stats name.
 		if len(cb.req.Push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.OutboundClusterStatName, string(service.Hostname), subset, port, 0, &service.Attributes)
-			ec.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix, cb.proxyVersion)
+			ec.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix)
 		}
 	}
 
@@ -392,7 +392,7 @@ func (cb *ClusterBuilder) buildInboundCluster(clusterPort int, bind string,
 		statPrefix := telemetry.BuildStatPrefix(cb.req.Push.Mesh.InboundClusterStatName,
 			string(instance.Service.Hostname), "", instance.Port.ServicePort, clusterPort,
 			&instance.Service.Attributes)
-		localCluster.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix, cb.proxyVersion)
+		localCluster.cluster.AltStatName = util.DelimitedStatsPrefix(statPrefix)
 	}
 	if clusterType == cluster.Cluster_ORIGINAL_DST {
 		// Disable cleanup for inbound clusters - set to Max possible duration.
@@ -517,7 +517,7 @@ func (cb *ClusterBuilder) buildBlackHoleCluster() *cluster.Cluster {
 		ConnectTimeout:       proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
 	}
-	c.AltStatName = util.DelimitedStatsPrefix(util.BlackHoleCluster, cb.proxyVersion)
+	c.AltStatName = util.DelimitedStatsPrefix(util.BlackHoleCluster)
 	return c
 }
 
@@ -533,7 +533,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 			v3.HttpProtocolOptionsType: passthroughHttpProtocolOptions,
 		},
 	}
-	cluster.AltStatName = util.DelimitedStatsPrefix(util.PassthroughCluster, cb.proxyVersion)
+	cluster.AltStatName = util.DelimitedStatsPrefix(util.PassthroughCluster)
 	cb.applyConnectionPool(cb.req.Push.Mesh, newClusterWrapper(cluster), &networking.ConnectionPoolSettings{})
 	cb.applyMetadataExchange(cluster)
 	return cluster
@@ -747,7 +747,7 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 			v3.HttpProtocolOptionsType: protoconv.MessageToAny(options),
 		},
 	}
-	c.AltStatName = util.DelimitedStatsPrefix(security.SDSExternalClusterName, cb.proxyVersion)
+	c.AltStatName = util.DelimitedStatsPrefix(security.SDSExternalClusterName)
 	return c
 }
 

--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -47,7 +47,7 @@ import (
 )
 
 // buildInternalUpstreamCluster builds a single endpoint cluster to the internal listener.
-func buildInternalUpstreamCluster(proxyVersion *model.IstioVersion, name string, internalListener string) *cluster.Cluster {
+func buildInternalUpstreamCluster(name string, internalListener string) *cluster.Cluster {
 	c := &cluster.Cluster{
 		Name:                 name,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STATIC},
@@ -61,23 +61,23 @@ func buildInternalUpstreamCluster(proxyVersion *model.IstioVersion, name string,
 		},
 	}
 
-	c.AltStatName = util.DelimitedStatsPrefix(name, proxyVersion)
+	c.AltStatName = util.DelimitedStatsPrefix(name)
 
 	return c
 }
 
 var (
-	GetMainInternalCluster = func(v *model.IstioVersion) *cluster.Cluster {
-		return buildInternalUpstreamCluster(v, MainInternalName, MainInternalName)
+	GetMainInternalCluster = func() *cluster.Cluster {
+		return buildInternalUpstreamCluster(MainInternalName, MainInternalName)
 	}
 
-	GetEncapCluster = func(v *model.IstioVersion) *cluster.Cluster {
-		return buildInternalUpstreamCluster(v, EncapClusterName, ConnectOriginate)
+	GetEncapCluster = func() *cluster.Cluster {
+		return buildInternalUpstreamCluster(EncapClusterName, ConnectOriginate)
 	}
 )
 
-func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters(v *model.IstioVersion) *cluster.Cluster {
-	return GetMainInternalCluster(v)
+func (configgen *ConfigGeneratorImpl) buildInboundHBONEClusters() *cluster.Cluster {
+	return GetMainInternalCluster()
 }
 
 func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
@@ -89,7 +89,7 @@ func (configgen *ConfigGeneratorImpl) buildWaypointInboundClusters(
 	clusters := make([]*cluster.Cluster, 0)
 	// Creates "main_internal" cluster to route to the main internal listener.
 	// Creates "encap" cluster to route to the encap listener.
-	clusters = append(clusters, GetMainInternalCluster(proxy.IstioVersion), GetEncapCluster(proxy.IstioVersion))
+	clusters = append(clusters, GetMainInternalCluster(), GetEncapCluster())
 	// Creates per-VIP load balancing upstreams.
 	clusters = append(clusters, cb.buildWaypointInboundVIP(proxy, svcs, push.Mesh)...)
 	// Upstream of the "encap" listener.
@@ -320,7 +320,7 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 		},
 	}
 
-	c.AltStatName = util.DelimitedStatsPrefix(ConnectOriginate, proxy.IstioVersion)
+	c.AltStatName = util.DelimitedStatsPrefix(ConnectOriginate)
 
 	return c
 }

--- a/pilot/pkg/networking/core/gateway.go
+++ b/pilot/pkg/networking/core/gateway.go
@@ -97,7 +97,7 @@ func (ml *MutableGatewayListener) build(builder *ListenerBuilder, opts gatewayLi
 			// If statPrefix has been set before calling this method, respect that.
 			if len(opt.httpOpts.statPrefix) == 0 {
 				statPrefix := strings.ToLower(ml.Listener.TrafficDirection.String()) + "_" + ml.Listener.Name
-				opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statPrefix, builder.node.IstioVersion)
+				opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statPrefix)
 			}
 			opt.httpOpts.port = opts.port
 			httpConnectionManagers[i] = builder.buildHTTPConnectionManager(opt.httpOpts)

--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -617,7 +617,7 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 			chain.Filters = opt.networkFilters
 		} else {
 			statsPrefix := strings.ToLower(l.TrafficDirection.String()) + "_" + l.Name
-			opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statsPrefix, builder.node.IstioVersion)
+			opt.httpOpts.statPrefix = util.DelimitedStatsPrefix(statsPrefix)
 			opt.httpOpts.port = le.servicePort.Port
 			hcm := builder.buildHTTPConnectionManager(opt.httpOpts)
 			filter := &listener.Filter{

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -91,7 +91,7 @@ type inboundChainConfig struct {
 }
 
 // StatPrefix returns the stat prefix for the config
-func (cc inboundChainConfig) StatPrefix(istioVersion *model.IstioVersion) string {
+func (cc inboundChainConfig) StatPrefix() string {
 	var statPrefix string
 	if cc.passthrough {
 		// A bit arbitrary, but for backwards compatibility just use the cluster name
@@ -100,7 +100,7 @@ func (cc inboundChainConfig) StatPrefix(istioVersion *model.IstioVersion) string
 		statPrefix = "inbound_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	}
 
-	statPrefix = util.DelimitedStatsPrefix(statPrefix, istioVersion)
+	statPrefix = util.DelimitedStatsPrefix(statPrefix)
 	return statPrefix
 }
 
@@ -812,7 +812,7 @@ func buildSidecarInboundHTTPOpts(lb *ListenerBuilder, cc inboundChainConfig) *ht
 		protocol:                  cc.port.Protocol,
 		class:                     istionetworking.ListenerClassSidecarInbound,
 		port:                      int(cc.port.TargetPort),
-		statPrefix:                cc.StatPrefix(lb.node.IstioVersion),
+		statPrefix:                cc.StatPrefix(),
 		hbone:                     cc.hbone,
 	}
 	// See https://github.com/grpc/grpc-web/tree/master/net/grpc/gateway/examples/helloworld#configure-the-proxy

--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -425,7 +425,7 @@ func (lb *ListenerBuilder) buildWaypointInboundHTTPFilters(svc *model.Service, c
 		suppressEnvoyDebugHeaders: ph.SuppressDebugHeaders,
 		protocol:                  cc.port.Protocol,
 		class:                     istionetworking.ListenerClassSidecarInbound,
-		statPrefix:                cc.StatPrefix(lb.node.IstioVersion),
+		statPrefix:                cc.StatPrefix(),
 		isWaypoint:                true,
 		policySvc:                 svc,
 	}

--- a/pilot/pkg/networking/grpcgen/cds.go
+++ b/pilot/pkg/networking/grpcgen/cds.go
@@ -152,7 +152,7 @@ func (b *clusterBuilder) build() []*cluster.Cluster {
 func (b *clusterBuilder) edsCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:                 name,
-		AltStatName:          util.DelimitedStatsPrefix(name, b.node.IstioVersion),
+		AltStatName:          util.DelimitedStatsPrefix(name),
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 		EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
 			ServiceName: name,

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -453,12 +453,6 @@ func MergeAnyWithAny(dst *anypb.Any, src *anypb.Any) (*anypb.Any, error) {
 	return retVal, nil
 }
 
-// IsIstioVersionGE123 checks whether the given Istio version is greater than or equals 1.23.
-func IsIstioVersionGE123(version *model.IstioVersion) bool {
-	return version == nil ||
-		version.Compare(&model.IstioVersion{Major: 1, Minor: 23, Patch: -1}) >= 0
-}
-
 // AppendLbEndpointMetadata adds metadata values to a lb endpoint using the passed in metadata as base.
 func AppendLbEndpointMetadata(istioMetadata *model.EndpointMetadata, envoyMetadata *core.Metadata,
 ) {
@@ -891,8 +885,8 @@ func VersionGreaterOrEqual124(proxy *model.Proxy) bool {
 	return proxy.VersionGreaterAndEqual(&model.IstioVersion{Major: 1, Minor: 24, Patch: -1})
 }
 
-func DelimitedStatsPrefix(statPrefix string, proxyVersion *model.IstioVersion) string {
-	if features.EnableDelimitedStatsTagRegex && IsIstioVersionGE123(proxyVersion) {
+func DelimitedStatsPrefix(statPrefix string) string {
+	if features.EnableDelimitedStatsTagRegex {
 		statPrefix += constants.StatPrefixDelimiter
 	}
 	return statPrefix


### PR DESCRIPTION
Proxy 1.22 cannot connect to Istiod 1.24 safely per our compatibility
guarantees, so clean up the tech tdebt
