### PR TITLE
Support serving mTLS and user mTLS/TLS on same port

### DIFF
--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -17,14 +17,13 @@ package core
 import (
 	"fmt"
 	"reflect"
-	"slices"
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -38,6 +37,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -895,9 +895,9 @@ func testSidecarInboundListenerFilters(t *testing.T, enableDualStack bool) {
 			virtualInbound := xdstest.ExtractListener("virtualInbound", listeners)
 			// ensure no duplicate filter chains
 			for idx, fc1 := range virtualInbound.FilterChains {
-				if slices.ContainsFunc(virtualInbound.FilterChains[:idx], func(fc2 *listener.FilterChain) bool {
+				if slices.FindFunc(virtualInbound.FilterChains[:idx], func(fc2 *listener.FilterChain) bool {
 					return proto.Equal(fc1.FilterChainMatch, fc2.FilterChainMatch)
-				}) {
+				}) != nil {
 					t.Fatal("Duplicate filter chains found!")
 				}
 			}

--- a/pilot/pkg/networking/core/listener_builder_test.go
+++ b/pilot/pkg/networking/core/listener_builder_test.go
@@ -824,7 +824,7 @@ func testSidecarInboundListenerFilters(t *testing.T, enableDualStack bool) {
 				filterChain := xdstest.ExtractFilterChain("1.1.1.1_80", virtualInbound)
 				expectIstioMTLS(t, filterChain)
 
-				permissiveFilterChain := xdstest.ExtractFilterChain("permissive_1.1.1.1_80", virtualInbound)
+				permissiveFilterChain := xdstest.ExtractFilterChain("user_tls_1.1.1.1_80", virtualInbound)
 				expectNonIstioTLS(t, permissiveFilterChain)
 			},
 		},
@@ -849,7 +849,7 @@ func testSidecarInboundListenerFilters(t *testing.T, enableDualStack bool) {
 				filterChain := xdstest.ExtractFilterChain("1.1.1.1_80", virtualInbound)
 				expectIstioMTLS(t, filterChain)
 
-				permissiveFilterChain := xdstest.ExtractFilterChain("permissive_1.1.1.1_80", virtualInbound)
+				permissiveFilterChain := xdstest.ExtractFilterChain("user_tls_1.1.1.1_80", virtualInbound)
 				expectNonIstioTLS(t, permissiveFilterChain)
 			},
 		},
@@ -874,7 +874,7 @@ func testSidecarInboundListenerFilters(t *testing.T, enableDualStack bool) {
 				filterChain := xdstest.ExtractFilterChain("1.1.1.1_80", virtualInbound)
 				expectIstioMTLS(t, filterChain)
 
-				permissiveFilterChain := xdstest.ExtractFilterChain("permissive_1.1.1.1_80", virtualInbound)
+				permissiveFilterChain := xdstest.ExtractFilterChain("user_tls_1.1.1.1_80", virtualInbound)
 				expectNonIstioTLS(t, permissiveFilterChain)
 			},
 		},

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -177,7 +177,7 @@ func (lb *ListenerBuilder) buildInboundHBONEListeners() []*listener.Listener {
 		lp := istionetworking.ModelProtocolToListenerProtocol(cc.port.Protocol)
 		// Internal chain has no mTLS
 		mtls := authn.MTLSSettings{Port: cc.port.TargetPort, Mode: model.MTLSDisable}
-		opts := getFilterChainMatchOptions(mtls, lp)
+		opts := getFilterChainMatchOptions(mtls, lp, false)
 		chains := lb.inboundChainForOpts(cc, mtls, opts)
 		for _, c := range chains {
 			lb.sanitizeFilterChainForHBONE(c)
@@ -263,7 +263,7 @@ func (lb *ListenerBuilder) buildInboundListeners() []*listener.Listener {
 
 		if cc.tlsSettings == nil || mtls.Mode != model.MTLSDisable {
 			lp := istionetworking.ModelProtocolToListenerProtocol(cc.port.Protocol)
-			opts = getFilterChainMatchOptions(mtls, lp)
+			opts = getFilterChainMatchOptions(mtls, lp, cc.tlsSettings != nil)
 			chains = append(chains, lb.inboundChainForOpts(cc, mtls, opts)...)
 		}
 
@@ -771,7 +771,7 @@ func buildInboundHBONEPassthroughChain(lb *ListenerBuilder) []*listener.FilterCh
 		hbone:       lb.node.IsWaypointProxy(),
 	}
 
-	opts := getFilterChainMatchOptions(mtls, istionetworking.ListenerProtocolAuto)
+	opts := getFilterChainMatchOptions(mtls, istionetworking.ListenerProtocolAuto, false)
 	return lb.inboundChainForOpts(cc, mtls, opts)
 }
 
@@ -800,7 +800,7 @@ func buildInboundPassthroughChains(lb *ListenerBuilder) []*listener.FilterChain 
 			passthrough: true,
 			hbone:       lb.node.IsWaypointProxy(),
 		}
-		opts := getFilterChainMatchOptions(mtls, istionetworking.ListenerProtocolAuto)
+		opts := getFilterChainMatchOptions(mtls, istionetworking.ListenerProtocolAuto, false)
 		filterChains = append(filterChains, lb.inboundChainForOpts(cc, mtls, opts)...)
 	}
 

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -105,8 +105,6 @@ func (cc inboundChainConfig) StatPrefix() string {
 	if cc.passthrough {
 		// A bit arbitrary, but for backwards compatibility just use the cluster name
 		statPrefix = cc.clusterName
-	} else if cc.permissive {
-		statPrefix = "inbound_permissive_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	} else {
 		statPrefix = "inbound_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	}

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -77,10 +77,10 @@ type inboundChainConfig struct {
 	// different configuration.
 	passthrough bool
 
-	// permissive should be set to true for the port-specific 'permissive' chains, created when
+	// isUserTLS should be set to true for the port-specific 'isUserTLS' chains, created when
 	// serving Istio-mTLS and mTLS/TLS on the same port. These have a few naming and quirks that require
 	// different configuration.
-	permissive bool
+	isUserTLS bool
 
 	// bindToPort determines if this chain should form a real listener that actually binds to a real port,
 	// or if it should just be a filter chain part of the 'virtual inbound' listener.
@@ -125,8 +125,8 @@ func (cc inboundChainConfig) Name(protocol istionetworking.ListenerProtocol) str
 	}
 
 	name := getListenerName(cc.bind, int(cc.port.TargetPort), istionetworking.TransportProtocolTCP)
-	if cc.permissive {
-		return "permissive_" + name
+	if cc.isUserTLS {
+		return "user_tls_" + name
 	}
 
 	// Everything else derived from bind/port
@@ -252,7 +252,7 @@ func (lb *ListenerBuilder) buildInboundListeners() []*listener.Listener {
 			// In permissive mode, both the Istio mTLS filter chains and user TLS filter chains
 			// are built. Set the flag to ensure when constructing them they are uniquely referencable.
 			if mtls.Mode == model.MTLSPermissive {
-				cc.permissive = true
+				cc.isUserTLS = true
 			}
 			lp := istionetworking.ModelProtocolToListenerProtocol(cc.port.Protocol)
 			opts = getTLSFilterChainMatchOptions(lp)

--- a/pilot/pkg/networking/core/listener_inbound.go
+++ b/pilot/pkg/networking/core/listener_inbound.go
@@ -77,6 +77,11 @@ type inboundChainConfig struct {
 	// different configuration.
 	passthrough bool
 
+	// permissive should be set to true for the port-specific 'permissive' chains, created when
+	// serving Istio-mTLS and mTLS/TLS on the same port. These have a few naming and quirks that require
+	// different configuration.
+	permissive bool
+
 	// bindToPort determines if this chain should form a real listener that actually binds to a real port,
 	// or if it should just be a filter chain part of the 'virtual inbound' listener.
 	bindToPort bool
@@ -100,6 +105,8 @@ func (cc inboundChainConfig) StatPrefix() string {
 	if cc.passthrough {
 		// A bit arbitrary, but for backwards compatibility just use the cluster name
 		statPrefix = cc.clusterName
+	} else if cc.permissive {
+		statPrefix = "inbound_permissive_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	} else {
 		statPrefix = "inbound_" + cc.Name(istionetworking.ListenerProtocolHTTP)
 	}
@@ -118,8 +125,14 @@ func (cc inboundChainConfig) Name(protocol istionetworking.ListenerProtocol) str
 		}
 		return model.VirtualInboundListenerName
 	}
+
+	name := getListenerName(cc.bind, int(cc.port.TargetPort), istionetworking.TransportProtocolTCP)
+	if cc.permissive {
+		return "permissive_" + name
+	}
+
 	// Everything else derived from bind/port
-	return getListenerName(cc.bind, int(cc.port.TargetPort), istionetworking.TransportProtocolTCP)
+	return name
 }
 
 // ToFilterChainMatch builds the FilterChainMatch for the config
@@ -225,21 +238,36 @@ func (lb *ListenerBuilder) buildInboundListeners() []*listener.Listener {
 		// to handle mTLS vs plaintext and HTTP vs TCP (depending on protocol and PeerAuthentication).
 		var opts []FilterChainMatchOptions
 		mtls := lb.authnBuilder.ForPort(cc.port.TargetPort)
-		// Chain has explicit user TLS config. This can only apply when the TLS mode is DISABLE to avoid conflicts.
-		if cc.tlsSettings != nil && mtls.Mode == model.MTLSDisable {
+
+		var chains []*listener.FilterChain
+		// Chain has explicit user TLS config. This can only apply when the TLS mode is DISABLE or PERMISSIVE to ensure
+		// security.
+		if cc.tlsSettings != nil && mtls.Mode != model.MTLSStrict {
+			// copy as may be used to build istio mTLS listener
+			cc := cc
+			mtls := mtls
+
 			// Since we are terminating TLS, we need to treat the protocol as if its terminated.
 			// Example: user specifies protocol=HTTPS and user TLS, we will use HTTP
 			cc.port.Protocol = cc.port.Protocol.AfterTLSTermination()
+
+			// In permissive mode, both the Istio mTLS filter chains and user TLS filter chains
+			// are built. Set the flag to ensure when constructing them they are uniquely referencable.
+			if mtls.Mode == model.MTLSPermissive {
+				cc.permissive = true
+			}
 			lp := istionetworking.ModelProtocolToListenerProtocol(cc.port.Protocol)
 			opts = getTLSFilterChainMatchOptions(lp)
 			mtls.TCP = BuildListenerTLSContext(cc.tlsSettings, lb.node, lb.push.Mesh, istionetworking.TransportProtocolTCP, false)
 			mtls.HTTP = mtls.TCP
-		} else {
+			chains = append(chains, lb.inboundChainForOpts(cc, mtls, opts)...)
+		}
+
+		if cc.tlsSettings == nil || mtls.Mode != model.MTLSDisable {
 			lp := istionetworking.ModelProtocolToListenerProtocol(cc.port.Protocol)
 			opts = getFilterChainMatchOptions(mtls, lp)
+			chains = append(chains, lb.inboundChainForOpts(cc, mtls, opts)...)
 		}
-		// Build the actual chain
-		chains := lb.inboundChainForOpts(cc, mtls, opts)
 
 		if cc.bindToPort {
 			// If this config is for bindToPort, we want to actually create a real Listener.

--- a/releasenotes/notes/dual-tls-ingress.yaml
+++ b/releasenotes/notes/dual-tls-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 51768
+releaseNotes:
+- |
+  **Updated** allow specifying the inbound server tls settings when peer authentication is set to permissive
+upgradeNotes: []
+docs:
+- '[Design] https://docs.google.com/document/d/13ciYV5H85rOc_EH1LcuoVyCFxFu_n4SpNq1luvHmRmA/edit?usp=sharing'
+securityNotes: []


### PR DESCRIPTION
**Please provide a description of this PR:**
Allow serving mTLS with Istio ALPNs and user mTLS/TLS on the same port if PeerAuthentication is permissive. See [RFC](https://docs.google.com/document/d/13ciYV5H85rOc_EH1LcuoVyCFxFu_n4SpNq1luvHmRmA/edit#heading=h.xw1gqgyqs5b).

Fixes #51768