### PR TITLE
Istio CNI in hostnet should have corresponding dnsPolicy

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -46,7 +46,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-      {{if .Values.ambient.enabled }}hostNetwork: true{{ end }}
+{{if .Values.ambient.enabled }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+{{ end }}
       nodeSelector:
         kubernetes.io/os: linux
       # Can be configured to allow for excluding istio-cni from being scheduled on specified nodes

--- a/releasenotes/notes/53861.yaml
+++ b/releasenotes/notes/53861.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes:
+  - |
+    **Added** a pod `dnsPolicy` of ClusterFirstWithHostNet to `istio-cni` when it runs with `hostNetwork=true` (i.e. ambient mode).


### PR DESCRIPTION
**Please provide a description of this PR:**

In Ambient mode, `istio-cni` runs with `hostNetwork: true` [and as per K8S recs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy), it is recommended to use a `dnsPolicy` of `ClusterFirstWithHostNet` in that case.

This can fix some issues with (for instance) Cilium running with its kube-proxy replacement and being unable to resolve stuff.