### PR TITLE
krt: drop the custom Key type

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -407,7 +407,7 @@ func getConditions[T controllers.ComparableObject](name types.NamespacedName, i 
 // Lookup finds all addresses associated with a given key. Many different key formats are supported; see inline comments.
 func (a *index) Lookup(key string) []model.AddressInfo {
 	// 1. Workload UID
-	if w := a.workloads.GetKey(krt.Key[model.WorkloadInfo](key)); w != nil {
+	if w := a.workloads.GetKey(key); w != nil {
 		return []model.AddressInfo{workloadToAddressInfo(w.Workload)}
 	}
 
@@ -436,7 +436,7 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 func (a *index) lookupService(key string) *model.ServiceInfo {
 	// 1. namespace/hostname format
-	s := a.services.GetKey(krt.Key[model.ServiceInfo](key))
+	s := a.services.GetKey(string(krt.Key[model.ServiceInfo](key)))
 	if s != nil {
 		return s
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex.go
@@ -436,7 +436,7 @@ func (a *index) Lookup(key string) []model.AddressInfo {
 
 func (a *index) lookupService(key string) *model.ServiceInfo {
 	// 1. namespace/hostname format
-	s := a.services.GetKey(string(krt.Key[model.ServiceInfo](key)))
+	s := a.services.GetKey(key)
 	if s != nil {
 		return s
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/ambientindex_test.go
@@ -631,7 +631,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.2")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(krt.Key[model.ServiceInfo](fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -653,7 +653,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(krt.Key[model.ServiceInfo](fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -674,7 +674,7 @@ func TestAmbientIndex_ServicesForWaypoint(t *testing.T) {
 			[]int32{80}, map[string]string{"app": "waypoint"}, "10.0.0.1")
 		s.assertEvent(s.t, s.svcXdsName("svc1"))
 
-		svc1Host := ptr.ToList(s.services.GetKey(krt.Key[model.ServiceInfo](fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1")))))
+		svc1Host := ptr.ToList(s.services.GetKey(fmt.Sprintf("%s/%s", testNS, s.hostnameForService("svc1"))))
 		assert.Equal(t, len(svc1Host), 1)
 		assert.EventuallyEqual(t, func() []model.ServiceInfo {
 			return s.ServicesForWaypoint(wpKey)
@@ -1160,7 +1160,7 @@ func TestDefaultAllowWaypointPolicy(t *testing.T) {
 
 	t.Run("policy with service accounts", func(t *testing.T) {
 		assert.EventuallyEqual(t, func() []string {
-			waypointPolicy := s.authorizationPolicies.GetKey(krt.Key[model.WorkloadAuthorization](policyName))
+			waypointPolicy := s.authorizationPolicies.GetKey(policyName)
 			if waypointPolicy == nil {
 				return nil
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/authorization_test.go
@@ -906,5 +906,5 @@ type TestWaypointPolicyStatusCollectionTestCase struct {
 }
 
 func getStatus[T any](col krt.Collection[T], name, namespace string) *T {
-	return col.GetKey(krt.Key[T](namespace + "/" + name))
+	return col.GetKey(namespace + "/" + name)
 }

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/sidecar_interop.go
@@ -106,7 +106,7 @@ func (a *index) ServicesWithWaypoint(key string) []model.ServiceWaypointInfo {
 	if key == "" {
 		svcs = a.services.List()
 	} else {
-		svcs = ptr.ToList(a.services.GetKey(krt.Key[model.ServiceInfo](key)))
+		svcs = ptr.ToList(a.services.GetKey(key))
 	}
 	for _, s := range svcs {
 		wp := s.Service.GetWaypoint()

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
@@ -151,7 +151,7 @@ func Register[T StatusWriter](q *StatusQueue, name string, col krt.Collection[T]
 			log.Debugf("processing snapshot")
 			for _, obj := range col.List() {
 				q.queue.Add(statusItem{
-					Key:      string(krt.GetKey(obj)),
+					Key:      krt.GetKey(obj),
 					Reporter: name,
 				})
 			}
@@ -163,7 +163,7 @@ func Register[T StatusWriter](q *StatusQueue, name string, col krt.Collection[T]
 				}
 				for _, o := range events {
 					ol := o.Latest()
-					key := string(krt.GetKey(ol))
+					key := krt.GetKey(ol)
 					log.Debugf("registering key for processing: %s", key)
 					q.queue.Add(statusItem{
 						Key:      key,

--- a/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
+++ b/pilot/pkg/serviceregistry/kube/controller/ambient/statusqueue/queue.go
@@ -138,7 +138,7 @@ type statusReporter struct {
 func Register[T StatusWriter](q *StatusQueue, name string, col krt.Collection[T], getPatcher func(T) (kclient.Patcher, []string)) {
 	sr := statusReporter{
 		getObject: func(s string) (StatusWriter, bool) {
-			if o := col.GetKey(krt.Key[T](s)); o != nil {
+			if o := col.GetKey(s); o != nil {
 				return *o, true
 			}
 			return nil, false

--- a/pkg/kube/krt/core.go
+++ b/pkg/kube/krt/core.go
@@ -26,7 +26,7 @@ var log = istiolog.RegisterScope("krt", "")
 // directly. Most importantly, consumers can subscribe to events when objects change.
 type Collection[T any] interface {
 	// GetKey returns an object by its key, if present. Otherwise, nil is returned.
-	GetKey(k Key[T]) *T
+	GetKey(k string) *T
 
 	// List returns all objects in the collection.
 	// Order of the list is undefined.

--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -59,7 +59,7 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 		// If they fetch a set of keys, directly Get these. Usually this is a single resource.
 		list = make([]T, 0, d.filter.keys.Len())
 		for _, k := range d.filter.keys.List() {
-			if i := c.GetKey(Key[T](k)); i != nil {
+			if i := c.GetKey(k); i != nil {
 				list = append(list, *i)
 			}
 		}

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -131,9 +131,9 @@ func (f *filter) Matches(object any, forList bool) bool {
 	if !forList {
 		// First, lookup directly by key. This is cheap
 		// an empty set will match none
-		if !f.keys.IsNil() && !f.keys.Contains(string(GetKey[any](object))) {
+		if !f.keys.IsNil() && !f.keys.Contains(GetKey[any](object)) {
 			if log.DebugEnabled() {
-				log.Debugf("no match key: %q vs %q", f.keys, string(GetKey[any](object)))
+				log.Debugf("no match key: %q vs %q", f.keys, GetKey[any](object))
 			}
 			return false
 		}

--- a/pkg/kube/krt/informer.go
+++ b/pkg/kube/krt/informer.go
@@ -63,7 +63,7 @@ func (i *informer[I]) Synced() Syncer {
 // nolint: unused // (not true, its to implement an interface)
 func (i *informer[I]) dump() CollectionDump {
 	return CollectionDump{
-		Outputs: eraseMap(slices.GroupUnique(i.inf.List(metav1.NamespaceAll, klabels.Everything()), GetKey)),
+		Outputs: eraseMap(slices.GroupUnique(i.inf.List(metav1.NamespaceAll, klabels.Everything()), getTypedKey)),
 	}
 }
 
@@ -81,13 +81,13 @@ func (i *informer[I]) List() []I {
 	return res
 }
 
-func (i *informer[I]) GetKey(k Key[I]) *I {
+func (i *informer[I]) GetKey(k string) *I {
 	// ns, n := splitKeyFunc(string(k))
 	// Internal optimization: we know kclient will eventually lookup "ns/name"
 	// We also have a key in this format.
 	// Rather than split and rejoin it later, just pass it as the name
 	// This is depending on "unstable" implementation details, but we own both libraries and tests would catch any issues.
-	if got := i.inf.Get(string(k), ""); !controllers.IsNil(got) {
+	if got := i.inf.Get(k, ""); !controllers.IsNil(got) {
 		return &got
 	}
 	return nil

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -93,23 +93,23 @@ type registerDependency interface {
 }
 
 // tryGetKey returns the Key for an object. If not possible, returns false
-func tryGetKey[O any](a O) (Key[O], bool) {
+func tryGetKey[O any](a O) (string, bool) {
 	as, ok := any(a).(string)
 	if ok {
-		return Key[O](as), true
+		return as, true
 	}
 	ao, ok := any(a).(controllers.Object)
 	if ok {
 		k, _ := cache.MetaNamespaceKeyFunc(ao)
-		return Key[O](k), true
+		return k, true
 	}
 	ac, ok := any(a).(config.Config)
 	if ok {
-		return Key[O](keyFunc(ac.Name, ac.Namespace)), true
+		return keyFunc(ac.Name, ac.Namespace), true
 	}
 	arn, ok := any(a).(ResourceNamer)
 	if ok {
-		return Key[O](arn.ResourceName()), true
+		return arn.ResourceName(), true
 	}
 	ack := GetApplyConfigKey(a)
 	if ack != nil {

--- a/pkg/kube/krt/join.go
+++ b/pkg/kube/krt/join.go
@@ -30,7 +30,7 @@ type join[T any] struct {
 	synced         <-chan struct{}
 }
 
-func (j *join[T]) GetKey(k Key[T]) *T {
+func (j *join[T]) GetKey(k string) *T {
 	for _, c := range j.collections {
 		if r := c.GetKey(k); r != nil {
 			return r
@@ -41,7 +41,7 @@ func (j *join[T]) GetKey(k Key[T]) *T {
 
 func (j *join[T]) List() []T {
 	res := []T{}
-	found := sets.New[Key[T]]()
+	found := sets.New[string]()
 	for _, c := range j.collections {
 		for _, i := range c.List() {
 			key := GetKey(i)

--- a/pkg/kube/krt/singleton.go
+++ b/pkg/kube/krt/singleton.go
@@ -65,7 +65,7 @@ type static[T any] struct {
 	collectionName string
 }
 
-func (d *static[T]) GetKey(k Key[T]) *T {
+func (d *static[T]) GetKey(k string) *T {
 	return d.val.Load()
 }
 

--- a/pkg/kube/krt/static.go
+++ b/pkg/kube/krt/static.go
@@ -29,13 +29,13 @@ type StaticCollection[T any] struct {
 
 type staticList[T any] struct {
 	mu       sync.RWMutex
-	vals     map[Key[T]]T
+	vals     map[string]T
 	handlers []func(o []Event[T], initialSync bool)
 	id       collectionUID
 }
 
 func NewStaticCollection[T any](vals []T) StaticCollection[T] {
-	res := map[Key[T]]T{}
+	res := make(map[string]T, len(vals))
 	for _, v := range vals {
 		res[GetKey(v)] = v
 	}
@@ -48,7 +48,7 @@ func NewStaticCollection[T any](vals []T) StaticCollection[T] {
 }
 
 // DeleteObject deletes an object from the collection.
-func (s *staticList[T]) DeleteObject(k Key[T]) {
+func (s *staticList[T]) DeleteObject(k string) {
 	s.mu.Lock() // Unlocked in runEventLocked
 	old, f := s.vals[k]
 	if f {
@@ -102,7 +102,7 @@ func (s *staticList[T]) UpdateObject(obj T) {
 	}
 }
 
-func (s *staticList[T]) GetKey(k Key[T]) *T {
+func (s *staticList[T]) GetKey(k string) *T {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if o, f := s.vals[k]; f {
@@ -124,7 +124,7 @@ func (s *staticList[T]) uid() collectionUID {
 // nolint: unused // (not true, its to implement an interface)
 func (s *staticList[T]) dump() CollectionDump {
 	return CollectionDump{
-		Outputs: eraseMap(slices.GroupUnique(s.List(), GetKey)),
+		Outputs: eraseMap(slices.GroupUnique(s.List(), getTypedKey)),
 	}
 }
 


### PR DESCRIPTION
The idea was this was supposed to avoid the ambiguity of which type the
`string` key was for. But in practice, there is no meaningful way to use
this, since a caller of `GetKey` has no way to get a key magically.

It is, however, slightly useful internally where we deal with multiple
types (like `map[Key[I]]Key[O]`).

This PR removes it from the user facing stuff but keeps the internal
usage where its helpful.
