### PR TITLE
Fix istioctl experimental injector list print redundant namespaces

### DIFF
--- a/istioctl/pkg/injector/injector-list.go
+++ b/istioctl/pkg/injector/injector-list.go
@@ -249,7 +249,7 @@ func getMatchingNamespaces(hook *admitv1.MutatingWebhookConfiguration, namespace
 	retval := make([]corev1.Namespace, 0, len(namespaces))
 	seen := sets.String{}
 	for _, webhook := range hook.Webhooks {
-		if webhook.Name != "rev.namespace.sidecar-injector.istio.io" {
+		if webhook.Name != "rev.namespace.sidecar-injector.istio.io" && webhook.Name != "namespace.sidecar-injector.istio.io" {
 			continue
 		}
 		nsSelector, err := metav1.LabelSelectorAsSelector(webhook.NamespaceSelector)

--- a/istioctl/pkg/injector/injector-list.go
+++ b/istioctl/pkg/injector/injector-list.go
@@ -249,6 +249,9 @@ func getMatchingNamespaces(hook *admitv1.MutatingWebhookConfiguration, namespace
 	retval := make([]corev1.Namespace, 0, len(namespaces))
 	seen := sets.String{}
 	for _, webhook := range hook.Webhooks {
+		if webhook.Name != "rev.namespace.sidecar-injector.istio.io" {
+			continue
+		}
 		nsSelector, err := metav1.LabelSelectorAsSelector(webhook.NamespaceSelector)
 		if err != nil {
 			return retval

--- a/releasenotes/notes/54095.yaml
+++ b/releasenotes/notes/54095.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+releaseNotes:
+- |
+  **Fixed** `istioctl experimental injector list` print redundant namespaces for injector webook.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fix `istioctln experimental injector list` print redundant namespaces, the discussion: https://github.com/istio/istio/pull/53583#discussion_r1851509977