### PR TITLE
Handle nil *xdsResponse for istioctl x version

### DIFF
--- a/istioctl/pkg/version/version.go
+++ b/istioctl/pkg/version/version.go
@@ -203,6 +203,9 @@ func xdsRemoteVersionWrapper(ctx cli.Context, opts *clioptions.ControlPlaneOptio
 func xdsProxyVersionWrapper(xdsResponse **discovery.DiscoveryResponse) func() (*[]istioVersion.ProxyInfo, error) {
 	return func() (*[]istioVersion.ProxyInfo, error) {
 		pi := []istioVersion.ProxyInfo{}
+		if *xdsResponse == nil {
+			return nil, fmt.Errorf("invalid xdsResponse")
+		}
 		for _, resource := range (*xdsResponse).Resources {
 			switch resource.TypeUrl {
 			case "type.googleapis.com/envoy.config.core.v3.Node":


### PR DESCRIPTION
**Please provide a description of this PR:**

Currently, if xdsRemoteVersionWrapper fails to get an xdsResponse, xdsProxyVersionWrapper does not properly handle a nil *xdsResponse. **xdsResponse is shared between xdsRemoteVersionWrapper and xdsProxyVersionWrapper. **xdsResponse shouldn't be nil since it is set to the address of a nil pointer.