### PR TITLE
cni: propogate log context further

### DIFF
--- a/cni/pkg/iptables/iptables_e2e_test.go
+++ b/cni/pkg/iptables/iptables_e2e_test.go
@@ -56,7 +56,7 @@ func TestIptablesCleanRoundTrip(t *testing.T) {
 
 	t.Log("starting cleanup")
 	// Cleanup, should work
-	assert.NoError(t, iptConfigurator.DeleteInpodRules())
+	assert.NoError(t, iptConfigurator.DeleteInpodRules(log))
 	validateIptablesClean(t)
 
 	t.Log("second run")

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -17,6 +17,7 @@ package nodeagent
 import (
 	"context"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"

--- a/cni/pkg/nodeagent/informers.go
+++ b/cni/pkg/nodeagent/informers.go
@@ -17,7 +17,6 @@ package nodeagent
 import (
 	"context"
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"

--- a/cni/pkg/nodeagent/net.go
+++ b/cni/pkg/nodeagent/net.go
@@ -255,7 +255,7 @@ func (s *NetServer) RemovePodFromMesh(ctx context.Context, pod *corev1.Pod, isDe
 		if openNetns != nil {
 			// pod is removed from the mesh, but is still running. remove iptables rules
 			log.Debugf("calling DeleteInpodRules")
-			if err := s.netnsRunner(openNetns, func() error { return s.podIptables.DeleteInpodRules() }); err != nil {
+			if err := s.netnsRunner(openNetns, func() error { return s.podIptables.DeleteInpodRules(log) }); err != nil {
 				return fmt.Errorf("failed to delete inpod rules: %w", err)
 			}
 		} else {

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -291,7 +291,7 @@ func (cfg *IptablesConfigurator) Run() error {
 		// Best effort since we don't know if the commands exist
 		_ = cfg.ext.Run(log.WithLabels(), constants.IPTablesSave, &iptVer, nil)
 		if cfg.cfg.EnableIPv6 {
-			_ = cfg.ext.Run(log.WithLabels(),constants.IPTablesSave, &ipt6Ver, nil)
+			_ = cfg.ext.Run(log.WithLabels(), constants.IPTablesSave, &ipt6Ver, nil)
 		}
 	}()
 
@@ -586,7 +586,7 @@ func (f UDPRuleApplier) RunV6(args ...string) {
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
-		f.ext.RunQuietlyAndIgnore(log.WithLabels(),constants.IPTables, f.ipt6V, nil, deleteArgs...)
+		f.ext.RunQuietlyAndIgnore(log.WithLabels(), constants.IPTables, f.ipt6V, nil, deleteArgs...)
 	}
 }
 

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -289,9 +289,9 @@ func (cfg *IptablesConfigurator) Run() error {
 
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		_ = cfg.ext.Run(constants.IPTablesSave, &iptVer, nil)
+		_ = cfg.ext.Run(log.WithLabels(), constants.IPTablesSave, &iptVer, nil)
 		if cfg.cfg.EnableIPv6 {
-			_ = cfg.ext.Run(constants.IPTablesSave, &ipt6Ver, nil)
+			_ = cfg.ext.Run(log.WithLabels(),constants.IPTablesSave, &ipt6Ver, nil)
 		}
 	}()
 
@@ -575,7 +575,7 @@ func (f UDPRuleApplier) RunV4(args ...string) {
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
-		f.ext.RunQuietlyAndIgnore(constants.IPTables, f.iptV, nil, deleteArgs...)
+		f.ext.RunQuietlyAndIgnore(log.WithLabels(), constants.IPTables, f.iptV, nil, deleteArgs...)
 	}
 }
 
@@ -586,7 +586,7 @@ func (f UDPRuleApplier) RunV6(args ...string) {
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
-		f.ext.RunQuietlyAndIgnore(constants.IPTables, f.ipt6V, nil, deleteArgs...)
+		f.ext.RunQuietlyAndIgnore(log.WithLabels(),constants.IPTables, f.ipt6V, nil, deleteArgs...)
 	}
 }
 
@@ -746,7 +746,7 @@ func (cfg *IptablesConfigurator) handleCaptureByOwnerGroup(filter config.Interce
 
 func (cfg *IptablesConfigurator) executeIptablesCommands(iptVer *dep.IptablesVersion, commands [][]string) error {
 	for _, cmd := range commands {
-		if err := cfg.ext.Run(constants.IPTables, iptVer, nil, cmd...); err != nil {
+		if err := cfg.ext.Run(log.WithLabels(), constants.IPTables, iptVer, nil, cmd...); err != nil {
 			return err
 		}
 	}
@@ -755,14 +755,14 @@ func (cfg *IptablesConfigurator) executeIptablesCommands(iptVer *dep.IptablesVer
 
 func (cfg *IptablesConfigurator) tryExecuteIptablesCommands(iptVer *dep.IptablesVersion, commands [][]string) {
 	for _, cmd := range commands {
-		cfg.ext.RunQuietlyAndIgnore(constants.IPTables, iptVer, nil, cmd...)
+		cfg.ext.RunQuietlyAndIgnore(log.WithLabels(), constants.IPTables, iptVer, nil, cmd...)
 	}
 }
 
 func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(iptVer *dep.IptablesVersion, data string) error {
 	log.Infof("Running iptables restore with: %s and the following input:\n%v", iptVer.CmdToString(constants.IPTablesRestore), strings.TrimSpace(data))
 	// --noflush to prevent flushing/deleting previous contents from table
-	return cfg.ext.Run(constants.IPTablesRestore, iptVer, strings.NewReader(data), "--noflush")
+	return cfg.ext.Run(log.WithLabels(), constants.IPTablesRestore, iptVer, strings.NewReader(data), "--noflush")
 }
 
 // VerifyIptablesState function verifies the current iptables state against the expected state.
@@ -789,7 +789,7 @@ check_loop:
 		{iptVer, cfg.ruleBuilder.BuildV4Restore(), cfg.ruleBuilder.BuildCheckV4()},
 		{ipt6Ver, cfg.ruleBuilder.BuildV6Restore(), cfg.ruleBuilder.BuildCheckV6()},
 	} {
-		output, err := cfg.ext.RunWithOutput(constants.IPTablesSave, ipCfg.ver, nil)
+		output, err := cfg.ext.RunWithOutput(log.WithLabels(), constants.IPTablesSave, ipCfg.ver, nil)
 		if err == nil {
 			currentState := cfg.ruleBuilder.GetStateFromSave(output.String())
 			log.Debugf("Current iptables state: %#v", currentState)

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -217,16 +217,16 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 }
 
 // Run runs a command
-func (r *RealDependencies) Run(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
-	return r.executeXTables(cmd, iptVer, false, stdin, args...)
+func (r *RealDependencies) Run(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
+	return r.executeXTables(logger, cmd, iptVer, false, stdin, args...)
 }
 
 // Run runs a command and returns stdout
-func (r *RealDependencies) RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
-	return r.executeXTablesWithOutput(cmd, iptVer, false, stdin, args...)
+func (r *RealDependencies) RunWithOutput(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+	return r.executeXTablesWithOutput(logger, cmd, iptVer, false, stdin, args...)
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
-func (r *RealDependencies) RunQuietlyAndIgnore(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
-	_ = r.executeXTables(cmd, iptVer, true, stdin, args...)
+func (r *RealDependencies) RunQuietlyAndIgnore(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
+	_ = r.executeXTables(logger, cmd, iptVer, true, stdin, args...)
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -217,16 +217,34 @@ func transformToXTablesErrorMessage(stderr string, err error) string {
 }
 
 // Run runs a command
-func (r *RealDependencies) Run(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
+func (r *RealDependencies) Run(
+	logger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	stdin io.ReadSeeker,
+	args ...string,
+) error {
 	return r.executeXTables(logger, cmd, iptVer, false, stdin, args...)
 }
 
 // Run runs a command and returns stdout
-func (r *RealDependencies) RunWithOutput(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+func (r *RealDependencies) RunWithOutput(
+	logger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	stdin io.ReadSeeker,
+	args ...string,
+) (*bytes.Buffer, error) {
 	return r.executeXTablesWithOutput(logger, cmd, iptVer, false, stdin, args...)
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
-func (r *RealDependencies) RunQuietlyAndIgnore(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
+func (r *RealDependencies) RunQuietlyAndIgnore(
+	logger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	stdin io.ReadSeeker,
+	args ...string,
+) {
 	_ = r.executeXTables(logger, cmd, iptVer, true, stdin, args...)
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -203,7 +203,7 @@ func mount(src, dst string) error {
 	return syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_RDONLY, "")
 }
 
-func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion,
+func (r *RealDependencies) executeXTablesWithOutput(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
 	ignoreErrors bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	mode := "without lock"
@@ -282,7 +282,7 @@ func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, i
 	return stdout, err
 }
 
-func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	_, err := r.executeXTablesWithOutput(cmd, iptVer, ignoreErrors, stdin, args...)
+func (r *RealDependencies) executeXTables(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+	_, err := r.executeXTablesWithOutput(logger, cmd, iptVer, ignoreErrors, stdin, args...)
 	return err
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_linux.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_linux.go
@@ -282,7 +282,14 @@ func (r *RealDependencies) executeXTablesWithOutput(log *log.Scope, cmd constant
 	return stdout, err
 }
 
-func (r *RealDependencies) executeXTables(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+func (r *RealDependencies) executeXTables(
+	logger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	ignoreErrors bool,
+	stdin io.ReadSeeker,
+	args ...string,
+) error {
 	_, err := r.executeXTablesWithOutput(logger, cmd, iptVer, ignoreErrors, stdin, args...)
 	return err
 }

--- a/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation_unspecified.go
@@ -22,22 +22,19 @@ import (
 	"errors"
 	"io"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 // ErrNotImplemented is returned when a requested feature is not implemented.
 var ErrNotImplemented = errors.New("not implemented")
 
-func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reader, args ...string) error {
-	return ErrNotImplemented
-}
-
-func (r *RealDependencies) executeXTables(cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
-	_, err := r.executeXTablesWithOutput(cmd, iptVer, ignoreErrors, stdin, args...)
+func (r *RealDependencies) executeXTables(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
+	_, err := r.executeXTablesWithOutput(log, cmd, iptVer, ignoreErrors, stdin, args...)
 	return err
 }
 
-func (r *RealDependencies) executeXTablesWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion,
+func (r *RealDependencies) executeXTablesWithOutput(log *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion,
 	ignoreErrors bool, stdin io.ReadSeeker, args ...string,
 ) (*bytes.Buffer, error) {
 	return nil, ErrNotImplemented

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -17,8 +17,9 @@ package dependencies
 import (
 	"bytes"
 	"io"
-	istiolog "istio.io/istio/pkg/log"
 
+
+	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -17,6 +17,7 @@ package dependencies
 import (
 	"bytes"
 	"io"
+	istiolog "istio.io/istio/pkg/log"
 
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
@@ -24,13 +25,13 @@ import (
 // Dependencies is used as abstraction for the commands used from the operating system
 type Dependencies interface {
 	// Run runs a command
-	Run(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error
+	Run(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error
 
 	// Run runs a command and get the output
-	RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error)
+	RunWithOutput(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error)
 
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
-	RunQuietlyAndIgnore(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string)
+	RunQuietlyAndIgnore(log *istiolog.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string)
 
 	// DetectIptablesVersion consults the available binaries and in-use tables to determine
 	// which iptables variant (legacy, nft, v6, v4) we should use in the current context.

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"io"
 
-
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -43,13 +43,25 @@ func (s *DependenciesStub) Run(logger *log.Scope, cmd constants.IptablesCmd, ipt
 	return nil
 }
 
-func (s *DependenciesStub) RunWithOutput(ogger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+func (s *DependenciesStub) RunWithOutput(
+	ogger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	stdin io.ReadSeeker,
+	args ...string,
+) (*bytes.Buffer, error) {
 	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return &bytes.Buffer{}, nil
 }
 
-func (s *DependenciesStub) RunQuietlyAndIgnore(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
+func (s *DependenciesStub) RunQuietlyAndIgnore(
+	logger *log.Scope,
+	cmd constants.IptablesCmd,
+	iptVer *IptablesVersion,
+	stdin io.ReadSeeker,
+	args ...string,
+) {
 	s.execute(true /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"istio.io/istio/pkg/log"
 	"os"
 	"strings"
 
@@ -36,19 +37,19 @@ type DependenciesStub struct {
 	ExecutedAll      []string
 }
 
-func (s *DependenciesStub) Run(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
+func (s *DependenciesStub) Run(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) error {
 	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return nil
 }
 
-func (s *DependenciesStub) RunWithOutput(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
+func (s *DependenciesStub) RunWithOutput(ogger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) (*bytes.Buffer, error) {
 	s.execute(false /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 	return &bytes.Buffer{}, nil
 }
 
-func (s *DependenciesStub) RunQuietlyAndIgnore(cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
+func (s *DependenciesStub) RunQuietlyAndIgnore(logger *log.Scope, cmd constants.IptablesCmd, iptVer *IptablesVersion, stdin io.ReadSeeker, args ...string) {
 	s.execute(true /*quietly*/, cmd, iptVer, stdin, args...)
 	_ = s.writeAllToDryRunPath()
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -19,11 +19,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"istio.io/istio/pkg/log"
 	"os"
 	"strings"
 
 	"istio.io/istio/pkg/env"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 


### PR DESCRIPTION
Ensure all logs in the CNI codepath have the pod context associated for
debugging.
