### PR TITLE
Update path template validation for AuthzPolicy

### DIFF
--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -139,7 +139,7 @@ func CheckValidPathTemplate(key string, paths []string) error {
 
 			// Validate glob is valid string literal
 			// Meets Envoy's valid pchar requirements from https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
-			if  containsPathTemplate && !IsValidLiteral(glob) {
+			if containsPathTemplate && !IsValidLiteral(glob) {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains segment %s with invalid string literal", path, key, glob)
 			}

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -143,13 +143,6 @@ func CheckValidPathTemplate(key string, paths []string) error {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains segment %s with invalid string literal", path, key, glob)
 			}
-
-			// If glob contains `*`, is not a supported path template and
-			// the path contains a supported path template, it is invalid.
-			if strings.Contains(glob, "*") && containsPathTemplate {
-				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
-					"Contains '*' beyond a supported path template", path, key)
-			}
 		}
 	}
 	return nil

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -112,8 +112,8 @@ func CheckEmptyValues(key string, values []string) error {
 
 func CheckValidPathTemplate(key string, paths []string) error {
 	for _, path := range paths {
-		foundMatchAnyTemplate := false
 		containsPathTemplate := ContainsPathTemplate(path)
+		foundMatchAnyTemplate := false
 		// Strip leading and trailing slashes if they exist
 		path = strings.Trim(path, "/")
 		globs := strings.Split(path, "/")
@@ -125,14 +125,14 @@ func CheckValidPathTemplate(key string, paths []string) error {
 			} else if glob == MatchAnyTemplate && !foundMatchAnyTemplate {
 				foundMatchAnyTemplate = true
 				continue
-			} else if (glob == MatchAnyTemplate || glob == MatchOneTemplate) && foundMatchAnyTemplate { 
+			} else if (glob == MatchAnyTemplate || glob == MatchOneTemplate) && foundMatchAnyTemplate {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"{**} is not the last operator", path, key)
 			}
 
 			// Validate glob is valid string literal
 			// Meets Envoy's valid pchar requirements from https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
-			if !validLiteral.MatchString(glob) {
+			if !IsValidLiteral(glob) && containsPathTemplate {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains segment %s with invalid string literal", path, key, glob)
 			}
@@ -142,6 +142,7 @@ func CheckValidPathTemplate(key string, paths []string) error {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains '{' or '}' beyond a supported path template", path, key)
 			}
+
 			// If glob contains `*`, is not a supported path template and
 			// the path contains a supported path template, it is invalid.
 			if strings.Contains(glob, "*") && containsPathTemplate {
@@ -151,6 +152,11 @@ func CheckValidPathTemplate(key string, paths []string) error {
 		}
 	}
 	return nil
+}
+
+// IsValidLiteral returns true if the glob is a valid string literal.
+func IsValidLiteral(glob string) bool {
+	return validLiteral.MatchString(glob)
 }
 
 // ContainsPathTemplate returns true if the path contains a valid path template.

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -139,7 +139,7 @@ func CheckValidPathTemplate(key string, paths []string) error {
 
 			// Validate glob is valid string literal
 			// Meets Envoy's valid pchar requirements from https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
-			if !IsValidLiteral(glob) && containsPathTemplate {
+			if  containsPathTemplate && !IsValidLiteral(glob) {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains segment %s with invalid string literal", path, key, glob)
 			}

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -130,17 +130,18 @@ func CheckValidPathTemplate(key string, paths []string) error {
 					"{**} is not the last operator", path, key)
 			}
 
+			// If glob is not a supported path template and contains `{`, or `}` it is invalid.
+			// Path is invalid if it contains `{` or `}` beyond a supported path template.
+			if strings.ContainsAny(glob, "{}") {
+				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
+					"Contains '{' or '}' beyond a supported path template", path, key)
+			}
+
 			// Validate glob is valid string literal
 			// Meets Envoy's valid pchar requirements from https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
 			if !IsValidLiteral(glob) && containsPathTemplate {
 				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
 					"Contains segment %s with invalid string literal", path, key, glob)
-			}
-
-			// If glob is not a supported path template and contains `{`, or `}` it is invalid.
-			if strings.ContainsAny(glob, "{}") {
-				return fmt.Errorf("invalid or unsupported path %s, found in %s. "+
-					"Contains '{' or '}' beyond a supported path template", path, key)
 			}
 
 			// If glob contains `*`, is not a supported path template and

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -231,6 +231,10 @@ func TestCheckValidPathTemplate(t *testing.T) {
 			values: []string{"/{*}/foo"},
 		},
 		{
+			name:   "valid path template - matchOneTemplate with trailing slash",
+			values: []string{"/{*}/foo/"},
+		},
+		{
 			name:   "valid path template - matchAnyTemplate",
 			values: []string{"/foo/{**}/bar"},
 		},
@@ -306,6 +310,26 @@ func TestCheckValidPathTemplate(t *testing.T) {
 		{
 			name:      "unsupported path template - matchOneTemplate with unmatched closed curly brace and `*`",
 			values:    []string{"/{*}/foo/temp}/*"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - matchAnyTemplate is not the last operator in the template",
+			values:    []string{"/{**}/foo/temp/{*}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - simple multiple matchAnyTemplates",
+			values:    []string{"/{**}/{**}"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - multiple matchAnyTemplates",
+			values:    []string{"/{**}/foo/temp/{**}/bar"},
+			wantError: true,
+		},
+		{
+			name:      "unsupported path template - invalid literal in path template",
+			values:    []string{"/{*}/foo/?abc"},
 			wantError: true,
 		},
 	}

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -341,6 +341,102 @@ func TestCheckValidPathTemplate(t *testing.T) {
 	}
 }
 
+func TestIsValidLiteral(t *testing.T) {
+	// Valid literals:
+	//   "a-zA-Z0-9-._~" - Unreserved
+	//   "%"             - pct-encoded
+	//   "!$&'()+,;"     - sub-delims excluding *=
+	//   ":@"
+	//   "="             - user included "=" allowed
+	cases := []struct {
+		name     string
+		glob     string
+		expected bool
+	}{
+		{
+			name:     "valid - alphabet chars and nums",
+			glob:     "123abcABC",
+			expected: true,
+		},
+		{
+			name:     "valid - unreserved chars",
+			glob:     "._~-",
+			expected: true,
+		},
+		{
+			name:     "valid - equals",
+			glob:     "a=c",
+			expected: true,
+		},
+		{
+			name:     "valid - mixed chars",
+			glob:     "-._~%20!$&'()+,;:@",
+			expected: true,
+		},
+		{
+			name:     "invalid - mixed chars",
+			glob:     "`~!@#$%^&()-_+;:,<.>'\"\\| ",
+			expected: false,
+		},
+		{
+			name:     "invalid - slash",
+			glob:     "abc/",
+			expected: false,
+		},
+		{
+			name:     "invalid - star with other chars",
+			glob:     "ab*c",
+			expected: false,
+		},
+		{
+			name:     "invalid - star",
+			glob:     "*",
+			expected: false,
+		},
+		{
+			name:     "invalid - double star with other chars",
+			glob:     "ab**c",
+			expected: false,
+		},
+		{
+			name:     "invalid - double star",
+			glob:     "**",
+			expected: false,
+		},
+		{
+			name:     "invalid - question mark",
+			glob:     "?abc",
+			expected: false,
+		},
+		{
+			name:     "invalid - question mark with equals",
+			glob:     "?a=c",
+			expected: false,
+		},
+		{
+			name:     "invalid - left curly brace",
+			glob:     "{abc",
+			expected: false,
+		},
+		{
+			name:     "invalid - right curly brace",
+			glob:     "abc}",
+			expected: false,
+		},
+		{
+			name:     "invalid - curly brace set",
+			glob:     "{abc}",
+			expected: false,
+		},
+	}
+	for _, c := range cases {
+		actual := security.IsValidLiteral(c.glob)
+		if c.expected != actual {
+			t.Fatalf("IsValidLiteral(%s): expected (%v), got (%v)", c.name, c.expected, actual)
+		}
+	}
+}
+
 func TestContainsPathTemplate(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tests/integration/security/authz_test.go
+++ b/tests/integration/security/authz_test.go
@@ -1055,6 +1055,14 @@ func TestAuthz_PathTemplating(t *testing.T) {
 							path:  "/store/cart",
 							allow: false,
 						},
+						{
+							path:  "/store/foo/cart",
+							allow: true,
+						},
+						{
+							path:  "/store/foo/bar/cart",
+							allow: true,
+						},
 					}
 
 					for _, c := range cases {


### PR DESCRIPTION
**Please provide a description of this PR:**

- Verifies each segment is a valid string literal
- Ensures `{**}` is the last operator in the template
- Aligns pre validation with Envoy's validation for path template