### PR TITLE
NewDelayedInformer allows using clients from Register

### DIFF
--- a/pkg/config/schema/kubeclient/common_test.go
+++ b/pkg/config/schema/kubeclient/common_test.go
@@ -29,9 +29,10 @@ import (
 )
 
 func TestCustomRegistration(t *testing.T) {
+	gvr := v1.SchemeGroupVersion.WithResource("networkpolicies")
+	gvk := v1.SchemeGroupVersion.WithKind("NetworkPolicy")
 	Register[*v1.NetworkPolicy](
-		v1.SchemeGroupVersion.WithResource("networkpolicies"),
-		v1.SchemeGroupVersion.WithKind("NetworkPolicy"),
+		gvr, gvk,
 		func(c ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
 			return c.Kube().NetworkingV1().NetworkPolicies(namespace).List(context.Background(), o)
 		},
@@ -39,12 +40,11 @@ func TestCustomRegistration(t *testing.T) {
 			return c.Kube().NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), o)
 		},
 	)
-
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "funkyns"}}
 
 	client := kube.NewFakeClient(ns)
 
-	inf := GetInformerFiltered[*v1.NetworkPolicy](client, ktypes.InformerOptions{})
+	inf := GetInformerFiltered[*v1.NetworkPolicy](client, ktypes.InformerOptions{}, gvr)
 	if inf.Informer == nil {
 		t.Errorf("Expected valid informer, got empty")
 	}

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -444,7 +444,7 @@ resources:
     plural: "telemetries"
     group: "telemetry.istio.io"
     version: "v1"
-    versionAliases: 
+    versionAliases:
     - "v1alpha1"
     proto: "istio.telemetry.v1alpha1.Telemetry"
     protoPackage: "istio.io/api/telemetry/v1alpha1"

--- a/pkg/kube/kclient/client.go
+++ b/pkg/kube/kclient/client.go
@@ -264,7 +264,7 @@ func New[T controllers.ComparableObject](c kube.Client) Client[T] {
 // Use with caution.
 func NewFiltered[T controllers.ComparableObject](c kube.Client, filter Filter) Client[T] {
 	gvr := types.MustToGVR[T](types.MustGVKFromType[T]())
-	inf := kubeclient.GetInformerFiltered[T](c, ToOpts(c, gvr, filter))
+	inf := kubeclient.GetInformerFiltered[T](c, ToOpts(c, gvr, filter), gvr)
 	return &fullClient[T]{
 		writeClient: writeClient[T]{client: c},
 		Informer:    newInformerClient[T](gvr, inf, filter),


### PR DESCRIPTION
```
	Register[*v1.NetworkPolicy](
		gvr, gvk,
		func(c ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
			return c.Kube().NetworkingV1().NetworkPolicies(namespace).List(context.Background(), o)
		},
		func(c ClientGetter, namespace string, o metav1.ListOptions) (watch.Interface, error) {
			return c.Kube().NetworkingV1().NetworkPolicies(namespace).Watch(context.Background(), o)
		},
	)

```

When we set up a dynamic client like this, we can easily get the informer with `GetInformerFiltered`. 

The most common utility used to setup the clients for KRT collections is to use `NewDelayedInformer` which bypasses `GetInformerFiltered`.

This change makes use go through `GetInformerFiltered[T]`  to ensure registered clients can be used. 