### PR TITLE
Use new istio-iptables cleanup methodology in VMs

### DIFF
--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -56,7 +56,7 @@ fi
 if [[ ${1-} == "clean" ]] ; then
   if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     # clean the previous Istio iptables chains.
-    "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
+    "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only
   fi
   exit 0
 fi
@@ -77,7 +77,7 @@ if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     if [[ ${1-} != "run" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
+      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only
 
       # Update iptables, based on config file
       "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -66,7 +66,7 @@ if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     if [[ ${1-} == "init" || ${1-} == "-p" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
+      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables "${@}" --cleanup-only
 
       # Update iptables, based on current config. This is for backward compatibility with the init image mode.
       # The sidecar image can replace the k8s init image, to avoid downloading 2 different images.

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -56,7 +56,7 @@ fi
 if [[ ${1-} == "clean" ]] ; then
   if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     # clean the previous Istio iptables chains.
-    "${ISTIO_BIN_BASE}/pilot-agent" istio-clean-iptables
+    "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
   fi
   exit 0
 fi
@@ -66,7 +66,7 @@ if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     if [[ ${1-} == "init" || ${1-} == "-p" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/pilot-agent" istio-clean-iptables
+      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
 
       # Update iptables, based on current config. This is for backward compatibility with the init image mode.
       # The sidecar image can replace the k8s init image, to avoid downloading 2 different images.
@@ -77,7 +77,7 @@ if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
     if [[ ${1-} != "run" ]] ; then
       # clean the previous Istio iptables chains. This part is different from the init image mode,
       # where the init container runs in a fresh environment and there cannot be previous Istio chains
-      "${ISTIO_BIN_BASE}/pilot-agent" istio-clean-iptables
+      "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables --cleanup-only "${@}"
 
       # Update iptables, based on config file
       "${ISTIO_BIN_BASE}/pilot-agent" istio-iptables


### PR DESCRIPTION
This update will change the current handling of start/stop/clean operations in VMs to rely on `istio-iptables --cleanup-only` instead of the old `istio-clean-iptables` command.

`istio-iptables --cleanup-only `computes the rules that need to be deleted in a "dynamic" way based on what the command would have applied if the cleanup option was not used.
On the other hand, `istio-clean-iptables` relied on hardcoded logic which was separate from the one used to create rules in istio-iptables. This approach required constant maintenance to ensure that the two different tools did not diverge over time.

This change removes the need to maintain `istio-clean-iptables `and prevents issues similar to #52835 and #41431 from occurring.

I'm not sure whether the istio-clean-iptables source code in the repo should be removed right away or not. We could keep it around for 1-2 releases in case someone is using it outside of our scripts but that would entail that we still need to support it a bit more in case of changes in istio-iptables rules.