### PR TITLE
Add zero length check for remoteVersion

### DIFF
--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -145,6 +145,9 @@ func coalesceVersions(remoteVersion *MeshInfo) *MeshInfo {
 }
 
 func identicalVersions(remoteVersion MeshInfo) bool {
+	if len(remoteVersion) == 0 {
+		return false
+	}
 	exemplar := remoteVersion[0].Info
 	for i := 1; i < len(remoteVersion); i++ {
 		candidate := (remoteVersion)[i].Info


### PR DESCRIPTION
For our internal implementation, remoteVersion is empty, which leads to out of index error. Added a zero length array check to mitigate it.