### PR TITLE
Fix telemetry WASM with OCI tests on Openshift

### DIFF
--- a/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
+++ b/pkg/test/framework/components/registryredirector/registry_redirector_server.yaml
@@ -40,7 +40,7 @@ spec:
         app: registry-redirector
     spec:
       containers:
-      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.4"}}
+      - image: {{ or .Image "gcr.io/istio-testing/fake-registry:1.5"}}
         name: registry-redirector
         {{- if .TargetRegistry }}
         args: ["--registry", {{ .TargetRegistry }}, "--scheme", {{ or .Scheme "https" }}]

--- a/tests/integration/telemetry/api/registry_setup_test.go
+++ b/tests/integration/telemetry/api/registry_setup_test.go
@@ -28,16 +28,25 @@ import (
 var registry registryredirector.Instance
 
 const (
-	// Same user name and password as specified at pkg/test/fakes/imageregistry
-	registryUser   = "user"
-	registryPasswd = "passwd"
+	// The password is a token that taken from the created service account
+	registryUser = "user"
 )
 
 func testRegistrySetup(ctx resource.Context) (err error) {
+	var targetRegistry, scheme string
+
+	if ctx.Settings().OpenShift {
+		targetRegistry = "image-registry.openshift-image-registry.svc:5000"
+		scheme = "https"
+	} else {
+		targetRegistry = "kind-registry:5000"
+		scheme = "http"
+	}
+
 	registry, err = registryredirector.New(ctx, registryredirector.Config{
 		Cluster:        ctx.AllClusters().Default(),
-		TargetRegistry: "kind-registry:5000",
-		Scheme:         "http",
+		TargetRegistry: targetRegistry,
+		Scheme:         scheme,
 	})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/api/testdata/cluster-role-binding.yaml
+++ b/tests/integration/telemetry/api/testdata/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: reg-sa-registry-editor-binding
+subjects:
+  - kind: ServiceAccount
+    name: reg-sa
+    namespace: {{ .AppNamespace }}
+roleRef:
+  kind: ClusterRole
+  name: registry-editor
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/integration/telemetry/api/testdata/service-account-secret.yaml
+++ b/tests/integration/telemetry/api/testdata/service-account-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reg-sa
+  annotations:
+    kubernetes.io/service-account.name: reg-sa
+type: kubernetes.io/service-account-token

--- a/tests/integration/telemetry/api/testdata/service-account.yaml
+++ b/tests/integration/telemetry/api/testdata/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reg-sa


### PR DESCRIPTION
**Please provide a description of this PR:**
Fixes: #54271 

This PR complements and depends on https://github.com/istio/istio/pull/54272
First https://github.com/istio/istio/pull/54272 should be merged.

Fix telemetry "TestGatewaySelection" and "TestImagePullPolicy" tests on Openshift.
The above mentioned tests are testing WASM configuration with OCI based images.
The "fake image registry" server is used to redirect the test OCI based requests to the environment registry.

In Kind based environment, such registry is a "kind-registry" container, running alongside with the Kind kubernetes cluster. The "kind-registry" is a flat registry and does not require any authentication to be made.
The "fake image registry" server simulates authentication by using a hardcoded credentials on both sides - client and server. And then matches between them.

In Openshift based environment, the Openshift internal registry is used. Internal Openshift registry required authentication to be used and uses tokens to perform it.

This patch introduces a new flow, to use a token based authentication for both environment - Kind and Openshift.
The token is taken from the created service account, with relevant permissions and used by the client to send the request to the registry through the "fake image registry" server.

- Create service account and assign it a nessesary permission to interact with registry. The token will be generated automatically with SA creation.
- Create a SA secret with "service-account-token" type to contain the "token", which will be fetched later by the test.
- Add a function to fetch the token from the secret.
- Add conditions to use the the relevant registry path and image path according to the used environment.