### PR TITLE
istioctl: fix injector list prints webhooks not related to istio

### DIFF
--- a/istioctl/pkg/injector/injector-list.go
+++ b/istioctl/pkg/injector/injector-list.go
@@ -102,7 +102,9 @@ func injectorListCommand(ctx cli.Context) *cobra.Command {
 				}
 			}
 
-			hooksList, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+			hooksList, err := client.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{
+				LabelSelector: "app=sidecar-injector",
+			})
 			if err != nil {
 				return err
 			}

--- a/releasenotes/notes/53571.yaml
+++ b/releasenotes/notes/53571.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** `istioctl experimental injector list` prints webhooks not related to istio.


### PR DESCRIPTION
**Please provide a description of this PR:**

`istioctl x injector list` will print out all webhook information. In an online environment, most of them are not related to istio. Printing them out is meaningless and the display effect is not friendly.