### PR TITLE
add jaeger to demo profile

### DIFF
--- a/manifests/charts/base/files/profile-demo.yaml
+++ b/manifests/charts/base/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/default/files/profile-demo.yaml
+++ b/manifests/charts/default/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/gateway/files/profile-demo.yaml
+++ b/manifests/charts/gateway/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/gateways/istio-egress/files/profile-demo.yaml
+++ b/manifests/charts/gateways/istio-egress/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/gateways/istio-ingress/files/profile-demo.yaml
+++ b/manifests/charts/gateways/istio-ingress/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/istio-cni/files/profile-demo.yaml
+++ b/manifests/charts/istio-cni/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/istio-control/istio-discovery/files/profile-demo.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/charts/ztunnel/files/profile-demo.yaml
+++ b/manifests/charts/ztunnel/files/profile-demo.yaml
@@ -21,6 +21,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:

--- a/manifests/helm-profiles/demo.yaml
+++ b/manifests/helm-profiles/demo.yaml
@@ -17,6 +17,10 @@ meshConfig:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+    - name: jaeger
+      opentelemetry:
+        port: 4317
+        service: jaeger-collector.istio-system.svc.cluster.local        
 
 cni:
   resources:


### PR DESCRIPTION
Make Jaeger work "out of the box" when using the demo profile, i.e. have a configured extension point which matches our sample installation, and doesn't require reinstalling Istio to configure `meshConfig`.

Fixes #53779

- [x] Installation
- [x] Extensions and Telemetry

/release-notes-none unless anyone cares