### PR TITLE
[release-1.22] Support clusterLocal host exclusions for multi-cluster

### DIFF
--- a/pilot/pkg/model/cluster_local_test.go
+++ b/pilot/pkg/model/cluster_local_test.go
@@ -142,6 +142,123 @@ func TestIsClusterLocal(t *testing.T) {
 			host:     "s.ns3.svc.cluster.local",
 			expected: false,
 		},
+		{
+			name: "global",
+			m: &meshconfig.MeshConfig{
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: true,
+						},
+						Hosts: []string{
+							"*",
+						},
+					},
+				},
+			},
+			host:     "s.ns1.svc.cluster.local",
+			expected: true,
+		},
+		{
+			name: "global with exclusion wildcard",
+			m: &meshconfig.MeshConfig{
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: true,
+						},
+						Hosts: []string{
+							"*",
+						},
+					},
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{
+							"*.ns1.svc.cluster.local",
+						},
+					},
+				},
+			},
+			host:     "s.ns1.svc.cluster.local",
+			expected: false,
+		},
+		{
+			name: "global with exclusion specific",
+			m: &meshconfig.MeshConfig{
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: true,
+						},
+						Hosts: []string{
+							"*",
+						},
+					},
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{
+							"service.ns1.svc.cluster.local",
+						},
+					},
+				},
+			},
+			host:     "service.ns1.svc.cluster.local",
+			expected: false,
+		},
+		{
+			name: "subdomain local with global",
+			m: &meshconfig.MeshConfig{
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: true,
+						},
+						Hosts: []string{
+							"*.cluster.local",
+						},
+					},
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{
+							"*",
+						},
+					},
+				},
+			},
+			host:     "echo.test.svc.cluster.local",
+			expected: true,
+		},
+		{
+			name: "other domain non-local global",
+			m: &meshconfig.MeshConfig{
+				ServiceSettings: []*meshconfig.MeshConfig_ServiceSettings{
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: true,
+						},
+						Hosts: []string{
+							"*.cluster.local",
+						},
+					},
+					{
+						Settings: &meshconfig.MeshConfig_ServiceSettings_Settings{
+							ClusterLocal: false,
+						},
+						Hosts: []string{
+							"*",
+						},
+					},
+				},
+			},
+			host:     "otherdomain",
+			expected: false,
+		},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/52367.yaml
+++ b/releasenotes/notes/52367.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: []
+releaseNotes:
+- |
+  **Fixed** Support clusterLocal host exclusions for multi-cluster.


### PR DESCRIPTION
Please provide a description of this PR:
Backport https://github.com/istio/istio/pull/52367 to Istio 1.22, support clusterLocal host exclusions for multi-cluster.
 
1.23 release here: https://github.com/istio/istio/pull/53443