### PR TITLE
don't process status queue while ambient index is not synched

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -524,7 +524,10 @@ func (a *index) NetworksSynced() {
 
 func (a *index) Run(stop <-chan struct{}) {
 	if a.statusQueue != nil {
-		go a.statusQueue.Run(stop)
+		go func() {
+			kubeclient.WaitForCacheSync("ambient-status-queue", stop, a.HasSynced)
+			a.statusQueue.Run(stop)
+		}()
 	}
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**

wait for index to sync before starting the status queue