### PR TITLE
feat(helm): add initContainers to the istio-discovery helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
+{{- with .Values.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.image }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -60,6 +60,9 @@ defaults:
   # Additional volumes to the istiod pod
   volumes: []
 
+  # Inject initContainers into the istiod pod
+  initContainers: []
+
   nodeSelector: {}
   podAnnotations: {}
   serviceAnnotations: {}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -47,6 +47,8 @@ defaults:
   volumeMounts: []
   # Additional volumes to the istiod pod
   volumes: []
+  # Inject initContainers into the istiod pod
+  initContainers: []
   nodeSelector: {}
   podAnnotations: {}
   serviceAnnotations: {}

--- a/releasenotes/notes/53120.yaml
+++ b/releasenotes/notes/53120.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 53120
+releaseNotes:
+- |
+  **Added** Add initContainers to the istio-discovery helm chart


### PR DESCRIPTION
**Please provide a description of this PR:**

The goal here is to allow injecting an `initContainer` that can download tooling (like aws-cli) and store it in a shared volume that the `istiod` container can then leverage.