### PR TITLE
Add coalesce function to gateway and ztunnel template

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             readOnlyRootFilesystem: true
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
             runAsUser: 1337
             runAsGroup: 1337
             {{- end }}

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 ---
-{{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+{{- if (eq .Values.platform "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/charts/ztunnel/templates/rbac.yaml
+++ b/manifests/charts/ztunnel/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- .Values.annotations | toYaml | nindent 4 }}
 {{- end }}
 ---
-{{- if (eq .Values.platform "openshift") }}
+{{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
This PR add the `coalesce` function to the gateway and ztunnel templates. After this [PR](https://github.com/istio/istio/pull/52981) I think we aim to use global but not limiting to only use it. Adding `coalesce` will avoid to have to set the same value in two var when we run the integration test pointing to openshift cluster, for example:

* run with:
```
--istio.test.kube.helm.values=global.platform=openshift
```
instead of:
```
--istio.test.kube.helm.values=platform=openshift,global.platform=openshift
```
Also, is affected because we where defaulting the values in the `platform-openshift.yaml` helm profile before.
cc @bleggett 


