### PR TITLE
release: use client-go from go.mod

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -67,7 +67,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: deps
   client-go:
     git: https://github.com/istio/client-go
-    branch: master
+    auto: modules
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master


### PR DESCRIPTION
This aligns with how we build in release-builder for the official builds
