### PR TITLE
istioctl: fix incorrect examples/descriptions for zc cmd

### DIFF
--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -118,7 +118,7 @@ func servicesCmd(ctx cli.Context) *cobra.Command {
 		Example: `  # Retrieve summary about services configuration for a randomly chosen ztunnel.
   istioctl ztunnel-config services
 
-  # Retrieve full certificate dump of workloads for a given Ztunnel instance.
+  # Retrieve full services dump of workloads for a given Ztunnel instance.
   istioctl ztunnel-config services <ztunnel-name[.namespace]> -o json
 `,
 		Aliases: []string{"services", "s", "svc"},
@@ -194,7 +194,7 @@ func allCmd(ctx cli.Context) *cobra.Command {
   istioctl ztunnel-config all
 
   # Retrieve full configuration dump of workloads for a given Ztunnel instance.
-  istioctl ztunnel-config policies <ztunnel-name[.namespace]> -o json
+  istioctl ztunnel-config all <ztunnel-name[.namespace]> -o json
 `,
 		Args: common.validateArgs,
 		RunE: runConfigDump(ctx, common, func(cw *ztunnelDump.ConfigWriter) error {

--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -287,7 +287,7 @@ func connectionsCmd(ctx cli.Context) *cobra.Command {
   istioctl ztunnel-config connections --node ambient-worker
 
   # Retrieve summary of connections for a given Ztunnel instance.
-  istioctl ztunnel-config workload <ztunnel-name[.namespace]>
+  istioctl ztunnel-config connections <ztunnel-name[.namespace]>
 `,
 		Aliases: []string{"cons"},
 		Args:    common.validateArgs,


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR fixes examples that didn't match up correctly with the associated ztunnel-config sub-command.