### PR TITLE
Complete list, and include name, of xds ports

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -116,12 +116,19 @@ spec:
           ports:
           - containerPort: 8080
             protocol: TCP
+            name: http-debug
           - containerPort: 15010
             protocol: TCP
+            name: grpc-xds
+          - containerPort: 15012
+            protocol: TCP
+            name: tls-xds
           - containerPort: 15017
             protocol: TCP
+            name: https-webhooks
           - containerPort: 15014
             protocol: TCP
+            name: http-monitoring
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
Having the names is useful for understanding or some APIs that match
against them. Include 15012 which was missing, likely since it was added
"recently" (~4.5 years ago).
