### PR TITLE
fix istioctl waypoint delete deletes things which are not waypoints 

### DIFF
--- a/istioctl/pkg/waypoint/waypoint.go
+++ b/istioctl/pkg/waypoint/waypoint.go
@@ -470,6 +470,9 @@ func deleteWaypoints(cmd *cobra.Command, kubeClient kube.CLIClient, namespace st
 			return err
 		}
 		for _, gw := range waypoints.Items {
+			if gw.Spec.GatewayClassName != constants.WaypointGatewayClassName {
+				continue
+			}
 			names = append(names, gw.Name)
 		}
 	}

--- a/releasenotes/notes/54064.yaml
+++ b/releasenotes/notes/54064.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 54056
+releaseNotes:
+- |
+  **Fixed** `istioctl waypoint delete --all` deletes gateway resources that are not waypoints.


### PR DESCRIPTION
**Please provide a description of this PR:**

**Fixed** `istioctl waypoint delete --all` deletes gateway resources that are not waypoints.

fix https://github.com/istio/istio/issues/54056