### PR TITLE
Reduce ambient flakes in TestServiceDynamicEnroll 2

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -3069,7 +3069,7 @@ func TestZtunnelRestart(t *testing.T) {
 func TestServiceDynamicEnroll(t *testing.T) {
 	const callInterval = 50 * time.Millisecond
 	// TODO(https://github.com/istio/istio/issues/53064) make this 100%
-	successThreshold := 0.8
+	successThreshold := 0.5
 
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		dst := apps.Captured


### PR DESCRIPTION
https://github.com/istio/istio/pull/53310 made the test stricter in some ways, and less strict in others.

The 'more strict' part is causing issues as well unfortunately, so revert that part