### PR TITLE
enable configuration of global.proxy.outlierLogPath for waypoints

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
@@ -120,6 +120,9 @@ spec:
         {{- if .Values.global.logAsJson }}
         - --log_as_json
         {{- end }}
+        {{- if .Values.global.proxy.outlierLogPath }}
+        - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+        {{- end}}
         env:
         - name: ISTIO_META_SERVICE_ACCOUNT
           valueFrom:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.44.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.44.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.52.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift-custom-injection.yaml.52.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.51.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-openshift.yaml.51.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.8.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.47.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.47.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/proxy-override-runas.yaml.34.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/reroute-virtual-interfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/reroute-virtual-interfaces.yaml.9.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.7.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.6.template.gen.yaml
@@ -1275,6 +1275,9 @@ templates:
             {{- if .Values.global.logAsJson }}
             - --log_as_json
             {{- end }}
+            {{- if .Values.global.proxy.outlierLogPath }}
+            - --outlierLogPath={{ .Values.global.proxy.outlierLogPath }}
+            {{- end}}
             env:
             - name: ISTIO_META_SERVICE_ACCOUNT
               valueFrom:


### PR DESCRIPTION
**Please provide a description of this PR:**

i noticed that outlierLogPath is not passed to envoy when used as a waypoint.  this PR attempts to fix this by including the helm value in the injection template.

i noticed that waypoint templates exist in other places in the repo, for automated testing, specifically under:
- operator/cmd/mesh/testdata/manifest-generate/output/
- pilot/pkg/config/kube/gateway/testdata/deployment/
- pkg/kube/inject/testdata/inputs/

let me know if a similar edit is needed in those places.