### PR TITLE
 Remove duplicate ambient index sync all

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -483,7 +483,7 @@ func (c *Controller) addOrUpdateService(pre, curr *v1.Service, currConv *model.S
 	prevConv := c.servicesMap[currConv.Hostname]
 	c.servicesMap[currConv.Hostname] = currConv
 	c.Unlock()
-	// This full push needed to update ALL ends endpoints, even though we do a full push on service add/update
+	// This full push needed to update all endpoints, even though we do a full push on service add/update
 	// as that full push is only triggered for the specific service.
 	if needsFullPush {
 		// networks are different, we need to update all eds endpoints

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -155,11 +155,6 @@ func (c *Controller) onNetworkChange() {
 		log.Errorf("one or more errors force-syncing endpoints: %v", err)
 	}
 	c.reloadNetworkGateways()
-	// This is to ensure the ambient workloads are updated dynamically, aligning them with the current network settings.
-	// With this, the pod do not need to restart when the network configuration changes.
-	if c.ambientIndex != nil {
-		c.ambientIndex.SyncAll()
-	}
 }
 
 // reloadMeshNetworks will read the mesh networks configuration to setup
@@ -266,7 +261,6 @@ func (c *Controller) reloadNetworkGateways() {
 	c.RUnlock()
 	if gwsChanged {
 		c.NotifyGatewayHandlers()
-		// TODO ConfigUpdate via gateway handler
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.NetworksTrigger)})
 	}
 }


### PR DESCRIPTION
**Please provide a description of this PR:**


The syncall has been registered as a gateway handler here
https://github.com/istio/istio/blob/f37a8d2481bdfa5fb4ffde695246cf122d5bba42/pilot/pkg/serviceregistry/kube/controller/controller.go#L306-L311

And it will be called in `reloadNetworkGateways`