### PR TITLE
Use per revision multicluster leader election

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -230,6 +230,10 @@ func NewLeaderElectionMulticluster(namespace, name, electionID, revision string,
 	return newLeaderElection(namespace, name, electionID, revision, false, remote, client)
 }
 
+func NewPerRevisionLeaderElectionMulticluster(namespace, name, electionID, revision string, remote bool, client kube.Client) *LeaderElection {
+	return newLeaderElection(namespace, name, electionID, revision, true, remote, client)
+}
+
 func newLeaderElection(namespace, name, electionID, revision string, perRevision bool, remote bool, client kube.Client) *LeaderElection {
 	var watcher revisions.DefaultWatcher
 	if features.EnableLeaderElection {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -204,7 +204,7 @@ func (m *Multicluster) initializeCluster(cluster *multicluster.Cluster, kubeCont
 				log.Infof("joining leader-election for %s in %s on cluster %s",
 					leaderelection.NamespaceController, options.SystemNamespace, options.ClusterID)
 				election := leaderelection.
-					NewLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
+					NewPerRevisionLeaderElectionMulticluster(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, m.revision, !configCluster, client).
 					AddRunFunction(func(leaderStop <-chan struct{}) {
 						log.Infof("starting namespace controller for cluster %s", cluster.ID)
 						nc := NewNamespaceController(client, m.caBundleWatcher)


### PR DESCRIPTION
**Please provide a description of this PR:**
Use per revision multicluster leader election to correctly implement `ENHANCED_RESOURCE_SCOPING` when `meshConfig.discoverySelectors` is set. Please see https://github.com/istio/istio/issues/52988 for more information

Fixes https://github.com/istio/istio/issues/52988