### PR TITLE
fix duplicate clusters in delta xds

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -601,11 +601,9 @@ func (ps *PushContext) AddMetric(metric monitoring.Metric, key string, proxyID, 
 }
 
 func (ps *PushContext) GetMetric(metric string) map[string]ProxyPushStatus {
-	ps.proxyStatusMutex.Lock()
-	defer ps.proxyStatusMutex.Unlock()
-
-	metricMap, _ := ps.ProxyStatus[metric]
-	return metricMap
+	ps.proxyStatusMutex.RLock()
+	defer ps.proxyStatusMutex.RUnlock()
+	return ps.ProxyStatus[metric]
 }
 
 var (

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -600,6 +600,14 @@ func (ps *PushContext) AddMetric(metric monitoring.Metric, key string, proxyID, 
 	metricMap[key] = ev
 }
 
+func (ps *PushContext) GetMetric(metric string) map[string]ProxyPushStatus {
+	ps.proxyStatusMutex.Lock()
+	defer ps.proxyStatusMutex.Unlock()
+
+	metricMap, _ := ps.ProxyStatus[metric]
+	return metricMap
+}
+
 var (
 
 	// EndpointNoPod tracks endpoints without an associated pod. This is an error condition, since


### PR DESCRIPTION
When a Service and Destination Rule is created, they select the same "service" - so there is a possibility to create duplicate clusters which would be later normalized. This PR fixes it to not create them.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
