### PR TITLE
Fix remote profile

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -65,11 +65,7 @@
       {{- end }}
       {{- end }}
       {{- if .Values.global.remotePilotAddress }}
-      {{- if .Values.enabled }}
-      discoveryAddress: {{ printf "istiod-remote.%s.svc" .Release.Namespace }}:15012
-      {{- else }}
       discoveryAddress: {{ printf "istiod.%s.svc" .Release.Namespace }}:15012
-      {{- end }}
       {{- else }}
       discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{.Release.Namespace}}.svc:15012
       {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -49,7 +49,7 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
-{{- if .Values.global.externalIstiod }}
+{{- if .Values.istiodRemote.enabled }}
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "get", "list", "watch", "update"]

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpoints.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-endpoints.yaml
@@ -5,11 +5,7 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
-  {{- if .Values.global.externalIstiod }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
-  {{- else }}
-  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
-  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: "istiod"

--- a/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/remote-istiod-service.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.global.externalIstiod }}
   name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}
-  {{- else }}
-  name: istiod{{- if .Values.revision }}-{{ .Values.revision}}{{- end }}-remote
-  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: "istiod"

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -399,9 +399,7 @@ _internal_defaults_do_not_set:
     # If not set explicitly, default to the Istio discovery address.
     caAddress: ""
 
-    # Configure a remote cluster data plane controlled by an external istiod.
-    # When set to true, istiod is not deployed locally and only a subset of the other
-    # discovery charts are enabled.
+    # Enable control of remote clusters.
     externalIstiod: false
 
     # Configure a remote cluster as the config cluster for an external istiod.

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -381,14 +381,15 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 		g.Expect(objs.kind(gvk.CustomResourceDefinition.Kind).nameEquals("adapters.config.istio.io")).Should(BeNil())
 		g.Expect(objs.kind(gvk.CustomResourceDefinition.Kind).nameEquals("authorizationpolicies.security.istio.io")).Should(Not(BeNil()))
 
+		const istiodServiceName = "istiod"
 		g.Expect(objs.kind(gvk.ConfigMap.Kind).nameEquals("istio-sidecar-injector")).Should(Not(BeNil()))
-		g.Expect(objs.kind(gvk.Service.Kind).nameEquals("istiod-remote")).Should(Not(BeNil()))
+		g.Expect(objs.kind(gvk.Service.Kind).nameEquals(istiodServiceName)).Should(Not(BeNil()))
 		g.Expect(objs.kind(gvk.ServiceAccount.Kind).nameEquals("istio-reader-service-account")).Should(Not(BeNil()))
 
 		mwc := mustGetMutatingWebhookConfiguration(g, objs, "istio-sidecar-injector").Unstructured.Object
 		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.url", "https://xxx:15017/inject"}))
 
-		ep := mustGetEndpoint(g, objs, "istiod-remote").Unstructured.Object
+		ep := mustGetEndpoint(g, objs, istiodServiceName).Unstructured.Object
 		g.Expect(ep).Should(HavePathValueEqual(PathValue{"subsets.[0].addresses.[0]", endpointSubsetAddressVal("", "169.10.112.88", "")}))
 		g.Expect(ep).Should(HavePathValueContain(PathValue{"subsets.[0].ports.[0]", portVal("tcp-istiod", 15012, -1)}))
 

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -370,6 +370,7 @@ func runRevisionedWebhookTest(t *testing.T, testResourceFile, whSource string) {
 func TestManifestGenerateIstiodRemote(t *testing.T) {
 	g := NewWithT(t)
 
+	const istiodServiceName = "istiod"
 	objss := runManifestCommands(t, "istiod_remote", "", liveCharts, nil)
 
 	for _, objs := range objss {
@@ -381,7 +382,6 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 		g.Expect(objs.kind(gvk.CustomResourceDefinition.Kind).nameEquals("adapters.config.istio.io")).Should(BeNil())
 		g.Expect(objs.kind(gvk.CustomResourceDefinition.Kind).nameEquals("authorizationpolicies.security.istio.io")).Should(Not(BeNil()))
 
-		const istiodServiceName = "istiod"
 		g.Expect(objs.kind(gvk.ConfigMap.Kind).nameEquals("istio-sidecar-injector")).Should(Not(BeNil()))
 		g.Expect(objs.kind(gvk.Service.Kind).nameEquals(istiodServiceName)).Should(Not(BeNil()))
 		g.Expect(objs.kind(gvk.ServiceAccount.Kind).nameEquals("istio-reader-service-account")).Should(Not(BeNil()))


### PR DESCRIPTION
**Please provide a description of this PR:**

- Fix inconsistent usages of `global.externalIstiod` (this setting should only be used in the primary cluster and should not affect remote clusters at all)

- Modify the charts so that the `istiod` service is always called `istiod`, even in remote clusters. This simplifies things and prevents bugs, such as referring to the wrong service name in webhooks. 

- Modify the charts so that `.Values.istiodRemote.enabled` determines whether  `istio-reader-clusterrole` gives access to configmaps and webhooks.