### PR TITLE
Fix a few issues in chart rendering

### DIFF
--- a/manifests/charts/base/templates/zzz_profile.yaml
+++ b/manifests/charts/base/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/default/templates/zzz_profile.yaml
+++ b/manifests/charts/default/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/gateway/templates/zzz_profile.yaml
+++ b/manifests/charts/gateway/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/istio-cni/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-cni/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if false }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/charts/ztunnel/templates/zzz_profile.yaml
+++ b/manifests/charts/ztunnel/templates/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if true }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/manifests/zzz_profile.yaml
+++ b/manifests/zzz_profile.yaml
@@ -21,7 +21,6 @@ Finally, we can set all of that under .Values so the chart behaves without aware
   ($.Values.defaults | toYaml |nindent 4)
 ) }}
 {{- end }}
-{{- $globals := $.Values.global | default dict | deepCopy }}
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
@@ -39,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if  $globals.platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" $globals.platform) }}
+{{- if ($.Values.global).platform }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" $globals.platform) }}
+{{ fail (cat "unknown platform" ($.Values.global).platform) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}
@@ -51,7 +50,7 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- end }}
 #  Flatten globals, if defined on a per-chart basis
 {{- if FLATTEN_GLOBALS_REPLACEMENT }}
-{{- $a := mustMergeOverwrite $defaults $globals  }}
+{{- $a := mustMergeOverwrite $defaults ($profile.global) ($.Values.global | default dict)  }}
 {{- end }}
 {{- $b := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}
 

--- a/operator/pkg/values/map.go
+++ b/operator/pkg/values/map.go
@@ -416,6 +416,8 @@ func parsePath(key string) []string { return strings.Split(key, ".") }
 // TODO: this could be automatically derived from the value_types.proto?
 var alwaysString = []string{
 	"spec.values.compatibilityVersion",
+	"spec.tag",
+	"spec.values.global.tag",
 	"spec.meshConfig.defaultConfig.proxyMetadata.",
 	"spec.values.meshConfig.defaultConfig.proxyMetadata.",
 	"spec.compatibilityVersion",


### PR DESCRIPTION
After
```
$ ikl manifest generate -d manifests --set profile=ambient --set values.global.tag=1728075945 |& rg 'image: g'
        image: gcr.io/istio-testing/install-cni:1728075945-distroless
        image: gcr.io/istio-testing/ztunnel:1.728075945e+09
        image: gcr.io/istio-testing/pilot:1728075945-distroless
```

Before:
```
$ ikl manifest generate -d manifests --set profile=ambient --set values.global.tag=1728075945 |& rg 'image: g'
        image: gcr.io/istio-testing/install-cni:1728075945-distroless
        image: gcr.io/istio-testing/ztunnel:1728075945-distroless
        image: gcr.io/istio-testing/pilot:1728075945-distroless
```

Two issues:
* Incorrect processing of string into a float
* We don't flatten globals from profile. We could fix this by working
  around in each profile, or flatten globals from profile; I chose the
latter.
