### PR TITLE
ambient: fully support Gateway's with IP address in status

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -887,15 +887,34 @@ type AmbientIndexes interface {
 type WaypointKey struct {
 	Namespace string
 	Hostnames []string
+
+	Network   string
+	Addresses []string
 }
 
 // WaypointKeyForProxy builds a key from a proxy to lookup
 func WaypointKeyForProxy(node *Proxy) WaypointKey {
 	key := WaypointKey{
 		Namespace: node.ConfigNamespace,
+		Network: node.Metadata.Network.String(),
 	}
 	for _, svct := range node.ServiceTargets {
 		key.Hostnames = append(key.Hostnames, svct.Service.Hostname.String())
+
+		ips := svct.Service.ClusterVIPs.GetAddressesFor(node.GetClusterID())
+		// if we find autoAllocated addresses then ips should contain constants.UnspecifiedIP which should not be used
+		foundAutoAllocated := false
+		if svct.Service.AutoAllocatedIPv4Address != "" {
+			key.Addresses = append(key.Addresses, svct.Service.AutoAllocatedIPv4Address)
+			foundAutoAllocated = true
+		}
+		if svct.Service.AutoAllocatedIPv6Address != "" {
+			key.Addresses = append(key.Addresses, svct.Service.AutoAllocatedIPv6Address)
+			foundAutoAllocated = true
+		}
+		if !foundAutoAllocated {
+			key.Addresses = append(key.Addresses, ips...)
+		}
 	}
 	return key
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -896,7 +896,7 @@ type WaypointKey struct {
 func WaypointKeyForProxy(node *Proxy) WaypointKey {
 	key := WaypointKey{
 		Namespace: node.ConfigNamespace,
-		Network: node.Metadata.Network.String(),
+		Network:   node.Metadata.Network.String(),
 	}
 	for _, svct := range node.ServiceTargets {
 		key.Hostnames = append(key.Hostnames, svct.Service.Hostname.String())

--- a/releasenotes/notes/waypoint-revision.yaml
+++ b/releasenotes/notes/waypoint-revision.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [53883]
+releaseNotes:
+  - |
+    **Fixed** an issue when upgrading waypoint proxies from Istio 1.23.x to Istio 1.24.x.


### PR DESCRIPTION
In 1.24, we started preferring to use Hostname as the gateway object. However, this has a (few) problem:
* During upgrade, there is a small amount of time before status is updated.
* With revisions, this time can be indefinite if the older revision is the leader
* 3p implementations can use IP address

This PR adds support for either type. A test is added to cover this case.

Fixes https://github.com/istio/istio/issues/53883