### PR TITLE
Added support for bytes buffer pool

### DIFF
--- a/pkg/config/labels/instance.go
+++ b/pkg/config/labels/instance.go
@@ -17,12 +17,12 @@ package labels
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
+	"istio.io/istio/pkg/util/bytesbufpool"
 )
 
 const (
@@ -139,13 +139,16 @@ func validateTagKey(k string) error {
 	return nil
 }
 
+var bytesBufferPool = bytesbufpool.New()
+
 func (i Instance) String() string {
 	// Ensure stable ordering
 	keys := slices.Sort(maps.Keys(i))
 
-	var buffer strings.Builder
 	// Assume each kv pair is roughly 25 characters. We could be under or over, this is just a guess to optimize
-	buffer.Grow(len(keys) * 25)
+	buffer := bytesBufferPool.GetWithCap(len(keys) * 25)
+	defer bytesBufferPool.Put(buffer)
+
 	first := true
 	for _, k := range keys {
 		v := i[k]

--- a/pkg/config/labels/instance_test.go
+++ b/pkg/config/labels/instance_test.go
@@ -15,6 +15,7 @@
 package labels_test
 
 import (
+	"fmt"
 	"testing"
 
 	"istio.io/istio/pkg/config/labels"
@@ -202,7 +203,8 @@ func TestInstanceValidate(t *testing.T) {
 func BenchmarkLabelString(b *testing.B) {
 	big := labels.Instance{}
 	for i := 0; i < 50; i++ {
-		big["topology.kubernetes.io/region"] = "some value"
+		key := fmt.Sprintf("topology.kubernetes.io/region-%d", i)
+		big[key] = "some value"
 	}
 	small := labels.Instance{
 		"app": "foo",

--- a/pkg/util/bytesbufpool/bytesbufpool.go
+++ b/pkg/util/bytesbufpool/bytesbufpool.go
@@ -19,15 +19,21 @@ import (
 	"sync"
 )
 
+// BufferPool is a simple wrapper around bytes.Buffer pool, used when buffers need to be
+// allocated repeatedly in a short period of time. It uses sync.Pool to cache allocated but
+// no longer used buffers for later reuse, thus reducing pressure on the garbage collector.
+
 type BufferPool struct {
-	cap  int // the bytes buffer minimum capacity
+	cap  int // the bytes.Buffer minimum capacity
 	pool sync.Pool
 }
 
+// New create a buffer pool.
 func New() *BufferPool {
 	return NewWithCap(64)
 }
 
+// NewWithCap create a buffer pool and specifies the `Get` method returned buffer's minimum capacity.
 func NewWithCap(n int) *BufferPool {
 	return &BufferPool{
 		cap:  n,
@@ -35,10 +41,12 @@ func NewWithCap(n int) *BufferPool {
 	}
 }
 
+// Get a buffer from the pool.
 func (p *BufferPool) Get() *bytes.Buffer {
 	return p.GetWithCap(p.cap)
 }
 
+// GetWithCap get a buffer of a specified the minimum capacity from the pool.
 func (p *BufferPool) GetWithCap(n int) *bytes.Buffer {
 	val := p.pool.Get()
 	if val != nil {
@@ -55,6 +63,7 @@ func (p *BufferPool) GetWithCap(n int) *bytes.Buffer {
 	return bytes.NewBuffer(make([]byte, 0, n))
 }
 
+// Put the buffer back in the pool.
 func (p *BufferPool) Put(buf *bytes.Buffer) {
 	if buf == nil {
 		return

--- a/pkg/util/bytesbufpool/bytesbufpool.go
+++ b/pkg/util/bytesbufpool/bytesbufpool.go
@@ -1,0 +1,75 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bytesbufpool
+
+import (
+	"bytes"
+	"sync"
+)
+
+type BufferPool struct {
+	cap  int // the bytes buffer minimum capacity
+	pool sync.Pool
+}
+
+func New() *BufferPool {
+	return NewWithCap(0)
+}
+
+func NewWithCap(n int) *BufferPool {
+	return &BufferPool{
+		cap:  n,
+		pool: sync.Pool{},
+	}
+}
+
+func (p *BufferPool) Get() *bytes.Buffer {
+	return p.GetWithCap(p.cap)
+}
+
+func (p *BufferPool) GetWithCap(n int) *bytes.Buffer {
+	val := p.pool.Get()
+	if val != nil {
+		buf, _ := val.(*bytes.Buffer)
+		if buf.Cap() < n {
+			buf.Grow(n)
+		}
+		return buf
+	}
+
+	if n < p.cap {
+		n = p.cap
+	}
+	return bytes.NewBuffer(make([]byte, 0, n))
+}
+
+func (p *BufferPool) Put(buf *bytes.Buffer) {
+	if buf == nil {
+		return
+	}
+
+	// Proper usage of a sync.BufferPool requires each entry to have approximately
+	// the same memory cost. To obtain this property when the stored type
+	// contains a variably-sized buffer, we add a hard limit on the maximum
+	// buffer to put back in the pool. If the buffer is larger than the
+	// limit, we drop the buffer and not put back.
+	if buf.Cap() >= 64*1024 {
+		buf = nil
+		return
+	}
+
+	buf.Reset()
+	p.pool.Put(buf)
+}

--- a/pkg/util/bytesbufpool/bytesbufpool.go
+++ b/pkg/util/bytesbufpool/bytesbufpool.go
@@ -25,7 +25,7 @@ type BufferPool struct {
 }
 
 func New() *BufferPool {
-	return NewWithCap(0)
+	return NewWithCap(64)
 }
 
 func NewWithCap(n int) *BufferPool {

--- a/pkg/util/bytesbufpool/bytesbufpool_test.go
+++ b/pkg/util/bytesbufpool/bytesbufpool_test.go
@@ -1,0 +1,96 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bytesbufpool
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestBytesBufferPool(t *testing.T) {
+	wg := sync.WaitGroup{}
+	pool := New()
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b := pool.Get()
+			if b.Len() != 0 {
+				t.Errorf("want len 0, but got %d", b.Len())
+			}
+			if b.Cap() != 64 {
+				t.Errorf("want cap 64(the default cap), but got %d", b.Cap())
+			}
+			b.WriteString("hello")
+			pool.Put(b)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetWithCap(t *testing.T) {
+	pool := NewWithCap(10)
+	b := pool.Get()
+	if b.Len() != 0 {
+		t.Errorf("want len 0, but got %d", b.Len())
+	}
+	if b.Cap() != 10 {
+		t.Errorf("want cap is 10 , but got %d", b.Cap())
+	}
+	pool.Put(b)
+}
+
+func BenchmarkCompare(b *testing.B) {
+	b.Run("pool with small string", func(b *testing.B) {
+		pool := New()
+		for i := 0; i < b.N; i++ {
+			buf := pool.Get()
+			buf.WriteString("small string")
+			_ = buf.String()
+			pool.Put(buf)
+		}
+	})
+
+	b.Run("pool with long string", func(b *testing.B) {
+		pool := New()
+		for i := 0; i < b.N; i++ {
+			buf := pool.Get()
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			_ = buf.String()
+			pool.Put(buf)
+		}
+	})
+
+	b.Run("bytes buffer with small string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf := bytes.Buffer{}
+			buf.WriteString("small string")
+			_ = buf.String()
+		}
+	})
+
+	b.Run("bytes buffer with long string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf := bytes.Buffer{}
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			buf.WriteString("Istio extends Kubernetes to establish a programmable, application-aware network.")
+			_ = buf.String()
+		}
+	})
+}


### PR DESCRIPTION
Added support for bytes buffer pool, which allows us to cache buffers that have been allocated but no longer used to reduce GC pressure.

In istio, I think most places that use `strings.Builder` and `bytes.Buffer` can be modified to use this buffer pool. As an experiment, I modified a few places in this PR. Benchmark see the CR comments.