### PR TITLE
cleanup deprecated function wait.PollImmediateUntil

### DIFF
--- a/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/k8sleaderelection/leaderelection.go
@@ -289,9 +289,10 @@ func (le *LeaderElector) renew(ctx context.Context) {
 	wait.Until(func() {
 		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, le.config.RenewDeadline)
 		defer timeoutCancel()
-		err := wait.PollImmediateUntil(le.config.RetryPeriod, func() (bool, error) {
-			return le.tryAcquireOrRenew(timeoutCtx), nil
-		}, timeoutCtx.Done())
+
+		err := wait.PollUntilContextCancel(timeoutCtx, le.config.RetryPeriod, true, func(ctx context.Context) (bool, error) {
+			return le.tryAcquireOrRenew(ctx), nil
+		})
 
 		le.maybeReportTransition()
 		desc := le.config.Lock.Describe()


### PR DESCRIPTION
**Please provide a description of this PR:**

The `wait.PollImmediateUntil` has been deprecated:

```
// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
// Note that the new method will no longer return ErrWaitTimeout and instead return errors
// defined by the context package. Will be removed in a future release.
func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
	return PollImmediateUntilWithContext(ContextForChannel(stopCh), interval, condition.WithContext())
}
```