### PR TITLE
Permit configurable set of cert providers for exclusion from certsigning clusterrole

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -95,8 +95,7 @@ rules:
     verbs: ["create", "get", "list", "watch", "update"]
 
   # Istiod and bootstrap.
-{{- $omitCertProvidersForClusterRole := list "istiod" "custom" "none"}}
-{{- if or .Values.env.EXTERNAL_CA (not (has .Values.global.pilotCertProvider $omitCertProvidersForClusterRole)) }}
+{{- if or .Values.env.EXTERNAL_CA (not (has .Values.global.pilotCertProvider .Values.global.omitCertProvidersForClusterRole)) }}
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "certificatesigningrequests"

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -480,6 +480,12 @@ defaults:
     # Istiod is the default
     pilotCertProvider: istiod
 
+    # Customizable list of providers for which the certificate signing cluster role should not be included.
+    omitCertProvidersForClusterRole:
+      - istiod
+      - custom
+      - none
+
     sds:
       # The JWT token for SDS and the aud field of such JWT. See RFC 7519, section 4.1.3.
       # When a CSR is sent from Istio Agent to the CA (e.g. Istiod), this aud is to make sure the

--- a/manifests/charts/istiod-remote/templates/clusterrole.yaml
+++ b/manifests/charts/istiod-remote/templates/clusterrole.yaml
@@ -96,8 +96,7 @@ rules:
     verbs: ["create", "get", "list", "watch", "update"]
 
   # Istiod and bootstrap.
-{{- $omitCertProvidersForClusterRole := list "istiod" "custom" "none"}}
-{{- if or .Values.env.EXTERNAL_CA (not (has .Values.global.pilotCertProvider $omitCertProvidersForClusterRole)) }}
+{{- if or .Values.env.EXTERNAL_CA (not (has .Values.global.pilotCertProvider .Values.global.omitCertProvidersForClusterRole)) }}
   - apiGroups: ["certificates.k8s.io"]
     resources:
       - "certificatesigningrequests"

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -406,6 +406,11 @@ defaults:
     # As some platforms may not have kubernetes signing APIs,
     # Istiod is the default
     pilotCertProvider: istiod
+    # Customizable list of providers for which the certificate signing cluster role should not be included.
+    omitCertProvidersForClusterRole:
+      - istiod
+      - custom
+      - none
     sds:
       # The JWT token for SDS and the aud field of such JWT. See RFC 7519, section 4.1.3.
       # When a CSR is sent from Istio Agent to the CA (e.g. Istiod), this aud is to make sure the

--- a/releasenotes/notes/customize-providers-limit-csr-clusterrole.yaml
+++ b/releasenotes/notes/customize-providers-limit-csr-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** a new `.Values.global.omitCertProvidersForClusterRole` to permit customizing the set of `pilotCertProvider`
+    values that are excluded from adding certificate signing permissions to istiod's cluster role. Previously this list
+    was hard-coded in templates.


### PR DESCRIPTION
**Please provide a description of this PR:**

This change is an extension of https://github.com/istio/istio/pull/43928, which added logic to exclude a specific set of certproviders from including CertificateSigningRequest permissions in istiod's cluster role.

We use a provider that is not one of the previously hard-coded set ['istiod', 'custom', 'none'], and would like to omit the CSR permissions in our environment.