### PR TITLE
Bring deferred_stat_options out of the cluster_manager's condition

### DIFF
--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -826,11 +826,11 @@
     "load_stats_config": {{- .load_stats_config_json_str }}
     {{- end }}
   }
+  {{- end }}
   {{ if .deferred_stats_creation }}
   ,
   "deferred_stat_options": {
     "enable_deferred_creation_stats": true
   }
-  {{- end }}
   {{ end }}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**

Earlier the deferred_stat_options were under the condition for cluster_manager. Now bringing it out of the condition.