### PR TITLE
Do not use circuit breakers on connect_originate clusters

### DIFF
--- a/pilot/pkg/networking/core/cluster_waypoint.go
+++ b/pilot/pkg/networking/core/cluster_waypoint.go
@@ -25,6 +25,7 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -293,8 +294,9 @@ func (cb *ClusterBuilder) buildConnectOriginate(proxy *model.Proxy, push *model.
 		Name:                          ConnectOriginate,
 		ClusterDiscoveryType:          &cluster.Cluster_Type{Type: cluster.Cluster_ORIGINAL_DST},
 		LbPolicy:                      cluster.Cluster_CLUSTER_PROVIDED,
-		ConnectTimeout:                durationpb.New(2 * time.Second),
+		ConnectTimeout:                proto.Clone(cb.req.Push.Mesh.ConnectTimeout).(*durationpb.Duration),
 		CleanupInterval:               durationpb.New(60 * time.Second),
+		CircuitBreakers:               &cluster.CircuitBreakers{Thresholds: []*cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThresholds()}},
 		TypedExtensionProtocolOptions: h2connectUpgrade(),
 		LbConfig: &cluster.Cluster_OriginalDstLbConfig_{
 			OriginalDstLbConfig: &cluster.Cluster_OriginalDstLbConfig{


### PR DESCRIPTION
We do this for every cluster *but* this one. Based on some
troubleshooting with a user
(https://istio.slack.com/archives/C37A4KAAD/p1724878840164799?thread_ts=1724224161.756969&cid=C37A4KAAD)
there is some signs pointing to this being the root cause of some
connectivity issues.

Additionally, do not hardcode the connect_timeout.

~I put a hold since we are going to get some production testing of this in ~12 hours so will wait to hear back~ actually we should do this anyways..
