### PR TITLE
optimize performance and minor refactor

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -500,29 +500,28 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 
 	hostsByNamespace := make(map[string]hostClassification)
 	for _, h := range istioListener.Hosts {
-		parts := strings.SplitN(h, "/", 2)
-		if len(parts) < 2 {
+		if strings.Count(h, "/") != 1 {
 			log.Errorf("Illegal host in sidecar resource: %s, host must be of form namespace/dnsName", h)
 			continue
 		}
-		if parts[0] == currentNamespace {
-			parts[0] = configNamespace
+		ns, name, _ := strings.Cut(h, "/")
+		if ns == currentNamespace {
+			ns = configNamespace
 		}
 
-		ns := parts[0]
-		hName := host.Name(parts[1])
-		if _, exists := hostsByNamespace[ns]; !exists {
-			hostsByNamespace[ns] = hostClassification{exactHosts: sets.New[host.Name](), allHosts: make([]host.Name, 0)}
+		hName := host.Name(name)
+		hc, exists := hostsByNamespace[ns]
+		if !exists {
+			hc = hostClassification{exactHosts: sets.New[host.Name](), allHosts: make([]host.Name, 0)}
 		}
 
 		// exact hosts are saved separately for map lookup
 		if !hName.IsWildCarded() {
-			hostsByNamespace[ns].exactHosts.Insert(hName)
+			hc.exactHosts.Insert(hName)
 		}
 
 		// allHosts contains the exact hosts and wildcard hosts,
 		// since SelectVirtualServices will use `Matches` semantic matching.
-		hc := hostsByNamespace[ns]
 		hc.allHosts = append(hc.allHosts, hName)
 		hostsByNamespace[ns] = hc
 	}


### PR DESCRIPTION
benchmark result:
```
goos: darwin
goarch: arm64
pkg: istio.io/istio/pilot/pkg/model
cpu: Apple M2
                                                 │   old.txt    │              new.txt              │
                                                 │    sec/op    │   sec/op     vs base              │
ConvertIstioListenerToWrapper/small-exact-8        2.320µ ±  1%   2.232µ ± 0%  -3.77% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-8     1.121µ ±  1%   1.042µ ± 1%  -7.05% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-match-all-8    5.409µ ±  0%   5.365µ ± 3%       ~ (p=0.061 n=6)
ConvertIstioListenerToWrapper/middle-exact-8       14.81µ ±  0%   14.50µ ± 0%  -2.09% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-8    15.23µ ±  1%   14.97µ ± 0%  -1.75% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-match-all-8   54.92µ ± 49%   55.05µ ± 1%       ~ (p=0.937 n=6)
ConvertIstioListenerToWrapper/big-exact-8          41.51µ ±  0%   41.07µ ± 0%  -1.06% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-8       57.40µ ±  0%   56.92µ ± 0%  -0.82% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-match-all-8      173.6µ ±  1%   173.9µ ± 0%       ~ (p=0.818 n=6)
geomean                                            16.08µ         15.78µ       -1.91%

                                                 │   old.txt    │               new.txt               │
                                                 │     B/op     │     B/op      vs base               │
ConvertIstioListenerToWrapper/small-exact-8        3.461Ki ± 0%   3.367Ki ± 0%   -2.71% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-8       464.0 ± 0%     368.0 ± 0%  -20.69% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-match-all-8    13.96Ki ± 0%   13.92Ki ± 0%   -0.22% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-exact-8       15.93Ki ± 0%   15.62Ki ± 0%   -1.96% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-8    1.844Ki ± 0%   1.531Ki ± 0%  -16.95% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-match-all-8   129.7Ki ± 0%   129.6Ki ± 0%   -0.02% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-exact-8          24.35Ki ± 0%   23.88Ki ± 0%   -1.93% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-8       3.750Ki ± 0%   3.281Ki ± 0%  -12.50% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-match-all-8      486.6Ki ± 0%   486.6Ki ± 0%   -0.01% (p=0.004 n=6)
geomean                                            11.57Ki        10.80Ki        -6.66%

                                                 │   old.txt   │              new.txt              │
                                                 │  allocs/op  │ allocs/op   vs base               │
ConvertIstioListenerToWrapper/small-exact-8         21.00 ± 0%   18.00 ± 0%  -14.29% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-wildcard-8     10.000 ± 0%   7.000 ± 0%  -30.00% (p=0.002 n=6)
ConvertIstioListenerToWrapper/small-match-all-8     32.00 ± 0%   31.00 ± 0%   -3.12% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-exact-8        47.00 ± 0%   37.00 ± 0%  -21.28% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-wildcard-8    19.000 ± 0%   9.000 ± 0%  -52.63% (p=0.002 n=6)
ConvertIstioListenerToWrapper/middle-match-all-8    148.0 ± 0%   147.0 ± 0%   -0.68% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-exact-8           60.00 ± 0%   45.00 ± 0%  -25.00% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-wildcard-8       24.000 ± 0%   9.000 ± 0%  -62.50% (p=0.002 n=6)
ConvertIstioListenerToWrapper/big-match-all-8       365.0 ± 0%   364.0 ± 0%   -0.27% (p=0.002 n=6)
geomean                                             42.65        31.22       -26.79%
```