### PR TITLE
minor optimize: use efficient string split func

### DIFF
--- a/pilot/pkg/model/addressmap.go
+++ b/pilot/pkg/model/addressmap.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/slices"
 )
 
 // AddressMap provides a thread-safe mapping of addresses for each Kubernetes cluster.
@@ -56,20 +57,16 @@ func (m *AddressMap) GetAddresses() map[cluster.ID][]string {
 		return nil
 	}
 
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
 	if m.Addresses == nil {
 		return nil
 	}
 
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
 	out := make(map[cluster.ID][]string)
 	for k, v := range m.Addresses {
-		if v == nil {
-			out[k] = nil
-		} else {
-			out[k] = append([]string{}, v...)
-		}
+		out[k] = slices.Clone(v)
 	}
 	return out
 }

--- a/pilot/pkg/networking/core/cluster_cache.go
+++ b/pilot/pkg/networking/core/cluster_cache.go
@@ -145,8 +145,8 @@ func (t *clusterCache) DependentConfigs() []model.ConfigHash {
 		configs = append(configs, model.ConfigKey{Kind: kind.ServiceEntry, Name: string(t.service.Hostname), Namespace: t.service.Attributes.Namespace}.HashCode())
 	}
 	for _, efKey := range t.envoyFilterKeys {
-		items := strings.Split(efKey, "/")
-		configs = append(configs, model.ConfigKey{Kind: kind.EnvoyFilter, Name: items[1], Namespace: items[0]}.HashCode())
+		ns, name, _ := strings.Cut(efKey, "/")
+		configs = append(configs, model.ConfigKey{Kind: kind.EnvoyFilter, Name: name, Namespace: ns}.HashCode())
 	}
 
 	// For now, this matches EndpointBuilder's DependentConfigs. No need to duplicate them.

--- a/pilot/pkg/networking/core/route/route_cache.go
+++ b/pilot/pkg/networking/core/route/route_cache.go
@@ -116,8 +116,8 @@ func (r *Cache) DependentConfigs() []model.ConfigHash {
 	}
 
 	for _, efKey := range r.EnvoyFilterKeys {
-		items := strings.Split(efKey, "/")
-		configs = append(configs, model.ConfigKey{Kind: kind.EnvoyFilter, Name: items[1], Namespace: items[0]}.HashCode())
+		ns, name, _ := strings.Cut(efKey, "/")
+		configs = append(configs, model.ConfigKey{Kind: kind.EnvoyFilter, Name: name, Namespace: ns}.HashCode())
 	}
 	return configs
 }

--- a/pkg/config/host/names.go
+++ b/pkg/config/host/names.go
@@ -120,13 +120,12 @@ func NewNames(hosts []string) Names {
 func NamesForNamespace(hosts []string, namespace string) Names {
 	result := make(Names, 0, len(hosts))
 	for _, host := range hosts {
-		if strings.Contains(host, "/") {
-			parts := strings.Split(host, "/")
-			if parts[0] != namespace && parts[0] != "*" {
+		if ns, name, found := strings.Cut(host, "/"); found {
+			if ns != namespace && ns != "*" {
 				continue
 			}
 			// strip the namespace
-			host = parts[1]
+			host = name
 		}
 		result = append(result, Name(host))
 	}


### PR DESCRIPTION

`strings.Cut` has better performance than `strings.Split` ~8 times, I think it makes sense to use efficient function in hot code.



```
func BenchmarkStrings(b *testing.B) {
	s := "namespace/name"
	b.Run("cut", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			ns, name, _ := strings.Cut(s, "/")
			_ = ns
			_ = name
		}
	})
	b.Run("split", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			ss := strings.Split(s, "/")
			_ = ss[0]
			_ = ss[1]
		}
	})
}

cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkStrings/cut-12         	193044396	         6.245 ns/op	       0 B/op	       0 allocs/op
BenchmarkStrings/split-12       	23637703	        48.05 ns/op	      32 B/op	       1 allocs/op
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
