### PR TITLE
[release 1.24] Set AppArmor annotation to unconfined on istio-cni-node (#53953)

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -41,6 +41,12 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "15014"
         prometheus.io/path: '/metrics'
+        # Add AppArmor annotation
+        # This is required to avoid conflicts with AppArmor profiles which block certain
+        # privileged pod capabilities.
+        # Required for Kubernetes 1.29 which does not support setting appArmorProfile in the
+        # securityContext which is otherwise preferred.
+        container.apparmor.security.beta.kubernetes.io/install-cni: unconfined
         # Custom annotations
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/releasenotes/notes/53829.yaml
+++ b/releasenotes/notes/53829.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+releaseNotes:
+- |
+  **Added** unconfined AppArmor annotation to the istio-cni-node DaemonSet to avoid conflicts with
+  AppArmor profiles which block certain privileged pod capabilities. Previously, AppArmor
+  (when enabled) was bypassed for the istio-cni-node DaemonSet since privileged was set to true
+  in the SecurityContext. This change ensures that the AppArmor profile is set to unconfined
+  for the istio-cni-node DaemonSet.


### PR DESCRIPTION
**Please provide a description of this PR:**

* Set AppArmor annotation instead of appArmorProfile
appArmorProfile is not support in Kubernetes 1.29
* Update release note
* clarify reasoning for setting annotation rather than appArmorProfile in the securityContext.