### PR TITLE
Explicitly specifiying ipset revision seems to fix some ipset creation/insertion corner cases

### DIFF
--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -42,8 +42,9 @@ func (m *realDeps) ipsetIPHashCreate(name string, v6 bool) error {
 
 	// Note: `vishvananda/netlink` seems to have a bug where it defaults to revision=1 for `hash:ip,port` but defaults to revision=0 for `hash:ip`
 	// This causes breakages in some cases with Docker-based nodes: https://github.com/istio/istio/issues/53512
-	// Setting `Revision=1` here seems to work correctly in all cases found thus far
-	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Revision: 1, Family: family})
+	// Setting `Revision=2` here seems to work correctly in all cases found thus far.
+	// Source: https://github.com/Olipro/ipset/blob/9f145b49100104d6570fe5c31a5236816ebb4f8f/kernel/net/netfilter/ipset/ip_set_hash_ip.c#L28
+	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Revision: 2, Family: family})
 	// Note there appears to be a bug in vishvananda/netlink here:
 	// https://github.com/vishvananda/netlink/issues/992
 	//

--- a/cni/pkg/ipset/nldeps_linux.go
+++ b/cni/pkg/ipset/nldeps_linux.go
@@ -39,7 +39,11 @@ func (m *realDeps) ipsetIPHashCreate(name string, v6 bool) error {
 	} else {
 		family = unix.AF_INET
 	}
-	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Family: family})
+
+	// Note: `vishvananda/netlink` seems to have a bug where it defaults to revision=1 for `hash:ip,port` but defaults to revision=0 for `hash:ip`
+	// This causes breakages in some cases with Docker-based nodes: https://github.com/istio/istio/issues/53512
+	// Setting `Revision=1` here seems to work correctly in all cases found thus far
+	err := netlink.IpsetCreate(name, "hash:ip", netlink.IpsetCreateOptions{Comments: true, Replace: true, Revision: 1, Family: family})
 	// Note there appears to be a bug in vishvananda/netlink here:
 	// https://github.com/vishvananda/netlink/issues/992
 	//

--- a/releasenotes/notes/53862.yaml
+++ b/releasenotes/notes/53862.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - https://github.com/istio/istio/issues/53512
+releaseNotes:
+  - |
+    **Fixed** an issue where ipset entry creation would fail on certain kinds of Docker-based kubernetes nodes


### PR DESCRIPTION
**Please provide a description of this PR:**

[`vishvananda/netlink` _seems to_ have a bug where it defaults to revision=1 for `hash:ip,port` ](https://github.com/vishvananda/netlink/blob/main/ipset_linux.go#L398) but defaults to revision=0 for `hash:ip` (what we use).

This causes breakages in some cases with Docker-based nodes: https://github.com/istio/istio/issues/53512

Explicitly setting `Revision=1` during ipset creation seems to work correctly in all cases found thus far.

I really am not clear on what `revision` _does_ so this is a bit sketch, but it seems to work more reliably, including in spots where before we got errors about `comment` validation (older images).