### PR TITLE
feat(helm): Add custom annotations for `sidecarInjectorWebhook`

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -48,6 +48,10 @@ metadata:
     release: {{ $.Release.Name }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" $ | nindent 4 }}
+{{- if $.Values.sidecarInjectorWebhookAnnotations }}
+  annotations:
+{{ toYaml $.Values.sidecarInjectorWebhookAnnotations | indent 4 }}
+{{- end }}
 webhooks:
 {{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.namespace.") ) }}
   namespaceSelector:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -67,6 +67,7 @@ defaults:
   podAnnotations: {}
   serviceAnnotations: {}
   serviceAccountAnnotations: {}
+  sidecarInjectorWebhookAnnotations: {}
 
   topologySpreadConstraints: []
 


### PR DESCRIPTION
About
---
This commit adds support for custom annotations in the `sidecarInjectorWebhook` manifest. This is consistent with the existing functionality for applying annotations to resources like Pods, Service Accounts, and others.

Background
---
I’m leveraging [Argo sync waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) to manage Istio. It is crucial to wait for istiod to be ready before applying the webhook to inject Istio sidecars. Argo requires custom annotations on Kubernetes resources to control the order in which manifests are applied. This PR introduces the ability to apply custom annotations to the sidecarInjectorWebhook, which can be beneficial in various other scenarios as well.