### PR TITLE
[release-1.21] Return nil if gRPC stream returns io.EOF instead of returning io.EOF itself.

### DIFF
--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -127,25 +127,40 @@ func containsExpectedMessage(msg string) bool {
 	return false
 }
 
-// IsExpectedGRPCError checks a gRPC error code and determines whether it is an expected error when
-// things are operating normally. This is basically capturing when the client disconnects.
-func IsExpectedGRPCError(err error) bool {
+type ErrorType string
+
+const (
+	// This indicates all the errors except the expected errors or graceful termination.
+	UnexpectedError ErrorType = "unexpectedError"
+	// This indicates an expected error when things are operating normally.
+	ExpectedError ErrorType = "expectedError"
+	// This indicates an error which happen when the connection is gracefully terminated.
+	// For example, the peer calls `SendClose()`.
+	GracefulTermination ErrorType = "gracefulTermination"
+)
+
+// GRPCErrorType checks a gRPC error code and determines its ErrorType.
+// This is basically capturing when the peer disconnects.
+func GRPCErrorType(err error) ErrorType {
 	if err == io.EOF {
-		return true
+		return GracefulTermination
 	}
 
 	if s, ok := status.FromError(err); ok {
 		if s.Code() == codes.Canceled || s.Code() == codes.DeadlineExceeded {
-			return true
+			return ExpectedError
 		}
 		if s.Code() == codes.Unavailable && containsExpectedMessage(s.Message()) {
-			return true
+			return ExpectedError
 		}
 	}
 	// If this is not a gRPCStatus we should just error message.
 	if strings.Contains(err.Error(), "stream terminated by RST_STREAM with error code: NO_ERROR") {
-		return true
+		return ExpectedError
+	}
+	if strings.Contains(err.Error(), "received prior goaway: code: NO_ERROR") {
+		return ExpectedError
 	}
 
-	return false
+	return ExpectedError
 }

--- a/pilot/pkg/grpc/grpc_test.go
+++ b/pilot/pkg/grpc/grpc_test.go
@@ -16,12 +16,32 @@ package grpc
 
 import (
 	"errors"
+	"io"
 	"testing"
 )
 
 func TestIsExpectedGRPCError(t *testing.T) {
-	err := errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR")
-	if got := IsExpectedGRPCError(err); !got {
-		t.Fatalf("expected true, got %v", got)
+	tests := []struct {
+		name string
+		err  error
+		want ErrorType
+	}{
+		{
+			name: "RST_STREAM",
+			err:  errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR"),
+			want: ExpectedError,
+		},
+		{
+			name: "EOF",
+			err:  io.EOF,
+			want: GracefulTermination,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GRPCErrorType(tc.err); got != tc.want {
+				t.Fatalf("expected got %v, but want: %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -163,7 +163,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 	for {
 		req, err := con.stream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -199,7 +199,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 	for {
 		req, err := con.deltaStream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				deltaLog.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/52840

Change-Id: I88e225acad5a359f663eaf6b215c601b13410ea0
