### PR TITLE
minor optimization in route patch matching

### DIFF
--- a/pilot/pkg/networking/core/envoyfilter/rc_patch.go
+++ b/pilot/pkg/networking/core/envoyfilter/rc_patch.go
@@ -283,21 +283,19 @@ func routeConfigurationMatch(patchContext networking.EnvoyFilter_PatchContext, r
 	}
 
 	// This is a gateway. Get all the fields in the gateway's RDS route name
-	routePortNumber, portName, gateway := model.ParseGatewayRDSRouteName(rc.Name)
-	if rMatch.PortNumber != 0 && !anyPortMatches(portMap, routePortNumber, int(rMatch.PortNumber)) {
+	if rMatch.Name != "" && rMatch.Name != rc.Name {
 		return false
 	}
+	routePortNumber, portName, gateway := model.ParseGatewayRDSRouteName(rc.Name)
 	if rMatch.PortName != "" && rMatch.PortName != portName {
 		return false
 	}
 	if rMatch.Gateway != "" && rMatch.Gateway != gateway {
 		return false
 	}
-
-	if rMatch.Name != "" && rMatch.Name != rc.Name {
+	if rMatch.PortNumber != 0 && !anyPortMatches(portMap, routePortNumber, int(rMatch.PortNumber)) {
 		return false
 	}
-
 	return true
 }
 


### PR DESCRIPTION
Similar to https://github.com/istio/istio/pull/52844, put the efficient comparison in front.

--

BTW, I think we can calculate the relevant information (listener port, route port number, port name...) in advance through `rc.Name` rather than calculating it every time `routeConfigurationMatch` is called. Since the number of envoyfilters is very large, the resource consumption of calculating it every time is considerable.