### PR TITLE
[release-1.22] Return nil if gRPC stream returns io.EOF instead of returning io.EOF itself.

### DIFF
--- a/pilot/pkg/grpc/grpc_test.go
+++ b/pilot/pkg/grpc/grpc_test.go
@@ -16,12 +16,32 @@ package grpc
 
 import (
 	"errors"
+	"io"
 	"testing"
 )
 
 func TestIsExpectedGRPCError(t *testing.T) {
-	err := errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR")
-	if got := IsExpectedGRPCError(err); !got {
-		t.Fatalf("expected true, got %v", got)
+	tests := []struct {
+		name string
+		err  error
+		want ErrorType
+	}{
+		{
+			name: "RST_STREAM",
+			err:  errors.New("code = Internal desc = stream terminated by RST_STREAM with error code: NO_ERROR"),
+			want: ExpectedError,
+		},
+		{
+			name: "EOF",
+			err:  io.EOF,
+			want: GracefulTermination,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GRPCErrorType(tc.err); got != tc.want {
+				t.Fatalf("expected got %v, but want: %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -164,7 +164,7 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 	for {
 		req, err := con.stream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				log.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -200,7 +200,7 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 	for {
 		req, err := con.deltaStream.Recv()
 		if err != nil {
-			if istiogrpc.IsExpectedGRPCError(err) {
+			if istiogrpc.GRPCErrorType(err) != istiogrpc.UnexpectedError {
 				deltaLog.Infof("ADS: %q %s terminated", con.peerAddr, con.conID)
 				return
 			}


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/52838

Change-Id: I88e225acad5a359f663eaf6b215c601b13410ea0
