### PR TITLE
Use the zone from the metadata for creating locality

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -271,10 +271,11 @@ func (e *gcpEnv) getPodZone() (string, error) {
 	if z != "" {
 		return z, nil
 	}
-	ctx, cfn := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cfn := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cfn()
 	z, err := zoneFn(ctx)
 	if err != nil {
+		log.Warnf("Error fetching GCP zone from the metadata server: %v", err)
 		return "", err
 	}
 	e.cachedZone.Store(z)
@@ -297,7 +298,7 @@ func (e *gcpEnv) Locality() *core.Locality {
 	if err != nil {
 		loc := e.Metadata()[GCPLocation]
 		if loc == "" {
-			log.Warnf("Error fetching GCP zone: %v", loc)
+			log.Warnf("Error fetching GCP zone from the GCP location: %s", loc)
 			return &l
 		}
 		z = zoneFromClusterLocation(loc)

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -88,6 +88,7 @@ var (
 	numericProjectIDFn = metadata.NumericProjectID
 	instanceNameFn     = metadata.InstanceName
 	instanceIDFn       = metadata.InstanceID
+	zoneFn             = metadata.ZoneWithContext
 
 	clusterNameFn = func() (string, error) {
 		cn, err := metadata.InstanceAttributeValue("cluster-name")
@@ -272,7 +273,7 @@ func (e *gcpEnv) getPodZone() (string, error) {
 	}
 	ctx, cfn := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cfn()
-	z, err := metadata.ZoneWithContext(ctx)
+	z, err := zoneFn(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -49,12 +49,14 @@ const (
 	GCEInstanceTemplate  = "gcp_gce_instance_template"
 	GCEInstanceCreatedBy = "gcp_gce_instance_created_by"
 	GCPQuotaProject      = "gcp_quota_project"
+	GCPZone              = "gcp_zone"
 )
 
 // GCPStaticMetadata holds the statically defined GCP metadata
 var GCPStaticMetadata = func() map[string]string {
 	gcpm := env.Register("GCP_METADATA", "", "Pipe separated GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE").Get()
 	quota := env.Register("GCP_QUOTA_PROJECT", "", "Allows specification of a quota project to be used in requests to GCP APIs.").Get()
+	zone := env.Register("GCP_ZONE", "", "GCP Zone where the workload is running on.").Get()
 	if len(gcpm) == 0 {
 		return map[string]string{}
 	}
@@ -73,6 +75,10 @@ var GCPStaticMetadata = func() map[string]string {
 
 	if clusterURL, err := constructGKEClusterURL(md); err == nil {
 		md[GCPClusterURL] = clusterURL
+	}
+
+	if zone != "" {
+		md[GCPZone] = zone
 	}
 	return md
 }()
@@ -171,7 +177,7 @@ func NewGCP() Environment {
 		fillMetadata: lazy.New(func() (bool, error) {
 			return shouldFillMetadata(), nil
 		}),
-		cachedZone: atomic.NewString(GCPStaticMetadata[os.Getenv("GCP_ZONE")]),
+		cachedZone: atomic.NewString(GCPStaticMetadata[GCPZone]),
 	}
 }
 

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -371,6 +372,7 @@ func TestLocality(t *testing.T) {
 		instanceIDFn        metadataFn
 		instanceTemplateFn  metadataFn
 		instanceCreatedByFn metadataFn
+		zoneFn              func(context.Context) (string, error)
 		env                 map[string]string
 		want                map[string]string
 	}{
@@ -385,6 +387,7 @@ func TestLocality(t *testing.T) {
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "", errors.New("error") },
 			map[string]string{
 				GCPProject:       "env_pid",
 				GCPProjectNumber: "env_pn",
@@ -404,6 +407,7 @@ func TestLocality(t *testing.T) {
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "", errors.New("error") },
 			map[string]string{},
 			map[string]string{"Zone": "us-west1-ir", "Region": "us-west1"},
 		},
@@ -418,6 +422,7 @@ func TestLocality(t *testing.T) {
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "", errors.New("error") },
 			map[string]string{},
 			map[string]string{},
 		},
@@ -432,16 +437,57 @@ func TestLocality(t *testing.T) {
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "", errors.New("error") },
 			map[string]string{},
 			map[string]string{},
+		},
+		{
+			"fill by metadata server",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "us-central1-ir", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "us-east1-ir", nil },
+			map[string]string{
+				GCPProject:       "env_pid",
+				GCPProjectNumber: "env_pn",
+				GCPCluster:       "env_cluster",
+				GCPLocation:      "us-west1-ir",
+			},
+			map[string]string{"Zone": "us-east1-ir", "Region": "us-east1"},
+		},
+		{
+			"fallback to unknown zone suffix",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "us-central1", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
+			func(context.Context) (string, error) { return "", errors.New("error") },
+			map[string]string{
+				GCPProject:       "env_pid",
+				GCPProjectNumber: "env_pn",
+				GCPCluster:       "env_cluster",
+				GCPLocation:      "us-west1",
+			},
+			map[string]string{"Zone": "us-west1-unknown", "Region": "us-west1"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			test.SetForTest(t, &GCPStaticMetadata, tt.env)
 			shouldFillMetadata, projectIDFn, numericProjectIDFn, clusterLocationFn, clusterNameFn,
-				instanceNameFn, instanceIDFn, instanceTemplateFn, createdByFn = tt.shouldFill, tt.projectIDFn,
-				tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn, tt.instanceTemplateFn, tt.instanceCreatedByFn
+				instanceNameFn, instanceIDFn, instanceTemplateFn, createdByFn, zoneFn = tt.shouldFill, tt.projectIDFn,
+				tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn, tt.instanceTemplateFn, tt.instanceCreatedByFn, tt.zoneFn
 
 			e := NewGCP()
 			got := e.Locality()

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -362,133 +362,44 @@ func TestDefaultPort(t *testing.T) {
 
 func TestLocality(t *testing.T) {
 	tests := []struct {
-		name                string
-		shouldFill          shouldFillFn
-		projectIDFn         metadataFn
-		numericProjectIDFn  metadataFn
-		locationFn          metadataFn
-		clusterNameFn       metadataFn
-		instanceNameFn      metadataFn
-		instanceIDFn        metadataFn
-		instanceTemplateFn  metadataFn
-		instanceCreatedByFn metadataFn
-		zoneFn              func(context.Context) (string, error)
-		env                 map[string]string
-		want                map[string]string
+		name   string
+		zoneFn func(context.Context) (string, error)
+		env    map[string]string
+		want   map[string]string
 	}{
 		{
 			"fill by env variable",
-			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
-			func(context.Context) (string, error) { return "", errors.New("error") },
+			func(context.Context) (string, error) { return "us-east1-ir", nil },
 			map[string]string{
-				GCPProject:       "env_pid",
-				GCPProjectNumber: "env_pn",
-				GCPCluster:       "env_cluster",
-				GCPLocation:      "us-west1-ir",
+				GCPZone: "us-central2-ir",
 			},
-			map[string]string{"Zone": "us-west1-ir", "Region": "us-west1"},
-		},
-		{
-			"no env variable",
-			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "us-west1-ir", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
-			func(context.Context) (string, error) { return "", errors.New("error") },
-			map[string]string{},
-			map[string]string{"Zone": "us-west1-ir", "Region": "us-west1"},
-		},
-		{
-			"empty result",
-			func() bool { return false },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "us-west1-ir", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
-			func(context.Context) (string, error) { return "", errors.New("error") },
-			map[string]string{},
-			map[string]string{},
-		},
-		{
-			"unable to reach compute metadata",
-			func() bool { return true },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
-			func(context.Context) (string, error) { return "", errors.New("error") },
-			map[string]string{},
-			map[string]string{},
+			map[string]string{"Zone": "us-central2-ir", "Region": "us-central2"},
 		},
 		{
 			"fill by metadata server",
-			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "us-central1-ir", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
 			func(context.Context) (string, error) { return "us-east1-ir", nil },
-			map[string]string{
-				GCPProject:       "env_pid",
-				GCPProjectNumber: "env_pn",
-				GCPCluster:       "env_cluster",
-				GCPLocation:      "us-west1-ir",
-			},
+			map[string]string{},
 			map[string]string{"Zone": "us-east1-ir", "Region": "us-east1"},
 		},
 		{
-			"fallback to unknown zone suffix",
-			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "us-central1", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			"fill by env variable without compute metadata",
 			func(context.Context) (string, error) { return "", errors.New("error") },
 			map[string]string{
-				GCPProject:       "env_pid",
-				GCPProjectNumber: "env_pn",
-				GCPCluster:       "env_cluster",
-				GCPLocation:      "us-west1",
+				GCPZone: "us-central2-ir",
 			},
-			map[string]string{"Zone": "us-west1-unknown", "Region": "us-west1"},
+			map[string]string{"Zone": "us-central2-ir", "Region": "us-central2"},
+		},
+		{
+			"no env variable and unable to reach compute metadata",
+			func(context.Context) (string, error) { return "", errors.New("error") },
+			map[string]string{},
+			map[string]string{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			test.SetForTest(t, &GCPStaticMetadata, tt.env)
-			shouldFillMetadata, projectIDFn, numericProjectIDFn, clusterLocationFn, clusterNameFn,
-				instanceNameFn, instanceIDFn, instanceTemplateFn, createdByFn, zoneFn = tt.shouldFill, tt.projectIDFn,
-				tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn, tt.instanceTemplateFn, tt.instanceCreatedByFn, tt.zoneFn
-
+			zoneFn = tt.zoneFn
 			e := NewGCP()
 			got := e.Locality()
 			assert.Equal(t, got.Zone, tt.want["Zone"])

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -450,3 +450,42 @@ func TestLocality(t *testing.T) {
 		})
 	}
 }
+
+func TestZoneToRegion(t *testing.T) {
+	tests := []struct {
+		zone       string
+		wantRegion string
+		wantErr    bool
+	}{
+		{
+			zone:       "us-central1-f",
+			wantRegion: "us-central1",
+		},
+		{
+			zone:    "us-central1",
+			wantErr: true,
+		},
+		{
+			zone:    "abcd",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.zone, func(t *testing.T) {
+			got, err := zoneToRegion(tc.zone)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error was not raised")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error was raised")
+				}
+				if got != tc.wantRegion {
+					t.Errorf("unexpected region was returned. (got: %v, want: %v)", got, tc.wantRegion)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current implementation is assuming that the cluster location is "zone" when creating Locality for GCP platform. 
However, for the GKE regional cluster, it is not true.

Therefore, this PR proposes to use "metadata" server to get the zone, if the cluster location is not zonal.

Change-Id: I27f1b699f7ea464eb43993eb7870ee15f7ffc8ad
