### PR TITLE
remove unnecessary tls inspector

### DIFF
--- a/pilot/pkg/networking/core/listener.go
+++ b/pilot/pkg/networking/core/listener.go
@@ -585,15 +585,7 @@ func buildListenerFromEntry(builder *ListenerBuilder, le *outboundListenerEntry,
 		}
 	}
 
-	// We add a TLS inspector when http inspector is needed for outbound only. This
-	// is because if we ever set ALPN in the match without
-	// transport_protocol=raw_buffer, Envoy will automatically inject a tls
-	// inspector: https://github.com/envoyproxy/envoy/issues/13601. This leads to
-	// excessive logging and loss of control over the config. For inbound this is not
-	// needed, since we are explicitly setting transport protocol in every single
-	// match. We can do this for outbound as well, at which point this could be
-	// removed, but have not yet
-	if needTLSInspector || needHTTPInspector {
+	if needTLSInspector {
 		l.ListenerFilters = append(l.ListenerFilters, xdsfilters.TLSInspector)
 	}
 

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -1810,7 +1810,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			}
 
 			verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[0])
-			verifyListenerFilters(t, listeners[0].ListenerFilters)
+			verifyHTTPListenerFilters(t, listeners[0].ListenerFilters)
 
 			if listeners[0].ListenerFiltersTimeout.GetSeconds() != 5 {
 				t.Fatalf("expected timeout 5s, found  ListenerFiltersTimeout %v",
@@ -1836,7 +1836,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 			http := getHTTPFilterChain(t, listeners[0])
 
 			verifyHTTPFilterChainMatch(t, http)
-			verifyListenerFilters(t, listeners[0].ListenerFilters)
+			verifyHTTPListenerFilters(t, listeners[0].ListenerFilters)
 
 			if listeners[0].ListenerFiltersTimeout == nil {
 				t.Fatalf("expected timeout, found ContinueOnListenerFiltersTimeout %v, ListenerFiltersTimeout %v",
@@ -2104,6 +2104,16 @@ func verifyListenerFilters(t *testing.T, lfilters []*listener.ListenerFilter) {
 	}
 }
 
+func verifyHTTPListenerFilters(t *testing.T, lfilters []*listener.ListenerFilter) {
+	t.Helper()
+	if len(lfilters) != 1 {
+		t.Fatalf("expected %d listener filter, found %d", 1, len(lfilters))
+	}
+	if lfilters[0].Name != wellknown.HTTPInspector {
+		t.Fatalf("expected listener filters not found, got %v", lfilters)
+	}
+}
+
 func verifyHTTPFilterChainMatch(t *testing.T, fc *listener.FilterChain) {
 	t.Helper()
 	if fc.FilterChainMatch.TransportProtocol != xdsfilters.RawBufferTransportProtocol {
@@ -2208,7 +2218,7 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 		}
 
 		verifyHTTPFilterChainMatch(t, l.FilterChains[0])
-		verifyListenerFilters(t, l.ListenerFilters)
+		verifyHTTPListenerFilters(t, l.ListenerFilters)
 
 		if l := findListenerByPort(listeners, 3306); !isMysqlListener(l) {
 			t.Fatalf("expected MySQL listener on port 3306, found %v", l)
@@ -2231,7 +2241,7 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 		}
 
 		verifyHTTPFilterChainMatch(t, l.FilterChains[0])
-		verifyListenerFilters(t, l.ListenerFilters)
+		verifyHTTPListenerFilters(t, l.ListenerFilters)
 	}
 }
 
@@ -2761,7 +2771,7 @@ func TestOutboundListenerConfig_TCPFailThrough(t *testing.T) {
 
 	verifyHTTPFilterChainMatch(t, l.FilterChains[0])
 	verifyPassThroughTCPFilterChain(t, l.DefaultFilterChain)
-	verifyListenerFilters(t, l.ListenerFilters)
+	verifyHTTPListenerFilters(t, l.ListenerFilters)
 }
 
 func verifyPassThroughTCPFilterChain(t *testing.T, fc *listener.FilterChain) {

--- a/pilot/pkg/networking/core/listener_test.go
+++ b/pilot/pkg/networking/core/listener_test.go
@@ -2093,17 +2093,6 @@ func testInboundListenerConfigWithoutService(t *testing.T, proxy *model.Proxy) {
 	verifyFilterChainMatch(t, l)
 }
 
-func verifyListenerFilters(t *testing.T, lfilters []*listener.ListenerFilter) {
-	t.Helper()
-	if len(lfilters) != 2 {
-		t.Fatalf("expected %d listener filter, found %d", 2, len(lfilters))
-	}
-	if lfilters[0].Name != wellknown.TLSInspector ||
-		lfilters[1].Name != wellknown.HTTPInspector {
-		t.Fatalf("expected listener filters not found, got %v", lfilters)
-	}
-}
-
 func verifyHTTPListenerFilters(t *testing.T, lfilters []*listener.ListenerFilter) {
 	t.Helper()
 	if len(lfilters) != 1 {


### PR DESCRIPTION
The relevant envoy issue has been fixed https://github.com/envoyproxy/envoy/issues/13601 - We do not have to add this automatically

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions