### PR TITLE
`profile` and `platform` should mirror each other in terms of scoping

### DIFF
--- a/manifests/charts/base/templates/zzz_profile.yaml
+++ b/manifests/charts/base/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/default/templates/zzz_profile.yaml
+++ b/manifests/charts/default/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/gateway/templates/zzz_profile.yaml
+++ b/manifests/charts/gateway/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/istio-cni/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-cni/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/charts/ztunnel/templates/zzz_profile.yaml
+++ b/manifests/charts/ztunnel/templates/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/manifests/zzz_profile.yaml
+++ b/manifests/zzz_profile.yaml
@@ -24,11 +24,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{- $defaults := $.Values._internal_defaults_do_not_set }}
 {{- $_ := unset $.Values "_internal_defaults_do_not_set" }}
 {{- $profile := dict }}
-{{- with .Values.profile }}
+{{- with (coalesce ($.Values).profile ($.Values.global).profile) }}
 {{- with $.Files.Get (printf "files/profile-%s.yaml" .)}}
 {{- $profile = (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown profile" $.Values.profile) }}
+{{ fail (cat "unknown profile" .) }}
 {{- end }}
 {{- end }}
 {{- with .Values.compatibilityVersion }}
@@ -38,11 +38,11 @@ Finally, we can set all of that under .Values so the chart behaves without aware
 {{ fail (cat "unknown compatibility version" $.Values.compatibilityVersion) }}
 {{- end }}
 {{- end }}
-{{- if ($.Values.global).platform }}
-{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" ($.Values.global).platform) }}
+{{- with (coalesce ($.Values).platform ($.Values.global).platform) }}
+{{- with $.Files.Get (printf "files/profile-platform-%s.yaml" .) }}
 {{- $ignore := mustMergeOverwrite $profile (. | fromYaml) }}
 {{- else }}
-{{ fail (cat "unknown platform" ($.Values.global).platform) }}
+{{ fail (cat "unknown platform" .) }}
 {{- end }}
 {{- end }}
 {{- if $profile }}

--- a/releasenotes/notes/54264.yaml
+++ b/releasenotes/notes/54264.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Improved** Both `platform` and `profile` Helm values overrides now equivalently support
+  global or local override forms, e.g.
+    - `--set global.platform=foo`
+    - `--set platform=foo`
+    - `--set global.profile=bar`
+    - `--set profile=bar`


### PR DESCRIPTION
**Please provide a description of this PR:**

This PR makes it so for all charts:
  - `--set global.platform=foo` works
  - `--set platform=foo` works
  - `--set global.profile=bar` works
  - `--set profile=bar` works
  
(and, implicitly, if both specified, the non-global form "wins").

Previously, `profile` didn't support the `global` form, and `platform` didn't support the `local` form. Both _should be_ global _only_ IMO, as they de-facto function as, and only make sense as, global (i.e. cross-chart) named value overrides, serving as our local replacement for standard Helm composition and user-specified values files.

But at least, in the short term, they should behave the same as each other in this regard, it's pointlessly confusing UX if they don't, and it's our UX.