### PR TITLE
Always wait for `iptables-legacy` lock, even if using sandboxing. Also, rename var.

### DIFF
--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -222,16 +222,14 @@ func getPodLevelTrafficOverrides(pod *corev1.Pod) iptables.PodLevelOverrides {
 
 func realDependenciesHost() *dep.RealDependencies {
 	return &dep.RealDependencies{
-		// We are in the host FS *and* the Host network
-		HostFilesystemPodNetwork: false,
+		UsePodScopedXtablesLock: false,
 		NetworkNamespace:         "",
 	}
 }
 
-func realDependenciesInpod() *dep.RealDependencies {
+func realDependenciesInpod(useScopedLocks bool) *dep.RealDependencies {
 	return &dep.RealDependencies{
-		// We are running the host FS, but the pod network -- setup rules differently (locking, etc)
-		HostFilesystemPodNetwork: true,
+		UsePodScopedXtablesLock: useScopedLocks,
 		NetworkNamespace:         "",
 	}
 }

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -223,14 +223,14 @@ func getPodLevelTrafficOverrides(pod *corev1.Pod) iptables.PodLevelOverrides {
 func realDependenciesHost() *dep.RealDependencies {
 	return &dep.RealDependencies{
 		UsePodScopedXtablesLock: false,
-		NetworkNamespace:         "",
+		NetworkNamespace:        "",
 	}
 }
 
 func realDependenciesInpod(useScopedLocks bool) *dep.RealDependencies {
 	return &dep.RealDependencies{
 		UsePodScopedXtablesLock: useScopedLocks,
-		NetworkNamespace:         "",
+		NetworkNamespace:        "",
 	}
 }
 

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -29,6 +29,7 @@ var (
 	Revision          = env.RegisterStringVar("REVISION", "", "").Get()
 	HostProbeSNATIP   = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
 	HostProbeSNATIPV6 = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IPV6", DefaultHostProbeSNATIPV6, "").Get())
+	UseScopedIptablesLegacyLocking = env.RegisterBoolVar("AMBIENT_USE_SCOPED_XTABLES_LOCKING", true, "").Get()
 )
 
 const (

--- a/cni/pkg/nodeagent/options.go
+++ b/cni/pkg/nodeagent/options.go
@@ -22,13 +22,13 @@ import (
 )
 
 var (
-	PodNamespace      = env.RegisterStringVar("POD_NAMESPACE", "", "pod's namespace").Get()
-	SystemNamespace   = env.RegisterStringVar("SYSTEM_NAMESPACE", constants.IstioSystemNamespace, "istio system namespace").Get()
-	PodName           = env.RegisterStringVar("POD_NAME", "", "").Get()
-	NodeName          = env.RegisterStringVar("NODE_NAME", "", "").Get()
-	Revision          = env.RegisterStringVar("REVISION", "", "").Get()
-	HostProbeSNATIP   = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
-	HostProbeSNATIPV6 = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IPV6", DefaultHostProbeSNATIPV6, "").Get())
+	PodNamespace                   = env.RegisterStringVar("POD_NAMESPACE", "", "pod's namespace").Get()
+	SystemNamespace                = env.RegisterStringVar("SYSTEM_NAMESPACE", constants.IstioSystemNamespace, "istio system namespace").Get()
+	PodName                        = env.RegisterStringVar("POD_NAME", "", "").Get()
+	NodeName                       = env.RegisterStringVar("NODE_NAME", "", "").Get()
+	Revision                       = env.RegisterStringVar("REVISION", "", "").Get()
+	HostProbeSNATIP                = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IP", DefaultHostProbeSNATIP, "").Get())
+	HostProbeSNATIPV6              = netip.MustParseAddr(env.RegisterStringVar("HOST_PROBE_SNAT_IPV6", DefaultHostProbeSNATIPV6, "").Get())
 	UseScopedIptablesLegacyLocking = env.RegisterBoolVar("AMBIENT_USE_SCOPED_XTABLES_LOCKING", true, "").Get()
 )
 

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -89,6 +89,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 		return nil, fmt.Errorf("error initializing the ztunnel server: %w", err)
 	}
 
+	// nolint: lll
 	hostIptables, podIptables, err := iptables.NewIptablesConfigurator(cfg, realDependenciesHost(), realDependenciesInpod(UseScopedIptablesLegacyLocking), iptables.RealNlDeps())
 	if err != nil {
 		return nil, fmt.Errorf("error configuring iptables: %w", err)

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -89,7 +89,7 @@ func NewServer(ctx context.Context, ready *atomic.Value, pluginSocket string, ar
 		return nil, fmt.Errorf("error initializing the ztunnel server: %w", err)
 	}
 
-	hostIptables, podIptables, err := iptables.NewIptablesConfigurator(cfg, realDependenciesHost(), realDependenciesInpod(), iptables.RealNlDeps())
+	hostIptables, podIptables, err := iptables.NewIptablesConfigurator(cfg, realDependenciesHost(), realDependenciesInpod(UseScopedIptablesLegacyLocking), iptables.RealNlDeps())
 	if err != nil {
 		return nil, fmt.Errorf("error configuring iptables: %w", err)
 	}

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -359,7 +359,7 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 	commonCases := getCommonTestCases()
 	ext := &dep.RealDependencies{
 		UsePodScopedXtablesLock: false,
-		NetworkNamespace:         "",
+		NetworkNamespace:        "",
 	}
 	iptVer, err := ext.DetectIptablesVersion(false)
 	if err != nil {
@@ -438,7 +438,7 @@ func TestIdempotentUnequaledRerun(t *testing.T) {
 	commonCases := getCommonTestCases()
 	ext := &dep.RealDependencies{
 		UsePodScopedXtablesLock: false,
-		NetworkNamespace:         "",
+		NetworkNamespace:        "",
 	}
 	iptVer, err := ext.DetectIptablesVersion(false)
 	if err != nil {

--- a/tools/istio-iptables/pkg/capture/run_test.go
+++ b/tools/istio-iptables/pkg/capture/run_test.go
@@ -358,7 +358,7 @@ func TestIdempotentEquivalentRerun(t *testing.T) {
 	setup(t)
 	commonCases := getCommonTestCases()
 	ext := &dep.RealDependencies{
-		HostFilesystemPodNetwork: false,
+		UsePodScopedXtablesLock: false,
 		NetworkNamespace:         "",
 	}
 	iptVer, err := ext.DetectIptablesVersion(false)
@@ -437,7 +437,7 @@ func TestIdempotentUnequaledRerun(t *testing.T) {
 	setup(t)
 	commonCases := getCommonTestCases()
 	ext := &dep.RealDependencies{
-		HostFilesystemPodNetwork: false,
+		UsePodScopedXtablesLock: false,
 		NetworkNamespace:         "",
 	}
 	iptVer, err := ext.DetectIptablesVersion(false)

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -203,7 +203,7 @@ func ProgramIptables(cfg *config.Config) error {
 	} else {
 		ext = &dep.RealDependencies{
 			UsePodScopedXtablesLock: cfg.HostFilesystemPodNetwork,
-			NetworkNamespace:         cfg.NetworkNamespace,
+			NetworkNamespace:        cfg.NetworkNamespace,
 		}
 	}
 

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -202,7 +202,7 @@ func ProgramIptables(cfg *config.Config) error {
 		ext = &dep.DependenciesStub{}
 	} else {
 		ext = &dep.RealDependencies{
-			HostFilesystemPodNetwork: cfg.HostFilesystemPodNetwork,
+			UsePodScopedXtablesLock: cfg.HostFilesystemPodNetwork,
 			NetworkNamespace:         cfg.NetworkNamespace,
 		}
 	}

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -54,7 +54,7 @@ var exittypeToString = map[XTablesExittype]string{
 
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
-	NetworkNamespace         string
+	NetworkNamespace string
 	// Should generally be set to true anytime we are "jumping" from a shared iptables
 	// context (the node, an agent container) into a pod to do iptables stuff,
 	// as it's faster and reduces contention for legacy iptables versions that use file-based locking.

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -55,7 +55,10 @@ var exittypeToString = map[XTablesExittype]string{
 // RealDependencies implementation of interface Dependencies, which is used in production
 type RealDependencies struct {
 	NetworkNamespace         string
-	HostFilesystemPodNetwork bool
+	// Should generally be set to true anytime we are "jumping" from a shared iptables
+	// context (the node, an agent container) into a pod to do iptables stuff,
+	// as it's faster and reduces contention for legacy iptables versions that use file-based locking.
+	UsePodScopedXtablesLock bool
 }
 
 const iptablesVersionPattern = `v([0-9]+(\.[0-9]+)+)`

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -219,7 +219,16 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 	run := func(c *exec.Cmd) error {
 		return c.Run()
 	}
-	if r.HostFilesystemPodNetwork {
+	if needLock {
+		// For _any_ mode where we need a lock (sandboxed or not)
+		// use the wait flag. In sandbox mode we use the container's netns itself
+		// as the lockfile, if one is needed, to avoid lock contention 99% of the time.
+		// But a container netns is just a file, and like any Linux file,
+		// we can't guarantee no other process has it locked.
+		args = append(args, "--wait=30")
+	}
+
+	if r.UsePodScopedXtablesLock {
 		c = exec.Command(cmdBin, args...)
 		// In CNI, we are running the pod network namespace, but the host filesystem, so we need to do some tricks
 		// Call our binary again, but with <original binary> "unshare (subcommand to trigger mounts)" --lock-file=<network namespace> <original command...>
@@ -227,14 +236,14 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 		var lockFile string
 		if needLock {
 			if iptVer.Version.LessThan(IptablesLockfileEnv) {
-				mode = "without lock by mount and nss"
+				mode = "sandboxed local lock by mount and nss"
 				lockFile = r.NetworkNamespace
 			} else {
-				mode = "without lock by env and nss"
+				mode = "sandboxed local lock by env and nss"
 				c.Env = append(c.Env, "XTABLES_LOCKFILE="+r.NetworkNamespace)
 			}
 		} else {
-			mode = "without nss"
+			mode = "sandboxed without lock"
 		}
 
 		run = func(c *exec.Cmd) error {
@@ -244,11 +253,8 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 		}
 	} else {
 		if needLock {
-			// We want the lock. Wait up to 30s for it.
-			args = append(args, "--wait=30")
 			c = exec.Command(cmdBin, args...)
 			log.Debugf("running with lock")
-			mode = "with wait lock"
 		} else {
 			// No locking supported/needed, just run as is. Nothing special
 			c = exec.Command(cmdBin, args...)

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -255,6 +255,7 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 		if needLock {
 			c = exec.Command(cmdBin, args...)
 			log.Debugf("running with lock")
+			mode = "with global lock"
 		} else {
 			// No locking supported/needed, just run as is. Nothing special
 			c = exec.Command(cmdBin, args...)


### PR DESCRIPTION
**Please provide a description of this PR:**
Related to https://github.com/istio/istio/issues/54050 but I want to do some more testing to see if I can reproduce that reliably first.

Basically:

- Always run `iptables-legacy` with a waitlock, even if we are using the sandboxed lockfile
  - In the sandboxed lock mode we have, we use the netns file as the lockfile, and assume we don't have to wait for it to be unlocked. This mostly works pretty well, but a netns is just a file like any other and we can't assume no other process on the node has locked the netns for some reason - so reintroduce the wait arg for that case too. This shouldn't trigger any blanket delays since we will only wait if we can't grab the sandboxed lockfile for that pod as a first thing.
  - Rename the `iptables-legacy` sandboxing variable to be a bit more clear about when it needs to be used.
    - It is never _required_ for ambient, as for ambient we are always using the binaries inside the `istio-cni` container, and always using a lockfile inside that container - we don't use host binaries or lockfiles, so we would only ever be contending with ourself.
    - As https://github.com/istio/istio/pull/51777 mentioned, it _does_ improve pod add performance in ambient, so added an env option to disable it if needed, but default that to true.