### PR TITLE
Add pod name and namespace info when inject sidecar error

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1068,7 +1068,7 @@ func applyOverlayYAML(target *corev1.Pod, overlayYAML []byte) (*corev1.Pod, erro
 	}
 
 	if err := json.Unmarshal(patched, &pod); err != nil {
-		return nil, fmt.Errorf("unmarshal patched pod(%s %s): %v", target.Name, target.Namespace, err)
+		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
 	}
 	return &pod, nil
 }
@@ -1088,7 +1088,7 @@ func applyOverlay(target *corev1.Pod, overlayJSON []byte) (*corev1.Pod, error) {
 	}
 
 	if err := json.Unmarshal(patched, &pod); err != nil {
-		return nil, fmt.Errorf("unmarshal patched pod(%s %s): %v", target.Name, target.Namespace, err)
+		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
 	}
 	return &pod, nil
 }
@@ -1174,7 +1174,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 
 	patchBytes, err := injectPod(params)
 	if err != nil {
-		handleError(fmt.Sprintf("Pod injection failed: %v", err))
+		handleError(fmt.Sprintf("Pod %s/%s injection failed: %v", pod.Namespace, podName, err))
 		return toAdmissionResponse(err)
 	}
 

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1068,7 +1068,7 @@ func applyOverlayYAML(target *corev1.Pod, overlayYAML []byte) (*corev1.Pod, erro
 	}
 
 	if err := json.Unmarshal(patched, &pod); err != nil {
-		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
+		return nil, fmt.Errorf("unmarshal patched pod(%s %s): %v", target.Name, target.Namespace, err)
 	}
 	return &pod, nil
 }
@@ -1088,7 +1088,7 @@ func applyOverlay(target *corev1.Pod, overlayJSON []byte) (*corev1.Pod, error) {
 	}
 
 	if err := json.Unmarshal(patched, &pod); err != nil {
-		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
+		return nil, fmt.Errorf("unmarshal patched pod(%s %s): %v", target.Name, target.Namespace, err)
 	}
 	return &pod, nil
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
We have received some error logs about injecting sidecar, but can not figure out which pod should I check, we have thousands pod, and it's hard, so I want add pod name and namespace info when injecting sidecar error:
Now

```
2024-09-11T09:30:24.387340Z    error    Pod injection failed: failed to run injection template: failed applying injection overlay: unmarshal patched pod: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'

```
 then
```bash
2024-09-11T09:30:24.387340Z    error    Pod injection failed: failed to run injection template: failed applying injection overlay: unmarshal patched pod(${pod_name} ${pod_namespace}): quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```