### PR TITLE
Allow extra spaces between namespaces in networking.istio.io/exportTo annotation

### DIFF
--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -86,6 +86,7 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 		namespaces := strings.Split(svc.Annotations[annotation.NetworkingExportTo.Name], ",")
 		exportTo = sets.NewWithLength[visibility.Instance](len(namespaces))
 		for _, ns := range namespaces {
+			ns = strings.TrimSpace(ns)
 			exportTo.Insert(visibility.Instance(ns))
 		}
 	}

--- a/pkg/config/analysis/analyzers/util/service_lookup.go
+++ b/pkg/config/analysis/analyzers/util/service_lookup.go
@@ -95,6 +95,7 @@ func getVisibleNamespacesFromExportToAnno(anno, resourceNamespace string) []stri
 		scopes = append(scopes, ExportToAllNamespaces)
 	} else {
 		for _, ns := range strings.Split(anno, ",") {
+			ns = strings.TrimSpace(ns)
 			if ns == ExportToNamespaceLocal {
 				scopes = append(scopes, resourceNamespace)
 			} else {

--- a/pkg/config/analysis/analyzers/util/service_lookup_test.go
+++ b/pkg/config/analysis/analyzers/util/service_lookup_test.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetVisibleNamespacesFromExportToAnno(t *testing.T) {
+	tests := []struct {
+		Annotation        string
+		ResourceNamespace string
+		Want              []string
+	}{
+		{"", "ns", []string{"*"}},
+		{"ns", "ns", []string{"ns"}},
+		{".", "ns", []string{"ns"}},
+		{"ns1,ns2", "ns1", []string{"ns1", "ns2"}},
+		{"ns1, ns2", "ns1", []string{"ns1", "ns2"}},
+		{"ns1 ,ns2", "ns1", []string{"ns1", "ns2"}},
+	}
+	for _, test := range tests {
+		got := getVisibleNamespacesFromExportToAnno(test.Annotation, test.ResourceNamespace)
+		if !cmp.Equal(got, test.Want) {
+			t.Errorf("getVisibleNamespacesFromExportToAnno(%q, %q) = %#v, but want %#v", test.Annotation, test.ResourceNamespace, got, test.Want)
+		}
+	}
+}

--- a/releasenotes/notes/53429.yaml
+++ b/releasenotes/notes/53429.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - https://github.com/istio/istio/issues/53429
+releaseNotes:
+- |
+  **Added** Allow users to put extra white spaces between namespaces in networking.istio.io/exportTo annotation.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR allows users to put extra spaces between namespaces in `networking.istio.io/exportTo` annotation.

Currently, adding extra spaces between namespaces in `networking.istio.io/exportTo` annotation causes unexpected behavior. For example, `networking.istio.io/exportTo: ns1, ns2` is recognized as `ns1` and ` ns2` namespaces (Note the extra space in `ns2` namespace), and as a result it's not exported to `ns2` namespace properly.

This PR trims the extra spaces after splitting the value into multiple items. In Kubernetes, Namespace must be [RFC 1123 label name](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns), so this doesn't break backward compatibility.

Fix: #53429