### PR TITLE
mx: use upstream filter instead to set the headers

### DIFF
--- a/pilot/pkg/networking/core/cluster.go
+++ b/pilot/pkg/networking/core/cluster.go
@@ -219,7 +219,7 @@ func (configgen *ConfigGeneratorImpl) buildClusters(proxy *model.Proxy, req *mod
 		cacheStats = cacheStats.merge(cs)
 		resources = append(resources, ob...)
 		// Add a blackhole and passthrough cluster for catching traffic to unresolved routes
-		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster())
+		clusters = outboundPatcher.conditionallyAppend(clusters, nil, cb.buildBlackHoleCluster(), cb.buildDefaultPassthroughCluster(true))
 		clusters = append(clusters, outboundPatcher.insertedClusters()...)
 		// Setup inbound clusters
 		inboundPatcher := clusterPatcher{efw: envoyFilterPatches, pctx: networking.EnvoyFilter_SIDECAR_INBOUND}

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -681,21 +681,22 @@ func (mc *clusterWrapper) build() *cluster.Cluster {
 	if mc == nil {
 		return nil
 	}
-	// Marshall Http Protocol options if they exist.
-	if mc.httpProtocolOptions != nil {
-		// UpstreamProtocolOptions is required field in Envoy. If we have not set this option earlier
-		// we need to set it to default http protocol options.
-		if mc.httpProtocolOptions.UpstreamProtocolOptions == nil {
-			mc.httpProtocolOptions.UpstreamProtocolOptions = &http.HttpProtocolOptions_ExplicitHttpConfig_{
-				ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
-					ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
-				},
-			}
+	// Enable HTTP pool if it was implicit before.
+	if mc.httpProtocolOptions == nil {
+		mc.httpProtocolOptions = &http.HttpProtocolOptions{}
+	}
+	// UpstreamProtocolOptions is required field in Envoy. If we have not set this option earlier
+	// we need to set it to default http protocol options.
+	if mc.httpProtocolOptions.UpstreamProtocolOptions == nil {
+		mc.httpProtocolOptions.UpstreamProtocolOptions = &http.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &http.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &http.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+			},
 		}
-		mc.httpProtocolOptions.HttpFilters = mc.upstreamHttpFilters
-		mc.cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
-			v3.HttpProtocolOptionsType: protoconv.MessageToAny(mc.httpProtocolOptions),
-		}
+	}
+	mc.httpProtocolOptions.HttpFilters = mc.upstreamHttpFilters
+	mc.cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+		v3.HttpProtocolOptionsType: protoconv.MessageToAny(mc.httpProtocolOptions),
 	}
 	return mc.cluster
 }

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -292,8 +292,9 @@ func (cb *ClusterBuilder) applyMetadataExchange(c *cluster.Cluster) {
 	} else {
 		// When an upstream uses an older xDS config for HTTP cluster (e.g. lacks protocol options),
 		// default to using an ALPN-based selection..
-		options.UpstreamProtocolOptions = &http.HttpProtocolOptions_AutoConfig{}
-
+		options.UpstreamProtocolOptions = &http.HttpProtocolOptions_AutoConfig{
+			AutoConfig: &http.HttpProtocolOptions_AutoHttpConfig{},
+		}
 	}
 	options.HttpFilters = []*hcm.HttpFilter{xdsfilters.InjectIstioHeadersUpstreamFilter, xdsfilters.UpstreamCodec}
 	c.TypedExtensionProtocolOptions[v3.HttpProtocolOptionsType] = protoconv.MessageToAny(&options)

--- a/pilot/pkg/networking/core/listener_builder.go
+++ b/pilot/pkg/networking/core/listener_builder.go
@@ -436,8 +436,6 @@ func appendMxFilter(httpOpts *httpListenerOpts, filters []*hcm.HttpFilter) []*hc
 		return append(filters, xdsfilters.SidecarInboundMetadataFilter)
 	}
 
-	if httpOpts.skipIstioMXHeaders {
-		return append(filters, xdsfilters.SidecarOutboundMetadataFilterSkipHeaders)
-	}
+	// TODO: Skip Istio headers for Passthrough and "external" clusters when configured.
 	return append(filters, xdsfilters.SidecarOutboundMetadataFilter)
 }

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -16,6 +16,7 @@ package filters
 
 import (
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	mutations "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -24,9 +25,11 @@ import (
 	fault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	grpcstats "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	grpcweb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
+	hm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	sfs "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/set_filter_state/v3"
 	statefulsession "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
+	uc "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/upstream_codec/v3"
 	httpinspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/http_inspector/v3"
 	originaldst "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/original_dst/v3"
 	originalsrc "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/original_src/v3"
@@ -253,38 +256,47 @@ var (
 							"workload_discovery": map[string]any{},
 						},
 					},
-					"upstream_propagation": []any{
-						map[string]any{
-							"istio_headers": map[string]any{},
-						},
-					},
 				}),
 		},
 	}
-	// TODO https://github.com/istio/istio/issues/46740
-	// false values can be omitted in protobuf, results in diff JSON values between control plane and envoy config dumps
-	// long term fix will be to add the metadata config to istio/api and use that over TypedStruct
-	SidecarOutboundMetadataFilterSkipHeaders = &hcm.HttpFilter{
-		Name: MxFilterName,
+	InjectIstioHeadersUpstreamFilter = &hcm.HttpFilter{
+		Name: "inject-istio-headers",
 		ConfigType: &hcm.HttpFilter_TypedConfig{
-			TypedConfig: protoconv.TypedStructWithFields("type.googleapis.com/io.istio.http.peer_metadata.Config",
-				map[string]any{
-					"upstream_discovery": []any{
-						map[string]any{
-							"istio_headers": map[string]any{},
+			TypedConfig: protoconv.MessageToAny(&hm.HeaderMutation{
+				Mutations: &hm.Mutations{
+					RequestMutations: []*mutations.HeaderMutation{
+						{
+							Action: &mutations.HeaderMutation_Append{
+								Append: &core.HeaderValueOption{
+									Header: &core.HeaderValue{
+										Key:   "x-envoy-peer-metadata",
+										Value: "%ENVIRONMENT(ISTIO_PEER_METADATA)%",
+									},
+									AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS,
+								},
+							},
 						},
-						map[string]any{
-							"workload_discovery": map[string]any{},
-						},
-					},
-					"upstream_propagation": []any{
-						map[string]any{
-							"istio_headers": map[string]any{
-								"skip_external_clusters": true,
+						{
+							Action: &mutations.HeaderMutation_Append{
+								Append: &core.HeaderValueOption{
+									Header: &core.HeaderValue{
+										Key:   "x-envoy-peer-metadata-id",
+										Value: "%ENVIRONMENT(ISTIO_PEER_METADATA_ID)%",
+									},
+									AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS,
+								},
 							},
 						},
 					},
-				}),
+				},
+			}),
+		},
+	}
+
+	UpstreamCodec = &hcm.HttpFilter{
+		Name: "envoy.filters.http.upstream_codec",
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: protoconv.MessageToAny(&uc.UpstreamCodec{}),
 		},
 	}
 


### PR DESCRIPTION
Change-Id: I150aaf4e14e17fb8d2b675eec8d93ae16198b869

Piece-meal approach to remove `peer_metadata` filter, starting with upstream HTTP filter to set the header.