### PR TITLE
Fix the missing kind error

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1207,7 +1207,7 @@ func (c *client) buildObject(cfg string, namespace string) (*unstructured.Unstru
 	obj := &unstructured.Unstructured{}
 	_, gvk, err := decUnstructured.Decode([]byte(cfg), nil, obj)
 	if err != nil {
-		return nil, nil, fmt.Errorf("decode: %v", err)
+		return nil, nil, err
 	}
 
 	dc, err := c.DynamicClientFor(*gvk, obj, namespace)


### PR DESCRIPTION
`pkg/kube/client.go > ssapplyYAML` [code](https://github.com/istio/istio/blob/876810aa99143e63e22e0fb6358807b78ba6a430/pkg/kube/client.go#L1070) skipped the missing kind error.
But after https://github.com/istio/istio/pull/52541, `buildObject` [code](https://github.com/istio/istio/blob/876810aa99143e63e22e0fb6358807b78ba6a430/pkg/kube/client.go#L1210)  wrap the error with `fmt.Errorf`. 
Therefore, `runtime.IsMissingKind` is no more working.

To fix it, let's just use the error from decode function without wrapping.

Change-Id: Ida3a7c818014902c15d1ab82c0664682f3f18112
