### PR TITLE
Include .Values.seLinuxOptions in istio-cni-node DaemonSet

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -111,6 +111,10 @@ spec:
               # network namespaces in `/proc` to obtain descriptors for entering pod network
               # namespaces. There does not appear to be a more granular capability for this.
               - SYS_ADMIN
+{{- if .Values.seLinuxOptions }}
+            seLinuxOptions:
+{{ toYaml .Values.seLinuxOptions | trim | indent 14 }}
+{{- end }}
 {{- if .Values.seccompProfile }}
             seccompProfile:
 {{ toYaml .Values.seccompProfile | trim | indent 14 }}


### PR DESCRIPTION
**Please provide a description of this PR:**

On OpenShift, the istio-cni-node pods either need to be privileged or have `seLinuxOptions.type` set to `spc_t` in order to be able to access `/var/run/istio` on the host's filesystem. We already set the type to `spc_t` in `profile-platform-openshift.yaml` for ztunnel, so we might as well re-use the same value for cni.