### PR TITLE
[release-1.22] Fix kube-virt-related rules cleanup in legacy istio-clean-iptables

### DIFF
--- a/releasenotes/notes/48368.yaml
+++ b/releasenotes/notes/48368.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 48368
+releaseNotes:
+  - |
+    **Fixed** kube-virt-related rules not being removed by istio-clean-iptables tool.

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
@@ -75,6 +75,20 @@ func TestIptables(t *testing.T) {
 			},
 		},
 		{
+			"ipnets-with-kube-virt-interfaces",
+			func(cfg *config.Config) {
+				cfg.KubeVirtInterfaces = "eth1,eth2"
+				cfg.OutboundIPRangesInclude = "10.0.0.0/8"
+			},
+		},
+		{
+			"kube-virt-interfaces",
+			func(cfg *config.Config) {
+				cfg.KubeVirtInterfaces = "eth1,eth2"
+				cfg.OutboundIPRangesInclude = "*"
+			},
+		},
+		{
 			"inbound-interception-mode",
 			func(cfg *config.Config) {
 				cfg.InboundInterceptionMode = "TPROXY"

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -1,0 +1,54 @@
+iptables -t PREROUTING -D PREROUTING nat -i eth1 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D PREROUTING nat -i eth2 -d 10.0.0.0/8 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth1 -j RETURN
+iptables -t PREROUTING -D nat -i eth2 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth1 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth2 -j RETURN
+iptables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_INBOUND
+iptables -t nat -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_INBOUND
+iptables -t mangle -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_DIVERT
+iptables -t mangle -X ISTIO_DIVERT
+iptables -t mangle -F ISTIO_TPROXY
+iptables -t mangle -X ISTIO_TPROXY
+iptables -t nat -F ISTIO_REDIRECT
+iptables -t nat -X ISTIO_REDIRECT
+iptables -t nat -F ISTIO_IN_REDIRECT
+iptables -t nat -X ISTIO_IN_REDIRECT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_INBOUND
+ip6tables -t nat -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_INBOUND
+ip6tables -t mangle -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_DIVERT
+ip6tables -t mangle -X ISTIO_DIVERT
+ip6tables -t mangle -F ISTIO_TPROXY
+ip6tables -t mangle -X ISTIO_TPROXY
+ip6tables -t nat -F ISTIO_REDIRECT
+ip6tables -t nat -X ISTIO_REDIRECT
+ip6tables -t nat -F ISTIO_IN_REDIRECT
+ip6tables -t nat -X ISTIO_IN_REDIRECT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -F ISTIO_OUTPUT
+iptables -t raw -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables-save
+ip6tables-save

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/ipnets-with-kube-virt-interfaces.golden
@@ -21,8 +21,6 @@ iptables -t nat -F ISTIO_REDIRECT
 iptables -t nat -X ISTIO_REDIRECT
 iptables -t nat -F ISTIO_IN_REDIRECT
 iptables -t nat -X ISTIO_IN_REDIRECT
-iptables -t nat -F ISTIO_OUTPUT
-iptables -t nat -X ISTIO_OUTPUT
 ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
 ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
 ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
@@ -40,15 +38,5 @@ ip6tables -t nat -F ISTIO_REDIRECT
 ip6tables -t nat -X ISTIO_REDIRECT
 ip6tables -t nat -F ISTIO_IN_REDIRECT
 ip6tables -t nat -X ISTIO_IN_REDIRECT
-ip6tables -t nat -F ISTIO_OUTPUT
-ip6tables -t nat -X ISTIO_OUTPUT
-iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
-iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
-ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
-ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
-iptables -t raw -F ISTIO_OUTPUT
-iptables -t raw -X ISTIO_OUTPUT
-iptables -t nat -F ISTIO_OUTPUT
-iptables -t nat -X ISTIO_OUTPUT
 iptables-save
 ip6tables-save

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
@@ -23,8 +23,6 @@ iptables -t nat -F ISTIO_REDIRECT
 iptables -t nat -X ISTIO_REDIRECT
 iptables -t nat -F ISTIO_IN_REDIRECT
 iptables -t nat -X ISTIO_IN_REDIRECT
-iptables -t nat -F ISTIO_OUTPUT
-iptables -t nat -X ISTIO_OUTPUT
 ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
 ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
 ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
@@ -42,15 +40,5 @@ ip6tables -t nat -F ISTIO_REDIRECT
 ip6tables -t nat -X ISTIO_REDIRECT
 ip6tables -t nat -F ISTIO_IN_REDIRECT
 ip6tables -t nat -X ISTIO_IN_REDIRECT
-ip6tables -t nat -F ISTIO_OUTPUT
-ip6tables -t nat -X ISTIO_OUTPUT
-iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
-iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
-ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
-ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
-iptables -t raw -F ISTIO_OUTPUT
-iptables -t raw -X ISTIO_OUTPUT
-iptables -t nat -F ISTIO_OUTPUT
-iptables -t nat -X ISTIO_OUTPUT
 iptables-save
 ip6tables-save

--- a/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
+++ b/tools/istio-clean-iptables/pkg/cmd/testdata/kube-virt-interfaces.golden
@@ -1,0 +1,56 @@
+iptables -t PREROUTING -D nat -i eth1 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth2 -j ISTIO_REDIRECT
+iptables -t PREROUTING -D nat -i eth1 -j RETURN
+iptables -t PREROUTING -D nat -i eth2 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth1 -j ISTIO_REDIRECT
+ip6tables -t PREROUTING -D nat -i eth2 -j ISTIO_REDIRECT
+ip6tables -t PREROUTING -D nat -i eth1 -j RETURN
+ip6tables -t PREROUTING -D nat -i eth2 -j RETURN
+iptables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+iptables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_INBOUND
+iptables -t nat -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_INBOUND
+iptables -t mangle -X ISTIO_INBOUND
+iptables -t mangle -F ISTIO_DIVERT
+iptables -t mangle -X ISTIO_DIVERT
+iptables -t mangle -F ISTIO_TPROXY
+iptables -t mangle -X ISTIO_TPROXY
+iptables -t nat -F ISTIO_REDIRECT
+iptables -t nat -X ISTIO_REDIRECT
+iptables -t nat -F ISTIO_IN_REDIRECT
+iptables -t nat -X ISTIO_IN_REDIRECT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t mangle -D PREROUTING -p tcp -j ISTIO_INBOUND
+ip6tables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+ip6tables -t nat -F ISTIO_INBOUND
+ip6tables -t nat -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_INBOUND
+ip6tables -t mangle -X ISTIO_INBOUND
+ip6tables -t mangle -F ISTIO_DIVERT
+ip6tables -t mangle -X ISTIO_DIVERT
+ip6tables -t mangle -F ISTIO_TPROXY
+ip6tables -t mangle -X ISTIO_TPROXY
+ip6tables -t nat -F ISTIO_REDIRECT
+ip6tables -t nat -X ISTIO_REDIRECT
+ip6tables -t nat -F ISTIO_IN_REDIRECT
+ip6tables -t nat -X ISTIO_IN_REDIRECT
+ip6tables -t nat -F ISTIO_OUTPUT
+ip6tables -t nat -X ISTIO_OUTPUT
+iptables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t nat -D OUTPUT -p udp -j ISTIO_OUTPUT
+ip6tables -t raw -D OUTPUT -p udp -j ISTIO_OUTPUT
+iptables -t raw -F ISTIO_OUTPUT
+iptables -t raw -X ISTIO_OUTPUT
+iptables -t nat -F ISTIO_OUTPUT
+iptables -t nat -X ISTIO_OUTPUT
+iptables-save
+ip6tables-save

--- a/tools/istio-clean-iptables/pkg/config/config.go
+++ b/tools/istio-clean-iptables/pkg/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	OwnerGroupsExclude      string   `json:"OUTBOUND_OWNER_GROUPS_EXCLUDE"`
 	InboundInterceptionMode string   `json:"INBOUND_INTERCEPTION_MODE"`
 	InboundTProxyMark       string   `json:"INBOUND_TPROXY_MARK"`
+	OutboundIPRangesInclude string   `json:"OUTBOUND_IPRANGES_INCLUDE"`
+	KubeVirtInterfaces      string   `json:"KUBE_VIRT_INTERFACES"`
 }
 
 func (c *Config) String() string {
@@ -69,6 +71,8 @@ func (c *Config) Print() {
 	fmt.Printf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6)
 	fmt.Printf("OUTBOUND_OWNER_GROUPS_INCLUDE=%s\n", c.OwnerGroupsInclude)
 	fmt.Printf("OUTBOUND_OWNER_GROUPS_EXCLUDE=%s\n", c.OwnerGroupsExclude)
+	fmt.Printf("OUTBOUND_IP_RANGES_INCLUDE=%s\n", c.OutboundIPRangesInclude)
+	fmt.Printf("KUBE_VIRT_INTERFACES=%s\n", c.KubeVirtInterfaces)
 	fmt.Println("")
 }
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Proper backporting of https://github.com/istio/istio/pull/53484 as the automatic one failed (#53491).
The tests failed as the testdata diverged due to https://github.com/istio/istio/pull/52881 missing in 1.22 branch (as it is not required there).