### PR TITLE
Fix gateway injection when using SPIRE

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -192,16 +192,16 @@ spec:
     - name: istio-podinfo
       mountPath: /etc/istio/pod
   volumes:
-  - emptyDir: {}
+  - emptyDir:
     name: workload-socket
-  - emptyDir: {}
+  - emptyDir:
     name: credential-socket
   {{- if eq .Values.global.caName "GkeWorkloadCertificate" }}
   - name: gke-workload-certificate
     csi:
       driver: workloadcertificates.security.cloud.google.com
   {{- else}}
-  - emptyDir: {}
+  - emptyDir:
     name: workload-certs
   {{- end }}
   # SDS channel between istioagent and Envoy

--- a/releasenotes/notes/53252.yaml
+++ b/releasenotes/notes/53252.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Fixed** gateway injection template so that SPIFFE CSI driver volume injection template works.


### PR DESCRIPTION
**Please provide a description of this PR:**

When using SPIRE, it’s necessary to define an injection template and to indicate to use it by default for sidecars, using the following Helm values:

```
  sidecarInjectorWebhook:
    templates:
      spire: |
        spec:
          volumes:
            - name: workload-socket
              csi:
                driver: "csi.spiffe.io"
                readOnly: true
```

This works as intended.

Then, to use it for a gateway, it’s necessary to add an annotation on the gateway pods, using the following Helm values:

```
  podAnnotations:
    inject.istio.io/templates: "gateway,spire"
```

However, it doesn’t work, the following error is shown in Kubernetes events:

```
Error creating: Pod "gateway-q68cn" is invalid: [spec.volumes[0].csi: Forbidden: may not specify more than 1 volume type, spec.containers[0].volumeMounts[0].name: Not found: "workload-socket", spec.containers[0].volumeMounts[1].name: Not found: "workload-socket"]
```

This PR fixes the issue by copying what is done in the sidecar injection template to the gateway injection template.