### PR TITLE
Reordered healthz test case to ensure that the health status is checked first

### DIFF
--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -474,6 +474,16 @@ func TestIngressRequestAuthentication(t *testing.T) {
 					customizeCall func(opts *echo.CallOptions, to echo.Target)
 				}{
 					{
+						name: "allow healthz",
+						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
+							opts.HTTP.Path = "/healthz"
+							opts.HTTP.Headers = headers.New().
+								WithHost(fmt.Sprintf("example.%s.com", to.ServiceName())).
+								Build()
+							opts.Check = check.OK()
+						},
+					},
+					{
 						name: "deny without token",
 						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
 							opts.HTTP.Path = "/"
@@ -559,16 +569,6 @@ func TestIngressRequestAuthentication(t *testing.T) {
 							opts.Check = check.Status(http.StatusForbidden)
 						},
 					},
-					{
-						name: "allow healthz",
-						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
-							opts.HTTP.Path = "/healthz"
-							opts.HTTP.Headers = headers.New().
-								WithHost(fmt.Sprintf("example.%s.com", to.ServiceName())).
-								Build()
-							opts.Check = check.OK()
-						},
-					},
 				}
 
 				newTrafficTest(t, apps.Ns1.All.Instances()).
@@ -613,6 +613,16 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 					name          string
 					customizeCall func(opts *echo.CallOptions, to echo.Target)
 				}{
+					{
+						name: "allow healthz",
+						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
+							opts.HTTP.Path = "/healthz"
+							opts.HTTP.Headers = headers.New().
+								WithHost(fmt.Sprintf("example.%s.com", to.ServiceName())).
+								Build()
+							opts.Check = check.OK()
+						},
+					},
 					{
 						name: "deny without token",
 						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
@@ -708,16 +718,6 @@ func TestGatewayAPIRequestAuthentication(t *testing.T) {
 								WithAuthz(jwt.TokenIssuer1).
 								Build()
 							opts.Check = check.Status(http.StatusForbidden)
-						},
-					},
-					{
-						name: "allow healthz",
-						customizeCall: func(opts *echo.CallOptions, to echo.Target) {
-							opts.HTTP.Path = "/healthz"
-							opts.HTTP.Headers = headers.New().
-								WithHost(fmt.Sprintf("example.%s.com", to.ServiceName())).
-								Build()
-							opts.Check = check.OK()
 						},
 					},
 				}


### PR DESCRIPTION
**Changes:**
- Moved the `/healthz` test case to the beginning of the subtests.

**Description:**
The /healthz endpoint is typically used to check the health status of services before performing more complex tests. If the health check fails, it would indicate that something is wrong with the setup or the system is not ready for the rest of the tests, potentially saving time in finding the root cause of test failure.

By running the allow healthz check first:

- We can detect if the service is up and operational early in the test.
- This provides faster feedback during continuous integration (CI) runs, especially in environments where test time is critical.

**Justification:**

- Efficiency: Ensures that system readiness is confirmed before running complex authentication tests.
- Error Isolation: Avoids false failures in other test cases that might be caused by system health issues.
- Best Practices: Running a health check first aligns with common best practices in integration and e2e testing, where system readiness is confirmed before performing business logic validation.

- [x] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
