### PR TITLE
Add --force-apply flag to istio-iptables

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -125,6 +125,8 @@ spec:
     {{ if .Values.pilot.cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
+    {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+    - "--force-apply"
     {{ end -}}
     {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
   {{- if .ProxyConfig.ProxyMetadata }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -377,6 +377,8 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
+      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+      force_apply_iptables: false
 
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -378,7 +378,7 @@ defaults:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
       # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
-      force_apply_iptables: false
+      forceApplyIptables: false
 
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -377,7 +377,8 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
-      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
+      # Bypasses iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
+      # Do not use unless you need to work around an idempotency issue. This flag will be removed in future releases.
       forceApplyIptables: false
 
     # configure remote pilot and istiod service and endpoint

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -378,7 +378,7 @@ defaults:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
       # Bypasses iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
-      # Do not use unless you need to work around an idempotency issue. This flag will be removed in future releases.
+      # Do not use unless you need to work around an issue of the idempotency handling. This flag will be removed in future releases.
       forceApplyIptables: false
 
     # configure remote pilot and istiod service and endpoint

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -377,7 +377,7 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
-      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
       force_apply_iptables: false
 
     # configure remote pilot and istiod service and endpoint

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -125,6 +125,8 @@ spec:
     {{ if .Values.pilot.cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
+    {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+    - "--force-apply"
     {{ end -}}
     {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
   {{- if .ProxyConfig.ProxyMetadata }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -316,7 +316,7 @@ defaults:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
       # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
-      force_apply_iptables: false
+      forceApplyIptables: false
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""
     ##############################################################################################

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -316,7 +316,7 @@ defaults:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
       # Bypasses iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
-      # Do not use unless you need to work around an idempotency issue. This flag will be removed in future releases.
+      # Do not use unless you need to work around an issue of the idempotency handling. This flag will be removed in future releases.
       forceApplyIptables: false
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -315,7 +315,7 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
-      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
       force_apply_iptables: false
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -315,7 +315,8 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
-      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
+      # Bypasses iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
+      # Do not use unless you need to work around an idempotency issue. This flag will be removed in future releases.
       forceApplyIptables: false
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -315,6 +315,8 @@ defaults:
     proxy_init:
       # Base name for the proxy_init container, used to configure iptables.
       image: proxyv2
+      # Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+      force_apply_iptables: false
     # configure remote pilot and istiod service and endpoint
     remotePilotAddress: ""
     ##############################################################################################

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -79,7 +79,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.values.gen.yaml
@@ -79,6 +79,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -78,7 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.values.gen.yaml
@@ -78,6 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -78,7 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.values.gen.yaml
@@ -78,6 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -79,7 +79,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.values.gen.yaml
@@ -79,6 +79,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -81,7 +81,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.values.gen.yaml
@@ -81,6 +81,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -78,7 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.values.gen.yaml
@@ -78,6 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
@@ -78,7 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.values.gen.yaml
@@ -78,6 +78,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -136,6 +136,8 @@ templates:
         {{ if .Values.pilot.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
+        {{ else if .Values.global.proxy_init.forceApplyIptables -}}
+        - "--force-apply"
         {{ end -}}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
       {{- if .ProxyConfig.ProxyMetadata }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -77,7 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
-      "force_apply_iptables": false,
+      "forceApplyIptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.values.gen.yaml
@@ -77,6 +77,7 @@
       "tracer": "none"
     },
     "proxy_init": {
+      "force_apply_iptables": false,
       "image": "proxyv2"
     },
     "remotePilotAddress": "",

--- a/releasenotes/notes/50328.yaml
+++ b/releasenotes/notes/50328.yaml
@@ -10,7 +10,7 @@ releaseNotes:
 ---
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 releaseNotes:
 - |
   **Added** `--cleanup-only` option to istio-iptables to perform a cleanup of chains/rules without creating new ones.

--- a/releasenotes/notes/52899.yaml
+++ b/releasenotes/notes/52899.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** `--force-apply` to override the idempotency logic if detection incorrectly assumes rules are already applied.

--- a/releasenotes/notes/52899.yaml
+++ b/releasenotes/notes/52899.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: networking
+area: traffic-management
 releaseNotes:
 - |
   **Added** `--force-apply` to override the idempotency logic if detection incorrectly assumes rules are already applied.

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -880,7 +880,7 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 	}
 
 	// Apply Step
-	if deltaExists && !cfg.cfg.CleanupOnly {
+	if (deltaExists || cfg.cfg.ForceApply) && !cfg.cfg.CleanupOnly {
 		log.Info("Applying iptables chains and rules")
 		if cfg.cfg.RestoreFormat {
 			// Execute iptables-restore
@@ -901,6 +901,10 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 				return err
 			}
 		}
+	}
+
+	if !deltaExists && cfg.cfg.ForceApply {
+		log.Warn("The forced apply of iptables changes succeeded despite the presence of conflicting rules or chains. If you encounter this message, please consider reporting it as an issue.")
 	}
 
 	return nil

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -904,7 +904,8 @@ func (cfg *IptablesConfigurator) executeCommands(iptVer, ipt6Ver *dep.IptablesVe
 	}
 
 	if !deltaExists && cfg.cfg.ForceApply {
-		log.Warn("The forced apply of iptables changes succeeded despite the presence of conflicting rules or chains. If you encounter this message, please consider reporting it as an issue.")
+		log.Warn("The forced apply of iptables changes succeeded despite the presence of conflicting rules or chains. " +
+			"If you encounter this message, please consider reporting it as an issue.")
 	}
 
 	return nil

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -403,6 +403,11 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 			// Second Pass
 			iptConfigurator = NewIptablesConfigurator(cfg, ext)
 			assert.NoError(t, iptConfigurator.Run())
+
+			// Execution should fail if force-apply is used and chains exists
+			cfg.ForceApply = true
+			iptConfigurator = NewIptablesConfigurator(cfg, ext)
+			assert.Error(t, iptConfigurator.Run())
 		})
 	}
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -144,7 +144,8 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 		&cfg.CleanupOnly)
 
 	// This flag is a safety measure in case the idempotency changes of #50328 backfire.
-	// Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
+	// Allow bypassing of iptables idempotency handling, and attempts to apply iptables rules regardless of table state, which may cause unrecoverable failures.
+	// Consider removing it after several releases with no reported issues.
 	flag.BindEnv(fs, constants.ForceApply, "", "Apply iptables changes even if they appear to already be in place.",
 		&cfg.ForceApply)
 }

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -137,11 +137,16 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 
 	flag.BindEnv(fs, constants.CNIMode, "", "Whether to run as CNI plugin.", &cfg.HostFilesystemPodNetwork)
 
-	flag.BindEnv(fs, constants.Reconcile, "", "Reconcile pre-existing and incompatible iptables rules instead of failing if drift is detected",
+	flag.BindEnv(fs, constants.Reconcile, "", "Reconcile pre-existing and incompatible iptables rules instead of failing if drift is detected.",
 		&cfg.Reconcile)
 
 	flag.BindEnv(fs, constants.CleanupOnly, "", "Perform a forced cleanup without creating new iptables chains or rules.",
 		&cfg.CleanupOnly)
+
+	// This flag is a safety measure in case the idempotency changes of #50328 backfire.
+	// Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+	flag.BindEnv(fs, constants.ForceApply, "", "Apply iptables changes even if they appear to already be in place.",
+		&cfg.ForceApply)
 }
 
 func GetCommand(logOpts *log.Options) *cobra.Command {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -144,7 +144,7 @@ func bindCmdlineFlags(cfg *config.Config, cmd *cobra.Command) {
 		&cfg.CleanupOnly)
 
 	// This flag is a safety measure in case the idempotency changes of #50328 backfire.
-	// Allows override if detection incorrectly assumes rules are already applied. Consider removing after several stable releases with no reported issues.
+	// Allows override if detection incorrectly assumes rules are already applied. Consider removing after several releases with no reported issues.
 	flag.BindEnv(fs, constants.ForceApply, "", "Apply iptables changes even if they appear to already be in place.",
 		&cfg.ForceApply)
 }

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -136,6 +136,9 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.HostFilesystemPodNetwork)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))
+	b.WriteString(fmt.Sprintf("RECONCILE=%t\n", c.Reconcile))
+	b.WriteString(fmt.Sprintf("CLEANUP_ONLY=%t\n", c.CleanupOnly))
+	b.WriteString(fmt.Sprintf("FORCE_APPLY=%t\n", c.ForceApply))
 	log.Infof("Istio iptables variables:\n%s", b.String())
 }
 

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	HostIPv4LoopbackCidr     string     `json:"HOST_IPV4_LOOPBACK_CIDR"`
 	Reconcile                bool       `json:"RECONCILE"`
 	CleanupOnly              bool       `json:"CLEANUP_ONLY"`
+	ForceApply               bool       `json:"FORCE_APPLY"`
 }
 
 func (c *Config) String() string {

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -108,6 +108,7 @@ const (
 	CNIMode                   = "cni-mode"
 	Reconcile                 = "reconcile"
 	CleanupOnly               = "cleanup-only"
+	ForceApply                = "force-apply"
 )
 
 // Environment variables that deliberately have no equivalent command-line flags.


### PR DESCRIPTION
**Please provide a description of this PR:**

This adds a flag --force--apply that acts like a safety measure in case the changes of #50328 backfire.
It allows override the idempotency logic if detection incorrectly assumes rules are already applied. We should consider removing this option after several releases with no reported issues.
The option can be enabled by setting values.global.proxy_init.force_apply_iptables=true.


Please note that in case the three following things happen simultaneously:
- --force--apply is set
- residueFound==true && deltaExists==false (current state of iptables is deemed compatible)
- the forced apply succeeds

Then a false negative in the idempotency logic (specifically in deltaExists) has been encountered. It's unexpected because iptables commands should not succeed if chains already exist, suggesting an underlying problem.
A [warning](https://github.com/istio/istio/blob/d30ff2d04bd5cd9de88d249764585e125c3348e6/tools/istio-iptables/pkg/capture/run.go#L906-L909) will be raised to ask the user to open an issue.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
