### PR TITLE
Sample: bump jaeger version

### DIFF
--- a/samples/addons/jaeger.yaml
+++ b/samples/addons/jaeger.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: "docker.io/jaegertracing/all-in-one:1.58"
+          image: "docker.io/jaegertracing/all-in-one:1.63.0"
           env:
             - name: BADGER_EPHEMERAL
               value: "false"


### PR DESCRIPTION
**Please provide a description of this PR:**

bump jaeger version  1.58 --> 1.63.0

https://github.com/jaegertracing/jaeger/releases/tag/v1.63.0