### PR TITLE
fix endpoint comparision logic in UpdateServiceEndpoints

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -609,7 +609,7 @@ func (ep *IstioEndpoint) FirstAddressOrNil() string {
 
 // Key returns a function suitable for usage to distinguish this IstioEndpoint from another
 func (ep *IstioEndpoint) Key() string {
-	return ep.FirstAddressOrNil() + "/" + ep.WorkloadName
+	return ep.FirstAddressOrNil() + "/" + ep.WorkloadName + "/" + ep.ServicePortName
 }
 
 // EndpointMetadata represents metadata set on Envoy LbEndpoint used for telemetry purposes.


### PR DESCRIPTION
**Please provide a description of this PR:**

This is similar to [PR #52189](https://github.com/istio/istio/pull/52189).

We should include service port name as well in the key to make sure multiport service entry selecting workload entry comparison works well.