### PR TITLE
feat(helm): custom annotations for `sidecarInjectorWebhook`

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -52,6 +52,10 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
+{{- if $.Values.sidecarInjectorWebhookAnnotations }}
+  annotations:
+{{ toYaml $.Values.sidecarInjectorWebhookAnnotations | indent 4 }}
+{{- end }}
 webhooks:
 {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
 

--- a/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/revision-tags.yaml
@@ -48,6 +48,10 @@ metadata:
     release: {{ $.Release.Name }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" $ | nindent 4 }}
+{{- if $.Values.sidecarInjectorWebhookAnnotations }}
+  annotations:
+{{ toYaml $.Values.sidecarInjectorWebhookAnnotations | indent 4 }}
+{{- end }}
 webhooks:
 {{- include "core" (mergeOverwrite (deepCopy $whv) (dict "Prefix" "rev.namespace.") ) }}
   namespaceSelector:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -67,6 +67,7 @@ defaults:
   podAnnotations: {}
   serviceAnnotations: {}
   serviceAccountAnnotations: {}
+  sidecarInjectorWebhookAnnotations: {}
 
   topologySpreadConstraints: []
 

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -52,10 +52,6 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
-{{- if $.Values.sidecarInjectorWebhookAnnotations }}
-  annotations:
-{{ toYaml $.Values.sidecarInjectorWebhookAnnotations | indent 4 }}
-{{- end }}
 webhooks:
 {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
 

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -52,6 +52,10 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/name: "istiod"
     {{- include "istio.labels" . | nindent 4 }}
+{{- if $.Values.sidecarInjectorWebhookAnnotations }}
+  annotations:
+{{ toYaml $.Values.sidecarInjectorWebhookAnnotations | indent 4 }}
+{{- end }}
 webhooks:
 {{- /* Set up the selectors. First section is for revision, rest is for "default" revision */}}
 

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -53,6 +53,7 @@ defaults:
   podAnnotations: {}
   serviceAnnotations: {}
   serviceAccountAnnotations: {}
+  sidecarInjectorWebhookAnnotations: {}
   topologySpreadConstraints: []
   # You can use jwksResolverExtraRootCA to provide a root certificate
   # in PEM format. This will then be trusted by pilot when resolving

--- a/releasenotes/notes/sidecarInjectorWebhook-custom-annotations.yaml
+++ b/releasenotes/notes/sidecarInjectorWebhook-custom-annotations.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** Allow user to add customized annotation to MutatingWebhookConfiguration for revision-tags through helm chart.


### PR DESCRIPTION
About
---
This commit adds support for custom annotations in the `sidecarInjectorWebhook` manifest. This is consistent with the existing functionality for applying annotations to resources like Pods, Service Accounts, and others.

Background
---
I’m leveraging [Argo sync waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) to manage Istio. It is crucial to wait for istiod to be ready before applying the webhook to inject Istio sidecars. Argo requires custom annotations on Kubernetes resources to control the order in which manifests are applied. This PR introduces the ability to apply custom annotations to the sidecarInjectorWebhook, which can be beneficial in various other scenarios as well.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.