### PR TITLE
`seLinuxOptions` is not a global/only used by ztunnel

### DIFF
--- a/manifests/charts/base/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/base/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/default/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/default/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateway/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateway/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-cni/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/istiod-remote/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
+++ b/manifests/charts/ztunnel/files/profile-openshift-ambient.yaml
@@ -9,8 +9,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true

--- a/manifests/helm-profiles/openshift-ambient.yaml
+++ b/manifests/helm-profiles/openshift-ambient.yaml
@@ -5,8 +5,8 @@ meshConfig:
 global:
   platform: openshift
   variant: distroless
-  seLinuxOptions:
-    type: spc_t
+seLinuxOptions:
+  type: spc_t
 cni:
   ambient:
     enabled: true


### PR DESCRIPTION
This ~sort of worked because of globals munging, but this is not a global and it's misleading to include it as one in the profile - only ztunnel chart uses `seLinuxOptions` anyway.

This does not change the UX as setting as a global explicitly with e.g. `set` would not have worked previously, you just would have thought it would if you looked at the profile.