### PR TITLE
fix LegacyKeyValueFormat docker warnings

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -28,7 +28,7 @@ ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs
-ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
+ENV ISTIO_META_ISTIO_PROXY_SHA=$proxy_version
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent

--- a/pilot/docker/Dockerfile.ztunnel
+++ b/pilot/docker/Dockerfile.ztunnel
@@ -24,6 +24,6 @@ ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/ztunnel /usr/local/bin/ztunnel
 
 # Environment variable indicating the exact build, for debugging
-ENV ISTIO_META_ISTIO_VERSION $istio_version
+ENV ISTIO_META_ISTIO_VERSION=$istio_version
 
 ENTRYPOINT ["/usr/local/bin/ztunnel"]

--- a/samples/bookinfo/src/details/Dockerfile
+++ b/samples/bookinfo/src/details/Dockerfile
@@ -21,9 +21,9 @@ RUN bundle install
 COPY details.rb /opt/microservices/
 
 ARG service_version
-ENV SERVICE_VERSION ${service_version:-v1}
+ENV SERVICE_VERSION=${service_version:-v1}
 ARG enable_external_book_service
-ENV ENABLE_EXTERNAL_BOOK_SERVICE ${enable_external_book_service:-false}
+ENV ENABLE_EXTERNAL_BOOK_SERVICE=${enable_external_book_service:-false}
 
 EXPOSE 9080
 

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -29,7 +29,7 @@ COPY static /opt/microservices/static
 COPY requirements.txt /opt/microservices/
 
 ARG flood_factor
-ENV FLOOD_FACTOR ${flood_factor:-0}
+ENV FLOOD_FACTOR=${flood_factor:-0}
 
 EXPOSE 9080
 WORKDIR /opt/microservices

--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG service_version
-ENV SERVICE_VERSION ${service_version:-v1}
+ENV SERVICE_VERSION=${service_version:-v1}
 
 COPY package.json /opt/microservices/
 COPY ratings.js /opt/microservices/

--- a/samples/bookinfo/src/reviews/Dockerfile
+++ b/samples/bookinfo/src/reviews/Dockerfile
@@ -23,7 +23,7 @@ RUN gradle build
 
 FROM open-liberty:24.0.0.1-kernel-slim-java17-openj9
 
-ENV SERVERDIRNAME reviews
+ENV SERVERDIRNAME=reviews
 
 COPY --from=builder /home/gradle/reviews-wlpcfg/servers/LibertyProjectServer/ /opt/ol/wlp/usr/servers/defaultServer/
 # Not sure why but we need root to build, but without it buildx cannot get network connectivity. We swap to 1001 later.
@@ -36,8 +36,8 @@ USER 1001
 ARG service_version
 ARG enable_ratings
 ARG star_color
-ENV SERVICE_VERSION ${service_version:-v1}
-ENV ENABLE_RATINGS ${enable_ratings:-false}
-ENV STAR_COLOR ${star_color:-black}
+ENV SERVICE_VERSION=${service_version:-v1}
+ENV ENABLE_RATINGS=${enable_ratings:-false}
+ENV STAR_COLOR=${star_color:-black}
 
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/samples/helloworld/src/Dockerfile
+++ b/samples/helloworld/src/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 EXPOSE 5000
 
 ARG service_version
-ENV SERVICE_VERSION ${service_version:-v1}
+ENV SERVICE_VERSION=${service_version:-v1}
 
 # image will bind on TCP6 by default. In k8s pod spec (in a deployment pod template most likely) override for explicit IPv4 if needed with the command shown below:
 # ["gunicorn", "-b", "[0.0.0.0]:5000", "app:app", "-k", "gevent"]


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix docker warnings when building images

`warning: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value"`