### PR TITLE
fix: fix k3s cniBinDir to static path

### DIFF
--- a/manifests/charts/base/files/profile-platform-k3s.yaml
+++ b/manifests/charts/base/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/default/files/profile-platform-k3s.yaml
+++ b/manifests/charts/default/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateway/files/profile-platform-k3s.yaml
+++ b/manifests/charts/gateway/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-k3s.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-k3s.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-cni/files/profile-platform-k3s.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3s.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/charts/ztunnel/files/profile-platform-k3s.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-k3s.yaml
@@ -4,4 +4,4 @@
 
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni

--- a/manifests/helm-profiles/platform-k3s.yaml
+++ b/manifests/helm-profiles/platform-k3s.yaml
@@ -1,3 +1,3 @@
 cni:
   cniConfDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
-  cniBinDir: /var/lib/rancher/k3s/data/current/bin/
+  cniBinDir: /var/lib/rancher/k3s/data/cni


### PR DESCRIPTION
k3s recently had an issue with non-static cni paths. They changed the setup to a static path, see here for details: 
https://github.com/k3s-io/k3s/issues/11076
https://github.com/k3s-io/k3s/pull/10868

`helm-profiles/platform-k3s.yaml` sets `/var/lib/rancher/k3s/data/current/bin/` as `cniBinDir` when `global.platform` is set to `k3s`. This change corrects the path to the new static path `/var/lib/rancher/k3s/data/cni` 





not sure about that.


This is my first contribution, I hope this is the only file to change ;)