### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/istioctl/pkg/writer/table/writer.go
+++ b/istioctl/pkg/writer/table/writer.go
@@ -109,13 +109,6 @@ func (c *ColoredTableWriter) Flush() {
 	}
 }
 
-func max(x, y int) int {
-	if x < y {
-		return y
-	}
-	return x
-}
-
 func getMaxWidths(output [][]Cell) []int {
 	widths := make([]int, len(output[0]))
 	for _, row := range output {

--- a/pilot/pkg/networking/core/httproute.go
+++ b/pilot/pkg/networking/core/httproute.go
@@ -775,13 +775,6 @@ func mergeAllVirtualHosts(vHostPortMap map[int][]*route.VirtualHost) []*route.Vi
 	return virtualHosts
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // getUniqueAndSharedDNSDomain computes the unique and shared DNS suffix from a FQDN service name and
 // the proxy's local domain with namespace. This is especially useful in Kubernetes environments, where
 // a two services can have same name in different namespaces (e.g., foo.ns1.svc.cluster.local,


### PR DESCRIPTION
**Please provide a description of this PR:**

We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max