### PR TITLE
Ambient: fix incorrect dualstack EDS with tunnelling

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -20,11 +20,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/maps"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 )
 
@@ -194,6 +196,12 @@ func (pc *PodCache) notifyWorkloadHandlers(pod *v1.Pod, ev model.Event) {
 	}
 	// fire instance handles for workload
 	ep := pc.c.NewEndpointBuilder(pod).buildIstioEndpoint(pod.Status.PodIP, 0, "", model.AlwaysDiscoverable, model.Healthy)
+	// If pod is dual stack, handle all IPs
+	if features.EnableDualStack && len(pod.Status.PodIPs) > 1 {
+		ep.Addresses = slices.Map(pod.Status.PodIPs, func(e v1.PodIP) string {
+			return e.IP
+		})
+	}
 	workloadInstance := &model.WorkloadInstance{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -595,29 +595,6 @@ func ExtractEnvoyEndpoints(locEps []*LocalityEndpoints) []*endpoint.LocalityLbEn
 
 // buildEnvoyLbEndpoint packs the endpoint based on istio info.
 func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnabled bool) *endpoint.LbEndpoint {
-	addr := util.BuildAddress(e.Addresses[0], e.EndpointPort)
-
-	// This change can support multiple addresses for an endpoint, then there are some use cases for it, such as
-	// 1. An endpoint can have both ipv4 or ipv6
-	// 2. An endpoint can be represented a serviceentry/workload instance with multiple IP addresses
-	// When the additional_addresses field is populated for EDS in Envoy configuration, there would be a Happy Eyeballs
-	// algorithm to instantiate for the Endpoint, first attempt connecting to the IP address in the address field.
-	// Thereafter it will interleave IP addresses in the `additional_addresses` field based on IP version, as described in rfc8305,
-	// and attempt connections with them with a delay of 300ms each. The first connection to succeed will be used.
-	// Note: it uses Hash Based Load Balancing Policies for multiple addresses support Endpoint, and only the first address of the
-	// endpoint will be used as the hash key for the ring or maglev list, however, the upstream address that load balancer ends up
-	// connecting to will depend on the one that ends up "winning" using the Happy Eyeballs algorithm.
-	// Please refer to https://docs.google.com/document/d/1AjmTcMWwb7nia4rAgqE-iqIbSbfiXCI4h1vk-FONFdM/ for more details.
-	var additionalAddrs []*endpoint.Endpoint_AdditionalAddress
-	if features.EnableDualStack {
-		for _, itemAddr := range e.Addresses[1:] {
-			coreAddr := util.BuildAddress(itemAddr, e.EndpointPort)
-			additionalAddr := &endpoint.Endpoint_AdditionalAddress{
-				Address: coreAddr,
-			}
-			additionalAddrs = append(additionalAddrs, additionalAddr)
-		}
-	}
 	healthStatus := e.HealthStatus
 	if features.DrainingLabel != "" && e.Labels[features.DrainingLabel] != "" {
 		healthStatus = model.Draining
@@ -627,12 +604,6 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		HealthStatus: corev3.HealthStatus(healthStatus),
 		LoadBalancingWeight: &wrapperspb.UInt32Value{
 			Value: e.GetLoadBalancingWeight(),
-		},
-		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-			Endpoint: &endpoint.Endpoint{
-				Address:             addr,
-				AdditionalAddresses: additionalAddrs,
-			},
 		},
 		Metadata: &corev3.Metadata{},
 	}
@@ -675,7 +646,9 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		tunnel = false
 	}
 	if tunnel {
-		addresses, port := e.Addresses, int(e.EndpointPort)
+		// Currently, Envoy cannot support tunneling to multiple IP families.
+		// TODO(https://github.com/envoyproxy/envoy/issues/36318)
+		address, port := e.Addresses[0], int(e.EndpointPort)
 		// We intentionally do not take into account waypoints here.
 		// 1. Workload waypoints: sidecar/ingress do not support sending traffic directly to workloads, only to services,
 		//    so these are not applicable.
@@ -690,10 +663,9 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		// Support connecting to server side waypoint proxy, if the destination has one. This is for sidecars and ingress.
 		// Setup tunnel metadata so requests will go through the tunnel
 		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{
-			Address:             util.BuildInternalAddressWithIdentifier(connectOriginate, net.JoinHostPort(addresses[0], strconv.Itoa(port))),
-			AdditionalAddresses: additionalAddrs,
+			Address: util.BuildInternalAddressWithIdentifier(connectOriginate, net.JoinHostPort(address, strconv.Itoa(port))),
 		}}
-		ep.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(addresses[0], port)
+		ep.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(address, port)
 		if b.dir != model.TrafficDirectionInboundVIP {
 			// Add TLS metadata matcher to indicate we can use HBONE for this endpoint.
 			// We skip this for service waypoint, which doesn't need to dynamically match mTLS vs HBONE.
@@ -702,6 +674,36 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 					model.TunnelLabelShortName: {Kind: &structpb.Value_StringValue{StringValue: model.TunnelHTTP}},
 				},
 			}
+		}
+	} else {
+		addr := util.BuildAddress(e.Addresses[0], e.EndpointPort)
+
+		// This change can support multiple addresses for an endpoint, then there are some use cases for it, such as
+		// 1. An endpoint can have both ipv4 or ipv6
+		// 2. An endpoint can be represented a serviceentry/workload instance with multiple IP addresses
+		// When the additional_addresses field is populated for EDS in Envoy configuration, there would be a Happy Eyeballs
+		// algorithm to instantiate for the Endpoint, first attempt connecting to the IP address in the address field.
+		// Thereafter it will interleave IP addresses in the `additional_addresses` field based on IP version, as described in rfc8305,
+		// and attempt connections with them with a delay of 300ms each. The first connection to succeed will be used.
+		// Note: it uses Hash Based Load Balancing Policies for multiple addresses support Endpoint, and only the first address of the
+		// endpoint will be used as the hash key for the ring or maglev list, however, the upstream address that load balancer ends up
+		// connecting to will depend on the one that ends up "winning" using the Happy Eyeballs algorithm.
+		// Please refer to https://docs.google.com/document/d/1AjmTcMWwb7nia4rAgqE-iqIbSbfiXCI4h1vk-FONFdM/ for more details.
+		var additionalAddrs []*endpoint.Endpoint_AdditionalAddress
+		if features.EnableDualStack {
+			for _, itemAddr := range e.Addresses[1:] {
+				coreAddr := util.BuildAddress(itemAddr, e.EndpointPort)
+				additionalAddr := &endpoint.Endpoint_AdditionalAddress{
+					Address: coreAddr,
+				}
+				additionalAddrs = append(additionalAddrs, additionalAddr)
+			}
+		}
+		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{
+			Endpoint: &endpoint.Endpoint{
+				Address:             addr,
+				AdditionalAddresses: additionalAddrs,
+			},
 		}
 	}
 

--- a/pilot/pkg/xds/waypoint_test.go
+++ b/pilot/pkg/xds/waypoint_test.go
@@ -1,0 +1,188 @@
+package xds_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	gateway "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/test/xds"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestWaypoint(t *testing.T) {
+	test.SetForTest(t, &features.EnableAmbient, true)
+	test.SetForTest(t, &features.EnableDualStack, true)
+	waypointSvc := `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gateway.istio.io/managed: istio.io-mesh-controller
+    gateway.networking.k8s.io/gateway-name: waypoint
+    istio.io/gateway-name: waypoint
+  name: waypoint
+  namespace: default
+spec:
+  clusterIP: 3.0.0.0
+  ports:
+  - appProtocol: hbone
+    name: mesh
+    port: 15008
+  selector:
+    gateway.networking.k8s.io/gateway-name: waypoint
+`
+	waypointInstance := `apiVersion: networking.istio.io/v1
+kind: WorkloadEntry
+metadata:
+  name: waypoint-a
+  namespace: default
+spec:
+  address: 3.0.0.1
+  labels:
+    gateway.networking.k8s.io/gateway-name: waypoint
+`
+	waypointGateway := `apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: default
+spec:
+  gatewayClassName: waypoint
+  listeners:
+    - name: mesh
+      port: 15009
+      protocol: HBONE
+status:
+  addresses:
+  - type: Hostname
+    value: waypoint.default.svc.cluster.local
+`
+	appServiceEntry := `apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: app
+  namespace: default
+  labels:
+    istio.io/use-waypoint: waypoint
+spec:
+  hosts:
+  - app.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: STATIC
+  workloadSelector:
+    labels:
+      app: app
+`
+	appWorkloadEntry := `apiVersion: networking.istio.io/v1
+kind: WorkloadEntry
+metadata:
+  name: app-a
+  namespace: default
+  labels:
+    app: app
+  annotations:
+    ambient.istio.io/redirection: enabled
+spec:
+  address: 1.1.1.1
+`
+	appPod := `apiVersion: v1
+kind: Pod
+metadata:
+  name: app-b
+  namespace: default
+  labels:
+    app: app
+  annotations:
+    ambient.istio.io/redirection: enabled
+spec: {}
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  podIP: 1.1.1.2
+  podIPs:
+  - ip: 1.1.1.2
+  - ip: 2001:20::2
+`
+	appPodNoMesh := `apiVersion: v1
+kind: Pod
+metadata:
+  name: app-c
+  namespace: default
+  labels:
+    app: app
+spec: {}
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  podIP: 1.1.1.3
+  podIPs:
+  - ip: 1.1.1.3
+  - ip: 2001:20::3
+`
+	d := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		ConfigString: joinYaml(waypointInstance, appServiceEntry, appWorkloadEntry),
+		KubeClientModifier: func(c kube.Client) {
+			// Because we are hitting the ambient controller, we want to create actual objects
+			createString[*gateway.Gateway](t, c, waypointGateway)
+			createString[*corev1.Service](t, c, waypointSvc)
+			createString[*corev1.Pod](t, c, appPod, appPodNoMesh)
+			createString[*networkingv1.WorkloadEntry](t, c, waypointInstance, appWorkloadEntry)
+			createString[*networkingv1.ServiceEntry](t, c, appServiceEntry)
+		},
+	})
+	proxy := d.SetupProxy(&model.Proxy{
+		Type:            model.Waypoint,
+		ConfigNamespace: "default",
+		IPAddresses:     []string{"3.0.0.1"}, // match the WE
+	})
+
+	eps := slices.Sort(xdstest.ExtractEndpoints(d.Endpoints(proxy)[0]))
+	assert.Equal(t, eps, []string{
+		// No tunnel, should get dual IPs
+		"1.1.1.3:80,[2001:20::3]:80",
+		"connect_originate;1.1.1.1:80",
+		// Tunnel doesn't support multiple IPs
+		"connect_originate;1.1.1.2:80",
+	})
+}
+
+func kubernetesObjectFromString(s string) (runtime.Object, error) {
+	decode := kube.IstioCodec.UniversalDeserializer().Decode
+	if len(strings.TrimSpace(s)) == 0 {
+		return nil, fmt.Errorf("empty kubernetes object")
+	}
+	o, _, err := decode([]byte(s), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed deserializing kubernetes object: %v (%v)", err, s)
+	}
+	return o, nil
+}
+
+func createString[T controllers.ComparableObject](t test.Failer, c kube.Client, objs ...string) {
+	for _, s := range objs {
+		obj, err := kubernetesObjectFromString(s)
+		assert.NoError(t, err)
+		clienttest.NewWriter[T](t, c).Create(obj.(T))
+	}
+}
+
+func joinYaml(s ...string) string {
+	return strings.Join(s, "\n---\n")
+}

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -16,6 +16,7 @@ package xdstest
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
 
@@ -324,17 +325,25 @@ func ExtractHealthEndpoints(cla *endpoint.ClusterLoadAssignment) ([]string, []st
 	unhealthy := []string{}
 	for _, ep := range cla.Endpoints {
 		for _, lb := range ep.LbEndpoints {
+			addresses := []*core.Address{lb.GetEndpoint().GetAddress()}
+			for _, aa := range lb.GetEndpoint().GetAdditionalAddresses() {
+				addresses = append(addresses, aa.GetAddress())
+			}
 			var addrString string
-			switch lb.GetEndpoint().GetAddress().Address.(type) {
-			case *core.Address_SocketAddress:
-				addrString = fmt.Sprintf("%s:%d",
-					lb.GetEndpoint().Address.GetSocketAddress().Address, lb.GetEndpoint().Address.GetSocketAddress().GetPortValue())
-			case *core.Address_Pipe:
-				addrString = lb.GetEndpoint().Address.GetPipe().Path
-			case *core.Address_EnvoyInternalAddress:
-				internalAddr := lb.GetEndpoint().Address.GetEnvoyInternalAddress().GetServerListenerName()
-				destinationAddr := lb.GetMetadata().GetFilterMetadata()[util.OriginalDstMetadataKey].GetFields()["local"].GetStringValue()
-				addrString = fmt.Sprintf("%s;%s", internalAddr, destinationAddr)
+			for i, addr := range addresses {
+				if i != 0 {
+					addrString += ","
+				}
+				switch addr.Address.(type) {
+				case *core.Address_SocketAddress:
+					addrString += net.JoinHostPort(addr.GetSocketAddress().Address, fmt.Sprint(addr.GetSocketAddress().GetPortValue()))
+				case *core.Address_Pipe:
+					addrString += addr.GetPipe().Path
+				case *core.Address_EnvoyInternalAddress:
+					internalAddr := addr.GetEnvoyInternalAddress().GetServerListenerName()
+					destinationAddr := lb.GetMetadata().GetFilterMetadata()[util.OriginalDstMetadataKey].GetFields()["local"].GetStringValue()
+					addrString += fmt.Sprintf("%s;%s", internalAddr, destinationAddr)
+				}
 			}
 			if lb.HealthStatus == core.HealthStatus_HEALTHY {
 				healthy = append(healthy, addrString)


### PR DESCRIPTION
Today, we set an address pointing to the internal listener, and an additionalAddress pointing to the raw IP. The raw IP is never used.

Per https://github.com/envoyproxy/envoy/issues/36318 - we cannot actually set the additional address with the internal listener.

In order to properly test this I also had to fix https://github.com/istio/istio/issues/53333