### PR TITLE
Remove references to values.pilot in helm chart

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -45,8 +45,8 @@ metadata:
     kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
     {{- end }}
     {{- end }}
-{{- if .Values.pilot.cni.enabled }}
-    {{- if eq .Values.pilot.cni.provider "multus" }}
+{{- if .Values.cni.enabled }}
+    {{- if eq .Values.cni.provider "multus" }}
     k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
     {{- end }}
     sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -70,7 +70,7 @@ spec:
       (not $nativeSidecar) }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-  {{ if .Values.pilot.cni.enabled -}}
+  {{ if .Values.cni.enabled -}}
   - name: istio-validation
   {{ else -}}
   - name: istio-init
@@ -122,7 +122,7 @@ spec:
     {{ if .Values.global.logAsJson -}}
     - "--log_as_json"
     {{ end -}}
-    {{ if .Values.pilot.cni.enabled -}}
+    {{ if .Values.cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
     {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -142,14 +142,14 @@ spec:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
       capabilities:
-    {{- if not .Values.pilot.cni.enabled }}
+    {{- if not .Values.cni.enabled }}
         add:
         - NET_ADMIN
         - NET_RAW
     {{- end }}
         drop:
         - ALL
-    {{- if not .Values.pilot.cni.enabled }}
+    {{- if not .Values.cni.enabled }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.traceSampling }}"
 {{- end }}
-# If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.pilot.env, then
+# If externalIstiod is set via Values.Global, then enable the pilot env variable. However, if it's set via Values.env, then
 # don't set it here to avoid duplication.
 # TODO (nshankar13): Move from Helm chart to code: https://github.com/istio/istio/issues/52449
 {{- if and .Values.global.externalIstiod (not (and .Values.env .Values.env.EXTERNAL_ISTIOD)) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -17116,8 +17116,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -17141,7 +17141,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -17193,7 +17193,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -17211,14 +17211,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -533,8 +533,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -558,7 +558,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -610,7 +610,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -628,14 +628,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/sidecar_template.golden.yaml
@@ -61,8 +61,8 @@ data:
             kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{- end }}
             {{- end }}
-        {{- if .Values.pilot.cni.enabled }}
-            {{- if eq .Values.pilot.cni.provider "multus" }}
+        {{- if .Values.cni.enabled }}
+            {{- if eq .Values.cni.provider "multus" }}
             k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -86,7 +86,7 @@ data:
               (not $nativeSidecar) }}
           initContainers:
           {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-          {{ if .Values.pilot.cni.enabled -}}
+          {{ if .Values.cni.enabled -}}
           - name: istio-validation
           {{ else -}}
           - name: istio-init
@@ -138,7 +138,7 @@ data:
             {{ if .Values.global.logAsJson -}}
             - "--log_as_json"
             {{ end -}}
-            {{ if .Values.pilot.cni.enabled -}}
+            {{ if .Values.cni.enabled -}}
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
@@ -156,14 +156,14 @@ data:
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               privileged: {{ .Values.global.proxy.privileged }}
               capabilities:
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
                 add:
                 - NET_ADMIN
                 - NET_RAW
             {{- end }}
                 drop:
                 - ALL
-            {{- if not .Values.pilot.cni.enabled }}
+            {{- if not .Values.cni.enabled }}
               readOnlyRootFilesystem: false
               runAsGroup: 0
               runAsNonRoot: false

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
+++ b/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-enabled-nsbydefault.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-absolute-override.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if not .Values.pilot.cni.enabled .Values.global.proxy.enableCoreDump }}
+      {{- if not .Values.cni.enabled .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
+++ b/pkg/config/analysis/analyzers/testdata/sidecar-injector-configmap-with-revision-canary.yaml
@@ -8,10 +8,10 @@ data:
       []
     template: |
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
-      {{- if or (not .Values.pilot.cni.enabled) .Values.global.proxy.enableCoreDump }}
+      {{- if or (not .Values.cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{- if not .Values.pilot.cni.enabled }}
+      {{- if not .Values.cni.enabled }}
       - name: istio-init
       {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.43.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.15.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.14.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.10.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.51.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.50.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.19.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.17.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.11.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.16.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.9.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.46.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.33.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -56,8 +56,8 @@ templates:
         kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
         {{- end }}
         {{- end }}
-    {{- if .Values.pilot.cni.enabled }}
-        {{- if eq .Values.pilot.cni.provider "multus" }}
+    {{- if .Values.cni.enabled }}
+        {{- if eq .Values.cni.provider "multus" }}
         k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
         {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
@@ -81,7 +81,7 @@ templates:
           (not $nativeSidecar) }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-      {{ if .Values.pilot.cni.enabled -}}
+      {{ if .Values.cni.enabled -}}
       - name: istio-validation
       {{ else -}}
       - name: istio-init
@@ -133,7 +133,7 @@ templates:
         {{ if .Values.global.logAsJson -}}
         - "--log_as_json"
         {{ end -}}
-        {{ if .Values.pilot.cni.enabled -}}
+        {{ if .Values.cni.enabled -}}
         - "--run-validation"
         - "--skip-rule-apply"
         {{ else if .Values.global.proxy_init.forceApplyIptables -}}
@@ -153,14 +153,14 @@ templates:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
           capabilities:
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
             add:
             - NET_ADMIN
             - NET_RAW
         {{- end }}
             drop:
             - ALL
-        {{- if not .Values.pilot.cni.enabled }}
+        {{- if not .Values.cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix remaining references to `Values.pilot.env` in istiod Helm chart, since `pilot` was removed from values.yaml. 