### PR TITLE
 [release-1.23] Backport to 1.23 the metrics port definition for istio-cni

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -76,6 +76,10 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
+          ports:
+          - containerPort: 15014
+            name: metrics
+            protocol: TCP
           readinessProbe:
             httpGet:
               path: /readyz

--- a/releasenotes/notes/53184.yaml
+++ b/releasenotes/notes/53184.yaml
@@ -1,0 +1,16 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+
+# issue is a list of GitHub issues resolved in this note.
+issue: []
+
+docs: []
+
+releaseNotes:
+- |
+  **Fixed** Added the metrics port in the daemonset containers spec of the istio-cni chart.
+
+upgradeNotes: []
+
+securityNotes: []


### PR DESCRIPTION
**Please provide a description of this PR:**

Added the metric port definition to the DaemonSet manifest of cni-node to allow prometheus metrics scrapping with a PodMonitor.
This pr backports these two pr's at once as a bug was introduced in the first one and fixed in the second one:
- #52461
- #52513

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Ambient
- [x] Configuration Infrastructure