### PR TITLE
[fix]: do not h2upgrade when useClientProtocol is set in DR

### DIFF
--- a/pilot/pkg/networking/core/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/cluster_builder_test.go
@@ -2472,6 +2472,18 @@ func TestShouldH2Upgrade(t *testing.T) {
 			upgrade: false,
 		},
 		{
+			name:        "mesh upgrade - dr useClientProtocol",
+			clusterName: "bar",
+			port:        &model.Port{Protocol: protocol.HTTP},
+			mesh:        &meshconfig.MeshConfig{H2UpgradePolicy: meshconfig.MeshConfig_UPGRADE},
+			connectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					UseClientProtocol: true,
+				},
+			},
+			upgrade: false,
+		},
+		{
 			name:        "non-http",
 			clusterName: "bar",
 			port:        &model.Port{Protocol: protocol.Unsupported},

--- a/pilot/pkg/networking/core/cluster_traffic_policy.go
+++ b/pilot/pkg/networking/core/cluster_traffic_policy.go
@@ -197,6 +197,12 @@ func shouldH2Upgrade(clusterName string, port *model.Port, mesh *meshconfig.Mesh
 	// Upgrade if tls.GetMode() == networking.TLSSettings_ISTIO_MUTUAL
 	if connectionPool != nil && connectionPool.Http != nil {
 		override := connectionPool.Http.H2UpgradePolicy
+		// If useClientProtocol is set, do not upgrade
+		if connectionPool.Http.UseClientProtocol {
+			log.Debugf("Not upgrading cluster because useClientProtocol is set: %v (%v %v)",
+				clusterName, mesh.H2UpgradePolicy, override)
+			return false
+		}
 		// If user wants an upgrade at destination rule/port level that means he is sure that
 		// it is a Http port - upgrade in such case. This is useful incase protocol sniffing is
 		// enabled and user wants to upgrade/preserve http protocol from client.


### PR DESCRIPTION
**Please provide a description of this PR:**

If the meshConfig has h2Upgrade set and DR has useClientProtocol, the h2Upgrade is done. This is not according to the [Istio Docs](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings), which says `when useClientProtocol is set set to true,
 h2_upgrade_policy will be ineffective i.e. the client connections will not be upgraded to http2.`

This PR corrects this behavior.