### PR TITLE
istioctl: support filter pod by labels for proxy-config

### DIFF
--- a/istioctl/pkg/proxyconfig/proxyconfig.go
+++ b/istioctl/pkg/proxyconfig/proxyconfig.go
@@ -337,9 +337,12 @@ func clusterConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"clusters", "c"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("cluster requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -349,8 +352,13 @@ func clusterConfigCmd(ctx cli.Context) *cobra.Command {
 				return err
 			}
 			var configWriter *configdump.ConfigWriter
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, false, c.OutOrStdout())
@@ -383,6 +391,7 @@ func clusterConfigCmd(ctx cli.Context) *cobra.Command {
 	clusterConfigCmd.PersistentFlags().StringVar(&direction, "direction", "", "Filter clusters by Direction field")
 	clusterConfigCmd.PersistentFlags().StringVar(&subset, "subset", "", "Filter clusters by substring of Subset field")
 	clusterConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter clusters by Port field")
+	clusterConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	clusterConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -390,6 +399,8 @@ func clusterConfigCmd(ctx cli.Context) *cobra.Command {
 }
 
 func allConfigCmd(ctx cli.Context) *cobra.Command {
+	var podName, podNamespace string
+
 	allConfigCmd := &cobra.Command{
 		Use:   "all [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves all configuration for the Envoy in the specified pod",
@@ -409,9 +420,12 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"a"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("all requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -424,8 +438,12 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 			case jsonOutput, yamlOutput:
 				var dump []byte
 				var err error
-				if len(args) == 1 {
-					podName, podNamespace, err := getPodName(ctx, args[0])
+				if len(args) == 1 || (labelSelector != "") {
+					if len(args) == 1 {
+						podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+					} else {
+						podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+					}
 					if err != nil {
 						return err
 					}
@@ -448,8 +466,12 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 
 			case summaryOutput:
 				var configWriter *configdump.ConfigWriter
-				if len(args) == 1 {
-					podName, podNamespace, err := getPodName(ctx, args[0])
+				if len(args) == 1 || (labelSelector != "") {
+					if len(args) == 1 {
+						podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+					} else {
+						podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+					}
 					if err != nil {
 						return err
 					}
@@ -503,6 +525,7 @@ func allConfigCmd(ctx cli.Context) *cobra.Command {
 	allConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump file")
 	allConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
+	allConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 
 	// cluster
 	allConfigCmd.PersistentFlags().StringVar(&fqdn, "fqdn", "", "Filter clusters by substring of Service FQDN field")
@@ -544,9 +567,12 @@ func listenerConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"listeners", "l"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("listener requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -556,8 +582,13 @@ func listenerConfigCmd(ctx cli.Context) *cobra.Command {
 				return err
 			}
 			var configWriter *configdump.ConfigWriter
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, false, c.OutOrStdout())
@@ -597,6 +628,7 @@ func listenerConfigCmd(ctx cli.Context) *cobra.Command {
 	listenerConfigCmd.PersistentFlags().BoolVar(&waypointProxyConfig, "waypoint", false, "Output waypoint information")
 	// Until stabilized
 	_ = listenerConfigCmd.PersistentFlags().MarkHidden("waypoint")
+	listenerConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	listenerConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -839,9 +871,12 @@ func routeConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"routes", "r"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("route requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -851,8 +886,13 @@ func routeConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, false, c.OutOrStdout())
@@ -881,6 +921,7 @@ func routeConfigCmd(ctx cli.Context) *cobra.Command {
 	routeConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
 	routeConfigCmd.PersistentFlags().StringVar(&routeName, "name", "", "Filter listeners by route name field")
 	routeConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
+	routeConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	routeConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -914,9 +955,12 @@ func endpointConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"endpoints", "ep"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("endpoints requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -926,8 +970,13 @@ func endpointConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodClustersWriter(kubeClient, podName, podNamespace, c.OutOrStdout())
@@ -962,6 +1011,7 @@ func endpointConfigCmd(ctx cli.Context) *cobra.Command {
 	endpointConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter endpoints by Port field")
 	endpointConfigCmd.PersistentFlags().StringVar(&clusterName, "cluster", "", "Filter endpoints by cluster name field")
 	endpointConfigCmd.PersistentFlags().StringVar(&status, "status", "", "Filter endpoints by status field")
+	endpointConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	endpointConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -1000,9 +1050,12 @@ func edsConfigCmd(ctx cli.Context) *cobra.Command {
   istioctl proxy-config eds --file envoy-config.json
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("eds requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -1012,8 +1065,13 @@ func edsConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, true, c.OutOrStdout())
@@ -1048,6 +1106,7 @@ func edsConfigCmd(ctx cli.Context) *cobra.Command {
 	endpointConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter endpoints by Port field")
 	endpointConfigCmd.PersistentFlags().StringVar(&clusterName, "cluster", "", "Filter endpoints by cluster name field")
 	endpointConfigCmd.PersistentFlags().StringVar(&status, "status", "", "Filter endpoints by status field")
+	endpointConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	endpointConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -1076,9 +1135,12 @@ func bootstrapConfigCmd(ctx cli.Context) *cobra.Command {
 `,
 		Aliases: []string{"b"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("bootstrap requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -1088,8 +1150,13 @@ func bootstrapConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, false, c.OutOrStdout())
@@ -1113,6 +1180,7 @@ func bootstrapConfigCmd(ctx cli.Context) *cobra.Command {
 	}
 
 	bootstrapConfigCmd.Flags().StringVarP(&outputFormat, "output", "o", jsonOutput, "Output format: one of json|yaml|short")
+	bootstrapConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	bootstrapConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -1134,9 +1202,12 @@ func secretConfigCmd(ctx cli.Context) *cobra.Command {
   istioctl proxy-config secret --file envoy-config.json`,
 		Aliases: []string{"secrets", "s"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("secret requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -1146,8 +1217,13 @@ func secretConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				cw, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, false, c.OutOrStdout())
@@ -1173,6 +1249,7 @@ func secretConfigCmd(ctx cli.Context) *cobra.Command {
 	}
 
 	secretConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	secretConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	secretConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 	return secretConfigCmd
@@ -1336,9 +1413,12 @@ func ecdsConfigCmd(ctx cli.Context) *cobra.Command {
   istioctl proxy-config ecds --file envoy-config.json
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if (len(args) == 1) != (configDumpFile == "") {
+			if (len(args) == 1 || (labelSelector != "")) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())
 				return fmt.Errorf("ecds requires pod name or --file parameter")
+			} else if len(args) == 1 && (labelSelector != "") {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("name cannot be provided when the label selector is specified")
 			}
 			return nil
 		},
@@ -1348,8 +1428,13 @@ func ecdsConfigCmd(ctx cli.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if len(args) == 1 {
-				if podName, podNamespace, err = getPodName(ctx, args[0]); err != nil {
+			if len(args) == 1 || (labelSelector != "") {
+				if len(args) == 1 {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, args[0])
+				} else {
+					podName, podNamespace, err = getPodInfo(ctx, kubeClient, labelSelector, "")
+				}
+				if err != nil {
 					return err
 				}
 				configWriter, err = setupPodConfigdumpWriter(kubeClient, podName, podNamespace, true, c.OutOrStdout())
@@ -1373,7 +1458,27 @@ func ecdsConfigCmd(ctx cli.Context) *cobra.Command {
 	}
 
 	ecdsConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|yaml|short")
+	ecdsConfigCmd.PersistentFlags().StringVarP(&labelSelector, "selector", "l", "", "Label selector")
 	ecdsConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "", "Envoy config dump JSON file")
 
 	return ecdsConfigCmd
+}
+
+func getPodInfo(ctx cli.Context, kubeClient kube.CLIClient, labelSelector, pod string) (podName, podNamespace string, err error) {
+	var podNames []string
+	if labelSelector != "" {
+		podNames, podNamespace, err = getPodNameBySelector(ctx, kubeClient, labelSelector)
+		if err != nil {
+			return "", "", err
+		}
+		if len(podNames) > 1 {
+			fmt.Printf("Multiple pods found, use the first one: %s.%s\n\n", podNames[0], podNamespace)
+		}
+		podName = podNames[0]
+	} else {
+		if podName, podNamespace, err = getPodName(ctx, pod); err != nil {
+			return "", "", err
+		}
+	}
+	return podName, podNamespace, nil
 }

--- a/releasenotes/notes/53089.yaml
+++ b/releasenotes/notes/53089.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for filtering Pods by label selector to `istioctl pc`.


### PR DESCRIPTION
**Please provide a description of this PR:**

istioctl: support filter pod by labels for proxy-config

include:
- `istioctl pc all`
- `istioctl pc cluster`
- `istioctl pc ecds`
- `istioctl pc endpoint`
- `istioctl pc listener`
- `istioctl pc route`
- `istioctl pc secret`
- `istioctl pc bootstrap`
- `istioctl pc eds`




The test result:

```bash
$./istioctln pc bootstrap -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

{
    "bootstrap": {
        "node": {
root@controller-node-1:~/istio# ./istioctln pc cluster -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

SERVICE FQDN                                                                    PORT      SUBSET     DIRECTION     TYPE             DESTINATION RULE
                                                                                80        -          inbound       ORIGINAL_DST
BlackHoleCluster                                                                -         -          -             STATIC

$./istioctln pc all -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

Istio Version:       1.22.3
Istio Proxy Version: fbc0329f0bf8ab3c22108a3552cf567358244494
Envoy Version:       1.30.5-dev/Clean/RELEASE/BoringSSL
root@controller-node-1:~/istio# ./istioctln pc endpoint -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

ENDPOINT                                                STATUS      OUTLIER CHECK     CLUSTER
10.233.74.103:80                                        HEALTHY     OK                outbound|80||hwameistor-apiserver.hwameistor.svc.cluster.local
10.233.74.104:3000                                      HEALTHY     OK                outbound|3000||aigc-oneapi-service.aigc-knowledge.svc.cluster.local

$ ./istioctln pc listener -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

ADDRESSES     PORT  MATCH                                                                    DESTINATION
              0     ALL                                                                      Cluster: connect_originate
10.233.0.3    53    ALL                                                                      Cluster: outbound|53||coredns.kube-system.svc.cluster.local

$ ./istioctln pc route -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

NAME                                                                                 VHOST NAME                                                                           DOMAINS                                                                                              MATCH                  VIRTUAL SERVICE
15010                                                                                istiod-v2.istio-system.svc.cluster.local:15010                                       istiod-v2.istio-system, 10.233.39.203                                                                /*
15010                                                                                istiod.istio-system.svc.cluster.local:15010                                          istiod.istio-system, 10.233.33.83                                                                    /*

$ ./istioctln pc secret -l app=nginx |head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

RESOURCE NAME     TYPE           STATUS     VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
default           Cert Chain     ACTIVE     true           59d4e34884a73a5e5200ba8d49b66ce0     2024-09-12T09:14:23Z     2024-09-11T09:12:23Z
ROOTCA            CA             ACTIVE     true           3d4c204018f8e3e4fce2dd76f7449686     2034-07-20T15:47:46Z     2024-07-22T15:47:46Z

$ ./istioctln pc eds -l app=nginx | head -n 5
Multiple pods found, use the first one: nginx-deployment-5f5c556c85-6hbjk.default

NAME                                             STATUS      LOCALITY     CLUSTER
127.0.0.1:15020                                  HEALTHY                  agent
10.233.74.104:3000                               HEALTHY                  outbound|3000||aigc-oneapi-service.aigc-knowledge.svc.cluster.local
```