### PR TITLE
Bump minimum Kubernetes version

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -28,7 +28,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion               = 26
+	MinK8SVersion               = 28
 	UnSupportedK8SVersionLogMsg = "\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is 1.%d.\n" +
 		"Proceeding with the installation, but you might experience problems. " +
 		"See https://istio.io/latest/docs/releases/supported-releases/ for a list of supported versions.\n"

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -79,6 +79,11 @@ var (
 		Minor:      "26",
 		GitVersion: "v1.26",
 	}
+	version1_28 = &version.Info{
+		Major:      "1",
+		Minor:      "28",
+		GitVersion: "v1.28",
+	}
 	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
@@ -244,6 +249,11 @@ func TestIsK8VersionSupported(t *testing.T) {
 		},
 		{
 			version: version1_26,
+			logMsg:  fmt.Sprintf(UnSupportedK8SVersionLogMsg, version1_26.GitVersion, pkgVersion.Info.Version, MinK8SVersion),
+			isValid: false,
+		},
+		{
+			version: version1_28,
 			isValid: true,
 		},
 	}


### PR DESCRIPTION
Align tooling with our documentation that is at
https://preliminary.istio.io/latest/docs/releases/supported-releases/.
