### PR TITLE
Fix nil pointer dereference in istiod-remote/templates/services.yaml

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
-  {{- if .Values.pilot.enabled }}
+  {{- if .Values.enabled }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.pilot.enabled }}
+  {{- if .Values.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}

--- a/manifests/charts/base/templates/zzy_descope_legacy.yaml
+++ b/manifests/charts/base/templates/zzy_descope_legacy.yaml
@@ -1,0 +1,3 @@
+{{/* Copy anything under `.pilot` to `.`, to avoid the need to specify a redundant prefix.
+Due to the file naming, this always happens after zzz_profile.yaml */}}
+{{- $_ := mustMergeOverwrite $.Values (index $.Values "pilot") }}

--- a/manifests/charts/istiod-remote/templates/endpoints.yaml
+++ b/manifests/charts/istiod-remote/templates/endpoints.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
-  {{- if .Values.pilot.enabled }}
+  {{- if .Values.enabled }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}

--- a/manifests/charts/istiod-remote/templates/services.yaml
+++ b/manifests/charts/istiod-remote/templates/services.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.pilot.enabled }}
+  {{- if .Values.enabled }}
   # when local istiod is enabled, we can't use istiod service name to reach the remote control plane
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
   {{- else }}

--- a/operator/cmd/mesh/test-util_test.go
+++ b/operator/cmd/mesh/test-util_test.go
@@ -227,10 +227,7 @@ func mustGetContainerFromDaemonset(g *WithT, objs *ObjectSet, daemonSetName, con
 // mustGetEndpoint returns the endpoint tree with the given name in the deployment with the given name.
 func mustGetEndpoint(g *WithT, objs *ObjectSet, endpointName string) *manifest.Manifest {
 	obj := objs.kind(gvk.Endpoints.Kind).nameEquals(endpointName)
-	if obj == nil {
-		return nil
-	}
-	g.Expect(obj).Should(Not(BeNil()))
+	g.Expect(obj).Should(Not(BeNil()), fmt.Sprintf("Expected to get endpoints %s", endpointName))
 	return obj
 }
 


### PR DESCRIPTION
The Helm values were flattened in #52036, but the endpoints.yaml and services.yaml templates weren't updated, causing the following error when rendering the istiod-remote chart:

```
executing "istiod-remote/templates/services.yaml" at <.Values.pilot.enabled>: nil pointer evaluating interface {}.enabled
```