### PR TITLE
feat(istioctl): add support for custom authz

### DIFF
--- a/istioctl/pkg/authz/authz_test.go
+++ b/istioctl/pkg/authz/authz_test.go
@@ -35,6 +35,7 @@ func TestAuthz(t *testing.T) {
 			ExpectedOutput: `ACTION   AuthorizationPolicy         RULES
 ALLOW    _anonymous_match_nothing_   1
 ALLOW    httpbin.default             1
+CUSTOM   ext-authz.default           1
 `,
 		},
 	}

--- a/istioctl/pkg/authz/listener.go
+++ b/istioctl/pkg/authz/listener.go
@@ -36,7 +36,8 @@ const (
 	anonymousName = "_anonymous_match_nothing_"
 )
 
-// Matches the policy name in RBAC filter config with format like ns[default]-policy[some-policy]-rule[1] and istio-ext-authz-ns[default]-policy[some-policy]-rule[1].
+// Matches the policy name in RBAC filter config with format like ns[default]-policy[some-policy]-rule[1]
+// and istio-ext-authz-ns[default]-policy[some-policy]-rule[1].
 var re = regexp.MustCompile(`(?:istio-ext-authz-)?ns\[(.+)\]-policy\[(.+)\]-rule\[(.+)\]`)
 
 type filterChain struct {
@@ -129,10 +130,10 @@ func extractName(name string) (string, string) {
 type policyAction string
 
 const (
-	POLICY_ACTION_ALLOW  policyAction = "ALLOW"
-	POLICY_ACTION_DENY   policyAction = "DENY"
-	POLICY_ACTION_LOG    policyAction = "LOG"
-	POLICY_ACTION_CUSTOM policyAction = "CUSTOM"
+	policyActionAllow  policyAction = "ALLOW"
+	policyActionDeny   policyAction = "DENY"
+	policyActionLog    policyAction = "LOG"
+	policyActionCustom policyAction = "CUSTOM"
 )
 
 // Print prints the AuthorizationPolicy in the listener.
@@ -167,7 +168,7 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 				for name := range rbacHTTP.GetShadowRules().GetPolicies() {
 					if strings.HasPrefix(name, "istio-ext-authz-") {
 						nameOfPolicy, indexOfRule := extractName(name)
-						addPolicy(POLICY_ACTION_CUSTOM, nameOfPolicy, indexOfRule)
+						addPolicy(policyActionCustom, nameOfPolicy, indexOfRule)
 					}
 				}
 				if len(rbacHTTP.GetRules().GetPolicies()) == 0 {
@@ -183,7 +184,7 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 				for name := range rbacTCP.GetShadowRules().GetPolicies() {
 					if strings.HasPrefix(name, "istio-ext-authz-") {
 						nameOfPolicy, indexOfRule := extractName(name)
-						addPolicy(POLICY_ACTION_CUSTOM, nameOfPolicy, indexOfRule)
+						addPolicy(policyActionCustom, nameOfPolicy, indexOfRule)
 					}
 				}
 				if len(rbacTCP.GetRules().GetPolicies()) == 0 {
@@ -195,7 +196,7 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 
 	buf := strings.Builder{}
 	buf.WriteString("ACTION\tAuthorizationPolicy\tRULES\n")
-	for _, action := range []policyAction{POLICY_ACTION_DENY, POLICY_ACTION_ALLOW, POLICY_ACTION_LOG, POLICY_ACTION_CUSTOM} {
+	for _, action := range []policyAction{policyActionDeny, policyActionAllow, policyActionLog, policyActionCustom} {
 		if names, ok := actionToPolicy[action]; ok {
 			sortedNames := make([]string, 0, len(names))
 			for name := range names {

--- a/istioctl/pkg/authz/listener.go
+++ b/istioctl/pkg/authz/listener.go
@@ -23,7 +23,6 @@ import (
 	"text/tabwriter"
 
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	rbachttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	rbactcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
@@ -37,8 +36,8 @@ const (
 	anonymousName = "_anonymous_match_nothing_"
 )
 
-// Matches the policy name in RBAC filter config with format like ns[default]-policy[some-policy]-rule[1].
-var re = regexp.MustCompile(`ns\[(.+)\]-policy\[(.+)\]-rule\[(.+)\]`)
+// Matches the policy name in RBAC filter config with format like ns[default]-policy[some-policy]-rule[1] and istio-ext-authz-ns[default]-policy[some-policy]-rule[1].
+var re = regexp.MustCompile(`(?:istio-ext-authz-)?ns\[(.+)\]-policy\[(.+)\]-rule\[(.+)\]`)
 
 type filterChain struct {
 	rbacHTTP []*rbachttp.RBAC
@@ -127,6 +126,15 @@ func extractName(name string) (string, string) {
 	return fmt.Sprintf("%s.%s", parts[2], parts[1]), parts[3]
 }
 
+type policyAction string
+
+const (
+	POLICY_ACTION_ALLOW  policyAction = "ALLOW"
+	POLICY_ACTION_DENY   policyAction = "DENY"
+	POLICY_ACTION_LOG    policyAction = "LOG"
+	POLICY_ACTION_CUSTOM policyAction = "CUSTOM"
+)
+
 // Print prints the AuthorizationPolicy in the listener.
 func Print(writer io.Writer, listeners []*listener.Listener) {
 	parsedListeners := parse(listeners)
@@ -134,10 +142,10 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 		return
 	}
 
-	actionToPolicy := map[rbacpb.RBAC_Action]map[string]struct{}{}
+	actionToPolicy := map[policyAction]map[string]struct{}{}
 	policyToRule := map[string]map[string]struct{}{}
 
-	addPolicy := func(action rbacpb.RBAC_Action, name string, rule string) {
+	addPolicy := func(action policyAction, name string, rule string) {
 		if actionToPolicy[action] == nil {
 			actionToPolicy[action] = map[string]struct{}{}
 		}
@@ -151,20 +159,32 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 	for _, parsed := range parsedListeners {
 		for _, fc := range parsed.filterChains {
 			for _, rbacHTTP := range fc.rbacHTTP {
-				action := rbacHTTP.GetRules().GetAction()
+				action := policyAction(rbacHTTP.GetRules().GetAction().String())
 				for name := range rbacHTTP.GetRules().GetPolicies() {
 					nameOfPolicy, indexOfRule := extractName(name)
 					addPolicy(action, nameOfPolicy, indexOfRule)
+				}
+				for name := range rbacHTTP.GetShadowRules().GetPolicies() {
+					if strings.HasPrefix(name, "istio-ext-authz-") {
+						nameOfPolicy, indexOfRule := extractName(name)
+						addPolicy(POLICY_ACTION_CUSTOM, nameOfPolicy, indexOfRule)
+					}
 				}
 				if len(rbacHTTP.GetRules().GetPolicies()) == 0 {
 					addPolicy(action, anonymousName, "0")
 				}
 			}
 			for _, rbacTCP := range fc.rbacTCP {
-				action := rbacTCP.GetRules().GetAction()
+				action := policyAction(rbacTCP.GetRules().GetAction().String())
 				for name := range rbacTCP.GetRules().GetPolicies() {
 					nameOfPolicy, indexOfRule := extractName(name)
 					addPolicy(action, nameOfPolicy, indexOfRule)
+				}
+				for name := range rbacTCP.GetShadowRules().GetPolicies() {
+					if strings.HasPrefix(name, "istio-ext-authz-") {
+						nameOfPolicy, indexOfRule := extractName(name)
+						addPolicy(POLICY_ACTION_CUSTOM, nameOfPolicy, indexOfRule)
+					}
 				}
 				if len(rbacTCP.GetRules().GetPolicies()) == 0 {
 					addPolicy(action, anonymousName, "0")
@@ -175,7 +195,7 @@ func Print(writer io.Writer, listeners []*listener.Listener) {
 
 	buf := strings.Builder{}
 	buf.WriteString("ACTION\tAuthorizationPolicy\tRULES\n")
-	for _, action := range []rbacpb.RBAC_Action{rbacpb.RBAC_DENY, rbacpb.RBAC_ALLOW, rbacpb.RBAC_LOG} {
+	for _, action := range []policyAction{POLICY_ACTION_DENY, POLICY_ACTION_ALLOW, POLICY_ACTION_LOG, POLICY_ACTION_CUSTOM} {
 		if names, ok := actionToPolicy[action]; ok {
 			sortedNames := make([]string, 0, len(names))
 			for name := range names {

--- a/istioctl/pkg/authz/testdata/configdump.yaml
+++ b/istioctl/pkg/authz/testdata/configdump.yaml
@@ -4256,6 +4256,214 @@
               }
              },
              {
+              "name": "envoy.filters.http.rbac",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+               "shadow_rules": {
+                "action": "DENY",
+                "policies": {
+                 "istio-ext-authz-ns[default]-policy[ext-authz]-rule[0]": {
+                  "permissions": [
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "GET"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "prefix": "/info"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "POST"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "exact": "/data"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ],
+                  "principals": [
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "exact": "spiffe://cluster.local/ns/default/sa/sleep"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "safe_regex": {
+                             "regex": ".*/ns/test/.*"
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ]
+                 }
+                }
+               },
+               "shadow_rules_stat_prefix": "istio_ext_authz_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.ext_authz",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+               "grpc_service": {
+                "envoy_grpc": {
+                 "cluster_name": "outbound|9191||sample-ext-authz-grpc",
+                 "authority": "sample-ext-authz-grpc.local"
+                },
+                "timeout": "600s"
+               },
+               "with_request_body": {
+                "max_request_bytes": 8000
+               },
+               "transport_api_version": "V3",
+               "filter_enabled_metadata": {
+                "filter": "envoy.filters.http.rbac",
+                "path": [
+                 {
+                  "key": "istio_ext_authz_shadow_effective_policy_id"
+                 }
+                ],
+                "value": {
+                 "string_match": {
+                  "prefix": "istio-ext-authz"
+                 }
+                }
+               }
+              }
+             },
+             {
               "name": "envoy.filters.http.grpc_stats",
               "typed_config": {
                "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
@@ -4751,6 +4959,214 @@
                 }
                },
                "shadow_rules_stat_prefix": "istio_dry_run_allow_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.rbac",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+               "shadow_rules": {
+                "action": "DENY",
+                "policies": {
+                 "istio-ext-authz-ns[default]-policy[ext-authz]-rule[0]": {
+                  "permissions": [
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "GET"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "prefix": "/info"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "POST"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "exact": "/data"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ],
+                  "principals": [
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "exact": "spiffe://cluster.local/ns/default/sa/sleep"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "safe_regex": {
+                             "regex": ".*/ns/test/.*"
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ]
+                 }
+                }
+               },
+               "shadow_rules_stat_prefix": "istio_ext_authz_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.ext_authz",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+               "grpc_service": {
+                "envoy_grpc": {
+                 "cluster_name": "outbound|9191||sample-ext-authz-grpc",
+                 "authority": "sample-ext-authz-grpc.local"
+                },
+                "timeout": "600s"
+               },
+               "with_request_body": {
+                "max_request_bytes": 8000
+               },
+               "transport_api_version": "V3",
+               "filter_enabled_metadata": {
+                "filter": "envoy.filters.http.rbac",
+                "path": [
+                 {
+                  "key": "istio_ext_authz_shadow_effective_policy_id"
+                 }
+                ],
+                "value": {
+                 "string_match": {
+                  "prefix": "istio-ext-authz"
+                 }
+                }
+               }
               }
              },
              {
@@ -5411,6 +5827,214 @@
               }
              },
              {
+              "name": "envoy.filters.http.rbac",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+               "shadow_rules": {
+                "action": "DENY",
+                "policies": {
+                 "istio-ext-authz-ns[default]-policy[ext-authz]-rule[0]": {
+                  "permissions": [
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "GET"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "prefix": "/info"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "POST"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "exact": "/data"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ],
+                  "principals": [
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "exact": "spiffe://cluster.local/ns/default/sa/sleep"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "safe_regex": {
+                             "regex": ".*/ns/test/.*"
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ]
+                 }
+                }
+               },
+               "shadow_rules_stat_prefix": "istio_ext_authz_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.ext_authz",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+               "grpc_service": {
+                "envoy_grpc": {
+                 "cluster_name": "outbound|9191||sample-ext-authz-grpc",
+                 "authority": "sample-ext-authz-grpc.local"
+                },
+                "timeout": "600s"
+               },
+               "with_request_body": {
+                "max_request_bytes": 8000
+               },
+               "transport_api_version": "V3",
+               "filter_enabled_metadata": {
+                "filter": "envoy.filters.http.rbac",
+                "path": [
+                 {
+                  "key": "istio_ext_authz_shadow_effective_policy_id"
+                 }
+                ],
+                "value": {
+                 "string_match": {
+                  "prefix": "istio-ext-authz"
+                 }
+                }
+               }
+              }
+             },
+             {
               "name": "envoy.filters.http.grpc_stats",
               "typed_config": {
                "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
@@ -5897,6 +6521,214 @@
                 }
                },
                "shadow_rules_stat_prefix": "istio_dry_run_allow_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.rbac",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+               "shadow_rules": {
+                "action": "DENY",
+                "policies": {
+                 "istio-ext-authz-ns[default]-policy[ext-authz]-rule[0]": {
+                  "permissions": [
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "GET"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "prefix": "/info"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "POST"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "exact": "/data"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ],
+                  "principals": [
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "exact": "spiffe://cluster.local/ns/default/sa/sleep"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "safe_regex": {
+                             "regex": ".*/ns/test/.*"
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ]
+                 }
+                }
+               },
+               "shadow_rules_stat_prefix": "istio_ext_authz_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.ext_authz",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+               "grpc_service": {
+                "envoy_grpc": {
+                 "cluster_name": "outbound|9191||sample-ext-authz-grpc",
+                 "authority": "sample-ext-authz-grpc.local"
+                },
+                "timeout": "600s"
+               },
+               "with_request_body": {
+                "max_request_bytes": 8000
+               },
+               "transport_api_version": "V3",
+               "filter_enabled_metadata": {
+                "filter": "envoy.filters.http.rbac",
+                "path": [
+                 {
+                  "key": "istio_ext_authz_shadow_effective_policy_id"
+                 }
+                ],
+                "value": {
+                 "string_match": {
+                  "prefix": "istio-ext-authz"
+                 }
+                }
+               }
               }
              },
              {
@@ -6523,6 +7355,214 @@
                 }
                },
                "shadow_rules_stat_prefix": "istio_dry_run_allow_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.rbac",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+               "shadow_rules": {
+                "action": "DENY",
+                "policies": {
+                 "istio-ext-authz-ns[default]-policy[ext-authz]-rule[0]": {
+                  "permissions": [
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "GET"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "prefix": "/info"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_rules": {
+                     "rules": [
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "header": {
+                           "name": ":method",
+                           "exact_match": "POST"
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_rules": {
+                        "rules": [
+                         {
+                          "url_path": {
+                           "path": {
+                            "exact": "/data"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ],
+                  "principals": [
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "exact": "spiffe://cluster.local/ns/default/sa/sleep"
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   },
+                   {
+                    "and_ids": {
+                     "ids": [
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "filter_state": {
+                           "key": "io.istio.peer_principal",
+                           "string_match": {
+                            "safe_regex": {
+                             "regex": ".*/ns/test/.*"
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      },
+                      {
+                       "or_ids": {
+                        "ids": [
+                         {
+                          "metadata": {
+                           "filter": "istio_authn",
+                           "path": [
+                            {
+                             "key": "request.auth.claims"
+                            },
+                            {
+                             "key": "iss"
+                            }
+                           ],
+                           "value": {
+                            "list_match": {
+                             "one_of": {
+                              "string_match": {
+                               "exact": "https://accounts.google.com"
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                        ]
+                       }
+                      }
+                     ]
+                    }
+                   }
+                  ]
+                 }
+                }
+               },
+               "shadow_rules_stat_prefix": "istio_ext_authz_"
+              }
+             },
+             {
+              "name": "envoy.filters.http.ext_authz",
+              "typed_config": {
+               "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+               "grpc_service": {
+                "envoy_grpc": {
+                 "cluster_name": "outbound|9191||sample-ext-authz-grpc",
+                 "authority": "sample-ext-authz-grpc.local"
+                },
+                "timeout": "600s"
+               },
+               "with_request_body": {
+                "max_request_bytes": 8000
+               },
+               "transport_api_version": "V3",
+               "filter_enabled_metadata": {
+                "filter": "envoy.filters.http.rbac",
+                "path": [
+                 {
+                  "key": "istio_ext_authz_shadow_effective_policy_id"
+                 }
+                ],
+                "value": {
+                 "string_match": {
+                  "prefix": "istio-ext-authz"
+                 }
+                }
+               }
               }
              },
              {

--- a/releasenotes/notes/53894.yaml
+++ b/releasenotes/notes/53894.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+releaseNotes:
+  - |
+    **Added** support for AuthorizationPolicies with `CUSTOM` action in the `istioct x authz check` command.


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR extends the `istioctl x authz check` command to support outputting AuthorizationPolicies with the `CUSTOM` action. Currently policies with the `CUSTOM` action aren't included in the output which makes debugging more difficult and might cause confusion as to which policies are actually loaded.