### PR TITLE
enable dualstack on services created by Gateway API

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -325,6 +325,7 @@ metadata:
     name: {{.Name}}
     uid: {{.UID}}
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   {{- range $key, $val := .Ports }}
   - name: {{ $val.Name | quote }}

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -234,6 +234,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/custom-class.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/infrastructure-labels-annotations.yaml
@@ -238,6 +238,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect-infra.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/kube-gateway-ambient-redirect.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   loadBalancerIP: 1.2.3.4
   ports:
   - appProtocol: tcp

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -238,6 +238,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
@@ -230,6 +230,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -238,6 +238,7 @@ metadata:
     name: default
     uid: null
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
   - appProtocol: tcp
     name: status-port

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.40.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.48.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.47.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.43.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1825,6 +1825,7 @@ templates:
         name: {{.Name}}
         uid: {{.UID}}
     spec:
+      ipFamilyPolicy: PreferDualStack
       ports:
       {{- range $key, $val := .Ports }}
       - name: {{ $val.Name | quote }}


### PR DESCRIPTION
**Please provide a description of this PR:**
We cannot create dualstack load balancers, so I updated Gateway to prefer creating dualstack loadbalancers where possible.

https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services We want IPv6 addresses allocated automatically if a cluster supports dualstack.