### PR TITLE
Fix httpbin sample's command

### DIFF
--- a/samples/httpbin/httpbin-vault.yaml
+++ b/samples/httpbin/httpbin-vault.yaml
@@ -53,6 +53,8 @@ spec:
         name: httpbin
         # Same as found in Dockerfile's CMD but using an unprivileged port
         command:
+        - pipenv
+        - run
         - gunicorn
         - -b
         - 0.0.0.0:8080

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -58,6 +58,8 @@ spec:
         name: httpbin
         # Same as found in Dockerfile's CMD but using an unprivileged port
         command:
+        - pipenv
+        - run
         - gunicorn
         - -b
         - "[::]:8080"


### PR DESCRIPTION
**Please provide a description of this PR:**

The httpbin sample received a new tag yesterday that breaks the command we inject in the samples. This fixes it to still continue to mirror the RUN command of the image but on an unprivileged port: https://hub.docker.com/layers/kong/httpbin/0.2.0/images/sha256-f142bf7c8d532447a3b81b33bb8060ac6ecaa94be9256d81a175945fd47ed8b8?context=explore