### PR TITLE
Fix bug where invalid redirect codes in VirtualService caused proto marshal errors

### DIFF
--- a/pilot/pkg/networking/core/route/route.go
+++ b/pilot/pkg/networking/core/route/route.go
@@ -790,7 +790,12 @@ func ApplyRedirect(out *route.Route, redirect *networking.HTTPRedirect, port int
 		action.Redirect.ResponseCode = route.RedirectAction_PERMANENT_REDIRECT
 	default:
 		log.Warnf("Redirect Code %d is not yet supported", redirect.RedirectCode)
-		action = nil
+		// Can't just set action to nil here because the proto marshaller will still see
+		// the Route_Redirect type of the variable and assume that the value is set
+		// (and panic because it's not). What we need to do is set out.Action directly to
+		// (a typeless) nil so that type assertions to Route_Redirect will fail.
+		out.Action = nil
+		return
 	}
 
 	out.Action = action

--- a/pilot/pkg/networking/core/route/route_test.go
+++ b/pilot/pkg/networking/core/route/route_test.go
@@ -933,6 +933,19 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(redirectAction.Redirect.ResponseCode).To(Equal(envoyroute.RedirectAction_PERMANENT_REDIRECT))
 	})
 
+	t.Run("for invalid redirect code", func(t *testing.T) {
+		g := NewWithT(t)
+		cg := core.NewConfigGenTest(t, core.TestOptions{})
+
+		routes, err := route.BuildHTTPRoutesForVirtualService(node(cg), virtualServiceWithInvalidRedirect, serviceRegistry,
+			nil, 8080, gatewayNames, route.RouteOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(len(routes)).To(Equal(1))
+
+		_, ok := routes[0].Action.(*envoyroute.Route_Redirect)
+		g.Expect(ok).To(BeFalse())
+	})
+
 	t.Run("for path prefix redirect", func(t *testing.T) {
 		g := NewWithT(t)
 		cg := core.NewConfigGenTest(t, core.TestOptions{})
@@ -1856,6 +1869,26 @@ var virtualServiceWithRedirect = config.Config{
 					Uri:          "example.org",
 					Authority:    "some-authority.default.svc.cluster.local",
 					RedirectCode: 308,
+				},
+			},
+		},
+	},
+}
+
+var virtualServiceWithInvalidRedirect = config.Config{
+	Meta: config.Meta{
+		GroupVersionKind: gvk.VirtualService,
+		Name:             "acme",
+	},
+	Spec: &networking.VirtualService{
+		Hosts:    []string{},
+		Gateways: []string{"some-gateway"},
+		Http: []*networking.HTTPRoute{
+			{
+				Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 317,
 				},
 			},
 		},


### PR DESCRIPTION
**Please provide a description of this PR:**
If you set an invalid redirect code in a `VirtualService`, istiod will crash due to the weird Go quirk that [nil is not always nil
](https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/). Added a comment and a test to prevent regressions