### PR TITLE
install: fix regression in default tag generation

### DIFF
--- a/istioctl/pkg/tag/generate.go
+++ b/istioctl/pkg/tag/generate.go
@@ -280,6 +280,7 @@ func generateMutatingWebhook(config *tagWebhookConfig, opts *GenerateOptions) (s
 		"values.revisionTags.[0]=" + config.Tag,
 		"values.sidecarInjectorWebhook.enableNamespacesByDefault=" + strconv.FormatBool(opts.AutoInjectNamespaces),
 		"values.istiodRemote.injectionURL=" + config.URL,
+		"values.global.istioNamespace=" + config.IstioNamespace,
 	}
 	mfs, _, err := render.GenerateManifest(nil, flags, false, nil, nil)
 	if err != nil {


### PR DESCRIPTION
We were accidentally dropping the IstioNamespace config part
