### PR TITLE
waypoint: enable TLS inspector if TLS service is enrolled

### DIFF
--- a/pilot/pkg/networking/core/listener_waypoint.go
+++ b/pilot/pkg/networking/core/listener_waypoint.go
@@ -262,7 +262,7 @@ func (lb *ListenerBuilder) buildWaypointInternal(wls []model.WorkloadInfo, svcs 
 				chains = append(chains, tcpChain)
 				portMapper.Map[portString] = match.ToChain(tcpChain.Name)
 				// TCP and HTTP on the same port, mark it as requiring sniffing
-				if portProtocols[port.Port] != "" && portProtocols[port.Port] != protocol.TCP {
+				if portProtocols[port.Port] != "" && !portProtocols[port.Port].IsTCP() {
 					portProtocols[port.Port] = protocol.Unsupported
 				} else {
 					portProtocols[port.Port] = port.Protocol

--- a/pilot/pkg/xds/waypoint_test.go
+++ b/pilot/pkg/xds/waypoint_test.go
@@ -154,6 +154,9 @@ metadata:
 spec:
   hosts: [app.com]
   ports:
+  - number: 443
+    name: https
+    protocol: TLS
   - number: 80
     name: http # HTTP, but will have another TCP port overlapping in another service
     protocol: HTTP
@@ -174,6 +177,9 @@ metadata:
 spec:
   hosts: [app2.com]
   ports:
+  - number: 443
+    name: https
+    protocol: TCP
   - number: 80
     name: tcp # conflicts with other HTTP port
     protocol: TCP
@@ -198,6 +204,8 @@ spec:
 	hasSniffing(81, false) // HTTP
 	hasSniffing(91, false) // TCP
 	hasSniffing(90, true)  // Unspecified
+	// This check fails for now
+	hasSniffing(443, false) // TLS and TCP on the same port - HTTP inspector not needed
 }
 
 func TestWaypoint(t *testing.T) {

--- a/pilot/pkg/xds/waypoint_test.go
+++ b/pilot/pkg/xds/waypoint_test.go
@@ -200,11 +200,10 @@ spec:
 		t.Helper()
 		assert.Equal(t, xdstest.EvaluateListenerFilterPredicates(fd, port), !expect)
 	}
-	hasSniffing(80, true)  // HTTP and TCP on same port
-	hasSniffing(81, false) // HTTP
-	hasSniffing(91, false) // TCP
-	hasSniffing(90, true)  // Unspecified
-	// This check fails for now
+	hasSniffing(80, true)   // HTTP and TCP on same port
+	hasSniffing(81, false)  // HTTP
+	hasSniffing(91, false)  // TCP
+	hasSniffing(90, true)   // Unspecified
 	hasSniffing(443, false) // TLS and TCP on the same port - HTTP inspector not needed
 }
 

--- a/releasenotes/notes/53588.yaml
+++ b/releasenotes/notes/53588.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 52752
+releaseNotes:
+  - |
+    **Added** support for `connection.sni` rule in `AuthorizationPolicy` applied to a waypoint.


### PR DESCRIPTION
This change adds support for `connection.sni` authz policy applied to a waypoint.

**Please provide a description of this PR:**

Fixes #52752.