### PR TITLE
Ambient cni node agent: Reconcile pod iptables rules on startup

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -669,3 +669,9 @@ func (cfg *IptablesConfigurator) AppendHostRules() *builder.IptablesRuleBuilder 
 
 	return iptablesBuilder
 }
+
+// ReconcileModeEnable returns true if this particular iptables configurator
+// supports/has idempotent execution enabled - i.e. reconcile mode.
+func (cfg *IptablesConfigurator) ReconcileModeEnabled() bool {
+	return cfg.cfg.Reconcile
+}

--- a/cni/pkg/nodeagent/fakes_test.go
+++ b/cni/pkg/nodeagent/fakes_test.go
@@ -17,11 +17,13 @@ package nodeagent
 import (
 	"context"
 	"embed"
+	"errors"
 	"io/fs"
 	"sync/atomic"
 	"syscall"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/cni/pkg/iptables"
 )
@@ -172,4 +174,10 @@ func (r *fakeIptablesDeps) AddLoopbackRoutes(cfg *iptables.IptablesConfig) error
 func (r *fakeIptablesDeps) DelLoopbackRoutes(cfg *iptables.IptablesConfig) error {
 	r.DelLoopbackRoutesCnt.Add(1)
 	return nil
+}
+
+type NoOpPodNetnsProcFinder struct{}
+
+func (p *NoOpPodNetnsProcFinder) FindNetnsForPods(pods map[types.UID]*corev1.Pod) (PodToNetns, error) {
+	return make(PodToNetns), errors.New("NoOpPodNetnsProcFinder always returns an error")
 }

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -50,15 +50,32 @@ var _ MeshDataplane = &NetServer{}
 // This cache will also be updated when the K8S informer gets a new pod.
 // This cache represents the "state of the world" of all enrolled pods on the node this agent
 // knows about, and will be sent to any connecting ztunnel as a startup message.
-func (s *NetServer) ConstructInitialSnapshot(ambientPods []*corev1.Pod) error {
+//
+// - For each of these existing snapshotted pods, steps into their netNS, and reconciles their
+// existing iptables rules against the expected set of rules. This is used to handle reconciling
+// iptables rule drift/changes between versions.
+func (s *NetServer) ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) error {
 	var consErr []error
 
-	podsByUID := slices.GroupUnique(ambientPods, (*corev1.Pod).GetUID)
+	podsByUID := slices.GroupUnique(existingAmbientPods, (*corev1.Pod).GetUID)
 	if err := s.buildZtunnelSnapshot(podsByUID); err != nil {
 		log.Warnf("failed to construct initial ztunnel snapshot: %v", err)
 		consErr = append(consErr, err)
 	}
 
+	if s.podIptables.ReconcileModeEnabled() {
+		log.Debug("inpod reconcile mode enabled")
+		for _, pod := range existingAmbientPods {
+			log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
+			log.Debug("upgrading and reconciling inpod rules for already-running pod if necessary")
+			err := s.reconcileExistingPod(pod)
+			if err != nil {
+				//nolint: lll
+				log.Errorf("failed to reconcile inpod rules for %s/%s, try restarting the pod, or removing and re-adding it to the mesh: %v", pod.Namespace, pod.Name, err)
+			}
+			consErr = append(consErr, err)
+		}
+	}
 	return errors.Join(consErr...)
 }
 
@@ -94,7 +111,7 @@ func (s *NetServer) Stop(_ bool) {
 // Any other error indicates the function call can be retried.
 func (s *NetServer) AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error {
 	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
-	log.Infof("adding pod to the mesh")
+	log.Info("adding pod to the mesh")
 	// make sure the cache is aware of the pod, even if we don't have the netns yet.
 	s.currentPodSnapshot.Ensure(string(pod.UID))
 	openNetns, err := s.getOrOpenNetns(pod, netNs)
@@ -176,6 +193,28 @@ func newNetServer(ztunnelServer ZtunnelServer, podNsMap *podNetnsCache, podIptab
 		podIptables:        podIptables,
 		netnsRunner:        NetnsDo,
 	}
+}
+
+// reconcileExistingPod is intended to run on node agent startup, for each pod that was already enrolled prior to startup.
+// Will reconcile any in-pod iptables rules the pod may already have against this node agent's expected/required in-pod iptables rules.
+//
+// This is used to handle upgrades and such. Note that this call should be idempotent for any pod already in the mesh,
+// but should never need to be invoked outside of node agent startup.
+func (s *NetServer) reconcileExistingPod(pod *corev1.Pod) error {
+	openNetns, err := s.getNetns(pod)
+	if err != nil {
+		return err
+	}
+
+	podCfg := getPodLevelTrafficOverrides(pod)
+
+	if err := s.netnsRunner(openNetns, func() error {
+		return s.podIptables.CreateInpodRules(log, podCfg)
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *NetServer) rescanPod(pod *corev1.Pod) error {

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -64,16 +64,15 @@ func (s *NetServer) ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) 
 	}
 
 	if s.podIptables.ReconcileModeEnabled() {
-		log.Debug("inpod reconcile mode enabled")
+		log.Info("inpod reconcile mode enabled")
 		for _, pod := range existingAmbientPods {
 			log := log.WithLabels("ns", pod.Namespace, "name", pod.Name)
 			log.Debug("upgrading and reconciling inpod rules for already-running pod if necessary")
 			err := s.reconcileExistingPod(pod)
 			if err != nil {
-				//nolint: lll
-				log.Errorf("failed to reconcile inpod rules for %s/%s, try restarting the pod, or removing and re-adding it to the mesh: %v", pod.Namespace, pod.Name, err)
+				// for now, we will simply log an error, no need to append this error to the generic snapshot list
+				log.Errorf("failed to reconcile inpod rules for pod, try restarting the pod, or removing and re-adding it to the mesh: %v", err)
 			}
-			consErr = append(consErr, err)
 		}
 	}
 	return errors.Join(consErr...)

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -45,7 +45,7 @@ var log = scopes.CNIAgent
 
 type MeshDataplane interface {
 	// MUST be called first, (even before Start()).
-	ConstructInitialSnapshot(ambientPods []*corev1.Pod) error
+	ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) error
 	Start(ctx context.Context)
 
 	AddPodToMesh(ctx context.Context, pod *corev1.Pod, podIPs []netip.Addr, netNs string) error
@@ -203,13 +203,13 @@ type meshDataplane struct {
 // It takes a "snapshot" of ambient pods that were already running when the server started,
 // and constructs various required "state" (adding the pods to the host-level node ipset,
 // building the state of the world snapshot send to connecting ztunnels)
-func (s *meshDataplane) ConstructInitialSnapshot(ambientPods []*corev1.Pod) error {
-	if err := s.syncHostIPSets(ambientPods); err != nil {
+func (s *meshDataplane) ConstructInitialSnapshot(existingAmbientPods []*corev1.Pod) error {
+	if err := s.syncHostIPSets(existingAmbientPods); err != nil {
 		log.Errorf("failed to sync host IPset: %v", err)
 		return err
 	}
 
-	return s.netServer.ConstructInitialSnapshot(ambientPods)
+	return s.netServer.ConstructInitialSnapshot(existingAmbientPods)
 }
 
 // Start starts the netserver.

--- a/manifests/charts/base/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/base/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/base/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/base/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/default/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/default/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateway/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/gateway/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/istio-cni/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-cni/templates/configmap-cni.yaml
+++ b/manifests/charts/istio-cni/templates/configmap-cni.yaml
@@ -14,9 +14,9 @@ metadata:
 data:
   CURRENT_AGENT_VERSION: {{ .Values.tag | default .Values.global.tag | quote }}
   AMBIENT_ENABLED: {{ .Values.ambient.enabled | quote }}
-  AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | default "false" | quote  }}
-  AMBIENT_IPV6: {{ .Values.ambient.ipv6 | default "false" | quote }}
-  AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | default "false" | quote }}
+  AMBIENT_DNS_CAPTURE: {{ .Values.ambient.dnsCapture | quote  }}
+  AMBIENT_IPV6: {{ .Values.ambient.ipv6 | quote }}
+  AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: {{ .Values.ambient.reconcileIptablesOnStartup | quote }}
   {{- if .Values.cniConfFileName }} # K8S < 1.24 doesn't like empty values
   CNI_CONF_NAME: {{ .Values.cniConfFileName }} # Name of the CNI config file to create. Only override if you know the exact path your CNI requires..
   {{- end }}

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -52,7 +52,8 @@ _internal_defaults_do_not_set:
     # If enabled, and ambient is enabled, enables ipv6 support
     ipv6: true
     # If enabled, and ambient is enabled, the CNI agent will reconcile incompatible iptables rules and chains at startup.
-    reconcileIptablesOnStartup: true
+    # This will eventually be enabled by default
+    reconcileIptablesOnStartup: false
 
 
   repair:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -52,7 +52,7 @@ _internal_defaults_do_not_set:
     # If enabled, and ambient is enabled, enables ipv6 support
     ipv6: true
     # If enabled, and ambient is enabled, the CNI agent will reconcile incompatible iptables rules and chains at startup.
-    reconcileIptablesOnStartup: false
+    reconcileIptablesOnStartup: true
 
 
   repair:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.22.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.22.yaml
@@ -24,3 +24,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.23.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.23.yaml
@@ -17,3 +17,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/charts/ztunnel/files/profile-compatibility-version-1.24.yaml
+++ b/manifests/charts/ztunnel/files/profile-compatibility-version-1.24.yaml
@@ -6,6 +6,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.22.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.22.yaml
@@ -20,3 +20,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.23.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.23.yaml
@@ -13,3 +13,7 @@ meshConfig:
       # 1.24 behaviour changes
       ENABLE_DEFERRED_STATS_CREATION: "false"
       BYPASS_OVERLOAD_MANAGER_FOR_STATIC_LISTENERS: "false"
+
+# Not present in <1.24, defaults to `true` in 1.25+
+ambient:
+  reconcileIptablesOnStartup: false

--- a/manifests/helm-profiles/compatibility-version-1.24.yaml
+++ b/manifests/helm-profiles/compatibility-version-1.24.yaml
@@ -2,6 +2,6 @@ pilot:
   env:
     # 1.24 behavioral changes
     PILOT_ENABLE_IP_AUTOALLOCATE: "false"
-cni:
-  ambient:
-    dnsCapture: false
+ambient:
+  dnsCapture: false
+  reconcileIptablesOnStartup: false

--- a/releasenotes/notes/53906.yaml
+++ b/releasenotes/notes/53906.yaml
@@ -1,9 +1,12 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issue:
+  - 1360
 releaseNotes:
 - |
   **Added** Support for reconciling in-pod iptables rules of existing ambient pods from the previous version on `istio-cni` upgrade. Feature can be toggled with `--set cni.ambient.reconcileIptablesOnStartup=true` and will be enabled by default in future releases.
+
 upgradeNotes:
   - title: Ambient pod upgrade reconcilation.
     content: |

--- a/releasenotes/notes/53906.yaml
+++ b/releasenotes/notes/53906.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+releaseNotes:
+- |
+  **Added** Support for reconciling in-pod iptables rules of existing ambient pods on `istio` upgrade. Feature can be toggled with `--set cni.ambient.reconcileIptablesOnStartup=false`
+upgradeNotes:
+  - title: Ambient pod upgrade reconcilation.
+    content: |
+      When a new `istio-cni` Daemonset pod starts up, it will inspect pods that were previously enrolled in the ambient mesh, and upgrade their in-pod iptables rules to the current state if there is a delta. This is on by default as of 1.25.0. Installing 1.25+ with a compatibility version target of a previous release will turn this off by default. Feature can be disabled by `helm install cni --set ambient.reconcileIptablesOnStartup=false` (helm) or `istioctl install --set values.cni.ambient.reconcileIptablesOnStartup=false` (istioctl)

--- a/releasenotes/notes/53906.yaml
+++ b/releasenotes/notes/53906.yaml
@@ -3,8 +3,8 @@ kind: feature
 area: traffic-management
 releaseNotes:
 - |
-  **Added** Support for reconciling in-pod iptables rules of existing ambient pods on `istio` upgrade. Feature can be toggled with `--set cni.ambient.reconcileIptablesOnStartup=false`
+  **Added** Support for reconciling in-pod iptables rules of existing ambient pods from the previous version on `istio-cni` upgrade. Feature can be toggled with `--set cni.ambient.reconcileIptablesOnStartup=true` and will be enabled by default in future releases.
 upgradeNotes:
   - title: Ambient pod upgrade reconcilation.
     content: |
-      When a new `istio-cni` Daemonset pod starts up, it will inspect pods that were previously enrolled in the ambient mesh, and upgrade their in-pod iptables rules to the current state if there is a delta. This is on by default as of 1.25.0. Installing 1.25+ with a compatibility version target of a previous release will turn this off by default. Feature can be disabled by `helm install cni --set ambient.reconcileIptablesOnStartup=false` (helm) or `istioctl install --set values.cni.ambient.reconcileIptablesOnStartup=false` (istioctl)
+      When a new `istio-cni` Daemonset pod starts up, it will inspect pods that were previously enrolled in the ambient mesh, and upgrade their in-pod iptables rules to the current state if there is a diff or delta. This is off by default as of 1.25.0, but will eventually be enabled by default. Feature can be enabled by `helm install cni --set ambient.reconcileIptablesOnStartup=true` (helm) or `istioctl install --set values.cni.ambient.reconcileIptablesOnStartup=true` (istioctl)

--- a/releasenotes/notes/ambient-dns-on.yaml
+++ b/releasenotes/notes/ambient-dns-on.yaml
@@ -1,10 +1,16 @@
 apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
+issues:
+    - 1360
 releaseNotes:
   - |
     **Promoted** the `cni.ambient.dnsCapture` value to default to `true`.
     This enables the DNS proxying for workloads in ambient mesh by default, improving security, performance, and enabling
-    a number of features.
-    This can be disabled explicitly or with `compatibilityVersion=1.24`.
-    Note: only new pods will have DNS enabled. To enable for existing pods, they must be restarted.
+    a number of features. This can be disabled explicitly or with `compatibilityVersion=1.24`.
+    Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconcilation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=false`.
+upgradeNotes:
+  -|
+    DNS proxying is enabled by default for ambient workloads in this release. Note that only new pods will have DNS enabled, existing pods will not have their DNS traffic captured.
+    To enable this feature for existing pods, existing pods must either be manually restarted, or alternatively the iptables reconcilation feature can be enabled when upgrading
+    `istio-cni` via `--set cni.ambient.reconcileIptablesOnStartup=true` which will reconcile existing pods automatically on upgrade.

--- a/releasenotes/notes/ambient-dns-on.yaml
+++ b/releasenotes/notes/ambient-dns-on.yaml
@@ -9,8 +9,10 @@ releaseNotes:
     This enables the DNS proxying for workloads in ambient mesh by default, improving security, performance, and enabling
     a number of features. This can be disabled explicitly or with `compatibilityVersion=1.24`.
     Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconcilation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=false`.
+
 upgradeNotes:
-  -|
-    DNS proxying is enabled by default for ambient workloads in this release. Note that only new pods will have DNS enabled, existing pods will not have their DNS traffic captured.
-    To enable this feature for existing pods, existing pods must either be manually restarted, or alternatively the iptables reconcilation feature can be enabled when upgrading
-    `istio-cni` via `--set cni.ambient.reconcileIptablesOnStartup=true` which will reconcile existing pods automatically on upgrade.
+  - title: Ambient DNS capture on by default
+    content: |
+        DNS proxying is enabled by default for ambient workloads in this release. Note that only new pods will have DNS enabled, existing pods will not have their DNS traffic captured.
+        To enable this feature for existing pods, existing pods must either be manually restarted, or alternatively the iptables reconcilation feature can be enabled when upgrading
+        `istio-cni` via `--set cni.ambient.reconcileIptablesOnStartup=true` which will reconcile existing pods automatically on upgrade.


### PR DESCRIPTION
**Please provide a description of this PR:**

This ~depends on (and currently pulls in, as that's not merged yet) https://github.com/istio/istio/pull/53153, and~ fixes https://github.com/istio/ztunnel/issues/1360

Most of the interesting bits are in that PR - this one just makes sure we run through all the "existing" ambient pods we find on ambient node agent startup, and run the iptables logic (which as of #53153 now support idempotency/reconciliation) on all of them.

This means that if you upgrade `istio-cni` it will make sure to rewrite all inpod iptables rules for pods (that would have been configured by the older version) to match what the current release expects.

This is important for several reasons:

- To fix bugs like https://github.com/istio/ztunnel/issues/1360
- To make sure that if we do things like turn on DNS by default (or anything like that in the future), existing pods from the previous version have their `iptables` rules, cleanly upgraded, when Istio itself is upgraded, so we don't require people to restart workloads en masse on upgrade.
- To at least begin logging/reporting in some fashion when we encounter pods that may have in-pod iptables rules injected by other 3rd-party apps (twistlock, et al)

**But in general, the goal is to allow ambient upgrades (and downgrades, to versions with this feature) without requiring users to restart every pod already captured by ambient, if that release happened to alter or change iptables/nft rules (or alternatively, doing mass-unenrolls/re-enrolls post-upgrade).**

### Note
Note that this PR is targeting 1.25, and is defaulting this feature to OFF. The plan is to switch this to default ON in later releases.

- Flags have been added to all pre-1.25 compatibility profiles supported at time of this PR to turn this OFF.