### PR TITLE
Resolve JWKS Resolver TOCTOU Race Conditions

### DIFF
--- a/releasenotes/notes/54118.yaml
+++ b/releasenotes/notes/54118.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: security
+issue:
+  - 52121
+releaseNotes:
+- |
+  **Fixed** Possible race conditions in JWK resolution cache for JWT policies that when triggered would cause
+  cache misses & failures to update signing keys when rotated


### PR DESCRIPTION
**Please provide a description of this PR:**

Resolves https://github.com/istio/istio/issues/52121

This updates the JWKS resolver cache accessing/refreshing logic respectively to resolve two TOC-TOU race conditions as mentioned in the issue.

**Updating lastUsedTime**

The prior implementation would potentially conflict with a public key refresh since `lastUsedTime` is incremented on each cache access and is stored in the same map. The value was read and stored without any mutex lock in between. The solution is to use `CompareAndSwap` to make a best-effort attempt to update the currently stored entry assuming no writes have occurred between load and store ops. If `CompareAndSwap` fails after a certain number of attempts, the code will assume that `lastUsedTime` will have been set to a close enough time value to simply disregard and proceed with the cached value.

**Delete then Store in Refresh Flow**

Two points in the refresh flow seem to be unnecessarily deleting the cache entry during the resolution process. Once when resolving JWKS from OIDC discovery data, and once more when resolving keys. In this case, it's sufficient to just leave the cached entry in place and overwrite it with the new data once its been resolved.