### PR TITLE
Add/Increase retry timeout due to delay for GKE on AWS platform in config propagation

### DIFF
--- a/tests/integration/pilot/gateway_test.go
+++ b/tests/integration/pilot/gateway_test.go
@@ -286,7 +286,7 @@ spec:
 		Address: fmt.Sprintf("gateway-istio.%s.svc.cluster.local", apps.Namespace.Name()),
 		Check:   check.OK(),
 		Retry: echo.Retry{
-			Options: []retry.Option{retry.Timeout(time.Minute)},
+			Options: []retry.Option{retry.Timeout(2 * time.Minute)},
 		},
 	})
 	apps.B[0].CallOrFail(t, echo.CallOptions{
@@ -298,7 +298,7 @@ spec:
 		Address: fmt.Sprintf("gateway-istio.%s.svc.cluster.local", apps.Namespace.Name()),
 		Check:   check.NotOK(),
 		Retry: echo.Retry{
-			Options: []retry.Option{retry.Timeout(time.Minute)},
+			Options: []retry.Option{retry.Timeout(2 * time.Minute)},
 		},
 	})
 }
@@ -510,6 +510,9 @@ spec:
 							Headers: headers.New().WithHost("my.domain.example").Build(),
 						},
 						Check: check.OK(),
+						Retry: echo.Retry{
+							Options: []retry.Option{retry.Timeout(2 * time.Minute)},
+						},
 					})
 				}
 			})


### PR DESCRIPTION
Add/Increase retry timeout due to delay in config propagation for GKE on AWS platform 