### PR TITLE
leader election: default revision properly

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -248,6 +248,10 @@ func newLeaderElection(namespace, name, electionID, revision string, perRevision
 	if features.EnableLeaderElection {
 		watcher = revisions.NewDefaultWatcher(client, revision)
 	}
+	// Default revision for consistency. Note that on Kubernetes, there is ~always a revision set.
+	if revision == "" {
+		revision = "default"
+	}
 	if name == "" {
 		hn, _ := os.Hostname()
 		name = fmt.Sprintf("unknown-%s", hn)


### PR DESCRIPTION
On kubernetes, we always set `REVISION`. It will be 'default' if there
is no revision.

When running in other environments, it may be `''`. This ends up with a
problem for leader election: two processes are leaders for the same
thing:

```
NAME                               HOLDER                    AGE
istio-gateway-deployment           not-on-kubernetes         26m
istio-gateway-deployment-default   istiod-7dd98766d4-mbqmw   57m
```

This normalizes the revision to avoid this issue
