### PR TITLE
helm: adding a `default` profile

### DIFF
--- a/manifests/charts/base/files/profile-default.yaml
+++ b/manifests/charts/base/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/default/files/profile-default.yaml
+++ b/manifests/charts/default/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/gateway/files/profile-default.yaml
+++ b/manifests/charts/gateway/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/gateways/istio-egress/files/profile-default.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/gateways/istio-ingress/files/profile-default.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/istio-cni/files/profile-default.yaml
+++ b/manifests/charts/istio-cni/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/istio-control/istio-discovery/files/profile-default.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/istiod-remote/files/profile-default.yaml
+++ b/manifests/charts/istiod-remote/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/charts/ztunnel/files/profile-default.yaml
+++ b/manifests/charts/ztunnel/files/profile-default.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+# The default profile does not override any values
+{}

--- a/manifests/helm-profiles/default.yaml
+++ b/manifests/helm-profiles/default.yaml
@@ -1,0 +1,2 @@
+# The default profile does not override any values
+{}


### PR DESCRIPTION
Adding a default profile to the Helm charts as a way to turn off ambient explicitly.

I am in the process of making `profile=ambient` the new default in our organisation, but that requires us to also have a reliable way to indicate "no-ambient" as an option, and overriding a set value with `null` or `""` is not always feasible.

I would assume "default" is the right name for such a profile, matching the `istioctl profile` naming convention, but other suggestions are welcome.