### PR TITLE
istioctl: add support for filtering resources by istio revision to injector list

### DIFF
--- a/releasenotes/notes/53583.yaml
+++ b/releasenotes/notes/53583.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+- |
+  **Added** support for filtering resources by istio revision to `istioctl experimental injector list`.


### PR DESCRIPTION
**Please provide a description of this PR:**

Supporting filtering by revision is a common and popular feature in istioctl, which can help us quickly locate istio information of a specified revision