### PR TITLE
Add user-overridable env to `istio-cni` chart, since we have it for everything else already

### DIFF
--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -28,3 +28,8 @@ data:
   REPAIR_INIT_CONTAINER_NAME: {{ .Values.repair.initContainerName | quote }}
   REPAIR_BROKEN_POD_LABEL_KEY: {{ .Values.repair.brokenPodLabelKey | quote }}
   REPAIR_BROKEN_POD_LABEL_VALUE: {{ .Values.repair.brokenPodLabelValue | quote }}
+  {{- with .Values.env }}
+  {{- range $key, $val := . }}
+  {{ $key }}: "{{ $val }}"
+  {{- end }}
+  {{- end }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -144,3 +144,6 @@ _internal_defaults_do_not_set:
       requests:
         cpu: 100m
         memory: 100Mi
+
+  # A `key: value` mapping of environment variables to add to the pod
+  env: {}

--- a/releasenotes/notes/53624.yaml
+++ b/releasenotes/notes/53624.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+  - |
+    **Added** support for providing arbitrary environment variables to `istio-cni` chart


### PR DESCRIPTION
**Please provide a description of this PR:**

In general, this is a bad pattern that has historically contributed to Istio's config and documentation sprawl in a bad way - env vars should not be a user-facing API, and if we have one we expect people to set, it should be a flag in `values.yaml` - which is a user-facing API/contract - versus a raw/naked env var - which is not.

But we do it for all the other charts, and it is also bad to have a lack of consistency across charts.