### PR TITLE
gateway: report status for istio-remote gateway

### DIFF
--- a/pilot/pkg/config/kube/gateway/testdata/eastwest-remote.status.yaml.golden
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest-remote.status.yaml.golden
@@ -5,6 +5,21 @@ metadata:
   name: eastwestgateway
   namespace: istio-system
 spec: null
+status:
+  addresses:
+  - type: IPAddress
+    value: 1.1.1.1
+  conditions:
+  - lastTransitionTime: fake
+    message: Resource accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: fake
+    message: This Gateway is remote; Istio will not program it
+    reason: Programmed
+    status: "True"
+    type: Programmed
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute

--- a/pilot/pkg/config/kube/gateway/testdata/eastwest-remote.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/eastwest-remote.yaml
@@ -6,18 +6,11 @@ metadata:
   labels:
     topology.istio.io/network: "network-1"
 spec:
+  addresses:
+    - value: 1.1.1.1
+      type: IPAddress
   gatewayClassName: istio-remote
   listeners:
-  - name: istiod-grpc
-    port: 15012
-    protocol: TLS
-    tls:
-      mode: Passthrough
-  - name: istiod-webhook
-    port: 15017
-    protocol: TLS
-    tls:
-      mode: Passthrough
   - name: cross-network
     hostname: "*.local"
     port: 15443
@@ -25,6 +18,7 @@ spec:
     tls:
       mode: Passthrough
 ---
+# These routes should be ignored since this is an istio-remote gateway!
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
@@ -32,13 +26,13 @@ metadata:
   namespace: istio-system
 spec:
   parentRefs:
-  - name: eastwestgateway
-    kind: Gateway
-    sectionName: istiod-grpc
+    - name: eastwestgateway
+      kind: Gateway
+      sectionName: istiod-grpc
   rules:
-  - backendRefs:
-    - name: istiod
-      port: 15012
+    - backendRefs:
+        - name: istiod
+          port: 15012
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
@@ -47,10 +41,10 @@ metadata:
   namespace: istio-system
 spec:
   parentRefs:
-  - name: eastwestgateway
-    kind: Gateway
-    sectionName: istiod-webhook
+    - name: eastwestgateway
+      kind: Gateway
+      sectionName: istiod-webhook
   rules:
-  - backendRefs:
-    - name: istiod
-      port: 15017
+    - backendRefs:
+        - name: istiod
+          port: 15017


### PR DESCRIPTION
This is the gateway mode that just represents a remote thing. it does
not get infrastructure deployed in the local cluster.

Writing status is useful merely because it shows up in `kubectl` and
makes things not show up as 'Unknown, waiting for controller'
everywhere.
