### PR TITLE
krt: introduce a reverse index for dependencies, dramatically reducing CPU usage

### DIFF
--- a/pkg/kube/krt/fetch.go
+++ b/pkg/kube/krt/fetch.go
@@ -63,9 +63,9 @@ func Fetch[T any](ctx HandlerContext, cc Collection[T], opts ...FetchOption) []T
 				list = append(list, *i)
 			}
 		}
-	} else if d.filter.listFromIndex != nil {
+	} else if d.filter.index != nil {
 		// Otherwise from an index; fetch from there. Often this is a list of a namespace
-		list = d.filter.listFromIndex().([]T)
+		list = d.filter.index.list().([]T)
 	} else {
 		// Otherwise get everything
 		list = c.List()

--- a/pkg/kube/krt/filter.go
+++ b/pkg/kube/krt/filter.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/smallset"
 )
 
@@ -33,8 +34,30 @@ type filter struct {
 	labels          map[string]string
 	generic         func(any) bool
 
-	listFromIndex func() any
-	indexMatches  func(any) bool
+	index *indexFilter
+}
+
+type indexFilter struct {
+	list         func() any
+	indexMatches func(any) bool
+	extractKeys  objectKeyExtractor
+	key          string
+}
+
+type objectKeyExtractor = func(o any) []string
+
+func getKeyExtractor(o any) []string {
+	return []string{GetKey(o)}
+}
+
+func (f *filter) reverseIndexKey() (string, objectKeyExtractor, bool) {
+	if f.keys.Len() == 1 {
+		return f.keys.List()[0], getKeyExtractor, true
+	}
+	if f.index != nil {
+		return f.index.key, f.index.extractKeys, true
+	}
+	return "", nil, false
 }
 
 func (f *filter) String() string {
@@ -89,11 +112,19 @@ func FilterSelects(lbls map[string]string) FetchOption {
 func FilterIndex[K comparable, I any](idx Index[K, I], k K) FetchOption {
 	return func(h *dependency) {
 		// Index is used to pre-filter on the List, and also to match in Matches. Provide type-erased methods for both
-		h.filter.listFromIndex = func() any {
-			return idx.Lookup(k)
-		}
-		h.filter.indexMatches = func(a any) bool {
-			return idx.objectHasKey(a.(I), k)
+		h.filter.index = &indexFilter{
+			list: func() any {
+				return idx.Lookup(k)
+			},
+			indexMatches: func(a any) bool {
+				return idx.objectHasKey(a.(I), k)
+			},
+			extractKeys: func(o any) []string {
+				return slices.Map(idx.extractKeys(o.(I)), func(e K) string {
+					return toString(e)
+				})
+			},
+			key: toString(k),
 		}
 	}
 }
@@ -138,11 +169,13 @@ func (f *filter) Matches(object any, forList bool) bool {
 			return false
 		}
 		// Index is also cheap, and often used to filter namespaces out. Make sure we do this early
-		if f.indexMatches != nil && !f.indexMatches(object) {
-			if log.DebugEnabled() {
-				log.Debugf("no match index")
+		if f.index != nil {
+			if !f.index.indexMatches(object) {
+				if log.DebugEnabled() {
+					log.Debugf("no match index")
+				}
+				return false
 			}
-			return false
 		}
 	}
 

--- a/pkg/kube/krt/index.go
+++ b/pkg/kube/krt/index.go
@@ -24,6 +24,7 @@ import (
 type Index[K comparable, O any] interface {
 	Lookup(k K) []O
 	objectHasKey(obj O, k K) bool
+	extractKeys(o O) []K
 }
 
 // NewNamespaceIndex is a small helper to index a collection by namespace
@@ -61,6 +62,11 @@ func (i index[K, O]) objectHasKey(obj O, k K) bool {
 		}
 	}
 	return false
+}
+
+// nolint: unused // (not true)
+func (i index[K, O]) extractKeys(o O) []K {
+	return i.extract(o)
 }
 
 // Lookup finds all objects matching a given key

--- a/pkg/kube/krt/internal.go
+++ b/pkg/kube/krt/internal.go
@@ -74,6 +74,11 @@ type collectionOptions struct {
 	debugger     *DebugHandler
 }
 
+type indexedDependency struct {
+	id  collectionUID
+	key string
+}
+
 // dependency is a specific thing that can be depended on
 type dependency struct {
 	id             collectionUID


### PR DESCRIPTION
This PR is in draft pending https://github.com/istio/istio/pull/53994, as it builds on it. I will rebase once that lands, and this will get much smaller

Consider a collection like this:

```go
NewCollection(Pods, func(p Pod) {
  services := Fetch(Services, FilterIndex(ServiceNamespaceIndex, p.Namespace))
})
```

We call `Pods` the primary dependency, and `Services` a secondary dependency.

Currently, when a secondary dependency changes, we need to determine which primary objects depend on it so we can recompute them. That is, when Service `foo/bar` changes, we look for any pods that depended on services in namespace `foo`.

Today, we do this by an O(n) scan on all primary inputs. This can be problematic when the secondary input changes often, and the size of the primary input is large. For instance, imagine if services change 10x/s and we have 100k pods -- this means we need to process 1M (100k * 10) pods per second.

This change instead builds a reverse index, from `SecondaryDependency->Primary`. So concretely, we may have something like this:

```
map {
  (Services, Namespace=Y) => [pod1, pod2],
  (Services, Namespace=Z) => [pod3],
}
```

Now when a secondary event comes in, we look up in the index first to get a pre-filtered list of objects we need to check for.

In practice at large scales, this has incredible performance gains. This test shows spinning up 30k pods, before and after this change
![2024-11-25_17-57-16](https://github.com/user-attachments/assets/ca194055-8df5-4ab4-b31d-f020bb92bf46)
![2024-11-25_17-23-28](https://github.com/user-attachments/assets/3a05ed5e-8f59-45ae-b294-f3ddbc6ee728)

Note that beyond the base ~20x CPU reducation, the "before" case is actually using high CPU for 20 minutes after all the pod events are done -- it is unable to keep up with the rate of churn. In the after case, it can handle this fine. I forgot to take pictures, but i also took the new build up to 150k pods without issues (~1 CPU usage during this, but keep in mind the test is creating like 500 pods/s which is unrealistic in the real world).