### PR TITLE
manifests: fix gateway waypoint template on OpenShift

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -224,8 +224,10 @@ spec:
           timeoutSeconds: 1
         securityContext:
           privileged: false
+        {{- if not (eq .Values.platform "openshift") }}
           runAsGroup: 1337
           runAsUser: 1337
+        {{- end }}
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -224,7 +224,7 @@ spec:
           timeoutSeconds: 1
         securityContext:
           privileged: false
-        {{- if not (eq .Values.platform "openshift") }}
+        {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
           runAsGroup: 1337
           runAsUser: 1337
         {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -224,7 +224,7 @@ spec:
           timeoutSeconds: 1
         securityContext:
           privileged: false
-        {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+        {{- if not (eq .Values.platform "openshift") }}
           runAsGroup: 1337
           runAsUser: 1337
         {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -224,7 +224,7 @@ spec:
           timeoutSeconds: 1
         securityContext:
           privileged: false
-        {{- if not (eq .Values.platform "openshift") }}
+        {{- if not (eq .Values.global.platform "openshift") }}
           runAsGroup: 1337
           runAsUser: 1337
         {{- end }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1374,8 +1374,10 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
+            {{- if not (eq .Values.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
+            {{- end }}
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1374,7 +1374,7 @@ templates:
               timeoutSeconds: 1
             securityContext:
               privileged: false
-            {{- if not (eq .Values.platform "openshift") }}
+            {{- if not (eq .Values.global.platform "openshift") }}
               runAsGroup: 1337
               runAsUser: 1337
             {{- end }}


### PR DESCRIPTION
This is a follow-up to #46835 and #46898

Currently, when I follow the Istio doc[1] and create a waypoint Gateway CR on OpenShift,
the gateway pod failed to start and the event shows errors:

```
$ istioctl waypoint apply -n ambient-demo

## Error creating: pods "waypoint-64fbbfd844-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].runAsUser: Invalid value: 1337: must be in the ranges: [1000710000, 1000719999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```
Reference: [1] https://istio.io/latest/docs/ambient/usage/waypoint/

This PR fix is adding a line `platform: "openshift"` in the platform-openshift.yaml helm profile.
Then we skip the Gateway container securityContext.runAsUser and .runAsGroup default 1337 settings when openshift profile is applied.

The custom securityContext is simply the one without the `runAsUser` and `runAsGroup` lines comparing to the Gateway templates. So we don't need insert or append in the template.

Let me know if I misunderstood a comment suggestion or concern. Thanks