### PR TITLE
Support grpc headers configuration of opentelemetry provider

### DIFF
--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -722,6 +722,9 @@ func buildHTTPHeaders(headers []*meshconfig.MeshConfig_ExtensionProvider_HttpHea
 }
 
 func buildInitialMetadata(metadata []*meshconfig.MeshConfig_ExtensionProvider_HttpHeader) []*core.HeaderValue {
+	if metadata == nil {
+		return nil
+	}
 	target := make([]*core.HeaderValue, 0, len(metadata))
 	for _, h := range metadata {
 		hv := &core.HeaderValue{

--- a/pilot/pkg/networking/core/tracing.go
+++ b/pilot/pkg/networking/core/tracing.go
@@ -269,19 +269,7 @@ func otelConfig(serviceName string, otelProvider *meshconfig.MeshConfig_Extensio
 		ServiceName: serviceName,
 	}
 
-	if otelProvider.GetGrpc() != nil {
-		// export via gRPC with options
-		oc.GrpcService = &core.GrpcService{
-			TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-				EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
-					ClusterName: cluster,
-					Authority:   hostname,
-				},
-			},
-			Timeout:         otelProvider.GetGrpc().GetTimeout(),
-			InitialMetadata: buildInitialMetadata(otelProvider.GetGrpc().GetInitialMetadata()),
-		}
-	} else if otelProvider.GetHttp() != nil {
+	if otelProvider.GetHttp() != nil {
 		// export via HTTP
 		httpService := otelProvider.GetHttp()
 		te, err := url.JoinPath(hostname, httpService.GetPath())
@@ -308,6 +296,8 @@ func otelConfig(serviceName string, otelProvider *meshconfig.MeshConfig_Extensio
 					Authority:   hostname,
 				},
 			},
+			Timeout:         otelProvider.GetGrpc().GetTimeout(),
+			InitialMetadata: buildInitialMetadata(otelProvider.GetGrpc().GetInitialMetadata()),
 		}
 	}
 

--- a/pilot/pkg/networking/core/tracing_test.go
+++ b/pilot/pkg/networking/core/tracing_test.go
@@ -210,10 +210,11 @@ func TestConfigureTracing(t *testing.T) {
 			wantReqIDExtCtx: nil,
 		},
 		{
-			name:            "basic config (with opentelemetry provider via grpc with initial metadata)",
-			inSpec:          fakeTracingSpec(fakeOpenTelemetryGrpcWithInitialMetadata(), 99.999, false, true),
-			opts:            fakeOptsOnlyOpenTelemetryGrpcWithInitialMetadataTelemetryAPI(),
-			want:            fakeTracingConfig(fakeOpenTelemetryGrpcWithInitialMetadataProvider(clusterName, authority), 99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
+			name:   "basic config (with opentelemetry provider via grpc with initial metadata)",
+			inSpec: fakeTracingSpec(fakeOpenTelemetryGrpcWithInitialMetadata(), 99.999, false, true),
+			opts:   fakeOptsOnlyOpenTelemetryGrpcWithInitialMetadataTelemetryAPI(),
+			want: fakeTracingConfig(fakeOpenTelemetryGrpcWithInitialMetadataProvider(clusterName, authority),
+				99.999, 256, append(defaultTracingTags(), fakeEnvTag)),
 			wantReqIDExtCtx: &defaultUUIDExtensionCtx,
 		},
 	}

--- a/pkg/config/validation/agent/extensionprovider.go
+++ b/pkg/config/validation/agent/extensionprovider.go
@@ -203,6 +203,9 @@ func ValidateExtensionProviderTracingOpentelemetry(provider *meshconfig.MeshConf
 	if err := validateExtensionProviderService(provider.Service); err != nil {
 		errs = AppendErrors(errs, err)
 	}
+	if provider.GetGrpc() != nil && provider.GetHttp() != nil {
+		errs = AppendErrors(errs, fmt.Errorf("OpenTelemetryTracingProvider cannot specify both grpc and http"))
+	}
 	return
 }
 

--- a/pkg/config/validation/agent/extensionprovider_test.go
+++ b/pkg/config/validation/agent/extensionprovider_test.go
@@ -506,6 +506,16 @@ func TestValidateExtensionProviderTracingOpentelemetry(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "set both grpc and http",
+			provider: &meshconfig.MeshConfig_ExtensionProvider_OpenTelemetryTracingProvider{
+				Service: "collector.namespace.svc",
+				Port:    4317,
+				Grpc:    &meshconfig.MeshConfig_ExtensionProvider_GrpcService{},
+				Http:    &meshconfig.MeshConfig_ExtensionProvider_HttpService{},
+			},
+			valid: false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/releasenotes/notes/52873.yaml
+++ b/releasenotes/notes/52873.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+# issue is a list of GitHub issues resolved in this note.
+issue:
+  - https://github.com/istio/istio/issues/52873
+
+releaseNotes:
+- |
+  **Added** support headers and timeout configurations of gRPC requests when exporting traces to OpenTelemetry Collector.

--- a/tests/integration/telemetry/tracing/otelcollector/testdata/test-otel-grpc-with-initial-metadata.yaml
+++ b/tests/integration/telemetry/tracing/otelcollector/testdata/test-otel-grpc-with-initial-metadata.yaml
@@ -1,0 +1,13 @@
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: otel-tracing
+spec:
+  tracing:
+  - providers:
+    - name: test-otel-grpc-with-initial-metadata
+    randomSamplingPercentage: 100.0
+    customTags:
+      "provider":
+        literal:
+          value: "test-otel-grpc-with-initial-metadata"

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -46,6 +46,9 @@ var otelTracingHTTPCfg string
 //go:embed testdata/otel-tracing-res-detectors.yaml
 var otelTracingResDetectorsCfg string
 
+//go:embed testdata/test-otel-grpc-with-initial-metadata.yaml
+var otelTracingGRPCWithInitialMetadataCfg string
+
 // TestProxyTracingOpenTelemetryProvider validates that Telemetry API configuration
 // referencing an OpenTelemetry provider will generate traces appropriately.
 // NOTE: This test relies on the priority of Telemetry API over MeshConfig tracing
@@ -71,6 +74,11 @@ func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
 			name:            "resource detectors",
 			customAttribute: "provider=otel-grpc-with-res-detectors",
 			cfgFile:         otelTracingResDetectorsCfg,
+		},
+		{
+			name:            "grpc exporter with initial metadata",
+			customAttribute: "provider=test-otel-grpc-with-initial-metadata",
+			cfgFile:         otelTracingGRPCWithInitialMetadataCfg,
 		},
 	}
 
@@ -151,6 +159,15 @@ meshConfig:
       resource_detectors:
         environment: {}
         dynatrace: {}
+  - name: test-otel-grpc-with-initial-metadata
+    opentelemetry:
+      service: opentelemetry-collector.istio-system.svc.cluster.local
+      port: 4317
+	  grpc:
+	    timeout: 3s
+	    initialMetadata:
+		- name: "Authentication"
+		  value: "token-xxxxx"
 `
 }
 

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -163,11 +163,11 @@ meshConfig:
     opentelemetry:
       service: opentelemetry-collector.istio-system.svc.cluster.local
       port: 4317
-	  grpc:
-	    timeout: 3s
-	    initialMetadata:
-		- name: "Authentication"
-		  value: "token-xxxxx"
+      grpc:
+        timeout: 3s
+        initialMetadata:
+        - name: "Authentication"
+          value: "token-xxxxx"
 `
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR aims to support this feature request https://github.com/istio/istio/issues/52873.

I have already tested this implementation on Alibaba Cloud OpenTelemetry, which requires adding header like `Authentication: token-xxxxx` on gRPC requests for authentication and it works fine on my cluster.