### PR TITLE
[release-1.24] Downgrade go-control-plane to match Envoy 1.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/cli v27.3.1+incompatible
-	github.com/envoyproxy/go-control-plane v0.13.2-0.20241022220226-23b7e55d7f65
+	github.com/envoyproxy/go-control-plane v0.13.1-0.20241009135036-bec043f2e850
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/fatih/color v1.17.0
 	github.com/felixge/fgprof v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.13.2-0.20241022220226-23b7e55d7f65 h1:MyrjwzTD9X0BbbUDh5WT2IUkFP8adIF90TQFxDpTZ1w=
-github.com/envoyproxy/go-control-plane v0.13.2-0.20241022220226-23b7e55d7f65/go.mod h1:X45hY0mufo6Fd0KW3rqsGvQMw58jvjymeCzBU3mWyHw=
+github.com/envoyproxy/go-control-plane v0.13.1-0.20241009135036-bec043f2e850 h1:wXrFiquLgpbofJ80z0RUZxsKKIaRU1JZ6j4HSaibx4E=
+github.com/envoyproxy/go-control-plane v0.13.1-0.20241009135036-bec043f2e850/go.mod h1:X45hY0mufo6Fd0KW3rqsGvQMw58jvjymeCzBU3mWyHw=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -83,7 +83,6 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/redis/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/common/async_files/v3"
-	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/common/aws/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/common/dynamic_forward_proxy/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/common/matching/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"


### PR DESCRIPTION
From the branch, we had g-c-p from `main`. We should match it to Envoy
1.32 per the release branching steps
