### PR TITLE
Add tcp port to peer authn test

### DIFF
--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -770,7 +770,7 @@ spec:
 			})
 			// general workload peerauth == STRICT, but we have a port-specific allowlist that is PERMISSIVE,
 			// so anything hitting that port should not be rejected.
-			// NOTE: Using port 80 since that's what
+			// NOTE: Using port 18080 since that's the http port for the echo deployment
 			t.NewSubTest("strict-permissive-ports").Run(func(t framework.TestContext) {
 				t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 					"Destination": dst.Config().Service,
@@ -841,7 +841,6 @@ spec:
         `).ApplyOrFail(t)
 				t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
 					"Destination": dst.Config().Service,
-					"Source":      src.Config().Service,
 					"Namespace":   apps.Namespace.Name(),
 				}, `
 apiVersion: security.istio.io/v1
@@ -861,6 +860,8 @@ spec:
 					// Expect deny if the dest is in the mesh (enforcing mTLS) but src is not (not sending mTLS)
 					opt.Check = CheckDeny
 				}
+				echo.DefaultCallRetryOptions()
+				opt.Retry = echo.Retry{Options: []retry.Option{retry.MaxAttempts(15)}}
 				src.CallOrFail(t, opt)
 			})
 		})

--- a/tests/integration/ambient/baseline_test.go
+++ b/tests/integration/ambient/baseline_test.go
@@ -823,6 +823,8 @@ spec:
   portLevelMtls:
     18080:
       mode: PERMISSIVE
+    19090:
+      mode: STRICT
         `).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				// Should pass for all workloads, in or out of mesh, targeting this port
@@ -854,14 +856,15 @@ spec:
   portLevelMtls:
     18080:
       mode: STRICT
+    19090:
+      mode: STRICT
+
         `).ApplyOrFail(t)
 				opt = opt.DeepCopy()
 				if !src.Config().HasProxyCapabilities() && dst.Config().HasProxyCapabilities() {
 					// Expect deny if the dest is in the mesh (enforcing mTLS) but src is not (not sending mTLS)
 					opt.Check = CheckDeny
 				}
-				echo.DefaultCallRetryOptions()
-				opt.Retry = echo.Retry{Options: []retry.Option{retry.MaxAttempts(15)}}
 				src.CallOrFail(t, opt)
 			})
 		})


### PR DESCRIPTION
The [failing](https://prow.istio.io/view/gs/istio-prow/logs/integ-ipv6_istio_postsubmit/1866264993557647360) test [flakes](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/54136/integ-ambient_istio/1863745610658615296) for the test flakes described in #54146 (potentially caused by #54073) are sending traffic to port 9090 while the test in question only has port rules for the http workload port (with a corresponding service port of 8080). If we add the workload tcp port to the policy, it should fix the flakes