### PR TITLE
helm: dynamic naming of ztunnel chart

### DIFF
--- a/manifests/charts/ztunnel/templates/_helpers.tpl
+++ b/manifests/charts/ztunnel/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+{{ define "ztunnel.release-name" }}{{ .Values.resourceName| default .Release.Name }}{{ end }}

--- a/manifests/charts/ztunnel/templates/daemonset.yaml
+++ b/manifests/charts/ztunnel/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: ztunnel

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -7,7 +7,7 @@ imagePullSecrets:
   {{- end }}
   {{- end }}
 metadata:
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: ztunnel
@@ -25,10 +25,10 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
   labels:
     app: ztunnel
-    release: {{ .Release.Name }}
+    release: {{ include "ztunnel.release-name" . }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
@@ -48,10 +48,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
   labels:
     app: ztunnel
-    release: {{ .Release.Name }}
+    release: {{ include "ztunnel.release-name" . }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     app.kubernetes.io/name: ztunnel
     {{- include "istio.labels" . | nindent 4}}
@@ -65,10 +65,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
 subjects:
 - kind: ServiceAccount
-  name: ztunnel
+  name: {{ include "ztunnel.release-name" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 ---

--- a/manifests/charts/ztunnel/values.yaml
+++ b/manifests/charts/ztunnel/values.yaml
@@ -12,6 +12,10 @@ _internal_defaults_do_not_set:
   # If Image contains a "/", it will replace the entire `image` in the pod.
   image: ztunnel
 
+  # resourceName, if set, will override the naming of resources. If not set, will default to the release name.
+  # It is recommended to not set this; this is primarily for backwards compatibility.
+  resourceName: ""
+
   # Labels to apply to all top level resources
   labels: {}
   # Annotations to apply to all top level resources

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -30,3 +30,5 @@ spec:
     gateways:
       istio-ingressgateway: {}
       istio-egressgateway: {}
+    ztunnel:
+      resourceName: ztunnel

--- a/manifests/sample-charts/ambient/values.yaml
+++ b/manifests/sample-charts/ambient/values.yaml
@@ -9,6 +9,7 @@ istiod:
 # Overrides for the `ztunnel` dep
 ztunnel:
   profile: ambient
+  resourceName: ztunnel
 
 # Overrides for the `cni` dep
 cni:

--- a/releasenotes/notes/ztunnel-helm-chart.yaml
+++ b/releasenotes/notes/ztunnel-helm-chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Improved** the ztunnel Helm chart to set resource names to `.Release.Name` instead of hard-coded to ztunnel.
+upgradeNotes:
+  - title: Ztunnel Helm chart changes
+    content: |
+      In previous releases, resources in the ztunnel Helm chart were always named `ztunnel`.
+      In this release, they are now named `.Resource.Name`.
+      
+      If you are installing the chart with a release name other than `ztunnel`, the resource names will change, triggering downtime.
+      In this scenario, it is recommended to set `--set resourceName=ztunnel` to override back to the previous default.


### PR DESCRIPTION
This allows multiple installs of this. For example I may want 1 with
nodeSelector=A and another for B.
