### PR TITLE
Respect port in gateway conflict check

### DIFF
--- a/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/pkg/config/analysis/analyzers/analyzers_test.go
@@ -251,6 +251,14 @@ var testGrid = []testCase{
 		},
 	},
 	{
+		name:       "gateways with no conflict",
+		inputFiles: []string{"testdata/conflicting-gateways-no-conflict.yaml"},
+		analyzer:   &gateway.ConflictingGatewayAnalyzer{},
+		expected:   []message{
+			// no messages, this test case verifies no false positives
+		},
+	},
+	{
 		name:       "conflicting gateways detect by sub selector",
 		inputFiles: []string{"testdata/conflicting-gateways-subSelector.yaml"},
 		analyzer:   &gateway.ConflictingGatewayAnalyzer{},

--- a/pkg/config/analysis/analyzers/gateway/conflictinggateway.go
+++ b/pkg/config/analysis/analyzers/gateway/conflictinggateway.go
@@ -111,7 +111,10 @@ func (*ConflictingGatewayAnalyzer) analyzeGateway(r *resource.Instance, c analys
 		var gateways []string
 		conflictingGWMatch := 0
 		sPortNumber := strconv.Itoa(int(server.GetPort().GetNumber()))
-		for _, values := range hitSameGateways {
+		for key, values := range hitSameGateways {
+			if strings.Split(key, "~")[1] != sPortNumber {
+				continue
+			}
 			for gwNameKey, gwHostsBind := range values {
 				// both selector and port number are the same, then check hosts and bind
 				if gwName != gwNameKey && isGWConflict(server, gwHostsBind) {

--- a/pkg/config/analysis/analyzers/testdata/conflicting-gateways-no-conflict.yaml
+++ b/pkg/config/analysis/analyzers/testdata/conflicting-gateways-no-conflict.yaml
@@ -1,0 +1,51 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: foo
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - foo.example.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+    tls:
+      httpsRedirect: true
+  - hosts:
+      - foo.example.com
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: foo-credential
+      mode: SIMPLE
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: bar
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+      - '*.bar.example.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+    tls:
+      httpsRedirect: true
+  - hosts:
+      - '*.bar.example.com'
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: bar-credential
+      mode: SIMPLE

--- a/releasenotes/notes/53973.yaml
+++ b/releasenotes/notes/53973.yaml
@@ -1,8 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: istioctl
-issue:
-  - 52413
 releaseNotes:
   - |
     **Fixed** istioctl analyze report IST0145 error when using the same host with different ports and multiple gateways.

--- a/releasenotes/notes/53973.yaml
+++ b/releasenotes/notes/53973.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 52413
+releaseNotes:
+  - |
+    **Fixed** istioctl analyze report IST0145 error when using the same host with different ports and multiple gateways.


### PR DESCRIPTION
**Please provide a description of this PR:**

If you use multiple non-conflicting gateways you get a "IST0145 Conflict with gateways...". The reason for that is a missing check of the port.