### PR TITLE
Feature: allow configuring the dns proxy upstream timeout

### DIFF
--- a/pilot/cmd/pilot-agent/options/agent.go
+++ b/pilot/cmd/pilot-agent/options/agent.go
@@ -63,6 +63,7 @@ func NewAgentOptions(proxy *ProxyArgs, cfg *meshconfig.ProxyConfig, sds istioage
 		DNSCapture:                  DNSCaptureByAgent.Get(),
 		DNSAtGateway:                EnableDNSAtGateway.Get(),
 		DNSForwardParallel:          DNSForwardParallel.Get(),
+		DNSForwardTimeout:           DNSForwardTimeout.Get(),
 		DNSAddr:                     DNSCaptureAddr.Get(),
 		ProxyNamespace:              PodNamespaceVar.Get(),
 		ProxyDomain:                 proxy.DNSDomain,

--- a/pilot/cmd/pilot-agent/options/options.go
+++ b/pilot/cmd/pilot-agent/options/options.go
@@ -113,6 +113,7 @@ var (
 
 	DNSForwardParallel = env.Register("DNS_FORWARD_PARALLEL", false,
 		"If set to true, agent will send parallel DNS queries to all upstream nameservers")
+	DNSForwardTimeout = env.Register("DNS_FORWARD_TIMEOUT", 5*time.Second, "The timeout when the agent queries an upstream nameserver")
 
 	// Ability of istio-agent to retrieve proxyConfig via XDS for dynamic configuration updates
 	enableProxyConfigXdsEnv = env.Register("PROXY_CONFIG_XDS_AGENT", false,

--- a/pkg/dns/client/dns.go
+++ b/pkg/dns/client/dns.go
@@ -86,7 +86,7 @@ const (
 	defaultTTLInSeconds = 30
 )
 
-func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, forwardToUpstreamParallel bool) (*LocalDNSServer, error) {
+func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, forwardToUpstreamParallel bool, timeout time.Duration) (*LocalDNSServer, error) {
 	h := &LocalDNSServer{
 		proxyNamespace:            proxyNamespace,
 		forwardToUpstreamParallel: forwardToUpstreamParallel,
@@ -165,7 +165,7 @@ func NewLocalDNSServer(proxyNamespace, proxyDomain string, addr string, forwardT
 	}
 	for _, ipAddr := range addresses {
 		for _, proto := range []string{"udp", "tcp"} {
-			proxy, err := newDNSProxy(proto, ipAddr, h)
+			proxy, err := newDNSProxy(proto, ipAddr, h, timeout)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/dns/client/dns_test.go
+++ b/pkg/dns/client/dns_test.go
@@ -43,7 +43,7 @@ func TestDNS(t *testing.T) {
 
 func TestBuildAlternateHosts(t *testing.T) {
 	// Create the server instance without starting it, as it's unnecessary for this test
-	d, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", false)
+	d, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", false, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,7 +589,7 @@ func makeUpstream(t test.Failer, responses map[string]string) string {
 
 func initDNS(t test.Failer, forwardToUpstreamParallel bool) *LocalDNSServer {
 	srv := makeUpstream(t, map[string]string{"www.bing.com.": "1.1.1.1"})
-	testAgentDNS, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", forwardToUpstreamParallel)
+	testAgentDNS, err := NewLocalDNSServer("ns1", "ns1.svc.cluster.local", "localhost:0", forwardToUpstreamParallel, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dns/client/proxy.go
+++ b/pkg/dns/client/proxy.go
@@ -32,15 +32,15 @@ type dnsProxy struct {
 	resolver       *LocalDNSServer
 }
 
-func newDNSProxy(protocol, addr string, resolver *LocalDNSServer) (*dnsProxy, error) {
+func newDNSProxy(protocol, addr string, resolver *LocalDNSServer, timeout time.Duration) (*dnsProxy, error) {
 	p := &dnsProxy{
 		serveMux: dns.NewServeMux(),
 		server:   &dns.Server{},
 		upstreamClient: &dns.Client{
 			Net:          protocol,
-			DialTimeout:  5 * time.Second,
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 5 * time.Second,
+			DialTimeout:  timeout,
+			ReadTimeout:  timeout,
+			WriteTimeout: timeout,
 		},
 		protocol: protocol,
 		resolver: resolver,

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -166,6 +166,8 @@ type AgentOptions struct {
 	DNSAddr string
 	// DNSForwardParallel indicates whether the agent should send parallel DNS queries to all upstream nameservers.
 	DNSForwardParallel bool
+	// DNSForwardTimeout sets the timeout when querying upstream nameservers.
+	DNSForwardTimeout time.Duration
 	// ProxyType is the type of proxy we are configured to handle
 	ProxyType model.NodeType
 	// ProxyNamespace to use for local dns resolution
@@ -540,7 +542,7 @@ func (a *Agent) startFileWatcher(ctx context.Context, filePath string, handler f
 func (a *Agent) initLocalDNSServer() (err error) {
 	if a.isDNSServerEnabled() {
 		if a.localDNSServer, err = dnsClient.NewLocalDNSServer(a.cfg.ProxyNamespace, a.cfg.ProxyDomain, a.cfg.DNSAddr,
-			a.cfg.DNSForwardParallel); err != nil {
+			a.cfg.DNSForwardParallel, a.cfg.DNSForwardTimeout); err != nil {
 			return err
 		}
 		a.localDNSServer.StartDNS()


### PR DESCRIPTION
**Please provide a description of this PR:**
* Introduce `DNS_FORWARD_TIMEOUT` which allows for configuring the timeout when sending a DNS request to an upstream server