### PR TITLE
Fix NACKS when service addresses partially overlap

### DIFF
--- a/pilot/pkg/networking/core/serviceentry_simulation_test.go
+++ b/pilot/pkg/networking/core/serviceentry_simulation_test.go
@@ -208,13 +208,69 @@ func TestServiceEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test for https://github.com/istio/istio/issues/52847
+			name: "partial overlap of IP",
+			config: tmpl.MustEvaluate(`apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se1
+spec:
+  hosts:
+  - blah1.somedomain
+  addresses: {{ . |toJson }}
+  ports:
+  - number: 9999
+    name: port-9999
+    protocol: TCP`, []string{"1.1.1.1"}) + "\n---\n" + tmpl.MustEvaluate(`apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se2
+spec:
+  hosts:
+  - blah2.somedomain
+  addresses: {{ . |toJson }}
+  ports:
+  - number: 9999
+    name: port-9999
+    protocol: TCP`, []string{"2.2.2.2", "1.1.1.1"}),
+			kubeConfig: "",
+			calls: []simulation.Expect{
+				{
+					Name: "unique IP",
+					Call: simulation.Call{
+						Port: 9999,
+						// Matches both, but more closely matches blah2, but SNI is blah1
+						Address: "2.2.2.2",
+					},
+					Result: simulation.Result{
+						Error:           nil,
+						ListenerMatched: "2.2.2.2_9999",
+						ClusterMatched:  "outbound|9999||blah2.somedomain",
+					},
+				},
+				{
+					Name: "shared IP",
+					Call: simulation.Call{
+						Port: 9999,
+						// Matches both, but more closely matches blah2, but SNI is blah1
+						Address: "1.1.1.1",
+					},
+					Result: simulation.Result{
+						Error:           nil,
+						ListenerMatched: "1.1.1.1_9999",
+						ClusterMatched:  "outbound|9999||blah1.somedomain",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			proxy := &model.Proxy{
 				Labels:      map[string]string{"app": "foo"},
-				Metadata:    &model.NodeMetadata{Labels: map[string]string{"app": "foo"}},
+				Metadata:    &model.NodeMetadata{Labels: map[string]string{"app": "foo"}, ClusterID: "Kubernetes"},
 				IPAddresses: []string{"127.0.0.1", "1234::1234"},
 			}
 			proxy.DiscoverIPMode()

--- a/pilot/pkg/serviceregistry/serviceentry/controller.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller.go
@@ -377,7 +377,7 @@ func getUpdatedConfigs(services []*model.Service) sets.Set[model.ConfigKey] {
 func (s *Controller) serviceEntryHandler(old, curr config.Config, event model.Event) {
 	log.Debugf("Handle event %s for service entry %s/%s", event, curr.Namespace, curr.Name)
 	currentServiceEntry := curr.Spec.(*networking.ServiceEntry)
-	cs := convertServices(curr, s.clusterID)
+	cs := convertServices(curr)
 	configsUpdated := sets.New[model.ConfigKey]()
 	key := curr.NamespacedName()
 

--- a/pilot/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/controller_test.go
@@ -1622,7 +1622,7 @@ func expectEvents(t testing.TB, ch *xdsfake.Updater, events ...Event) {
 
 func expectServiceInstances(t testing.TB, sd *Controller, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
-	svcs := convertServices(*cfg, "")
+	svcs := convertServices(*cfg)
 	if len(svcs) != len(expected) {
 		t.Fatalf("got more services than expected: %v vs %v", len(svcs), len(expected))
 	}
@@ -1856,8 +1856,8 @@ func TestServicesDiff(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			as := convertServices(*tt.current, "")
-			bs := convertServices(*tt.new, "")
+			as := convertServices(*tt.current)
+			bs := convertServices(*tt.new)
 			added, deleted, updated, unchanged := servicesDiff(as, bs)
 			for i, item := range []struct {
 				hostnames []host.Name

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -154,7 +154,7 @@ func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Confi
 }
 
 // convertServices transforms a ServiceEntry config to a list of internal Service objects.
-func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
+func convertServices(cfg config.Config) []*model.Service {
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	// ShouldV2AutoAllocateIP already checks that there are no addresses in the spec however this is critical enough to likely be worth checking
 	// explicitly as well in case the logic changes. We never want to overwrite addresses in the spec if there are any
@@ -359,7 +359,7 @@ func (s *Controller) convertServiceEntryToInstances(cfg config.Config, services 
 		return nil
 	}
 	if services == nil {
-		services = convertServices(cfg, s.clusterID)
+		services = convertServices(cfg)
 	}
 
 	endpointsNum := len(serviceEntry.Endpoints)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -34,7 +34,6 @@ import (
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/kube/labels"
 	"istio.io/istio/pkg/network"
-	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	netutil "istio.io/istio/pkg/util/net"
 	"istio.io/istio/pkg/util/sets"
@@ -50,7 +49,7 @@ func convertPort(port *networking.ServicePort) *model.Port {
 
 type HostAddress struct {
 	host           string
-	addresses      []string
+	address        string
 	autoAssignedV4 string
 	autoAssignedV6 string
 }
@@ -62,6 +61,7 @@ type HostAddress struct {
 // See kube.ConvertService for the conversion from K8S to internal Service.
 func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Config {
 	gvk := gvk.ServiceEntry
+
 	getSvcAddresses := func(s *model.Service, node *model.Proxy) []string {
 		if node.Metadata != nil && node.Metadata.ClusterID == "" {
 			var addresses []string
@@ -78,9 +78,9 @@ func ServiceToServiceEntry(svc *model.Service, proxy *model.Proxy) *config.Confi
 		// Host is fully qualified: name, namespace, domainSuffix
 		Hosts: []string{string(svc.Hostname)},
 
-		// ServiceEntry can represent multiple services, so we return all the addresses of the services
-		// if proxy ClusterID unset.
-		// And only the cluster specific addresses when proxy ClusterID set.
+		// Internal Service and K8S Service have a single Address.
+		// ServiceEntry can represent multiple - but we are not using that. SE may be merged.
+		// Will be 0.0.0.0 if not specified as ClusterIP or ClusterIP==None. In such case resolution is Passthrough.
 		Addresses: getSvcAddresses(svc, proxy),
 
 		// This is based on alpha.istio.io/canonical-serviceaccounts and
@@ -202,26 +202,22 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 	if serviceEntry.WorkloadSelector != nil {
 		labelSelectors = serviceEntry.WorkloadSelector.Labels
 	}
-
 	hostAddresses := []*HostAddress{}
 	for _, hostname := range serviceEntry.Hosts {
-		localAddresses := addresses
-		if len(localAddresses) > 0 {
-			ha := &HostAddress{hostname, []string{}, "", ""}
-			for _, address := range localAddresses {
-				// Check if addresses is an IP first because that is the most common case.
+		if len(serviceEntry.Addresses) > 0 {
+			for _, address := range serviceEntry.Addresses {
+				// Check if address is an IP first because that is the most common case.
 				if netutil.IsValidIPAddress(address) {
-					ha.addresses = append(ha.addresses, address)
+					hostAddresses = append(hostAddresses, &HostAddress{hostname, address, "", ""})
 				} else if cidr, cidrErr := netip.ParsePrefix(address); cidrErr == nil {
 					newAddress := address
 					if cidr.Bits() == cidr.Addr().BitLen() {
-						// /32 mask. Remove the /32 and make it a normal IP addresses
+						// /32 mask. Remove the /32 and make it a normal IP address
 						newAddress = cidr.Addr().String()
 					}
-					ha.addresses = append(ha.addresses, newAddress)
+					hostAddresses = append(hostAddresses, &HostAddress{hostname, newAddress, "", ""})
 				}
 			}
-			hostAddresses = append(hostAddresses, ha)
 		} else {
 			var v4, v6 string
 			if autoAddresses, ok := addressLookup[hostname]; ok {
@@ -234,7 +230,7 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 					}
 				}
 			}
-			hostAddresses = append(hostAddresses, &HostAddress{hostname, []string{constants.UnspecifiedIP}, v4, v6})
+			hostAddresses = append(hostAddresses, &HostAddress{hostname, constants.UnspecifiedIP, v4, v6})
 		}
 	}
 
@@ -248,7 +244,7 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 			CreationTime:   creationTime,
 			MeshExternal:   serviceEntry.Location == networking.ServiceEntry_MESH_EXTERNAL,
 			Hostname:       host.Name(ha.host),
-			DefaultAddress: ha.addresses[0],
+			DefaultAddress: ha.address,
 			Ports:          svcPorts,
 			Resolution:     resolution,
 			Attributes: model.ServiceAttributes{
@@ -268,13 +264,6 @@ func convertServices(cfg config.Config, clusterID cluster.ID) []*model.Service {
 		}
 		if ha.autoAssignedV6 != "" {
 			svc.AutoAllocatedIPv6Address = ha.autoAssignedV6
-		}
-		if !slices.Equal(ha.addresses, []string{constants.UnspecifiedIP}) {
-			svc.ClusterVIPs = model.AddressMap{
-				Addresses: map[cluster.ID][]string{
-					clusterID: ha.addresses,
-				},
-			}
 		}
 		out = append(out, svc)
 	}
@@ -473,7 +462,7 @@ func (s *Controller) convertWorkloadEntryToWorkloadInstance(cfg config.Config, c
 		dnsServiceEntryOnly = true
 	}
 	if addr != "" && !netutil.IsValidIPAddress(addr) {
-		// k8s can't use workloads with hostnames in the addresses field.
+		// k8s can't use workloads with hostnames in the address field.
 		dnsServiceEntryOnly = true
 	}
 	tlsMode := getTLSModeFromWorkloadEntry(we)

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/network"
-	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 )
@@ -604,11 +603,6 @@ func makeService(hostname host.Name, configName, configNamespace string, address
 			K8sAttributes:   model.K8sAttributes{ObjectName: configName},
 		},
 	}
-	if !slices.Equal(addresses, []string{constants.UnspecifiedIP}) {
-		svc.ClusterVIPs = model.AddressMap{
-			Addresses: map[cluster.ID][]string{"": addresses},
-		}
-	}
 
 	if autoV4 != "" {
 		svc.AutoAllocatedIPv4Address = autoV4
@@ -859,7 +853,11 @@ func testConvertServiceBody(t *testing.T) {
 			services: []*model.Service{
 				makeService("tcp1.com", "multiAddrInternal", "multiAddrInternal", []string{"1.1.1.0/16", "2.2.2.0/16"}, "", "",
 					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+				makeService("tcp1.com", "multiAddrInternal", "multiAddrInternal", []string{"2.2.2.0/16", "1.1.1.0/16"}, "", "",
+					map[string]int{"tcp-444": 444}, false, model.Passthrough),
 				makeService("tcp2.com", "multiAddrInternal", "multiAddrInternal", []string{"1.1.1.0/16", "2.2.2.0/16"}, "", "",
+					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+				makeService("tcp2.com", "multiAddrInternal", "multiAddrInternal", []string{"2.2.2.0/16", "1.1.1.0/16"}, "", "",
 					map[string]int{"tcp-444": 444}, false, model.Passthrough),
 			},
 		},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -657,7 +657,7 @@ func makeInstanceWithServiceAccount(cfg *config.Config, addresses []string, port
 func makeTarget(cfg *config.Config, address string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
 ) model.ServiceTarget {
-	services := convertServices(*cfg, "")
+	services := convertServices(*cfg)
 	svc := services[0] // default
 	for _, s := range services {
 		if string(s.Hostname) == address {
@@ -688,7 +688,7 @@ func makeTarget(cfg *config.Config, address string, port int,
 func makeInstance(cfg *config.Config, addresses []string, port int,
 	svcPort *networking.ServicePort, svcLabels map[string]string, mtlsMode MTLSMode,
 ) *model.ServiceInstance {
-	services := convertServices(*cfg, "")
+	services := convertServices(*cfg)
 	svc := services[0] // default
 	getSvc := false
 	for _, s := range services {
@@ -876,7 +876,7 @@ func testConvertServiceBody(t *testing.T) {
 	})
 
 	for _, tt := range serviceTests {
-		services := convertServices(*tt.externalSvc, "")
+		services := convertServices(*tt.externalSvc)
 		if err := compare(t, services, tt.services); err != nil {
 			t.Errorf("testcase: %v\n%v ", tt.externalSvc.Name, err)
 		}
@@ -1063,7 +1063,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
-			services := convertServices(*tt.se, "")
+			services := convertServices(*tt.se)
 			s := &Controller{meshWatcher: mesh.NewFixedWatcher(mesh.DefaultMeshConfig())}
 			instances := s.convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{}, tt.clusterID)
 			sortServiceInstances(instances)

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -32,7 +32,13 @@ import (
 func ValidateListeners(t testing.TB, ls []*listener.Listener) {
 	t.Helper()
 	found := sets.New[string]()
+	foundAddresses := sets.New[string]()
 	for _, l := range ls {
+		for _, addr := range ExtractListenerAddresses(l) {
+			if foundAddresses.InsertContains(addr) {
+				t.Errorf("found duplicate address %s", addr)
+			}
+		}
 		if found.InsertContains(l.Name) {
 			t.Errorf("duplicate listener name %v", l.Name)
 		}

--- a/pkg/dns/server/name_table.go
+++ b/pkg/dns/server/name_table.go
@@ -41,120 +41,122 @@ func BuildNameTable(cfg Config) *dnsProto.NameTable {
 	out := &dnsProto.NameTable{
 		Table: make(map[string]*dnsProto.NameTable_NameInfo),
 	}
-	for _, svc := range cfg.Node.SidecarScope.Services() {
-		var addressList []string
-		hostName := svc.Hostname
-		headless := false
-		for _, svcAddress := range svc.GetAllAddressesForProxy(cfg.Node) {
-			if svcAddress == constants.UnspecifiedIP {
-				headless = true
-				break
+	for _, el := range cfg.Node.SidecarScope.EgressListeners {
+		for _, svc := range el.Services() {
+			var addressList []string
+			hostName := svc.Hostname
+			headless := false
+			for _, svcAddress := range svc.GetAllAddressesForProxy(cfg.Node) {
+				if svcAddress == constants.UnspecifiedIP {
+					headless = true
+					break
+				}
+				// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
+				// should be caught in validation.
+				if !netutil.IsValidIPAddress(svcAddress) {
+					continue
+				}
+				addressList = append(addressList, svcAddress)
 			}
-			// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
-			// should be caught in validation.
-			if !netutil.IsValidIPAddress(svcAddress) {
-				continue
-			}
-			addressList = append(addressList, svcAddress)
-		}
-		if headless {
-			// The IP will be unspecified here if its headless service or if the auto
-			// IP allocation logic for service entry was unable to allocate an IP.
-			if svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
-				for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
-					// addresses may be empty or invalid here
-					isValidInstance := true
-					for _, addr := range instance.Addresses {
-						if !netutil.IsValidIPAddress(addr) {
-							isValidInstance = false
-							break
+			if headless {
+				// The IP will be unspecified here if its headless service or if the auto
+				// IP allocation logic for service entry was unable to allocate an IP.
+				if svc.Resolution == model.Passthrough && len(svc.Ports) > 0 {
+					for _, instance := range cfg.Push.ServiceEndpointsByPort(svc, svc.Ports[0].Port, nil) {
+						// addresses may be empty or invalid here
+						isValidInstance := true
+						for _, addr := range instance.Addresses {
+							if !netutil.IsValidIPAddress(addr) {
+								isValidInstance = false
+								break
+							}
 						}
-					}
-					if len(instance.Addresses) == 0 || !isValidInstance ||
-						(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus == model.UnHealthy) {
-						continue
-					}
-					// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
-					sameNetwork := cfg.Node.InNetwork(instance.Network)
-					sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
-					// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
-					// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
-					if instance.SubDomain != "" && sameNetwork {
-						// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
-						// i.e. "mysql-0.mysql.default.svc.cluster.local".
-						parts := strings.SplitN(hostName.String(), ".", 2)
-						if len(parts) != 2 {
+						if len(instance.Addresses) == 0 || !isValidInstance ||
+							(!svc.Attributes.PublishNotReadyAddresses && instance.HealthStatus == model.UnHealthy) {
 							continue
 						}
-						address := instance.Addresses
-						shortName := instance.HostName + "." + instance.SubDomain
-						host := shortName + "." + parts[1] // Add cluster domain.
-						nameInfo := &dnsProto.NameTable_NameInfo{
-							Ips:       address,
-							Registry:  string(svc.Attributes.ServiceRegistry),
-							Namespace: svc.Attributes.Namespace,
-							Shortname: shortName,
-						}
+						// TODO(stevenctl): headless across-networks https://github.com/istio/istio/issues/38327
+						sameNetwork := cfg.Node.InNetwork(instance.Network)
+						sameCluster := cfg.Node.InCluster(instance.Locality.ClusterID)
+						// For all k8s headless services, populate the dns table with the endpoint IPs as k8s does.
+						// And for each individual pod, populate the dns table with the endpoint IP with a manufactured host name.
+						if instance.SubDomain != "" && sameNetwork {
+							// Follow k8s pods dns naming convention of "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>"
+							// i.e. "mysql-0.mysql.default.svc.cluster.local".
+							parts := strings.SplitN(hostName.String(), ".", 2)
+							if len(parts) != 2 {
+								continue
+							}
+							address := instance.Addresses
+							shortName := instance.HostName + "." + instance.SubDomain
+							host := shortName + "." + parts[1] // Add cluster domain.
+							nameInfo := &dnsProto.NameTable_NameInfo{
+								Ips:       address,
+								Registry:  string(svc.Attributes.ServiceRegistry),
+								Namespace: svc.Attributes.Namespace,
+								Shortname: shortName,
+							}
 
-						if _, f := out.Table[host]; !f || sameCluster {
-							// We may have the same pod in two clusters (ie mysql-0 deployed in both places).
-							// We can only return a single IP for these queries. We should prefer the local cluster,
-							// so if the entry already exists only overwrite it if the instance is in our own cluster.
-							out.Table[host] = nameInfo
+							if _, f := out.Table[host]; !f || sameCluster {
+								// We may have the same pod in two clusters (ie mysql-0 deployed in both places).
+								// We can only return a single IP for these queries. We should prefer the local cluster,
+								// so if the entry already exists only overwrite it if the instance is in our own cluster.
+								out.Table[host] = nameInfo
+							}
 						}
+						skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
+						if skipForMulticluster || !sameNetwork {
+							// We take only cluster-local endpoints. While this seems contradictory to
+							// our logic other parts of the code, where cross-cluster is the default.
+							// However, this only impacts the DNS response. If we were to send all
+							// endpoints, cross network routing would break, as we do passthrough LB and
+							// don't go through the network gateway. While we could, hypothetically, send
+							// "network-local" endpoints, this would still make enabling DNS give vastly
+							// different load balancing than without, so its probably best to filter.
+							// This ends up matching the behavior of Kubernetes DNS.
+							continue
+						}
+						// TODO: should we skip the node's own IP like we do in listener?
+						addressList = append(addressList, instance.Addresses...)
 					}
-					skipForMulticluster := !cfg.MulticlusterHeadlessEnabled && !sameCluster
-					if skipForMulticluster || !sameNetwork {
-						// We take only cluster-local endpoints. While this seems contradictory to
-						// our logic other parts of the code, where cross-cluster is the default.
-						// However, this only impacts the DNS response. If we were to send all
-						// endpoints, cross network routing would break, as we do passthrough LB and
-						// don't go through the network gateway. While we could, hypothetically, send
-						// "network-local" endpoints, this would still make enabling DNS give vastly
-						// different load balancing than without, so its probably best to filter.
-						// This ends up matching the behavior of Kubernetes DNS.
-						continue
-					}
-					// TODO: should we skip the node's own IP like we do in listener?
-					addressList = append(addressList, instance.Addresses...)
 				}
 			}
-		}
-		if len(addressList) == 0 {
-			// could not reliably determine the addresses of endpoints of headless service
-			// or this is not a k8s service
-			continue
-		}
+			if len(addressList) == 0 {
+				// could not reliably determine the addresses of endpoints of headless service
+				// or this is not a k8s service
+				continue
+			}
 
-		if ni, f := out.Table[hostName.String()]; !f {
-			nameInfo := &dnsProto.NameTable_NameInfo{
-				Ips:      addressList,
-				Registry: string(svc.Attributes.ServiceRegistry),
-			}
-			if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
-				!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
-				// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
-				// No need to provide a DNS entry for each variant.
-				//
-				// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
-				// to avoid conflicting with the entries for the regular (cluster.local) service.
-				nameInfo.Namespace = svc.Attributes.Namespace
-				nameInfo.Shortname = svc.Attributes.Name
-			}
-			out.Table[hostName.String()] = nameInfo
-		} else if provider.ID(ni.Registry) != provider.Kubernetes {
-			// 2 possible cases:
-			// 1. If the SE has multiple addresses(vips) specified, merge the ips
-			// 2. If the previous SE is a decorator of the k8s service, give precedence to the k8s service
-			if svc.Attributes.ServiceRegistry == provider.Kubernetes {
-				ni.Ips = addressList
-				ni.Registry = string(provider.Kubernetes)
-				if !strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
-					ni.Namespace = svc.Attributes.Namespace
-					ni.Shortname = svc.Attributes.Name
+			if ni, f := out.Table[hostName.String()]; !f {
+				nameInfo := &dnsProto.NameTable_NameInfo{
+					Ips:      addressList,
+					Registry: string(svc.Attributes.ServiceRegistry),
 				}
-			} else {
-				ni.Ips = append(ni.Ips, addressList...)
+				if svc.Attributes.ServiceRegistry == provider.Kubernetes &&
+					!strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+					// The agent will take care of resolving a, a.ns, a.ns.svc, etc.
+					// No need to provide a DNS entry for each variant.
+					//
+					// NOTE: This is not done for Kubernetes Multi-Cluster Services (MCS) hosts, in order
+					// to avoid conflicting with the entries for the regular (cluster.local) service.
+					nameInfo.Namespace = svc.Attributes.Namespace
+					nameInfo.Shortname = svc.Attributes.Name
+				}
+				out.Table[hostName.String()] = nameInfo
+			} else if provider.ID(ni.Registry) != provider.Kubernetes {
+				// 2 possible cases:
+				// 1. If the SE has multiple addresses(vips) specified, merge the ips
+				// 2. If the previous SE is a decorator of the k8s service, give precedence to the k8s service
+				if svc.Attributes.ServiceRegistry == provider.Kubernetes {
+					ni.Ips = addressList
+					ni.Registry = string(provider.Kubernetes)
+					if !strings.HasSuffix(hostName.String(), "."+constants.DefaultClusterSetLocalDomain) {
+						ni.Namespace = svc.Attributes.Namespace
+						ni.Shortname = svc.Attributes.Name
+					}
+				} else {
+					ni.Ips = append(ni.Ips, addressList...)
+				}
 			}
 		}
 	}

--- a/pkg/dns/server/name_table_test.go
+++ b/pkg/dns/server/name_table_test.go
@@ -593,7 +593,7 @@ func TestNameTable(t *testing.T) {
 			expectedNameTable: &dnsProto.NameTable{
 				Table: map[string]*dnsProto.NameTable_NameInfo{
 					serviceWithVIP1.Hostname.String(): {
-						Ips:      []string{serviceWithVIP1.DefaultAddress},
+						Ips:      []string{serviceWithVIP1.DefaultAddress, serviceWithVIP2.DefaultAddress},
 						Registry: provider.External.String(),
 					},
 				},

--- a/releasenotes/notes/fix-overlapping-se.yaml
+++ b/releasenotes/notes/fix-overlapping-se.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 52847
+releaseNotes:
+  - |
+    **Fixed** an issue causing configuration to be rejected when there is a partial overlap between IP addresses across multiple services.
+    For example, a Service with `[IP-A]` and one with `[IP-B, IP-A]`.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3511,6 +3511,8 @@ spec:
 
 	for _, client := range flatten(t.Apps.VM, t.Apps.A, t.Apps.Tproxy) {
 		v4, v6 := getSupportedIPFamilies(t, client)
+		log := scopes.Framework.WithLabels("client", client.ServiceName())
+
 		var expectedIPv4, expectedIPv6 []string
 		if v4 && v6 {
 			expectedIPv4 = ipv4
@@ -3522,6 +3524,7 @@ spec:
 			expectedIPv4 = ipv4[:1]
 			expectedIPv6 = ipv6
 		}
+		log.Infof("%v/%v: %v/%v", v4, v6, expectedIPv4, expectedIPv6)
 		// If a client is deployed in a remote cluster, which is not a config cluster, i.e. Istio resources
 		// are not created in that cluster, it will resolve only the default address, because the ServiceEntry
 		// created in this test is internally assigned to the config cluster, so function GetAllAddressesForProxy(remote),
@@ -3610,6 +3613,7 @@ spec:
 			if tt.expected == nil {
 				checker = check.Error()
 			}
+			log.Infof("%v: %v", address, tt.expected)
 			t.RunTraffic(TrafficTestCase{
 				name:   fmt.Sprintf("%s/%s", client.Config().Service, tt.name),
 				config: makeSE(tt.ips...),

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3513,18 +3513,9 @@ spec:
 		v4, v6 := getSupportedIPFamilies(t, client)
 		log := scopes.Framework.WithLabels("client", client.ServiceName())
 
-		var expectedIPv4, expectedIPv6 []string
-		if v4 && v6 {
-			expectedIPv4 = ipv4
-			expectedIPv6 = ipv6
-		} else if v4 {
-			expectedIPv4 = ipv4
-			expectedIPv6 = ipv6[:1]
-		} else {
-			expectedIPv4 = ipv4[:1]
-			expectedIPv6 = ipv6
-		}
-		log.Infof("%v/%v: %v/%v", v4, v6, expectedIPv4, expectedIPv6)
+		expectedIPv4 := ipv4
+		expectedIPv6 := ipv6
+		log.Infof("v4=%v v6=%v wantv4=%v wantv6=%v", v4, v6, expectedIPv4, expectedIPv6)
 		// If a client is deployed in a remote cluster, which is not a config cluster, i.e. Istio resources
 		// are not created in that cluster, it will resolve only the default address, because the ServiceEntry
 		// created in this test is internally assigned to the config cluster, so function GetAllAddressesForProxy(remote),
@@ -3603,8 +3594,11 @@ spec:
 				address += "&server=" + tt.server
 			}
 			var checker echo.Checker = func(result echo.CallResult, _ error) error {
+				if len(result.Responses) == 0 {
+					return fmt.Errorf("no responses")
+				}
 				for _, r := range result.Responses {
-					if !reflect.DeepEqual(r.Body(), tt.expected) {
+					if !sets.New(r.Body()...).Equals(sets.New(tt.expected...)) {
 						return fmt.Errorf("unexpected dns response: wanted %v, got %v", tt.expected, r.Body())
 					}
 				}
@@ -3613,7 +3607,6 @@ spec:
 			if tt.expected == nil {
 				checker = check.Error()
 			}
-			log.Infof("%v: %v", address, tt.expected)
 			t.RunTraffic(TrafficTestCase{
 				name:   fmt.Sprintf("%s/%s", client.Config().Service, tt.name),
 				config: makeSE(tt.ips...),

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -3516,19 +3516,6 @@ spec:
 		expectedIPv4 := ipv4
 		expectedIPv6 := ipv6
 		log.Infof("v4=%v v6=%v wantv4=%v wantv6=%v", v4, v6, expectedIPv4, expectedIPv6)
-		// If a client is deployed in a remote cluster, which is not a config cluster, i.e. Istio resources
-		// are not created in that cluster, it will resolve only the default address, because the ServiceEntry
-		// created in this test is internally assigned to the config cluster, so function GetAllAddressesForProxy(remote),
-		// will only return the default address for that service.
-		remotes := client.Clusters().Remotes()
-		if len(remotes) > 0 && len(remotes.Configs()) == 0 {
-			if v4 {
-				expectedIPv4 = []string{"1.2.3.4"}
-			}
-			if v6 {
-				expectedIPv6 = []string{"1234:1234:1234::1234:1234:1234"}
-			}
-		}
 		cases := []struct {
 			name     string
 			ips      []string


### PR DESCRIPTION
This has a very long history of back-and-forth on bugs/fixes/regressions. Ill try to capture the history accurately...

Istio 1.22 introduced a regression: https://github.com/istio/istio/issues/51747 causing SE with multiple addresses to get some of their addresses ignored. I cannot actually find the PR that broke things but the issue has plenty of detail.

From that investigation, we found this occurs only when there is no Sidecar object -- otherwise its fine. 

Meanwhile, https://github.com/istio/istio/pull/51967 was merged and cherrypicked to 1.22 and 1.23. This fixed the issue, but caused 2 new ones:
* https://github.com/istio/istio/issues/52847
* https://github.com/istio/istio/issues/52944

This was reverted in 1.22 https://github.com/istio/istio/pull/52952 and 1.23 https://github.com/istio/istio/pull/53000 but left on 1.24.

In 1.24, https://github.com/istio/istio/pull/51776 was merged. This fixes #51747 (the original bug we were trying to fix!!) and #52944 but **does not fix** #52847. Since we did not revert the original fix in 1.24, that leaves 1.24 susceptible to #52847.

I think this was simply a mistake; I had intended to merge a fix like this in 1.24 but lost track.

This PR _partially_ reverts https://github.com/istio/istio/pull/51967. There were still some good changes included in that PR, but the change to collapse a SE with multiple IPs into a single model.Service (rather than multiple model.Services) is the root cause and which is removed.

In addition, tests covering #51967 are added.


Tagging reviewers:
* @keithmattix @hzxuzhonghu - original PR reviewers
* @ilrudie - this slightly touches some of the auto-allocation stuff. I think its fine but more :eyes: is better
* @jewertow - this reverts a subset of your changes


---

DNS code has some new fixes, and a similar long history.

Consider if I have a SE with [ipv4-1, ipv4-2, ipv6]...

Istio 1.20: only ipv4-1

master:
  Kubernetes pods: [ipv4-1, ipv4-2]
  VMs: [ipv4-1] (this behavior is wrong)

master with dual stack: 
  Kubernetes pods: [ipv4-1, ipv4-2, ipv6]
  VMs: [ipv4-1, ipv6] (this behavior is wrong)

This PR:
  Single stack: [ipv4-1, ipv4-2]
  Dual stack: [ipv4-1, ipv4-2, ipv6]

This is done by replacing .SidecarScope (which picks a **single service**) with .EgressListeners iteration which includes all the services, mirroring how LDS code works