### PR TITLE
Respect --namespace flag in `istioctl ztunnelconfig`

### DIFF
--- a/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
+++ b/istioctl/pkg/ztunnelconfig/ztunnelconfig.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/model"
 	"istio.io/istio/pkg/slices"
 )
 
@@ -522,7 +523,8 @@ func setupZtunnelLogs(kubeClient kube.CLIClient, param, podName, podNamespace st
 
 // getComponentPodName returns the pod name and namespace of the Istio component
 func getComponentPodName(ctx cli.Context, podflag string) (string, string, error) {
-	return getPodNameWithNamespace(ctx, podflag, ctx.IstioNamespace())
+	// If user passed --namespace, respect it. Else fallback to --istio-namespace (which is typically defaulted, to istio-system).
+	return getPodNameWithNamespace(ctx, podflag, model.GetOrDefault(ctx.Namespace(), ctx.IstioNamespace()))
 }
 
 func getPodNameWithNamespace(ctx cli.Context, podflag, ns string) (string, string, error) {

--- a/tests/integration/ambient/istioctl_test.go
+++ b/tests/integration/ambient/istioctl_test.go
@@ -49,7 +49,6 @@ func TestZtunnelConfig(t *testing.T) {
 			}
 
 			args := []string{
-				"--namespace=dummy",
 				"zc", "all", podName, "-o", "json",
 			}
 			var zDumpAll configdump.ZtunnelDump
@@ -64,7 +63,6 @@ func TestZtunnelConfig(t *testing.T) {
 
 			var zDump configdump.ZtunnelDump
 			args = []string{
-				"--namespace=dummy",
 				"zc", "services", podName, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
@@ -73,7 +71,6 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Services).To(Not(BeNil()))
 
 			args = []string{
-				"--namespace=dummy",
 				"zc", "workloads", podName, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
@@ -82,7 +79,6 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Workloads).To(Not(BeNil()))
 
 			args = []string{
-				"--namespace=dummy",
 				"zc", "policies", podName, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)
@@ -91,7 +87,6 @@ func TestZtunnelConfig(t *testing.T) {
 			g.Expect(zDump.Policies).To(Not(BeNil()))
 
 			args = []string{
-				"--namespace=dummy",
 				"zc", "certificates", podName, "-o", "json",
 			}
 			out, _ = istioCtl.InvokeOrFail(t, args)


### PR DESCRIPTION
Right now its just entirely ignored, as seen from our tests passing a
bogus flag entirely. This means if ztunnel is outside of istio-system we
cannot do anything about it really.
