### PR TITLE
Rewrite container lifeycle hooks for pilot to takeover

### DIFF
--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -781,6 +781,19 @@ func TestAppProbe(t *testing.T) {
 			statusCode: http.StatusOK,
 		},
 		{
+			name:      "http-prestopz-path",
+			probePath: "app-lifecycle/hello-world/prestopz",
+			config: KubeAppProbers{
+				"/app-lifecycle/hello-world/prestopz": &Prober{
+					HTTPGet: &apimirror.HTTPGetAction{
+						Path: "hello/texas",
+						Port: apimirror.IntOrString{IntVal: int32(appPort)},
+					},
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
 			name:      "http-livez-path",
 			probePath: "app-health/hello-world/livez",
 			config: KubeAppProbers{

--- a/pkg/kube/inject/app_probe_test.go
+++ b/pkg/kube/inject/app_probe_test.go
@@ -185,7 +185,7 @@ func TestDumpAppGRPCProbers(t *testing.T) {
 }`,
 		},
 		{
-			name: "gRPC startup probe with service and timeout",
+			name: "gRPC startup probe with service and timeout including a http lifecycle handler",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -199,18 +199,38 @@ func TestDumpAppGRPCProbers(t *testing.T) {
 							},
 							TimeoutSeconds: 10,
 						},
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/foo",
+									Port: intstr.IntOrString{
+										IntVal: 1234,
+									},
+									Host:   "foo",
+									Scheme: "HTTP",
+								},
+							},
+						},
 					},
 				},
 			}},
 			expected: `
 {
-    "/app-health/foo/startupz": {
-        "grpc": {
-            "port": 1234,
-            "service": "foo"
-        },
-        "timeoutSeconds": 10
+  "/app-health/foo/startupz": {
+    "grpc": {
+      "port": 1234,
+      "service": "foo"
+    },
+    "timeoutSeconds": 10
+  },
+  "/app-lifecycle/foo/prestopz": {
+    "httpGet": {
+      "path": "/foo",
+      "port": 1234,
+      "host": "foo",
+      "scheme": "HTTP"
     }
+  }
 }`,
 		},
 	} {

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -107,7 +107,7 @@ spec:
         - name: TRUST_DOMAIN
           value: cluster.local
         - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
+          value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}},"/app-lifecycle/hello/poststartz":{"tcpSocket":{"port":93}},"/app-lifecycle/hello/prestopz":{"httpGet":{"port":91}}}'
         image: gcr.io/istio-testing/proxyv2:latest
         lifecycle:
           postStart:
@@ -169,6 +169,15 @@ spec:
         - mountPath: /etc/istio/pod
           name: istio-podinfo
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /app-lifecycle/hello/poststartz
+              port: 15020
+          preStop:
+            httpGet:
+              path: /app-lifecycle/hello/prestopz
+              port: 15020
         livenessProbe:
           httpGet:
             path: /app-health/hello/livez

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml
@@ -28,6 +28,13 @@ spec:
           readinessProbe:
             httpGet:
               port: 3333
+          lifecycle:
+            preStop:
+              httpGet:
+                port: 91
+            postStart:
+              tcpSocket:
+                port: 93
         - name: world
           image: "fake.docker.io/google-samples/hello-go-gke:1.0"
           ports:

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -32,6 +32,15 @@ spec:
     spec:
       containers:
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        lifecycle:
+          postStart:
+            httpGet:
+              path: /app-lifecycle/hello/poststartz
+              port: 15020
+          preStop:
+            httpGet:
+              path: /app-lifecycle/hello/prestopz
+              port: 15020
         livenessProbe:
           httpGet:
             path: /app-health/hello/livez
@@ -136,7 +145,7 @@ spec:
         - name: TRUST_DOMAIN
           value: cluster.local
         - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
+          value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}},"/app-lifecycle/hello/poststartz":{"tcpSocket":{"port":93}},"/app-lifecycle/hello/prestopz":{"httpGet":{"port":91}}}'
         image: gcr.io/istio-testing/proxyv2:latest
         name: istio-proxy
         ports:


### PR DESCRIPTION
**Please provide a description of this PR:**

Rewrite the `postStart` and `preStop` lifecycle hooks in app containers if present when `sidecar.istio.io/rewriteAppHTTPProbers` is enabled.

Refer #30857 