### PR TITLE
Set AppArmor annotation instead of appArmorProfile

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -41,6 +41,10 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "15014"
         prometheus.io/path: '/metrics'
+        # Add AppArmor annotation
+        # This is required to avoid conflicts with AppArmor profiles
+        # which block certain privileged pod capabilities.
+        container.apparmor.security.beta.kubernetes.io/install-cni: unconfined
         # Custom annotations
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -92,8 +96,6 @@ spec:
               path: /readyz
               port: 8000
           securityContext:
-            appArmorProfile:
-              type: Unconfined
             privileged: false
             runAsGroup: 0
             runAsUser: 0

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -42,8 +42,10 @@ spec:
         prometheus.io/port: "15014"
         prometheus.io/path: '/metrics'
         # Add AppArmor annotation
-        # This is required to avoid conflicts with AppArmor profiles
-        # which block certain privileged pod capabilities.
+        # This is required to avoid conflicts with AppArmor profiles which block certain
+        # privileged pod capabilities.
+        # Required for Kubernetes 1.29 which does not support setting appArmorProfile in the
+        # securityContext which is otherwise preferred.
         container.apparmor.security.beta.kubernetes.io/install-cni: unconfined
         # Custom annotations
         {{- if .Values.podAnnotations }}

--- a/releasenotes/notes/53829.yaml
+++ b/releasenotes/notes/53829.yaml
@@ -3,7 +3,7 @@ kind: bug-fix
 area: security
 releaseNotes:
 - |
-  **Added** unconfined AppArmorProfile to the istio-cni-node DaemonSet to avoid conflicts with
+  **Added** unconfined AppArmor annotation to the istio-cni-node DaemonSet to avoid conflicts with
   AppArmor profiles which block certain privileged pod capabilities. Previously, AppArmor
   (when enabled) was bypassed for the istio-cni-node DaemonSet since privileged was set to true
   in the SecurityContext. This change ensures that the AppArmor profile is set to unconfined


### PR DESCRIPTION
**Please provide a description of this PR:**

`appArmorProfile` is not support in [Kubernetes 1.29](https://v1-29.docs.kubernetes.io/docs/tutorials/security/apparmor/#securing-a-pod)

Follow up to https://github.com/istio/istio/pull/53888

TODO: 
- [ ] test annotation in Kubernetes 1.31 where it is deprecated 