### PR TITLE
1.23: Revert networking: match multiple VIPs in sidecar outbound listener

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -264,10 +264,10 @@ func (l listenerBinding) Primary() string {
 
 // Extra returns any additional bindings. This is always empty if dual stack is disabled
 func (l listenerBinding) Extra() []string {
-	if len(l.binds) > 1 {
-		return l.binds[1:]
+	if !features.EnableDualStack || len(l.binds) == 1 {
+		return nil
 	}
-	return nil
+	return l.binds[1:]
 }
 
 type outboundListenerEntry struct {
@@ -818,8 +818,9 @@ func (lb *ListenerBuilder) buildSidecarOutboundListener(listenerOpts outboundLis
 				} else {
 					// Address is a CIDR. Fall back to 0.0.0.0 and
 					// filter chain match
+					// TODO: this probably needs to handle dual stack better
 					listenerOpts.bind.binds = actualWildcards
-					listenerOpts.cidr = append([]string{svcListenAddress}, svcExtraListenAddresses...)
+					listenerOpts.cidr = svcListenAddress
 				}
 			}
 		}
@@ -1058,7 +1059,7 @@ type outboundListenerOpts struct {
 	proxy *model.Proxy
 
 	bind listenerBinding
-	cidr []string
+	cidr string
 
 	port    *model.Port
 	service *model.Service

--- a/pilot/pkg/networking/core/tls.go
+++ b/pilot/pkg/networking/core/tls.go
@@ -100,7 +100,7 @@ func hashRuntimeTLSMatchPredicates(match *v1alpha3.TLSMatchAttributes) string {
 	return strings.Join(match.SniHosts, ",") + "|" + strings.Join(match.DestinationSubnets, ",")
 }
 
-func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDRs []string,
+func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDR string,
 	service *model.Service, bind string, listenPort *model.Port,
 	gateways sets.String, configs []config.Config,
 ) []*filterChainOpts {
@@ -142,7 +142,11 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 					// Use the service's CIDRs.
 					// But if a virtual service overrides it with its own destination subnet match
 					// give preference to the user provided one
-					// destinationCIDRs will be empty for services with VIPs
+					// destinationCIDR will be empty for services with VIPs
+					var destinationCIDRs []string
+					if destinationCIDR != "" {
+						destinationCIDRs = []string{destinationCIDR}
+					}
 					// Only set CIDR match if the listener is bound to an IP.
 					// If its bound to a unix domain socket, then ignore the CIDR matches
 					// Unix domain socket bound ports have Port value set to 0
@@ -206,7 +210,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 			svcListenAddress = constants.UnspecifiedIPv6
 		}
 
-		if len(destinationCIDRs) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
+		if len(destinationCIDR) > 0 || len(svcListenAddress) == 0 || (svcListenAddress == actualWildcard && bind == actualWildcard) {
 			sniHosts = []string{string(service.Hostname)}
 			for _, a := range service.Attributes.Aliases {
 				alt := GenerateAltVirtualHosts(a.Hostname.String(), 0, node.DNSDomain)
@@ -216,6 +220,10 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		}
 		destinationRule := CastDestinationRule(node.SidecarScope.DestinationRule(
 			model.TrafficDirectionOutbound, node, service.Hostname).GetRule())
+		var destinationCIDRs []string
+		if destinationCIDR != "" {
+			destinationCIDRs = []string{destinationCIDR}
+		}
 		out = append(out, &filterChainOpts{
 			sniHosts:         sniHosts,
 			destinationCIDRs: destinationCIDRs,
@@ -227,7 +235,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 	return out
 }
 
-func buildSidecarOutboundTCPFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDRs []string,
+func buildSidecarOutboundTCPFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDR string,
 	service *model.Service, listenPort *model.Port,
 	gateways sets.String, configs []config.Config,
 ) []*filterChainOpts {
@@ -246,6 +254,10 @@ TcpLoop:
 	for _, cfg := range configs {
 		virtualService := cfg.Spec.(*v1alpha3.VirtualService)
 		for _, tcp := range virtualService.Tcp {
+			var destinationCIDRs []string
+			if destinationCIDR != "" {
+				destinationCIDRs = []string{destinationCIDR}
+			}
 			if len(tcp.Match) == 0 {
 				// implicit match
 				out = append(out, &filterChainOpts{
@@ -322,6 +334,10 @@ TcpLoop:
 		if len(push.Mesh.OutboundClusterStatName) != 0 {
 			statPrefix = telemetry.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), "",
 				&model.Port{Port: port}, 0, &service.Attributes)
+		}
+		var destinationCIDRs []string
+		if destinationCIDR != "" {
+			destinationCIDRs = []string{destinationCIDR}
 		}
 		out = append(out, &filterChainOpts{
 			destinationCIDRs: destinationCIDRs,

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -363,7 +363,7 @@ func getUpdatedConfigs(services []*model.Service) sets.Set[model.ConfigKey] {
 func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Event) {
 	log.Debugf("Handle event %s for service entry %s/%s", event, curr.Namespace, curr.Name)
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
-	cs := convertServices(curr, s.clusterID)
+	cs := convertServices(curr)
 	configsUpdated := sets.New[model.ConfigKey]()
 	key := curr.NamespacedName()
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1496,7 +1496,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 
 func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
-	svcs := convertServices(*cfg, "")
+	svcs := convertServices(*cfg)
 	if len(svcs) != len(expected) {
 		t.Fatalf("got more services than expected: %v vs %v", len(svcs), len(expected))
 	}
@@ -1730,8 +1730,8 @@ func TestServicesDiff(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			as := convertServices(*tt.current, "")
-			bs := convertServices(*tt.new, "")
+			as := convertServices(*tt.current)
+			bs := convertServices(*tt.new)
 			added, deleted, updated, unchanged := servicesDiff(as, bs)
 			for i, item := range []struct {
 				hostnames []host.Name

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -42,7 +42,6 @@ import (
 	xdsfake "istio.io/istio/pilot/test/xds"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -1231,8 +1230,7 @@ func updateServiceResolution(s *xdsfake.FakeDiscoveryServer, resolution model.Re
 
 func addOverlappingEndpoints(s *xdsfake.FakeDiscoveryServer) {
 	svc := &model.Service{
-		DefaultAddress: constants.UnspecifiedIP,
-		Hostname:       "overlapping.cluster.local",
+		Hostname: "overlapping.cluster.local",
 		Ports: model.PortList{
 			{
 				Name:     "dns",
@@ -1265,8 +1263,7 @@ func addOverlappingEndpoints(s *xdsfake.FakeDiscoveryServer) {
 
 func addUnhealthyCluster(s *xdsfake.FakeDiscoveryServer) {
 	svc := &model.Service{
-		DefaultAddress: constants.UnspecifiedIP,
-		Hostname:       "unhealthy.svc.cluster.local",
+		Hostname: "unhealthy.svc.cluster.local",
 		Ports: model.PortList{
 			{
 				Name:     "tcp-dns",

--- a/releasenotes/notes/51967.yaml
+++ b/releasenotes/notes/51967.yaml
@@ -1,8 +1,0 @@
-apiVersion: release-notes/v2
-kind: bug-fix
-area: traffic-management
-issue:
-  - 51747
-releaseNotes:
-  - |
-    **Fixed** matching multiple service VIPs in ServiceEntry.

--- a/releasenotes/notes/revert-multi-vip.yaml
+++ b/releasenotes/notes/revert-multi-vip.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 52944
+  - 52847
+releaseNotes:
+  - |
+    **Removed** a change in Istio 1.23.0 causing regressions for ServiceEntries with multiple addresses defined.
+    Note: the reverted change did fix an issue around missing addresses (#51747), but introduce a new set of issues.
+    The original issue can be worked around by creating a Sidecar resource.


### PR DESCRIPTION
This mirrors https://github.com/istio/istio/pull/52952/files on 1.22 branch.

This PR caused 2 regressions: https://github.com/istio/istio/issues/52847 and https://github.com/istio/istio/issues/52944.

By reverting this, we bring back the original issue (which has been in Istio for many releases): that multiple addresses may be dropped in a SE. However, users can workaround this by creating a Sidecar resource. See TestOverlappingServices for a reproduction of this (with and without Sidecar).

The long term path forward will be to merge https://github.com/istio/istio/pull/51776. This is a risky change, though, so will be kept on the master branch