### PR TITLE
Generate a new certificate after SECRET_TTL * SECRET_GRACE_PERIOD_RAT…

### DIFF
--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -73,7 +73,7 @@ var (
 		"The trust domain for spiffe certificates").Get()
 
 	secretTTLEnv = env.Register("SECRET_TTL", 24*time.Hour,
-		"The cert lifetime requested by istio agent").Get()
+		"The cert lifetime requested by istio agent (0 to disable)").Get()
 
 	fileDebounceDuration = env.Register("FILE_DEBOUNCE_DURATION", 100*time.Millisecond,
 		"The duration for which the file read operation is delayed once file update is detected").Get()


### PR DESCRIPTION
Force the recreation of the certification after the SECRET_TTL * SECRET_GRACE_PERIOD_RATIO or the certificate is expired.

**Please provide a description of this PR:**

This PR fixes the issue #53118 by running GenerateClient when after the delay. It also includes a unit-test that evaluates if the change works.