### PR TITLE
ambient: only set app tunnel if configured

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads.go
@@ -243,10 +243,12 @@ func (a *index) podWorkloadBuilder(
 		var appTunnel *workloadapi.ApplicationTunnel
 		var targetWaypoint *Waypoint
 		if instancedWaypoint := fetchWaypointForInstance(ctx, waypoints, p.ObjectMeta); instancedWaypoint != nil {
-			// we're an instance of a waypoint, set inbound tunnel info
-			appTunnel = &workloadapi.ApplicationTunnel{
-				Protocol: instancedWaypoint.DefaultBinding.Protocol,
-				Port:     instancedWaypoint.DefaultBinding.Port,
+			// we're an instance of a waypoint, set inbound tunnel info if needed
+			if db := instancedWaypoint.DefaultBinding; db != nil {
+				appTunnel = &workloadapi.ApplicationTunnel{
+					Protocol: db.Protocol,
+					Port:     db.Port,
+				}
 			}
 		} else if waypoint, err := fetchWaypointForWorkload(ctx, waypoints, namespaces, p.ObjectMeta); err == nil {
 			// there is a workload-attached waypoint, point there with a GatewayAddress

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/workloads_test.go
@@ -27,6 +27,7 @@ import (
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	securityclient "istio.io/client-go/pkg/apis/security/v1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/kind"
@@ -41,6 +42,16 @@ import (
 )
 
 func TestPodWorkloads(t *testing.T) {
+	waypointAddr := &workloadapi.GatewayAddress{
+		Destination: &workloadapi.GatewayAddress_Hostname{
+			Hostname: &workloadapi.NamespacedHostname{
+				Namespace: "ns",
+				Hostname:  "hostname.example",
+			},
+		},
+		// TODO: look up the HBONE port instead of hardcoding it
+		HboneMtlsPort: 15008,
+	}
 	cases := []struct {
 		name   string
 		inputs []any
@@ -354,6 +365,91 @@ func TestPodWorkloads(t *testing.T) {
 					"istio-system/root-ns",
 					"ns/local-ns",
 				},
+			},
+		},
+		{
+			name: "pod with waypoint",
+			inputs: []any{
+				Waypoint{
+					Named: krt.Named{
+						Name:      "waypoint",
+						Namespace: "ns",
+					},
+					TrafficType: constants.AllTraffic,
+					Address:     waypointAddr,
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app":                             "foo",
+						constants.AmbientUseWaypointLabel: "waypoint",
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					PodIP:      "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/ns/name",
+				Name:              "name",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "foo",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "name",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
+				Waypoint:          waypointAddr,
+			},
+		},
+		{
+			name: "pod that is a waypoint",
+			inputs: []any{
+				Waypoint{
+					Named: krt.Named{
+						Name:      "waypoint",
+						Namespace: "ns",
+					},
+					TrafficType: constants.AllTraffic,
+					Address:     waypointAddr,
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					// This pod *is* the waypoint
+					Name:      "waypoint",
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.GatewayNameLabel: "waypoint",
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: podReady,
+					PodIP:      "1.2.3.4",
+				},
+			},
+			result: &workloadapi.Workload{
+				Uid:               "cluster0//Pod/ns/waypoint",
+				Name:              "waypoint",
+				Namespace:         "ns",
+				Addresses:         [][]byte{netip.AddrFrom4([4]byte{1, 2, 3, 4}).AsSlice()},
+				Network:           testNW,
+				CanonicalName:     "waypoint",
+				CanonicalRevision: "latest",
+				WorkloadType:      workloadapi.WorkloadType_POD,
+				WorkloadName:      "waypoint",
+				Status:            workloadapi.WorkloadStatus_HEALTHY,
+				ClusterId:         testC,
 			},
 		},
 		{


### PR DESCRIPTION
Before we always sent it, but with empty config. Just a bit more
clear/clean to not set it at all.

Also add two new tests:
* Pod with a waypoint
* A pod that *is* a waypoint
