### PR TITLE
Always set type to spc_t for istio-cni if seLinux is configured

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -112,8 +112,10 @@ spec:
               # namespaces. There does not appear to be a more granular capability for this.
               - SYS_ADMIN
 {{- if .Values.seLinuxOptions }}
+{{ with (merge .Values.seLinuxOptions (dict "type" "spc_t")) }}
             seLinuxOptions:
-{{ toYaml .Values.seLinuxOptions | trim | indent 14 }}
+{{ toYaml . | trim | indent 14 }}
+{{- end }}
 {{- end }}
 {{- if .Values.seccompProfile }}
             seccompProfile:


### PR DESCRIPTION
**Please provide a description of this PR:**
Reduce some churn for seLinux users
/cc @luksa 


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions