### PR TITLE
Add release note that was missed for PR 53708

### DIFF
--- a/releasenotes/notes/propagate-injection-config-errors.yaml
+++ b/releasenotes/notes/propagate-injection-config-errors.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+
+issue:
+  - https://github.com/istio/istio/issues/53357
+
+releaseNotes:
+- |
+  **Fixed** Injection config errors were being silenced (i.e. logged and not returned) when the sidecar injector was unable to process the sidecar config. This change will now propagate the error to the user instead of continuing to process a faulty config.


### PR DESCRIPTION
**Please provide a description of this PR:**
Add the release note that was missed for PR #53708. (Adding this now after realizing a backport might make sense for the change). As a consequence, we should backport this wherever #53708 ends up.
