### PR TITLE
Fix missing directory for manifests dump in integration test

### DIFF
--- a/pkg/test/framework/components/istio/installer.go
+++ b/pkg/test/framework/components/istio/installer.go
@@ -152,7 +152,7 @@ func (i *installer) Dump(resource.Context) {
 	}
 	for clusterName, manifests := range i.manifests {
 		clusterDir := path.Join(manifestsDir, clusterName)
-		if err := os.Mkdir(manifestsDir, 0o700); err != nil {
+		if err := os.Mkdir(clusterDir, 0o700); err != nil {
 			scopes.Framework.Errorf("Unable to create directory for dumping %s install manifests: %v", clusterName, err)
 		}
 		for i, manifest := range manifests {


### PR DESCRIPTION
**Please provide a description of this PR:**

This is a typo fix to ensure per cluster direcotories created before writing dump files.

Triggered when `-istio.test.istio.dumpManifests` flag is specified during the test. E.g.

```
2024-09-27T23:32:45.782114Z     info    tf      === BEGIN: Cleanup Istio [Suite=security] ===
2024-09-27T23:32:45.782489Z     error   tf      Unable to create directory for dumping cluster-0 install manifests: mkdir /tmp/security-e2dec165f98347419cbcd5/_suite_context/istio-deployment-3933594192/manifests: file exists
2024-09-27T23:32:45.782928Z     error   tf      Failed writing manifest 0/1 in cluster-0: open /tmp/security-e2dec165f98347419cbcd5/_suite_context/istio-deployment-3933594192/manifests/cluster-0/manifest-0.yaml: no such file or directory
2024-09-27T23:32:45.783061Z     error   tf      Failed writing manifest 1/1 in cluster-0: open /tmp/security-e2dec165f98347419cbcd5/_suite_context/istio-deployment-3933594192/manifests/cluster-0/manifest-1.yaml: no such file or directory
2024-09-27T23:32:45.783087Z     info    tf      clean up cluster cluster-0
```