### PR TITLE
modify GRPCErrorType function return UnexpectedError in the end

### DIFF
--- a/pilot/pkg/grpc/grpc.go
+++ b/pilot/pkg/grpc/grpc.go
@@ -137,5 +137,5 @@ func GRPCErrorType(err error) ErrorType {
 		return ExpectedError
 	}
 
-	return ExpectedError
+	return UnexpectedError
 }


### PR DESCRIPTION
**Please provide a description of this PR:**
https://github.com/istio/istio/blob/7a52323d5e9228898b2b332251898c4420c3cab5/pilot/pkg/grpc/grpc.go#L119-L141
The GRPCErrorType function does not return `UnexpectedError` causing it to always be true when used.
So I modify GRPCErrorType function return UnexpectedError in the end.

#53730 