### PR TITLE
waypoint: log when we cannot find a route in the internal listener

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -350,6 +350,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 			},
 		},
 	}
+	accessLogBuilder.setListenerAccessLog(lb.push, lb.node, l, istionetworking.ListenerClassSidecarInbound)
 	return l
 }
 


### PR DESCRIPTION
This mirrors what we do for sidecars, gateways, etc
