### PR TITLE
Fix bug(#53828) where CSR organization is set to an empty string

### DIFF
--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -85,10 +85,11 @@ func GenCSR(options CertOptions) ([]byte, []byte, error) {
 
 // GenCSRTemplate generates a certificateRequest template with the given options.
 func GenCSRTemplate(options CertOptions) (*x509.CertificateRequest, error) {
-	template := &x509.CertificateRequest{
-		Subject: pkix.Name{
+	template := &x509.CertificateRequest{}
+	if options.Org != "" {
+		template.Subject = pkix.Name{
 			Organization: []string{options.Org},
-		},
+		}
 	}
 
 	if h := options.Host; len(h) > 0 {

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -45,6 +45,12 @@ func TestGenCSR(t *testing.T) {
 				ECSigAlg: EcdsaSigAlg,
 			},
 		},
+		"GenCSR without org": {
+			csrOptions: CertOptions{
+				Host:     "test_ca.com",
+				ECSigAlg: EcdsaSigAlg,
+			},
+		},
 		"GenCSR with EC errors due to invalid signature algorithm": {
 			csrOptions: CertOptions{
 				Host:     "test_ca.com",
@@ -79,8 +85,16 @@ func TestGenCSR(t *testing.T) {
 		if err = csr.CheckSignature(); err != nil {
 			t.Errorf("%s: csr signature is invalid", id)
 		}
-		if csr.Subject.Organization[0] != "MyOrg" {
-			t.Errorf("%s: csr subject does not match", id)
+		if tc.csrOptions.Org != "" {
+			if len(csr.Subject.Organization) != 1 {
+				t.Errorf("%s: csr subject does not contain exactly one organization", id)
+			}
+
+			if csr.Subject.Organization[0] != "MyOrg" {
+				t.Errorf("%s: csr subject does not match", id)
+			}
+		} else if csr.Subject.Organization != nil {
+			t.Errorf("%s: csr subject organization should be unset", id)
 		}
 		if !strings.HasSuffix(string(csr.Extensions[0].Value), "test_ca.com") {
 			t.Errorf("%s: csr host does not match", id)


### PR DESCRIPTION
**Please provide a description of this PR:**

This fixes the bug described in https://github.com/istio/istio/issues/53828 where the subject Organization field in CSRs is set even when the configured value is unset (`""`).

>[!WARNING]
> THIS IS A BREAKING CHANGE

While this seems like an minor bug fix, this is arguably a breaking change for anybody using Istio, or using a library that calls this function (such as istio-csr). Currently, to work around this issue, users that are both using cert-manager for certificate signing and a certificate approver (such as `cert-manager-approver-policy`) must write polies that either allow or require this field to be empty. For an example of such a policy, see [here](https://github.com/solidDoWant/infra-mk3/blob/81105f23edac9f065ecfd4582cd829b3a51f372e/cluster/gitops/istio-system/istio/ingressgateway/certificate-request-policy.yaml#L22) and [here](https://github.com/solidDoWant/infra-mk3/blob/81105f23edac9f065ecfd4582cd829b3a51f372e/cluster/gitops/istio-system/istio/istio-csr/certificate-request-policies.yaml#L63).

If this is merged, it could break Istio (and other) deployments for customers that are currently working around the bug as specified above.