### PR TITLE
Add ports on deployment

### DIFF
--- a/manifests/charts/gateway/templates/deployment.yaml
+++ b/manifests/charts/gateway/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             value: {{ $val | quote }}
           {{- end }}
           ports:
+          {{- range $key, $val := .Values.service.ports }}
+          - containerPort: {{ $val.targetPort | default $val.port }}
+            protocol: {{ $val.protocol | default "TCP" }}
+          {{- end }}
           - containerPort: 15090
             protocol: TCP
             name: http-envoy-prom


### PR DESCRIPTION
**Add ports on deployments:**

Service ports are added on gateway deployment resource, to preserve ports as it did in the old Helm charts.