### PR TITLE
Fix httpbin version typo

### DIFF
--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -48,7 +48,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: docker.io/mccutchen/go-httpbin:v2.5.0
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:


### PR DESCRIPTION
Found this typo while manually cherry picking the original commit for 1.23 in PR https://github.com/istio/istio/pull/53732 

Original PR https://github.com/istio/istio/pull/53315