### PR TITLE
Add abilility to use traffic distribution on old k8s clusters

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -295,7 +295,7 @@ metadata:
     {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{- toJsonMap
-      (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+      (strdict "networking.istio.io/traffic-distribution" "PreferClose")
       .InfrastructureLabels
       (strdict
         "gateway.networking.k8s.io/gateway-name" .Name

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -295,6 +295,7 @@ metadata:
     {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
   labels:
     {{- toJsonMap
+      (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
       .InfrastructureLabels
       (strdict
         "gateway.networking.k8s.io/gateway-name" .Name

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -224,9 +224,9 @@ kind: Service
 metadata:
   annotations: {}
   labels:
-    experimental.istio.io/traffic-distribution: PreferClose
     gateway.istio.io/managed: istio.io-mesh-controller
     gateway.networking.k8s.io/gateway-name: namespace
+    networking.istio.io/traffic-distribution: PreferClose
     topology.istio.io/network: network-1
   name: namespace
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint-no-network-label.yaml
@@ -224,6 +224,7 @@ kind: Service
 metadata:
   annotations: {}
   labels:
+    experimental.istio.io/traffic-distribution: PreferClose
     gateway.istio.io/managed: istio.io-mesh-controller
     gateway.networking.k8s.io/gateway-name: namespace
     topology.istio.io/network: network-1

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -224,9 +224,9 @@ kind: Service
 metadata:
   annotations: {}
   labels:
-    experimental.istio.io/traffic-distribution: PreferClose
     gateway.istio.io/managed: istio.io-mesh-controller
     gateway.networking.k8s.io/gateway-name: namespace
+    networking.istio.io/traffic-distribution: PreferClose
     topology.istio.io/network: network-1
   name: namespace
   namespace: default

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/waypoint.yaml
@@ -224,6 +224,7 @@ kind: Service
 metadata:
   annotations: {}
   labels:
+    experimental.istio.io/traffic-distribution: PreferClose
     gateway.istio.io/managed: istio.io-mesh-controller
     gateway.networking.k8s.io/gateway-name: namespace
     topology.istio.io/network: network-1

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -150,7 +150,7 @@ func (a *index) constructServiceEntries(svc *networkingclient.ServiceEntry, w *W
 	var lb *workloadapi.LoadBalancing
 	preferClose := strings.EqualFold(svc.Annotations["networking.istio.io/traffic-distribution"], v1.ServiceTrafficDistributionPreferClose)
 	if preferClose {
-		lb = preferCloseLoadBalancer()
+		lb = preferCloseLoadBalancer
 	}
 
 	// TODO this is only checking one controller - we may be missing service vips for instances in another cluster
@@ -201,7 +201,7 @@ func (a *index) constructService(svc *v1.Service, w *Waypoint) *workloadapi.Serv
 		preferClose = *svc.Spec.TrafficDistribution == v1.ServiceTrafficDistributionPreferClose
 	}
 	if preferClose {
-		lb = preferCloseLoadBalancer()
+		lb = preferCloseLoadBalancer
 	}
 	if itp := svc.Spec.InternalTrafficPolicy; itp != nil && *itp == v1.ServiceInternalTrafficPolicyLocal {
 		lb = &workloadapi.LoadBalancing{

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -243,17 +243,15 @@ func (a *index) constructService(svc *v1.Service, w *Waypoint) *workloadapi.Serv
 	}
 }
 
-func preferCloseLoadBalancer() *workloadapi.LoadBalancing {
-	return &workloadapi.LoadBalancing{
-		// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
-		RoutingPreference: []workloadapi.LoadBalancing_Scope{
-			workloadapi.LoadBalancing_NETWORK,
-			workloadapi.LoadBalancing_REGION,
-			workloadapi.LoadBalancing_ZONE,
-			workloadapi.LoadBalancing_SUBZONE,
-		},
-		Mode: workloadapi.LoadBalancing_FAILOVER,
-	}
+var preferCloseLoadBalancer = &workloadapi.LoadBalancing{
+	// Prefer endpoints in close zones, but allow spilling over to further endpoints where required.
+	RoutingPreference: []workloadapi.LoadBalancing_Scope{
+		workloadapi.LoadBalancing_NETWORK,
+		workloadapi.LoadBalancing_REGION,
+		workloadapi.LoadBalancing_ZONE,
+		workloadapi.LoadBalancing_SUBZONE,
+	},
+	Mode: workloadapi.LoadBalancing_FAILOVER,
 }
 
 func getVIPs(svc *v1.Service) []string {

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/services.go
@@ -17,6 +17,7 @@ package ambient
 
 import (
 	"net/netip"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -188,7 +189,7 @@ func (a *index) constructService(svc *v1.Service, w *Waypoint) *workloadapi.Serv
 	var lb *workloadapi.LoadBalancing
 
 	// The TrafficDistribution field is quite new, so we allow a legacy annotation option as well
-	preferClose := svc.Annotations["experimental.istio.io/traffic-distribution"] == "PreferClose"
+	preferClose := strings.EqualFold(svc.Annotations["experimental.istio.io/traffic-distribution"], v1.ServiceTrafficDistributionPreferClose)
 	if svc.Spec.TrafficDistribution != nil {
 		preferClose = *svc.Spec.TrafficDistribution == v1.ServiceTrafficDistributionPreferClose
 	}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.39.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.39.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.39.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.39.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.47.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.47.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.46.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1445,7 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
-          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "experimental.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.42.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.42.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1445,6 +1445,7 @@ templates:
         {{ toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
       labels:
         {{- toJsonMap
+          (strdict "networking.istio.io/traffic-distribution" "PreferClose")
           .InfrastructureLabels
           (strdict
             "gateway.networking.k8s.io/gateway-name" .Name


### PR DESCRIPTION
TrafficDistribution is alpha in k8s 1.30. So it will be 2-3 years before
its something we can depend on.

We really want to make waypoints PreferClose, so we hardcoded a waypoint
hack. But this leaves all other services out of the picture.

This adds a temporary (where temporary is ~2-3 years) annotation to
allow users on Kubernetes clusters w/o this field to utilize ztunnel
locality aware load balancing. Additionally, the waypoint hack is
dropped and moved to use this annotation. Conveniently, this also means
a user can chose to opt-out of this, if they want.
