### PR TITLE
Use platform profile for GKE as well, and drop the K8S version detect

### DIFF
--- a/manifests/charts/base/files/profile-platform-gke.yaml
+++ b/manifests/charts/base/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/default/files/profile-platform-gke.yaml
+++ b/manifests/charts/default/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/gateway/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateway/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/istio-cni/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-cni/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -210,14 +210,14 @@ spec:
         {{- end }}
         - name: cni-net-dir
           hostPath:
-            path: {{ default "/etc/cni/net.d" .Values.cniConfDir }}
+            path: {{ .Values.cniConfDir }}
         # Used for UDS sockets for logging, ambient eventing
         - name: cni-socket-dir
           hostPath:
             path: /var/run/istio-cni
         - name: cni-netns-dir
           hostPath:
-            path: {{ .Values.cniNetnsDir | default "/var/run/netns" }}
+            path: {{ .Values.cniNetnsDir }}
             type: DirectoryOrCreate # DirectoryOrCreate instead of Directory for the following reason - CNI may not bind mount this until a non-hostnetwork pod is scheduled on the node,
             # and we don't want to block CNI agent pod creation on waiting for the first non-hostnetwork pod.
             # Once the CNI does mount this, it will get populated and we're good.

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -1,6 +1,14 @@
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
+#
+# $detectedBinDir exists to support a GKE-specific platform override,
+# and is deprecated in favor of using the explicit `gke` platform profile.
+{{- $detectedBinDir :=
+    (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
+      "/home/kubernetes/bin"
+      .Values.cniBinDir
+}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -195,7 +203,7 @@ spec:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
-            path: {{ .Values.cniBinDir }}
+            path: {{ $detectedBinDir }}
         {{- if or .Values.repair.repairPods .Values.ambient.enabled }}
         - name: cni-host-procfs
           hostPath:

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -1,11 +1,6 @@
 # This manifest installs the Istio install-cni container, as well
 # as the Istio CNI plugin and config on
 # each master and worker node in a Kubernetes cluster.
-{{- $defaultBinDir :=
-    (.Capabilities.KubeVersion.GitVersion | contains "-gke") | ternary
-      "/home/kubernetes/bin"
-      "/opt/cni/bin"
-}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -200,7 +195,7 @@ spec:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
-            path: {{ .Values.cniBinDir | default $defaultBinDir }}
+            path: {{ .Values.cniBinDir }}
         {{- if or .Values.repair.repairPods .Values.ambient.enabled }}
         - name: cni-host-procfs
           hostPath:

--- a/manifests/charts/istio-cni/values.yaml
+++ b/manifests/charts/istio-cni/values.yaml
@@ -16,15 +16,13 @@ _internal_defaults_do_not_set:
   # Example
   # cniConfFileName: 10-calico.conflist
 
-  # CNI bin and conf dir override settings
-  # defaults:
-  cniBinDir: "" # Auto-detected based on version; defaults to /opt/cni/bin.
+  # CNI-and-platform specific path defaults.
+  # These may need to be set to platform-specific values, consult
+  # overrides for your platform in `manifests/helm-profiles/platform-*.yaml`
+  cniBinDir: /opt/cni/bin
   cniConfDir: /etc/cni/net.d
   cniConfFileName: ""
-  # This directory must exist on the node, if it does not, consult your container runtime
-  # documentation for the appropriate path.
-  cniNetnsDir: # Defaults to '/var/run/netns', in minikube/docker/others can be '/var/run/docker/netns'.
-
+  cniNetnsDir: "/var/run/netns"
 
   excludeNamespaces:
     - kube-system

--- a/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/charts/ztunnel/files/profile-platform-gke.yaml
+++ b/manifests/charts/ztunnel/files/profile-platform-gke.yaml
@@ -1,0 +1,6 @@
+# WARNING: DO NOT EDIT, THIS FILE IS A COPY.
+# The original version of this file is located at /manifests/helm-profiles directory.
+# If you want to make a change in this file, edit the original one and run "make gen".
+
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/manifests/helm-profiles/platform-gke.yaml
+++ b/manifests/helm-profiles/platform-gke.yaml
@@ -1,0 +1,2 @@
+cni:
+  cniBinDir: /home/kubernetes/bin

--- a/releasenotes/notes/54141.yaml
+++ b/releasenotes/notes/54141.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** GKE platform profile for ambient mode. When installing on GKE, use `--set global.platform=gke` (Helm) or `--set values.global.platform=gke` (istioctl) to apply GKE-specific value overrides. This replaces the previous GKE autodetection based on K8S version used in the `istio-cni` chart.


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes: https://github.com/istio/istio/issues/39534

and closes out: https://github.com/istio/istio/issues/51121

Since we have had platform profiles for some time and people generally are OK with them, this removes the (one) instance of K8S version autodetection we were doing in the `istio-cni` chart and just creates a platform profile for GKE like the others we already have for other platforms.

3 problems with autodetection in the Helm template:

1. It's fragile
2. It's not obvious/discoverable
3. It doesn't work if you template the charts ahead-of-time and install them with a different tool(Argo, kubectl) unless you use the correct option flag when templating (`--current-cluster` for istioctl/`--kube-version` for helm)