### PR TITLE
Adapt fake image registry server to Openshift

### DIFF
--- a/pkg/test/fakes/imageregistry/Makefile
+++ b/pkg/test/fakes/imageregistry/Makefile
@@ -22,7 +22,7 @@ BIN_NAME := main
 
 # NOTE: TAG should be updated whenever changes are made in this directory
 # This should also be updated in dependent components
-TAG := 1.4
+TAG := 1.5
 
 all: build_and_push clean
 


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #54271

During tests execution on Kind, a "kind-registry" docker container is used as a registry to hold all the images.
This registry does not have any authentication mechanism and the requires could interact with registry in flat requests. The credentials, which hardcoded within the code flow, just simulate registry authentication, but does not perform such mechanism in reality.

When we're executing the tests in Openshift, an internal, builtin Openshift registry is used.
The Openshift internal registry requires authentication by using "token" as authorization process.

In order to make the "fake image registry" server usable by Openshift, a different approach of authentication should be used.

Instead of hard coding the registry credentials, a service account will be created. Such SA generates a token, which could be used as an authentication mechanism.

Such a flow could be used in both Kind and Openshift environments.

For that:
- Remove the hardcoded credentials.
- Create a new http request with will use provided registry credentials to perform authentication.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
