### PR TITLE
Fix kube-virt-related rules cleanup in legacy istio-clean-iptables

### DIFF
--- a/releasenotes/notes/48368.yaml
+++ b/releasenotes/notes/48368.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 48368
+releaseNotes:
+  - |
+    **Fixed** kube-virt-related rules not being removed by istio-clean-iptables tool.

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -15,6 +15,10 @@
 package cmd
 
 import (
+	"fmt"
+	"net/netip"
+	"os"
+
 	"istio.io/istio/tools/istio-clean-iptables/pkg/config"
 	"istio.io/istio/tools/istio-iptables/pkg/builder"
 	common "istio.io/istio/tools/istio-iptables/pkg/capture"
@@ -35,6 +39,42 @@ type IptablesCleaner struct {
 	cfg   *config.Config
 	iptV  *dep.IptablesVersion
 	ipt6V *dep.IptablesVersion
+}
+
+type NetworkRange struct {
+	IsWildcard    bool
+	CIDRs         []netip.Prefix
+	HasLoopBackIP bool
+}
+
+func separateV4V6(cidrList string) (NetworkRange, NetworkRange, error) {
+	if cidrList == "*" {
+		return NetworkRange{IsWildcard: true}, NetworkRange{IsWildcard: true}, nil
+	}
+	ipv6Ranges := NetworkRange{}
+	ipv4Ranges := NetworkRange{}
+	for _, ipRange := range types.Split(cidrList) {
+		ipp, err := netip.ParsePrefix(ipRange)
+		if err != nil {
+			_, err = fmt.Fprintf(os.Stderr, "Ignoring error for bug compatibility with istio-iptables: %s\n", err.Error())
+			if err != nil {
+				return ipv4Ranges, ipv6Ranges, err
+			}
+			continue
+		}
+		if ipp.Addr().Is4() {
+			ipv4Ranges.CIDRs = append(ipv4Ranges.CIDRs, ipp)
+			if ipp.Addr().IsLoopback() {
+				ipv4Ranges.HasLoopBackIP = true
+			}
+		} else {
+			ipv6Ranges.CIDRs = append(ipv6Ranges.CIDRs, ipp)
+			if ipp.Addr().IsLoopback() {
+				ipv6Ranges.HasLoopBackIP = true
+			}
+		}
+	}
+	return ipv4Ranges, ipv6Ranges, nil
 }
 
 func NewIptablesCleaner(cfg *config.Config, iptV, ipt6V *dep.IptablesVersion, ext dep.Dependencies) *IptablesCleaner {
@@ -85,6 +125,35 @@ func removeOldChains(cfg *config.Config, ext dep.Dependencies, iptV *dep.Iptable
 	flushAndDeleteChains(ext, iptV, constants.NAT, chains)
 }
 
+func cleanupKubeVirt(cfg *config.Config, ext dep.Dependencies, iptV *dep.IptablesVersion, iptV6 *dep.IptablesVersion) {
+	cleanupFunc := func(iptVer *dep.IptablesVersion, rangeInclude NetworkRange) {
+		if rangeInclude.IsWildcard {
+			// Wildcard specified. Redirect all remaining outbound traffic to Envoy.
+			for _, internalInterface := range types.Split(cfg.KubeVirtInterfaces) {
+				DeleteRule(ext, iptVer, constants.PREROUTING, constants.NAT, "-i", internalInterface, "-j", constants.ISTIOREDIRECT)
+			}
+		} else if len(rangeInclude.CIDRs) > 0 {
+			// User has specified a non-empty list of cidrs to be redirected to Envoy.
+			for _, cidr := range rangeInclude.CIDRs {
+				for _, internalInterface := range types.Split(cfg.KubeVirtInterfaces) {
+					DeleteRule(ext, iptVer, constants.PREROUTING, constants.PREROUTING, constants.NAT, "-i", internalInterface,
+						"-d", cidr.String(), "-j", constants.ISTIOREDIRECT)
+				}
+			}
+		}
+		// cleanup short circuit
+		for _, internalInterface := range types.Split(cfg.KubeVirtInterfaces) {
+			DeleteRule(ext, iptVer, constants.PREROUTING, constants.NAT, "-i", internalInterface, "-j", constants.RETURN)
+		}
+	}
+
+	ipv4RangesInclude, ipv6RangesInclude, err := separateV4V6(cfg.OutboundIPRangesInclude)
+	if err == nil {
+		cleanupFunc(iptV, ipv4RangesInclude)
+		cleanupFunc(iptV6, ipv6RangesInclude)
+	}
+}
+
 // cleanupDNSUDP removes any IPv4/v6 UDP rules.
 // TODO BML drop `HandleDSNUDP` and friends, no real need to tread UDP rules specially
 // or create unique abstractions for them
@@ -116,6 +185,8 @@ func (c *IptablesCleaner) Run() {
 	}()
 
 	// clean v4/v6
+	// cleanup kube-virt-related jumps
+	cleanupKubeVirt(c.cfg, c.ext, c.iptV, c.ipt6V)
 	// Remove chains (run once per v4/v6)
 	removeOldChains(c.cfg, c.ext, c.iptV)
 	removeOldChains(c.cfg, c.ext, c.ipt6V)

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
@@ -75,6 +75,20 @@ func TestIptables(t *testing.T) {
 			},
 		},
 		{
+			"ipnets-with-kube-virt-interfaces",
+			func(cfg *config.Config) {
+				cfg.KubeVirtInterfaces = "eth1,eth2"
+				cfg.OutboundIPRangesInclude = "10.0.0.0/8"
+			},
+		},
+		{
+			"kube-virt-interfaces",
+			func(cfg *config.Config) {
+				cfg.KubeVirtInterfaces = "eth1,eth2"
+				cfg.OutboundIPRangesInclude = "*"
+			},
+		},
+		{
 			"inbound-interception-mode",
 			func(cfg *config.Config) {
 				cfg.InboundInterceptionMode = "TPROXY"

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -1,0 +1,54 @@
+iptables -t PREROUTING -D PREROUTING nat -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D PREROUTING nat -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth1 -j RETURN
+iptables -t PREROUTING -D nat -i eth2 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth1 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth2 -j RETURN
+iptables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_INBOUND
+iptables -t nat -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_INBOUND
+iptables -t mangle -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_DIVERT
+iptables -t mangle -X ISTIO_DIVERT
+iptables -t mangle -F ISTIO_TPROXY
+iptables -t mangle -X ISTIO_TPROXY
+iptables -t nat -F ISTIO_REDIRECT
+iptables -t nat -X ISTIO_REDIRECT
+iptables -t nat -F ISTIO_IN_REDIRECT
+iptables -t nat -X ISTIO_IN_REDIRECT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_INBOUND
+ip6tables -t nat -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_INBOUND
+ip6tables -t mangle -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_DIVERT
+ip6tables -t mangle -X ISTIO_DIVERT
+ip6tables -t mangle -F ISTIO_TPROXY
+ip6tables -t mangle -X ISTIO_TPROXY
+ip6tables -t nat -F ISTIO_REDIRECT
+ip6tables -t nat -X ISTIO_REDIRECT
+ip6tables -t nat -F ISTIO_IN_REDIRECT
+ip6tables -t nat -X ISTIO_IN_REDIRECT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -F ISTIO_OUTPUT
+iptables -t raw -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables-save
+ip6tables-save

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
@@ -1,0 +1,56 @@
+iptables -t PREROUTING -D nat -i eth1 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth2 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth1 -j RETURN
+iptables -t PREROUTING -D nat -i eth2 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth1 -j ISTIO_REDIRECT
+ip6tables -t PREROUTING -D nat -i eth2 -j ISTIO_REDIRECT
+ip6tables -t PREROUTING -D nat -i eth1 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth2 -j RETURN
+iptables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_INBOUND
+iptables -t nat -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_INBOUND
+iptables -t mangle -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_DIVERT
+iptables -t mangle -X ISTIO_DIVERT
+iptables -t mangle -F ISTIO_TPROXY
+iptables -t mangle -X ISTIO_TPROXY
+iptables -t nat -F ISTIO_REDIRECT
+iptables -t nat -X ISTIO_REDIRECT
+iptables -t nat -F ISTIO_IN_REDIRECT
+iptables -t nat -X ISTIO_IN_REDIRECT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_INBOUND
+ip6tables -t nat -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_INBOUND
+ip6tables -t mangle -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_DIVERT
+ip6tables -t mangle -X ISTIO_DIVERT
+ip6tables -t mangle -F ISTIO_TPROXY
+ip6tables -t mangle -X ISTIO_TPROXY
+ip6tables -t nat -F ISTIO_REDIRECT
+ip6tables -t nat -X ISTIO_REDIRECT
+ip6tables -t nat -F ISTIO_IN_REDIRECT
+ip6tables -t nat -X ISTIO_IN_REDIRECT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -F ISTIO_OUTPUT
+iptables -t raw -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables-save
+ip6tables-save

--- a/tools/istio-clean-iptables/pkg/config/config.go
+++ b/tools/istio-clean-iptables/pkg/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	OwnerGroupsExclude      string   `json:"OUTBOUND_OWNER_GROUPS_EXCLUDE"`
 	InboundInterceptionMode string   `json:"INBOUND_INTERCEPTION_MODE"`
 	InboundTProxyMark       string   `json:"INBOUND_TPROXY_MARK"`
+	OutboundIPRangesInclude string   `json:"OUTBOUND_IPRANGES_INCLUDE"`
+	KubeVirtInterfaces      string   `json:"KUBE_VIRT_INTERFACES"`
 }
 
 func (c *Config) String() string {
@@ -69,6 +71,8 @@ func (c *Config) Print() {
 	fmt.Printf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6)
 	fmt.Printf("OUTBOUND_OWNER_GROUPS_INCLUDE=%s\n", c.OwnerGroupsInclude)
 	fmt.Printf("OUTBOUND_OWNER_GROUPS_EXCLUDE=%s\n", c.OwnerGroupsExclude)
+	fmt.Printf("OUTBOUND_IP_RANGES_INCLUDE=%s\n", c.OutboundIPRangesInclude)
+	fmt.Printf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces)
 	fmt.Println("")
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes #48368

This issue does not affect Istio 1.24 out-of-the-box, as 1.24 is the first version to use the new cleanup methodology by default (via `istio-iptables --cleanup-only`).

This commit fixes the legacy istio-clean-iptables methodology, which is the only one available for Istio 1.22 and 1.23 (a cherry-pick will be needed for those versions).

I plan to remove the legacy istio-clean-iptables methodology in Istio 1.25, as it is prone to issues like this, which have occurred 3 or 4 times already.