### PR TITLE
feat(helm): add settings to stabilize gateways for high traffic

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
-      {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       securityContext:
       {{- if .Values.securityContext }}

--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -15,6 +15,13 @@ spec:
   replicas: {{ . }}
   {{- end }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
@@ -38,6 +45,9 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       securityContext:
@@ -93,7 +103,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -60,6 +60,18 @@
         "env": {
           "type": "object"
         },
+        "strategy": {
+          "type": "object"
+        },
+        "minReadySeconds": {
+          "type": [ "null", "integer" ]
+        },
+        "terminationGracePeriodSeconds": {
+          "type": [ "null", "integer" ]
+        },
+        "readinessProbe": {
+          "type": [ "null", "object" ]
+        },
         "labels": {
           "type": "object"
         },

--- a/manifests/charts/gateway/values.schema.json
+++ b/manifests/charts/gateway/values.schema.json
@@ -66,9 +66,6 @@
         "minReadySeconds": {
           "type": [ "null", "integer" ]
         },
-        "terminationGracePeriodSeconds": {
-          "type": [ "null", "integer" ]
-        },
         "readinessProbe": {
           "type": [ "null", "object" ]
         },

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -84,6 +84,20 @@ defaults:
   # Pod environment variables
   env: {}
 
+  # Deployment Update strategy
+  strategy: {}
+  
+  # Sets the Deployment minReadySeconds value
+  minReadySeconds:
+  
+  # Sets the per-pod terminationGracePeriodSeconds setting.
+  terminationGracePeriodSeconds:
+  
+  # Optionally configure a custom readinessProbe. By default the control plane
+  # automatically injects the readinessProbe. If you wish to override that
+  # behavior, you may define your own readinessProbe here.
+  readinessProbe: {}
+
   # Labels to apply to all resources
   labels: {}
 

--- a/manifests/charts/gateway/values.yaml
+++ b/manifests/charts/gateway/values.yaml
@@ -90,9 +90,6 @@ defaults:
   # Sets the Deployment minReadySeconds value
   minReadySeconds:
   
-  # Sets the per-pod terminationGracePeriodSeconds setting.
-  terminationGracePeriodSeconds:
-  
   # Optionally configure a custom readinessProbe. By default the control plane
   # automatically injects the readinessProbe. If you wish to override that
   # behavior, you may define your own readinessProbe here.
@@ -151,6 +148,7 @@ defaults:
   #
   podDisruptionBudget: {}
 
+  # Sets the per-pod terminationGracePeriodSeconds setting.
   terminationGracePeriodSeconds: 30
 
   # A list of `Volumes` added into the Gateway Pods. See

--- a/releasenotes/notes/53121.yaml
+++ b/releasenotes/notes/53121.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+  - 53121
+releaseNotes:
+- |
+  **Added** Add settings to stabilizew gateways for high traffic


### PR DESCRIPTION
**Please provide a description of this PR:**

Re-opening https://github.com/istio/istio/pull/45914/files and hoping to get it pushed through this time. 

We operate our IngressGateways at fairly high traffic volumes - frequently exceeding 50,000 QPS of inbound traffic with a _wide_ range of traffic shapes. We've found that in order to safely replace pods at this scale, we need to make tweaks to the Deployment rollout process. These three settings (`spec.strategy`, `spec.minReadySeconds` and `spec.template.spec.terminationGracePeriodSeconds`) are critical to tuning the rollout process to be stable and smooth no matter the traffic load.