### PR TITLE
Fix openshift and openshift-ambient profiles

### DIFF
--- a/manifests/profiles/openshift-ambient.yaml
+++ b/manifests/profiles/openshift-ambient.yaml
@@ -12,4 +12,7 @@ spec:
     - name: istio-ingressgateway
       enabled: false
   values:
-    profile: openshift-ambient
+    profile: ambient
+    global:
+      platform: openshift
+

--- a/manifests/profiles/openshift.yaml
+++ b/manifests/profiles/openshift.yaml
@@ -6,4 +6,5 @@ spec:
       enabled: true
       namespace: kube-system
   values:
-    profile: openshift
+    global:
+      platform: openshift


### PR DESCRIPTION
Fixes #53573

Istioctl install command failed when openshift or openshift-ambient profile was used:
````
$ istioctl install --set profile=openshift
Error: generate config: helm render: render chart: execution error at (base/templates/zzz_profile.yaml:31:3): unknown profile openshift

$ istioctl install --set profile=openshift-ambient
Error: generate config: helm render: render chart: execution error at (base/templates/zzz_profile.yaml:31:3): unknown profile openshift-ambient
```

