### PR TITLE
fix panic comparing empty hostnames

### DIFF
--- a/pkg/config/host/names.go
+++ b/pkg/config/host/names.go
@@ -42,7 +42,7 @@ func MoreSpecific(a, b Name) bool {
 	}
 
 	// we sort longest to shortest, alphabetically, with wildcards last
-	ai, aj := isWildCarded(a), isWildCarded(b)
+	ai, aj := strings.HasPrefix(a.String(), "*"), strings.HasPrefix(b.String(), "*")
 	if ai && !aj {
 		// h[i] is a wildcard, but h[j] isn't; therefore h[j] < h[i]
 		return false
@@ -60,7 +60,7 @@ func MoreSpecific(a, b Name) bool {
 }
 
 // isWildCarded checks if the string starts with a wildcard character '*'.
-func isWildCarded(host Name) bool {
+func isWildCarded(host string) bool {
 	return len(host) > 0 && host[0] == '*'
 }
 

--- a/pkg/config/host/names.go
+++ b/pkg/config/host/names.go
@@ -59,11 +59,6 @@ func MoreSpecific(a, b Name) bool {
 	return len(a) > len(b)
 }
 
-// isWildCarded checks if the string starts with a wildcard character '*'.
-func isWildCarded(host string) bool {
-	return len(host) > 0 && host[0] == '*'
-}
-
 func (h Names) Swap(i, j int) {
 	h[i], h[j] = h[j], h[i]
 }

--- a/pkg/config/host/names.go
+++ b/pkg/config/host/names.go
@@ -42,7 +42,7 @@ func MoreSpecific(a, b Name) bool {
 	}
 
 	// we sort longest to shortest, alphabetically, with wildcards last
-	ai, aj := string(a[0]) == "*", string(b[0]) == "*"
+	ai, aj := isWildCarded(a), isWildCarded(b)
 	if ai && !aj {
 		// h[i] is a wildcard, but h[j] isn't; therefore h[j] < h[i]
 		return false
@@ -57,6 +57,11 @@ func MoreSpecific(a, b Name) bool {
 	}
 
 	return len(a) > len(b)
+}
+
+// isWildCarded checks if the string starts with a wildcard character '*'.
+func isWildCarded(host Name) bool {
+	return len(host) > 0 && host[0] == '*'
 }
 
 func (h Names) Swap(i, j int) {

--- a/pkg/config/host/names_test.go
+++ b/pkg/config/host/names_test.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -237,7 +236,10 @@ func TestMoreSpecific(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			require.Equal(t, test.expected, host.MoreSpecific(test.host1, test.host2))
+			result := host.MoreSpecific(test.host1, test.host2)
+			if !reflect.DeepEqual(test.expected, result) {
+				t.Fatalf("%v.MoreSpecific(%v) = %v, want %v", test.host1, test.host2, result, test.expected)
+			}
 		})
 	}
 }

--- a/pkg/config/host/names_test.go
+++ b/pkg/config/host/names_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"istio.io/istio/pkg/config/host"
 )
 
@@ -205,5 +206,38 @@ func BenchmarkNamesSort(b *testing.B) {
 		given := make(host.Names, len(unsorted))
 		copy(given, unsorted)
 		sort.Sort(given)
+	}
+}
+
+func TestMoreSpecific(t *testing.T) {
+	tests := []struct {
+		host1       host.Name
+		host2       host.Name
+		expected    bool
+		description string
+	}{
+		// Both hostnames are empty
+		{"", "", true, "Both hostnames are empty"},
+		// One hostname is empty, other is not
+		{"", "example.com", false, "One hostname is empty, other is not"},
+		{"example.com", "", true, "One hostname is empty, other is not"},
+		// Hostnames have the same length, MoreSpecific does not check if both host1 and host2 are of the same subset
+		{"example.com", "example.net", true, "Hostnames have the same length and are compared alphabetically"},
+		{"example.net", "example.com", false, "Hostnames have the same length and are compared alphabetically"},
+		// Hostnames have different lengths
+		{"example.com", "test.example.com", false, "Hostnames have different lengths, longer hostname is more specific"},
+		{"test.example.com", "example.com", true, "Hostnames have different lengths, longer hostname is more specific"},
+		// Hostnames have different lengths and both have wildcards
+		{"*.example.com", "*.example.co.in", false, "Hostnames have different lengths and both have wildcards"},
+		{"*.example.co.in", "*.example.com", true, "Hostnames have different lengths and both have wildcards"},
+		// Hostnames have different lengths and only one has a wildcard
+		{"*.example.com", "example.net", false, "One hostname has a wildcard but the other does not"},
+		{"example.net", "*.example.com", true, "One hostname has a wildcard but the other does not"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.Equal(t, test.expected, host.MoreSpecific(test.host1, test.host2))
+		})
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
This is a small patch to fix panic while comparing two empty hostname string. Although there is a validation done by webhook so a hostname should never be empty. But this can occur if webhook is not validating first for any reason.