### PR TITLE
istioctl: support filter resource by namespace for injector list

### DIFF
--- a/releasenotes/notes/53450.yaml
+++ b/releasenotes/notes/53450.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for filtering resources by namespace to `istioctl experimental injector list`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Support filter resource by namespace for `istioctl x injector list`:

1. The global flags include flags for specifying namespaces, but they are not implemented in this command.
2. When there are too many resources such as namespaces, it is useful to support filtering and printing resources by namespace.