### PR TITLE
Add seLinuxOptions to istio-cni/values.yaml

### DIFF
--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -83,6 +83,9 @@ _internal_defaults_do_not_set:
   # Set to `type: RuntimeDefault` to use the default profile if available.
   seccompProfile: {}
 
+  # SELinux options to set in the istio-cni-node pods. You may need to set this to `type: spc_t` for some platforms.
+  seLinuxOptions: {}
+
   resources:
     requests:
       cpu: 100m

--- a/releasenotes/notes/53566.yaml
+++ b/releasenotes/notes/53566.yaml
@@ -1,0 +1,13 @@
+apiVersion: release-notes/v2
+kind: feature
+
+area: installation
+
+issue:
+  - https://github.com/istio/istio/issues/53558
+
+releaseNotes:
+- |
+  **Added** value `seLinuxOptions` to istio-cni chart. On some platforms (e.g. OpenShift) it is necessary to set 
+  `seLinuxOptions.type` to `spc_t` in order to work around some SELinux constraints related to hostPath volumes. 
+  Without this setting, the istio-cni-nodes pods may fail to start.


### PR DESCRIPTION
**Please provide a description of this PR:**

This adds `seLinuxOptions` to istio-cni/values.yaml. This value was added to the templates in #53529.