### PR TITLE
Fix telemetry tracing tests on Openshift

### DIFF
--- a/pkg/test/framework/components/zipkin/zipkin.go
+++ b/pkg/test/framework/components/zipkin/zipkin.go
@@ -27,7 +27,7 @@ type Instance interface {
 
 	// QueryTraces gets at most number of limit most recent available traces from zipkin.
 	// spanName filters that only trace with the given span name will be included.
-	QueryTraces(limit int, spanName, annotationQuery string) ([]Trace, error)
+	QueryTraces(limit int, spanName, annotationQuery, hostDomain string) ([]Trace, error)
 }
 
 type Config struct {

--- a/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
+++ b/tests/integration/telemetry/tracing/otelcollector/tracing_test.go
@@ -100,9 +100,14 @@ func TestProxyTracingOpenTelemetryProvider(t *testing.T) {
 									if err != nil {
 										return fmt.Errorf("cannot send traffic from cluster %s: %v", cluster.Name(), err)
 									}
+									hostDomain := ""
+									if ctx.Settings().OpenShift {
+										ingressAddr, _ := tracing.GetIngressInstance().HTTPAddresses()
+										hostDomain = ingressAddr[0]
+									}
 
 									// the OTel collector exports to Zipkin
-									traces, err := tracing.GetZipkinInstance().QueryTraces(300, "", tc.customAttribute)
+									traces, err := tracing.GetZipkinInstance().QueryTraces(300, "", tc.customAttribute, hostDomain)
 									t.Logf("got traces %v from %s", traces, cluster)
 									if err != nil {
 										return fmt.Errorf("cannot get traces from zipkin: %v", err)

--- a/tests/integration/telemetry/tracing/zipkin/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/client_tracing_test.go
@@ -50,8 +50,13 @@ func TestClientTracing(t *testing.T) {
 						if err != nil {
 							return fmt.Errorf("cannot send traffic from cluster %s: %v", cluster.Name(), err)
 						}
+						hostDomain := ""
+						if t.Settings().OpenShift {
+							ingressAddr, _ := tracing.GetIngressInstance().HTTPAddresses()
+							hostDomain = ingressAddr[0]
+						}
 						traces, err := tracing.GetZipkinInstance().QueryTraces(100,
-							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "")
+							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "", hostDomain)
 						if err != nil {
 							return fmt.Errorf("cannot get traces from zipkin: %v", err)
 						}

--- a/tests/integration/telemetry/tracing/zipkin/server_tracing_test.go
+++ b/tests/integration/telemetry/tracing/zipkin/server_tracing_test.go
@@ -44,8 +44,13 @@ func TestServerTracing(t *testing.T) {
 						if err != nil {
 							return fmt.Errorf("cannot send traffic from cluster %s: %v", cluster.Name(), err)
 						}
+						hostDomain := ""
+						if t.Settings().OpenShift {
+							ingressAddr, _ := tracing.GetIngressInstance().HTTPAddresses()
+							hostDomain = ingressAddr[0]
+						}
 						traces, err := tracing.GetZipkinInstance().QueryTraces(300,
-							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "")
+							fmt.Sprintf("server.%s.svc.cluster.local:80/*", appNsInst.Name()), "", hostDomain)
 						if err != nil {
 							return fmt.Errorf("cannot get traces from zipkin: %v", err)
 						}


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #53977 

All telemetry tracing tests are failing during execution on Openshift.

During the tests execution, the traffic is being sent and should be captured through the service routed through ingress gateway.

In Kind environment, the "sslip.io" service is used, which servers as a DNS service that works with embedded ip addresses and returns that ip address as a name during query.
But in Openshift it's not working.

The Openshift cluster has a routable and dns resolvable ingress gateway. But when the test adds the service "tracing' to the ingress gateway - "tracing.<ingress-gateway>/api/v2...",
dns resolve is not working anymore and query to that url fails. Since we're not able to create a custom dns record to that url during each test execution, the following solution approach applied:

When the test executes on Openshift, a "Host" header is inserted into the http request to resolve the "tracing.<ingress-gateway>/api/v2..." service domain name and the url is used with the ip address of the "ingress-gateway".

That way, Openshift is able to execute the test and reach out to the service with http request.
The Kind environment flow remains the same.