### PR TITLE
Update Gateway API version in samples to v1

### DIFF
--- a/samples/ambient-argo/application/details-waypoint.yaml
+++ b/samples/ambient-argo/application/details-waypoint.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   labels:

--- a/samples/ambient-argo/application/ingress-gateway.yaml
+++ b/samples/ambient-argo/application/ingress-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: bookinfo-gateway
@@ -12,7 +12,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: bookinfo

--- a/samples/ambient-argo/application/reviews-waypoint.yaml
+++ b/samples/ambient-argo/application/reviews-waypoint.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   labels:

--- a/samples/ambient-argo/application/route-reviews-90-10.yaml
+++ b/samples/ambient-argo/application/route-reviews-90-10.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews

--- a/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
+++ b/samples/bookinfo/gateway-api/bookinfo-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: bookinfo-gateway
@@ -12,7 +12,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: bookinfo

--- a/samples/bookinfo/gateway-api/route-all-v1.yaml
+++ b/samples/bookinfo/gateway-api/route-all-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews
@@ -13,7 +13,7 @@ spec:
     - name: reviews-v1
       port: 9080
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: productpage
@@ -28,7 +28,7 @@ spec:
     - name: productpage-v1
       port: 9080
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ratings
@@ -43,7 +43,7 @@ spec:
     - name: ratings-v1
       port: 9080
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: details

--- a/samples/bookinfo/gateway-api/route-reviews-50-v3.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-50-v3.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews

--- a/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-90-10.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews

--- a/samples/bookinfo/gateway-api/route-reviews-v1.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews

--- a/samples/bookinfo/gateway-api/route-reviews-v3.yaml
+++ b/samples/bookinfo/gateway-api/route-reviews-v3.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: reviews

--- a/samples/helloworld/gateway-api/helloworld-gateway.yaml
+++ b/samples/helloworld/gateway-api/helloworld-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: helloworld-gateway
@@ -12,7 +12,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: helloworld

--- a/samples/helloworld/gateway-api/helloworld-route.yaml
+++ b/samples/helloworld/gateway-api/helloworld-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: helloworld

--- a/samples/httpbin/gateway-api/httpbin-gateway.yaml
+++ b/samples/httpbin/gateway-api/httpbin-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -12,7 +12,7 @@ spec:
       namespaces:
         from: All
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httpbin

--- a/samples/tcp-echo/gateway-api/tcp-echo-all-v1.yaml
+++ b/samples/tcp-echo/gateway-api/tcp-echo-all-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: tcp-echo-gateway


### PR DESCRIPTION
**Please provide a description of this PR:**

s/v1beta1/v1/ for Gateway and HTTPRoute objects.  TCPRoute remains only in the v1alpha2 group.

- [ ] Ambient
- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions