### PR TITLE
fix integration-test TestBadWasmRemoteLoad for default deny-all policy

### DIFF
--- a/tests/integration/telemetry/api/stats_test.go
+++ b/tests/integration/telemetry/api/stats_test.go
@@ -313,7 +313,7 @@ func SendTrafficOrFailExpectForbidden(t test.Failer, from echo.Instance) {
 		Retry: echo.Retry{
 			NoRetry: true,
 		},
-		Check: check.Forbidden(protocol.HTTP),
+		Check: check.OK(),
 	})
 }
 

--- a/tests/integration/telemetry/api/stats_test.go
+++ b/tests/integration/telemetry/api/stats_test.go
@@ -303,6 +303,12 @@ func SendTrafficOrFailExpectForbidden(t test.Failer, from echo.Instance) {
 		Port: echo.Port{
 			Name: "http",
 		},
+		Retry: echo.Retry{
+			Options: []retry.Option{
+				retry.Delay(framework.TelemetryRetryDelay),
+				retry.MaxAttempts(10),
+			},
+		},
 		Check: check.Forbidden(protocol.HTTP),
 	})
 	from.CallOrFail(t, echo.CallOptions{
@@ -311,9 +317,12 @@ func SendTrafficOrFailExpectForbidden(t test.Failer, from echo.Instance) {
 			Name: "http",
 		},
 		Retry: echo.Retry{
-			NoRetry: true,
+			Options: []retry.Option{
+				retry.Delay(framework.TelemetryRetryDelay),
+				retry.MaxAttempts(10),
+			},
 		},
-		Check: check.OK(),
+		Check: check.Forbidden(protocol.HTTP),
 	})
 }
 

--- a/tests/integration/telemetry/api/wasmplugin_test.go
+++ b/tests/integration/telemetry/api/wasmplugin_test.go
@@ -408,9 +408,9 @@ func badWasmTestHelper(t framework.TestContext, filterConfigPath string, restart
 
 	if forbiddenAfterConfig {
 		SendTrafficOrFailExpectForbidden(t, to)
-		t.Log("echo server will return 403 after bad wasm filter is applied.")
+		t.Log("echo server returns 403 after bad wasm(FAIL_CLOSE) filter is applied.")
 	} else {
 		SendTrafficOrFail(t, to)
-		t.Log("echo server still returns ok after bad wasm filter is applied.")
+		t.Log("echo server still returns ok after bad wasm(FAIL_OPEN) filter is applied.")
 	}
 }

--- a/tests/integration/telemetry/api/wasmplugin_test.go
+++ b/tests/integration/telemetry/api/wasmplugin_test.go
@@ -408,9 +408,9 @@ func badWasmTestHelper(t framework.TestContext, filterConfigPath string, restart
 
 	if forbiddenAfterConfig {
 		SendTrafficOrFailExpectForbidden(t, to)
+		t.Log("echo server will return 403 after bad wasm filter is applied.")
 	} else {
 		SendTrafficOrFail(t, to)
+		t.Log("echo server still returns ok after bad wasm filter is applied.")
 	}
-
-	t.Log("echo server still returns ok after bad wasm filter is applied.")
 }


### PR DESCRIPTION
fix integration-test TestBadWasmRemoteLoad for default deny-all policy when wasmplugin  FAIL_CLOSE

**Please provide a description of this PR:**
#53363 broke TestBadWasmRemoteLoad and this PR is a fix for it.