### PR TITLE
fix(helm): render service account properly when adding annotations

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/serviceaccount.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "istio.labels" . | nindent 4 }}
   {{- if .Values.serviceAccountAnnotations }}
   annotations:
-{{- toYaml .Values.serviceAccountAnnotations | indent 4 }}
+{{- toYaml .Values.serviceAccountAnnotations | nindent 4 }}
   {{- end }}
 {{- end }}
 ---

--- a/releasenotes/notes/53989.yaml
+++ b/releasenotes/notes/53989.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 51289
+releaseNotes:
+- |
+  **Fixed** Helm render to properly apply annotations on pilot `serviceAccount`


### PR DESCRIPTION
**Please provide a description of this PR:**

This should fix `Issue`: https://github.com/istio/istio/issues/51289

Though that issue is `Closed`, I don't think the PR linked in that ticket _actually_ fixed it.

## Proof 

By running `helm template test --debug --set 1-23-x.pilot.serviceAccountAnnotations.foo=bar .` on latest 1.23.x (v1.23.3) chart

**Before the fix**:

```
# Source: [...]/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: istiod-1-23-x
  namespace: istio-system
  labels:
    app: istiod
    release: test
  annotations:    foo: bar
```

**After the fix**:

```
# Source: [...]/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: istiod-1-23-x
  namespace: istio-system
  labels:
    app: istiod
    release: test
  annotations:
    foo: bar
```

## The Fix/Bug

The dash (`-`) directly after the opening brackets on that line makes Helm/Go templating chomp all whitespace before it (including newline). This causes the bad formatting.

So replacing `indent` with a newline indent (`nindent`) gets us what we want.

**Maintainers**: Is it possible to get this in the next patch version of v1.24? Without this, we have to maintain a custom Istio chart with this fix.
  