### PR TITLE
Support sending from ingress -> service waypoint

### DIFF
--- a/pilot/pkg/features/ambient.go
+++ b/pilot/pkg/features/ambient.go
@@ -56,6 +56,9 @@ var (
 		false, false,
 		"If enabled, zTunnel will receive synthetic authorization policies for each workload ALLOW the Waypoint's identity. "+
 			"Unless other ALLOW policies are created, this effectively denies traffic that doesn't go through the waypoint.")
+
+	EnableIngressWaypointRouting = registerAmbient("ENABLE_INGRESS_WAYPOINT_ROUTING", true, false,
+		"If true, Gateways will call service waypoints if the 'istio.io/ingress-use-waypoint' label set on the Service.")
 )
 
 // registerAmbient registers a variable that is allowed only if EnableAmbient is set

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -2518,3 +2518,9 @@ func (ps *PushContext) WorkloadsForWaypoint(key WaypointKey) []WorkloadInfo {
 func (ps *PushContext) ServicesForWaypoint(key WaypointKey) []ServiceInfo {
 	return ps.ambientIndex.ServicesForWaypoint(key)
 }
+
+// ServicesWithWaypoint returns all services associated with any waypoint.
+// Key can optionally be provided in the form 'namespace/hostname'. If unset, all are returned
+func (ps *PushContext) ServicesWithWaypoint(key string) []ServiceWaypointInfo {
+	return ps.ambientIndex.ServicesWithWaypoint(key)
+}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -1047,6 +1047,8 @@ func (i ServiceInfo) GetConditions() ConditionSet {
 type WaypointBindingStatus struct {
 	// ResourceName that clients should use when addressing traffic to this Service.
 	ResourceName string
+	// IngressUseWaypoint specifies whether ingress gateways should use the waypoint for this service.
+	IngressUseWaypoint bool
 	// Error represents some error
 	Error *StatusMessage
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -867,6 +867,7 @@ type ServiceDiscovery interface {
 }
 
 type AmbientIndexes interface {
+	ServicesWithWaypoint(key string) []ServiceWaypointInfo
 	AddressInformation(addresses sets.String) ([]AddressInfo, sets.String)
 	AdditionalPodSubscriptions(
 		proxy *Proxy,
@@ -929,6 +930,10 @@ func (u NoopAmbientIndexes) WorkloadsForWaypoint(WaypointKey) []WorkloadInfo {
 	return nil
 }
 
+func (u NoopAmbientIndexes) ServicesWithWaypoint(string) []ServiceWaypointInfo {
+	return nil
+}
+
 var _ AmbientIndexes = NoopAmbientIndexes{}
 
 type AddressInfo struct {
@@ -965,6 +970,11 @@ func (i AddressInfo) ResourceName() string {
 		name = serviceResourceName(addr.Service)
 	}
 	return name
+}
+
+type ServiceWaypointInfo struct {
+	Service          *workloadapi.Service
+	WaypointHostname string
 }
 
 type TypedObject struct {

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -52,8 +52,6 @@ type clusterCache struct {
 	downstreamAuto bool
 	supportsIPv4   bool
 
-	hasWaypointServices bool
-
 	// dependent configs
 	service         *model.Service
 	destinationRule *model.ConsolidatedDestRule
@@ -87,8 +85,6 @@ func (t *clusterCache) Key() any {
 	h.WriteString(strconv.FormatBool(t.supportsIPv4))
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(t.hbone))
-	h.Write(Separator)
-	h.WriteString(strconv.FormatBool(t.hasWaypointServices))
 	h.Write(Separator)
 
 	if t.proxyView != nil {
@@ -191,7 +187,6 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 			service, dr,
 		)
 	}
-	waypointServices := len(cb.req.Push.ServicesWithWaypoint(service.Attributes.Namespace+"/"+string(service.Hostname))) > 0
 	return clusterCache{
 		clusterName:     clusterName,
 		proxyVersion:    cb.proxyVersion.String(),
@@ -210,7 +205,5 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		peerAuthVersion: cb.req.Push.AuthnPolicies.GetVersion(),
 		serviceAccounts: cb.req.Push.ServiceAccounts(service.Hostname, service.Attributes.Namespace),
 		endpointBuilder: eb,
-
-		hasWaypointServices: waypointServices,
 	}
 }

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -52,6 +52,8 @@ type clusterCache struct {
 	downstreamAuto bool
 	supportsIPv4   bool
 
+	hasWaypointServices bool
+
 	// dependent configs
 	service         *model.Service
 	destinationRule *model.ConsolidatedDestRule
@@ -85,6 +87,8 @@ func (t *clusterCache) Key() any {
 	h.WriteString(strconv.FormatBool(t.supportsIPv4))
 	h.Write(Separator)
 	h.WriteString(strconv.FormatBool(t.hbone))
+	h.Write(Separator)
+	h.WriteString(strconv.FormatBool(t.hasWaypointServices))
 	h.Write(Separator)
 
 	if t.proxyView != nil {
@@ -187,6 +191,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 			service, dr,
 		)
 	}
+	waypointServices := len(cb.req.Push.ServicesWithWaypoint(service.Attributes.Namespace+"/"+string(service.Hostname))) > 0
 	return clusterCache{
 		clusterName:     clusterName,
 		proxyVersion:    cb.proxyVersion.String(),
@@ -205,5 +210,7 @@ func buildClusterKey(service *model.Service, port *model.Port, cb *ClusterBuilde
 		peerAuthVersion: cb.req.Push.AuthnPolicies.GetVersion(),
 		serviceAccounts: cb.req.Push.ServiceAccounts(service.Hostname, service.Attributes.Namespace),
 		endpointBuilder: eb,
+
+		hasWaypointServices: waypointServices,
 	}
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -716,10 +716,13 @@ func GetEndpointHost(e *endpoint.LbEndpoint) string {
 	return ""
 }
 
-func BuildTunnelMetadataStruct(address string, port int) *structpb.Struct {
+func BuildTunnelMetadataStruct(address string, port int, waypoint string) *structpb.Struct {
 	m := map[string]interface{}{
 		// logical destination behind the tunnel, on which policy and telemetry will be applied
 		"local": net.JoinHostPort(address, strconv.Itoa(port)),
+	}
+	if waypoint != "" {
+		m["waypoint"] = waypoint
 	}
 	st, _ := structpb.NewStruct(m)
 	return st

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -65,6 +65,17 @@ func (c *Controller) ServicesForWaypoint(key model.WaypointKey) []model.ServiceI
 	return res
 }
 
+func (c *Controller) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
+	if !features.EnableAmbient || !features.EnableIngressWaypointRouting {
+		return nil
+	}
+	var res []model.ServiceWaypointInfo
+	for _, p := range c.GetRegistries() {
+		res = append(res, p.ServicesWithWaypoint(key)...)
+	}
+	return res
+}
+
 func (c *Controller) WorkloadsForWaypoint(key model.WaypointKey) []model.WorkloadInfo {
 	if !features.EnableAmbientWaypoints {
 		return nil

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -66,7 +66,7 @@ func (c *Controller) ServicesForWaypoint(key model.WaypointKey) []model.ServiceI
 }
 
 func (c *Controller) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
-	if !features.EnableAmbient || !features.EnableIngressWaypointRouting {
+	if !features.EnableAmbient {
 		return nil
 	}
 	var res []model.ServiceWaypointInfo

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -304,6 +304,16 @@ func New(options Options) Index {
 			return model.ConfigKey{Kind: kind.Address, Name: i.ResourceName()}, false
 		})), false)
 
+	if features.EnableIngressWaypointRouting {
+		RegisterEdsShim(
+			a.XDSUpdater,
+			Workloads,
+			WorkloadServiceIndex,
+			WorkloadServices,
+			ServiceAddressIndex,
+		)
+	}
+
 	a.workloads = workloadsCollection{
 		Collection:       Workloads,
 		ByAddress:        WorkloadAddressIndex,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -75,6 +75,7 @@ const (
 func init() {
 	features.EnableAmbientWaypoints = true
 	features.EnableAmbient = true
+	features.EnableIngressWaypointRouting = true
 }
 
 var validTrafficTypes = sets.New(constants.ServiceTraffic, constants.WorkloadTraffic, constants.AllTraffic, constants.NoTraffic)
@@ -269,7 +270,8 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 	s.assertEvent(t, s.podXdsName("pod1"), s.svcXdsName("svc1"))
 
 	s.labelService(t, "svc1", testNS, map[string]string{label.IoIstioUseWaypoint.Name: "test-wp"})
-	s.assertEvent(t, s.svcXdsName("svc1"))
+	// Should get an Address event and ServiceEntry event (for EDS)
+	s.assertEvent(t, s.svcXdsName("svc1"), s.hostnameForService("svc1"))
 	s.assertNoEvent(t)
 
 	// We should now see the waypoint service IP when we look up the annotated svc
@@ -1551,6 +1553,10 @@ func newAmbientTestServer(t *testing.T, clusterID cluster.ID, networkID network.
 }
 
 func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, trafficType string, ready bool) {
+	s.addWaypointSpecificAddress(t, ip, fmt.Sprintf("%s.%s.svc.%s", name, testNS, s.DomainSuffix), name, trafficType, ready)
+}
+
+func (s *ambientTestServer) addWaypointSpecificAddress(t *testing.T, ip, hostname, name, trafficType string, ready bool) {
 	t.Helper()
 
 	fromSame := k8sv1.NamespacesFromSame
@@ -1591,17 +1597,15 @@ func (s *ambientTestServer) addWaypoint(t *testing.T, ip, name, trafficType stri
 	gateway.Labels = labels
 
 	if ready {
+		addr := []k8sv1.GatewayStatusAddress{}
+		if ip != "" {
+			addr = append(addr, k8sv1.GatewayStatusAddress{Type: ptr.Of(k8sbeta.IPAddressType), Value: ip})
+		}
+		if hostname != "" {
+			addr = append(addr, k8sv1.GatewayStatusAddress{Type: ptr.Of(k8sbeta.HostnameAddressType), Value: hostname})
+		}
 		gateway.Status = k8sbeta.GatewayStatus{
-			Addresses: []k8sv1.GatewayStatusAddress{
-				{
-					Type:  ptr.Of(k8sbeta.IPAddressType),
-					Value: ip,
-				},
-				{
-					Type:  ptr.Of(k8sbeta.HostnameAddressType),
-					Value: fmt.Sprintf("%s.%s.svc.%s", name, testNS, s.DomainSuffix),
-				},
-			},
+			Addresses: addr,
 		}
 	}
 	s.grc.CreateOrUpdate(&gateway)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -270,8 +270,7 @@ func TestAmbientIndex_ServiceAttachedWaypoints(t *testing.T) {
 	s.assertEvent(t, s.podXdsName("pod1"), s.svcXdsName("svc1"))
 
 	s.labelService(t, "svc1", testNS, map[string]string{label.IoIstioUseWaypoint.Name: "test-wp"})
-	// Should get an Address event and ServiceEntry event (for EDS)
-	s.assertEvent(t, s.svcXdsName("svc1"), s.hostnameForService("svc1"))
+	s.assertEvent(t, s.svcXdsName("svc1"))
 	s.assertNoEvent(t)
 
 	// We should now see the waypoint service IP when we look up the annotated svc

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -66,6 +66,7 @@ func (a *index) serviceServiceBuilder(
 		waypoint, wperr := fetchWaypointForService(ctx, waypoints, namespaces, s.ObjectMeta)
 		if waypoint != nil {
 			waypointStatus.ResourceName = waypoint.ResourceName()
+			waypointStatus.IngressUseWaypoint = s.Labels["istio.io/ingress-use-waypoint"] == "true"
 		}
 		waypointStatus.Error = wperr
 
@@ -110,6 +111,7 @@ func (a *index) serviceEntriesInfo(s *networkingclient.ServiceEntry, w *Waypoint
 	waypoint := model.WaypointBindingStatus{}
 	if w != nil {
 		waypoint.ResourceName = w.ResourceName()
+		waypoint.IngressUseWaypoint = s.Labels["istio.io/ingress-use-waypoint"] == "true"
 	}
 	if wperr != nil {
 		waypoint.Error = wperr

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -55,6 +55,11 @@ func RegisterEdsShim(
 	ServiceEds := krt.NewCollection(
 		Services,
 		func(ctx krt.HandlerContext, svc model.ServiceInfo) *serviceEDS {
+			if !svc.Waypoint.IngressUseWaypoint {
+				// Currently, we only need this for ingres -> waypoint usage
+				// If we extend this to sidecars, etc we can drop this.
+				return nil
+			}
 			wp := svc.Service.Waypoint
 			if wp == nil {
 				return nil

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -1,0 +1,137 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint: gocritic
+package ambient
+
+import (
+	"net/netip"
+	"strings"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/schema/kind"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/workloadapi"
+)
+
+// serviceEDS represents a service and a list of all instances of waypoints.
+// For example, we may have ServiceKey=httpbin.org and WaypointInstance=[list of *waypoint workloads* attached].
+// This is to map to the eventual EDS structure.
+type serviceEDS struct {
+	ServiceKey       string
+	WaypointInstance []*workloadapi.Workload
+}
+
+func (w serviceEDS) ResourceName() string {
+	return w.ServiceKey
+}
+
+// RegisterEdsShim handles triggering xDS events when Envoy EDS needs to change.
+// Most of ambient index works to build `workloadapi` types - Workload, Service, etc.
+// Envoy uses a different API, with different relationships between types.
+// To ensure Envoy are updated properly on changes, we compute this information.
+// Currently, this is only used to trigger events.
+// Ideally, the information we are using in Envoy and the event trigger are using the same data directly.
+func RegisterEdsShim(
+	xdsUpdater model.XDSUpdater,
+	Workloads krt.Collection[model.WorkloadInfo],
+	WorkloadsByServiceKey krt.Index[string, model.WorkloadInfo],
+	Services krt.Collection[model.ServiceInfo],
+	ServicesByAddress krt.Index[networkAddress, model.ServiceInfo],
+) {
+	// When sending information to a workload, we need two bits of information:
+	// * Does it support tunnel? If so, we will need to use HBONE
+	// * Does it have a waypoint? if so, we will need to send to the waypoint
+	// Record both of these.
+	ServiceEds := krt.NewCollection(
+		Services,
+		func(ctx krt.HandlerContext, svc model.ServiceInfo) *serviceEDS {
+			wp := svc.Service.Waypoint
+			if wp == nil {
+				return nil
+			}
+			var waypointServiceKey string
+			switch addr := wp.Destination.(type) {
+			// Easy case: waypoint is already a hostname. Just return it directly
+			case *workloadapi.GatewayAddress_Hostname:
+				hn := addr.Hostname
+				waypointServiceKey = hn.Namespace + "/" + hn.Hostname
+			// Hard case: waypoint is an IP address. Need to look it up.
+			case *workloadapi.GatewayAddress_Address:
+				wAddress := addr.Address
+				serviceKey := networkAddress{
+					network: wAddress.Network,
+					ip:      mustByteIPToString(wAddress.Address),
+				}
+				waypointSvc := krt.FetchOne(ctx, Services, krt.FilterIndex(ServicesByAddress, serviceKey))
+				if waypointSvc == nil {
+					return nil
+				}
+				waypointServiceKey = waypointSvc.ResourceName()
+			}
+			workloads := krt.Fetch(ctx, Workloads, krt.FilterIndex(WorkloadsByServiceKey, waypointServiceKey))
+			return &serviceEDS{
+				ServiceKey: svc.ResourceName(),
+				WaypointInstance: slices.Map(workloads, func(e model.WorkloadInfo) *workloadapi.Workload {
+					return e.Workload
+				}),
+			}
+		},
+		krt.WithName("ServiceEds"))
+	ServiceEds.RegisterBatch(
+		PushXds(xdsUpdater, func(svc serviceEDS) (model.ConfigKey, bool) {
+			ns, hostname, _ := strings.Cut(svc.ServiceKey, "/")
+			return model.ConfigKey{Kind: kind.ServiceEntry, Name: hostname, Namespace: ns}, true
+		}), false)
+}
+
+func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
+	res := []model.ServiceWaypointInfo{}
+	var svcs []model.ServiceInfo
+	if key == "" {
+		svcs = a.services.List()
+	} else {
+		svcs = ptr.ToList(a.services.GetKey(krt.Key[model.ServiceInfo](key)))
+	}
+	for _, s := range svcs {
+		wp := a.waypoints.GetKey(krt.Key[Waypoint](s.Waypoint.ResourceName))
+		if wp == nil {
+			continue
+		}
+		wi := model.ServiceWaypointInfo{
+			Service: s.Service,
+		}
+		switch addr := wp.GetAddress().GetDestination().(type) {
+		// Easy case: waypoint is already a hostname. Just return it directly
+		case *workloadapi.GatewayAddress_Hostname:
+			wi.WaypointHostname = addr.Hostname.Hostname
+		// Hard case: waypoint is an IP address. Need to look it up.
+		case *workloadapi.GatewayAddress_Address:
+			wpAddr, _ := netip.AddrFromSlice(addr.Address.Address)
+			wpNetAddr := networkAddress{
+				network: addr.Address.Network,
+				ip:      wpAddr.String(),
+			}
+			waypoints := a.services.ByAddress.Lookup(wpNetAddr)
+			if len(waypoints) == 0 {
+				// No waypoint found.
+				continue
+			}
+		}
+		res = append(res, wi)
+	}
+	return res
+}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -92,9 +92,9 @@ func RegisterEdsShim(
 		},
 		krt.WithName("ServiceEds"))
 	ServiceEds.RegisterBatch(
-		PushXds(xdsUpdater, func(svc serviceEDS) (model.ConfigKey, bool) {
+		PushXds(xdsUpdater, func(svc serviceEDS) model.ConfigKey {
 			ns, hostname, _ := strings.Cut(svc.ServiceKey, "/")
-			return model.ConfigKey{Kind: kind.ServiceEntry, Name: hostname, Namespace: ns}, true
+			return model.ConfigKey{Kind: kind.ServiceEntry, Name: hostname, Namespace: ns}
 		}), false)
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
@@ -41,7 +41,7 @@ func TestIngressInterop(t *testing.T) {
 	}
 
 	s.addService(t, "svc1",
-		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc"},
+		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc", "istio.io/ingress-use-waypoint": "true"},
 		map[string]string{},
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.2")
 	s.assertEvent(t, addressUpdate("svc1"))

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/slices"
@@ -41,7 +42,7 @@ func TestIngressInterop(t *testing.T) {
 	}
 
 	s.addService(t, "svc1",
-		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc", "istio.io/ingress-use-waypoint": "true"},
+		map[string]string{label.IoIstioUseWaypoint.Name: "wp-svc", "istio.io/ingress-use-waypoint": "true"},
 		map[string]string{},
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.2")
 	s.assertEvent(t, addressUpdate("svc1"))
@@ -67,7 +68,7 @@ func TestIngressInterop(t *testing.T) {
 
 	// now we are going to change to a different waypoint, this will be hostname based
 	s.addService(t, "svc1",
-		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc-host"},
+		map[string]string{label.IoIstioUseWaypoint.Name: "wp-svc-host"},
 		map[string]string{},
 		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.2")
 	s.addWaypointSpecificAddress(t, "", "example.com", "wp-svc-host", constants.AllTraffic, true)

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop_test.go
@@ -1,0 +1,75 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ambient
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/test/util/assert"
+)
+
+func TestIngressInterop(t *testing.T) {
+	// Test that we can get updates for EDS when we have service bound waypoints.
+	s := newAmbientTestServer(t, testC, testNW)
+	// the two types return different keys.. rename to make it more clear
+	addressUpdate := s.svcXdsName
+	edsUpdate := s.hostnameForService
+	assertServicesWithWaypoint := func(want ...string) {
+		t.Helper()
+		got := s.ServicesWithWaypoint(s.svcXdsName("svc1"))
+		gots := slices.Map(got, func(e model.ServiceWaypointInfo) string {
+			return e.Service.Hostname + "/" + e.WaypointHostname
+		})
+		assert.Equal(t, want, gots)
+	}
+
+	s.addService(t, "svc1",
+		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc"},
+		map[string]string{},
+		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.2")
+	s.assertEvent(t, addressUpdate("svc1"))
+	assertServicesWithWaypoint()
+
+	// Add waypoint...
+	// We should get a service update for EDS to update
+	// First we will test an IP-based waypoint...
+	s.addWaypointSpecificAddress(t, "10.0.0.1", "", "wp-svc", constants.AllTraffic, true)
+	s.addService(t, "wp-svc",
+		map[string]string{},
+		map[string]string{},
+		[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
+	s.assertEvent(t, edsUpdate("svc1"))
+	assertServicesWithWaypoint(s.hostnameForService("svc1") + "/" + s.hostnameForService("wp-svc"))
+
+	// add a waypoint instance... we should get an EDS update
+	s.addPods(t, "127.0.0.4", "wp-pod1", "wp-sa", map[string]string{"app": "waypoint"}, nil, true, corev1.PodRunning)
+	s.assertEvent(t, edsUpdate("svc1"))
+	s.addPods(t, "127.0.0.5", "wp-pod2", "wp-sa", map[string]string{"app": "waypoint"}, nil, true, corev1.PodRunning)
+	s.assertEvent(t, edsUpdate("svc1"))
+	assertServicesWithWaypoint(s.hostnameForService("svc1") + "/" + s.hostnameForService("wp-svc"))
+
+	// now we are going to change to a different waypoint, this will be hostname based
+	s.addService(t, "svc1",
+		map[string]string{constants.AmbientUseWaypointLabel: "wp-svc-host"},
+		map[string]string{},
+		[]int32{80}, map[string]string{"app": "a"}, "10.0.0.2")
+	s.addWaypointSpecificAddress(t, "", "example.com", "wp-svc-host", constants.AllTraffic, true)
+	s.assertEvent(t, edsUpdate("svc1"))
+}

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -376,6 +376,10 @@ func (sd *ServiceDiscovery) ServicesForWaypoint(model.WaypointKey) []model.Servi
 	return nil
 }
 
+func (sd *ServiceDiscovery) ServicesWithWaypoint(string) []model.ServiceWaypointInfo {
+	return nil
+}
+
 func (sd *ServiceDiscovery) Waypoint(string, string) []netip.Addr {
 	return nil
 }

--- a/pilot/pkg/xds/endpoints/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoints/endpoint_builder.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pkg/config/schema/kind"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/network"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/hash"
 	netutil "istio.io/istio/pkg/util/net"
@@ -323,7 +324,8 @@ func (b *EndpointBuilder) FromServiceEndpoints() []*endpoint.LocalityLbEndpoints
 	}
 	svcEps := b.push.ServiceEndpointsByPort(b.service, b.port, b.subsetLabels)
 	// don't use the pre-computed endpoints for CDS to preserve previous behavior
-	return ExtractEnvoyEndpoints(b.generate(svcEps))
+	// CDS is always toServiceWaypoint=false. We do not yet support calling waypoints for CDS (DNS type)
+	return ExtractEnvoyEndpoints(b.generate(svcEps, false))
 }
 
 // BuildClusterLoadAssignment converts the shards for this EndpointBuilder's Service
@@ -333,6 +335,15 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 	if svcPort == nil {
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
+
+	if features.EnableIngressWaypointRouting {
+		if waypointEps, f := b.findServiceWaypoint(endpointIndex); f {
+			// endpoints are from waypoint service but the envoy endpoint is different envoy cluster
+			locLbEps := b.generate(waypointEps, true)
+			return b.createClusterLoadAssignment(locLbEps)
+		}
+	}
+
 	svcEps := b.snapshotShards(endpointIndex)
 	svcEps = slices.FilterInPlace(svcEps, func(ep *model.IstioEndpoint) bool {
 		// filter out endpoints that don't match the service port
@@ -353,7 +364,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 		return true
 	})
 
-	localityLbEndpoints := b.generate(svcEps)
+	localityLbEndpoints := b.generate(svcEps, false)
 	if len(localityLbEndpoints) == 0 {
 		return buildEmptyClusterLoadAssignment(b.clusterName)
 	}
@@ -381,7 +392,7 @@ func (b *EndpointBuilder) BuildClusterLoadAssignment(endpointIndex *model.Endpoi
 }
 
 // generate endpoints with applies weights, multi-network mapping and other filtering
-func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint) []*LocalityEndpoints {
+func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint, toServiceWaypoint bool) []*LocalityEndpoints {
 	// shouldn't happen here
 	if !b.ServiceFound() {
 		return nil
@@ -394,7 +405,7 @@ func (b *EndpointBuilder) generate(eps []*model.IstioEndpoint) []*LocalityEndpoi
 	localityEpMap := make(map[string]*LocalityEndpoints)
 	for _, ep := range eps {
 		mtlsEnabled := b.mtlsChecker.checkMtlsEnabled(ep, b.proxy.IsWaypointProxy())
-		eep := buildEnvoyLbEndpoint(b, ep, mtlsEnabled)
+		eep := buildEnvoyLbEndpoint(b, ep, mtlsEnabled, toServiceWaypoint)
 		if eep == nil {
 			continue
 		}
@@ -595,7 +606,7 @@ func ExtractEnvoyEndpoints(locEps []*LocalityEndpoints) []*endpoint.LocalityLbEn
 }
 
 // buildEnvoyLbEndpoint packs the endpoint based on istio info.
-func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnabled bool) *endpoint.LbEndpoint {
+func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnabled bool, toServiceWaypoint bool) *endpoint.LbEndpoint {
 	healthStatus := e.HealthStatus
 	if features.DrainingLabel != "" && e.Labels[features.DrainingLabel] != "" {
 		healthStatus = model.Draining
@@ -646,10 +657,30 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 	if b.proxy.Metadata.DisableHBONESend {
 		tunnel = false
 	}
+	// Waypoints always use HBONE
+	if toServiceWaypoint {
+		tunnel = true
+	}
+
 	if tunnel {
 		// Currently, Envoy cannot support tunneling to multiple IP families.
 		// TODO(https://github.com/envoyproxy/envoy/issues/36318)
 		address, port := e.Addresses[0], int(e.EndpointPort)
+
+		waypoint := ""
+		if toServiceWaypoint {
+			// Address of this specific waypoint endpoint
+			// Currently our setup cannot support dual stack, so we need to pick the first address.
+			waypoint = net.JoinHostPort(e.Addresses[0], strconv.Itoa(port))
+			// Get the VIP of the service we are targeting (not the waypoint service)
+			serviceVIPs := b.service.ClusterVIPs.GetAddressesFor(e.Locality.ClusterID)
+			if len(serviceVIPs) == 0 {
+				serviceVIPs = []string{b.service.DefaultAddress}
+			}
+			// // If there are multiple VIPs, we just use one. Hostname would be ideal here but isn't supported.
+			address = serviceVIPs[0]
+			port = b.port
+		}
 		// We intentionally do not take into account waypoints here.
 		// 1. Workload waypoints: sidecar/ingress do not support sending traffic directly to workloads, only to services,
 		//    so these are not applicable.
@@ -663,10 +694,11 @@ func buildEnvoyLbEndpoint(b *EndpointBuilder, e *model.IstioEndpoint, mtlsEnable
 		//    However, it's not safe to do that by default; perhaps a future API could opt into this.
 		// Support connecting to server side waypoint proxy, if the destination has one. This is for sidecars and ingress.
 		// Setup tunnel metadata so requests will go through the tunnel
+		target := ptr.NonEmptyOrDefault(waypoint, net.JoinHostPort(address, strconv.Itoa(port)))
 		ep.HostIdentifier = &endpoint.LbEndpoint_Endpoint{Endpoint: &endpoint.Endpoint{
-			Address: util.BuildInternalAddressWithIdentifier(connectOriginate, net.JoinHostPort(address, strconv.Itoa(port))),
+			Address: util.BuildInternalAddressWithIdentifier(connectOriginate, target),
 		}}
-		ep.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(address, port)
+		ep.Metadata.FilterMetadata[util.OriginalDstMetadataKey] = util.BuildTunnelMetadataStruct(address, port, waypoint)
 		if b.dir != model.TrafficDirectionInboundVIP {
 			// Add TLS metadata matcher to indicate we can use HBONE for this endpoint.
 			// We skip this for service waypoint, which doesn't need to dynamically match mTLS vs HBONE.
@@ -795,4 +827,60 @@ func getSubSetLabels(dr *v1alpha3.DestinationRule, subsetName string) labels.Ins
 	}
 
 	return nil
+}
+
+// For services that have a waypoint, we want to send to the waypoints rather than the service endpoints.
+// Lookup the
+func (b *EndpointBuilder) findServiceWaypoint(endpointIndex *model.EndpointIndex) ([]*model.IstioEndpoint, bool) {
+	if b.nodeType != model.Router {
+		// Currently only ingress will call waypoints
+		return nil, false
+	}
+	// ...and they must explicitly opt in
+	if b.service.Attributes.Labels["istio.io/ingress-use-waypoint"] != "true" {
+		return nil, false
+	}
+	if b.service.GetAddressForProxy(b.proxy) == constants.UnspecifiedIP {
+		// No VIP, so skip this. Currently, waypoints can only accept VIP traffic
+		return nil, false
+	}
+
+	svcs := b.push.ServicesWithWaypoint(b.service.Attributes.Namespace + "/" + string(b.hostname))
+	if len(svcs) == 0 {
+		// Service isn't captured by a waypoint
+		return nil, false
+	}
+	if len(svcs) > 1 {
+		log.Warnf("unexpected multiple waypoint services for %v", b.clusterName)
+	}
+	svc := svcs[0]
+	waypointClusterName := model.BuildSubsetKey(
+		model.TrafficDirectionOutbound,
+		"",
+		host.Name(svc.WaypointHostname),
+		int(svc.Service.GetWaypoint().GetHboneMtlsPort()),
+	)
+	endpointBuilder := NewEndpointBuilder(waypointClusterName, b.proxy, b.push)
+	waypointEndpoints, _ := endpointBuilder.snapshotEndpointsForPort(endpointIndex)
+	return waypointEndpoints, true
+}
+
+func (b *EndpointBuilder) snapshotEndpointsForPort(endpointIndex *model.EndpointIndex) ([]*model.IstioEndpoint, bool) {
+	svcPort := b.servicePort(b.port)
+	if svcPort == nil {
+		return nil, false
+	}
+	svcEps := b.snapshotShards(endpointIndex)
+	svcEps = slices.FilterInPlace(svcEps, func(ep *model.IstioEndpoint) bool {
+		// filter out endpoints that don't match the service port
+		if svcPort.Name != ep.ServicePortName {
+			return false
+		}
+		// filter out endpoints that don't match the subset
+		if !b.subsetLabels.SubsetOf(ep.Labels) {
+			return false
+		}
+		return true
+	})
+	return svcEps, true
 }

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -343,6 +343,9 @@ func ExtractHealthEndpoints(cla *endpoint.ClusterLoadAssignment) ([]string, []st
 					internalAddr := addr.GetEnvoyInternalAddress().GetServerListenerName()
 					destinationAddr := lb.GetMetadata().GetFilterMetadata()[util.OriginalDstMetadataKey].GetFields()["local"].GetStringValue()
 					addrString += fmt.Sprintf("%s;%s", internalAddr, destinationAddr)
+					if wp := lb.GetMetadata().GetFilterMetadata()[util.OriginalDstMetadataKey].GetFields()["waypoint"].GetStringValue(); wp != "" {
+						addrString += fmt.Sprintf(";%s", wp)
+					}
 				}
 			}
 			if lb.HealthStatus == core.HealthStatus_HEALTHY {

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -58,6 +58,7 @@ type EventStream[T any] interface {
 	// Otherwise, behaves the same as Register.
 	// Additionally, skipping the default behavior of "send all current state through the handler" can be turned off.
 	// This is important when we register in a handler itself, which would cause duplicative events.
+	// Handlers MUST not mutate the event list.
 	RegisterBatch(f func(o []Event[T], initialSync bool), runExistingState bool) Syncer
 }
 

--- a/pkg/kube/krt/util.go
+++ b/pkg/kube/krt/util.go
@@ -24,7 +24,7 @@ import (
 // Note this is in addition to the normal event mechanics, so this can only filter things further.
 func BatchedEventFilter[I, O any](cf func(a I) O, handler func(events []Event[I], initialSync bool)) func(o []Event[I], initialSync bool) {
 	return func(events []Event[I], initialSync bool) {
-		ev := slices.FilterInPlace(events, func(e Event[I]) bool {
+		ev := slices.Filter(events, func(e Event[I]) bool {
 			if e.Old != nil && e.New != nil {
 				if equal(cf(*e.Old), cf(*e.New)) {
 					// Equal under conversion, so we can skip

--- a/tests/integration/ambient/waypoint_test.go
+++ b/tests/integration/ambient/waypoint_test.go
@@ -32,10 +32,13 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/check"
+	"istio.io/istio/pkg/test/framework/components/echo/common/ports"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource/config/apply"
@@ -625,6 +628,194 @@ spec:
 				},
 			)
 		})
+}
+
+func TestIngressToWaypoint(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		// Apply a deny-all waypoint policy. This allows us to test the traffic traverses the waypoint
+		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+			"Waypoint": apps.ServiceAddressedWaypoint.Config().ServiceWaypointProxy,
+		}, `
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all-waypoint
+spec:
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: {{.Waypoint}}
+`).ApplyOrFail(t)
+		t.NewSubTest("sidecar-service").Run(func(t framework.TestContext) {
+			for _, src := range apps.Sidecar {
+				for _, dst := range apps.ServiceAddressedWaypoint {
+					for _, opt := range callOptions {
+						t.NewSubTestf("%v", opt.Scheme).Run(func(t framework.TestContext) {
+							opt = opt.DeepCopy()
+							opt.To = dst
+							// Sidecar does not currently traverse waypoint, so we expect to bypass it and get success
+							opt.Check = check.OK()
+							src.CallOrFail(t, opt)
+						})
+					}
+				}
+			}
+		})
+		t.NewSubTest("sidecar-workload").Run(func(t framework.TestContext) {
+			for _, src := range apps.Sidecar {
+				for _, dst := range apps.WorkloadAddressedWaypoint {
+					for _, dstWl := range dst.WorkloadsOrFail(t) {
+						for _, opt := range callOptions {
+							t.NewSubTestf("%v-%v", opt.Scheme, dstWl.Address()).Run(func(t framework.TestContext) {
+								opt = opt.DeepCopy()
+								opt.Address = dstWl.Address()
+								opt.Port = echo.Port{ServicePort: ports.All().MustForName(opt.Port.Name).WorkloadPort}
+								// Sidecar does not currently traverse waypoint, so we expect to bypass it and get success
+								opt.Check = check.OK()
+								src.CallOrFail(t, opt)
+							})
+						}
+					}
+				}
+			}
+		})
+		t.NewSubTest("ingress-service").Run(func(t framework.TestContext) {
+			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+				"Destination": apps.ServiceAddressedWaypoint.ServiceName(),
+			}, `apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts: ["*"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route
+spec:
+  gateways:
+  - gateway
+  hosts:
+  - "*"
+  http:
+  - route:
+    - destination:
+        host: "{{.Destination}}"
+`).ApplyOrFail(t)
+			ingress := istio.DefaultIngressOrFail(t, t)
+			t.NewSubTest("endpoint routing").Run(func(t framework.TestContext) {
+				ingress.CallOrFail(t, echo.CallOptions{
+					Port: echo.Port{
+						Protocol:    protocol.HTTP,
+						ServicePort: 80,
+					},
+					Scheme: scheme.HTTP,
+					Check:  check.OK(),
+				})
+			})
+			t.NewSubTest("service routing").Run(func(t framework.TestContext) {
+				SetIngressUseWaypoint(t, apps.ServiceAddressedWaypoint.ServiceName(), apps.ServiceAddressedWaypoint.NamespaceName())
+				ingress.CallOrFail(t, echo.CallOptions{
+					Port: echo.Port{
+						Protocol:    protocol.HTTP,
+						ServicePort: 80,
+					},
+					Scheme: scheme.HTTP,
+					Check:  CheckDeny,
+				})
+			})
+		})
+		t.NewSubTest("ingress-workload").Run(func(t framework.TestContext) {
+			t.Skip("not implemented")
+			t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+				"Destination": apps.WorkloadAddressedWaypoint.ServiceName(),
+			}, `apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts: ["*"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: route
+spec:
+  gateways:
+  - gateway
+  hosts:
+  - "*"
+  http:
+  - route:
+    - destination:
+        host: "{{.Destination}}"
+`).ApplyOrFail(t)
+			ingress := istio.DefaultIngressOrFail(t, t)
+			t.NewSubTest("endpoint routing").Run(func(t framework.TestContext) {
+				ingress.CallOrFail(t, echo.CallOptions{
+					Port: echo.Port{
+						Protocol:    protocol.HTTP,
+						ServicePort: 80,
+					},
+					Scheme: scheme.HTTP,
+					Check:  CheckDeny,
+				})
+			})
+			t.NewSubTest("service routing").Run(func(t framework.TestContext) {
+				// This will be ignored entirely if there is only workload waypoint, so this behaves the same as endpoint routing.
+				SetIngressUseWaypoint(t, apps.WorkloadAddressedWaypoint.ServiceName(), apps.WorkloadAddressedWaypoint.NamespaceName())
+				ingress.CallOrFail(t, echo.CallOptions{
+					Port: echo.Port{
+						Protocol:    protocol.HTTP,
+						ServicePort: 80,
+					},
+					Scheme: scheme.HTTP,
+					Check:  CheckDeny,
+				})
+			})
+		})
+	})
+}
+
+func SetIngressUseWaypoint(t framework.TestContext, name, ns string) {
+	for _, c := range t.Clusters() {
+		set := func(service bool) error {
+			var set string
+			if service {
+				set = fmt.Sprintf("%q", "true")
+			} else {
+				set = "null"
+			}
+			label := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":%s}}}`,
+				"istio.io/ingress-use-waypoint", set))
+			_, err := c.Kube().CoreV1().Services(ns).Patch(context.TODO(), name, types.MergePatchType, label, metav1.PatchOptions{})
+			return err
+		}
+
+		if err := set(true); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := set(false); err != nil {
+				scopes.Framework.Errorf("failed resetting service-addressed for %s", name)
+			}
+		})
+	}
 }
 
 func GetCondition(conditions []metav1.Condition, condition string) *metav1.Condition {


### PR DESCRIPTION
This PR adds new functionality to support ingress envoys sending to waypoints.

This is a tricky case. Both the ingress and waypoints are applying routing and other policies. For instance, I may do an "add header foo=bar" operation.

In the traditional sidecar model, you would apply the same policy to 'mesh' and to the gateway; traffic never goes through _both_.

Today, we force users to do the same thing with the waypoint model, which seems sub-optimal. For instance, why should I (as a service producer) define a canary rule in two places? This is especially troublesome with the ownership and delegation requirements to give a lower privilege service owner write access to the high-priv gateway.

However, unconditionally forwarding the waypoint has the problem of double policies. In the 'add header' case, for instance, we would add the header twice! This fails in various ways for different policies; we may fault inject too often, canary twice(!), rewrite a URL multiple times, ....

When users are aware of this double-routing topology, though, they can write their policies different to handle this compositional nature. For instance, rather than duplicating everything in the ingress and mesh/waypoint rules, users would be able to:

At the gateway, have minimal routing logic. Strictly enough to pick a backend. Often this would be `foo.example.com -> foo` or `example.com/foo -> foo with /foo stripped`. For policies, only apply policies that apply only at the edge (rate limits, user authn, etc).

At the waypoint, apply everything else. This could be canaries or whatever.

To opt in, this PR proposes a `istio.io/ingress-use-waypoint` label on Service. This nicely mirrors the `istio.io/use-waypoint` label.