### PR TITLE
Update validations to check for incompatible Calico CNI fields

### DIFF
--- a/operator/pkg/apis/validation/validation.go
+++ b/operator/pkg/apis/validation/validation.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 
@@ -88,27 +90,41 @@ func environmentalDetection(client kube.Client, iop *apis.IstioOperator) (Warnin
 
 func detectCniIncompatibility(client kube.Client, cniEnabled bool, ztunnelEnabled bool) util.Errors {
 	var errs util.Errors
+	calicoResource := schema.GroupVersionResource{Group: "projectcalico.org", Version: "v3", Resource: "felixconfigurations"}
+	calico, err := client.Dynamic().Resource(calicoResource).Get(context.Background(), "default", metav1.GetOptions{})
+	if err == nil {
+		bpfConnectTimeLoadBalancing, found, _ := unstructured.NestedString(calico.Object, "spec", "bpfConnectTimeLoadBalancing")
+		if found && ztunnelEnabled && bpfConnectTimeLoadBalancing != "Disabled" {
+			// Need to disable Calico connect-time load balancing since it send traffic directly to the backend pod IP
+			// nolint: lll
+			errs = util.AppendErr(errs, fmt.Errorf("detected Calico CNI with 'bpfConnectTimeLoadBalancing=%s'; this must be set to 'bpfConnectTimeLoadBalancing=Disabled' in the Calico configuration", bpfConnectTimeLoadBalancing))
+		}
+		bpfConnectTimeLoadBalancingEnabled, found, _ := unstructured.NestedBool(calico.Object, "spec", "bpfConnectTimeLoadBalancingEnabled")
+		if found && ztunnelEnabled && bpfConnectTimeLoadBalancingEnabled {
+			// Same behavior as BpfconnectTimeLoadBalancing
+			// nolint: lll
+			errs = util.AppendErr(errs, fmt.Errorf("detected Calico CNI with 'bpfConnectTimeLoadBalancingEnabled=true'; this must be set to 'bpfConnectTimeLoadBalancingEnabled=false' in the Calico configuration"))
+		}
+	}
 	cilium, err := client.Kube().CoreV1().ConfigMaps("kube-system").Get(context.Background(), "cilium-config", metav1.GetOptions{})
-	if err != nil {
-		// Ignore errors, user may not be running Cilium at all
-		return nil
-	}
-	if cniEnabled && cilium.Data["cni-exclusive"] == "true" {
-		// Without this, Cilium will constantly overwrite our CNI config.
-		errs = util.AppendErr(errs,
-			fmt.Errorf("detected Cilium CNI with 'cni-exclusive=true'; this must be set to 'cni-exclusive=false' in the Cilium configuration"))
-	}
-	if ztunnelEnabled && cilium.Data["enable-bpf-masquerade"] == "true" {
-		// See https://github.com/istio/istio/issues/52208
-		errs = util.AppendErr(errs,
-			fmt.Errorf("detected Cilium CNI with 'enable-bpf-masquerade=true'; this must be set to 'false' when using ambient mode"))
-	}
-	bpfLbSocket := cilium.Data["bpf-lb-sock"] == "true"                 // Unset implies 'false', so this check is ok
-	bpfLbHostnsOnly := cilium.Data["bpf-lb-sock-hostns-only"] == "true" // Unset implies 'false', so this check is ok
-	if bpfLbSocket && !bpfLbHostnsOnly {
-		// See https://github.com/istio/istio/issues/27619
-		errs = util.AppendErr(errs,
-			errors.New("detected Cilium CNI with 'bpf-lb-sock=true'; this requires 'bpf-lb-sock-hostns-only=true' to be set"))
+	if err == nil {
+		if cniEnabled && cilium.Data["cni-exclusive"] == "true" {
+			// Without this, Cilium will constantly overwrite our CNI config.
+			errs = util.AppendErr(errs,
+				fmt.Errorf("detected Cilium CNI with 'cni-exclusive=true'; this must be set to 'cni-exclusive=false' in the Cilium configuration"))
+		}
+		if ztunnelEnabled && cilium.Data["enable-bpf-masquerade"] == "true" {
+			// See https://github.com/istio/istio/issues/52208
+			errs = util.AppendErr(errs,
+				fmt.Errorf("detected Cilium CNI with 'enable-bpf-masquerade=true'; this must be set to 'false' when using ambient mode"))
+		}
+		bpfLbSocket := cilium.Data["bpf-lb-sock"] == "true"                 // Unset implies 'false', so this check is ok
+		bpfLbHostnsOnly := cilium.Data["bpf-lb-sock-hostns-only"] == "true" // Unset implies 'false', so this check is ok
+		if bpfLbSocket && !bpfLbHostnsOnly {
+			// See https://github.com/istio/istio/issues/27619
+			errs = util.AppendErr(errs,
+				errors.New("detected Cilium CNI with 'bpf-lb-sock=true'; this requires 'bpf-lb-sock-hostns-only=true' to be set"))
+		}
 	}
 	return errs
 }

--- a/operator/pkg/apis/validation/validation.go
+++ b/operator/pkg/apis/validation/validation.go
@@ -94,13 +94,13 @@ func detectCniIncompatibility(client kube.Client, cniEnabled bool, ztunnelEnable
 	calico, err := client.Dynamic().Resource(calicoResource).Get(context.Background(), "default", metav1.GetOptions{})
 	if err == nil {
 		bpfConnectTimeLoadBalancing, found, _ := unstructured.NestedString(calico.Object, "spec", "bpfConnectTimeLoadBalancing")
-		if found && ztunnelEnabled && bpfConnectTimeLoadBalancing != "Disabled" {
+		if found && bpfConnectTimeLoadBalancing != "Disabled" {
 			// Need to disable Calico connect-time load balancing since it send traffic directly to the backend pod IP
 			// nolint: lll
 			errs = util.AppendErr(errs, fmt.Errorf("detected Calico CNI with 'bpfConnectTimeLoadBalancing=%s'; this must be set to 'bpfConnectTimeLoadBalancing=Disabled' in the Calico configuration", bpfConnectTimeLoadBalancing))
 		}
 		bpfConnectTimeLoadBalancingEnabled, found, _ := unstructured.NestedBool(calico.Object, "spec", "bpfConnectTimeLoadBalancingEnabled")
-		if found && ztunnelEnabled && bpfConnectTimeLoadBalancingEnabled {
+		if found && bpfConnectTimeLoadBalancingEnabled {
 			// Same behavior as BpfconnectTimeLoadBalancing
 			// nolint: lll
 			errs = util.AppendErr(errs, fmt.Errorf("detected Calico CNI with 'bpfConnectTimeLoadBalancingEnabled=true'; this must be set to 'bpfConnectTimeLoadBalancingEnabled=false' in the Calico configuration"))

--- a/operator/pkg/apis/validation/validation_test.go
+++ b/operator/pkg/apis/validation/validation_test.go
@@ -376,12 +376,6 @@ func TestDetectCniIncompatibility(t *testing.T) {
 	}{
 		{
 			desc: "Calico bpfConnectTimeLoadBalancing TCP",
-			ioYamlStr: `
-spec:
-  components:
-    ztunnel:
-      enabled: true
-`,
 			calicoConfig: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "projectcalico.org/v3",
@@ -399,12 +393,6 @@ spec:
 		},
 		{
 			desc: "Calico bpfConnectTimeLoadBalancingEnabled true",
-			ioYamlStr: `
-spec:
-  components:
-    ztunnel:
-      enabled: true
-`,
 			calicoConfig: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "projectcalico.org/v3",

--- a/operator/pkg/apis/validation/validation_test.go
+++ b/operator/pkg/apis/validation/validation_test.go
@@ -15,14 +15,21 @@
 package validation_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"istio.io/istio/operator/pkg/apis"
 	"istio.io/istio/operator/pkg/apis/validation"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/values"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/assert"
 )
 
@@ -353,6 +360,100 @@ cni:
 			_, errs := validation.ParseAndValidateIstioOperator(values.MakeMap(m, "spec", "values"), nil)
 			if gotErr, wantErr := errs, tt.wantErrs; !util.EqualErrors(gotErr, wantErr) {
 				t.Errorf("CheckValues(%s)(%v): gotErr:%s, wantErr:%s", tt.desc, tt.yamlStr, gotErr, wantErr)
+			}
+		})
+	}
+}
+
+// nolint: lll
+func TestDetectCniIncompatibility(t *testing.T) {
+	tests := []struct {
+		desc         string
+		ioYamlStr    string
+		calicoConfig *unstructured.Unstructured
+		ciliumConfig *v1.ConfigMap
+		wantWarnings util.Errors
+	}{
+		{
+			desc: "Calico bpfConnectTimeLoadBalancing TCP",
+			ioYamlStr: `
+spec:
+  components:
+    ztunnel:
+      enabled: true
+`,
+			calicoConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "projectcalico.org/v3",
+					"kind":       "FelixConfiguration",
+					"metadata": map[string]interface{}{
+						"name": "default",
+					},
+					"spec": map[string]interface{}{
+						"bpfConnectTimeLoadBalancing": "TCP",
+					},
+				},
+			},
+
+			wantWarnings: makeErrors([]string{`detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP'; this must be set to 'bpfConnectTimeLoadBalancing=Disabled' in the Calico configuration`}),
+		},
+		{
+			desc: "Calico bpfConnectTimeLoadBalancingEnabled true",
+			ioYamlStr: `
+spec:
+  components:
+    ztunnel:
+      enabled: true
+`,
+			calicoConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "projectcalico.org/v3",
+					"kind":       "FelixConfiguration",
+					"metadata": map[string]interface{}{
+						"name": "default",
+					},
+					"spec": map[string]interface{}{
+						"bpfConnectTimeLoadBalancingEnabled": true,
+					},
+				},
+			},
+
+			wantWarnings: makeErrors([]string{`detected Calico CNI with 'bpfConnectTimeLoadBalancingEnabled=true'; this must be set to 'bpfConnectTimeLoadBalancingEnabled=false' in the Calico configuration`}),
+		},
+		{
+			desc: "Cilium enable-bpf-masquerade true",
+			ioYamlStr: `
+spec:
+  components:
+    ztunnel:
+      enabled: true
+`,
+			ciliumConfig: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cilium-config"},
+				Data: map[string]string{
+					"enable-bpf-masquerade": "true",
+				},
+			},
+			wantWarnings: makeErrors([]string{`detected Cilium CNI with 'enable-bpf-masquerade=true'; this must be set to 'false' when using ambient mode`}),
+		},
+	}
+
+	calicoResource := schema.GroupVersionResource{Group: "projectcalico.org", Version: "v3", Resource: "felixconfigurations"}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			m, err := values.MapFromYaml([]byte(tt.ioYamlStr))
+			assert.NoError(t, err)
+
+			client := kube.NewFakeClient()
+			if tt.calicoConfig != nil {
+				client.Dynamic().Resource(calicoResource).Create(context.Background(), tt.calicoConfig, metav1.CreateOptions{})
+			}
+			if tt.ciliumConfig != nil {
+				client.Kube().CoreV1().ConfigMaps("kube-system").Create(context.Background(), tt.ciliumConfig, metav1.CreateOptions{})
+			}
+			warnings, _ := validation.ParseAndValidateIstioOperator(m, client)
+			if gotWarnings, wantWarnings := warnings, tt.wantWarnings; !util.EqualErrors(gotWarnings, wantWarnings) {
+				t.Errorf("CheckValues(%s): gotWarnings:%s, wantWarnings:%s", tt.desc, gotWarnings, wantWarnings)
 			}
 		})
 	}


### PR DESCRIPTION
The Calico eBPF configuration `bpfConnectTimeLoadBalancing` will perform connect-time load balancing by hooking into the socket BPF hooks and connecting directly to the backend pod IP. Thus this needs to be set to `Disabled` for use with Istio.

This displays a warning when a user attempts to install via `istioctl`, e.g.

```
❗ detected Calico CNI with 'bpfConnectTimeLoadBalancing=Enabled'; this must be set to 'bpfConnectTimeLoadBalancing=Disabled' in the Calico configuration
```

It's slightly annoying to check for, since these fields are configured for Felix by a CRD `FelixConfiguration`, which defaults to the name `default` (and is cluster-scoped). Opted to go down the Dynamic/Unstructured path, but if there is a better way to handle that please let me know.

Also added some unit test coverage for CNI validations.

Resolves: https://github.com/istio/istio/issues/53750 