### PR TITLE
Prep for iptables idempotency by making ipset ops (safely) idempotent by doubling-down on comments

### DIFF
--- a/cni/pkg/ipset/ipset.go
+++ b/cni/pkg/ipset/ipset.go
@@ -39,6 +39,7 @@ type NetlinkIpsetDeps interface {
 	deleteIP(name string, ip netip.Addr, ipProto uint8) error
 	flush(name string) error
 	clearEntriesWithComment(name string, comment string) error
+	clearEntriesWithIPAndComment(name string, ip netip.Addr, comment string) (string, error)
 	clearEntriesWithIP(name string, ip netip.Addr) error
 	listEntriesByIP(name string) ([]netip.Addr, error)
 }
@@ -127,6 +128,15 @@ func (m *IPSet) ClearEntriesWithIP(ip netip.Addr) error {
 		return m.Deps.clearEntriesWithIP(m.V6Name, ipToClear)
 	}
 	return m.Deps.clearEntriesWithIP(m.V4Name, ipToClear)
+}
+
+func (m *IPSet) ClearEntriesWithIPAndComment(ip netip.Addr, comment string) (string, error) {
+	ipToClear := ip.Unmap()
+
+	if ipToClear.Is6() {
+		return m.Deps.clearEntriesWithIPAndComment(m.V6Name, ipToClear, comment)
+	}
+	return m.Deps.clearEntriesWithIPAndComment(m.V4Name, ipToClear, comment)
 }
 
 func (m *IPSet) ListEntriesByIP() ([]netip.Addr, error) {

--- a/cni/pkg/ipset/nldeps_mock.go
+++ b/cni/pkg/ipset/nldeps_mock.go
@@ -63,6 +63,11 @@ func (m *MockedIpsetDeps) clearEntriesWithIP(name string, ip netip.Addr) error {
 	return args.Error(0)
 }
 
+func (m *MockedIpsetDeps) clearEntriesWithIPAndComment(name string, ip netip.Addr, comment string) (string, error) {
+	args := m.Called(name, ip, comment)
+	return args.Get(0).(string), args.Error(1)
+}
+
 func (m *MockedIpsetDeps) listEntriesByIP(name string) ([]netip.Addr, error) {
 	args := m.Called(name)
 	return args.Get(0).([]netip.Addr), args.Error(1)

--- a/cni/pkg/nodeagent/server.go
+++ b/cni/pkg/nodeagent/server.go
@@ -336,7 +336,22 @@ func (s *meshDataplane) syncHostIPSets(ambientPods []*corev1.Pod) error {
 // 3. update ipsets accordingly
 // 4. return the ones we added successfully, and errors for any we couldn't (dupes)
 //
-// Dupe IPs should be considered an IPAM error and should never happen.
+// For each set (v4, v6), each pod IP can appear exactly once.
+//
+// Note that for adds, because we have 2 potential sources of async adds (CNI plugin and informer)
+// we want this to be an upsert.
+//
+// This is important to make sure reconciliation and overlapping events do not cause problems -
+// adds can come from two sources, but removes can only come from one source (informer).
+//
+// Ex:
+// Pod UID "A", IP 1.1.1.1
+// Pod UID "B", IP 1.1.1.1
+//
+// Add for UID "B", IP 1.1.1.1 is handled before Remove for UID "A", IP 1.1.1.1
+// -> we no longer have an entry for either, which is bad (pod fails healthchecks)
+//
+// So "add" always overwrites, and remove only removes if the pod IP AND the pod UID match.
 func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr) ([]netip.Addr, error) {
 	// Add the pod UID as an ipset entry comment, so we can (more) easily find and delete
 	// all relevant entries for a pod later.
@@ -354,11 +369,7 @@ func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr
 		// set it to true, but in theory that could mask weird scenarios where K8S triggers events out of order ->
 		// an add(sameIPreused) then delete(originalIP).
 		// Which will result in the new pod starting to fail healthchecks.
-		//
-		// Since we purge on restart of CNI, and remove pod IPs from the set on every pod removal/deletion,
-		// we _shouldn't_ get any overwrite/overlap, unless something is wrong and we are asked to add
-		// a pod by an IP we already have in the set (which will give an error, which we want).
-		if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, false); err != nil {
+		if err := s.hostsideProbeIPSet.AddIP(pip, ipProto, podUID, true); err != nil {
 			ipsetAddrErrs = append(ipsetAddrErrs, err)
 			log.Errorf("failed adding pod %s to ipset %s with ip %s, error was %s",
 				pod.Name, &s.hostsideProbeIPSet.Prefix, pip, err)
@@ -370,13 +381,21 @@ func (s *meshDataplane) addPodToHostNSIpset(pod *corev1.Pod, podIPs []netip.Addr
 	return addedIps, errors.Join(ipsetAddrErrs...)
 }
 
+// removePodFromHostNSIpset will remove (v4, v6) pod IPs from the host IP set(s).
+// Note that unlike when we add the IP to the set, on removal we will simply
+// skip removing the IP if the IP matches, but the UID comment does not match our pod.
 func removePodFromHostNSIpset(pod *corev1.Pod, hostsideProbeSet *ipset.IPSet) error {
+	podUID := string(pod.ObjectMeta.UID)
+	log := log.WithLabels("ns", pod.Namespace, "name", pod.Name, "podUID", podUID, "ipset", hostsideProbeSet.Prefix)
+
 	podIPs := util.GetPodIPsIfPresent(pod)
 	for _, pip := range podIPs {
-		if err := hostsideProbeSet.ClearEntriesWithIP(pip); err != nil {
+		if uidMismatch, err := hostsideProbeSet.ClearEntriesWithIPAndComment(pip, podUID); err != nil {
 			return err
+		} else if uidMismatch != "" {
+			log.Warnf("pod ip %s could not be removed from ipset, found entry with pod UID %s instead", pip, uidMismatch)
 		}
-		log.Debugf("removed pod name %s with UID %s from host ipset %s by ip %s", pod.Name, pod.UID, hostsideProbeSet.Prefix, pip)
+		log.Debugf("removed pod from host ipset by ip %s", pip)
 	}
 
 	return nil

--- a/cni/pkg/nodeagent/server_test.go
+++ b/cni/pkg/nodeagent/server_test.go
@@ -475,6 +475,7 @@ func TestMeshDataplaneRemovePodIPFromHostNSIPSetsIgnoresEntriesWithMismatchedUID
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }
+
 func TestMeshDataplaneSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 	pod := buildConvincingPod(false)
 

--- a/cni/pkg/nodeagent/server_test.go
+++ b/cni/pkg/nodeagent/server_test.go
@@ -178,7 +178,7 @@ func TestMeshDataplaneRemovePodRemovesAnnotation(t *testing.T) {
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	m := getFakeDPWithIPSet(server, fakeClientSet, set)
-	expectPodRemovedFromIPSet(fakeIPSetDeps, pod.Status.PodIPs)
+	expectPodRemovedFromIPSet(fakeIPSetDeps, string(pod.ObjectMeta.UID), pod.Status.PodIPs)
 
 	err := m.RemovePodFromMesh(fakeCtx, pod, false)
 	assert.NoError(t, err)
@@ -208,7 +208,7 @@ func TestMeshDataplaneRemovePodErrorDoesntRemoveAnnotation(t *testing.T) {
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	m := getFakeDPWithIPSet(server, fakeClientSet, set)
-	expectPodRemovedFromIPSet(fakeIPSetDeps, pod.Status.PodIPs)
+	expectPodRemovedFromIPSet(fakeIPSetDeps, string(pod.ObjectMeta.UID), pod.Status.PodIPs)
 
 	err := m.RemovePodFromMesh(fakeCtx, pod, false)
 	assert.Error(t, err)
@@ -238,7 +238,7 @@ func TestMeshDataplaneDelPod(t *testing.T) {
 	fakeIPSetDeps := ipset.FakeNLDeps()
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 	m := getFakeDPWithIPSet(server, fakeClientSet, set)
-	expectPodRemovedFromIPSet(fakeIPSetDeps, pod.Status.PodIPs)
+	expectPodRemovedFromIPSet(fakeIPSetDeps, string(pod.ObjectMeta.UID), pod.Status.PodIPs)
 
 	// pod is not in fake client, so if this will try to remove annotation, it will fail.
 	err := m.RemovePodFromMesh(fakeCtx, pod, true)
@@ -267,7 +267,7 @@ func TestMeshDataplaneDelPodErrorDoesntPatchPod(t *testing.T) {
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	m := getFakeDPWithIPSet(server, fakeClientSet, set)
-	expectPodRemovedFromIPSet(fakeIPSetDeps, pod.Status.PodIPs)
+	expectPodRemovedFromIPSet(fakeIPSetDeps, string(pod.ObjectMeta.UID), pod.Status.PodIPs)
 
 	// pod is not in fake client, so if this will try to remove annotation, it will fail.
 	err := m.RemovePodFromMesh(fakeCtx, pod, true)
@@ -297,7 +297,7 @@ func TestMeshDataplaneAddPodToHostNSIPSets(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -305,7 +305,7 @@ func TestMeshDataplaneAddPodToHostNSIPSets(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
@@ -335,7 +335,7 @@ func TestMeshDataplaneAddPodToHostNSIPSetsV6(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3164"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -343,7 +343,7 @@ func TestMeshDataplaneAddPodToHostNSIPSetsV6(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece2:2f9b:3165"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr(pod.Status.PodIPs[0].IP), netip.MustParseAddr(pod.Status.PodIPs[1].IP)}
@@ -373,7 +373,7 @@ func TestMeshDataplaneAddPodToHostNSIPSetsDualstack(t *testing.T) {
 		netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -381,7 +381,7 @@ func TestMeshDataplaneAddPodToHostNSIPSetsDualstack(t *testing.T) {
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	podIPs := []netip.Addr{netip.MustParseAddr("e9ac:1e77:90ca:399f:4d6d:ece3:2f9b:3162"), netip.MustParseAddr("99.9.9.9")}
@@ -411,7 +411,7 @@ func TestMeshDataplaneAddPodIPToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T)
 		netip.MustParseAddr("99.9.9.9"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -419,7 +419,7 @@ func TestMeshDataplaneAddPodIPToHostNSIPSetsReturnsErrorIfOneFails(t *testing.T)
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(errors.New("bwoah"))
 
 	podIPs := []netip.Addr{netip.MustParseAddr("99.9.9.9"), netip.MustParseAddr("2.2.2.2")}
@@ -436,21 +436,45 @@ func TestMeshDataplaneRemovePodIPFromHostNSIPSets(t *testing.T) {
 	fakeIPSetDeps := ipset.FakeNLDeps()
 	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
-	fakeIPSetDeps.On("clearEntriesWithIP",
+	fakeIPSetDeps.On("clearEntriesWithIPAndComment",
 		"foo-v4",
 		netip.MustParseAddr("3.3.3.3"),
-	).Return(nil)
+		string(pod.ObjectMeta.UID),
+	).Return("", nil)
 
-	fakeIPSetDeps.On("clearEntriesWithIP",
+	fakeIPSetDeps.On("clearEntriesWithIPAndComment",
 		"foo-v4",
 		netip.MustParseAddr("2.2.2.2"),
-	).Return(nil)
+		string(pod.ObjectMeta.UID),
+	).Return("", nil)
 
 	err := removePodFromHostNSIpset(pod, &set)
 	assert.NoError(t, err)
 	fakeIPSetDeps.AssertExpectations(t)
 }
 
+func TestMeshDataplaneRemovePodIPFromHostNSIPSetsIgnoresEntriesWithMismatchedUIDs(t *testing.T) {
+	pod := buildConvincingPod(false)
+
+	fakeIPSetDeps := ipset.FakeNLDeps()
+	set := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
+
+	fakeIPSetDeps.On("clearEntriesWithIPAndComment",
+		"foo-v4",
+		netip.MustParseAddr("3.3.3.3"),
+		string(pod.ObjectMeta.UID),
+	).Return("mismatched-uid", nil)
+
+	fakeIPSetDeps.On("clearEntriesWithIPAndComment",
+		"foo-v4",
+		netip.MustParseAddr("2.2.2.2"),
+		string(pod.ObjectMeta.UID),
+	).Return("mismatched-uid", nil)
+
+	err := removePodFromHostNSIpset(pod, &set)
+	assert.NoError(t, err)
+	fakeIPSetDeps.AssertExpectations(t)
+}
 func TestMeshDataplaneSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 	pod := buildConvincingPod(false)
 
@@ -472,7 +496,7 @@ func TestMeshDataplaneSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -480,7 +504,7 @@ func TestMeshDataplaneSyncHostIPSetsPrunesNothingIfNoExtras(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("listEntriesByIP",
@@ -518,7 +542,7 @@ func TestMeshDataplaneSyncHostIPSetsIgnoresPodIPAddErrorAndContinues(t *testing.
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		pod1UID,
-		false,
+		true,
 	).Return(errors.New("CANNOT ADD"))
 
 	fakeIPSetDeps.On("addIP",
@@ -526,7 +550,7 @@ func TestMeshDataplaneSyncHostIPSetsIgnoresPodIPAddErrorAndContinues(t *testing.
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		pod1UID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -534,7 +558,7 @@ func TestMeshDataplaneSyncHostIPSetsIgnoresPodIPAddErrorAndContinues(t *testing.
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		pod2UID,
-		false,
+		true,
 	).Return(errors.New("CANNOT ADD"))
 
 	fakeIPSetDeps.On("addIP",
@@ -542,7 +566,7 @@ func TestMeshDataplaneSyncHostIPSetsIgnoresPodIPAddErrorAndContinues(t *testing.
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		pod2UID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("listEntriesByIP",
@@ -599,7 +623,7 @@ func TestMeshDataplaneSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 		netip.MustParseAddr("3.3.3.3"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	fakeIPSetDeps.On("addIP",
@@ -607,7 +631,7 @@ func TestMeshDataplaneSyncHostIPSetsPrunesIfExtras(t *testing.T) {
 		netip.MustParseAddr("2.2.2.2"),
 		ipProto,
 		podUID,
-		false,
+		true,
 	).Return(nil)
 
 	// List should return one IP not in our "pod snapshot", which means we prune
@@ -731,16 +755,17 @@ func expectPodAddedToIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIP netip.Addr, p
 		podIP,
 		uint8(unix.IPPROTO_TCP),
 		string(podMeta.UID),
-		false,
+		true,
 	).Return(nil)
 }
 
-func expectPodRemovedFromIPSet(ipsetDeps *ipset.MockedIpsetDeps, podIPs []corev1.PodIP) {
+func expectPodRemovedFromIPSet(ipsetDeps *ipset.MockedIpsetDeps, podUID string, podIPs []corev1.PodIP) {
 	for _, ip := range podIPs {
-		ipsetDeps.On("clearEntriesWithIP",
+		ipsetDeps.On("clearEntriesWithIPAndComment",
 			"foo-v4",
 			netip.MustParseAddr(ip.IP),
-		).Return(nil)
+			podUID,
+		).Return("", nil)
 	}
 }
 
@@ -763,7 +788,7 @@ func getFakeDP(fs *fakeServer, fakeClient kubernetes.Interface) *meshDataplane {
 		mock.Anything,
 	).Return(nil).Maybe()
 
-	fakeIPSetDeps.On("clearEntriesWithIP", mock.Anything, mock.Anything).Return(nil).Maybe()
+	fakeIPSetDeps.On("clearEntriesWithIPAndComment", mock.Anything, mock.Anything, mock.Anything).Return("", nil).Maybe()
 	fakeSet := ipset.IPSet{V4Name: "foo-v4", Prefix: "foo", Deps: fakeIPSetDeps}
 
 	return getFakeDPWithIPSet(fs, fakeClient, fakeSet)


### PR DESCRIPTION
**Please provide a description of this PR:**



Fundamentally we have 2 sources of pod ADDs in ambient's node agent that we have to ensure don't step on each other (we only have 1 possible source of pod REMOVEs, so that's easier to reason about) - the CNI plugin, and the informer.

Once we get [iptables reconciliation](https://github.com/istio/istio/pull/53153) in ambient, this gets much easier, but there's one other annoying bit of state that traditionally doesn't play nice with upserts or idempotency - the `ipsets` we use for pod health checks.

This PR attempts to fix that, anticipating https://github.com/istio/istio/pull/53153 so that we can eventually just not care about synchronization in the informer as much, since it will be safe to ADD the same pod 2x regardless of source.

I had previously been a little leery of relying on ipset comments to make `ipset` entry insertion/removal smarter due to kernel prereqs, but we've had a release or two with comment support in place, and I think the issue mostly is with the CLI tool and not the `go` library, so the benefits outweigh the downsides imo.

Conceptually but not functionally related to https://github.com/istio/istio/pull/54218

### What this does

- On pod ADD, make the ipset insert of (podIP, UID) be an overwriting upsert (again).
- On pod REMOVE, make the ipset removal of (podIP, UID) only actually remove the entry if both the pod IP and pod UID being removed match the entry.

This should be eventually consistent because while we have 2 possible sources of ADD, we only ever have 1 possible source of REMOVE. This also avoids the problems we had previously where an new pod ADD happened before an old pod REMOVE, and the IP clashed, causing the new pod to lose its entry.