### PR TITLE
pilot: enable new ConnectionPoolPerDownstreamConnection feature in Envoy

### DIFF
--- a/pilot/pkg/features/experimental.go
+++ b/pilot/pkg/features/experimental.go
@@ -25,6 +25,10 @@ import (
 
 // Define experimental features here.
 var (
+	EnablePassthroughConnections = env.Register("PILOT_ENABLE_PASSTHROUGH_CONNECTIONS", true,
+		"If enabled, HTTP pooling will be disabled on the passthrough cluster. This means each downstream connection will result in one upstream connection. " +
+		"Without this, there may only be a small number of upstream connections, limiting load balancing.").Get()
+
 	// FilterGatewayClusterConfig controls if a subset of clusters(only those required) should be pushed to gateways
 	FilterGatewayClusterConfig = env.Register("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false,
 		"If enabled, Pilot will send only clusters that referenced in gateway virtual services attached to gateway").Get()

--- a/pilot/pkg/networking/core/cluster_builder.go
+++ b/pilot/pkg/networking/core/cluster_builder.go
@@ -495,6 +495,7 @@ func (cb *ClusterBuilder) buildInboundPassthroughCluster() *cluster.Cluster {
 		})
 	}
 	c := cb.buildDefaultPassthroughCluster()
+	c.ConnectionPoolPerDownstreamConnection = false
 	c.Name = util.InboundPassthroughCluster
 	c.Filters = nil
 	c.UpstreamBindConfig = &core.BindConfig{
@@ -531,6 +532,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			v3.HttpProtocolOptionsType: passthroughHttpProtocolOptions,
 		},
+		ConnectionPoolPerDownstreamConnection: features.EnablePassthroughConnections,
 	}
 	cluster.AltStatName = util.DelimitedStatsPrefix(util.PassthroughCluster)
 	cb.applyConnectionPool(cb.req.Push.Mesh, newClusterWrapper(cluster), &networking.ConnectionPoolSettings{})


### PR DESCRIPTION
I will make a compatibility profile, release notes, etc if we have consensus on this

With this (test workload is out of sidecar scope, so using passthrough):
```
for i in {0..100}; do curl -s echo.other | grep Hostname=; done | sort | uniq -c
     21 Hostname=echo-79dcbf57cc-7wcpc
     28 Hostname=echo-79dcbf57cc-k7h2z
     21 Hostname=echo-79dcbf57cc-pfjbg
     16 Hostname=echo-79dcbf57cc-tmmlw
     15 Hostname=echo-79dcbf57cc-xj22w
```

Without:

```
$for i in {0..100}; do curl -s echo.other | grep Hostname=; done | sort | uniq -c
     53 Hostname=echo-79dcbf57cc-7wcpc
     48 Hostname=echo-79dcbf57cc-tmmlw
```

Fixes https://github.com/istio/istio/issues/46959.
See https://github.com/envoyproxy/envoy/issues/19458 for more info on motivations as well (beyond the 'only hit 2 backends' part).
