### PR TITLE
add default deny rule for wasmplugin & fix default network allow-all

### DIFF
--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	httprbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	wasmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -501,8 +503,6 @@ func TestECDSWasmConversion(t *testing.T) {
 	if !proto.Equal(gotEcdsConfig, wantEcdsConfig) {
 		t.Errorf("xds proxy wasm config conversion got %v want %v", gotEcdsConfig, wantEcdsConfig)
 	}
-	v1 := proxy.ecdsLastAckVersion
-	n1 := proxy.ecdsLastNonce
 
 	// reset wasm cache to a NACK cache, and recreate xds server as well to simulate a version bump
 	proxy.wasmCache = &fakeNackCache{}
@@ -527,18 +527,25 @@ func TestECDSWasmConversion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait until nonce was updated, which represents an ACK/NACK has been received.
-	retry.UntilSuccessOrFail(t, func() error {
-		if proxy.ecdsLastNonce.Load() == n1.Load() {
-			return errors.New("last process nonce has not been updated. no ecds ack/nack is received yet")
-		}
-		return nil
-	}, retry.Timeout(time.Second), retry.Delay(time.Millisecond))
-
-	// Verify that the last ack version remains the same, which represents the latest DiscoveryRequest is a NACK.
-	v2 := proxy.ecdsLastAckVersion
-	if v1.Load() == v2.Load() {
-		t.Errorf("last ack ecds request was updated. expect it to remain the same which represents a nack for ecds update")
+	gotResp, err = downstream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotResp.Resources) != 1 {
+		t.Errorf("xds proxy ecds wasm conversion number of received resource got %v want 1", len(gotResp.Resources))
+	}
+	if err := gotResp.Resources[0].UnmarshalTo(gotEcdsConfig); err != nil {
+		t.Fatalf("wasm config conversion output %v failed to unmarshal", gotResp.Resources[0])
+	}
+	httpDenyAll := &httprbac.RBAC{
+		Rules: &rbacv3.RBAC{},
+	}
+	wantEcdsConfig = &core.TypedExtensionConfig{
+		Name:        "extension-config",
+		TypedConfig: protoconv.MessageToAny(httpDenyAll),
+	}
+	if !proto.Equal(gotEcdsConfig, wantEcdsConfig) {
+		t.Errorf("xds proxy wasm config conversion got %v want %v", gotEcdsConfig, wantEcdsConfig)
 	}
 }
 

--- a/pkg/wasm/convert.go
+++ b/pkg/wasm/convert.go
@@ -22,7 +22,10 @@ import (
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	httprbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	httpwasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	networkrbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	networkwasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/wasm/v3"
 	wasmextensions "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
@@ -37,24 +40,48 @@ import (
 var (
 	allowHTTPTypedConfig = &anypb.Any{
 		TypeUrl: "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+		// no rules mean allow all.
 	}
-	allowNetworkTypedConfig = &anypb.Any{
-		TypeUrl: "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-	}
+	denyHTTPTypedConfig, _ = anypb.New(&httprbac.RBAC{
+		// empty rule means deny all.
+		Rules: &rbacv3.RBAC{},
+	})
+
+	allowNetworkTypeConfig, _ = anypb.New(&networkrbac.RBAC{
+		// no rules mean allow all.
+		StatPrefix: "wasm-default-allow",
+	})
+	denyNetworkTypedConfig, _ = anypb.New(&networkrbac.RBAC{
+		// empty rule means deny all.
+		Rules:      &rbacv3.RBAC{},
+		StatPrefix: "wasm-default-deny",
+	})
 )
 
-func createHTTPAllowAllFilter(name string) (*anypb.Any, error) {
+func createHTTPDefaultFilter(name string, failOpen bool) (*anypb.Any, error) {
+	var tc *anypb.Any
+	if failOpen {
+		tc = allowHTTPTypedConfig
+	} else {
+		tc = denyHTTPTypedConfig
+	}
 	ec := &core.TypedExtensionConfig{
 		Name:        name,
-		TypedConfig: allowHTTPTypedConfig,
+		TypedConfig: tc,
 	}
 	return anypb.New(ec)
 }
 
-func createNetworkAllowAllFilter(name string) (*anypb.Any, error) {
+func createNetworkDefaultFilter(name string, failOpen bool) (*anypb.Any, error) {
+	var tc *anypb.Any
+	if failOpen {
+		tc = allowNetworkTypeConfig
+	} else {
+		tc = denyNetworkTypedConfig
+	}
 	ec := &core.TypedExtensionConfig{
 		Name:        name,
-		TypedConfig: allowNetworkTypedConfig,
+		TypedConfig: tc,
 	}
 	return anypb.New(ec)
 }
@@ -96,12 +123,8 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 			if wasmHTTPConfig != nil {
 				newExtensionConfig, err := convertHTTPWasmConfigFromRemoteToLocal(extConfig, wasmHTTPConfig, cache)
 				if err != nil {
-					if !wasmHTTPConfig.GetConfig().GetFailOpen() {
-						convertErrs[i] = err
-						return
-					}
 					// Use NOOP filter because the download failed.
-					newExtensionConfig, err = createHTTPAllowAllFilter(extConfig.GetName())
+					newExtensionConfig, err = createHTTPDefaultFilter(extConfig.GetName(), wasmHTTPConfig.GetConfig().GetFailOpen())
 					if err != nil {
 						// If the fallback is failing, send the Nack regardless of fail_open.
 						err = fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err)
@@ -113,12 +136,8 @@ func MaybeConvertWasmExtensionConfig(resources []*anypb.Any, cache Cache) error 
 			} else {
 				newExtensionConfig, err := convertNetworkWasmConfigFromRemoteToLocal(extConfig, wasmNetworkConfig, cache)
 				if err != nil {
-					if !wasmNetworkConfig.GetConfig().GetFailOpen() {
-						convertErrs[i] = err
-						return
-					}
 					// Use NOOP filter because the download failed.
-					newExtensionConfig, err = createNetworkAllowAllFilter(extConfig.GetName())
+					newExtensionConfig, err = createNetworkDefaultFilter(extConfig.GetName(), wasmNetworkConfig.GetConfig().GetFailOpen())
 					if err != nil {
 						// If the fallback is failing, send the Nack regardless of fail_open.
 						err = fmt.Errorf("failed to create allow-all filter as a fallback of %s Wasm Module: %w", extConfig.GetName(), err)

--- a/pkg/wasm/convert_test.go
+++ b/pkg/wasm/convert_test.go
@@ -23,6 +23,7 @@ import (
 
 	udpa "github.com/cncf/xds/go/udpa/type/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	rbacv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
@@ -225,26 +226,16 @@ func TestWasmConvert(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "remote load fail",
-			input: []*core.TypedExtensionConfig{
-				extensionConfigMap["remote-load-fail"],
-			},
-			wantOutput: []*core.TypedExtensionConfig{
-				extensionConfigMap["remote-load-fail"],
-			},
-			wantErr: true,
-		},
-		{
 			name: "mix",
 			input: []*core.TypedExtensionConfig{
-				extensionConfigMap["remote-load-fail"],
+				extensionConfigMap["remote-load-fail-close"],
 				extensionConfigMap["remote-load-success"],
 			},
 			wantOutput: []*core.TypedExtensionConfig{
-				extensionConfigMap["remote-load-fail"],
+				extensionConfigMap["remote-load-deny"],
 				extensionConfigMap["remote-load-success-local-file"],
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "remote load fail open",
@@ -253,6 +244,16 @@ func TestWasmConvert(t *testing.T) {
 			},
 			wantOutput: []*core.TypedExtensionConfig{
 				extensionConfigMap["remote-load-allow"],
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote load fail close",
+			input: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-fail-close"],
+			},
+			wantOutput: []*core.TypedExtensionConfig{
+				extensionConfigMap["remote-load-deny"],
 			},
 			wantErr: false,
 		},
@@ -292,9 +293,9 @@ func TestWasmConvert(t *testing.T) {
 				extensionConfigMap["no-http-uri"],
 			},
 			wantOutput: []*core.TypedExtensionConfig{
-				extensionConfigMap["no-http-uri"],
+				extensionConfigMap["remote-load-deny"],
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "secret",
@@ -391,7 +392,7 @@ var extensionConfigMap = map[string]*core.TypedExtensionConfig{
 			},
 		},
 	}),
-	"no-http-uri": buildTypedStructExtensionConfig("no-remote-load", &wasm.Wasm{
+	"no-http-uri": buildTypedStructExtensionConfig("remote-load-fail", &wasm.Wasm{
 		Config: &v3.PluginConfig{
 			Vm: &v3.PluginConfig_VmConfig{
 				VmConfig: &v3.VmConfig{
@@ -447,7 +448,7 @@ var extensionConfigMap = map[string]*core.TypedExtensionConfig{
 			},
 		},
 	}),
-	"remote-load-fail": buildTypedStructExtensionConfig("remote-load-fail", &wasm.Wasm{
+	"remote-load-fail-close": buildTypedStructExtensionConfig("remote-load-fail", &wasm.Wasm{
 		Config: &v3.PluginConfig{
 			Vm: &v3.PluginConfig_VmConfig{
 				VmConfig: &v3.VmConfig{
@@ -479,6 +480,9 @@ var extensionConfigMap = map[string]*core.TypedExtensionConfig{
 		},
 	}),
 	"remote-load-allow": buildAnyExtensionConfig("remote-load-fail", &rbac.RBAC{}),
+	"remote-load-deny": buildAnyExtensionConfig("remote-load-fail", &rbac.RBAC{
+		Rules: &rbacv3.RBAC{},
+	}),
 	"remote-load-secret": buildTypedStructExtensionConfig("remote-load-success", &wasm.Wasm{
 		Config: &v3.PluginConfig{
 			Vm: &v3.PluginConfig_VmConfig{

--- a/releasenotes/notes/53279.yaml
+++ b/releasenotes/notes/53279.yaml
@@ -10,4 +10,4 @@ issue:
 
 releaseNotes:
 - |
-  **Fixed** For a WasmPlugin of type FAIL_CLOSE, if the wasm image fetch fails, a DENY-ALL RBAC filter will be used.
+  **Fixed** an issue where if a wasm image fetch fails, an allow all RBAC filter is used. Now if `failStrategy` is set to `FAIL_CLOSE`, a DENY-ALL RBAC filter will be used.

--- a/releasenotes/notes/53279.yaml
+++ b/releasenotes/notes/53279.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+
+# issue is a list of GitHub issues resolved in this note.
+# If issue is not in the current repo, specify its full URL instead.
+issue:
+  - https://github.com/istio/istio/issues/53279
+  - 23624
+
+releaseNotes:
+- |
+  **Fixed** For a WasmPlugin of type FAIL_CLOSE, if the wasm image fetch fails, a DENY-ALL RBAC filter will be used.

--- a/tests/binary/dependencies_test.go
+++ b/tests/binary/dependencies_test.go
@@ -57,6 +57,8 @@ func TestDependencies(t *testing.T) {
 				`envoy/extensions/filters/(http|network)/wasm/`,
 				`github.com/envoyproxy/protoc-gen-validate/validate`,
 				`github.com/envoyproxy/go-control-plane/pkg/conversion`,
+				`github.com/envoyproxy/go-control-plane/envoy/config`,
+				`github.com/envoyproxy/go-control-plane/envoy/extensions/filters`,
 				`contrib/envoy/extensions/private_key_providers/`,
 				`^istio\.io/api/(annotation|label|mcp|mesh|networking|type)`,
 				`^istio\.io/api/analysis/v1alpha1`,

--- a/tests/integration/telemetry/api/stats_test.go
+++ b/tests/integration/telemetry/api/stats_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/env"
@@ -296,6 +297,26 @@ func SendTrafficOrFail(t test.Failer, from echo.Instance) {
 		Retry: echo.Retry{
 			NoRetry: true,
 		},
+	})
+}
+
+func SendTrafficOrFailExpectForbidden(t test.Failer, from echo.Instance) {
+	from.CallOrFail(t, echo.CallOptions{
+		To: GetTarget(),
+		Port: echo.Port{
+			Name: "http",
+		},
+		Check: check.Forbidden(protocol.HTTP),
+	})
+	from.CallOrFail(t, echo.CallOptions{
+		To: apps.Naked,
+		Port: echo.Port{
+			Name: "http",
+		},
+		Retry: echo.Retry{
+			NoRetry: true,
+		},
+		Check: check.Forbidden(protocol.HTTP),
 	})
 }
 

--- a/tests/integration/telemetry/api/wasmplugin_test.go
+++ b/tests/integration/telemetry/api/wasmplugin_test.go
@@ -339,7 +339,8 @@ func TestBadWasmRemoteLoad(t *testing.T) {
 		Run(func(t framework.TestContext) {
 			// Enable logging for debugging
 			applyTelemetryResource(t, true)
-			badWasmTestHelper(t, "testdata/bad-filter.yaml", false, true)
+			// if wasm image is not ready, a deny-all rbac filter while be added instead. ecds is not rejected.
+			badWasmTestHelper(t, "testdata/bad-filter.yaml", false, false, true)
 		})
 }
 
@@ -355,11 +356,11 @@ func TestBadWasmWithFailOpen(t *testing.T) {
 			// Enable logging for debugging
 			applyTelemetryResource(t, true)
 			// since this case is for "fail_open=true", ecds is not rejected.
-			badWasmTestHelper(t, "testdata/bad-wasm-envoy-filter-fail-open.yaml", true, false)
+			badWasmTestHelper(t, "testdata/bad-wasm-envoy-filter-fail-open.yaml", true, false, false)
 		})
 }
 
-func badWasmTestHelper(t framework.TestContext, filterConfigPath string, restartTarget bool, ecdsShouldReject bool) {
+func badWasmTestHelper(t framework.TestContext, filterConfigPath string, restartTarget bool, ecdsShouldReject bool, forbiddenAfterConfig bool) {
 	t.Helper()
 	// Test bad wasm remote load in only one cluster.
 	// There is no need to repeat the same testing logic in multiple clusters.
@@ -405,8 +406,11 @@ func badWasmTestHelper(t framework.TestContext, filterConfigPath string, restart
 
 	t.Log("got istio_agent_wasm_remote_fetch_count metric in prometheus, bad wasm filter is applied, send request to echo server again.")
 
-	// Verify that echo server could still return 200
-	SendTrafficOrFail(t, to)
+	if forbiddenAfterConfig {
+		SendTrafficOrFailExpectForbidden(t, to)
+	} else {
+		SendTrafficOrFail(t, to)
+	}
 
 	t.Log("echo server still returns ok after bad wasm filter is applied.")
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR aims to fix this issue #53279
* Add default deny rule for network/http wasmplugin when pull wasm image fails.
* fix default allow-all network rbac rule, cause `StatPrefix` in network rbac filter is required.