### PR TITLE
Ignore delete cmds errors from optional iptables rules

### DIFF
--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -179,10 +179,7 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 		}
 
 		for _, cmd := range optionalDeleteCmds {
-			err := cfg.ext.Run(iptablesconstants.IPTables, &iptVer, nil, cmd...)
-			if err != nil {
-				log.Debugf("ignoring error deleting optional iptables rule: %v", err)
-			}
+			cfg.ext.RunQuietlyAndIgnore(iptablesconstants.IPTables, &iptVer, nil, cmd...)
 		}
 	}
 	return errors.Join(delErrs...)

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -142,13 +142,13 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
 		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
+		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 	}
 
 	// these sometimes fail due to "Device or resource busy" or because they are optional given the iptables cfg
 	optionalDeleteCmds := [][]string{
 		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
-		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		// flush-then-delete our created chains
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodOutput},

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -142,13 +142,13 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
 		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
-		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 	}
 
 	// these sometimes fail due to "Device or resource busy" or because they are optional given the iptables cfg
 	optionalDeleteCmds := [][]string{
 		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
+		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		// flush-then-delete our created chains
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodOutput},

--- a/cni/pkg/iptables/iptables.go
+++ b/cni/pkg/iptables/iptables.go
@@ -141,14 +141,14 @@ func (cfg *IptablesConfigurator) executeDeleteCommands() error {
 	deleteCmds := [][]string{
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
-		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
-		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
-		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
 	}
 
-	// these sometimes fail due to "Device or resource busy"
+	// these sometimes fail due to "Device or resource busy" or because they are optional given the iptables cfg
 	optionalDeleteCmds := [][]string{
+		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
+		{"-t", iptablesconstants.RAW, "-D", iptablesconstants.OUTPUT, "-j", ChainInpodOutput},
+		{"-t", iptablesconstants.NAT, "-D", iptablesconstants.PREROUTING, "-j", ChainInpodPrerouting},
 		// flush-then-delete our created chains
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodPrerouting},
 		{"-t", iptablesconstants.MANGLE, "-F", ChainInpodOutput},

--- a/releasenotes/notes/53951.yaml
+++ b/releasenotes/notes/53951.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+- |
+  **Fixed** errors being raised during cleanup of iptables of Ambient workloads with either tproxy or ingressMode enabled.

--- a/releasenotes/notes/53951.yaml
+++ b/releasenotes/notes/53951.yaml
@@ -3,4 +3,4 @@ kind: bug-fix
 area: traffic-management
 releaseNotes:
 - |
-  **Fixed** errors being raised during cleanup of iptables of Ambient workloads with either tproxy or ingressMode enabled.
+  **Fixed** errors being raised during cleanup of iptables rules that are conditional on the iptables configuration.

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -274,6 +274,9 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 		}
 
 		log.Errorf("Command error output: %v", stderrStr)
+	} else if err != nil && ignoreErrors {
+		// Log ignored errors for debugging purposes
+		log.Debugf("Ignoring iptables command error: %v", err)
 	}
 
 	return stdout, err


### PR DESCRIPTION
Change-Id: Ib636985911338401aeefb9d03e8789af2b65e9c9

This was spun out of the idempotency/reconciliation PR (#53153) as it is no longer planned for 1.24.1.
Automated test coverage for this is already present in that PR.

**Please provide a description of this PR:**
Fixed in-pod deletion errors caused by the deletion logic incorrectly assuming that certain commands would work, even when the relevant rules were not present. The creation of these rules depends on the values of tproxy and ingressMode. Therefore, certain failed deletion commands cannot reliably indicate successful deletion.