### PR TITLE
add option to include all services in name table

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -174,6 +174,9 @@ var (
 	MulticlusterHeadlessEnabled = env.Register("ENABLE_MULTICLUSTER_HEADLESS", true,
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 
+	IncludeAllServicesInDNS = env.Register("INCLUDE_ALL_SERVICES_IN_DNS", true,
+		"If true, include all services in the DNS response, even if they are not in the sidecar scope..").Get()
+
 	ResolveHostnameGateways = env.Register("RESOLVE_HOSTNAME_GATEWAYS", true,
 		"If true, hostnames in the LoadBalancer addresses of a Service will be resolved at the control plane for use in cross-network gateways.").Get()
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -177,7 +177,8 @@ var (
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 
 	IncludeAllServicesInDNS = atomic.NewBool(env.Register("INCLUDE_ALL_SERVICES_IN_DNS", false,
-		"If true, include all services in the DNS response, even if they are not in the sidecar scope.").Get())
+		"If true, include all services in the DNS response, even if they are not in the sidecar scope. "+
+			"In this mode it acts like a true DNS proxy like Kube DNS.").Get())
 
 	ResolveHostnameGateways = env.Register("RESOLVE_HOSTNAME_GATEWAYS", true,
 		"If true, hostnames in the LoadBalancer addresses of a Service will be resolved at the control plane for use in cross-network gateways.").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/atomic"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"
@@ -174,8 +175,8 @@ var (
 	MulticlusterHeadlessEnabled = env.Register("ENABLE_MULTICLUSTER_HEADLESS", true,
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 
-	IncludeAllServicesInDNS = env.Register("INCLUDE_ALL_SERVICES_IN_DNS", true,
-		"If true, include all services in the DNS response, even if they are not in the sidecar scope..").Get()
+	IncludeAllServicesInDNS = atomic.NewBool(env.Register("INCLUDE_ALL_SERVICES_IN_DNS", false,
+		"If true, include all services in the DNS response, even if they are not in the sidecar scope.").Get())
 
 	ResolveHostnameGateways = env.Register("RESOLVE_HOSTNAME_GATEWAYS", true,
 		"If true, hostnames in the LoadBalancer addresses of a Service will be resolved at the control plane for use in cross-network gateways.").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/env"
 	"istio.io/istio/pkg/jwt"

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -29,6 +29,6 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 		Node:                        node,
 		Push:                        push,
 		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
-		AllServices:                 features.IncludeAllServicesInDNS,
+		AllServices:                 features.IncludeAllServicesInDNS.Load(),
 	})
 }

--- a/pilot/pkg/networking/core/name_table.go
+++ b/pilot/pkg/networking/core/name_table.go
@@ -29,5 +29,6 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 		Node:                        node,
 		Push:                        push,
 		MulticlusterHeadlessEnabled: features.MulticlusterHeadlessEnabled,
+		AllServices:                 features.IncludeAllServicesInDNS,
 	})
 }

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -32,6 +32,9 @@ type Config struct {
 	// MulticlusterHeadlessEnabled if true, the DNS name table for a headless service will resolve to
 	// same-network endpoints in any cluster.
 	MulticlusterHeadlessEnabled bool
+
+	// AllServices if true, include all services in the name table, even if they are not in the sidecar scope.
+	AllServices bool
 }
 
 // BuildNameTable produces a table of hostnames and their associated IPs that can then
@@ -41,7 +44,13 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 	out := &dnsProto.NameTable{
 		Table: make(map[string]*dnsProto.NameTable_NameInfo),
 	}
-	for _, svc := range cfg.Node.SidecarScope.Services() {
+	var services []*model.Service
+	if cfg.AllServices {
+		services = cfg.Push.GetAllServices()
+	} else {
+		services = cfg.Node.SidecarScope.Services()
+	}
+	for _, svc := range services {
 		var addressList []string
 		hostName := svc.Hostname
 		headless := false


### PR DESCRIPTION
Add an option to include all services in name table. This is useful when we enable DNS proxy at Gateway to work as a "true" DNS proxy 